### PR TITLE
fix: handle Composio API breaking change from results to main_tools

### DIFF
--- a/apps/rowboat/src/application/lib/copilot/copilot.ts
+++ b/apps/rowboat/src/application/lib/copilot/copilot.ts
@@ -41,10 +41,12 @@ const composioToolSearchToolSuggestion = z.object({
     tool_slug: z.string(),
     description: z.string(),
 });
+
 const composioToolSearchResponseSchema = z.object({
-    results: z.array(composioToolSearchToolSuggestion),
-    related_tools: z.array(composioToolSearchToolSuggestion),
-});
+    main_tools: z.array(composioToolSearchToolSuggestion).optional(),
+    related_tools: z.array(composioToolSearchToolSuggestion).optional(),
+    results: z.array(composioToolSearchToolSuggestion).optional(), // Keep for backward compatibility
+}).passthrough();
 
 function getContextPrompt(context: z.infer<typeof CopilotChatContext> | null): string {
     let prompt = '';
@@ -127,17 +129,21 @@ async function searchRelevantTools(usageTracker: UsageTracker, query: string): P
     });
 
     // parse results
+    logger.log(`raw search result data: ${JSON.stringify(searchResult.data)}`);
     const result = composioToolSearchResponseSchema.safeParse(searchResult.data);
     if (!result.success) {
-        logger.log(`tool search response is invalid: ${result.error}`);
+        logger.log(`tool search response is invalid: ${JSON.stringify(result.error)}`);
+        logger.log(`expected schema: results (array), got: ${JSON.stringify(Object.keys(searchResult.data || {}))}`);
         return 'No tools found!';
     }
-    if (!result.data.results.length) {
+    const tools = result.data.main_tools || result.data.results || [];
+    
+    if (!tools.length) {
         logger.log(`tool search yielded no results`);
         return 'No tools found!';
     }
 
-    const toolSlugs = result.data.results.map((item) => item.tool_slug);
+    const toolSlugs = tools.map((item) => item.tool_slug);
     logger.log(`found tool slugs: ${toolSlugs.join(', ')}`);
     console.log("✅ TOOL CALL SUCCESS: COMPOSIO_SEARCH_TOOLS", { 
         toolSlugs, 


### PR DESCRIPTION
- Composio SDK upgrade (0.1.40 -> 0.1.48) changed COMPOSIO_SEARCH_TOOLS response format
- API now returns main_tools instead of results field
- Updated schema to support both formats for backward compatibility
- Fixes tool search functionality that was broken since August 27th upgrade

Resolves: Tool search returning 'No tools found' despite valid tools being available