### PR TITLE
fix: make dev script cross-platform for Windows PowerShell

### DIFF
--- a/apps/rowboat/package.json
+++ b/apps/rowboat/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "npx next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Problem

Running `npm run dev` on Windows PowerShell fails with:

'next' is not recognized as an internal or external command.

Although dependencies install correctly, PowerShell does not reliably resolve local binaries from `node_modules/.bin`.

## Cause

The dev script uses:

next dev --turbopack

which works on macOS/Linux but may fail on Windows due to shell resolution differences.

## Solution

Update the dev script to explicitly invoke Next.js using `npx`:

npx next dev --turbopack

## Verification

- Reproduced issue on Windows 11
- Direct execution via `node_modules/.bin/next.cmd` works
- `npm run dev` works correctly after change
- No behavior change observed on other platforms

## Impact

Improves cross-platform developer onboarding and allows Windows users to start the development server without manual workarounds.
