### PR TITLE
feat: minimal Today.md UI polish - no emoji headings, better track chip

### DIFF
--- a/apps/x/apps/renderer/src/extensions/track-block.tsx
+++ b/apps/x/apps/renderer/src/extensions/track-block.tsx
@@ -108,8 +108,8 @@ function TrackBlockView({ node, deleteNode, extension }: {
       >
         <span className="track-block-chip-icon">
           {isRunning
-            ? <Loader2 size={16} className="animate-spin" />
-            : <TrackIcon trackId={trackId} size={16} />}
+            ? <Loader2 size={24} className="animate-spin" />
+            : <TrackIcon trackId={trackId} size={24} />}
         </span>
         <span className="track-block-chip-id">{trackId || 'track'}</span>
         {instruction && <span className="track-block-chip-sep">·</span>}

--- a/apps/x/apps/renderer/src/extensions/track-block.tsx
+++ b/apps/x/apps/renderer/src/extensions/track-block.tsx
@@ -1,18 +1,28 @@
 import { z } from 'zod'
-import { useMemo } from 'react'
+import { useMemo, type ComponentType } from 'react'
 import { mergeAttributes, Node } from '@tiptap/react'
 import { ReactNodeViewRenderer, NodeViewWrapper } from '@tiptap/react'
-import { Radio, Loader2, CalendarDays, Mail, Clock, ListTodo, History } from 'lucide-react'
+import { Radio, Loader2, type LucideProps } from 'lucide-react'
+import * as LucideIcons from 'lucide-react'
 import { parse as parseYaml } from 'yaml'
 import { TrackBlockSchema } from '@x/shared/dist/track-block.js'
 import { useTrackStatus } from '@/hooks/use-track-status'
 
-function TrackIcon({ trackId, size }: { trackId: string; size: number }) {
-  if (trackId === 'up-next') return <Clock size={size} />
-  if (trackId === 'calendar') return <CalendarDays size={size} />
-  if (trackId === 'emails') return <Mail size={size} />
-  if (trackId === 'what-you-missed') return <History size={size} />
-  if (trackId === 'priorities') return <ListTodo size={size} />
+function resolveIcon(iconName: string): ComponentType<LucideProps> | null {
+  const key = iconName
+    .split('-')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('')
+  const component = (LucideIcons as Record<string, unknown>)[key]
+  if (component != null) return component as ComponentType<LucideProps>
+  return null
+}
+
+function TrackIcon({ icon, size }: { icon?: string; size: number }) {
+  if (icon) {
+    const Icon = resolveIcon(icon)
+    if (Icon) return <Icon size={size} />
+  }
   return <Radio size={size} />
 }
 
@@ -109,7 +119,7 @@ function TrackBlockView({ node, deleteNode, extension }: {
         <span className="track-block-chip-icon">
           {isRunning
             ? <Loader2 size={24} className="animate-spin" />
-            : <TrackIcon trackId={trackId} size={24} />}
+            : <TrackIcon icon={track?.icon} size={24} />}
         </span>
         <span className="track-block-chip-id">{trackId || 'track'}</span>
         {instruction && <span className="track-block-chip-sep">·</span>}

--- a/apps/x/apps/renderer/src/extensions/track-block.tsx
+++ b/apps/x/apps/renderer/src/extensions/track-block.tsx
@@ -2,10 +2,19 @@ import { z } from 'zod'
 import { useMemo } from 'react'
 import { mergeAttributes, Node } from '@tiptap/react'
 import { ReactNodeViewRenderer, NodeViewWrapper } from '@tiptap/react'
-import { Radio, Loader2 } from 'lucide-react'
+import { Radio, Loader2, CalendarDays, Mail, Clock, ListTodo, History } from 'lucide-react'
 import { parse as parseYaml } from 'yaml'
 import { TrackBlockSchema } from '@x/shared/dist/track-block.js'
 import { useTrackStatus } from '@/hooks/use-track-status'
+
+function TrackIcon({ trackId, size }: { trackId: string; size: number }) {
+  if (trackId === 'up-next') return <Clock size={size} />
+  if (trackId === 'calendar') return <CalendarDays size={size} />
+  if (trackId === 'emails') return <Mail size={size} />
+  if (trackId === 'what-you-missed') return <History size={size} />
+  if (trackId === 'priorities') return <ListTodo size={size} />
+  return <Radio size={size} />
+}
 
 function truncate(text: string, maxLen: number): string {
   const clean = text.replace(/\s+/g, ' ').trim()
@@ -87,6 +96,7 @@ function TrackBlockView({ node, deleteNode, extension }: {
       data-type="track-block"
       data-trigger={triggerType}
       data-active={active ? 'true' : 'false'}
+      data-trackid={trackId}
     >
       <button
         type="button"
@@ -96,13 +106,13 @@ function TrackBlockView({ node, deleteNode, extension }: {
         onMouseDown={(e) => e.stopPropagation()}
         title={instruction ? `${trackId}: ${instruction}` : trackId}
       >
-        {isRunning
-          ? <Loader2 size={13} className="animate-spin track-block-chip-icon" />
-          : <Radio size={13} className="track-block-chip-icon" />}
+        <span className="track-block-chip-icon">
+          {isRunning
+            ? <Loader2 size={16} className="animate-spin" />
+            : <TrackIcon trackId={trackId} size={16} />}
+        </span>
         <span className="track-block-chip-id">{trackId || 'track'}</span>
-        {instruction && (
-          <span className="track-block-chip-sep">·</span>
-        )}
+        {instruction && <span className="track-block-chip-sep">·</span>}
         {instruction && (
           <span className="track-block-chip-instruction">{truncate(instruction, 80)}</span>
         )}

--- a/apps/x/apps/renderer/src/styles/editor.css
+++ b/apps/x/apps/renderer/src/styles/editor.css
@@ -677,7 +677,7 @@
   width: 100%;
   padding: 24px 16px;
   font-family: inherit;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.3;
   color: var(--foreground);
   background: color-mix(in srgb, var(--muted) 40%, transparent);

--- a/apps/x/apps/renderer/src/styles/editor.css
+++ b/apps/x/apps/renderer/src/styles/editor.css
@@ -661,8 +661,8 @@
 
 .tiptap-editor .ProseMirror .track-block-chip-wrapper {
   --track-accent: #64748b; /* default: manual/slate */
-  margin: 4px 0;
-  display: inline-block;
+  margin: 8px 0;
+  display: block;
 }
 
 .tiptap-editor .ProseMirror .track-block-chip-wrapper[data-trigger="scheduled"] { --track-accent: #6366f1; }
@@ -674,24 +674,22 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  max-width: 100%;
-  padding: 6px 12px;
+  width: 100%;
+  padding: 24px 16px;
   font-family: inherit;
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.3;
   color: var(--foreground);
-  background: color-mix(in srgb, var(--track-accent) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--track-accent) 35%, transparent);
-  border-left: 3px solid var(--track-accent);
-  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted) 40%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.12s ease, box-shadow 0.12s ease, transform 0.06s ease;
+  transition: background-color 0.15s ease;
   user-select: none;
 }
 
 .tiptap-editor .ProseMirror .track-block-chip:hover {
-  background: color-mix(in srgb, var(--track-accent) 14%, transparent);
-  box-shadow: 0 1px 4px color-mix(in srgb, var(--track-accent) 20%, transparent);
+  background: color-mix(in srgb, var(--muted) 70%, transparent);
 }
 
 .tiptap-editor .ProseMirror .track-block-chip:active {
@@ -719,12 +717,18 @@
 
 .tiptap-editor .ProseMirror .track-block-chip-icon {
   flex-shrink: 0;
-  color: var(--track-accent);
+  color: color-mix(in srgb, var(--foreground) 45%, transparent);
 }
+
+.tiptap-editor .ProseMirror .track-block-chip-wrapper[data-trackid="up-next"]         .track-block-chip-icon { color: #3b82f6; }
+.tiptap-editor .ProseMirror .track-block-chip-wrapper[data-trackid="calendar"]        .track-block-chip-icon { color: #22c55e; }
+.tiptap-editor .ProseMirror .track-block-chip-wrapper[data-trackid="emails"]          .track-block-chip-icon { color: #f59e0b; }
+.tiptap-editor .ProseMirror .track-block-chip-wrapper[data-trackid="what-you-missed"] .track-block-chip-icon { color: #3b82f6; }
+.tiptap-editor .ProseMirror .track-block-chip-wrapper[data-trackid="priorities"]      .track-block-chip-icon { color: #ef4444; }
 
 .tiptap-editor .ProseMirror .track-block-chip-id {
   font-weight: 600;
-  color: var(--track-accent);
+  color: color-mix(in srgb, var(--foreground) 75%, transparent);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -735,7 +739,7 @@
 }
 
 .tiptap-editor .ProseMirror .track-block-chip-instruction {
-  color: color-mix(in srgb, var(--foreground) 80%, transparent);
+  color: color-mix(in srgb, var(--foreground) 55%, transparent);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/x/packages/core/src/knowledge/ensure_daily_note.ts
+++ b/apps/x/packages/core/src/knowledge/ensure_daily_note.ts
@@ -15,7 +15,7 @@ interface Section {
 
 const SECTIONS: Section[] = [
     {
-        heading: '## ⏱ Up Next',
+        heading: '## Up Next',
         track: {
             trackId: 'up-next',
             instruction:
@@ -41,7 +41,7 @@ Plain markdown prose only — no calendar block, no email block, no headings.`,
         },
     },
     {
-        heading: '## 📅 Calendar',
+        heading: '## Calendar',
         track: {
             trackId: 'calendar',
             instruction:
@@ -60,7 +60,7 @@ After the block, you MAY add one short markdown line per event giving useful pre
         },
     },
     {
-        heading: '## 📧 Emails',
+        heading: '## Emails',
         track: {
             trackId: 'emails',
             instruction:
@@ -81,7 +81,7 @@ Do NOT re-list threads the user has already seen unless their state changed (new
         },
     },
     {
-        heading: '## 📰 What You Missed',
+        heading: '## What You Missed',
         track: {
             trackId: 'what-you-missed',
             instruction:
@@ -106,7 +106,7 @@ Do NOT manufacture content to fill the section.`,
         },
     },
     {
-        heading: '## ✅ Today\'s Priorities',
+        heading: '## Today\'s Priorities',
         track: {
             trackId: 'priorities',
             instruction:
@@ -154,7 +154,28 @@ function buildDailyNoteContent(): string {
     return parts.join('\n');
 }
 
+function migrateEmojiHeadings(): void {
+    if (!fs.existsSync(DAILY_NOTE_PATH)) return;
+    let content = fs.readFileSync(DAILY_NOTE_PATH, 'utf-8');
+    const original = content;
+    const replacements: [string, string][] = [
+        ['## ⏱ Up Next', '## Up Next'],
+        ['## 📅 Calendar', '## Calendar'],
+        ['## 📧 Emails', '## Emails'],
+        ['## 📰 What You Missed', '## What You Missed'],
+        ["## ✅ Today's Priorities", "## Today's Priorities"],
+    ];
+    for (const [from, to] of replacements) {
+        content = content.split(from).join(to);
+    }
+    if (content !== original) {
+        fs.writeFileSync(DAILY_NOTE_PATH, content, 'utf-8');
+        console.log('[DailyNote] Migrated emoji headings');
+    }
+}
+
 export function ensureDailyNote(): void {
+    migrateEmojiHeadings();
     if (fs.existsSync(DAILY_NOTE_PATH)) return;
     fs.writeFileSync(DAILY_NOTE_PATH, buildDailyNoteContent(), 'utf-8');
     console.log('[DailyNote] Created today.md');

--- a/apps/x/packages/core/src/knowledge/ensure_daily_note.ts
+++ b/apps/x/packages/core/src/knowledge/ensure_daily_note.ts
@@ -18,6 +18,7 @@ const SECTIONS: Section[] = [
         heading: '## Up Next',
         track: {
             trackId: 'up-next',
+            icon: 'clock',
             instruction:
 `Write 1-3 sentences of plain markdown giving the user a shoulder-tap about what's next on their calendar today.
 
@@ -44,6 +45,7 @@ Plain markdown prose only — no calendar block, no email block, no headings.`,
         heading: '## Calendar',
         track: {
             trackId: 'calendar',
+            icon: 'calendar-days',
             instruction:
 `Emit today's meetings as a calendar block titled "Today's Meetings".
 
@@ -63,6 +65,7 @@ After the block, you MAY add one short markdown line per event giving useful pre
         heading: '## Emails',
         track: {
             trackId: 'emails',
+            icon: 'mail',
             instruction:
 `Maintain a digest of email threads worth the user's attention today, rendered as zero or more email blocks (one per thread).
 
@@ -84,6 +87,7 @@ Do NOT re-list threads the user has already seen unless their state changed (new
         heading: '## What You Missed',
         track: {
             trackId: 'what-you-missed',
+            icon: 'history',
             instruction:
 `Short markdown summary of what happened yesterday that matters this morning.
 
@@ -109,6 +113,7 @@ Do NOT manufacture content to fill the section.`,
         heading: '## Today\'s Priorities',
         track: {
             trackId: 'priorities',
+            icon: 'list-todo',
             instruction:
 `Ranked markdown list of the real, actionable items the user should focus on today.
 

--- a/apps/x/packages/shared/src/track-block.ts
+++ b/apps/x/packages/shared/src/track-block.ts
@@ -27,6 +27,7 @@ export const TrackBlockSchema = z.object({
     schedule: TrackScheduleSchema.optional(),
     model: z.string().optional().describe('ADVANCED — leave unset. Per-track LLM model override (e.g. "anthropic/claude-sonnet-4.6"). Only set when the user explicitly asked for a specific model for THIS track. The global default already picks a tuned model for tracks; overriding usually makes things worse, not better.'),
     provider: z.string().optional().describe('ADVANCED — leave unset. Per-track provider name override (e.g. "openai", "anthropic"). Only set when the user explicitly asked for a specific provider for THIS track. Almost always omitted; the global default flows through correctly.'),
+    icon: z.string().optional().describe('Lucide icon name for the chip (e.g. "clock", "calendar-days", "mail", "history", "list-todo"). Omit to use the default icon for this track.'),
     lastRunAt: z.string().optional().describe('Runtime-managed — never write this yourself'),
     lastRunId: z.string().optional().describe('Runtime-managed — never write this yourself'),
     lastRunSummary: z.string().optional().describe('Runtime-managed — never write this yourself'),


### PR DESCRIPTION
 ## The Problem
  The `TrackIcon` component had a hardcoded `if/else` chain in the renderer that mapped specific `trackId` strings Lucide icon components:

  ```tsx
  if (trackId === 'up-next') return <Clock />
  if (trackId === 'calendar') return <CalendarDays />
  if (trackId === 'emails') return <Mail />
  ```

  This meant two things:

  1. Adding a new built-in track required a code change in the renderer to get a non-default icon
  2. Users creating custom tracks had no way to control the icon at all — it always fell back to Radio

  The icon was invisible to the YAML — you could read or edit a track block and have no idea what icon it was showing how to change it.

  ## The Fix

  Moved icon ownership into the YAML where it belongs.

  - Added an optional icon field to TrackBlockSchema — accepts any Lucide icon name in kebab-case (e.g. icon: bell, icon: calendar-days)
  - Built-in tracks now declare their icon directly in their YAML via ensure_daily_note.ts, right alongside trackId and instruction — no separate renderer mapping
  - The renderer reads the icon field from the parsed YAML and resolves it dynamically from lucide-react at runtime
  - If icon is missing or invalid, falls back to Radio 

  ## Result

  The icon is now a first-class YAML field. A custom track just needs:
```
  trackId: my-track
  icon: bell
  instruction: ...
```
  No code change needed. Any valid Lucide icon name works.