### PR TITLE
fix: bypass gateway for local model connection tests

### DIFF
--- a/apps/x/packages/core/package.json
+++ b/apps/x/packages/core/package.json
@@ -6,7 +6,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "dev": "tsc -w"
+    "dev": "tsc -w",
+    "test": "tsc --pretty false && node --test dist/models/models.test.js"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.63",

--- a/apps/x/packages/core/src/models/models.test.ts
+++ b/apps/x/packages/core/src/models/models.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldUseGatewayForModelTest } from "./models.js";
+
+test("signed-in ollama model tests bypass the gateway", () => {
+    assert.equal(shouldUseGatewayForModelTest("ollama", true), false);
+});
+
+test("signed-in openai-compatible model tests bypass the gateway", () => {
+    assert.equal(shouldUseGatewayForModelTest("openai-compatible", true), false);
+});
+
+test("signed-in hosted model tests still use the gateway", () => {
+    assert.equal(shouldUseGatewayForModelTest("openai", true), true);
+});
+
+test("signed-out hosted model tests do not use the gateway", () => {
+    assert.equal(shouldUseGatewayForModelTest("openai", false), false);
+});

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -70,6 +70,14 @@ export function createProvider(config: z.infer<typeof Provider>): ProviderV2 {
     }
 }
 
+export function shouldUseGatewayForModelTest(
+    flavor: z.infer<typeof Provider>["flavor"],
+    signedIn: boolean,
+): boolean {
+    const isLocal = flavor === "ollama" || flavor === "openai-compatible";
+    return signedIn && !isLocal;
+}
+
 export async function testModelConnection(
     providerConfig: z.infer<typeof Provider>,
     model: string,
@@ -80,7 +88,8 @@ export async function testModelConnection(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), effectiveTimeout);
     try {
-        const provider = await isSignedIn()
+        const signedIn = await isSignedIn();
+        const provider = shouldUseGatewayForModelTest(providerConfig.flavor, signedIn)
             ? await getGatewayProvider()
             : createProvider(providerConfig);
         const languageModel = provider.languageModel(model);


### PR DESCRIPTION
## Summary

Fix issue #471 by making local provider connection tests bypass the Rowboat gateway even when the user is signed in.

Today `testModelConnection()` routes all signed-in tests through `getGatewayProvider()`. That works for Rowboat-managed hosted models, but it breaks local providers because the gateway doesn't know local model ids like `llama3.3:70b` or `qwen3.5:latest`.

This patch keeps the current gateway behavior for hosted providers while always testing these local providers directly:

- `ollama`
- `openai-compatible`

## Changes

- add `shouldUseGatewayForModelTest()` in `apps/x/packages/core/src/models/models.ts`
- update `testModelConnection()` to bypass the gateway for signed-in local providers
- add a focused regression test in `apps/x/packages/core/src/models/models.test.ts`

## Testing

- `pnpm test` in `apps/x/packages/core`
  - verifies signed-in `ollama` bypasses the gateway
  - verifies signed-in `openai-compatible` bypasses the gateway
  - verifies hosted providers still use the gateway when signed in

## Notes

I kept this intentionally narrow to the failing connection-test path. I did not change onboarding model-list behavior because the local-provider UI already falls back to manual model entry.

Fixes #471.
