### PR TITLE
fix: merge consecutive tool results for Anthropic API compatibility

### DIFF
--- a/apps/x/packages/core/src/agents/runtime.ts
+++ b/apps/x/packages/core/src/agents/runtime.ts
@@ -354,7 +354,8 @@ export async function loadAgent(id: string): Promise<z.infer<typeof Agent>> {
 
 export function convertFromMessages(messages: z.infer<typeof Message>[]): ModelMessage[] {
     const result: ModelMessage[] = [];
-    for (const msg of messages) {
+    for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
         const { providerOptions } = msg;
         switch (msg.role) {
             case "assistant":
@@ -401,23 +402,50 @@ export function convertFromMessages(messages: z.infer<typeof Message>[]): ModelM
                     providerOptions,
                 });
                 break;
-            case "tool":
+            case "tool": {
+                // Collect all consecutive tool messages into a single message
+                // This is required by Anthropic's API which expects all tool_result blocks
+                // for parallel tool calls to be in a single message
+                const toolResults: Array<{
+                    type: "tool-result";
+                    toolCallId: string;
+                    toolName: string;
+                    output: { type: "text"; value: string };
+                }> = [];
+
+                // Add current tool message
+                toolResults.push({
+                    type: "tool-result",
+                    toolCallId: msg.toolCallId,
+                    toolName: msg.toolName,
+                    output: {
+                        type: "text",
+                        value: msg.content,
+                    },
+                });
+
+                // Collect any consecutive tool messages
+                while (i + 1 < messages.length && messages[i + 1].role === "tool") {
+                    i++;
+                    const nextMsg = messages[i] as z.infer<typeof ToolMessage>;
+                    toolResults.push({
+                        type: "tool-result",
+                        toolCallId: nextMsg.toolCallId,
+                        toolName: nextMsg.toolName,
+                        output: {
+                            type: "text",
+                            value: nextMsg.content,
+                        },
+                    });
+                }
+
                 result.push({
                     role: "tool",
-                    content: [
-                        {
-                            type: "tool-result",
-                            toolCallId: msg.toolCallId,
-                            toolName: msg.toolName,
-                            output: {
-                                type: "text",
-                                value: msg.content,
-                            },
-                        },
-                    ],
+                    content: toolResults,
                     providerOptions,
                 });
                 break;
+            }
         }
     }
     // doing this because: https://github.com/OpenRouterTeam/ai-sdk-provider/issues/262


### PR DESCRIPTION
## Summary
- Fixes parallel tool call failures when using Anthropic API
- Merges consecutive tool result messages into a single message with all `tool_result` content blocks

## Problem
When an agent workflow triggers multiple parallel tool calls, the Anthropic API returns an error:
> "tool_use ids were found without tool_result blocks immediately after"

This happens because each tool result was being sent as a separate message, but Anthropic's API requires all tool results for parallel calls to be in a single message.

## Solution
Modified `convertFromMessages()` in `runtime.ts` to detect consecutive tool messages and merge them into one message containing all `tool_result` blocks.

Fixes #375