### PR TITLE
fix(editor): disable StarterKit Link to prevent duplicate extension warning

### DIFF
--- a/apps/x/apps/renderer/src/components/markdown-editor.tsx
+++ b/apps/x/apps/renderer/src/components/markdown-editor.tsx
@@ -311,6 +311,7 @@ export function MarkdownEditor({
         heading: {
           levels: [1, 2, 3],
         },
+        link: false, // Disable StarterKit's Link to use custom-configured one below
       }),
       Link.configure({
         openOnClick: false,


### PR DESCRIPTION
## Summary

Fixes console warning: "Duplicate extension names found: ['link']"

Fixes #433

## Problem

StarterKit v3.x now includes the Link extension by default. The codebase separately adds `Link.configure()` with custom settings (`openOnClick: false`, custom HTMLAttributes), resulting in two Link extensions being registered.

This causes:

- Console warning spam on every editor mount
- Unpredictable behavior when two extensions share a name
- Configuration conflicts between StarterKit's Link defaults and the custom settings

## Solution

Add `link: false` to StarterKit configuration to disable its built-in Link, allowing the custom-configured Link to be used exclusively.

## Changes

- `apps/x/apps/renderer/src/components/markdown-editor.tsx`:
  - Added `link: false` to `StarterKit.configure()` options

## Testing

1. Start the app
2. Open a markdown file
3. Verify no "Duplicate extension names" warning in console
4. Test link functionality:
   - Links should not open on click (custom behavior)
   - Links should have correct rel and target attributes