### PR TITLE
Oauth migration

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -51,6 +51,7 @@ import {
   extractDeepLinkFromArgv,
   setMainWindowForDeepLinks,
 } from "./deeplink.js";
+import { disconnectGoogleIfScopesStale } from "./oauth-handler.js";
 
 const execAsync = promisify(exec);
 
@@ -350,6 +351,11 @@ app.whenReady().then(async () => {
   registerConsumer(liveNoteEventConsumer);
   registerConsumer(backgroundTaskEventConsumer);
   initEventProcessor();
+
+  // If the stored Google grant predates a scope change (only old scopes),
+  // disconnect it now so the user re-connects with the current scopes before
+  // any Google sync runs against the stale grant.
+  await disconnectGoogleIfScopesStale();
 
   // start gmail sync
   initGmailSync();

--- a/apps/x/apps/main/src/oauth-handler.ts
+++ b/apps/x/apps/main/src/oauth-handler.ts
@@ -535,21 +535,29 @@ export async function disconnectProvider(provider: string): Promise<{ success: b
 /**
  * Startup migration for Google scope changes. When a connected Google grant was
  * issued before a scope was added (e.g. old installs on gmail.readonly that
- * never received gmail.modify), disconnect it so the renderer re-prompts the
- * user through the normal connect flow and they re-grant with the current
- * scopes. The currently-requested scopes in the provider config are the source
- * of truth: a grant missing any of them is treated as stale.
+ * never received gmail.modify), invalidate it so the user is prompted to
+ * reconnect and re-grant with the current scopes. The currently-requested
+ * scopes in the provider config are the source of truth: a grant missing any
+ * of them is treated as stale.
+ *
+ * We revoke + clear the stale token but DELIBERATELY keep the provider entry
+ * with an `error` set rather than calling disconnectProvider (which deletes the
+ * whole entry). The renderer's reconnect prompts — the sidebar "Reconnect your
+ * accounts" alert and the connectors "Reconnect" row — key off this `error`
+ * field, not off the connected flag. A fully deleted entry has no error and is
+ * indistinguishable from "never connected", so no prompt would ever appear.
  *
  * Tokens with no recorded scopes (very old installs that never persisted them)
  * are also treated as stale. Safe to call on every startup — it's a no-op once
- * the grant covers all current scopes.
+ * the grant covers all current scopes, and once invalidated the early return on
+ * the missing token keeps it from re-running until the user reconnects.
  */
 export async function disconnectGoogleIfScopesStale(): Promise<void> {
   try {
     const oauthRepo = getOAuthRepo();
     const connection = await oauthRepo.read('google');
 
-    // Not connected — nothing to migrate.
+    // Not connected (or already invalidated) — nothing to migrate.
     if (!connection.tokens) {
       return;
     }
@@ -568,9 +576,32 @@ export async function disconnectGoogleIfScopesStale(): Promise<void> {
 
     console.log(
       `[OAuth] Google grant is missing current scopes [${missingScopes.join(', ')}]; ` +
-      'disconnecting so the user can reconnect with the new scopes.'
+      'invalidating it so the user is prompted to reconnect with the new scopes.'
     );
-    await disconnectProvider('google');
+
+    // Best-effort revoke at Google for rowboat-mode grants (mirrors disconnectProvider).
+    if (connection.mode === 'rowboat' && connection.tokens.access_token) {
+      try {
+        const revokeUrl = `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(connection.tokens.access_token)}`;
+        const res = await fetch(revokeUrl, { method: 'POST', signal: AbortSignal.timeout(5000) });
+        if (!res.ok) {
+          console.warn(`[OAuth] Google revoke returned ${res.status}; continuing with local invalidation`);
+        }
+      } catch (error) {
+        console.warn('[OAuth] Google revoke failed; continuing with local invalidation:', error);
+      }
+    }
+
+    // Drop the stale token but keep the entry with an error so the reconnect
+    // prompt fires (see the note above).
+    await oauthRepo.upsert('google', {
+      tokens: null,
+      error: 'Google permissions changed. Please reconnect to continue.',
+    });
+
+    // Nudge any already-open window to re-read state. The renderer's initial
+    // mount also re-reads, so the prompt shows even if no window is up yet.
+    emitOAuthEvent({ provider: 'google', success: false });
   } catch (error) {
     console.error('[OAuth] Google scope migration check failed:', error);
   }

--- a/apps/x/apps/main/src/oauth-handler.ts
+++ b/apps/x/apps/main/src/oauth-handler.ts
@@ -508,7 +508,7 @@ export async function disconnectProvider(provider: string): Promise<{ success: b
       if (connection.mode === 'rowboat' && connection.tokens?.access_token) {
         try {
           const revokeUrl = `https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(connection.tokens.access_token)}`;
-          const res = await fetch(revokeUrl, { method: 'POST' });
+          const res = await fetch(revokeUrl, { method: 'POST', signal: AbortSignal.timeout(5000) });
           if (!res.ok) {
             console.warn(`[OAuth] Google revoke returned ${res.status}; continuing with local disconnect`);
           }
@@ -529,6 +529,50 @@ export async function disconnectProvider(provider: string): Promise<{ success: b
   } catch (error) {
     console.error('OAuth disconnect failed:', error);
     return { success: false };
+  }
+}
+
+/**
+ * Startup migration for Google scope changes. When a connected Google grant was
+ * issued before a scope was added (e.g. old installs on gmail.readonly that
+ * never received gmail.modify), disconnect it so the renderer re-prompts the
+ * user through the normal connect flow and they re-grant with the current
+ * scopes. The currently-requested scopes in the provider config are the source
+ * of truth: a grant missing any of them is treated as stale.
+ *
+ * Tokens with no recorded scopes (very old installs that never persisted them)
+ * are also treated as stale. Safe to call on every startup — it's a no-op once
+ * the grant covers all current scopes.
+ */
+export async function disconnectGoogleIfScopesStale(): Promise<void> {
+  try {
+    const oauthRepo = getOAuthRepo();
+    const connection = await oauthRepo.read('google');
+
+    // Not connected — nothing to migrate.
+    if (!connection.tokens) {
+      return;
+    }
+
+    const providerConfig = await getProviderConfig('google');
+    const requiredScopes = providerConfig.scopes ?? [];
+    if (requiredScopes.length === 0) {
+      return;
+    }
+
+    const granted = new Set(connection.tokens.scopes ?? []);
+    const missingScopes = requiredScopes.filter((scope) => !granted.has(scope));
+    if (missingScopes.length === 0) {
+      return;
+    }
+
+    console.log(
+      `[OAuth] Google grant is missing current scopes [${missingScopes.join(', ')}]; ` +
+      'disconnecting so the user can reconnect with the new scopes.'
+    );
+    await disconnectProvider('google');
+  } catch (error) {
+    console.error('[OAuth] Google scope migration check failed:', error);
   }
 }
 


### PR DESCRIPTION
---
  Summary

  Adds a startup migration that forces existing Google connections onto the current OAuth scope set.
  When the app launches, if a connected Google account is missing any scope the app now requires (e.g.
   older grants on gmail.readonly that never received gmail.modify), the stale grant is revoked +
  cleared and the connection is flagged so the user is prompted to reconnect.

  Motivation: We changed the requested Google scopes (gmail.readonly → gmail.modify, dropped
  drive.readonly — commit 84aa9808). Users who authed before that change hold tokens without
  gmail.modify, so the new Gmail features (send/archive/delete) don't work. There was no mechanism to
  move them onto the new scopes; they'd silently stay on the old grant. This adds that mechanism.

  Changes

  apps/main/src/oauth-handler.ts
  - New exported disconnectGoogleIfScopesStale():
    - Reads the stored google connection. No-op if there's no token (not connected, or already
  invalidated by a prior run).
    - Treats the scopes in the provider config (providers.ts → google.scopes) as the source of truth.
  Computes missingScopes = required − granted. No-op if nothing is missing (so it's idempotent and a
  no-op once the grant is current).
    - If scopes are missing: best-effort revoke at Google (rowboat mode only, 5s timeout), then
  upsert('google', { tokens: null, error: 'Google permissions changed. Please reconnect to continue.'
  }), then emits the OAuth event.
  - Added a 5s AbortSignal.timeout to the existing revoke fetch in disconnectProvider (defensive —
  keeps a hung revoke from stalling things).

  apps/main/src/main.ts
  - Imports and awaits disconnectGoogleIfScopesStale() during startup, before initGmailSync() /
  initCalendarSync(), so the stale grant is invalidated before any Google sync runs against it.

  Key design decision (please review this part)

  The migration deliberately does not call disconnectProvider (which does oauthRepo.delete('google')
  and removes the whole entry). Instead it keeps the entry and sets an error.

  Reason: every reconnect prompt in the renderer keys off the connection's error field, not off
  connected === false:
  - Sidebar "Reconnect your accounts" alert — sidebar-content.tsx hasOauthError = some(entry.error)
  - Connectors "Reconnect" row — connectors-popover.tsx needsReconnect = Boolean(error)

  A fully-deleted entry has no error and is indistinguishable from "never connected," so no prompt
  would fire. By clearing tokens but persisting error, the renderer's initial mount fetch
  (oauth:getState) sees the error and auto-opens the reconnect dialog (showOauthAlert defaults to
  true). This matches the existing token-refresh-failure path, which sets error: 'Reconnect Google'
  while keeping the entry.

  User-initiated disconnects are unchanged — they still fully delete the entry, which is correct (an
  explicit disconnect shouldn't leave a reconnect nag).

  Behavior notes / edge cases

  - Modes: In BYOK mode the desktop's providers.ts scopes drive consent directly. In rowboat
  (signed-in) mode the scopes come from the backend's grant — the check still correctly flags any
  token missing a required scope; the backend must already request the new scope for the subsequent
  reconnect to grant it (it does).
  - Idempotent: After invalidation, tokens is null so the early return prevents re-running. The
  persisted error keeps the prompt showing across restarts until the user reconnects; reconnect clears
   the error (startConnect → error: null).
  - No-scope tokens: very old tokens that never recorded scopes are treated as stale (missing
  everything) and invalidated.
  - All failures are caught/logged; the migration can never break startup.

  Tradeoff to be aware of

  This is a hard cutoff: clearing the token stops Gmail/Calendar sync until the user reconnects. If
  we'd rather keep the old readonly grant working as a graceful nudge (sync keeps running, prompt just
   enables the new features), drop tokens: null from the upsert. Flagging for reviewer preference.

  Testing

  1. Point the app at a workdir whose config/oauth.json has a google token without gmail.modify in
  tokens.scopes (an old grant, or hand-edit to remove it).
  2. Launch the app. Expected: log line [OAuth] Google grant is missing current scopes [...];
  invalidating it..., the "Reconnect your accounts" dialog auto-opens, and oauth.json's google entry
  now has tokens: null + the error.
  3. Click Reconnect → full OAuth flow → grant includes gmail.modify, error cleared, prompt gone.
  4. Relaunch with a token that already has all current scopes → no-op, no prompt.