### PR TITLE
fix(cli): correct main entry and add bin alias

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@rowboatlabs/rowboatx",
   "version": "0.16.0",
-  "main": "index.js",
+  "main": "dist/app.js",
+  "preferGlobal": true,
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -14,7 +15,8 @@
     "bin"
   ],
   "bin": {
-    "rowboatx": "bin/app.js"
+    "rowboatx": "bin/app.js",
+    "rowboat": "bin/app.js"
   },
   "keywords": [],
   "author": "Rowboat Labs",


### PR DESCRIPTION
## Summary
Fixes issues where the \owboatx\ CLI was not correctly installed to the system PATH.

## Changes
- Updated \main\ field in \pps/cli/package.json\ to point to \dist/app.js\ (was \index.js\, which does not exist).
- Added \preferGlobal: true\ to hint package managers.
- Added \owboat\ alias to \in\ configuration to improve discoverability and provide a fallback if the scoped name causes linking issues.

Closes #310