### PR TITLE
fix(security): close & (background) command-executor allowlist bypass

### DIFF
--- a/apps/cli/src/application/lib/command-executor.ts
+++ b/apps/cli/src/application/lib/command-executor.ts
@@ -4,7 +4,13 @@ import { getSecurityAllowList, SECURITY_CONFIG_PATH } from '../../config/securit
 import { getExecutionShell } from '../assistant/runtime-context.js';
 
 const execPromise = promisify(exec);
-const COMMAND_SPLIT_REGEX = /(?:\|\||&&|;|\||\n)/;
+// Order matters: longer separators (`||`, `&&`) must precede their single-char
+// prefixes (`|`, `&`) so the leftmost-longest match consumes the right token.
+// `&` (background), backtick / `$(` (command substitution), and `(` `)`
+// (subshell) are also command separators — without them, `echo hi & rm /x`,
+// `echo \`rm /x\``, and `echo $(rm /x)` slip past isBlocked() with only
+// `echo` in the allowlist.
+const COMMAND_SPLIT_REGEX = /(?:\|\||&&|&|;|\||\n|`|\$\(|\(|\))/;
 const ENV_ASSIGNMENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*=.*/;
 const WRAPPER_COMMANDS = new Set(['sudo', 'env', 'time', 'command']);
 const EXECUTION_SHELL = getExecutionShell();

--- a/apps/x/packages/core/src/application/lib/command-executor.ts
+++ b/apps/x/packages/core/src/application/lib/command-executor.ts
@@ -5,7 +5,11 @@ import { getExecutionShell } from '../assistant/runtime-context.js';
 
 const execPromise = promisify(exec);
 
-const COMMAND_SPLIT_REGEX = /(?:\|\||&&|;|\||\n|`|\$\(|\(|\))/;
+// Order matters: longer separators (`||`, `&&`) must precede their single-char
+// prefixes (`|`, `&`) so the leftmost-longest match consumes the right token.
+// Missing `&` here let `echo hi & rm -rf $HOME` slip past isBlocked() — the
+// parser saw only `echo`, but the shell ran both commands.
+const COMMAND_SPLIT_REGEX = /(?:\|\||&&|&|;|\||\n|`|\$\(|\(|\))/;
 const ENV_ASSIGNMENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*=.*/;
 const WRAPPER_COMMANDS = new Set(['sudo', 'env', 'time', 'command']);
 


### PR DESCRIPTION
## Summary

`extractCommandNames()` in `command-executor.ts` enumerates the commands an LLM-generated shell string will invoke by splitting on shell separators, then `isBlocked()` decides whether to ask the user for permission via `tool-permission-request`. The split regex was missing single-`&` (background separator), so commands chained via `&` were silently allowed when only the leading command was in the allowlist.

## Impact

With the default allowlist (which includes `echo`, `cat`, `ls`, `find`, `grep`, etc.), an LLM-issued or prompt-injected command like:

```
echo done & rm -rf $HOME
```

bypasses the gate entirely:

- `extractCommandNames(...)` → `['echo']` (the `&` isn't a separator, so the second segment is never tokenized as a separate command)
- `isBlocked(...)` → `false`
- the agent runtime executes it without `tool-permission-request`
- bash runs `echo done` in the background, then `rm -rf $HOME` synchronously

Threat model: the allowlist exists to bound damage from prompt injection in tool outputs / fetched documents / model self-confusion. The whole point is "don't let the model run `rm` without me confirming." This bypass defeats that for any command an attacker can wedge after `&`.

The CLI parser (`apps/cli/src/application/lib/command-executor.ts`) was additionally missing backtick, `$(`, `(`, and `)`, so `echo $(rm /x)`, `` echo `rm /x` ``, and `(rm /x)` slipped through it for the same reason. The desktop parser (`apps/x/packages/core/src/application/lib/command-executor.ts`) already covered those.

## Location

- `apps/x/packages/core/src/application/lib/command-executor.ts:8`
- `apps/cli/src/application/lib/command-executor.ts:7`

Gate call sites that consume `isBlocked`:
- `apps/x/packages/core/src/agents/runtime.ts:1236`
- `apps/cli/src/agents/runtime.ts:717`

## Fix

Add `&` to `COMMAND_SPLIT_REGEX` in both files, ordered after `&&` so leftmost-longest match still consumes `&&` first. Also bring the cli regex up to parity with the apps/x version (adds backtick, `$(`, `(`, `)`).

```diff
-const COMMAND_SPLIT_REGEX = /(?:\|\||&&|;|\||\n|`|\$\(|\(|\))/;
+const COMMAND_SPLIT_REGEX = /(?:\|\||&&|&|;|\||\n|`|\$\(|\(|\))/;
```

## Verification

Reproducing the bypass and the fix with a one-shot Node simulation of the parser (default allowlist subset):

```
allowlist = ['echo','cat','ls','env']

before fix:
  ALLOW  "echo hi & rm -rf /tmp/x"   -> echo            (BYPASS)
  BLOCK  "echo hi && rm -rf /tmp/x"  -> echo,rm
  BLOCK  "echo hi; rm -rf /tmp/x"    -> echo,rm

after fix:
  BLOCK  "echo hi & rm -rf /tmp/x"   -> echo,rm         (closed)
  ALLOW  "cat foo & ls bar"          -> cat,ls          (legit chain still works)
  ALLOW  "echo & cat foo"            -> echo,cat        (legit chain still works)
```

Repo has no test suite for this module, so the diff is the change and the simulation above is the verification. Happy to wire up a vitest/jest harness in a follow-up if you'd like the regression locked in.

## Detected by

Aeon + semgrep `javascript.lang.security.detect-child-process` flag, then manual parser review against bash control-operator grammar.

- Severity: **high**
- CWE-78 (OS Command Injection), CWE-863 (Incorrect Authorization)

## Notes / out of scope

The parser is heuristic and there are still indirect-execution cases it can't catch by design — `xargs`, `find -exec`, `nohup`, `nice`, and similar argv-passing wrappers all run a subcommand the regex won't see. The right architectural fix for those is either expanding `WRAPPER_COMMANDS` or moving to a structured argv with no shell at all. Not addressing those here — kept this PR focused on the immediate `&` miss so it's easy to review and ship. Happy to file a follow-up issue with the broader list if useful.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
