### PR TITLE
Fix Google OAuth invalid_client setup + improve desktop guidance

### DIFF
--- a/apps/x/apps/main/src/oauth-handler.ts
+++ b/apps/x/apps/main/src/oauth-handler.ts
@@ -53,10 +53,15 @@ function cancelActiveFlow(reason: string = 'cancelled'): void {
 
   // Only emit event for user-visible cancellations
   if (reason !== 'new_flow_started') {
+    const provider = activeFlow.provider;
+    const error = (reason === 'timed_out' && provider === 'google')
+      ? 'Timed out waiting for Google OAuth to finish. If your browser showed “Error 401: invalid_client”, double-check that you entered the OAuth Client ID (it should end with .apps.googleusercontent.com) and that it was created as a Desktop app OAuth client. Setup guide: https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md'
+      : `OAuth flow ${reason}`;
+
     emitOAuthEvent({
-      provider: activeFlow.provider,
+      provider,
       success: false,
-      error: `OAuth flow ${reason}`
+      error,
     });
   }
 

--- a/apps/x/apps/renderer/src/components/google-client-id-modal.tsx
+++ b/apps/x/apps/renderer/src/components/google-client-id-modal.tsx
@@ -49,7 +49,7 @@ export function GoogleClientIdModal({
         <DialogHeader>
           <DialogTitle>Enter Google Client ID</DialogTitle>
           <DialogDescription>
-            This app does not store the client ID. You will be prompted each session.
+            Paste the OAuth Client ID (it should end with .apps.googleusercontent.com). Do not paste the client secret. This app does not store it, so you will be prompted each session.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-2">

--- a/google-setup.md
+++ b/google-setup.md
@@ -114,25 +114,38 @@ Click **Create Credentials → OAuth Client ID**
 
 Select:
 
-**Universal Windows Platform (UWP)**
+**Desktop app**
 
 - Name it anything (e.g. `Rowboat Desktop`)
-- Store ID can be anything (e.g. `test` )
 - Click **Create**
 
-![Create OAuth Client ID (UWP)](https://raw.githubusercontent.com/rowboatlabs/rowboat/main/apps/docs/docs/img/google-setup/05-create-oauth-client-uwp.png)
+> Note: Rowboat Desktop uses a local redirect URI during OAuth:
+>
+> `http://localhost:8080/oauth/callback`
 
 ---
 
 ## 7️⃣ Copy the Client ID
 
-After creation, Google will show:
+After creation, Google will show a **Client ID** (and sometimes a **Client Secret**).
 
-- **Client ID**
-- **Client Secret**
-
-Copy the **Client ID** and paste it into Rowboat where prompted.
+Copy the **Client ID** and paste it into Rowboat where prompted. (Rowboat uses PKCE and does not require the client secret.)
 
 ![Copy Client ID](https://raw.githubusercontent.com/rowboatlabs/rowboat/main/apps/docs/docs/img/google-setup/06-copy-client-id.png)
+
+---
+
+## Troubleshooting
+
+### Error 401: invalid_client ("The OAuth client was not found")
+
+- Make sure you pasted the **Client ID** (not the client secret, API key, service account, or project ID).
+- A Google OAuth Client ID typically looks like:
+  `xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com`
+- Ensure the OAuth Client was created in the same Google Cloud project where you enabled the Gmail/Calendar/Drive APIs.
+
+### OAuth times out / never returns to Rowboat
+
+- Make sure nothing else is using port `8080` and that your firewall allows `http://localhost:8080` connections.
 
 ---


### PR DESCRIPTION
Fixes #353.

### What changed
- Updated google-setup.md to recommend creating a Desktop app OAuth client (Rowboat uses a localhost loopback redirect) and added troubleshooting for Error 401: invalid_client.
- Improved the Google Client ID prompt to clarify what value to paste (Client ID ending in .apps.googleusercontent.com) and to not paste the client secret.
- When the OAuth flow times out for Google (e.g. user sees an error page in the browser and never reaches the localhost callback), Rowboat now emits a more actionable message pointing to the most common invalid_client causes + the setup guide.

### Tests
- pnpm -C apps/x run deps
- pnpm -C apps/x/apps/main run build
- pnpm -C apps/x/apps/renderer run build
