### PR TITLE
fix(uploads): prevent path traversal in file upload/download endpoint

### DIFF
--- a/apps/rowboat/app/api/uploads/[fileId]/route.ts
+++ b/apps/rowboat/app/api/uploads/[fileId]/route.ts
@@ -9,6 +9,15 @@ const UPLOADS_DIR = process.env.RAG_UPLOADS_DIR || '/uploads';
 
 const dataSourceDocsRepository = container.resolve<IDataSourceDocsRepository>('dataSourceDocsRepository');
 
+function getSafeFilePath(uploadsDir: string, fileId: string): string | null {
+    const resolvedBase = path.resolve(uploadsDir);
+    const resolvedPath = path.resolve(uploadsDir, fileId);
+    if (!resolvedPath.startsWith(resolvedBase + path.sep) && resolvedPath !== resolvedBase) {
+        return null;
+    }
+    return resolvedPath;
+}
+
 // PUT endpoint to handle file uploads
 export async function PUT(request: NextRequest, props: { params: Promise<{ fileId: string }> }) {
     const params = await props.params;
@@ -17,7 +26,10 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ fileI
         return NextResponse.json({ error: 'Missing file ID' }, { status: 400 });
     }
 
-    const filePath = path.join(UPLOADS_DIR, fileId);
+    const filePath = getSafeFilePath(UPLOADS_DIR, fileId);
+    if (!filePath) {
+        return NextResponse.json({ error: 'Invalid file ID' }, { status: 400 });
+    }
 
     try {
         const data = await request.arrayBuffer();
@@ -55,7 +67,11 @@ export async function GET(request: NextRequest, props: { params: Promise<{ fileI
 
     try {
         // strip uploads dir from path
-        const filePath = path.join(UPLOADS_DIR, doc.data.path.split('/api/uploads/')[1]);
+        const rawFileId = doc.data.path.split('/api/uploads/')[1];
+        const filePath = getSafeFilePath(UPLOADS_DIR, rawFileId);
+        if (!filePath) {
+            return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
+        }
 
         // Check if file exists
         await fs.access(filePath);


### PR DESCRIPTION
## Summary

The file upload/download endpoint at `PUT /api/uploads/[fileId]` is vulnerable to path traversal (CWE-22), allowing an attacker to write arbitrary files on the server by supplying a crafted `fileId` parameter containing directory traversal sequences like `../../`.

## Vulnerability Details

**Affected file:** `apps/rowboat/app/api/uploads/[fileId]/route.ts`

**Severity:** High — unauthenticated arbitrary file write

**Data flow:** The `fileId` route parameter is extracted from the URL, then passed directly to `path.join(UPLOADS_DIR, fileId)` to construct a file path. The resulting path is used with `fs.writeFile()` (PUT) and `fs.createReadStream()` (GET) without any validation that the resolved path stays within the uploads directory.

**Authentication:** The Next.js middleware in `middleware.ts` explicitly skips authentication for all `/api/` routes — requests matching `/api/*` receive CORS headers (`Access-Control-Allow-Origin: *`) and pass through without session checks. The `authCheck` function is only invoked for `/projects`, `/billing`, and `/onboarding` paths, and even then only when `USE_AUTH=true`. This means the upload endpoint is accessible to any network client.

## Proof of Concept

An attacker can overwrite arbitrary files on the server filesystem (limited by the Node.js process permissions):

```bash
# Write a file outside the uploads directory
# This writes to /tmp/pwned by traversing out of /uploads
curl -X PUT \
  -H "Content-Type: application/octet-stream" \
  --data-binary "malicious content" \
  "http://localhost:3000/api/uploads/..%2F..%2Ftmp%2Fpwned"
```

Next.js decodes the `[fileId]` dynamic segment, so `..%2F..%2Ftmp%2Fpwned` becomes `../../tmp/pwned`. The original code then computes `path.join('/uploads', '../../tmp/pwned')` which resolves to `/tmp/pwned`, and the request body is written there.

Depending on the deployment environment, this could be escalated to remote code execution by overwriting application files, configuration, or cron jobs.

## Fix Description

This PR adds a `getSafeFilePath()` helper that:

1. Resolves both the base uploads directory and the constructed file path to absolute paths using `path.resolve()`
2. Checks that the resolved file path starts with the base directory path (plus a path separator) to prevent traversal
3. Returns `null` if the path escapes the uploads directory, which the route handlers convert to a 400 response

Both the `PUT` and `GET` handlers now use this function instead of the raw `path.join()` call.

## Testing

- Verified that a normal upload (`PUT /api/uploads/valid-file-id`) still resolves to a path within the uploads directory and is accepted
- Verified that traversal payloads (`../../etc/passwd`, `..%2F..%2Ftmp%2Ftest`) are rejected with a 400 response
- Verified the GET handler's path construction (which splits on `/api/uploads/` and joins the remainder) is also protected
- Edge cases: empty fileId, fileId equal to the base directory itself, and deeply nested traversal sequences are all handled correctly

## Adversarial Review

Before submitting, we attempted to disprove this finding by checking whether Next.js middleware, framework-level protections, or Auth0 session guards would prevent exploitation. They don't — the middleware explicitly passes `/api/` routes through without authentication, and Next.js does not sanitize dynamic route segments against directory traversal. The CORS policy is set to `*`, so this is also exploitable cross-origin from any webpage.