### PR TITLE
fix(granola): add incremental sync with early termination

### DIFF
--- a/apps/x/packages/core/src/knowledge/granola/sync.ts
+++ b/apps/x/packages/core/src/knowledge/granola/sync.ts
@@ -24,6 +24,7 @@ const API_DELAY_MS = 1000; // 1 second delay between API calls
 const RATE_LIMIT_RETRY_DELAY_MS = 60 * 1000; // Wait 1 minute on rate limit
 const MAX_RETRIES = 3; // Maximum retries for rate-limited requests
 const MAX_BATCH_SIZE = 10; // Process max 10 documents per folder per sync
+const EARLY_TERMINATION_STREAK = 20; // Stop fetching after this many consecutive unchanged docs
 
 // --- Wake Signal for Immediate Sync Trigger ---
 let wakeResolve: (() => void) | null = null;
@@ -172,13 +173,17 @@ async function apiCall<T>(
     return data;
 }
 
-async function getDocuments(accessToken: string, limit: number, offset: number) {
+async function getDocuments(accessToken: string, limit: number, offset: number, updatedSince?: string) {
+    const body: Record<string, unknown> = {
+        limit,
+        offset,
+        include_last_viewed_panel: true,
+    };
+    if (updatedSince) {
+        body.updated_since = updatedSince;
+    }
     const response = await callWithRateLimit(
-        () => apiCall<unknown>('/v2/get-documents', accessToken, {
-            limit,
-            offset,
-            include_last_viewed_panel: true,
-        }),
+        () => apiCall<unknown>('/v2/get-documents', accessToken, body),
         'get-documents'
     );
     if (!response) return null;
@@ -368,7 +373,14 @@ async function syncNotes(): Promise<void> {
         let updatedCount = 0;
         let offset = 0;
         let hasMore = true;
+        let unchangedStreak = 0;
         const changedTitles: string[] = [];
+
+        // Use lastSyncDate for incremental fetch (API may ignore if unsupported)
+        const updatedSince = state.lastSyncDate || undefined;
+        if (updatedSince) {
+            console.log(`[Granola] Requesting docs updated since: ${updatedSince}`);
+        }
 
         // Fetch documents with pagination
         while (hasMore) {
@@ -377,7 +389,7 @@ async function syncNotes(): Promise<void> {
                 await sleep(API_DELAY_MS);
             }
 
-            const docsResponse = await getDocuments(accessToken, MAX_BATCH_SIZE, offset);
+            const docsResponse = await getDocuments(accessToken, MAX_BATCH_SIZE, offset, updatedSince);
             if (!docsResponse) {
                 console.log('[Granola] Failed to fetch documents');
                 break;
@@ -398,8 +410,20 @@ async function syncNotes(): Promise<void> {
                 const needsSync = !lastSyncedAt || lastSyncedAt !== docUpdatedAt;
 
                 if (!needsSync) {
+                    unchangedStreak++;
+                    // Early termination: if we hit many consecutive unchanged docs,
+                    // the API likely returned all docs (ignoring updated_since)
+                    // and we've reached the older unchanged portion
+                    if (unchangedStreak >= EARLY_TERMINATION_STREAK) {
+                        console.log(`[Granola] Early termination: ${unchangedStreak} consecutive unchanged docs`);
+                        hasMore = false;
+                        break;
+                    }
                     continue;
                 }
+
+                // Reset streak when we find a doc that needs sync
+                unchangedStreak = 0;
 
                 await ensureRun();
                 const docTitle = doc.title || 'Untitled';


### PR DESCRIPTION
### Summary

Reduces API calls and sync time for Granola integration by:
1. Passing `updated_since` parameter to the API (works if API supports it)
2. Early termination after 20 consecutive unchanged documents (fallback)

Fixes #435

### Problem

The Granola sync fetches ALL documents from the API on every sync cycle, even when most documents haven't changed. With 500 meetings, this means ~50 API calls with 1-second delays = 50+ seconds per sync, even when nothing changed.

### Solution

**Dual strategy with graceful fallback:**

1. **Try `updated_since` parameter** - If the Granola API accepts this parameter, it will return only documents updated since the last sync, drastically reducing API calls.

2. **Early termination fallback** - If the API ignores the parameter (returning all docs anyway), the sync stops after hitting 20 consecutive documents that haven't changed since the last sync. This works because the API typically returns documents in a consistent order.

### Changes

**`apps/x/packages/core/src/knowledge/granola/sync.ts`:**

1. Add `EARLY_TERMINATION_STREAK = 20` constant
2. Modify `getDocuments()` to accept optional `updatedSince` parameter
3. Pass `state.lastSyncDate` to API request as `updated_since`
4. Track `unchangedStreak` counter in sync loop
5. Break out of pagination when streak reaches threshold

### Testing

1. Enable Granola integration with an account that has many meetings
2. Start the app and observe console logs for sync behavior
3. On first sync: all documents should be fetched (no early termination)
4. On subsequent syncs: should see "Early termination: 20 consecutive unchanged docs" log
5. If a new Granola meeting is created, it should be picked up on next sync

### Impact

- First sync: No change in behavior (all docs fetched)
- Subsequent syncs: Dramatically faster when no changes (~2-3 API calls vs ~50+)
- API rate limit consumption significantly reduced

Made with [Cursor](https://cursor.com)