### PR TITLE
feat(core): add 'Claude Subscription' model provider support

### DIFF
--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -28,6 +28,7 @@ export function createProvider(config: z.infer<typeof Provider>): ProviderV2 {
                 headers,
             });
         case "anthropic":
+        case "anthropic-subscription":
             return createAnthropic({
                 apiKey,
                 baseURL,

--- a/apps/x/packages/shared/src/models.ts
+++ b/apps/x/packages/shared/src/models.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const LlmProvider = z.object({
-  flavor: z.enum(["openai", "anthropic", "google", "openrouter", "aigateway", "ollama", "openai-compatible"]),
+  flavor: z.enum(["openai", "anthropic", "google", "openrouter", "aigateway", "ollama", "openai-compatible", "anthropic-subscription"]),
   apiKey: z.string().optional(),
   baseURL: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
## Summary
Adds a new model provider flavor `anthropic-subscription` (labeled 'Claude Subscription') to the onboarding list.

### Why?
Users who want to use their Claude Subscription (likely via session tokens or alternative auth methods compared to standard API keys) need a distinct configuration path. This PR adds the plumbing to select this provider in the UI.

### Changes
- Updated `packages/shared/src/models.ts`: Added flavor to Zod schema.
- Updated `packages/core/src/models/models.ts`: Mapped flavor to Anthropic SDK provider.
- Updated `packages/core/src/models/models-dev.ts`: Added to onboarding list, aliasing the 'anthropic' model catalog.