### PR TITLE
ability to symlink a vault

### DIFF
--- a/apps/x/packages/core/src/config/initConfigs.ts
+++ b/apps/x/packages/core/src/config/initConfigs.ts
@@ -4,6 +4,7 @@ import type { IMcpConfigRepo } from "../mcp/repo.js";
 import type { IAgentScheduleRepo } from "../agent-schedule/repo.js";
 import type { IAgentScheduleStateRepo } from "../agent-schedule/state-repo.js";
 import { ensureSecurityConfig } from "./security.js";
+import { ensureKnowledgeVaultsConfig } from "./knowledge_vaults.js";
 
 /**
  * Initialize all config files at app startup.
@@ -22,5 +23,6 @@ export async function initConfigs(): Promise<void> {
         agentScheduleRepo.ensureConfig(),
         agentScheduleStateRepo.ensureState(),
         ensureSecurityConfig(),
+        Promise.resolve(ensureKnowledgeVaultsConfig()),
     ]);
 }

--- a/apps/x/packages/core/src/config/knowledge_vaults.ts
+++ b/apps/x/packages/core/src/config/knowledge_vaults.ts
@@ -1,0 +1,159 @@
+import fs from 'fs';
+import path from 'path';
+import { WorkDir } from './config.js';
+
+export interface KnowledgeVault {
+    name: string;
+    path: string;
+    mountPath: string;
+    readOnly: boolean;
+    addedAt: string;
+}
+
+interface KnowledgeVaultsConfig {
+    vaults: KnowledgeVault[];
+}
+
+const CONFIG_FILE = path.join(WorkDir, 'config', 'knowledge_vaults.json');
+const RESERVED_NAMES = new Set([
+    'People',
+    'Organizations',
+    'Projects',
+    'Topics',
+    '.assets',
+    '.trash',
+]);
+
+function normalizeVaultName(input: string): string {
+    return input
+        .trim()
+        .replace(/[\\/]/g, '-')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function normalizeRelPath(relPath: string): string {
+    return relPath.split(path.sep).join('/');
+}
+
+function readConfig(): KnowledgeVaultsConfig {
+    try {
+        if (!fs.existsSync(CONFIG_FILE)) {
+            return { vaults: [] };
+        }
+        const raw = fs.readFileSync(CONFIG_FILE, 'utf-8');
+        const parsed = JSON.parse(raw) as KnowledgeVaultsConfig;
+        if (!parsed || !Array.isArray(parsed.vaults)) {
+            return { vaults: [] };
+        }
+        return {
+            vaults: parsed.vaults.filter((vault) => typeof vault?.mountPath === 'string'),
+        };
+    } catch {
+        return { vaults: [] };
+    }
+}
+
+function writeConfig(config: KnowledgeVaultsConfig): void {
+    const dir = path.dirname(CONFIG_FILE);
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+export function ensureKnowledgeVaultsConfig(): void {
+    if (!fs.existsSync(CONFIG_FILE)) {
+        writeConfig({ vaults: [] });
+    }
+}
+
+export function listKnowledgeVaults(): KnowledgeVault[] {
+    return readConfig().vaults;
+}
+
+export function getKnowledgeVaultMountPaths(): string[] {
+    return readConfig().vaults.map((vault) => normalizeRelPath(vault.mountPath));
+}
+
+export function isKnowledgeVaultMountPath(relPath: string): boolean {
+    const normalized = normalizeRelPath(relPath);
+    return getKnowledgeVaultMountPaths().includes(normalized);
+}
+
+export function addKnowledgeVault({
+    name,
+    path: vaultPath,
+    readOnly = false,
+}: {
+    name: string;
+    path: string;
+    readOnly?: boolean;
+}): KnowledgeVault {
+    const normalizedName = normalizeVaultName(name);
+    if (!normalizedName) {
+        throw new Error('Vault name is required');
+    }
+    if (RESERVED_NAMES.has(normalizedName)) {
+        throw new Error('Vault name is reserved');
+    }
+
+    const stats = fs.statSync(vaultPath);
+    if (!stats.isDirectory()) {
+        throw new Error('Vault path must be a directory');
+    }
+
+    const config = readConfig();
+    const mountPath = `knowledge/${normalizedName}`;
+    if (config.vaults.some((vault) => vault.name.toLowerCase() === normalizedName.toLowerCase())) {
+        throw new Error('A vault with that name already exists');
+    }
+    if (config.vaults.some((vault) => vault.path === vaultPath)) {
+        throw new Error('That vault is already added');
+    }
+
+    const mountAbsPath = path.join(WorkDir, mountPath);
+    if (fs.existsSync(mountAbsPath)) {
+        throw new Error(`Mount path already exists: ${mountPath}`);
+    }
+
+    const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+    fs.symlinkSync(vaultPath, mountAbsPath, linkType);
+
+    const vault: KnowledgeVault = {
+        name: normalizedName,
+        path: vaultPath,
+        mountPath,
+        readOnly: readOnly === true,
+        addedAt: new Date().toISOString(),
+    };
+
+    config.vaults.push(vault);
+    writeConfig(config);
+    return vault;
+}
+
+export function removeKnowledgeVault(nameOrMountPath: string): KnowledgeVault | null {
+    const config = readConfig();
+    const normalizedInput = nameOrMountPath.trim();
+    const mountPath = normalizedInput.startsWith('knowledge/')
+        ? normalizedInput
+        : `knowledge/${normalizeVaultName(normalizedInput)}`;
+    const idx = config.vaults.findIndex((vault) => vault.mountPath === mountPath);
+    if (idx === -1) {
+        return null;
+    }
+    const [removed] = config.vaults.splice(idx, 1);
+    writeConfig(config);
+
+    const mountAbsPath = path.join(WorkDir, mountPath);
+    try {
+        const stats = fs.lstatSync(mountAbsPath);
+        if (stats.isSymbolicLink()) {
+            fs.unlinkSync(mountAbsPath);
+        }
+    } catch {
+        // Ignore missing or invalid mount path
+    }
+    return removed;
+}

--- a/apps/x/packages/core/src/knowledge/build_graph.ts
+++ b/apps/x/packages/core/src/knowledge/build_graph.ts
@@ -180,6 +180,7 @@ async function createNotesFromBatch(
     message += `- Use the KNOWLEDGE BASE INDEX below to resolve entities - DO NOT grep/search for existing notes\n`;
     message += `- Extract entities (people, organizations, projects, topics) from ALL files below\n`;
     message += `- Create or update notes in "knowledge" directory (workspace-relative paths like "knowledge/People/Name.md")\n`;
+    message += `- For NEW notes, always write to the base knowledge folders (knowledge/People, knowledge/Organizations, knowledge/Projects, knowledge/Topics), not mounted vaults\n`;
     message += `- If the same entity appears in multiple files, merge the information into a single note\n`;
     message += `- Use workspace tools to read existing notes (when you need full content) and write updates\n`;
     message += `- Follow the note templates and guidelines in your instructions\n\n`;

--- a/apps/x/packages/core/src/knowledge/knowledge_index.ts
+++ b/apps/x/packages/core/src/knowledge/knowledge_index.ts
@@ -222,7 +222,19 @@ function getFolderType(filePath: string): string {
         return 'root';
     }
 
-    // Return the first folder name
+    const categoryFolders = new Set(['People', 'Organizations', 'Projects', 'Topics']);
+
+    // Standard layout: knowledge/<Category>/...
+    if (categoryFolders.has(parts[0])) {
+        return parts[0];
+    }
+
+    // Vault layout: knowledge/<VaultName>/<Category>/...
+    if (parts.length > 1 && categoryFolders.has(parts[1])) {
+        return parts[1];
+    }
+
+    // Return the first folder name for non-standard layouts
     return parts[0];
 }
 

--- a/apps/x/packages/core/src/workspace/watcher.ts
+++ b/apps/x/packages/core/src/workspace/watcher.ts
@@ -23,6 +23,7 @@ export async function createWorkspaceWatcher(
 
   const watcher = chokidar.watch(WorkDir, {
     ignoreInitial: true,
+    followSymlinks: true,
     awaitWriteFinish: {
       stabilityThreshold: 150,
       pollInterval: 50,
@@ -74,4 +75,3 @@ export async function createWorkspaceWatcher(
 
   return watcher;
 }
-

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -11,6 +11,14 @@ import { ServiceEvent } from './service-events.js';
 // Runtime Validation Schemas (Single Source of Truth)
 // ============================================================================
 
+const KnowledgeVault = z.object({
+  name: z.string(),
+  path: z.string(),
+  mountPath: z.string(),
+  readOnly: z.boolean(),
+  addedAt: z.string(),
+});
+
 const ipcSchemas = {
   'app:getVersions': {
     req: z.null(),
@@ -103,6 +111,36 @@ const ipcSchemas = {
   'workspace:didChange': {
     req: WorkspaceChangeEvent,
     res: z.null(),
+  },
+  'knowledge:listVaults': {
+    req: z.null(),
+    res: z.object({
+      vaults: z.array(KnowledgeVault),
+    }),
+  },
+  'knowledge:pickVaultDirectory': {
+    req: z.null(),
+    res: z.object({
+      path: z.string().nullable(),
+    }),
+  },
+  'knowledge:addVault': {
+    req: z.object({
+      path: z.string(),
+      name: z.string(),
+      readOnly: z.boolean().optional(),
+    }),
+    res: z.object({
+      vault: KnowledgeVault,
+    }),
+  },
+  'knowledge:removeVault': {
+    req: z.object({
+      nameOrMountPath: z.string(),
+    }),
+    res: z.object({
+      removed: KnowledgeVault.nullable(),
+    }),
   },
   'mcp:listTools': {
     req: z.object({


### PR DESCRIPTION
Feature: Link external “knowledge folders” into Rowboat
Users can now add an external folder (e.g., an Obsidian vault) into Knowledge. It is mounted as a symlink at:

~/.rowboat/knowledge/<folder-name>
This mount:

appears in the Knowledge tree
is searchable by workspace-grep
is included in the knowledge graph index
remains read/write (deleting files inside it affects the real folder)
can be “unlinked” from the UI without touching the external data
Core config + backend plumbing
New config file
[knowledge_vaults.ts](app://-/index.html#)

Stores metadata in [knowledge_vaults.json](app://-/index.html#)
Tracks: name, path, mountPath, readOnly, addedAt
Validates names and prevents collisions with reserved folder names
Handles symlink creation and removal
Guards against duplicates
Config auto‑init
[initConfigs.ts](app://-/index.html#)

Ensures vault config file exists at startup via ensureKnowledgeVaultsConfig()
IPC + main process
New IPC channels
[ipc.ts](app://-/index.html#)

knowledge:listVaults
knowledge:pickVaultDirectory
knowledge:addVault
knowledge:removeVault
Handler implementation
[ipc.ts](app://-/index.html#)

Folder picker via Electron dialog.showOpenDialog
knowledge:addVault creates symlink + persists config
knowledge:removeVault unlinks + removes config entry
Workspace tools now follow mounted folders safely
Workspace API
[workspace.ts](app://-/index.html#)

stat now resolves symlink targets, preserving isSymlink
readFile returns stats based on target file
readdir:
includes symlinked folders only if they are known mounts
recurses into those symlinks
prevents symlink cycles using realpath tracking
Helper to validate symlink mounts from config
Search tools
[builtin-tools.ts](app://-/index.html#)

workspace-grep now follows symlinks under knowledge/
uses rg --follow
fallback uses grep -R
workspace-glob uses follow: true under knowledge/
Watcher
[watcher.ts](app://-/index.html#)

followSymlinks: true so file changes in linked folders appear in the app
Knowledge graph integration
[knowledge_index.ts](app://-/index.html#)

Recognizes:
knowledge/<folder>/People
knowledge/<folder>/Projects
knowledge/<folder>/Organizations
knowledge/<folder>/Topics
as valid category roots
So graph index and entity resolution work for mounted folders
[build_graph.ts](app://-/index.html#)

Added explicit instruction: new notes must be created only in base knowledge folders, not mounted folders
Updates to existing notes (including in linked folders) are still allowed
UI: Add Knowledge Folder
Quick action
[sidebar-content.tsx](app://-/index.html#)

Adds “Add Knowledge Folder” action in Knowledge toolbar
Uses circled plus icon (PlusCircle)
Dialog
[App.tsx](app://-/index.html#)

Open folder picker → show dialog to name the folder
Creates symlink via IPC
Toasts updated to “knowledge folder” copy
Wording changed per your request (“Add Knowledge Folder”, “Link an existing folder…”)
UI: Unlink instead of delete for mounted folders
[sidebar-content.tsx](app://-/index.html#)

On right‑click:
If folder is a symlink mount, action becomes “Unlink Knowledge Folder”
Otherwise it stays “Delete”
Prevents renaming of linked folders (to avoid breaking config)
Uses workspace:stat lazily to detect symlink
Unlink calls IPC to remove mount + config
Bugfix
[workspace.ts](app://-/index.html#)

Fixed TS type error in readFile stats by explicitly typing stat as [workspace.Stat](app://-/index.html#)
Other notable changes
Updated UI text everywhere to avoid the word “vault”
Updated toast messages to match new copy
Resolved rebase conflict in [App.tsx](app://-/index.html#) after upstream changes (new tab support, etc.)