### PR TITLE
fix(renderer): prevent empty content from polluting editor cache

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -747,6 +747,8 @@ function App() {
   }, [])
 
   const handleEditorChange = useCallback((path: string, markdown: string) => {
+    // Don't cache empty content (prevents editor initialization from polluting cache)
+    if (!markdown) return
     setEditorCacheForPath(path, markdown)
     const nextSelectedPath = selectedPathRef.current
     if (nextSelectedPath !== path) {
@@ -887,7 +889,9 @@ function App() {
     }
     if (selectedPath.endsWith('.md')) {
       const cachedContent = editorContentByPathRef.current.get(selectedPath)
-      if (cachedContent !== undefined) {
+      // Primary guard: handleEditorChange prevents empty content from being cached.
+      // Secondary guard: explicit length check as defense in depth.
+      if (cachedContent !== undefined && cachedContent.length > 0) {
         setFileContent(cachedContent)
         setEditorContent(cachedContent)
         editorContentRef.current = cachedContent

--- a/apps/x/apps/renderer/src/components/markdown-editor.tsx
+++ b/apps/x/apps/renderer/src/components/markdown-editor.tsx
@@ -492,7 +492,8 @@ export function MarkdownEditor({
       const currentContent = getMarkdownWithBlankLines(editor)
       // Normalize for comparison (trim trailing whitespace from lines)
       const normalizeForCompare = (s: string) => s.split('\n').map(line => line.trimEnd()).join('\n').trim()
-      if (normalizeForCompare(currentContent) !== normalizeForCompare(content)) {
+      const shouldUpdate = normalizeForCompare(currentContent) !== normalizeForCompare(content)
+      if (shouldUpdate) {
         isInternalUpdate.current = true
         // Pre-process to preserve blank lines
         const preprocessed = preprocessMarkdown(content)


### PR DESCRIPTION
## Summary

- Prevents MarkdownEditor initialization from polluting the editor cache with empty content
- First file opened after app start now displays correctly instead of appearing blank

Fixes #414

## Problem

When the app starts and a markdown file is opened, the file appears blank. Switching to another file and back would show the content correctly. This was caused by the Tiptap editor firing `onUpdate('')` during initialization, which cached an empty string that was then returned on the cache lookup.

## Solution

Two-layer fix:

1. **Primary guard** in `handleEditorChange`: Skip caching when markdown content is empty
2. **Secondary guard** in cache lookup: Explicit `cachedContent.length > 0` check as defense in depth

## Changes

- `apps/x/apps/renderer/src/App.tsx`:
  - Added early return in `handleEditorChange` for empty content
  - Added explicit length check in cache lookup condition
  
- `apps/x/apps/renderer/src/components/markdown-editor.tsx`:
  - Minor refactor (no functional change)

## Testing

1. Start the app fresh (or restart)
2. Open any markdown file
3. File should display content immediately (previously was blank)
4. Opening additional files should continue to work correctly
5. External file modifications should still be detected correctly

## Notes

Issue #414 was previously closed but the problem persisted. This fix addresses the root cause: the editor cache being polluted by empty content during Tiptap initialization.

Made with [Cursor](https://cursor.com)