### PR TITLE
fix(security): prevent path traversal in file upload/download endpoints

### DIFF
--- a/apps/rowboat/app/api/uploads/[fileId]/route.ts
+++ b/apps/rowboat/app/api/uploads/[fileId]/route.ts
@@ -9,6 +9,15 @@ const UPLOADS_DIR = process.env.RAG_UPLOADS_DIR || '/uploads';
 
 const dataSourceDocsRepository = container.resolve<IDataSourceDocsRepository>('dataSourceDocsRepository');
 
+/**
+ * Validates that a resolved file path stays within the uploads directory.
+ * Prevents path traversal attacks (e.g., fileId containing "../").
+ */
+function validateUploadPath(resolvedPath: string): boolean {
+    const normalizedUploadsDir = path.resolve(UPLOADS_DIR);
+    return resolvedPath.startsWith(normalizedUploadsDir + path.sep) || resolvedPath === normalizedUploadsDir;
+}
+
 // PUT endpoint to handle file uploads
 export async function PUT(request: NextRequest, props: { params: Promise<{ fileId: string }> }) {
     const params = await props.params;
@@ -17,11 +26,14 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ fileI
         return NextResponse.json({ error: 'Missing file ID' }, { status: 400 });
     }
 
-    const filePath = path.join(UPLOADS_DIR, fileId);
+    const resolvedPath = path.resolve(UPLOADS_DIR, fileId);
+    if (!validateUploadPath(resolvedPath)) {
+        return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
+    }
 
     try {
         const data = await request.arrayBuffer();
-        await fs.writeFile(filePath, new Uint8Array(data));
+        await fs.writeFile(resolvedPath, new Uint8Array(data));
         
         return NextResponse.json({ success: true });
     } catch (error) {
@@ -41,6 +53,12 @@ export async function GET(request: NextRequest, props: { params: Promise<{ fileI
         return NextResponse.json({ error: 'Missing file ID' }, { status: 400 });
     }
 
+    // Validate the fileId path as well
+    const resolvedIdPath = path.resolve(UPLOADS_DIR, fileId);
+    if (!validateUploadPath(resolvedIdPath)) {
+        return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
+    }
+
     // get mimetype from database
     const doc = await dataSourceDocsRepository.fetch(fileId);
     if (!doc) {
@@ -55,7 +73,11 @@ export async function GET(request: NextRequest, props: { params: Promise<{ fileI
 
     try {
         // strip uploads dir from path
-        const filePath = path.join(UPLOADS_DIR, doc.data.path.split('/api/uploads/')[1]);
+        const pathSegment = doc.data.path.split('/api/uploads/')[1];
+        const filePath = path.resolve(UPLOADS_DIR, pathSegment);
+        if (!validateUploadPath(filePath)) {
+            return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
+        }
 
         // Check if file exists
         await fs.access(filePath);


### PR DESCRIPTION
## Vulnerability: Path Traversal in File Upload API (P0)

### Summary
The file upload/download endpoint at `apps/rowboat/app/api/uploads/[fileId]/route.ts` uses the `fileId` URL parameter directly in `path.join(UPLOADS_DIR, fileId)` without any sanitization. An attacker can craft a `fileId` containing `../` sequences to read or write arbitrary files on the server filesystem.

### Impact
- **Arbitrary file read**: Via GET requests with crafted `fileId` values, an attacker can read any file accessible to the application process (e.g., `/etc/passwd`, environment files, secrets).
- **Arbitrary file write**: Via PUT requests, an attacker can overwrite critical system or application files, potentially achieving remote code execution.

### Fix
- Added a `validateUploadPath()` helper that resolves the full path using `path.resolve()` and verifies it stays within the `UPLOADS_DIR` directory.
- Applied the check to both the **PUT handler** (file uploads) and the **GET handler** (file downloads).
- In the GET handler, also validated the path segment extracted from `doc.data.path` (via `split("/api/uploads/")[1]`) since this database-sourced value could also contain traversal sequences.
- Uses `path.resolve()` to normalize the path before comparison, preventing bypass via mixed encodings or double slashes.

### Test Plan
- Verify that normal file upload/download operations still work
- Attempt GET/PUT with `fileId=../../../etc/passwd` — should return 400
- Attempt GET/PUT with `fileId=..%2F..%2Fetc%2Fpasswd` — should return 400
- Verify legitimate files within UPLOADS_DIR continue to resolve correctly