### PR TITLE
fix: gracefully truncate conversation history when context window is …

### DIFF
--- a/apps/x/packages/core/src/agents/context-utils.ts
+++ b/apps/x/packages/core/src/agents/context-utils.ts
@@ -1,0 +1,97 @@
+interface AnyMessage {
+  [key: string]: unknown;
+  role: string;
+  content: unknown;
+}
+
+/**
+ * Estimates the token count for a string using a character-based heuristic.
+ * ~4 characters per token is a reliable average for English/mixed content.
+ * This intentionally over-estimates slightly to remain conservative.
+ */
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Extracts a plain-text representation of a message's content for token estimation.
+ */
+function getMessageText(message: AnyMessage): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  if (Array.isArray(message.content)) {
+    return (message.content as unknown[])
+      .map((part) => {
+        if (part && typeof part === "object") {
+          const p = part as Record<string, unknown>;
+          if (typeof p["text"] === "string") return p["text"];
+          if (typeof p["content"] === "string") return p["content"];
+        }
+        return "";
+      })
+      .join(" ");
+  }
+  return "";
+}
+/**
+ * Truncates the message list so the estimated total token count stays within
+ * `maxTokens`. The system message (if any) is always preserved. Messages are
+ * dropped from the oldest end first, so the most recent context is retained.
+ *
+ * Tool call / tool-result pairs are kept together: if the first kept message is
+ * a tool-result without a preceding tool-call, it is dropped to avoid sending
+ * an unmatched tool call to the model.
+ *
+ * @param messages  Full conversation history.
+ * @param maxTokens Token budget (default: 80,000 — conservative cross-model limit).
+ * @param systemText  Optional system prompt text to deduct from the budget upfront.
+ * @returns A (possibly shorter) messages array that fits within the budget.
+ */
+export function truncateMessagesToFit<T extends AnyMessage>(
+  messages: T[],
+  maxTokens = 80_000,
+  systemText = "",
+): T[] {
+  const systemMessages = messages.filter((msg) => msg.role === "system");
+  const otherMessages = messages.filter((msg) => msg.role !== "system");
+
+  const systemTokens =
+    systemMessages.reduce(
+      (sum, msg) => sum + estimateTokens(getMessageText(msg)),
+      0,
+    ) + estimateTokens(systemText);
+
+  let availableTokens = maxTokens - systemTokens;
+
+  const truncatedMessages: T[] = [];
+
+  for (let i = otherMessages.length - 1; i >= 0; i--) {
+    const msg = otherMessages[i];
+    const msgTokens = estimateTokens(getMessageText(msg));
+    if (msgTokens <= availableTokens) {
+      truncatedMessages.unshift(msg);
+      availableTokens -= msgTokens;
+    } else {
+      // Budget exhausted — drop this and all older messages
+
+      break;
+    }
+  }
+  // Never start with  unmatched tool-result (AI SDK requirement)
+  while (truncatedMessages.length > 0 && truncatedMessages[0].role === "tool") {
+    truncatedMessages.shift();
+  }
+
+  const finalMessages = [...systemMessages, ...truncatedMessages];
+  if (finalMessages.length < messages.length) {
+    const dropped = messages.length - finalMessages.length;
+    console.log(
+      `[context-utils] Truncated ${dropped} oldest message(s) to fit context window ` +
+        `(budget: ${maxTokens} tokens, system: ${systemTokens} tokens).`,
+    );
+  }
+
+  return finalMessages;
+}

--- a/apps/x/packages/core/src/agents/runtime.ts
+++ b/apps/x/packages/core/src/agents/runtime.ts
@@ -33,6 +33,7 @@ import { getRaw as getLabelingAgentRaw } from "../knowledge/labeling_agent.js";
 import { getRaw as getNoteTaggingAgentRaw } from "../knowledge/note_tagging_agent.js";
 import { getRaw as getInlineTaskAgentRaw } from "../knowledge/inline_task_agent.js";
 import { getRaw as getAgentNotesAgentRaw } from "../knowledge/agent_notes_agent.js";
+import { truncateMessagesToFit } from "./context-utils.js";
 
 const AGENT_NOTES_DIR = path.join(WorkDir, 'knowledge', 'Agent Notes');
 const WORKDIR_CONFIG_FILE = path.join(WorkDir, 'config', 'workdir.json');
@@ -1285,7 +1286,9 @@ async function* streamLlm(
     signal?: AbortSignal,
     analytics?: StreamLlmAnalytics,
 ): AsyncGenerator<z.infer<typeof LlmStepStreamEvent>, void, unknown> {
-    const converted = convertFromMessages(messages);
+
+    const truncated = truncateMessagesToFit(messages);
+    const converted = convertFromMessages(truncated);
     console.log(`! SENDING payload to model: `, JSON.stringify(converted))
     const { fullStream } = streamText({
         model,


### PR DESCRIPTION
# fix: gracefully truncate conversation history when context window is exceeded
 
Closes #514 

 
## Problem
 
When a conversation grows long, Rowboat passes the full message history to the
model API unchanged. If the history exceeds the model's context window limit the
API returns a hard `400 bad_request_error` (`context window exceeds limit`) and
the error is surfaced directly to the user with no recovery.
 
## Solution
 
Add a lightweight `truncateMessagesToFit()` utility
(`apps/x/packages/core/src/agents/context-utils.ts`) that is called inside
`streamLlm()` — the single callsite that builds the payload sent to the AI SDK —
before `convertFromMessages()` runs.
 
### How it works
 
1. **System messages are always preserved** — they carry agent instructions and
   are never dropped regardless of length.
2. **Oldest non-system messages are dropped first** — the most recent context is
   the most valuable, so we walk the history newest → oldest and stop when the
   token budget is exhausted.
3. **Tool-result / tool-call pairing is respected** — if dropping old messages
   leaves a `tool` (tool-result) message at the head of the kept list, it is
   also dropped, because the AI SDK requires every tool-result to have a
   preceding tool-call message.
4. **Token counting is heuristic** — we use `ceil(charCount / 4)` which is a
   well-known approximation that intentionally over-estimates to remain
   conservative. A tokenizer library would be more precise but adds a
   dependency; the heuristic is sufficient for truncation purposes.
### Default budget
 
`80,000` tokens. This comfortably fits within the context windows of every
model currently supported by Rowboat (Claude 3.x, GPT-4o, Gemini 1.5, Llama 3,
etc.) while leaving headroom for the system prompt and the model's output.
 
## Files changed
 
| File | Change |
|---|---|
| `apps/x/packages/core/src/agents/context-utils.ts` | New — `truncateMessagesToFit()` utility |
| `apps/x/packages/core/src/agents/runtime.ts` | Apply truncation inside `streamLlm()` before sending to AI SDK |
 
## Testing
 
The utility has no external dependencies and can be exercised with a simple
Node script:
 
```ts
import { truncateMessagesToFit } from "./context-utils.js";
 
const msgs = [
  { role: "system",    content: "You are a helpful assistant." },
  { role: "user",      content: "A".repeat(400_000) }, // ~100k tokens — over budget
  { role: "assistant", content: "Here is my reply." },
  { role: "user",      content: "Follow-up question." },
];
 
const result = truncateMessagesToFit(msgs);
// system message preserved, oldest oversized message dropped,
// two most-recent messages retained.
console.assert(result[0].role === "system");
console.assert(result.length === 3); // system + last assistant + last user
```
 