### PR TITLE
fix(browser): redact typed values from automatic Browser2 snapshots

### DIFF
--- a/apps/x/apps/main/src/browser/page-scripts.ts
+++ b/apps/x/apps/main/src/browser/page-scripts.ts
@@ -100,6 +100,19 @@ const getElementType = (element) => {
   return null;
 };
 
+const isTextEntryElement = (element) => (
+  element instanceof HTMLInputElement
+  || element instanceof HTMLTextAreaElement
+  || (element instanceof HTMLElement && element.isContentEditable)
+);
+
+const shouldRedactVerificationValue = (element) => (
+  element instanceof HTMLInputElement
+    ? !['checkbox', 'radio', 'range', 'button', 'submit', 'reset'].includes((element.type || '').toLowerCase())
+    : element instanceof HTMLTextAreaElement
+      || (element instanceof HTMLElement && element.isContentEditable)
+);
+
 const getElementLabel = (element) => {
   const ariaLabel = truncateText(element.getAttribute('aria-label') ?? '', 120);
   if (ariaLabel) return ariaLabel;
@@ -121,10 +134,12 @@ const getElementLabel = (element) => {
   const placeholder = truncateText(element.getAttribute('placeholder') ?? '', 120);
   if (placeholder) return placeholder;
 
+  if (isTextEntryElement(element)) {
+    return null;
+  }
+
   const text = truncateText(
-    element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
-      ? element.value
-      : element.textContent ?? '',
+    element.textContent ?? '',
     120,
   );
   return text || null;
@@ -187,7 +202,9 @@ const getVerificationTargetState = (element) => {
         ? element.checked
         : null,
     value:
-      element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
+      shouldRedactVerificationValue(element)
+        ? null
+        : element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
         ? truncateText(element.value ?? '', 200)
         : element instanceof HTMLSelectElement
           ? truncateText(element.value ?? '', 200)


### PR DESCRIPTION
## Summary

This is a narrow follow-up to #508.

The Browser2 page-inspection helpers were using live text-entry values as automatic labels and verification payloads. That means unlabeled inputs could expose typed content directly in page-read / verification output, including password values.

This patch keeps selectors and non-secret metadata intact while redacting text-entry controls from automatic labels and verification values.

## Related issues

- Fixes rowboatlabs/rowboat#508

## Changes

- `apps/x/apps/main/src/browser/page-scripts.ts`
  - add `isTextEntryElement()` to distinguish controls whose live values should not be used as labels
  - add `shouldRedactVerificationValue()` to suppress verification values for text-entry controls
  - stop using `.value` as the fallback label for text-entry controls
  - keep non-secret metadata (`selector`, `role`, `placeholder`, `disabled`, etc.) available for automation flows

## Why this scope

I kept the fix intentionally narrow: it only removes automatic exposure of typed values while preserving stable selectors and other non-secret state that Browser2 still needs.

## Testing

1. `cd apps/x && pnpm install && pnpm run deps`
2. `cd apps/main && npm run build`
3. Re-ran the local fixture validation after the patch:

```text
ROWBOAT_REDACTION_RECHECK {"labels":[{"id":"email","type":"email","label":null,"rawValue":"alice@example.com"},{"id":"pwd","type":"password","label":null,"rawValue":"super-secret-password"},{"id":"notes","type":"textarea","label":null,"rawValue":"confidential draft"}],"passwordVerification":{"selector":"#pwd","descriptor":"input","text":null,"checked":null,"value":null,"selectedIndex":null,"open":null,"disabled":false,"active":false,"ariaChecked":null,"ariaPressed":null,"ariaExpanded":null}}
```
