### PR TITLE
fix: keep light canvas for styled emails in dark mode

### DIFF
--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -300,7 +300,10 @@ function buildEmailDocument(
   opts: { theme: 'light' | 'dark'; adaptToTheme: boolean },
 ): string {
   const useDark = opts.theme === 'dark' && opts.adaptToTheme
-  const colorScheme = opts.theme === 'dark' ? 'light dark' : 'light'
+  // Only opt into the dark color scheme when the email actually adapts to the
+  // theme — otherwise Chromium paints the canvas dark under emails that
+  // assume a white background.
+  const colorScheme = useDark ? 'light dark' : 'light'
   const bodyColor = useDark ? '#d4d4d8' : '#202124'
   const linkColor = useDark ? '#a78bfa' : '#1a73e8'
   const quoteBorder = useDark ? '#2e2e35' : '#dadce0'


### PR DESCRIPTION
  fix: keep light canvas for styled emails in dark mode
  
  Styled HTML emails (newsletters, branded mail) were unreadable in dark mode — dark gray text on a near-black background.

  Root cause: buildEmailDocument() declared color-scheme: light dark on the iframe document whenever the app theme was dark, even for styled emails that are meant to keep their white "paper" look. Chromium
  resolves the document to the dark scheme and paints an opaque dark canvas, overriding the background: transparent on the body. Emails that assume a white canvas then render with dark-on-dark text.

  Fix: Only declare color-scheme: light dark when useDark is true — i.e., when the email has no custom styling and actually adapts to the app theme. Styled emails now always resolve to the light scheme and get
  the white canvas their layout expects. Plain Gmail-style replies are unaffected and still adapt to dark mode.

