### PR TITLE
Model switch

### DIFF
--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -152,9 +152,19 @@ function ChatInputInner({
           }
         }
       }
+      const defaultKey = parsed?.provider?.flavor && parsed?.model
+        ? `${parsed.provider.flavor}/${parsed.model}`
+        : ''
+      models.sort((a, b) => {
+        const aKey = `${a.flavor}/${a.model}`
+        const bKey = `${b.flavor}/${b.model}`
+        if (aKey === defaultKey) return -1
+        if (bKey === defaultKey) return 1
+        return 0
+      })
       setConfiguredModels(models)
-      if (parsed?.provider?.flavor && parsed?.model) {
-        setActiveModelKey(`${parsed.provider.flavor}/${parsed.model}`)
+      if (defaultKey) {
+        setActiveModelKey(defaultKey)
       }
     } catch {
       // No config yet

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -223,15 +223,31 @@ function ModelSettings({ dialogOpen }: { dialogOpen: boolean }) {
         if (parsed?.provider?.flavor && parsed?.model) {
           const flavor = parsed.provider.flavor as LlmProviderFlavor
           setProvider(flavor)
-          setProviderConfigs(prev => ({
-            ...prev,
-            [flavor]: {
+          setProviderConfigs(prev => {
+            const next = { ...prev };
+            // Hydrate all saved providers from the providers map
+            if (parsed.providers) {
+              for (const [key, entry] of Object.entries(parsed.providers)) {
+                if (key in next) {
+                  const e = entry as any;
+                  next[key as LlmProviderFlavor] = {
+                    apiKey: e.apiKey || "",
+                    baseURL: e.baseURL || (defaultBaseURLs[key as LlmProviderFlavor] || ""),
+                    model: e.model || "",
+                    knowledgeGraphModel: e.knowledgeGraphModel || "",
+                  };
+                }
+              }
+            }
+            // Active provider takes precedence from top-level config
+            next[flavor] = {
               apiKey: parsed.provider.apiKey || "",
               baseURL: parsed.provider.baseURL || (defaultBaseURLs[flavor] || ""),
               model: parsed.model,
               knowledgeGraphModel: parsed.knowledgeGraphModel || "",
-            },
-          }))
+            };
+            return next;
+          })
         }
       } catch {
         // No existing config or parse error - use defaults

--- a/apps/x/packages/core/src/models/repo.ts
+++ b/apps/x/packages/core/src/models/repo.ts
@@ -44,10 +44,12 @@ export class FSModelConfigRepo implements IModelConfigRepo {
         }
 
         existingProviders[config.provider.flavor] = {
+            ...existingProviders[config.provider.flavor],
             apiKey: config.provider.apiKey,
             baseURL: config.provider.baseURL,
             headers: config.provider.headers,
             model: config.model,
+            models: config.models,
             knowledgeGraphModel: config.knowledgeGraphModel,
         };
 

--- a/apps/x/packages/shared/src/models.ts
+++ b/apps/x/packages/shared/src/models.ts
@@ -10,5 +10,6 @@ export const LlmProvider = z.object({
 export const LlmModelConfig = z.object({
   provider: LlmProvider,
   model: z.string(),
+  models: z.array(z.string()).optional(),
   knowledgeGraphModel: z.string().optional(),
 });


### PR DESCRIPTION
  Summary of Changes: Model Selector & Multi-Model Support

  1. packages/shared/src/models.ts (+1 line)

  Schema change: Added models: z.array(z.string()).optional() to LlmModelConfig. This allows storing a
  list of configured models per provider alongside the single active model field. The field is optional
  for backward compatibility.

  2. packages/core/src/models/repo.ts (+22/-5 lines)

  Persistence change:
  - setConfig() now saves the models array into the provider entry in the providers map
  - Spreads existing provider fields (...existingProviders[flavor]) before overwriting, so unknown fields
  aren't lost when saving

  3. apps/renderer/src/components/settings-dialog.tsx (+324/-88 lines)

  Multi-model support in Settings:
  - State changed from single model: string to models: string[] per provider
  - Added updateModelAt(), addModel(), removeModel() helpers for managing the array
  - UI shows a list of model inputs/selects with an X button (overlay on hover) to remove each, and an +
  Add assistant model button to add more
  - Assistant model and Knowledge graph model displayed as equal-width side-by-side columns
  - "Test & Save" sends the full models array; tests against the first (default) model

  Default provider management:
  - Added defaultProvider state, set from disk on load and updated on save
  - Provider cards show a "Default" pill badge on the current default
  - Non-default configured providers show "Set as default" link (calls models:saveConfig with that
  provider's config)
  - "Set as default" link appears alongside a "Remove" link

  Provider deletion:
  - "Remove" link on non-default configured provider cards
  - handleDeleteProvider() reads models.json, deletes the provider from the providers map, and if the
  deleted provider was the top-level active one, rewrites the top-level config to point to the current
  default provider
  - Load logic no longer re-hydrates a provider from top-level config if it was deleted from the providers
   map

  Cross-component sync:
  - All config-modifying actions (handleTestAndSave, handleSetDefault, handleDeleteProvider) dispatch a
  models-config-changed custom window event

  4. apps/renderer/src/components/chat-input-with-mentions.tsx (+190/-12 lines)

  Model selector dropdown in chat input:
  - New imports: ChevronDown icon, DropdownMenu components
  - providerDisplayNames map and ConfiguredModel interface
  - On mount/activation, reads config/models.json and builds a flat list of all configured models across
  all providers (reading models array, falling back to single model)
  - Dropdown uses DropdownMenuRadioGroup showing each model with its provider name

  Layout:
  - Two-row layout: textarea on top, toolbar below
  - Toolbar: [+ attach] on left, [Model ▾] and [send] on right (matching the design screenshot)

  Default model ordering:
  - Models are sorted so the default provider's default model appears first in the dropdown

  Model switching:
  - handleModelChange calls models:saveConfig with the selected model AND preserves the full models array
  for that provider (preventing the array from being wiped)

  Live sync with Settings:
  - Listens for models-config-changed window event to reload the model list immediately when settings
  change (add/remove/default)
