### PR TITLE
Filter non-chat models from BYOK model picker

### DIFF
--- a/apps/x/packages/core/src/models/models-dev.ts
+++ b/apps/x/packages/core/src/models/models-dev.ts
@@ -224,3 +224,22 @@ export async function listOnboardingModels(): Promise<{ providers: ProviderSumma
 
   return { providers, lastUpdated: fetchedAt };
 }
+
+export async function getChatModelIds(
+  flavor: "openai" | "anthropic" | "google",
+): Promise<Set<string>> {
+  try {
+    const { data } = await getModelsDevData();
+    const provider = pickProvider(data, flavor);
+    if (!provider) return new Set();
+    const ids = new Set<string>();
+    for (const [id, model] of Object.entries(provider.models)) {
+      if (isStableModel(model) && supportsToolCall(model)) {
+        ids.add(model.id ?? id);
+      }
+    }
+    return ids;
+  } catch {
+    return new Set();
+  }
+}

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -10,6 +10,7 @@ import { LlmModelConfig, LlmProvider } from "@x/shared/dist/models.js";
 import z from "zod";
 import { getGatewayProvider } from "./gateway.js";
 import { getDefaultModelAndProvider, resolveProviderConfig } from "./defaults.js";
+import { getChatModelIds } from "./models-dev.js";
 import { withUseCase } from "../analytics/use_case.js";
 
 export const Provider = LlmProvider;
@@ -158,7 +159,16 @@ export async function listModelsForProvider(
             // OpenAI-shaped: { data: [{ id: "..." }] }
             ids = (data.data ?? []).map((m: { id: string }) => m.id);
         }
-        return ids.filter((id: string) => typeof id === "string" && id.length > 0);
+        const cleaned = ids.filter((id: string) => typeof id === "string" && id.length > 0);
+        if (flavor === "openai" || flavor === "anthropic" || flavor === "google") {
+            const chatIds = await getChatModelIds(flavor);
+            // Only filter when models.dev returned data; if it's empty (offline/no
+            // cache/unknown provider) keep the full list rather than showing none.
+            if (chatIds.size > 0) {
+                return cleaned.filter((id) => chatIds.has(id));
+            }
+        }
+        return cleaned;
     } finally {
         clearTimeout(timeout);
     }


### PR DESCRIPTION
## What
The chat model picker was showing non-chat models (image, video, TTS, music, embeddings, etc.) for BYOK providers. This filters them out so only real chat models show up.

## Why
When a user connects a provider with their key, we fetch the provider's full model list. For Gemini/OpenAI this includes image (imagen), video (veo), music (lyria), TTS, and embedding models that can't be used for chat. They cluttered the dropdown.

## How
- Added `getChatModelIds(flavor)` in `models-dev.ts` — uses our existing models.dev data and returns only models marked as tool-call capable and stable.
- In `listModelsForProvider` (models.ts), after fetching the provider's list, we keep only those models for openai/anthropic/google.
- Key validation is unchanged; we only drop the non-chat entries.

## Edge cases
- models.dev unavailable / no cache → keep the full list (don't show an empty dropdown).
- Providers models.dev doesn't know (openrouter, ollama, openai-compatible) → no filtering, list passes through.

## Files
- packages/core/src/models/models-dev.ts
- packages/core/src/models/models.ts

## How to test
1. Sign out (BYOK), reset onboarding, connect a Gemini key.
2. Open the chat model dropdown → only chat models; no imagen/veo/lyria/tts/embedding.
3. Anthropic/OpenAI lists also clean.