### PR TITLE
fix runtime issue

### DIFF
--- a/apps/x/packages/core/src/agents/runtime.ts
+++ b/apps/x/packages/core/src/agents/runtime.ts
@@ -99,6 +99,7 @@ export class AgentRuntime implements IAgentRuntime {
     private modelConfigRepo: IModelConfigRepo;
     private runsLock: IRunsLock;
     private abortRegistry: IAbortRegistry;
+    private rerunRequested: Set<string> = new Set();
 
     constructor({
         runsRepo,
@@ -129,9 +130,11 @@ export class AgentRuntime implements IAgentRuntime {
     async trigger(runId: string): Promise<void> {
         if (!await this.runsLock.lock(runId)) {
             console.log(`unable to acquire lock on run ${runId}`);
+            this.rerunRequested.add(runId);
             return;
         }
         const signal = this.abortRegistry.createForRun(runId);
+        let shouldRerun = false;
         try {
             await this.bus.publish({
                 runId,
@@ -194,6 +197,28 @@ export class AgentRuntime implements IAgentRuntime {
                 await this.runsRepo.appendEvents(runId, [stoppedEvent]);
                 await this.bus.publish(stoppedEvent);
             }
+        } catch (error) {
+            if (isAbortError(error) || signal.aborted) {
+                const stoppedEvent: z.infer<typeof RunEvent> = {
+                    runId,
+                    type: "run-stopped",
+                    reason: "user-requested",
+                    subflow: [],
+                };
+                await this.runsRepo.appendEvents(runId, [stoppedEvent]);
+                await this.bus.publish(stoppedEvent);
+            } else {
+                const message = formatRunError(error);
+                console.error(`Run ${runId} failed:`, error);
+                const errorEvent: z.infer<typeof RunEvent> = {
+                    runId,
+                    type: "error",
+                    error: message,
+                    subflow: [],
+                };
+                await this.runsRepo.appendEvents(runId, [errorEvent]);
+                await this.bus.publish(errorEvent);
+            }
         } finally {
             this.abortRegistry.cleanup(runId);
             await this.runsLock.release(runId);
@@ -202,6 +227,10 @@ export class AgentRuntime implements IAgentRuntime {
                 type: "run-processing-end",
                 subflow: [],
             });
+            shouldRerun = this.rerunRequested.delete(runId);
+        }
+        if (shouldRerun) {
+            void this.trigger(runId);
         }
     }
 }
@@ -346,26 +375,68 @@ export class StreamStepMessageBuilder {
 
 function formatLlmStreamError(rawError: unknown): string {
     let name: string | undefined;
+    let message: string | undefined;
     let responseBody: string | undefined;
     if (rawError && typeof rawError === "object") {
         const err = rawError as Record<string, unknown>;
         const nested = (err.error && typeof err.error === "object") ? err.error as Record<string, unknown> : null;
         const nameValue = err.name ?? nested?.name;
+        const messageValue = err.message ?? nested?.message;
         const responseBodyValue = err.responseBody ?? nested?.responseBody;
         if (nameValue !== undefined) {
             name = String(nameValue);
+        }
+        if (messageValue !== undefined) {
+            message = String(messageValue);
         }
         if (responseBodyValue !== undefined) {
             responseBody = String(responseBodyValue);
         }
     } else if (typeof rawError === "string") {
-        responseBody = rawError;
+        message = rawError;
     }
 
     const lines: string[] = [];
     if (name) lines.push(`name: ${name}`);
+    if (message) lines.push(`message: ${message}`);
     if (responseBody) lines.push(`responseBody: ${responseBody}`);
     return lines.length ? lines.join("\n") : "Model stream error";
+}
+
+function formatRunError(error: unknown): string {
+    if (error instanceof Error) {
+        return error.stack || error.message || error.name;
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return String(error);
+    }
+}
+
+function isAbortError(error: unknown): boolean {
+    return error instanceof Error && error.name === "AbortError";
+}
+
+function toJsonCompatible(value: unknown): unknown {
+    if (value === undefined) {
+        return null;
+    }
+    try {
+        const serialized = JSON.stringify(value);
+        if (serialized === undefined) {
+            return null;
+        }
+        return JSON.parse(serialized);
+    } catch (error) {
+        return {
+            success: false,
+            error: `Tool returned a non-serializable result: ${formatRunError(error)}`,
+        };
+    }
 }
 
 export async function loadAgent(id: string): Promise<z.infer<typeof Agent>> {
@@ -942,29 +1013,42 @@ export async function* streamAgent({
                 subflow: [],
             });
             let result: unknown = null;
-            if (agent.tools![toolCall.toolName].type === "agent") {
-                const subflowState = state.subflowStates[toolCallId];
-                for await (const event of streamAgent({
-                    state: subflowState,
-                    idGenerator,
-                    runId,
-                    messageQueue,
-                    modelConfigRepo,
-                    signal,
-                    abortRegistry,
-                })) {
-                    yield* processEvent({
-                        ...event,
-                        subflow: [toolCallId, ...event.subflow],
-                    });
+            try {
+                if (agent.tools![toolCall.toolName].type === "agent") {
+                    const subflowState = state.subflowStates[toolCallId];
+                    for await (const event of streamAgent({
+                        state: subflowState,
+                        idGenerator,
+                        runId,
+                        messageQueue,
+                        modelConfigRepo,
+                        signal,
+                        abortRegistry,
+                    })) {
+                        yield* processEvent({
+                            ...event,
+                            subflow: [toolCallId, ...event.subflow],
+                        });
+                    }
+                    if (!subflowState.getPendingAskHumans().length && !subflowState.getPendingPermissions().length) {
+                        result = subflowState.finalResponse();
+                    }
+                } else {
+                    result = await execTool(agent.tools![toolCall.toolName], toolCall.arguments, { runId, signal, abortRegistry });
                 }
-                if (!subflowState.getPendingAskHumans().length && !subflowState.getPendingPermissions().length) {
-                    result = subflowState.finalResponse();
+            } catch (error) {
+                if (isAbortError(error) || signal.aborted) {
+                    throw error;
                 }
-            } else {
-                result = await execTool(agent.tools![toolCall.toolName], toolCall.arguments, { runId, signal, abortRegistry });
+                const message = formatRunError(error);
+                _logger.log('tool failed', message);
+                result = {
+                    success: false,
+                    error: message,
+                    toolName: toolCall.toolName,
+                };
             }
-            const resultPayload = result === undefined ? null : result;
+            const resultPayload = toJsonCompatible(result);
             const resultMsg: z.infer<typeof ToolMessage> = {
                 role: "tool",
                 content: JSON.stringify(resultPayload),
@@ -1189,85 +1273,95 @@ async function* streamLlm(
     signal?: AbortSignal,
 ): AsyncGenerator<z.infer<typeof LlmStepStreamEvent>, void, unknown> {
     const converted = convertFromMessages(messages);
-    console.log(`! SENDING payload to model: `, JSON.stringify(converted))
-    const { fullStream } = streamText({
-        model,
-        messages: converted,
-        system: instructions,
-        tools,
-        stopWhen: stepCountIs(1),
-        abortSignal: signal,
-    });
-    for await (const event of fullStream) {
-        // Check abort on every chunk for responsiveness
-        signal?.throwIfAborted();
-        console.log("-> \t\tstream event", JSON.stringify(event));
-        switch (event.type) {
-            case "error":
-                yield {
-                    type: "error",
-                    error: formatLlmStreamError((event as { error?: unknown }).error ?? event),
-                };
-                return;
-            case "reasoning-start":
-                yield {
-                    type: "reasoning-start",
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "reasoning-delta":
-                yield {
-                    type: "reasoning-delta",
-                    delta: event.text,
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "reasoning-end":
-                yield {
-                    type: "reasoning-end",
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "text-start":
-                yield {
-                    type: "text-start",
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "text-end":
-                yield {
-                    type: "text-end",
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "text-delta":
-                yield {
-                    type: "text-delta",
-                    delta: event.text,
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "tool-call":
-                yield {
-                    type: "tool-call",
-                    toolCallId: event.toolCallId,
-                    toolName: event.toolName,
-                    input: event.input,
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            case "finish-step":
-                yield {
-                    type: "finish-step",
-                    usage: event.usage,
-                    finishReason: event.finishReason,
-                    providerOptions: event.providerMetadata,
-                };
-                break;
-            default:
-                console.log('unknown stream event:', JSON.stringify(event));
-                continue;
+    console.log(`! SENDING payload to model: `, JSON.stringify(converted));
+    try {
+        const { fullStream } = streamText({
+            model,
+            messages: converted,
+            system: instructions,
+            tools,
+            stopWhen: stepCountIs(1),
+            abortSignal: signal,
+        });
+        for await (const event of fullStream) {
+            // Check abort on every chunk for responsiveness
+            signal?.throwIfAborted();
+            console.log("-> \t\tstream event", JSON.stringify(event));
+            switch (event.type) {
+                case "error":
+                    yield {
+                        type: "error",
+                        error: formatLlmStreamError((event as { error?: unknown }).error ?? event),
+                    };
+                    return;
+                case "reasoning-start":
+                    yield {
+                        type: "reasoning-start",
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "reasoning-delta":
+                    yield {
+                        type: "reasoning-delta",
+                        delta: event.text,
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "reasoning-end":
+                    yield {
+                        type: "reasoning-end",
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "text-start":
+                    yield {
+                        type: "text-start",
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "text-end":
+                    yield {
+                        type: "text-end",
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "text-delta":
+                    yield {
+                        type: "text-delta",
+                        delta: event.text,
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "tool-call":
+                    yield {
+                        type: "tool-call",
+                        toolCallId: event.toolCallId,
+                        toolName: event.toolName,
+                        input: event.input,
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                case "finish-step":
+                    yield {
+                        type: "finish-step",
+                        usage: event.usage,
+                        finishReason: event.finishReason,
+                        providerOptions: event.providerMetadata,
+                    };
+                    break;
+                default:
+                    console.log('unknown stream event:', JSON.stringify(event));
+                    continue;
+            }
         }
+    } catch (error) {
+        if (isAbortError(error) || signal?.aborted) {
+            throw error;
+        }
+        yield {
+            type: "error",
+            error: formatLlmStreamError(error),
+        };
     }
 }
 export const MappedToolCall = z.object({

--- a/apps/x/packages/core/src/runs/runs.ts
+++ b/apps/x/packages/core/src/runs/runs.ts
@@ -23,7 +23,7 @@ export async function createMessage(runId: string, message: UserMessageContentTy
     const queue = container.resolve<IMessageQueue>('messageQueue');
     const id = await queue.enqueue(runId, message, voiceInput, voiceOutput, searchEnabled, middlePaneContext);
     const runtime = container.resolve<IAgentRuntime>('agentRuntime');
-    runtime.trigger(runId);
+    void runtime.trigger(runId);
     return id;
 }
 
@@ -57,7 +57,7 @@ export async function authorizePermission(runId: string, ev: z.infer<typeof Tool
     };
     await repo.appendEvents(runId, [event]);
     const runtime = container.resolve<IAgentRuntime>('agentRuntime');
-    runtime.trigger(runId);
+    void runtime.trigger(runId);
 }
 
 export async function replyToHumanInputRequest(runId: string, ev: z.infer<typeof AskHumanResponsePayload>): Promise<void> {
@@ -69,7 +69,7 @@ export async function replyToHumanInputRequest(runId: string, ev: z.infer<typeof
     };
     await repo.appendEvents(runId, [event]);
     const runtime = container.resolve<IAgentRuntime>('agentRuntime');
-    runtime.trigger(runId);
+    void runtime.trigger(runId);
 }
 
 export async function stop(runId: string, force: boolean = false): Promise<void> {


### PR DESCRIPTION
Fix intermittent assistant no-response issue by making run triggering resilient and runtime
  failures observable

  This change addresses the intermittent cases where the assistant appeared to stop responding,
  sometimes after a few tool calls and sometimes even after the first user message.

  Primary fix: prevent queued work from getting stranded

  The assistant runtime uses a per-run lock so only one processing loop runs for a conversation
  at a time. Previously, if a new trigger arrived while that lock was held, the trigger was
  dropped after logging “unable to acquire lock.” That is fine only if the active loop naturally
  discovers all new work before it exits. In practice, there are edge cases around run shutdown,
  permission/human-input continuations, and queued user messages where work can be enqueued while
  the active loop is near completion or paused, then never picked up again.

  The runtime now records that a rerun was requested when it cannot acquire the lock. Once the
  active run releases the lock, it checks that flag and immediately triggers the run again. This
  makes trigger delivery edge-triggered plus level-triggered: even if the immediate trigger loses
  the lock race, the queued message or continuation is processed after the current cycle ends.

  This directly addresses the “assistant does not respond” symptom because messages and
  continuation events are no longer silently stranded behind a missed trigger.

  Secondary fix: surface runtime failures instead of ending silently

  Previously, `runs:createMessage` fired `runtime.trigger(runId)` in the background and returned
  success to the renderer. If the background runtime later threw outside the model stream’s own
  error-event path, the UI could receive only `run-processing-end` without any `error` event or
  assistant message. From the user’s perspective, the assistant simply stopped.

  The runtime now catches non-abort failures at the top level, logs them, persists a run `error`
  event, publishes that event to the renderer, and still emits `run-processing-end` for cleanup.
  That means model setup failures, provider/client exceptions, run-state issues, serialization
  failures, and other unexpected runtime exceptions are visible in the chat instead of looking
  like a silent no-op.

  Additional robustness: tool and model stream errors recover more cleanly

  Tool execution exceptions are now converted into tool-result error payloads when they are not
  aborts. This lets the model observe that a tool failed and continue or explain the issue,
  instead of the entire run dying mid-tool-call.

  Model stream setup and iteration errors are also converted into model stream `error` events.
  The existing stream error handling can then produce a run error event and show it in the UI.

  Small cleanup

  The call sites that intentionally fire `runtime.trigger(runId)` in the background now use `void
  runtime.trigger(runId)` to make that behavior explicit.

  Net effect

  The main behavior change is that assistant work is no longer dropped when a trigger races with
  an active run lock. If something still fails, the failure is now surfaced as a visible run
  error rather than leaving the user with an indefinitely silent or completed-looking
  conversation.