### PR TITLE
fix(onboarding): center step connector line & refresh welcome layout

### DIFF
--- a/apps/x/apps/renderer/src/components/onboarding/step-indicator.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/step-indicator.tsx
@@ -26,7 +26,7 @@ export function StepIndicator({ currentStep, path }: StepIndicatorProps) {
   const currentIndex = steps.findIndex(s => s.step === currentStep)
 
   return (
-    <div className="flex items-center gap-2 mb-8 px-4">
+    <div className="flex items-center gap-2 mb-14 px-4">
       {steps.map((s, i) => (
         <React.Fragment key={s.step}>
           {i > 0 && (

--- a/apps/x/apps/renderer/src/components/onboarding/step-indicator.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/step-indicator.tsx
@@ -37,7 +37,7 @@ export function StepIndicator({ currentStep, path }: StepIndicatorProps) {
               )}
             />
           )}
-          <div className="flex flex-col items-center gap-1.5">
+          <div className="relative flex flex-col items-center">
             <div
               className={cn(
                 "size-8 rounded-full flex items-center justify-center text-xs font-medium transition-all duration-300",
@@ -54,7 +54,7 @@ export function StepIndicator({ currentStep, path }: StepIndicatorProps) {
             </div>
             <span
               className={cn(
-                "text-[11px] font-medium transition-colors duration-300",
+                "absolute top-full mt-1.5 whitespace-nowrap text-[11px] font-medium transition-colors duration-300",
                 i <= currentIndex ? "text-foreground" : "text-muted-foreground"
               )}
             >

--- a/apps/x/apps/renderer/src/components/onboarding/steps/welcome-step.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/steps/welcome-step.tsx
@@ -12,15 +12,21 @@ export function WelcomeStep({ state }: WelcomeStepProps) {
 
   return (
     <div className="flex flex-col items-center justify-center text-center flex-1">
-      {/* Logo with ambient glow */}
+      {/* Logo + main heading on the same level */}
       <motion.div
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
-        className="relative mb-8"
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className="flex items-center gap-4 mb-4"
       >
-        <div className="absolute inset-0 size-16 rounded-2xl bg-primary/10 blur-xl scale-[2.5]" />
-        <img src="/logo-only.png" alt="Rowboat" className="relative size-16" />
+        <h1 className="text-3xl font-bold tracking-tight">
+          Welcome to Rowboat
+        </h1>
+        {/* Logo with ambient glow */}
+        <div className="relative shrink-0">
+          <div className="absolute inset-0 size-12 rounded-2xl bg-primary/10 blur-xl scale-[2.5]" />
+          <img src="/logo-only.png" alt="Rowboat" className="relative size-12" />
+        </div>
       </motion.div>
 
       {/* Tagline badge */}
@@ -28,21 +34,11 @@ export function WelcomeStep({ state }: WelcomeStepProps) {
         initial={{ opacity: 0, y: 6 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.15 }}
-        className="inline-flex items-center gap-2 rounded-full border bg-muted/50 px-3.5 py-1.5 text-xs font-medium text-muted-foreground mb-6"
+        className="inline-flex items-center gap-2 rounded-full border bg-muted/50 px-3.5 py-1.5 text-xs font-medium text-muted-foreground mb-10"
       >
         <span className="size-1.5 rounded-full bg-green-500 animate-pulse" />
         Your AI coworker, with memory
       </motion.div>
-
-      {/* Main heading */}
-      <motion.h1
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.2 }}
-        className="text-3xl font-bold tracking-tight mb-3"
-      >
-        Welcome to Rowboat
-      </motion.h1>
       <motion.p
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}


### PR DESCRIPTION
## Summary
UI polish for the onboarding screens.

- **Step indicator:** the connector line was vertically centered against the circle+label column, so it sat *below* the circles' center. Labels are now absolutely positioned beneath each circle, so the row height equals just the circle and `items-center` aligns the line to the circle center.
- **Welcome step:** logo now sits inline to the **right** of the "Welcome to Rowboat" heading (sized to `size-12`), the "Your AI coworker, with memory" badge moved **below** the heading with more spacing, and added breathing room between the step indicator and the step content.

## Test plan
- Reset onboarding (`onboardingComplete=false` in `~/.rowboat/config/note_creation.json`) and relaunch `npm run dev`
- Verify the 1·2·3 connector line runs through the middle of the circles
- Verify the welcome screen shows the logo to the right of the heading, tagline below, with clear spacing from the indicator