### PR TITLE
Config graph model

### DIFF
--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -416,13 +416,14 @@ function ModelSettings({ dialogOpen }: { dialogOpen: boolean }) {
             />
           ) : (
             <Select
-              value={activeConfig.knowledgeGraphModel}
-              onValueChange={(value) => updateConfig(provider, { knowledgeGraphModel: value })}
+              value={activeConfig.knowledgeGraphModel || "__same__"}
+              onValueChange={(value) => updateConfig(provider, { knowledgeGraphModel: value === "__same__" ? "" : value })}
             >
               <SelectTrigger>
-                <SelectValue placeholder={activeConfig.model || "Same as assistant"} />
+                <SelectValue placeholder="Select a model" />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="__same__">Same as assistant</SelectItem>
                 {modelsForProvider.map((model) => (
                   <SelectItem key={model.id} value={model.id}>
                     {model.name || model.id}

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -364,74 +364,74 @@ function ModelSettings({ dialogOpen }: { dialogOpen: boolean }) {
         )}
       </div>
 
-      {/* Model selection */}
-      <div className="space-y-2">
-        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Assistant model</span>
-        {modelsLoading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="size-4 animate-spin" />
-            Loading models...
-          </div>
-        ) : showModelInput ? (
-          <Input
-            value={activeConfig.model}
-            onChange={(e) => updateConfig(provider, { model: e.target.value })}
-            placeholder="Enter model"
-          />
-        ) : (
-          <Select
-            value={activeConfig.model}
-            onValueChange={(value) => updateConfig(provider, { model: value })}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select a model" />
-            </SelectTrigger>
-            <SelectContent>
-              {modelsForProvider.map((model) => (
-                <SelectItem key={model.id} value={model.id}>
-                  {model.name || model.id}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-        {modelsError && (
-          <div className="text-xs text-destructive">{modelsError}</div>
-        )}
-      </div>
+      {/* Model selection - side by side */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Assistant model</span>
+          {modelsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading...
+            </div>
+          ) : showModelInput ? (
+            <Input
+              value={activeConfig.model}
+              onChange={(e) => updateConfig(provider, { model: e.target.value })}
+              placeholder="Enter model"
+            />
+          ) : (
+            <Select
+              value={activeConfig.model}
+              onValueChange={(value) => updateConfig(provider, { model: value })}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {modelsForProvider.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.name || model.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {modelsError && (
+            <div className="text-xs text-destructive">{modelsError}</div>
+          )}
+        </div>
 
-      {/* Knowledge graph model selection */}
-      <div className="space-y-2">
-        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Knowledge graph model</span>
-        <p className="text-xs text-muted-foreground">Used for note creation, email drafts, and meeting prep. Defaults to assistant model if empty.</p>
-        {modelsLoading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="size-4 animate-spin" />
-            Loading models...
-          </div>
-        ) : showModelInput ? (
-          <Input
-            value={activeConfig.knowledgeGraphModel}
-            onChange={(e) => updateConfig(provider, { knowledgeGraphModel: e.target.value })}
-            placeholder={activeConfig.model || "Enter model"}
-          />
-        ) : (
-          <Select
-            value={activeConfig.knowledgeGraphModel}
-            onValueChange={(value) => updateConfig(provider, { knowledgeGraphModel: value })}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder={activeConfig.model || "Same as assistant model"} />
-            </SelectTrigger>
-            <SelectContent>
-              {modelsForProvider.map((model) => (
-                <SelectItem key={model.id} value={model.id}>
-                  {model.name || model.id}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
+        <div className="space-y-2">
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Knowledge graph model</span>
+          {modelsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading...
+            </div>
+          ) : showModelInput ? (
+            <Input
+              value={activeConfig.knowledgeGraphModel}
+              onChange={(e) => updateConfig(provider, { knowledgeGraphModel: e.target.value })}
+              placeholder={activeConfig.model || "Enter model"}
+            />
+          ) : (
+            <Select
+              value={activeConfig.knowledgeGraphModel}
+              onValueChange={(value) => updateConfig(provider, { knowledgeGraphModel: value })}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={activeConfig.model || "Same as assistant"} />
+              </SelectTrigger>
+              <SelectContent>
+                {modelsForProvider.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.name || model.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
       </div>
 
       {/* API Key */}

--- a/apps/x/packages/core/src/agents/runtime.ts
+++ b/apps/x/packages/core/src/agents/runtime.ts
@@ -711,7 +711,7 @@ export async function* streamAgent({
         ? modelConfig.knowledgeGraphModel
         : modelConfig.model;
     const model = provider.languageModel(modelId);
-    console.log(`[main] [GraphBuilder] Agent "${state.agentName}" using model: ${modelId}`);
+    logger.log(`using model: ${modelId}`);
 
     let loopCounter = 0;
     while (true) {

--- a/apps/x/packages/core/src/agents/runtime.ts
+++ b/apps/x/packages/core/src/agents/runtime.ts
@@ -706,7 +706,12 @@ export async function* streamAgent({
 
     // set up provider + model
     const provider = createProvider(modelConfig.provider);
-    const model = provider.languageModel(modelConfig.model);
+    const knowledgeGraphAgents = ["note_creation", "email-draft", "meeting-prep"];
+    const modelId = (knowledgeGraphAgents.includes(state.agentName!) && modelConfig.knowledgeGraphModel)
+        ? modelConfig.knowledgeGraphModel
+        : modelConfig.model;
+    const model = provider.languageModel(modelId);
+    console.log(`[main] [GraphBuilder] Agent "${state.agentName}" using model: ${modelId}`);
 
     let loopCounter = 0;
     while (true) {

--- a/apps/x/packages/shared/src/models.ts
+++ b/apps/x/packages/shared/src/models.ts
@@ -10,4 +10,5 @@ export const LlmProvider = z.object({
 export const LlmModelConfig = z.object({
   provider: LlmProvider,
   model: z.string(),
+  knowledgeGraphModel: z.string().optional(),
 });


### PR DESCRIPTION
Here's a summary of all changes:

  1. packages/shared/src/models.ts

  - Added knowledgeGraphModel: z.string().optional() to LlmModelConfig schema

  2. packages/core/src/agents/runtime.ts

  - Added model selection logic: if the agent is note_creation, email-draft, or meeting-prep and
  knowledgeGraphModel is set, use it instead of the assistant model
  - Added a log line via PrefixLogger that prints the model being used when any agent run starts

  3. apps/renderer/src/components/settings-dialog.tsx

  - Renamed "Model" label to "Assistant model"
  - Added "Knowledge graph model" dropdown beside it (side-by-side grid-cols-2 layout)
  - Knowledge graph dropdown has a "Same as assistant" option at the top, selected by default
  - Added knowledgeGraphModel to provider config state, loading, and save payload

  4. apps/renderer/src/components/onboarding-modal.tsx

  - Same changes as settings dialog: side-by-side "Assistant model" / "Knowledge graph model" dropdowns
  - Added knowledgeGraphModel to provider config state and save payload

  Key behavior

  - Knowledge graph model defaults to the assistant model when unset
  - Both dropdowns share the same provider/API key — only the model name differs
  - The runtime log shows which model each agent run uses (e.g. [run-abc-note_creation] using model:
  gpt-4o)