### PR TITLE
fix(ci): make electron release artifacts deterministic

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
           cache-dependency-path: 'apps/x/pnpm-lock.yaml'
 
@@ -111,6 +111,7 @@ jobs:
         with:
           name: distributables
           path: apps/x/apps/main/out/make/*
+          if-no-files-found: error
           retention-days: 30
 
   build-linux:
@@ -128,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
           cache-dependency-path: 'apps/x/pnpm-lock.yaml'
 
@@ -175,6 +176,7 @@ jobs:
         with:
           name: distributables-linux
           path: apps/x/apps/main/out/make/*
+          if-no-files-found: error
           retention-days: 30
 
   build-windows:
@@ -192,7 +194,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
           cache-dependency-path: 'apps/x/pnpm-lock.yaml'
 
@@ -241,4 +243,5 @@ jobs:
         with:
           name: distributables-windows
           path: apps/x/apps/main/out/make/*
+          if-no-files-found: error
           retention-days: 30


### PR DESCRIPTION
Pin Electron release builds to Node 24.15.0, the last known-good runner version for Windows/Linux packaging, and fail artifact upload when out/make is empty so successful jobs cannot hide missing release assets.