### PR TITLE
Fix AttributeError when usage is None for non-Openai models

### DIFF
--- a/apps/rowboat_agents/src/graph/core.py
+++ b/apps/rowboat_agents/src/graph/core.py
@@ -196,9 +196,13 @@ async def run_turn_streamed(
                     if event.type == "raw_response_event":
                         # Handle token usage counting
                         if hasattr(event.data, 'type') and event.data.type == "response.completed" and hasattr(event.data.response, 'usage'):
-                            tokens_used["total"] += event.data.response.usage.total_tokens
-                            tokens_used["prompt"] += event.data.response.usage.input_tokens
-                            tokens_used["completion"] += event.data.response.usage.output_tokens
+                            usage = getattr(event.data.response, "usage", None)
+                            if usage and getattr(usage, "total_tokens", None) is not None:
+                                tokens_used["total"] += usage.total_tokens
+                            if usage and getattr(usage, "prompt_tokens", None) is not None:
+                                tokens_used["prompt"] += usage.prompt_tokens
+                            if usage and getattr(usage, "completion_tokens", None) is not None:
+                                tokens_used["completion"] += usage.completion_tokens
                             print('-'*50)
                             print(f"Found usage information. Updated cumulative tokens: {tokens_used}")
                             print('-'*50)


### PR DESCRIPTION
Issue #113
The code is trying to access event.data.response.usage.total_tokens at apps/rowboat_agents/src/graph/core.py , but event.data.response.usage is None. This happens when the response object does not include usage information for non-OpenAI models like Azure OpenAI.


Fix:
Adding a guard clause before accessing total_tokens to prevent the AttributeError when usage is None.