### PR TITLE
Updated docker-compose.yml with correct syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
     environment:
       - QDRANT_URL=${QDRANT_URL}
       - QDRANT_API_KEY=${QDRANT_API_KEY}
-    restart: no
+    restart: "no"
 
   delete_qdrant:
     build:
@@ -115,7 +115,7 @@ services:
     environment:
       - QDRANT_URL=${QDRANT_URL}
       - QDRANT_API_KEY=${QDRANT_API_KEY}
-    restart: no
+    restart: "no"
 
   rag_files_worker:
     build:
@@ -180,7 +180,6 @@ services:
     ports:
       - "27017:27017"
     restart: unless-stopped
-    attach: false
     volumes:
       - ./data/mongo:/data/db
 


### PR DESCRIPTION
Updated the correct syntax for docker-compose.yml

- restart policy should be set to "no"
-  attach: false is not valid in docker-compose.yml

Fixes Issue #103 