### PR TITLE
fix: acpx fails to spawn claude code on windows

### DIFF
--- a/apps/x/packages/core/src/application/lib/builtin-tools.ts
+++ b/apps/x/packages/core/src/application/lib/builtin-tools.ts
@@ -1,7 +1,7 @@
 import { z, ZodType } from "zod";
 import * as path from "path";
 import * as fs from "fs/promises";
-import { createReadStream } from "fs";
+import { createReadStream, existsSync, readFileSync } from "fs";
 import { createInterface } from "readline";
 import { execSync } from "child_process";
 import { glob } from "glob";
@@ -66,6 +66,44 @@ const LLMPARSE_MIME_TYPES: Record<string, string> = {
     '.bmp': 'image/bmp',
     '.tiff': 'image/tiff',
 };
+
+// Windows-only workaround: the Claude ACP bridge spawns CLAUDE_CODE_EXECUTABLE
+// without `shell: true`, and Node refuses to spawn .cmd files that way (EINVAL).
+// When the LLM invokes acpx via executeCommand, pre-resolve claude's real .exe
+// from the npm-shim layout and inject it via env so the bridge can spawn it.
+function resolveClaudeExeOnWindows(): string | undefined {
+    const pathDirs = (process.env.PATH ?? '').split(';');
+    for (const dir of pathDirs) {
+        const trimmed = dir.trim();
+        if (!trimmed) continue;
+        const cmdPath = path.join(trimmed, 'claude.cmd');
+        if (!existsSync(cmdPath)) continue;
+        const exeFromLayout = path.join(trimmed, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+        if (existsSync(exeFromLayout)) return exeFromLayout;
+        try {
+            const content = readFileSync(cmdPath, 'utf-8');
+            const absMatch = content.match(/[A-Z]:[\\/][^\s"]*claude\.exe/i);
+            if (absMatch && existsSync(absMatch[0])) return absMatch[0];
+            const relMatch = content.match(/%~dp0[\\/]?([^\s"%]+claude\.exe)/i);
+            if (relMatch) {
+                const resolved = path.join(trimmed, relMatch[1]);
+                if (existsSync(resolved)) return resolved;
+            }
+        } catch {
+            // ignore shim parse failures
+        }
+    }
+    return undefined;
+}
+
+function envForCommand(command: string): NodeJS.ProcessEnv | undefined {
+    if (process.platform !== 'win32') return undefined;
+    if (!/\bacpx\b/.test(command)) return undefined;
+    if (process.env.CLAUDE_CODE_EXECUTABLE) return undefined;
+    const exe = resolveClaudeExeOnWindows();
+    if (!exe) return undefined;
+    return { ...process.env, CLAUDE_CODE_EXECUTABLE: exe };
+}
 
 export const BuiltinTools: z.infer<typeof BuiltinToolsSchema> = {
     loadSkill: {
@@ -963,11 +1001,14 @@ export const BuiltinTools: z.infer<typeof BuiltinToolsSchema> = {
                 //     };
                 // }
 
+                const envOverride = envForCommand(command);
+
                 // Use abortable version when we have a signal
                 if (ctx?.signal) {
                     const { promise, process: proc } = executeCommandAbortable(command, {
                         cwd: workingDir,
                         signal: ctx.signal,
+                        env: envOverride,
                         onData: (chunk: string) => {
                             ctx.publish({
                                 runId: ctx.runId,

--- a/apps/x/packages/core/src/application/lib/command-executor.ts
+++ b/apps/x/packages/core/src/application/lib/command-executor.ts
@@ -144,6 +144,7 @@ export function executeCommandAbortable(
     maxBuffer?: number;
     signal?: AbortSignal;
     onData?: (chunk: string) => void;
+    env?: NodeJS.ProcessEnv;
   }
 ): { promise: Promise<AbortableCommandResult>; process: ChildProcess } {
   // Check if already aborted before spawning
@@ -166,6 +167,7 @@ export function executeCommandAbortable(
   const proc = spawn(command, [], {
     shell,
     cwd: options?.cwd,
+    env: options?.env,
     detached: process.platform !== 'win32', // Create process group on Unix
     stdio: ['ignore', 'pipe', 'pipe'],
   });


### PR DESCRIPTION
## What
- The coding skill (`code-with-agents`) couldn't run on Windows: acpx failed `session/new` with a generic `RUNTIME: Internal error`.
- Root cause is in `@agentclientprotocol/claude-agent-acp`: it spawns the path in `CLAUDE_CODE_EXECUTABLE` without `shell: true`, and Node refuses to spawn `.cmd` files that way (CVE-2024-27980 hardening) → `spawn EINVAL`.
- Workaround in Rowboat instead of waiting on an upstream fix: pre-resolve the real `claude.exe` and pass that to acpx via the env var, so the bridge spawns the `.exe` directly.

## How
- New `resolveClaudeExeOnWindows()` in `builtin-tools.ts`: walks `PATH`, finds `claude.cmd`, then locates its sibling `.exe` via the npm-install layout, with a regex fallback that reads the shim contents for other shim styles.
- `envForCommand()` only triggers on Windows when the command contains `acpx` and `CLAUDE_CODE_EXECUTABLE` isn't already set — no-op everywhere else.
- `executeCommandAbortable` gained an optional `env` passthrough so the override reaches `spawn`.

## Test plan
- Built `npm run deps`; lint clean for touched files.
- Repro that previously failed (`acpx --cwd "G:\tmp\test space dir" claude exec ...`) now starts the bridge and returns a normal Claude Code response.
- Verified the resolver picks the npm-layout `.exe` path on this machine; falls back to regex shim parsing when that layout doesn't apply.
- No-op confirmed on non-Windows and on non-acpx commands.