### PR TITLE
fix: context-aware folder/note creation in knowledge panel

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -477,7 +477,8 @@ function flattenMeetingsTree(nodes: TreeNode[]): TreeNode[] {
       }
       collectFiles(sourceNode, [])
 
-      if (dateGroups.size === 0) return []
+      // Pass through user-created folders that have no meeting-style date files
+      if (dateGroups.size === 0) return [sourceNode]
 
       // Build date folder nodes, sorted reverse chronologically
       const dateFolderNodes: TreeNode[] = [...dateGroups.entries()]
@@ -3770,7 +3771,7 @@ function App() {
   }, [])
 
   const knowledgeActions = React.useMemo(() => ({
-    createNote: async (parentPath: string = 'knowledge/Notes') => {
+    createNote: async (parentPath: string = 'knowledge') => {
       try {
         let index = 0
         let name = untitledBaseName
@@ -3787,18 +3788,22 @@ function App() {
           data: `# ${name}\n\n`,
           opts: { encoding: 'utf8' }
         })
+        setExpandedPaths(prev => new Set([...prev, parentPath]))
         navigateToFile(fullPath)
       } catch (err) {
         console.error('Failed to create note:', err)
         throw err
       }
     },
-    createFolder: async (parentPath: string = 'knowledge/Notes') => {
+    createFolder: async (parentPath: string = 'knowledge'): Promise<string> => {
+      const newPath = `${parentPath}/new-folder-${Date.now()}`
       try {
         await window.ipc.invoke('workspace:mkdir', {
-          path: `${parentPath}/new-folder-${Date.now()}`,
+          path: newPath,
           recursive: true
         })
+        setExpandedPaths(prev => new Set([...prev, parentPath]))
+        return newPath
       } catch (err) {
         console.error('Failed to create folder:', err)
         throw err

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -1143,21 +1143,25 @@ function KnowledgeSection({
     }
   }, [selectedPath, expandedPaths, tree])
 
-  // Intercept file/folder clicks to track the active folder context
+  // Folder clicks highlight the folder; file clicks clear folder highlight
   const handleSelect = React.useCallback((path: string, kind: "file" | "dir") => {
     if (kind === 'dir') {
       setSelectedFolderPath(path)
     } else {
-      const parts = path.split('/')
-      setSelectedFolderPath(parts.length > 1 ? parts.slice(0, -1).join('/') : 'knowledge')
+      setSelectedFolderPath(null)
     }
     onSelectFile(path, kind)
   }, [onSelectFile])
 
-  // Resolve the parent path for new items based on current context
+  // Resolve the parent path for new items: explicit folder > open file's parent > root
   const deriveParent = React.useCallback((): string => {
-    return selectedFolderPath ?? 'knowledge'
-  }, [selectedFolderPath])
+    if (selectedFolderPath) return selectedFolderPath
+    if (selectedPath) {
+      const parts = selectedPath.split('/')
+      if (parts.length > 1) return parts.slice(0, -1).join('/')
+    }
+    return 'knowledge'
+  }, [selectedFolderPath, selectedPath])
 
   // Wrap actions to inject context-aware parent and capture rename target
   const wrappedActions = React.useMemo<KnowledgeActions>(() => ({

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -109,7 +109,7 @@ interface TreeNode {
 
 type KnowledgeActions = {
   createNote: (parentPath?: string) => void
-  createFolder: (parentPath?: string) => void
+  createFolder: (parentPath?: string) => Promise<string>
   openGraph: () => void
   openBases: () => void
   expandAll: () => void
@@ -1111,6 +1111,8 @@ function KnowledgeSection({
 }) {
   const isExpanded = expandedPaths.size > 0
   const treeContainerRef = React.useRef<HTMLDivElement | null>(null)
+  const [selectedFolderPath, setSelectedFolderPath] = useState<string | null>(null)
+  const [renameTarget, setRenameTarget] = useState<string | null>(null)
 
   useEffect(() => {
     if (!selectedPath) return
@@ -1141,9 +1143,36 @@ function KnowledgeSection({
     }
   }, [selectedPath, expandedPaths, tree])
 
+  // Intercept file/folder clicks to track the active folder context
+  const handleSelect = React.useCallback((path: string, kind: "file" | "dir") => {
+    if (kind === 'dir') {
+      setSelectedFolderPath(path)
+    } else {
+      const parts = path.split('/')
+      setSelectedFolderPath(parts.length > 1 ? parts.slice(0, -1).join('/') : 'knowledge')
+    }
+    onSelectFile(path, kind)
+  }, [onSelectFile])
+
+  // Resolve the parent path for new items based on current context
+  const deriveParent = React.useCallback((): string => {
+    return selectedFolderPath ?? 'knowledge'
+  }, [selectedFolderPath])
+
+  // Wrap actions to inject context-aware parent and capture rename target
+  const wrappedActions = React.useMemo<KnowledgeActions>(() => ({
+    ...actions,
+    createNote: (parentPath?: string) => actions.createNote(parentPath ?? deriveParent()),
+    createFolder: async (parentPath?: string): Promise<string> => {
+      const newPath = await actions.createFolder(parentPath ?? deriveParent())
+      setRenameTarget(newPath)
+      return newPath
+    },
+  }), [actions, deriveParent])
+
   const quickActions = [
-    { icon: FilePlus, label: "New Note", action: () => actions.createNote() },
-    { icon: FolderPlus, label: "New Folder", action: () => actions.createFolder() },
+    { icon: FilePlus, label: "New Note", action: () => wrappedActions.createNote() },
+    { icon: FolderPlus, label: "New Folder", action: () => void wrappedActions.createFolder() },
     { icon: Network, label: "Graph View", action: () => actions.openGraph() },
     { icon: Table2, label: "Bases", action: () => actions.openBases() },
   ]
@@ -1194,9 +1223,12 @@ function KnowledgeSection({
                     item={item}
                     selectedPath={selectedPath}
                     expandedPaths={expandedPaths}
-                    onSelect={onSelectFile}
+                    onSelect={handleSelect}
                     onToggleFolder={onToggleFolder}
-                    actions={actions}
+                    actions={wrappedActions}
+                    selectedFolderPath={selectedFolderPath}
+                    renameTarget={renameTarget}
+                    onRenameTargetConsumed={() => setRenameTarget(null)}
                   />
                 ))}
               </SidebarMenu>
@@ -1205,11 +1237,11 @@ function KnowledgeSection({
         </SidebarGroup>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-48">
-        <ContextMenuItem onClick={() => actions.createNote()}>
+        <ContextMenuItem onClick={() => wrappedActions.createNote()}>
           <FilePlus className="mr-2 size-4" />
           New Note
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => actions.createFolder()}>
+        <ContextMenuItem onClick={() => void wrappedActions.createFolder()}>
           <FolderPlus className="mr-2 size-4" />
           New Folder
         </ContextMenuItem>
@@ -1234,6 +1266,9 @@ function Tree({
   onSelect,
   onToggleFolder,
   actions,
+  selectedFolderPath,
+  renameTarget,
+  onRenameTargetConsumed,
 }: {
   item: TreeNode
   selectedPath: string | null
@@ -1241,10 +1276,14 @@ function Tree({
   onSelect: (path: string, kind: "file" | "dir") => void
   onToggleFolder?: (path: string) => void
   actions: KnowledgeActions
+  selectedFolderPath?: string | null
+  renameTarget?: string | null
+  onRenameTargetConsumed?: () => void
 }) {
   const isDir = item.kind === 'dir'
   const isExpanded = expandedPaths.has(item.path)
   const isSelected = selectedPath === item.path
+  const isFolderSelected = isDir && selectedFolderPath === item.path
   const [isRenaming, setIsRenaming] = useState(false)
   const isSubmittingRef = React.useRef(false)
   const displayName = (isDir && FOLDER_DISPLAY_NAMES[item.name]) || item.name
@@ -1254,6 +1293,17 @@ function Tree({
     ? item.name.slice(0, -3)
     : item.name
   const [newName, setNewName] = useState(baseName)
+
+  // Auto-enter rename mode when this node is the rename target
+  React.useEffect(() => {
+    if (renameTarget === item.path) {
+      setNewName(baseName)
+      isSubmittingRef.current = false
+      setIsRenaming(true)
+      onRenameTargetConsumed?.()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renameTarget, item.path])
 
   // Sync newName when baseName changes (e.g., after external rename)
   React.useEffect(() => {
@@ -1385,7 +1435,7 @@ function Tree({
       <ContextMenu>
         <ContextMenuTrigger asChild>
           <SidebarMenuItem className="group/file-item">
-            <SidebarMenuButton onClick={() => onSelect(item.path, item.kind)}>
+            <SidebarMenuButton isActive={isFolderSelected} onClick={() => onSelect(item.path, item.kind)}>
               <Folder className="size-4 shrink-0" />
               <div className="flex w-full items-center gap-1 min-w-0">
                 <span className="min-w-0 flex-1 truncate">{displayName}</span>
@@ -1420,6 +1470,9 @@ function Tree({
                     onSelect={onSelect}
                     onToggleFolder={onToggleFolder}
                     actions={actions}
+                    selectedFolderPath={selectedFolderPath}
+                    renameTarget={renameTarget}
+                    onRenameTargetConsumed={onRenameTargetConsumed}
                   />
                 ))}
               </SidebarMenuSub>
@@ -1471,7 +1524,7 @@ function Tree({
             className="group/collapsible [&[data-state=open]>button>svg:first-child]:rotate-90"
           >
             <CollapsibleTrigger asChild>
-              <SidebarMenuButton>
+              <SidebarMenuButton isActive={isFolderSelected}>
                 <ChevronRight className="transition-transform size-4" />
                 <div className="flex w-full items-center gap-1 min-w-0">
                   <span className="min-w-0 flex-1 truncate">{displayName}</span>
@@ -1490,6 +1543,9 @@ function Tree({
                     onSelect={onSelect}
                     onToggleFolder={onToggleFolder}
                     actions={actions}
+                    selectedFolderPath={selectedFolderPath}
+                    renameTarget={renameTarget}
+                    onRenameTargetConsumed={onRenameTargetConsumed}
                   />
                 ))}
               </SidebarMenuSub>

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -186,16 +186,16 @@ importers:
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@tiptap/extension-placeholder':
         specifier: 3.22.4
-        version: 3.22.4(@tiptap/extensions@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))
+        version: 3.22.4(@tiptap/extensions@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))
       '@tiptap/extension-table':
         specifier: 3.22.4
         version: 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@tiptap/extension-task-item':
         specifier: 3.22.4
-        version: 3.22.4(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))
+        version: 3.22.4(@tiptap/extension-list@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))
       '@tiptap/extension-task-list':
         specifier: 3.22.4
-        version: 3.22.4(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))
+        version: 3.22.4(@tiptap/extension-list@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))
       '@tiptap/pm':
         specifier: 3.22.4
         version: 3.22.4
@@ -1482,30 +1482,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.80':
     resolution: {integrity: sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
     resolution: {integrity: sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.80':
     resolution: {integrity: sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.80':
     resolution: {integrity: sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.80':
     resolution: {integrity: sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==}
@@ -2628,56 +2633,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -2996,24 +3012,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3149,6 +3169,12 @@ packages:
     peerDependencies:
       '@tiptap/extension-list': 3.22.5
 
+  '@tiptap/extension-list@3.22.4':
+    resolution: {integrity: sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.4
+      '@tiptap/pm': 3.22.4
+
   '@tiptap/extension-list@3.22.5':
     resolution: {integrity: sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==}
     peerDependencies:
@@ -3200,6 +3226,12 @@ packages:
     resolution: {integrity: sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extensions@3.22.4':
+    resolution: {integrity: sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==}
+    peerDependencies:
+      '@tiptap/core': 3.22.4
+      '@tiptap/pm': 3.22.4
 
   '@tiptap/extensions@3.22.5':
     resolution: {integrity: sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==}
@@ -5599,24 +5631,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -11131,6 +11167,11 @@ snapshots:
     dependencies:
       '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
 
+  '@tiptap/extension-list@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
+      '@tiptap/pm': 3.22.4
+
   '@tiptap/extension-list@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
     dependencies:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
@@ -11144,9 +11185,9 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
 
-  '@tiptap/extension-placeholder@3.22.4(@tiptap/extensions@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))':
+  '@tiptap/extension-placeholder@3.22.4(@tiptap/extensions@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))':
     dependencies:
-      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
+      '@tiptap/extensions': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
 
   '@tiptap/extension-strike@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))':
     dependencies:
@@ -11157,13 +11198,13 @@ snapshots:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
       '@tiptap/pm': 3.22.4
 
-  '@tiptap/extension-task-item@3.22.4(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))':
+  '@tiptap/extension-task-item@3.22.4(@tiptap/extension-list@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))':
     dependencies:
-      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
+      '@tiptap/extension-list': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
 
-  '@tiptap/extension-task-list@3.22.4(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))':
+  '@tiptap/extension-task-list@3.22.4(@tiptap/extension-list@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))':
     dependencies:
-      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
+      '@tiptap/extension-list': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
 
   '@tiptap/extension-text@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))':
     dependencies:
@@ -11172,6 +11213,11 @@ snapshots:
   '@tiptap/extension-underline@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))':
     dependencies:
       '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
+
+  '@tiptap/extensions@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
+      '@tiptap/pm': 3.22.4
 
   '@tiptap/extensions@3.22.5(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
     dependencies:


### PR DESCRIPTION
## What

Three bugs fixed in the knowledge panel:

**1. New folder/note always created in `knowledge/Notes`**
`createFolder` and `createNote` had a hardcoded default of `knowledge/Notes` with no awareness of where the user was. Clicking the button from inside `Projects/` still dropped the new item into `Notes/`.

**2. No visual feedback after creation**
`createFolder` just called `workspace:mkdir` and returned — it didn't expand the parent folder, didn't scroll to the new item, and didn't trigger rename mode. The folder was created on disk but the user saw nothing change (parent was collapsed), so it looked like the button did nothing.

**3. Folder highlight bleed**
When a folder was highlighted (clicked to select it) and then a note inside it was opened, the folder stayed highlighted alongside the note. Only the note should be active.

**Bonus bug found during testing:**
`flattenMeetingsTree` was silently dropping any user-created subfolder under `knowledge/Meetings` — the flatten logic returned `[]` for folders with no date-structured meeting files, so new folders created there just disappeared from the tree.

## How
- `createFolder` now returns the new path and expands the parent in `expandedPaths`
- `KnowledgeSection` tracks `selectedFolderPath` (set on folder click, cleared on file click) and wraps actions to inject the derived parent before delegating to `App.tsx`
- `Tree` accepts a `renameTarget` prop and enters rename mode via `useEffect` when the newly created node mounts
- `flattenMeetingsTree` passes through user-created subfolders instead of dropping them

## Test plan
- New Folder button with no selection → creates in `knowledge/`
- New Folder button with folder selected → creates inside that folder
- New Folder button with note open → creates in the note's parent folder
- Right-click empty panel → New Note / New Folder use same context logic
- Right-click on a folder → creates inside that folder
- Inline rename appears immediately after folder creation
- Opening a note clears folder highlight; clicking a folder highlights it
- Creating a folder under Meetings works and stays visible in the tree