### PR TITLE
Fix Bus.unsubscribe splice(-1) bug and copilot-stream auth validation

### DIFF
--- a/apps/cli/src/application/lib/bus.ts
+++ b/apps/cli/src/application/lib/bus.ts
@@ -29,7 +29,8 @@ export class InMemoryBus implements IBus {
         }
         this.subscribers.get(runId)!.push(handler);
         return () => {
-            this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
+            const idx = this.subscribers.get(runId)!.indexOf(handler);
+            if (idx !== -1) this.subscribers.get(runId)!.splice(idx, 1);
         };
     }
 }

--- a/apps/rowboat/app/api/copilot-stream-response/[streamId]/route.ts
+++ b/apps/rowboat/app/api/copilot-stream-response/[streamId]/route.ts
@@ -10,6 +10,15 @@ export async function GET(request: Request, props: { params: Promise<{ streamId:
   // get user data
   const user = await requireAuth();
 
+  // Validate auth token
+  const apiKey = request.headers.get("Authorization")?.split(" ")[1];
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "Missing or invalid Authorization header" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const runCopilotCachedTurnController = container.resolve<IRunCopilotCachedTurnController>("runCopilotCachedTurnController");
 
   const encoder = new TextEncoder();
@@ -21,7 +30,7 @@ export async function GET(request: Request, props: { params: Promise<{ streamId:
         for await (const event of runCopilotCachedTurnController.execute({
           caller: "user",
           userId: user.id,
-          apiKey: request.headers.get("Authorization")?.split(" ")[1],
+          apiKey,
           key: params.streamId,
         })) {
           // Check if this is a content event

--- a/apps/x/packages/core/src/application/lib/bus.ts
+++ b/apps/x/packages/core/src/application/lib/bus.ts
@@ -29,7 +29,8 @@ export class InMemoryBus implements IBus {
         }
         this.subscribers.get(runId)!.push(handler);
         return () => {
-            this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
+            const idx = this.subscribers.get(runId)!.indexOf(handler);
+            if (idx !== -1) this.subscribers.get(runId)!.splice(idx, 1);
         };
     }
 }


### PR DESCRIPTION
## Summary

Fixes two security/auth bugs reported in issues #493 and #494:

### Issue #492: CLI Bus.unsubscribe splice(-1) bug
**Problem:**  without guarding against  returning . Double-unsubscribe removes the wrong handler (last element via ).

**Fix:** Added index guard before splice in both  and .



### Issues #493/#494: Missing auth validation on copilot-stream-response endpoint
**Problem:**  passes  apiKey when Bearer token is missing, allowing requests to bypass auth.

**Fix:** Added 401 response when token is missing/empty in .



## Testing
Both bugs are verifiable by replaying the reproduction steps in issues #492 and #493.