### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
   <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
     <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
   </a>
+  <a href="https://gitcgr.com/rowboatlabs/rowboat">
+    <img src="https://gitcgr.com/badge/rowboatlabs/rowboat.svg" alt="gitcgr" />
+  </a>
 </p>
 
 # Rowboat  


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/rowboatlabs/rowboat.svg)](https://gitcgr.com/rowboatlabs/rowboat)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).