### PR TITLE
fix: guard indexOf result in Bus.unsubscribe to prevent splice(-1)

### DIFF
--- a/apps/cli/src/application/lib/bus.ts
+++ b/apps/cli/src/application/lib/bus.ts
@@ -29,7 +29,8 @@ export class InMemoryBus implements IBus {
         }
         this.subscribers.get(runId)!.push(handler);
         return () => {
-            this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
+            const idx = this.subscribers.get(runId)!.indexOf(handler);
+            if (idx !== -1) this.subscribers.get(runId)!.splice(idx, 1);
         };
     }
 }

--- a/apps/x/packages/core/src/application/lib/bus.ts
+++ b/apps/x/packages/core/src/application/lib/bus.ts
@@ -29,7 +29,8 @@ export class InMemoryBus implements IBus {
         }
         this.subscribers.get(runId)!.push(handler);
         return () => {
-            this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
+            const idx = this.subscribers.get(runId)!.indexOf(handler);
+            if (idx !== -1) this.subscribers.get(runId)!.splice(idx, 1);
         };
     }
 }


### PR DESCRIPTION
Closes #492

## Problem

`Bus.unsubscribe()` called `splice(indexOf(handler), 1)` without checking the result of `indexOf`. When the same unsubscribe function was called twice, the second call found no match and returned `-1`. `splice(-1, 1)` silently removed the **last** subscriber in the array — the wrong handler.

## Fix

Store the `indexOf` result and only call `splice` when `idx !== -1`, making a double-unsubscribe a safe no-op.

## Files changed

- `apps/cli/src/application/lib/bus.ts`
- `apps/x/packages/core/src/application/lib/bus.ts`