### PR TITLE
fix(oauth): preserve full callback URL for token exchange + persist Google Client ID

### DIFF
--- a/apps/x/apps/main/src/auth-server.ts
+++ b/apps/x/apps/main/src/auth-server.ts
@@ -22,10 +22,11 @@ export interface AuthServerResult {
 /**
  * Create a local HTTP server to handle OAuth callback
  * Listens on http://localhost:8080/oauth/callback
+ * Passes the full callback URL (including iss, scope, etc.) so openid-client validation succeeds.
  */
 export function createAuthServer(
   port: number = DEFAULT_PORT,
-  onCallback: (params: Record<string, string>) => void | Promise<void>
+  onCallback: (callbackUrl: URL) => void | Promise<void>
 ): Promise<AuthServerResult> {
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
@@ -38,8 +39,6 @@ export function createAuthServer(
       const url = new URL(req.url, `http://localhost:${port}`);
       
       if (url.pathname === OAUTH_CALLBACK_PATH) {
-        const code = url.searchParams.get('code');
-        const state = url.searchParams.get('state');
         const error = url.searchParams.get('error');
 
         if (error) {
@@ -65,9 +64,8 @@ export function createAuthServer(
           return;
         }
 
-        // Handle callback - either traditional OAuth with code/state or Composio-style notification
-        // Composio callbacks may not have code/state, just a notification that the flow completed
-        onCallback(Object.fromEntries(url.searchParams.entries()));
+        // Handle callback - pass full URL so params like iss (OpenID Connect) are preserved for token exchange
+        onCallback(url);
 
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(`

--- a/apps/x/apps/main/src/composio-handler.ts
+++ b/apps/x/apps/main/src/composio-handler.ts
@@ -151,7 +151,7 @@ export async function initiateConnection(toolkitSlug: string): Promise<{
         // Set up callback server
         const timeoutRef: { current: NodeJS.Timeout | null } = { current: null };
         let callbackHandled = false;
-        const { server } = await createAuthServer(8081, async () => {
+        const { server } = await createAuthServer(8081, async (_callbackUrl) => {
             // Guard against duplicate callbacks (browser may send multiple requests)
             if (callbackHandled) return;
             callbackHandled = true;

--- a/apps/x/apps/main/src/oauth-handler.ts
+++ b/apps/x/apps/main/src/oauth-handler.ts
@@ -14,6 +14,43 @@ import { emitOAuthEvent } from './ipc.js';
 
 const REDIRECT_URI = 'http://localhost:8080/oauth/callback';
 
+/** Top-level openid-client messages that often wrap a more specific cause. */
+const OPAQUE_OAUTH_TOP_MESSAGES = new Set(['invalid response encountered']);
+
+function firstCauseMessage(error: unknown): string | undefined {
+  if (error == null || typeof error !== 'object' || !('cause' in error)) {
+    return undefined;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error && cause.message.trim()) {
+    return cause.message;
+  }
+  if (typeof cause === 'string' && cause.trim()) {
+    return cause;
+  }
+  return undefined;
+}
+
+/**
+ * User-facing message for token-exchange failures. Prefer the first cause message when
+ * the top-level message is opaque (common for openid-client) or when code is OAUTH_INVALID_RESPONSE.
+ * The catch block below still logs the full cause chain for any error; this helper stays conservative.
+ */
+function getOAuthErrorMessage(error: unknown): string {
+  const msg = error instanceof Error ? error.message : 'Unknown error';
+  const code = error != null && typeof error === 'object' && 'code' in error
+    ? (error as { code?: string }).code
+    : undefined;
+  const causeMsg = firstCauseMessage(error);
+  if (code === 'OAUTH_INVALID_RESPONSE' && causeMsg) {
+    return causeMsg;
+  }
+  if (causeMsg && OPAQUE_OAUTH_TOP_MESSAGES.has(msg.trim().toLowerCase())) {
+    return causeMsg;
+  }
+  return msg;
+}
+
 // Store active OAuth flows (state -> { codeVerifier, provider, config })
 const activeFlows = new Map<string, {
   codeVerifier: string;
@@ -167,6 +204,11 @@ export async function connectProvider(provider: string, clientId?: string): Prom
     // Get or create OAuth configuration
     const config = await getProviderConfiguration(provider, clientId);
 
+    // Persist Google client ID so it survives restarts and failed token exchanges
+    if (provider === 'google' && clientId) {
+      await oauthRepo.upsert(provider, { clientId });
+    }
+
     // Generate PKCE codes
     const { verifier: codeVerifier, challenge: codeChallenge } = await oauthClient.generatePKCE();
     const state = oauthClient.generateState();
@@ -187,12 +229,17 @@ export async function connectProvider(provider: string, clientId?: string): Prom
 
     // Create callback server
     let callbackHandled = false;
-    const { server } = await createAuthServer(8080, async (params: Record<string, string>) => {
+    const { server } = await createAuthServer(8080, async (callbackUrl) => {
       // Guard against duplicate callbacks (browser may send multiple requests)
       if (callbackHandled) return;
       callbackHandled = true;
-      // Validate state
-      if (params.state !== state) {
+      const receivedState = callbackUrl.searchParams.get('state');
+      if (receivedState == null || receivedState === '') {
+        throw new Error(
+          'OAuth callback missing state parameter. Complete sign-in in the browser or check the redirect URI.'
+        );
+      }
+      if (receivedState !== state) {
         throw new Error('Invalid state parameter - possible CSRF attack');
       }
 
@@ -202,10 +249,7 @@ export async function connectProvider(provider: string, clientId?: string): Prom
       }
 
       try {
-        // Build callback URL for token exchange
-        const callbackUrl = new URL(`${REDIRECT_URI}?${new URLSearchParams(params).toString()}`);
-
-        // Exchange code for tokens
+        // Use full callback URL (includes iss, scope, etc.) so openid-client validation succeeds
         console.log(`[OAuth] Exchanging authorization code for tokens (${provider})...`);
         const tokens = await oauthClient.exchangeCodeForTokens(
           flow.config,
@@ -234,7 +278,15 @@ export async function connectProvider(provider: string, clientId?: string): Prom
         emitOAuthEvent({ provider, success: true });
       } catch (error) {
         console.error('OAuth token exchange failed:', error);
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        // Log cause chain for debugging (e.g. OAUTH_INVALID_RESPONSE -> OperationProcessingError)
+        let cause: unknown = error;
+        while (cause != null && typeof cause === 'object' && 'cause' in cause) {
+          cause = (cause as { cause?: unknown }).cause;
+          if (cause != null) {
+            console.error('[OAuth] Caused by:', cause);
+          }
+        }
+        const errorMessage = getOAuthErrorMessage(error);
         emitOAuthEvent({ provider, success: false, error: errorMessage });
         throw error;
       } finally {
@@ -302,8 +354,8 @@ export async function disconnectProvider(provider: string): Promise<{ success: b
 export async function getAccessToken(provider: string): Promise<string | null> {
   try {
     const oauthRepo = getOAuthRepo();
-    
-    const { tokens } = await oauthRepo.read(provider);
+
+    let { tokens } = await oauthRepo.read(provider);
     if (!tokens) {
       return null;
     }
@@ -319,11 +371,12 @@ export async function getAccessToken(provider: string): Promise<string | null> {
       try {
         // Get configuration for refresh
         const config = await getProviderConfiguration(provider);
-        
+
         // Refresh token, preserving existing scopes
         const existingScopes = tokens.scopes;
         const refreshedTokens = await oauthClient.refreshTokens(config, tokens.refresh_token, existingScopes);
-        await oauthRepo.upsert(provider, { tokens });
+        await oauthRepo.upsert(provider, { tokens: refreshedTokens });
+        tokens = refreshedTokens;
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Token refresh failed';
         await oauthRepo.upsert(provider, { error: message });

--- a/apps/x/apps/renderer/src/components/onboarding-modal.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding-modal.tsx
@@ -517,6 +517,10 @@ export function OnboardingModal({ open, onComplete }: OnboardingModalProps) {
           isConnecting: false,
         }
       }
+      // Hydrate in-memory Google client ID from persisted config so Connect can skip re-entry
+      if (config.google?.clientId) {
+        setGoogleClientId(config.google.clientId)
+      }
     } catch (error) {
       console.error('Failed to check connection status for providers:', error)
       for (const provider of providers) {

--- a/apps/x/apps/renderer/src/hooks/useConnectors.ts
+++ b/apps/x/apps/renderer/src/hooks/useConnectors.ts
@@ -426,6 +426,9 @@ export function useConnectors(active: boolean) {
     try {
       const result = await window.ipc.invoke('oauth:getState', null)
       const config = result.config || {}
+      if (config.google?.clientId) {
+        setGoogleClientId(config.google.clientId)
+      }
       const statusMap: Record<string, ProviderStatus> = {}
 
       for (const provider of providers) {

--- a/apps/x/packages/core/src/auth/repo.ts
+++ b/apps/x/packages/core/src/auth/repo.ts
@@ -18,6 +18,7 @@ const OAuthConfigSchema = z.object({
 const ClientFacingConfigSchema = z.record(z.string(), z.object({
   connected: z.boolean(),
   error: z.string().nullable().optional(),
+  clientId: z.string().nullable().optional(),
 }));
 
 const LegacyOauthConfigSchema = z.record(z.string(), OAuthTokens);
@@ -111,8 +112,9 @@ export class FSOAuthRepo implements IOAuthRepo {
       clientFacingConfig[provider] = {
         connected: !!providerConfig.tokens,
         error: providerConfig.error,
+        clientId: providerConfig.clientId ?? null,
       };
     }
-    return clientFacingConfig;
+    return ClientFacingConfigSchema.parse(clientFacingConfig);
   } 
 }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -252,6 +252,7 @@ const ipcSchemas = {
         connected: z.boolean(),
         error: z.string().nullable().optional(),
         userId: z.string().optional(),
+        clientId: z.string().nullable().optional(),
       })),
     }),
   },

--- a/google-setup.md
+++ b/google-setup.md
@@ -122,6 +122,14 @@ Select:
 
 ![Create OAuth Client ID (UWP)](https://raw.githubusercontent.com/rowboatlabs/rowboat/main/apps/docs/docs/img/google-setup/05-create-oauth-client-uwp.png)
 
+### Authorized redirect URIs (if shown)
+
+If your OAuth client configuration shows **Authorized redirect URIs**, add:
+
+- `http://localhost:8080/oauth/callback`
+
+Use this exactly: no trailing slash, port **8080**. This must match what the app uses for the OAuth callback. (Some client types, e.g. UWP, may not expose redirect URIs; that is fine.)
+
 ---
 
 ## 7️⃣ Copy the Client ID
@@ -134,5 +142,17 @@ After creation, Google will show:
 Copy the **Client ID** and paste it into Rowboat where prompted.
 
 ![Copy Client ID](https://raw.githubusercontent.com/rowboatlabs/rowboat/main/apps/docs/docs/img/google-setup/06-copy-client-id.png)
+
+---
+
+## Troubleshooting
+
+**Error after "Authorization Successful"**
+
+If the browser shows "Authorization Successful" but the app then shows an error (e.g. "invalid response encountered" or "response parameter \"iss\" (issuer) missing"):
+
+1. **Check the app logs** (e.g. terminal or dev tools) for the full error. The message there will often indicate the cause (e.g. redirect URI mismatch, missing parameter).
+2. **Verify redirect URI in Google Cloud Console**: Open [Credentials → your OAuth 2.0 Client ID](https://console.cloud.google.com/auth/clients). If the client type allows **Authorized redirect URIs**, ensure `http://localhost:8080/oauth/callback` is listed exactly.
+3. **Client type**: Use **Desktop** or **UWP** as the application type. A "Web application" client may require the redirect URI to be set and can behave differently with localhost.
 
 ---


### PR DESCRIPTION
## Summary

Fixes two issues in the Google OAuth flow:

1. **Post-callback token exchange failure:** When the user completes authorization in the browser and is redirected to `http://localhost:8080/oauth/callback` with `code`, `state`, and `iss` (issuer), the app was only passing `code` and `state` into the token exchange. The openid-client library validates the authorization response and expects the `iss` parameter (OpenID Connect). Because we rebuilt a minimal callback URL without `iss`, the library threw `OperationProcessingError: response parameter "iss" (issuer) missing`, which was surfaced to the user as "invalid response encountered". This PR passes the full callback URL from the auth server to the handler and uses it in `exchangeCodeForTokens`, so `iss` (and other params) are preserved and validation succeeds.

2. **Client ID not persisted:** The Google Client ID was only written to `~/.rowboat/config/oauth.json` when token exchange succeeded. If exchange failed (e.g. due to the bug above) or the user had not yet completed a successful flow, the Client ID was never saved. The UI also relied on an in-memory store that was not restored from disk, so users had to re-enter the Client ID after every restart or app update. This PR persists the Client ID when starting the OAuth flow (before opening the browser), exposes it via `oauth:getState`, and hydrates the UI so the modal can be pre-filled or skipped when a Client ID is already stored.

3. **Review follow-up:** After `refreshTokens()` succeeds, the code previously upserted `refreshedTokens` to disk but `getAccessToken` could still return the **pre-refresh** access token from the initial `read()`. The refresh path now assigns the refreshed credentials before returning so the access token matches what was persisted. If the authorization server omits `state` on the redirect, we throw a clear **missing state** error instead of mislabeling it as a CSRF mismatch. `getOAuthErrorMessage` unwraps a one-level `cause` when the top-level message is an opaque openid-client string (e.g. "invalid response encountered"), in addition to `OAUTH_INVALID_RESPONSE`. Full cause chains are still logged in the catch block for debugging.

## Related issues

- Fixes [#432](https://github.com/rowboatlabs/rowboat/issues/432) — Google OAuth shows "invalid response encountered" after successful browser authorization.
- Fixes [#391](https://github.com/rowboatlabs/rowboat/issues/391) — Google connection loses Client ID after updates.

## Changes

- **apps/x/apps/main/src/auth-server.ts**  
  - Callback signature changed from `(code: string, state: string)` to `(callbackUrl: URL)`. The handler receives the full request URL so query params such as `iss` and `scope` are preserved for token exchange.

- **apps/x/apps/main/src/oauth-handler.ts**  
  - Callback uses the full `callbackUrl` for state validation and passes it to `exchangeCodeForTokens` instead of building a minimal `REDIRECT_URI?code=...&state=...`.  
  - Missing or empty `state` on the redirect throws a dedicated error before the CSRF check.  
  - Persists Google `clientId` when starting the flow (after `getProviderConfiguration`), so it is stored even if token exchange fails later.  
  - `getOAuthErrorMessage()` surfaces underlying causes for `OAUTH_INVALID_RESPONSE` and opaque top-level messages; the token-exchange catch block logs the full cause chain for debugging.  
  - Token refresh: upserts `refreshedTokens` after `refreshTokens()`, and `getAccessToken` returns the refreshed access token after a successful refresh (not the pre-refresh token object).

- **apps/x/apps/main/src/composio-handler.ts**  
  - Callback updated to accept `(callbackUrl: URL)` to match the new auth-server signature; Composio does not use the URL.

- **apps/x/packages/core/src/auth/repo.ts**  
  - `ClientFacingConfigSchema` and `getClientFacingConfig()` now include optional `clientId` per provider so the renderer can pre-fill or skip the Google Client ID modal.

- **apps/x/packages/shared/src/ipc.ts**  
  - `oauth:getState` response schema extended with optional `clientId` per provider.

- **apps/x/apps/renderer (connectors-popover, onboarding-modal)**  
  - When loading OAuth state, if `config.google?.clientId` is present, hydrate the in-memory store so the user is not prompted to re-enter after restart or when reconnecting.

- **google-setup.md**  
  - Authorized redirect URI and troubleshooting for browser success vs in-app error.

## Testing

1. `cd apps/x && pnpm run deps && pnpm run lint`; `cd apps/main && npm run build`.
2. Run the app (`./dev.sh` or `cd apps/x && npm run dev`).
3. Connect Google (or Reconnect): enter a valid OAuth Client ID (per google-setup.md). Complete the browser flow; you should see "Authorization Successful" in the browser and success in the app (no "invalid response encountered").
4. Restart the app: Google Client ID should still be present (modal pre-filled or Reconnect usable without re-entering).
