### PR TITLE
fix(mcp): forward configured headers to HTTP MCP transports

### DIFF
--- a/apps/cli/src/mcp/mcp.ts
+++ b/apps/cli/src/mcp/mcp.ts
@@ -20,6 +20,20 @@ type mcpState = {
 };
 const clients: Record<string, mcpState> = {};
 
+async function connectClient(transport: Transport): Promise<Client> {
+    const client = new Client({
+        name: 'rowboatx',
+        version: '1.0.0',
+    });
+    try {
+        await client.connect(transport);
+    } catch (error) {
+        await transport.close().catch(() => undefined);
+        throw error;
+    }
+    return client;
+}
+
 async function getClient(serverName: string): Promise<Client> {
     if (clients[serverName] && clients[serverName].state === "connected") {
         return clients[serverName].client!;
@@ -30,34 +44,25 @@ async function getClient(serverName: string): Promise<Client> {
     if (!config) {
         throw new Error(`MCP server ${serverName} not found`);
     }
-    let transport: Transport | undefined = undefined;
     try {
-        // create transport
+        let client: Client;
         if ("command" in config) {
-            transport = new StdioClientTransport({
+            client = await connectClient(new StdioClientTransport({
                 command: config.command,
                 args: config.args,
                 env: config.env,
-            });
+            }));
         } else {
+            const url = new URL(config.url);
+            // forward configured headers (e.g. Authorization) to the transport
+            const requestInit = config.headers ? { headers: config.headers } : undefined;
             try {
-                transport = new StreamableHTTPClientTransport(new URL(config.url));
+                client = await connectClient(new StreamableHTTPClientTransport(url, { requestInit }));
             } catch (error) {
                 // if that fails, try sse transport
-                transport = new SSEClientTransport(new URL(config.url));
+                client = await connectClient(new SSEClientTransport(url, { requestInit }));
             }
         }
-
-        if (!transport) {
-            throw new Error(`No transport found for ${serverName}`);
-        }
-
-        // create client
-        const client = new Client({
-            name: 'rowboatx',
-            version: '1.0.0',
-        });
-        await client.connect(transport);
 
         // store
         clients[serverName] = {
@@ -72,7 +77,6 @@ async function getClient(serverName: string): Promise<Client> {
             client: null,
             error: error instanceof Error ? error.message : "Unknown error",
         };
-        transport?.close();
         throw error;
     }
 }

--- a/apps/x/packages/core/src/mcp/mcp.ts
+++ b/apps/x/packages/core/src/mcp/mcp.ts
@@ -19,6 +19,20 @@ type mcpState = {
 };
 const clients: Record<string, mcpState> = {};
 
+async function connectClient(transport: Transport): Promise<Client> {
+    const client = new Client({
+        name: 'rowboatx',
+        version: '1.0.0',
+    });
+    try {
+        await client.connect(transport);
+    } catch (error) {
+        await transport.close().catch(() => undefined);
+        throw error;
+    }
+    return client;
+}
+
 async function getClient(serverName: string): Promise<Client> {
     if (clients[serverName] && clients[serverName].state === "connected") {
         return clients[serverName].client!;
@@ -29,34 +43,25 @@ async function getClient(serverName: string): Promise<Client> {
     if (!config) {
         throw new Error(`MCP server ${serverName} not found`);
     }
-    let transport: Transport | undefined = undefined;
     try {
-        // create transport
+        let client: Client;
         if ("command" in config) {
-            transport = new StdioClientTransport({
+            client = await connectClient(new StdioClientTransport({
                 command: config.command,
                 args: config.args,
                 env: config.env,
-            });
+            }));
         } else {
+            const url = new URL(config.url);
+            // forward configured headers (e.g. Authorization) to the transport
+            const requestInit = config.headers ? { headers: config.headers } : undefined;
             try {
-                transport = new StreamableHTTPClientTransport(new URL(config.url));
+                client = await connectClient(new StreamableHTTPClientTransport(url, { requestInit }));
             } catch {
                 // if that fails, try sse transport
-                transport = new SSEClientTransport(new URL(config.url));
+                client = await connectClient(new SSEClientTransport(url, { requestInit }));
             }
         }
-
-        if (!transport) {
-            throw new Error(`No transport found for ${serverName}`);
-        }
-
-        // create client
-        const client = new Client({
-            name: 'rowboatx',
-            version: '1.0.0',
-        });
-        await client.connect(transport);
 
         // store
         clients[serverName] = {
@@ -71,7 +76,6 @@ async function getClient(serverName: string): Promise<Client> {
             client: null,
             error: error instanceof Error ? error.message : "Unknown error",
         };
-        transport?.close();
         throw error;
     }
 }


### PR DESCRIPTION
## Problem

Fixes #580.

HTTP MCP servers configured with `headers` in `config/mcp.json` fail to connect. The config schema (`HttpMcpServerConfig`) explicitly supports a `headers` field, but `getClient()` in both `apps/x/packages/core/src/mcp/mcp.ts` and `apps/cli/src/mcp/mcp.ts` never passes it to the transport — so `Authorization` (or any other header) is silently dropped and authenticated servers reject the handshake:

```json
{
  "mcpServers": {
    "my-server": {
      "url": "https://example.com/mcp",
      "headers": { "Authorization": "Bearer token" }
    }
  }
}
```

There is a second, related problem in the same code path: the SSE fallback is dead code. The `try/catch` wraps only the **constructors**, which don't perform any network I/O — the actual connection happens later at `client.connect(transport)`, outside the inner `try`. So a server that only supports the legacy SSE transport can never connect either.

## Solution

- Pass `{ requestInit: { headers: config.headers } }` to both `StreamableHTTPClientTransport` and `SSEClientTransport`. The SDK merges these into every request (initial POST, GET stream, and SSE message POSTs) and sets its own `Accept` headers after the merge, so spec-required headers can't be clobbered.
- Move the fallback boundary from transport construction to `client.connect()`: try Streamable HTTP first, and only if connecting fails, retry with SSE — mirroring what `apps/rowboat/app/lib/mcp.ts` already does. The failed transport is closed before retrying.

Same fix applied to the duplicated client in `apps/cli` (separate commit).

## Testing

- `cd apps/x && npm run deps` — compiles clean; `eslint packages/core/src/mcp/mcp.ts` — no issues. `apps/cli` `tsc` build also clean.
- Manual verification against a local MCP server (SDK `StreamableHTTPServerTransport`) that requires `Authorization: Bearer <token>`:
  - with this patch the client connects, lists tools, and calls a tool successfully;
  - negative control (no headers forwarded — the old behavior) is rejected with 401, reproducing the issue.
- SSE fallback verified against a legacy SSE-only server (SDK `SSEServerTransport`) that answers Streamable HTTP initialize POSTs with 405: the client now falls back to SSE, connects, and the configured headers are present on both the GET stream and message POSTs.