### PR TITLE
fix: EAI_AGAIN error on docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
     restart: unless-stopped
     volumes:
       - uploads:/app/uploads
+    networks:
+      - rowboat_net
 
   rowboat_agents:
     build:
@@ -77,6 +79,8 @@ services:
       - MAX_CALLS_PER_CHILD_AGENT=${MAX_CALLS_PER_CHILD_AGENT}
       - ENABLE_TRACING=${ENABLE_TRACING}
     restart: unless-stopped
+    networks:
+      - rowboat_net
 
   copilot:
     build:
@@ -92,6 +96,8 @@ services:
       - PROVIDER_DEFAULT_MODEL=${PROVIDER_DEFAULT_MODEL}
       - PROVIDER_COPILOT_MODEL=${PROVIDER_COPILOT_MODEL}
     restart: unless-stopped
+    networks:
+      - rowboat_net
 
   # tools_webhook:
   #   build:
@@ -127,6 +133,8 @@ services:
       - QDRANT_API_KEY=${QDRANT_API_KEY}
       - EMBEDDING_VECTOR_SIZE=${EMBEDDING_VECTOR_SIZE}
     restart: no
+    networks:
+      - rowboat_net
 
   delete_qdrant:
     build:
@@ -141,6 +149,8 @@ services:
       - QDRANT_URL=http://qdrant:6333
       - QDRANT_API_KEY=${QDRANT_API_KEY}
     restart: no
+    networks:
+      - rowboat_net
 
   rag_files_worker:
     build:
@@ -170,6 +180,8 @@ services:
     restart: unless-stopped
     volumes:
       - uploads:/app/uploads
+    networks:
+      - rowboat_net
 
   rag_urls_worker:
     build:
@@ -191,6 +203,8 @@ services:
       - BILLING_API_URL=${BILLING_API_URL}
       - BILLING_API_KEY=${BILLING_API_KEY}
     restart: unless-stopped
+    networks:
+      - rowboat_net
 
   rag_text_worker:
     build:
@@ -211,6 +225,8 @@ services:
       - BILLING_API_URL=${BILLING_API_URL}
       - BILLING_API_KEY=${BILLING_API_KEY}
     restart: unless-stopped
+    networks:
+      - rowboat_net
 
   # chat_widget:
   #   build:
@@ -233,12 +249,16 @@ services:
     attach: false
     volumes:
       - ./data/mongo:/data/db
+    networks:
+      - rowboat_net
 
   redis:
     image: redis:latest
     ports:
       - "6379:6379"
     restart: unless-stopped
+    networks:
+      - rowboat_net
 
   docs:
     build:
@@ -247,6 +267,8 @@ services:
     profiles: [ "docs" ]
     ports:
       - "8000:8000"
+    networks:
+      - rowboat_net
 
   # twilio_handler:
   #   build:
@@ -277,3 +299,8 @@ services:
       interval: 5s
       timeout: 10s
       retries: 3
+    networks:
+      - rowboat_net
+
+networks:
+  rowboat_net:


### PR DESCRIPTION
Hi folks, this PR fixes the EAI_AGAIN errors in Docker Compose. 

When running Docker Compose, I was getting these errors
```
rowboat-1  |  ⨯ TypeError: fetch failed
rowboat-1  |     at node:internal/deps/undici/undici:12637:11
rowboat-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
rowboat-1  |     at async h (/app/.next/server/app/api/copilot-stream-response/[streamId]/route.js:1:3585)
rowboat-1  |     at async /app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:38411
rowboat-1  |     at async e_.execute (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:27880)
rowboat-1  |     at async e_.handle (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:39943)
rowboat-1  |     at async doRender (/app/node_modules/next/dist/server/base-server.js:1366:42)
rowboat-1  |     at async cacheEntry.responseCache.get.routeKind (/app/node_modules/next/dist/server/base-server.js:1588:28)
rowboat-1  |     at async NextNodeServer.renderToResponseWithComponentsImpl (/app/node_modules/next/dist/server/base-server.js:1496:28)
rowboat-1  |     at async NextNodeServer.renderPageComponent (/app/node_modules/next/dist/server/base-server.js:1924:24) {
rowboat-1  |   cause: Error: getaddrinfo EAI_AGAIN copilot
rowboat-1  |       at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)
rowboat-1  |       at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:128:17) {
rowboat-1  |     errno: -3001,
rowboat-1  |     code: 'EAI_AGAIN',
rowboat-1  |     syscall: 'getaddrinfo',
rowboat-1  |     hostname: 'copilot'
rowboat-1  |   }
rowboat-1  | }
rowboat-1  |  ⨯ TypeError: fetch failed
rowboat-1  |     at node:internal/deps/undici/undici:12637:11
rowboat-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
rowboat-1  |     at async f (/app/.next/server/app/api/stream-response/[streamId]/route.js:1:1809)
rowboat-1  |     at async /app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:38411
rowboat-1  |     at async e_.execute (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:27880)
rowboat-1  |     at async e_.handle (/app/node_modules/next/dist/compiled/next-server/app-route.runtime.prod.js:6:39943)
rowboat-1  |     at async doRender (/app/node_modules/next/dist/server/base-server.js:1366:42)
rowboat-1  |     at async cacheEntry.responseCache.get.routeKind (/app/node_modules/next/dist/server/base-server.js:1588:28)
rowboat-1  |     at async NextNodeServer.renderToResponseWithComponentsImpl (/app/node_modules/next/dist/server/base-server.js:1496:28)
rowboat-1  |     at async NextNodeServer.renderPageComponent (/app/node_modules/next/dist/server/base-server.js:1924:24) {
rowboat-1  |   cause: Error: getaddrinfo EAI_AGAIN rowboat_agents
rowboat-1  |       at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)
rowboat-1  |       at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:128:17) {
rowboat-1  |     errno: -3001,
rowboat-1  |     code: 'EAI_AGAIN',
rowboat-1  |     syscall: 'getaddrinfo',
rowboat-1  |     hostname: 'rowboat_agents'
rowboat-1  |   }
rowboat-1  | }
```

The rowboat container couldn't find the other containers, explicitly adding all of them to the same network fixes the issue.

I believe this was happening on my side because of the initialization order, maybe another fix could be adding some `depends_on`, but the network seems to be a more reliable fix. Thanks for considering this PR.