### PR TITLE
fix(browser): stop auto-approving Browser2 media/display-capture

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -116,21 +116,26 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
-const ALLOWED_SESSION_PERMISSIONS = new Set(["media", "display-capture", "clipboard-read", "clipboard-sanitized-write"]);
+const APP_SESSION_PERMISSIONS = new Set(["media", "display-capture", "clipboard-read", "clipboard-sanitized-write"]);
+const BROWSER_SESSION_PERMISSIONS = new Set(["clipboard-read", "clipboard-sanitized-write"]);
 
-function configureSessionPermissions(targetSession: Session): void {
+function configureSessionPermissions(targetSession: Session, allowedPermissions: Set<string>): void {
   targetSession.setPermissionCheckHandler((_webContents, permission) => {
-    return ALLOWED_SESSION_PERMISSIONS.has(permission);
+    return allowedPermissions.has(permission);
   });
 
   targetSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-    callback(ALLOWED_SESSION_PERMISSIONS.has(permission));
+    callback(allowedPermissions.has(permission));
   });
 
-  // Auto-approve display media requests and route system audio as loopback.
-  // Electron requires a video source in the callback even if we only want audio.
-  // We pass the first available screen source; the renderer discards the video track.
+  // Only sessions that explicitly allow display-capture should receive an
+  // auto-approved source. Embedded browser tabs use a separate session with a
+  // narrower permission set.
   targetSession.setDisplayMediaRequestHandler(async (_request, callback) => {
+    if (!allowedPermissions.has("display-capture")) {
+      callback({});
+      return;
+    }
     const sources = await desktopCapturer.getSources({ types: ['screen'] });
     if (sources.length === 0) {
       callback({});
@@ -159,8 +164,8 @@ function createWindow() {
     },
   });
 
-  configureSessionPermissions(session.defaultSession);
-  configureSessionPermissions(session.fromPartition(BROWSER_PARTITION));
+  configureSessionPermissions(session.defaultSession, APP_SESSION_PERMISSIONS);
+  configureSessionPermissions(session.fromPartition(BROWSER_PARTITION), BROWSER_SESSION_PERMISSIONS);
 
   // Show window when content is ready to prevent blank screen
   win.once("ready-to-show", () => {


### PR DESCRIPTION
## Summary

This is a narrow follow-up to #507.

Browser2 tabs currently inherit the app-wide media / display-capture auto-approval path. That means embedded pages can receive automatic capture approval instead of going through an explicit consent boundary.

This patch keeps the existing app session behavior intact, but narrows the Browser2 session to clipboard-only permissions and returns an empty display-media response there.

## Related issues

- Fixes rowboatlabs/rowboat#507

## Changes

- `apps/x/apps/main/src/main.ts`
  - split the previous shared permission allowlist into `APP_SESSION_PERMISSIONS` and `BROWSER_SESSION_PERMISSIONS`
  - parameterize `configureSessionPermissions()` so different sessions can have different permission policies
  - keep app-level capture behavior unchanged
  - stop auto-approving `media` / `display-capture` for `session.fromPartition(BROWSER_PARTITION)`
  - return `{}` from the display-media handler when the session does not explicitly allow `display-capture`

## Why this scope

I kept the patch intentionally small so it only restores an explicit consent boundary for Browser2. If Browser2 later needs capture features, a separate user-facing approval flow can be layered on top without widening the shared allowlist again.

## Testing

1. `cd apps/x && pnpm install && pnpm run deps`
2. `cd apps/main && npm run build`
3. Re-ran the source-backed permission validation against the patched branch:

```json
{
  "browserAllowed": ["clipboard-read", "clipboard-sanitized-write"],
  "browserMediaCheckAllowed": false,
  "browserDisplayCheckAllowed": false,
  "browserMediaRequestAllowed": false,
  "browserDisplayRequestAllowed": false,
  "browserDisplayResponse": {}
}
```
