### PR TITLE
fix(rag-worker): use deterministic embedding point ids to avoid orphaned duplicate vectors

### DIFF
--- a/apps/rowboat/app/scripts/rag-worker.ts
+++ b/apps/rowboat/app/scripts/rag-worker.ts
@@ -61,6 +61,27 @@ async function retryable<T>(fn: () => Promise<T>, maxAttempts: number = 3): Prom
     }
 }
 
+// Fixed namespace for deriving deterministic Qdrant point IDs (RFC 4122 v5).
+const EMBEDDING_ID_NAMESPACE = 'a4d1f3e2-7b6c-5a4d-9e8f-1c2b3a4d5e6f';
+
+/**
+ * Derives a stable, deterministic point ID for an embedding from its document
+ * id and chunk index. Re-processing the same document chunk (e.g. when a job is
+ * retried after the Qdrant upsert succeeded but a later step failed) produces
+ * the same id, so the upsert overwrites the existing point instead of inserting
+ * a duplicate. Returns a valid UUID, as required by `EmbeddingRecord.id`.
+ */
+function embeddingPointId(docId: string, chunkIndex: number): string {
+    const namespace = Buffer.from(EMBEDDING_ID_NAMESPACE.replace(/-/g, ''), 'hex');
+    const name = Buffer.from(`${docId}-chunk-${chunkIndex}`, 'utf8');
+    const hash = crypto.createHash('sha1').update(namespace).update(name).digest();
+    const bytes = hash.subarray(0, 16);
+    bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+    const hex = bytes.toString('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 async function runProcessFilePipeline(_logger: PrefixLogger, usageTracker: UsageTracker, job: z.infer<typeof DataSource>, doc: z.infer<typeof DataSourceDoc>) {
     if (doc.data.type !== 'file_local' && doc.data.type !== 'file_s3') {
         throw new Error("Invalid data source type");

--- a/apps/rowboat/app/scripts/rag-worker.ts
+++ b/apps/rowboat/app/scripts/rag-worker.ts
@@ -174,7 +174,7 @@ async function runProcessFilePipeline(_logger: PrefixLogger, usageTracker: Usage
     // store embeddings in qdrant
     logger.log("Storing embeddings in Qdrant");
     const points: z.infer<typeof EmbeddingRecord>[] = embeddings.map((embedding, i) => ({
-        id: crypto.randomUUID(),
+        id: embeddingPointId(doc.id, i),
         vector: embedding,
         payload: {
             projectId: job.projectId,
@@ -243,7 +243,7 @@ async function runScrapePipeline(_logger: PrefixLogger, usageTracker: UsageTrack
     // store embeddings in qdrant
     logger.log("Storing embeddings in Qdrant");
     const points: z.infer<typeof EmbeddingRecord>[] = embeddings.map((embedding, i) => ({
-        id: crypto.randomUUID(),
+        id: embeddingPointId(doc.id, i),
         vector: embedding,
         payload: {
             projectId: job.projectId,
@@ -295,7 +295,7 @@ async function runProcessTextPipeline(_logger: PrefixLogger, usageTracker: Usage
     // store embeddings in qdrant
     logger.log("Storing embeddings in Qdrant");
     const points: z.infer<typeof EmbeddingRecord>[] = embeddings.map((embedding, i) => ({
-        id: crypto.randomUUID(),
+        id: embeddingPointId(doc.id, i),
         vector: embedding,
         payload: {
             projectId: job.projectId,


### PR DESCRIPTION
## Problem

Closes #603.

The RAG worker writes embeddings to Qdrant and then updates the document record in MongoDB as two separate network calls. Point IDs are generated with `crypto.randomUUID()` on every run:

```ts
const points = embeddings.map((embedding, i) => ({
    id: crypto.randomUUID(),
    // ...
}));
await qdrantClient.upsert("embeddings", { points });
await dataSourceDocsRepository.updateByVersion(/* ... */);
```

If the Qdrant upsert succeeds but a later step fails (MongoDB timeout, connection drop, version conflict), the worker throws and the document becomes eligible for retry. On retry, fresh random UUIDs are generated, so a **new** set of points is inserted while the originals remain in the collection — the app no longer holds any reference to them. Over time this accumulates orphaned duplicate vectors that:

- return duplicate chunks during vector search,
- waste context space and degrade retrieval quality,
- grow unbounded with no tracking.

The same pattern is present in all three pipelines: `runProcessFilePipeline`, `runScrapePipeline`, and `runProcessTextPipeline`.

## Solution

Derive each point ID deterministically from the document id and chunk index instead of generating a random UUID per run:

```ts
id: embeddingPointId(doc.id, i),
```

`embeddingPointId()` produces an RFC 4122 v5 (name-based) UUID from `${docId}-chunk-${chunkIndex}` under a fixed namespace. Because the same chunk always maps to the same id, a retry **upserts over** the existing points rather than inserting duplicates — the operation becomes idempotent. The return value is a valid UUID, which `EmbeddingRecord.id` (`z.string().uuid()`) requires.

The helper is dependency-free (uses the already-imported Node `crypto` module), so no new packages are added. Deletion (`runDeletionPipeline`) filters by the `docId` payload field rather than by point id, so it is unaffected.

## Testing

The repo has no test harness, so I verified the helper's behavior in isolation:

- **Deterministic** — `embeddingPointId("doc123", 0)` returns the same id across calls.
- **Unique per chunk / per doc** — different chunk index or doc id yields a different id.
- **Valid v5 UUID** — output matches `^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`, satisfying `EmbeddingRecord`.

Re-running any pipeline for the same document now overwrites the existing points in Qdrant instead of adding a duplicate set.