### PR TITLE
fix(code-mode): use System32 bsdtar to extract engines on Windows

### DIFF
--- a/apps/x/packages/core/src/code-mode/acp/engine-provisioner.ts
+++ b/apps/x/packages/core/src/code-mode/acp/engine-provisioner.ts
@@ -189,7 +189,29 @@ function verifyIntegrity(file: string, integrity: string): void {
 // contents land directly in destDir. Uses the system tar (bsdtar on macOS/Windows 10+,
 // GNU tar on Linux) — all support -xzf and --strip-components.
 function extractTarball(tarPath: string, destDir: string): void {
-    const r = spawnSync('tar', ['-xzf', tarPath, '-C', destDir, '--strip-components=1'], { stdio: 'pipe' });
+    let tarCmd = 'tar';
+    let tarArgs = ['-xzf', tarPath, '-C', destDir, '--strip-components=1'];
+    let spawnOpts: Parameters<typeof spawnSync>[2] = { stdio: 'pipe' };
+
+    // Windows: PATH `tar` may resolve to a GNU tar from Git/MSYS2, which misreads the
+    // absolute archive path "C:\...\engine.tgz" as a remote "host:path" spec and fails with
+    // "tar (child): Cannot connect to C: resolve failed" (then "gzip: stdin: unexpected end
+    // of file"). Pin to the bsdtar shipped in System32, which handles drive-letter paths
+    // natively — this is the tar this code was always meant to use on Windows 10+.
+    if (process.platform === 'win32') {
+        const sysTar = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'tar.exe');
+        if (fs.existsSync(sysTar)) {
+            tarCmd = sysTar;
+        } else {
+            // No system bsdtar (very old/stripped Windows): fall back to PATH tar, but run
+            // from the archive's own directory and pass the bare filename so no drive-letter
+            // colon reaches tar's -f argument — works for both GNU tar and bsdtar.
+            tarArgs = ['-xzf', path.basename(tarPath), '-C', destDir, '--strip-components=1'];
+            spawnOpts = { stdio: 'pipe', cwd: path.dirname(tarPath) };
+        }
+    }
+
+    const r = spawnSync(tarCmd, tarArgs, spawnOpts);
     if (r.status !== 0) {
         const err = r.stderr?.toString().trim() || r.error?.message || `tar exited ${r.status}`;
         throw new Error(`Code mode: failed to extract engine — ${err}`);


### PR DESCRIPTION
## Problem

Enabling **Claude Code** or **Codex** in Settings → Code Mode fails on Windows:

```
Code mode: failed to extract engine — tar (child): Cannot connect to C: resolve failed
gzip: stdin: unexpected end of file
tar: Child returned status 128
```

The engine provisioner downloads the per-platform npm tarball and extracts it with `spawnSync('tar', …)` against an absolute path like `C:\Users\…\.rowboat\engines\…\engine.tgz`.

On Windows, PATH `tar` resolves to a **GNU tar** (from Git for Windows / MSYS2), not the bsdtar this code was designed for. GNU tar reads the colon in `C:\…` as a remote `host:path` spec, tries to connect to host `C`, fails, and feeds nothing into gzip. macOS never hits this because its system `tar` is bsdtar.

## Fix

`extractTarball()` in `engine-provisioner.ts` only:

- **Windows:** pin extraction to the bsdtar shipped at `%SystemRoot%\System32\tar.exe`, which handles drive-letter paths natively (the tar this code already assumed for "Windows 10+").
- **Fallback** (System32 tar missing): run from the archive's own directory and pass the bare filename so no drive-letter colon reaches tar's `-f` argument — safe for both GNU tar and bsdtar.
- **macOS/Linux:** untouched — byte-identical behavior.

Purely additive (a new Windows branch); no existing working code paths changed.

## Verification

- `npm run deps` — `shared`, `core`, `preload` compile clean, no TS errors.
- `npm run lint` — no new errors in `engine-provisioner.ts` (pre-existing dev lint errors in unrelated files remain).
- Not yet exercised on a Windows machine via the Enable flow — recommend a quick manual smoke test before merge.