### PR TITLE
added icon and rowboat url scheme handler to linux packages

### DIFF
--- a/apps/x/apps/main/forge.config.cjs
+++ b/apps/x/apps/main/forge.config.cjs
@@ -66,7 +66,9 @@ module.exports = {
                     bin: "rowboat",
                     description: 'AI coworker with memory',
                     maintainer: 'rowboatlabs',
-                    homepage: 'https://rowboatlabs.com'
+                    homepage: 'https://rowboatlabs.com',
+                    icon: path.join(__dirname, 'icons/icon.png'),
+                    mimeType: ['x-scheme-handler/rowboat'],
                 }
             })
         },
@@ -77,7 +79,9 @@ module.exports = {
                     name: `Rowboat-linux`,
                     bin: "rowboat",
                     description: 'AI coworker with memory',
-                    homepage: 'https://rowboatlabs.com'
+                    homepage: 'https://rowboatlabs.com',
+                    icon: path.join(__dirname, 'icons/icon.png'),
+                    mimeType: ['x-scheme-handler/rowboat'],
                 }
             }
         },


### PR DESCRIPTION
### Summary                                                                                                                                                                                                          
                  
  Adds Linux package-level registration for the rowboat:// deep link URL scheme and an app icon to the .deb and .rpm makers in apps/x/apps/main/forge.config.cjs.
                                                                                                                                                                                                                   
  Without this, the OS / desktop environment has no way to route rowboat:// links to the app on a freshly installed Linux system, and the installed app has no icon in launchers/menus.                            
                                                                                                                                                                                                                   
 ### What changed                                                                                                                                                                                                     
                  
  apps/x/apps/main/forge.config.cjs — added icon and mimeType to both Linux maker configs:                                                                                                                         
                  
  - DEB maker (@electron-forge/maker-deb)                                                                                                                                                                          
  - RPM maker (@electron-forge/maker-rpm)
                                                                                                                                                                                                                   
  icon: path.join(__dirname, 'icons/icon.png'),
  mimeType: ['x-scheme-handler/rowboat'],                                                                                                                                                                          
   
  The icon already exists at apps/x/apps/main/icons/icon.png (used by the existing macOS config).                                                                                                                  
                  
  ### Why                                                                                                                                                                                                              
                  
  The Rowboat app already registers itself as the handler for rowboat:// URLs at runtime via app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME) in apps/x/apps/main/src/main.ts:76-81. This is sufficient on macOS   
  and Windows, but on Linux the OS-level URL scheme association is driven by .desktop files and the MimeType= field they declare. Electron's runtime API can't reliably create or modify these entries from inside
  a sandboxed/installed app.                                                                                                                                                                                       
                  
  Declaring mimeType: ['x-scheme-handler/rowboat'] in the maker config bakes the scheme association into the package's .desktop file at build time, so:                                                            
   
  - Clicking a rowboat:// link from a browser, terminal, or another app routes to Rowboat from the moment the package is installed — without requiring the user to open the app first.                             
  - OAuth flows like rowboat://oauth/google/done?session=<state> (see apps/x/apps/main/src/deeplink.ts:35, apps/x/apps/main/src/oauth-handler.ts:467) work correctly on Linux installations.
                                                                                                                                                                                                                   
  The icon field ensures the installed app shows the Rowboat icon in the application menu / launcher, matching the macOS experience.                                                                               
                                                                                                                                                                                                                   
  ### Affected platforms                                                                                                                                                                                               
                  
  - Linux (.deb — Debian/Ubuntu)
  - Linux (.rpm — Fedora/RHEL)
  - No changes to macOS or Windows builds.                                                                                                                                                                         
   
  ### Test plan                                                                                                                                                                                                        
                  
  - Build a .deb: cd apps/x/apps/main && npm run make on Linux; verify the generated .desktop file contains MimeType=x-scheme-handler/rowboat; and Icon= points to the bundled icon.                               
  - Install the .deb on a clean Ubuntu VM; verify the Rowboat icon appears in the app menu.
  - From a terminal on the same VM, run xdg-open "rowboat://action/test" and verify it launches Rowboat and routes through deeplink.ts.                                                                            
  - Trigger a Google OAuth flow end-to-end on Linux; verify the rowboat://oauth/google/done?session=... callback returns control to the app.                                                                       
  - Repeat the install/launch/deep-link tests with the .rpm on a Fedora VM.                                                                                                                                        
  - macOS build still produces a working .app (no regressions in forge.config.cjs).                                                                                                                                
                                                                                                                                                                                                                   
  ---                                                          