### PR TITLE
fix path traversal and CLI command validation

### DIFF
--- a/apps/x/packages/core/src/application/lib/command-executor.ts
+++ b/apps/x/packages/core/src/application/lib/command-executor.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import { getSecurityAllowList } from '../../config/security.js';
 
 const execPromise = promisify(exec);
-const COMMAND_SPLIT_REGEX = /(?:\|\||&&|;|\||\n)/;
+const COMMAND_SPLIT_REGEX = /(?:\|\||&&|;|\||\n|`|\$\(|\))/;
 const ENV_ASSIGNMENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*=.*/;
 const WRAPPER_COMMANDS = new Set(['sudo', 'env', 'time', 'command']);
 


### PR DESCRIPTION
Updated the PR to only include changes for  apps/x  as requested. I've also added explicit checks for subshell-related characters in the command splitting logic.

The previous regex was missing several edge cases that could allow command injection via nested subshells. For example:
- Backticks:  `id` 
- Dollar-parenthesis:  $(id) 
- Nested parenthesis:  (id) 

By adding these to the  COMMAND_SPLIT_REGEX , the executor now correctly identifies and blocks these attempts when they aren't part of the allowed command structure.