### PR TITLE
fix(bus): guard indexOf in InMemoryBus unsubscribe to prevent splice(-1)

### DIFF
--- a/apps/x/packages/core/src/application/lib/bus.test.ts
+++ b/apps/x/packages/core/src/application/lib/bus.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type z from "zod";
+import { RunEvent } from "@x/shared/dist/runs.js";
+import { InMemoryBus } from "./bus.js";
+
+function makeEvent(runId: string): z.infer<typeof RunEvent> {
+    return {
+        type: "run-processing-start",
+        runId,
+        subflow: [],
+    } as z.infer<typeof RunEvent>;
+}
+
+describe("InMemoryBus", () => {
+    it("delivers events to all handlers subscribed to a runId", async () => {
+        const bus = new InMemoryBus();
+        const a = vi.fn(async () => {});
+        const b = vi.fn(async () => {});
+
+        await bus.subscribe("run-1", a);
+        await bus.subscribe("run-1", b);
+        await bus.publish(makeEvent("run-1"));
+
+        expect(a).toHaveBeenCalledTimes(1);
+        expect(b).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops delivering to a handler after it unsubscribes", async () => {
+        const bus = new InMemoryBus();
+        const a = vi.fn(async () => {});
+
+        const unsubscribe = await bus.subscribe("run-1", a);
+        unsubscribe();
+        await bus.publish(makeEvent("run-1"));
+
+        expect(a).not.toHaveBeenCalled();
+    });
+
+    it("treats double-unsubscribe as a no-op and keeps other handlers (#491)", async () => {
+        const bus = new InMemoryBus();
+        const a = vi.fn(async () => {});
+        const b = vi.fn(async () => {});
+
+        const unsubscribeA = await bus.subscribe("run-1", a);
+        await bus.subscribe("run-1", b);
+
+        unsubscribeA();
+        unsubscribeA(); // second call must not remove handler b
+
+        await bus.publish(makeEvent("run-1"));
+
+        expect(a).not.toHaveBeenCalled();
+        expect(b).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/x/packages/core/src/application/lib/bus.ts
+++ b/apps/x/packages/core/src/application/lib/bus.ts
@@ -29,7 +29,10 @@ export class InMemoryBus implements IBus {
         }
         this.subscribers.get(runId)!.push(handler);
         return () => {
-            this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
+            const handlers = this.subscribers.get(runId);
+            if (!handlers) return;
+            const idx = handlers.indexOf(handler);
+            if (idx >= 0) handlers.splice(idx, 1);
         };
     }
 }


### PR DESCRIPTION
## Problem

Closes #491.

The desktop app's `InMemoryBus` (`apps/x/packages/core/src/application/lib/bus.ts`) builds its unsubscribe closure as:

```ts
this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
```

`indexOf` is not checked for `-1`. If `unsubscribe()` is called twice (or after the handler is already gone), `indexOf` returns `-1` and `splice(-1, 1)` silently removes the **last** handler in the array — a different, still-active subscriber.

Reproduction:
1. Subscribe two handlers `a` and `b` to the same `runId`.
2. Call `a`'s unsubscribe.
3. Call `a`'s unsubscribe again.
4. `b` is now gone, so it no longer receives published events.

## Solution

Guard both the missing-`runId` entry and the `-1` index so a repeated unsubscribe is a true no-op:

```ts
const handlers = this.subscribers.get(runId);
if (!handlers) return;
const idx = handlers.indexOf(handler);
if (idx >= 0) handlers.splice(idx, 1);
```

This matches the pattern already used by the other buses in the same package (`background-tasks/bus.ts`, `knowledge/live-note/bus.ts`).

Note: the CLI bus has an identical bug tracked separately in #492 — this PR only touches the desktop app bus for #491.

## Testing

Added `bus.test.ts` covering event delivery, single unsubscribe, and the double-unsubscribe no-op regression.

```
$ npx vitest run src/application/lib/bus.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`npm run build` (tsc) passes.