### PR TITLE
Make chat work directory per-run instead of global

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -524,6 +524,10 @@ export function setupIpcHandlers() {
     'runs:fetch': async (_event, args) => {
       return runsCore.fetchRun(args.runId);
     },
+    'runs:setWorkdir': async (_event, args) => {
+      await runsCore.setWorkdir(args.runId, args.workingDirectory);
+      return { success: true as const };
+    },
     'runs:list': async (_event, args) => {
       return runsCore.listRuns(args.cursor);
     },

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -970,6 +970,7 @@ function App() {
   const newChatTabId = () => `chat-tab-${++chatTabIdCounterRef.current}`
   const chatDraftsRef = useRef(new Map<string, string>())
   const selectedModelByTabRef = useRef(new Map<string, { provider: string; model: string }>())
+  const pendingWorkDirByTabRef = useRef(new Map<string, string>())
   const chatScrollTopByTabRef = useRef(new Map<string, number>())
   const [toolOpenByTab, setToolOpenByTab] = useState<Record<string, Record<string, boolean>>>({})
   const [chatViewportAnchorByTab, setChatViewportAnchorByTab] = useState<Record<string, ChatViewportAnchorState>>({})
@@ -2354,10 +2355,13 @@ function App() {
       let newRunCreatedAt: string | null = null
       if (!currentRunId) {
         const selected = selectedModelByTabRef.current.get(submitTabId)
+        const pendingWorkDir = pendingWorkDirByTabRef.current.get(submitTabId)
         const run = await window.ipc.invoke('runs:create', {
           agentId,
           ...(selected ? { model: selected.model, provider: selected.provider } : {}),
+          ...(pendingWorkDir ? { workingDirectory: pendingWorkDir } : {}),
         })
+        pendingWorkDirByTabRef.current.delete(submitTabId)
         currentRunId = run.id
         newRunCreatedAt = run.createdAt
         setRunId(currentRunId)
@@ -2666,6 +2670,7 @@ function App() {
     })
     chatDraftsRef.current.delete(tabId)
     selectedModelByTabRef.current.delete(tabId)
+    pendingWorkDirByTabRef.current.delete(tabId)
     chatScrollTopByTabRef.current.delete(tabId)
     setToolOpenByTab((prev) => {
       if (!(tabId in prev)) return prev
@@ -5300,6 +5305,13 @@ function App() {
                                 selectedModelByTabRef.current.delete(tab.id)
                               }
                             }}
+                            onWorkDirChange={(dir) => {
+                              if (dir) {
+                                pendingWorkDirByTabRef.current.set(tab.id, dir)
+                              } else {
+                                pendingWorkDirByTabRef.current.delete(tab.id)
+                              }
+                            }}
                             isRecording={isActive && isRecording}
                             recordingText={isActive ? voice.interimText : undefined}
                             recordingState={isActive ? (voice.state === 'connecting' ? 'connecting' : 'listening') : undefined}
@@ -5358,6 +5370,13 @@ function App() {
                     selectedModelByTabRef.current.set(tabId, m)
                   } else {
                     selectedModelByTabRef.current.delete(tabId)
+                  }
+                }}
+                onWorkDirChangeForTab={(tabId, dir) => {
+                  if (dir) {
+                    pendingWorkDirByTabRef.current.set(tabId, dir)
+                  } else {
+                    pendingWorkDirByTabRef.current.delete(tabId)
                   }
                 }}
                 pendingAskHumanRequests={pendingAskHumanRequests}

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -133,6 +133,9 @@ interface ChatInputInnerProps {
   onTtsModeChange?: (mode: 'summary' | 'full') => void
   /** Fired when the user picks a different model in the dropdown (only when no run exists yet). */
   onSelectedModelChange?: (model: SelectedModel | null) => void
+  /** Fired when the user sets/clears the work directory before a run exists, so the
+   * parent can pass it into runs:create. Once a run exists, changes go straight to the run. */
+  onWorkDirChange?: (dir: string | null) => void
 }
 
 function ChatInputInner({
@@ -159,6 +162,7 @@ function ChatInputInner({
   onToggleTts,
   onTtsModeChange,
   onSelectedModelChange,
+  onWorkDirChange,
 }: ChatInputInnerProps) {
   const controller = usePromptInputController()
   const message = controller.textInput.value
@@ -256,21 +260,22 @@ function ChatInputInner({
     return () => window.removeEventListener('models-config-changed', handler)
   }, [loadModelConfig])
 
-  // Load currently configured work directory
-  const loadWorkDir = useCallback(async () => {
-    try {
-      const result = await window.ipc.invoke('workspace:readFile', { path: 'config/workdir.json' })
-      const parsed = JSON.parse(result.data)
-      const value = typeof parsed?.path === 'string' ? parsed.path.trim() : ''
-      setWorkDir(value || null)
-    } catch {
-      setWorkDir(null)
-    }
-  }, [])
-
+  // The work directory is run-scoped. For an existing run, load it from the run.
+  // For a new chat (no run yet) the chosen directory lives in local state until
+  // the run is created, and is reported up via onWorkDirChange so it can be
+  // passed into runs:create.
   useEffect(() => {
-    loadWorkDir()
-  }, [isActive, loadWorkDir])
+    if (!runId) {
+      setWorkDir(null)
+      return
+    }
+    let cancelled = false
+    window.ipc.invoke('runs:fetch', { runId }).then((run) => {
+      if (cancelled) return
+      setWorkDir(run.workingDirectory ?? null)
+    }).catch(() => { /* legacy run or fetch failure — leave as-is */ })
+    return () => { cancelled = true }
+  }, [runId])
 
   const handleSetWorkDir = useCallback(async () => {
     try {
@@ -279,31 +284,33 @@ function ChatInputInner({
         defaultPath: workDir ?? undefined,
       })
       if (!chosen) return
-      await window.ipc.invoke('workspace:writeFile', {
-        path: 'config/workdir.json',
-        data: JSON.stringify({ path: chosen }, null, 2),
-      })
+      if (runId) {
+        await window.ipc.invoke('runs:setWorkdir', { runId, workingDirectory: chosen })
+      } else {
+        onWorkDirChange?.(chosen)
+      }
       setWorkDir(chosen)
       toast.success(`Work directory set: ${chosen}`)
     } catch (err) {
       console.error('Failed to set work directory', err)
       toast.error('Failed to set work directory')
     }
-  }, [workDir])
+  }, [workDir, runId, onWorkDirChange])
 
   const handleClearWorkDir = useCallback(async () => {
     try {
-      await window.ipc.invoke('workspace:writeFile', {
-        path: 'config/workdir.json',
-        data: JSON.stringify({}, null, 2),
-      })
+      if (runId) {
+        await window.ipc.invoke('runs:setWorkdir', { runId, workingDirectory: null })
+      } else {
+        onWorkDirChange?.(null)
+      }
       setWorkDir(null)
       toast.success('Work directory cleared')
     } catch (err) {
       console.error('Failed to clear work directory', err)
       toast.error('Failed to clear work directory')
     }
-  }, [])
+  }, [runId, onWorkDirChange])
 
   // Check search tool availability (exa or signed-in via gateway)
   useEffect(() => {
@@ -790,6 +797,7 @@ export interface ChatInputWithMentionsProps {
   onToggleTts?: () => void
   onTtsModeChange?: (mode: 'summary' | 'full') => void
   onSelectedModelChange?: (model: SelectedModel | null) => void
+  onWorkDirChange?: (dir: string | null) => void
 }
 
 export function ChatInputWithMentions({
@@ -819,6 +827,7 @@ export function ChatInputWithMentions({
   onToggleTts,
   onTtsModeChange,
   onSelectedModelChange,
+  onWorkDirChange,
 }: ChatInputWithMentionsProps) {
   return (
     <PromptInputProvider knowledgeFiles={knowledgeFiles} recentFiles={recentFiles} visibleFiles={visibleFiles}>
@@ -846,6 +855,7 @@ export function ChatInputWithMentions({
         onToggleTts={onToggleTts}
         onTtsModeChange={onTtsModeChange}
         onSelectedModelChange={onSelectedModelChange}
+        onWorkDirChange={onWorkDirChange}
       />
     </PromptInputProvider>
   )

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -195,6 +195,7 @@ interface ChatSidebarProps {
   getInitialDraft?: (tabId: string) => string | undefined
   onDraftChangeForTab?: (tabId: string, text: string) => void
   onSelectedModelChangeForTab?: (tabId: string, model: SelectedModel | null) => void
+  onWorkDirChangeForTab?: (tabId: string, dir: string | null) => void
   pendingAskHumanRequests?: ChatTabViewState['pendingAskHumanRequests']
   allPermissionRequests?: ChatTabViewState['allPermissionRequests']
   permissionResponses?: ChatTabViewState['permissionResponses']
@@ -250,6 +251,7 @@ export function ChatSidebar({
   getInitialDraft,
   onDraftChangeForTab,
   onSelectedModelChangeForTab,
+  onWorkDirChangeForTab,
   pendingAskHumanRequests = new Map(),
   allPermissionRequests = new Map(),
   permissionResponses = new Map(),
@@ -742,6 +744,7 @@ export function ChatSidebar({
                           initialDraft={getInitialDraft?.(tab.id)}
                           onDraftChange={onDraftChangeForTab ? (text) => onDraftChangeForTab(tab.id, text) : undefined}
                           onSelectedModelChange={onSelectedModelChangeForTab ? (m) => onSelectedModelChangeForTab(tab.id, m) : undefined}
+                          onWorkDirChange={onWorkDirChangeForTab ? (dir) => onWorkDirChangeForTab(tab.id, dir) : undefined}
                           isRecording={isActive && isRecording}
                           recordingText={isActive ? recordingText : undefined}
                           recordingState={isActive ? recordingState : undefined}

--- a/apps/x/packages/core/src/agents/runtime.ts
+++ b/apps/x/packages/core/src/agents/runtime.ts
@@ -36,19 +36,6 @@ import { getRaw as getInlineTaskAgentRaw } from "../knowledge/inline_task_agent.
 import { getRaw as getAgentNotesAgentRaw } from "../knowledge/agent_notes_agent.js";
 
 const AGENT_NOTES_DIR = path.join(WorkDir, 'knowledge', 'Agent Notes');
-const WORKDIR_CONFIG_FILE = path.join(WorkDir, 'config', 'workdir.json');
-
-function loadUserWorkDir(): string | null {
-    try {
-        if (!fs.existsSync(WORKDIR_CONFIG_FILE)) return null;
-        const raw = fs.readFileSync(WORKDIR_CONFIG_FILE, 'utf-8');
-        const parsed = JSON.parse(raw) as { path?: unknown };
-        const value = typeof parsed.path === 'string' ? parsed.path.trim() : '';
-        return value || null;
-    } catch {
-        return null;
-    }
-}
 
 function loadAgentNotesContext(): string | null {
     const sections: string[] = [];
@@ -673,6 +660,7 @@ export class AgentState {
     runProvider: string | null = null;
     runUseCase: UseCase | null = null;
     runSubUseCase: string | null = null;
+    workingDirectory: string | null = null;
     messages: z.infer<typeof MessageList> = [];
     lastAssistantMsg: z.infer<typeof AssistantMessage> | null = null;
     subflowStates: Record<string, AgentState> = {};
@@ -790,6 +778,10 @@ export class AgentState {
                 this.runProvider = event.provider;
                 this.runUseCase = event.useCase ?? null;
                 this.runSubUseCase = event.subUseCase ?? null;
+                this.workingDirectory = event.workingDirectory ?? null;
+                break;
+            case "workdir-changed":
+                this.workingDirectory = event.workingDirectory ?? null;
                 break;
             case "spawn-subflow":
                 // Seed the subflow state with its agent so downstream loadAgent works.
@@ -1122,7 +1114,7 @@ export async function* streamAgent({
             if (agentNotesContext) {
                 instructionsWithDateTime += `\n\n${agentNotesContext}`;
             }
-            const userWorkDir = loadUserWorkDir();
+            const userWorkDir = state.workingDirectory;
             if (userWorkDir) {
                 loopLogger.log('injecting user work directory', userWorkDir);
                 instructionsWithDateTime += `\n\n# User Work Directory

--- a/apps/x/packages/core/src/runs/repo.ts
+++ b/apps/x/packages/core/src/runs/repo.ts
@@ -5,7 +5,7 @@ import path from "path";
 import fsp from "fs/promises";
 import fs from "fs";
 import readline from "readline";
-import { Run, RunEvent, StartEvent, ListRunsResponse, MessageEvent, UseCase } from "@x/shared/dist/runs.js";
+import { Run, RunEvent, StartEvent, ListRunsResponse, MessageEvent, UseCase, WorkdirChangedEvent } from "@x/shared/dist/runs.js";
 import { getDefaultModelAndProvider } from "../models/defaults.js";
 
 /**
@@ -37,6 +37,7 @@ export type CreateRunRepoOptions = {
     provider: string;
     useCase: z.infer<typeof UseCase>;
     subUseCase?: string;
+    workingDirectory?: string;
 };
 
 function runLogPath(runId: string): string {
@@ -206,6 +207,7 @@ export class FSRunsRepo implements IRunsRepo {
             provider: options.provider,
             useCase: options.useCase,
             ...(options.subUseCase ? { subUseCase: options.subUseCase } : {}),
+            ...(options.workingDirectory ? { workingDirectory: options.workingDirectory } : {}),
             subflow: [],
             ts,
         };
@@ -218,6 +220,7 @@ export class FSRunsRepo implements IRunsRepo {
             provider: options.provider,
             useCase: options.useCase,
             ...(options.subUseCase ? { subUseCase: options.subUseCase } : {}),
+            ...(options.workingDirectory ? { workingDirectory: options.workingDirectory } : {}),
             log: [start],
         };
     }
@@ -244,6 +247,14 @@ export class FSRunsRepo implements IRunsRepo {
         };
         const events: z.infer<typeof RunEvent>[] = [start, ...rawEvents.slice(1) as z.infer<typeof RunEvent>[]];
         const title = this.extractTitle(events);
+        // The current work directory is the start event's value, overridden by the
+        // most recent workdir-changed event (append-only log — last write wins).
+        let workingDirectory: string | undefined = start.workingDirectory || undefined;
+        for (const event of events) {
+            if (event.type === 'workdir-changed') {
+                workingDirectory = (event as z.infer<typeof WorkdirChangedEvent>).workingDirectory || undefined;
+            }
+        }
         return {
             id,
             title,
@@ -253,6 +264,7 @@ export class FSRunsRepo implements IRunsRepo {
             provider: start.provider,
             ...(start.useCase ? { useCase: start.useCase } : {}),
             ...(start.subUseCase ? { subUseCase: start.subUseCase } : {}),
+            ...(workingDirectory ? { workingDirectory } : {}),
             log: events,
         };
     }

--- a/apps/x/packages/core/src/runs/runs.ts
+++ b/apps/x/packages/core/src/runs/runs.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import container from "../di/container.js";
 import { IMessageQueue, UserMessageContentType, VoiceOutputMode, MiddlePaneContext } from "../application/lib/message-queue.js";
-import { AskHumanResponseEvent, ToolPermissionRequestEvent, ToolPermissionResponseEvent, CreateRunOptions, Run, ListRunsResponse, ToolPermissionAuthorizePayload, AskHumanResponsePayload } from "@x/shared/dist/runs.js";
+import { AskHumanResponseEvent, ToolPermissionRequestEvent, ToolPermissionResponseEvent, CreateRunOptions, Run, ListRunsResponse, ToolPermissionAuthorizePayload, AskHumanResponsePayload, WorkdirChangedEvent } from "@x/shared/dist/runs.js";
 import { IRunsRepo } from "./repo.js";
 import { IAgentRuntime } from "../agents/runtime.js";
 import { IBus } from "../application/lib/bus.js";
@@ -34,9 +34,21 @@ export async function createRun(opts: z.infer<typeof CreateRunOptions>): Promise
         provider,
         useCase,
         ...(opts.subUseCase ? { subUseCase: opts.subUseCase } : {}),
+        ...(opts.workingDirectory ? { workingDirectory: opts.workingDirectory } : {}),
     });
     await bus.publish(run.log[0]);
     return run;
+}
+
+export async function setWorkdir(runId: string, workingDirectory: string | null): Promise<void> {
+    const repo = container.resolve<IRunsRepo>('runsRepo');
+    const event: z.infer<typeof WorkdirChangedEvent> = {
+        runId,
+        type: "workdir-changed",
+        subflow: [],
+        ...(workingDirectory ? { workingDirectory } : {}),
+    };
+    await repo.appendEvents(runId, [event]);
 }
 
 export async function createMessage(runId: string, message: UserMessageContentType, voiceInput?: boolean, voiceOutput?: VoiceOutputMode, searchEnabled?: boolean, middlePaneContext?: MiddlePaneContext): Promise<string> {

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -234,6 +234,15 @@ const ipcSchemas = {
     }),
     res: Run,
   },
+  'runs:setWorkdir': {
+    req: z.object({
+      runId: z.string(),
+      workingDirectory: z.string().nullable(),
+    }),
+    res: z.object({
+      success: z.literal(true),
+    }),
+  },
   'runs:list': {
     req: z.object({
       cursor: z.string().optional(),

--- a/apps/x/packages/shared/src/runs.ts
+++ b/apps/x/packages/shared/src/runs.ts
@@ -31,6 +31,9 @@ export const StartEvent = BaseRunEvent.extend({
         "knowledge_sync",
     ]).optional(),
     subUseCase: z.string().optional(),
+    // Per-run work directory chosen at creation. Optional: a run may have none,
+    // and it can be changed later via WorkdirChangedEvent.
+    workingDirectory: z.string().optional(),
 });
 
 export const SpawnSubFlowEvent = BaseRunEvent.extend({
@@ -105,6 +108,12 @@ export const RunStoppedEvent = BaseRunEvent.extend({
     reason: z.enum(["user-requested", "force-stopped"]).optional(),
 });
 
+export const WorkdirChangedEvent = BaseRunEvent.extend({
+    type: z.literal("workdir-changed"),
+    // Absent/empty means the work directory was cleared.
+    workingDirectory: z.string().optional(),
+});
+
 export const RunEvent = z.union([
     RunProcessingStartEvent,
     RunProcessingEndEvent,
@@ -121,6 +130,7 @@ export const RunEvent = z.union([
     ToolPermissionResponseEvent,
     RunErrorEvent,
     RunStoppedEvent,
+    WorkdirChangedEvent,
 ]);
 
 export const ToolPermissionAuthorizePayload = ToolPermissionResponseEvent.pick({
@@ -153,6 +163,7 @@ export const Run = z.object({
     provider: z.string(),
     useCase: UseCase.optional(),
     subUseCase: z.string().optional(),
+    workingDirectory: z.string().optional(),
     log: z.array(RunEvent),
 });
 
@@ -172,4 +183,5 @@ export const CreateRunOptions = z.object({
     provider: z.string().optional(),
     useCase: UseCase.optional(),
     subUseCase: z.string().optional(),
+    workingDirectory: z.string().optional(),
 });

--- a/apps/x/plan.md
+++ b/apps/x/plan.md
@@ -1,0 +1,280 @@
+# Plan: Make the chat "work directory" per-chat instead of global
+
+## 1. Problem / current behavior
+
+In the Electron app (`apps/x`), a chat can have a **work directory** — a folder the
+agent treats as the default location for file operations. The user sets it from the
+chat input's dropdown ("Set / Change / Clear work directory").
+
+**Bug:** the work directory is **global**, not per-chat. Setting it in one chat changes
+it for *every* chat — new chats and previously-created chats alike. Opening a different
+chat shows (and uses) whatever directory was last set anywhere.
+
+**Desired behavior:**
+- The work directory belongs to a single chat (run). Setting it in chat A must not affect
+  chat B.
+- A brand-new chat starts with **no** work directory.
+- The user can **set, change, or clear** the work directory at any point in a chat, and
+  the change applies to that chat only and to its subsequent messages.
+
+## 2. Root cause
+
+The work directory lives in one shared file — `config/workdir.json` in the Rowboat
+workspace — and there is no per-run storage for it.
+
+| Concern | Location | What it does |
+|---|---|---|
+| Write (UI) | `apps/renderer/src/components/chat-input-with-mentions.tsx:275-306` (`handleSetWorkDir` / `handleClearWorkDir`) | Writes the chosen path to the global `config/workdir.json`. |
+| Read for display (UI) | `apps/renderer/src/components/chat-input-with-mentions.tsx:259-273` (`loadWorkDir`, called on `isActive`) | Re-reads the same global file whenever any tab becomes active. |
+| Read for the agent | `packages/core/src/agents/runtime.ts:41-51` (`loadUserWorkDir`) injected at `runtime.ts:1125-1146` | On every message, reads the same global file and injects it into the prompt, regardless of which run the message belongs to. |
+
+The data model has nowhere to store it per chat:
+- `Run` / `StartEvent` schema: `packages/shared/src/runs.ts:19-34` and `147-157` — no work-dir field.
+- `CreateRunOptions`: `packages/shared/src/runs.ts:169-175` — not accepted at creation.
+- The run is created in the renderer at `apps/renderer/src/App.tsx:2357` (`runs:create`) and the work dir is never passed through.
+
+## 3. Design
+
+Make the work directory **run-scoped metadata**, captured at run creation and updatable
+mid-chat via an appended event (run logs are append-only JSONL, so "change" = append a new
+event; readers use the latest one).
+
+Three moving parts:
+
+1. **Schema** — add an optional `workingDirectory` to `StartEvent` (initial value) and add a
+   new `WorkdirChangedEvent` to the run-event union (later changes). Derive a
+   `workingDirectory` field on the `Run` object from the latest of these.
+2. **Runtime** — `AgentState` tracks `workingDirectory` (set by the start event, overwritten
+   by each `workdir-changed` event). The prompt injection uses `state.workingDirectory`
+   instead of reading the global file.
+3. **Renderer** — the chat input reads the work dir from the active run (via `runs:fetch`),
+   not the global file. For a new chat (no run yet), the chosen dir is held in tab-local
+   state and passed into `runs:create`. Set/Change/Clear on an existing run calls a new
+   `runs:setWorkdir` IPC that appends a `workdir-changed` event.
+
+The global `config/workdir.json` is no longer read or written. New chats therefore start
+empty, which is what fixes the reported bug. (No migration needed — old runs simply have no
+stored work dir and start empty going forward. Optionally delete the stale file; see step 7.)
+
+## 4. Execution steps
+
+### Step 1 — Schema (`packages/shared/src/runs.ts`)
+
+1. Add `workingDirectory` to `StartEvent` (after `subUseCase`, line ~33):
+   ```ts
+   workingDirectory: z.string().optional(),
+   ```
+2. Add a new event type near the other event definitions (e.g. after `RunStoppedEvent`,
+   line ~106):
+   ```ts
+   export const WorkdirChangedEvent = BaseRunEvent.extend({
+       type: z.literal("workdir-changed"),
+       // empty string / undefined means "cleared"
+       workingDirectory: z.string().optional(),
+   });
+   ```
+3. Add `WorkdirChangedEvent` to the `RunEvent` union (line ~108-124).
+4. Add the derived field to the `Run` schema (line ~147-157):
+   ```ts
+   workingDirectory: z.string().optional(),
+   ```
+5. Add it to `CreateRunOptions` (line ~169-175):
+   ```ts
+   workingDirectory: z.string().optional(),
+   ```
+
+> Note: the read-side `LegacyStartEvent` in `packages/core/src/runs/repo.ts:21-30` extends
+> `StartEvent`, so the new optional field is picked up automatically. No legacy change needed.
+
+### Step 2 — Persist work dir at run creation (`packages/core/src/runs/`)
+
+1. `runs/repo.ts` — extend `CreateRunRepoOptions` (line ~34) with
+   `workingDirectory?: string;`. In `create()` (the `start` event object, ~where
+   `subUseCase` is spread), include:
+   ```ts
+   ...(options.workingDirectory ? { workingDirectory: options.workingDirectory } : {}),
+   ```
+   Add the same spread to the returned `Run` object literal.
+2. `runs/repo.ts` — in `fetch()`, derive the current work dir as **the last
+   `workdir-changed` event's value, falling back to the start event's
+   `workingDirectory`**, and include it on the returned `Run`:
+   ```ts
+   const lastWorkdirEvent = [...events].reverse()
+       .find((e) => e.type === 'workdir-changed') as
+       | z.infer<typeof WorkdirChangedEvent> | undefined;
+   const workingDirectory = lastWorkdirEvent
+       ? (lastWorkdirEvent.workingDirectory || undefined)
+       : (start.workingDirectory || undefined);
+   // ...
+   ...(workingDirectory ? { workingDirectory } : {}),
+   ```
+   (Import `WorkdirChangedEvent` from `@x/shared/dist/runs.js`.)
+3. `runs/runs.ts` — `createRun()` (line ~31) passes `workingDirectory` through to
+   `repo.create({ ... })`:
+   ```ts
+   ...(opts.workingDirectory ? { workingDirectory: opts.workingDirectory } : {}),
+   ```
+4. `runs/runs.ts` — add a new exported function to change the work dir mid-chat:
+   ```ts
+   export async function setWorkdir(runId: string, workingDirectory: string | null): Promise<void> {
+       const repo = container.resolve<IRunsRepo>('runsRepo');
+       const event: z.infer<typeof WorkdirChangedEvent> = {
+           runId,
+           type: "workdir-changed",
+           subflow: [],
+           ...(workingDirectory ? { workingDirectory } : {}),
+       };
+       await repo.appendEvents(runId, [event]);
+   }
+   ```
+   (No `runtime.trigger()` — this only updates metadata; it'll be read on the next message.)
+
+### Step 3 — Runtime reads per-run work dir (`packages/core/src/agents/runtime.ts`)
+
+1. Add a field to `AgentState` (class at line 668, near `runSubUseCase`, line ~675):
+   ```ts
+   workingDirectory: string | null = null;
+   ```
+2. In `AgentState.ingest()` (line 773):
+   - In the `case "start":` block (line ~786-793) add:
+     ```ts
+     this.workingDirectory = event.workingDirectory ?? null;
+     ```
+   - Add a new case:
+     ```ts
+     case "workdir-changed":
+         this.workingDirectory = event.workingDirectory ?? null;
+         break;
+     ```
+3. Replace the global-file read at the injection site. At `runtime.ts:1125`, change:
+   ```ts
+   const userWorkDir = loadUserWorkDir();
+   ```
+   to:
+   ```ts
+   const userWorkDir = state.workingDirectory;
+   ```
+   Leave the rest of the prompt block (lines 1126-1146) unchanged.
+4. Delete the now-unused `loadUserWorkDir` function (lines 41-51) and the
+   `WORKDIR_CONFIG_FILE` constant (line 39).
+
+### Step 4 — IPC surface (`packages/shared/src/ipc.ts`)
+
+1. `runs:create` already uses `CreateRunOptions` as its `req` (line 176-179) — the new
+   optional field flows through automatically once Step 1 lands. No change needed there.
+2. Add a new channel `runs:setWorkdir`:
+   ```ts
+   'runs:setWorkdir': {
+     req: z.object({
+       runId: z.string(),
+       workingDirectory: z.string().nullable(),
+     }),
+     res: z.object({ success: z.literal(true) }),
+   },
+   ```
+3. Wire the handler in `apps/main/src/ipc.ts` (alongside the other `runs:*` handlers,
+   e.g. near line 509):
+   ```ts
+   'runs:setWorkdir': async (_event, args) => {
+     await runsCore.setWorkdir(args.runId, args.workingDirectory);
+     return { success: true as const };
+   },
+   ```
+   (Confirm the import name used for the runs core module — it's `runsCore` in the existing
+   `runs:createMessage` handler.)
+
+### Step 5 — Renderer: chat input reads/writes per-run (`apps/renderer/src/components/chat-input-with-mentions.tsx`)
+
+The component already has `runId` as a prop (lines 119/146/777/806) and already loads
+run-scoped data via `runs:fetch` for model-locking (lines 178-192) — mirror that pattern.
+
+1. **Load from the run, not the global file.** Replace `loadWorkDir` (lines 259-273) so it:
+   - If `runId` is set: `runs:fetch` and `setWorkDir(run.workingDirectory ?? null)`.
+   - If `runId` is null: do **not** read any global file. Instead reflect the tab-local
+     pending value supplied by the parent (see new props below). Default `null`.
+   Remove the `workspace:readFile` call on `config/workdir.json`.
+2. **Set / change.** In `handleSetWorkDir` (lines 275-292), after the user picks a folder:
+   - If `runId` is set: `await window.ipc.invoke('runs:setWorkdir', { runId, workingDirectory: chosen })`.
+   - If `runId` is null: call a new prop `onPendingWorkDirChange(chosen)` so the parent stores
+     it for this tab until the run is created.
+   - In both cases `setWorkDir(chosen)`.
+   Remove the `workspace:writeFile` to `config/workdir.json`.
+3. **Clear.** In `handleClearWorkDir` (lines 294-306), same branching with
+   `workingDirectory: null` / `onPendingWorkDirChange(null)`, then `setWorkDir(null)`.
+4. **Props.** Add to `ChatInputInnerProps` (line 111) and `ChatInputWithMentionsProps`
+   (line 766), and thread through the wrapper (line 795-833):
+   ```ts
+   pendingWorkDir?: string | null
+   onPendingWorkDirChange?: (dir: string | null) => void
+   ```
+   When `runId` is null, drive the displayed `workDir` from `pendingWorkDir`.
+
+### Step 6 — Renderer: hold pending work dir per tab + pass to run creation (`apps/renderer/src/App.tsx`)
+
+Mirror the existing per-tab model pattern (`selectedModelByTabRef`, line 972; cleared on
+tab close at line 2668; set/read at 2356, 5298-5300, 5358-5360).
+
+1. Add a tab-keyed store for the pending (pre-run) work dir. A ref works, but since the UI
+   must re-render when it changes, prefer state keyed by tab id, e.g.
+   `const [pendingWorkDirByTab, setPendingWorkDirByTab] = useState<Record<string, string | null>>({})`.
+2. Pass to each `<ChatInputWithMentions>` (lines 5282 and 5347):
+   ```tsx
+   pendingWorkDir={pendingWorkDirByTab[tab.id] ?? null}
+   onPendingWorkDirChange={(dir) =>
+     setPendingWorkDirByTab((prev) => ({ ...prev, [tab.id]: dir }))}
+   ```
+3. In the submit handler where the run is created (lines 2355-2372), pass the pending dir
+   into `runs:create`:
+   ```ts
+   const pendingWorkDir = pendingWorkDirByTab[submitTabId] ?? undefined
+   const run = await window.ipc.invoke('runs:create', {
+     agentId,
+     ...(selected ? { model: selected.model, provider: selected.provider } : {}),
+     ...(pendingWorkDir ? { workingDirectory: pendingWorkDir } : {}),
+   })
+   ```
+   After the run is created, the work dir lives on the run; clear the pending entry for that
+   tab (optional, keeps state tidy).
+4. On tab close (near line 2668) delete the tab's entry from `pendingWorkDirByTab`.
+
+### Step 7 — Cleanup / backward compatibility
+
+- No data migration required. Existing runs have no stored work dir → they show empty and
+  behave correctly going forward.
+- The global `config/workdir.json` is no longer read or written. Optionally delete it once
+  on startup so the stale value doesn't linger (low priority; safe to skip).
+- Grep to confirm no remaining readers/writers of `config/workdir.json` outside the files
+  changed above:
+  ```bash
+  grep -rn "workdir.json\|loadUserWorkDir\|WORKDIR_CONFIG_FILE" apps/x
+  ```
+
+## 5. Build & verify
+
+```bash
+cd apps/x && npm run deps     # rebuild shared -> core -> preload (schema + IPC changes)
+cd apps/x && npm run lint
+```
+
+Manual checks in dev (`cd apps/x && npm run dev`):
+1. New chat A → set work dir to /pathA. Open a new chat B → it shows **no** work dir.
+2. In chat A, send a message → agent should treat /pathA as the work dir (check the
+   injected "User Work Directory" block / `loopLogger` "injecting user work directory").
+3. Reopen chat B, set /pathB → chat A still shows /pathA (reopen A to confirm).
+4. In chat A, change to /pathC mid-conversation → next message uses /pathC; earlier behavior
+   unaffected. Clear it → subsequent messages have no work dir injected.
+5. Reload the app and reopen chat A → it still shows its last work dir (persisted on the run
+   log via `workdir-changed` / start event).
+
+## 6. Touched files summary
+
+| File | Change |
+|---|---|
+| `packages/shared/src/runs.ts` | Add `workingDirectory` to `StartEvent`, `Run`, `CreateRunOptions`; add `WorkdirChangedEvent` + add to union. |
+| `packages/shared/src/ipc.ts` | Add `runs:setWorkdir` channel. |
+| `packages/core/src/runs/repo.ts` | Persist `workingDirectory` in `create()`; derive latest in `fetch()`. |
+| `packages/core/src/runs/runs.ts` | Pass through in `createRun()`; add `setWorkdir()`. |
+| `packages/core/src/agents/runtime.ts` | `AgentState.workingDirectory`; ingest start + `workdir-changed`; inject `state.workingDirectory`; remove `loadUserWorkDir` + `WORKDIR_CONFIG_FILE`. |
+| `apps/main/src/ipc.ts` | Handler for `runs:setWorkdir`. |
+| `apps/renderer/src/components/chat-input-with-mentions.tsx` | Read/write per-run (via `runs:fetch` / `runs:setWorkdir`); new `pendingWorkDir` + `onPendingWorkDirChange` props; drop global-file I/O. |
+| `apps/renderer/src/App.tsx` | Per-tab pending work dir state; pass to `runs:create`; clear on tab close. |


### PR DESCRIPTION
## Summary

The chat **work directory** was stored in a single shared config file (`config/workdir.json`). Because both the UI and the agent runtime read/wrote that one file, setting the work directory in one chat changed it for **every** chat, and new chats inherited a stale value.

This change makes the work directory **run-scoped**:

- Captured on the run's `start` event at creation, and updatable mid-chat via an appended `workdir-changed` event (append-only log, last write wins).
- The agent runtime reads the per-run value from `AgentState` instead of the global file.
- The chat input reads the directory from the run (`runs:fetch`) and writes it back via a new `runs:setWorkdir` IPC; for a chat that doesn't exist yet, the chosen directory is held per-tab and passed into `runs:create`.
- New chats start with **no** work directory. The value persists across app restarts because it lives in the run log on disk.

## Notes

- Starting clean (no migration): chats that had a work directory set under the old global file won't carry it over, since that value is no longer read. They'll show empty until set once, then persist normally.

## Test plan

- [ ] Set a work dir in chat A, open a new chat B → B has no work dir
- [ ] Set different dirs in chats A and B → each retains its own
- [ ] Change/clear the work dir mid-chat → the next message uses the new value
- [ ] Restart the app and reopen a chat → its work dir persists
- [ ] Confirm the agent uses the per-run dir for generic file operations
