### PR TITLE
feat(email): Superhuman-style shortcuts, drafts, search & read-state controls

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -69,7 +69,7 @@ import { summarizeMeeting } from '@x/core/dist/knowledge/summarize_meeting.js';
 import { getAccessToken } from '@x/core/dist/auth/tokens.js';
 import { getRowboatConfig } from '@x/core/dist/config/rowboat.js';
 import { runLiveNoteAgent } from '@x/core/dist/knowledge/live-note/runner.js';
-import { listImportantThreads, listEverythingElseThreads, saveMessageBodyHeight, triggerSync as triggerGmailSync, sendThreadReply, archiveThread, trashThread, markThreadRead, getAccountEmail, getAccountName, getConnectionStatus as getGmailConnectionStatus } from '@x/core/dist/knowledge/sync_gmail.js';
+import { listImportantThreads, listEverythingElseThreads, saveMessageBodyHeight, triggerSync as triggerGmailSync, sendThreadReply, saveThreadDraft, deleteThreadDraft, listDraftThreads, searchThreads, archiveThread, trashThread, markThreadRead, markSectionRead, getAccountEmail, getAccountName, getConnectionStatus as getGmailConnectionStatus } from '@x/core/dist/knowledge/sync_gmail.js';
 import { searchContacts as searchGmailContacts, warmContactIndex } from '@x/core/dist/knowledge/gmail_contacts.js';
 import { searchSentContacts, warmSentContacts } from '@x/core/dist/knowledge/gmail_sent_contacts.js';
 import { getGoogleDocsConnectionStatus, importGoogleDoc, syncGoogleDocDown, syncGoogleDocUp, getGoogleDocLink } from '@x/core/dist/knowledge/google_docs.js';
@@ -740,6 +740,18 @@ export function setupIpcHandlers() {
     'gmail:sendReply': async (_event, args) => {
       return sendThreadReply(args);
     },
+    'gmail:saveDraft': async (_event, args) => {
+      return saveThreadDraft(args);
+    },
+    'gmail:deleteDraft': async (_event, args) => {
+      return deleteThreadDraft(args.draftId);
+    },
+    'gmail:getDrafts': async () => {
+      return listDraftThreads();
+    },
+    'gmail:search': async (_event, args) => {
+      return searchThreads(args.query, { limit: args.limit });
+    },
     'gmail:getConnectionStatus': async () => {
       return getGmailConnectionStatus();
     },
@@ -756,7 +768,10 @@ export function setupIpcHandlers() {
       return trashThread(args.threadId);
     },
     'gmail:markThreadRead': async (_event, args) => {
-      return markThreadRead(args.threadId);
+      return markThreadRead(args.threadId, args.read);
+    },
+    'gmail:markSectionRead': async (_event, args) => {
+      return markSectionRead(args.section, args.read);
     },
     'gmail:saveMessageHeight': async (_event, args) => {
       saveMessageBodyHeight(args.threadId, args.messageId, args.height);

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -69,7 +69,8 @@ import { summarizeMeeting } from '@x/core/dist/knowledge/summarize_meeting.js';
 import { getAccessToken } from '@x/core/dist/auth/tokens.js';
 import { getRowboatConfig } from '@x/core/dist/config/rowboat.js';
 import { runLiveNoteAgent } from '@x/core/dist/knowledge/live-note/runner.js';
-import { listImportantThreads, listEverythingElseThreads, saveMessageBodyHeight, triggerSync as triggerGmailSync, sendThreadReply, saveThreadDraft, deleteThreadDraft, listDraftThreads, searchThreads, archiveThread, trashThread, markThreadRead, markSectionRead, getAccountEmail, getAccountName, getConnectionStatus as getGmailConnectionStatus } from '@x/core/dist/knowledge/sync_gmail.js';
+import { listImportantThreads, listEverythingElseThreads, saveMessageBodyHeight, triggerSync as triggerGmailSync, sendThreadReply, saveThreadDraft, deleteThreadDraft, listDraftThreads, searchThreads, archiveThread, trashThread, markThreadRead, markSectionRead, downloadAttachment, getAccountEmail, getAccountName, getConnectionStatus as getGmailConnectionStatus } from '@x/core/dist/knowledge/sync_gmail.js';
+import { getAutoReadEverythingElse, setAutoReadEverythingElse } from '@x/core/dist/config/gmail_sync_config.js';
 import { searchContacts as searchGmailContacts, warmContactIndex } from '@x/core/dist/knowledge/gmail_contacts.js';
 import { searchSentContacts, warmSentContacts } from '@x/core/dist/knowledge/gmail_sent_contacts.js';
 import { getGoogleDocsConnectionStatus, importGoogleDoc, syncGoogleDocDown, syncGoogleDocUp, getGoogleDocLink } from '@x/core/dist/knowledge/google_docs.js';
@@ -772,6 +773,16 @@ export function setupIpcHandlers() {
     },
     'gmail:markSectionRead': async (_event, args) => {
       return markSectionRead(args.section, args.read);
+    },
+    'gmail:downloadAttachment': async (_event, args) => {
+      return downloadAttachment(args);
+    },
+    'gmail:getAutoReadEverythingElse': async () => {
+      return { enabled: getAutoReadEverythingElse() };
+    },
+    'gmail:setAutoReadEverythingElse': async (_event, args) => {
+      setAutoReadEverythingElse(args.enabled);
+      return {};
     },
     'gmail:saveMessageHeight': async (_event, args) => {
       saveMessageBodyHeight(args.threadId, args.messageId, args.height);

--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -169,6 +169,25 @@
   color: var(--gm-placeholder);
 }
 
+.gmail-search-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--gm-text-muted);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.gmail-search-clear:hover {
+  background: var(--gm-icon-hover-bg);
+  color: var(--gm-text);
+}
+
 .gmail-icon-button {
   display: inline-flex;
   align-items: center;

--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -224,6 +224,46 @@
   flex-direction: column;
 }
 
+/* Native list virtualization: offscreen rows skip layout and paint entirely.
+   Applied only to rows without a mounted ThreadDetail (those hold iframes and
+   composers, which must keep rendering while offscreen). */
+.gmail-row-group-cv {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 40px;
+}
+
+/* While the list is scrolling, rows ignore the pointer so hover restyles and
+   prefetch timers don't compete with frame rendering. */
+.gmail-shell[data-scrolling] .gmail-row-shell {
+  pointer-events: none;
+}
+
+/* Archived/trashed rows slide out and collapse before removal. Removing the
+   class (failed action) snaps the row back. */
+.gmail-row-group-leaving {
+  overflow: hidden;
+  pointer-events: none;
+  animation: gmail-row-leave 160ms ease-in forwards;
+}
+
+@keyframes gmail-row-leave {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+    max-height: 48px;
+  }
+  60% {
+    opacity: 0;
+    transform: translateX(32px);
+    max-height: 48px;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(32px);
+    max-height: 0;
+  }
+}
+
 .gmail-list-header {
   position: sticky;
   top: 0;
@@ -338,6 +378,20 @@
   background: var(--gm-bg-row-selected-hover);
 }
 
+/* The j/k keyboard cursor. Declared after the hover rules (same specificity)
+   so the focus ring survives hovering the focused row. */
+.gmail-row-focused,
+.gmail-row-focused:hover {
+  background: var(--gm-bg-row-hover);
+  box-shadow: inset 0 0 0 1px var(--gm-accent);
+}
+
+.gmail-row-selected.gmail-row-focused,
+.gmail-row-selected.gmail-row-focused:hover {
+  background: var(--gm-bg-row-selected);
+  box-shadow: inset 2px 0 0 var(--gm-accent), inset 0 0 0 1px var(--gm-accent);
+}
+
 .gmail-row-unread {
   color: var(--gm-text);
 }
@@ -413,10 +467,48 @@
   border-top: 1px solid var(--gm-border);
   border-bottom: 1px solid var(--gm-border);
   box-shadow: inset 2px 0 0 var(--gm-accent);
+  /* Replays whenever the detail is shown — hidden details are display: none,
+     so un-hiding restarts the animation. */
+  animation: gmail-detail-open 140ms ease-out;
 }
 
 .gmail-detail-hidden {
   display: none;
+}
+
+@keyframes gmail-detail-open {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The inline reply/forward composer pops in from below the thread. */
+.gmail-compose-inline {
+  animation: gmail-compose-open 140ms ease-out;
+}
+
+@keyframes gmail-compose-open {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gmail-detail-inline,
+  .gmail-compose-inline,
+  .gmail-row-group-leaving {
+    animation: none;
+  }
 }
 
 .gmail-detail-toolbar {

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -499,16 +499,32 @@ function formatAttachmentSize(bytes?: number): string {
 }
 
 function MessageAttachments({ attachments }: { attachments: NonNullable<GmailThreadMessage['attachments']> }) {
-  const openAttachment = (path: string, filename: string) => {
-    void window.ipc
-      .invoke('shell:openPath', { path })
-      .then((result) => {
-        if (result?.error) toast(`Could not open ${filename}: ${result.error}`, 'error')
-      })
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : String(err)
-        toast(`Could not open ${filename}: ${message}`, 'error')
-      })
+  const openAttachment = async (att: NonNullable<GmailThreadMessage['attachments']>[number]) => {
+    try {
+      // Ensure the file is on disk before handing off to the OS opener. Inbox
+      // attachments are saved during sync, but search-result attachments are
+      // only fetched on demand. gmail:downloadAttachment short-circuits when the
+      // file already exists, so calling it first is cheap and guarantees the
+      // file is present — we can't rely on shell:openPath reporting a missing
+      // file as an error (xdg-open on Linux reports success even when the path
+      // doesn't exist, so the old open-then-download fallback never fired).
+      if (att.messageId) {
+        const dl = await window.ipc.invoke('gmail:downloadAttachment', {
+          messageId: att.messageId,
+          savedPath: att.savedPath,
+          attachmentId: att.attachmentId,
+        })
+        if (!dl.ok) {
+          toast(`Could not download ${att.filename}: ${dl.error ?? 'unknown error'}`, 'error')
+          return
+        }
+      }
+      const result = await window.ipc.invoke('shell:openPath', { path: att.savedPath })
+      if (result?.error) toast(`Could not open ${att.filename}: ${result.error}`, 'error')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast(`Could not open ${att.filename}: ${message}`, 'error')
+    }
   }
 
   return (
@@ -520,7 +536,7 @@ function MessageAttachments({ attachments }: { attachments: NonNullable<GmailThr
             key={att.savedPath}
             type="button"
             className="gmail-attachment"
-            onClick={() => openAttachment(att.savedPath, att.filename)}
+            onClick={() => void openAttachment(att)}
             title={`Open ${att.filename}`}
           >
             <Paperclip size={13} />
@@ -1975,6 +1991,8 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   const [searching, setSearching] = useState(false)
   const [searchError, setSearchError] = useState<string | null>(null)
   const searchEpoch = useRef(0)
+  // Persistent preference: auto-mark future "Everything else" mail as read.
+  const [autoReadOther, setAutoReadOther] = useState(false)
   // Gmail sync uses the native Google OAuth connection.
   const [emailConnection, setEmailConnection] = useState<GmailConnectionStatus | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -2025,6 +2043,16 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     }, 400)
     return () => window.clearTimeout(handle)
   }, [query])
+
+  // Load the persisted "auto-read Everything else" preference on mount.
+  useEffect(() => {
+    let cancelled = false
+    void window.ipc
+      .invoke('gmail:getAutoReadEverythingElse', {})
+      .then((res) => { if (!cancelled) setAutoReadOther(res.enabled) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
 
   const deleteDraftAction = useCallback(async (thread: GmailThread) => {
     const id = thread.draftId
@@ -2154,6 +2182,19 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
       toast(`Could not update read state: ${err instanceof Error ? err.message : String(err)}`, 'error')
     }
   }, [setSection])
+
+  // "Mark as read" toggle for Everything else. Turning it ON persists the
+  // preference AND marks every current "other" thread read; turning it OFF only
+  // clears the preference (future mail), leaving existing threads untouched.
+  const setAutoReadOtherAction = useCallback(async (enabled: boolean) => {
+    setAutoReadOther(enabled)
+    try {
+      await window.ipc.invoke('gmail:setAutoReadEverythingElse', { enabled })
+    } catch (err) {
+      toast(`Could not update preference: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+    if (enabled) await markSectionReadAction('other', true)
+  }, [markSectionReadAction])
 
   const archiveThreadAction = useCallback(async (threadId: string) => {
     try {
@@ -2447,8 +2488,6 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   const visibleImportant = useMemo(() => filterThreads(important.threads), [important.threads, filterThreads])
   const visibleOther = useMemo(() => filterThreads(other.threads), [other.threads, filterThreads])
   const visibleDrafts = useMemo(() => filterThreads(drafts), [drafts, filterThreads])
-  const importantHasUnread = important.threads.some((t) => t.unread)
-  const otherHasUnread = other.threads.some((t) => t.unread)
 
   const hasAny = important.threads.length > 0 || other.threads.length > 0
   const initialLoading = !hasAny && refreshing
@@ -2570,6 +2609,17 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search all mail"
             />
+            {query && (
+              <button
+                type="button"
+                className="gmail-search-clear"
+                onClick={() => setQuery('')}
+                title="Clear search"
+                aria-label="Clear search"
+              >
+                <X size={16} />
+              </button>
+            )}
           </div>
           <div className="gmail-topbar-actions">
             <div className="flex items-center rounded-md border border-border p-0.5 text-xs font-medium">
@@ -2642,19 +2692,9 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Important</span>
-                  <div className="flex items-center gap-2.5">
-                    <div className="flex items-center gap-1.5" title={importantHasUnread ? 'Mark all in Important as read' : 'Mark all in Important as unread'}>
-                      <span className="text-xs text-muted-foreground">Read</span>
-                      <Switch
-                        checked={!importantHasUnread}
-                        onCheckedChange={(checked) => void markSectionReadAction('important', checked)}
-                        aria-label="Mark all of Important read or unread"
-                      />
-                    </div>
-                    <span>
-                      {important.threads.length}{important.hasReachedEnd ? '' : '+'} thread{important.threads.length === 1 ? '' : 's'}
-                    </span>
-                  </div>
+                  <span>
+                    {important.threads.length}{important.hasReachedEnd ? '' : '+'} thread{important.threads.length === 1 ? '' : 's'}
+                  </span>
                 </div>
                 {visibleImportant.map(renderRow)}
                 {!important.hasReachedEnd && (
@@ -2671,12 +2711,12 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
                 <div className="gmail-list-header">
                   <span>Everything else</span>
                   <div className="flex items-center gap-2.5">
-                    <div className="flex items-center gap-1.5" title={otherHasUnread ? 'Mark all in Everything else as read' : 'Mark all in Everything else as unread'}>
-                      <span className="text-xs text-muted-foreground">Read</span>
+                    <div className="flex items-center gap-1.5" title="Mark Everything else as read — applies to these and future emails">
+                      <span className="text-xs text-muted-foreground">Mark as read</span>
                       <Switch
-                        checked={!otherHasUnread}
-                        onCheckedChange={(checked) => void markSectionReadAction('other', checked)}
-                        aria-label="Mark all of Everything else read or unread"
+                        checked={autoReadOther}
+                        onCheckedChange={(checked) => void setAutoReadOtherAction(checked)}
+                        aria-label="Mark Everything else as read now and going forward"
                       />
                     </div>
                     <span>

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '@/contexts/theme-context'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 
 type GmailThread = blocks.GmailThread
@@ -166,6 +167,11 @@ function buildRecipients(
   selfEmail: string,
 ): { to: string[]; cc: string[] } {
   if (mode === 'forward') return { to: [], cc: [] }
+  // Editing an existing draft: recipients are whatever the draft already has.
+  if (mode === 'draft') {
+    const draftMsg = latestMessage(thread)
+    return { to: splitAddresses(draftMsg?.to), cc: splitAddresses(draftMsg?.cc) }
+  }
 
   const latest = latestMessage(thread)
   const self = selfEmail.toLowerCase()
@@ -195,6 +201,7 @@ function buildRecipients(
 // Subject line for a reply ("Re: …") or forward ("Fwd: …"), avoiding double prefixes.
 function composeSubject(mode: ComposeMode, rawSubject?: string): string {
   const raw = (rawSubject || '').trim()
+  if (mode === 'draft') return raw // keep the draft's own subject verbatim
   if (mode === 'forward') return /^fwd:/i.test(raw) ? raw : `Fwd: ${raw}`.trim()
   return /^re:/i.test(raw) ? raw : `Re: ${raw}`.trim()
 }
@@ -526,7 +533,7 @@ function MessageAttachments({ attachments }: { attachments: NonNullable<GmailThr
   )
 }
 
-type ComposeMode = 'reply' | 'replyAll' | 'forward' | 'new'
+type ComposeMode = 'reply' | 'replyAll' | 'forward' | 'new' | 'draft'
 
 function ComposeToolbarButton({
   editor,
@@ -977,6 +984,25 @@ const TONE_PRESETS: Array<{ key: string; label: string; instruction: string }> =
   { key: 'longer', label: 'Longer', instruction: 'Rewrite this email to be more detailed and thorough.' },
 ]
 
+// Debounce before autosaving the composer to a Gmail draft after the last edit.
+const DRAFT_AUTOSAVE_MS = 1500
+
+// Shape of the gmail:saveDraft request, kept here so we can stash a snapshot in
+// a ref for the close/unmount flush without re-reading a torn-down editor.
+type DraftPayload = {
+  draftId?: string
+  threadId?: string
+  to?: string
+  cc?: string
+  bcc?: string
+  subject: string
+  bodyHtml: string
+  bodyText: string
+  inReplyTo?: string
+  references?: string
+  attachments?: Array<{ filename: string; mimeType: string; contentBase64: string }>
+}
+
 // Composer for replies, forwards, and (mode 'new') from-scratch emails. With a
 // thread it renders as an inline card under the thread; in 'new' mode it has no
 // thread and renders as a centered modal with the AI writing bar.
@@ -992,7 +1018,9 @@ const ComposeBox = memo(function ComposeBox({
   onClose: () => void
 }) {
   const isNew = mode === 'new'
-  const latest = thread ? latestMessage(thread) : undefined
+  // Drafts and new messages share the full-modal layout (subject line, AI bar).
+  const isModal = isNew || mode === 'draft'
+  const latest = useMemo(() => (thread ? latestMessage(thread) : undefined), [thread])
   const initialRecipients = useMemo(
     () => (thread ? buildRecipients(mode, thread, selfEmail) : { to: [], cc: [] }),
     [mode, thread, selfEmail],
@@ -1004,11 +1032,16 @@ const ComposeBox = memo(function ComposeBox({
   const [showCc, setShowCc] = useState<boolean>(initialRecipients.cc.length > 0)
   const [showBcc, setShowBcc] = useState<boolean>(false)
   const [subject, setSubject] = useState<string>(() => (thread ? composeSubject(mode, thread.subject) : ''))
-  const modeLabel = isNew ? 'New message' : mode === 'forward' ? 'Forward' : mode === 'replyAll' ? 'Reply All' : 'Reply'
+  const modeLabel = mode === 'draft' ? 'Draft' : isNew ? 'New message' : mode === 'forward' ? 'Forward' : mode === 'replyAll' ? 'Reply All' : 'Reply'
 
   const initialContent = useMemo(() => {
     if (!thread) return ''
     if (mode === 'forward') return buildForwardedContent(thread)
+    // For a saved draft, reopen the exact HTML we stored so formatting survives.
+    if (mode === 'draft') {
+      const draftMsg = latestMessage(thread)
+      if (draftMsg?.bodyHtml) return draftMsg.bodyHtml
+    }
     // Gmail-side draft (user's own work) wins over the AI-generated draft.
     const source = stripQuotedReplyText(thread.gmail_draft || thread.draft_response || '')
     if (!source) return ''
@@ -1023,7 +1056,7 @@ const ComposeBox = memo(function ComposeBox({
       StarterKit.configure({ link: false }),
       Link.configure({ openOnClick: false, autolink: true }),
       Placeholder.configure({
-        placeholder: isNew || mode === 'forward' ? 'Write a message…' : 'Write your reply…',
+        placeholder: isModal || mode === 'forward' ? 'Write a message…' : 'Write your reply…',
       }),
     ],
     editorProps: {
@@ -1255,6 +1288,155 @@ const ComposeBox = memo(function ComposeBox({
     setAttachments((prev) => prev.filter((a) => a.id !== id))
   }
 
+  // ── Draft autosave ─────────────────────────────────────────────────────────
+  // Keep a real Gmail draft in sync with the composer while the user types
+  // (debounced) and flush a final save on close, so closing keeps the work in
+  // Gmail's Drafts folder (synced to every device) instead of discarding it.
+  // Empty/whitespace drafts are skipped. The core saveThreadDraft reuses an
+  // existing thread draft and tracks the id so edits update in place.
+  // Seeded when editing an existing draft so the first save updates it in place.
+  const draftIdRef = useRef<string | undefined>(thread?.draftId)
+  const lastPayloadRef = useRef<DraftPayload | null>(null)
+  const savingRef = useRef(false)        // a saveDraft IPC is in flight
+  const pendingRef = useRef(false)        // edits arrived mid-flight; save once more
+  const sentRef = useRef(false)           // suppress autosave after a successful send
+  const discardedRef = useRef(false)      // suppress autosave after discard
+  const closedRef = useRef(false)         // close already handled; skip unmount flush
+  const dirtyRef = useRef(false)          // user has edited since open
+  const fieldsMounted = useRef(false)     // skip the field effect's initial run
+  const autosaveTimer = useRef<number | null>(null)
+  const saveDraftNowRef = useRef<() => Promise<void>>(undefined)
+
+  const buildDraftPayload = useCallback((): DraftPayload | null => {
+    if (!editor || editor.isDestroyed) return null
+    const text = editor.getText().trim()
+    if (!text) return null // skip empty/whitespace drafts
+    const html = editor.getHTML()
+    const messageIds = (thread?.messages ?? [])
+      .map((m) => m.messageIdHeader)
+      .filter((v): v is string => Boolean(v))
+    const references = messageIds.join(' ')
+    const inReplyTo = latest?.messageIdHeader
+    // Only replies stay on the thread; forwards and new emails start fresh.
+    const isThreaded = Boolean(thread) && mode !== 'forward' && !isNew
+    return {
+      draftId: draftIdRef.current,
+      threadId: isThreaded ? thread?.threadId : undefined,
+      to: toList.join(', '),
+      cc: ccList.length ? ccList.join(', ') : undefined,
+      bcc: bccList.length ? bccList.join(', ') : undefined,
+      subject: subject.trim() || (thread ? composeSubject(mode, thread.subject) : ''),
+      bodyHtml: html,
+      bodyText: text,
+      inReplyTo: isThreaded ? inReplyTo : undefined,
+      references: isThreaded ? references || undefined : undefined,
+      attachments: attachments.length
+        ? attachments.map(({ filename, mimeType, contentBase64 }) => ({ filename, mimeType, contentBase64 }))
+        : undefined,
+    }
+  }, [editor, thread, mode, isNew, toList, ccList, bccList, subject, attachments, latest])
+
+  const saveDraftNow = useCallback(async () => {
+    if (sentRef.current || discardedRef.current) return
+    if (savingRef.current) { pendingRef.current = true; return }
+    const payload = lastPayloadRef.current
+    if (!payload) return
+    savingRef.current = true
+    pendingRef.current = false
+    try {
+      payload.draftId = draftIdRef.current
+      const res = await window.ipc.invoke('gmail:saveDraft', payload)
+      if (res?.draftId && !discardedRef.current) draftIdRef.current = res.draftId
+    } catch {
+      // Autosave is best-effort; a failure just leaves the prior draft in place.
+    } finally {
+      savingRef.current = false
+      // Coalesce edits that landed mid-flight into one more save.
+      if (pendingRef.current && !sentRef.current && !discardedRef.current) {
+        pendingRef.current = false
+        void saveDraftNowRef.current?.()
+      }
+    }
+  }, [])
+  useEffect(() => { saveDraftNowRef.current = saveDraftNow }, [saveDraftNow])
+
+  const scheduleAutosave = useCallback(() => {
+    if (autosaveTimer.current) window.clearTimeout(autosaveTimer.current)
+    autosaveTimer.current = window.setTimeout(() => { void saveDraftNow() }, DRAFT_AUTOSAVE_MS)
+  }, [saveDraftNow])
+
+  // Wait (briefly, capped) for any in-flight autosave to settle so send/discard
+  // don't race it into a duplicate or orphaned draft.
+  const waitForSaveIdle = useCallback(async () => {
+    for (let guard = 0; savingRef.current && guard < 40; guard++) {
+      await new Promise((r) => window.setTimeout(r, 50))
+    }
+  }, [])
+
+  // Autosave on body edits (typing, AI insert, undo/redo).
+  useEffect(() => {
+    if (!editor) return
+    const onUpdate = () => {
+      dirtyRef.current = true
+      lastPayloadRef.current = buildDraftPayload()
+      scheduleAutosave()
+    }
+    editor.on('update', onUpdate)
+    return () => { editor.off('update', onUpdate) }
+  }, [editor, buildDraftPayload, scheduleAutosave])
+
+  // Autosave on header edits (recipients, subject, attachments), skipping mount.
+  useEffect(() => {
+    if (!fieldsMounted.current) { fieldsMounted.current = true; return }
+    dirtyRef.current = true
+    lastPayloadRef.current = buildDraftPayload()
+    scheduleAutosave()
+  }, [toList, ccList, bccList, subject, attachments, buildDraftPayload, scheduleAutosave])
+
+  // Safety net: if the composer is torn down without an explicit close (e.g.
+  // navigating away), still flush unsaved edits. closedRef guards the common
+  // path where handleClose already saved.
+  useEffect(() => {
+    return () => {
+      if (autosaveTimer.current) window.clearTimeout(autosaveTimer.current)
+      if (closedRef.current || sentRef.current || discardedRef.current || savingRef.current) return
+      if (!dirtyRef.current) return
+      const payload = lastPayloadRef.current
+      if (!payload) return
+      payload.draftId = draftIdRef.current
+      void window.ipc.invoke('gmail:saveDraft', payload).catch(() => {})
+    }
+  }, [])
+
+  // Close (X / click-away): keep the draft. Flush a final save when there are
+  // unsaved edits. If a save is already in flight it will persist the latest
+  // content, so we skip here to avoid creating a duplicate.
+  const handleClose = useCallback(() => {
+    closedRef.current = true
+    if (autosaveTimer.current) window.clearTimeout(autosaveTimer.current)
+    if (!sentRef.current && !discardedRef.current && !savingRef.current && dirtyRef.current) {
+      const payload = buildDraftPayload()
+      if (payload) {
+        payload.draftId = draftIdRef.current
+        void window.ipc.invoke('gmail:saveDraft', payload).catch(() => {})
+      }
+    }
+    onClose()
+  }, [buildDraftPayload, onClose])
+
+  // Discard: delete the autosaved draft (if any), then close.
+  const handleDiscard = useCallback(() => {
+    discardedRef.current = true
+    closedRef.current = true
+    if (autosaveTimer.current) window.clearTimeout(autosaveTimer.current)
+    void (async () => {
+      await waitForSaveIdle()
+      const id = draftIdRef.current
+      if (id) await window.ipc.invoke('gmail:deleteDraft', { draftId: id }).catch(() => {})
+    })()
+    onClose()
+  }, [onClose, waitForSaveIdle])
+
   const [sending, setSending] = useState(false)
   const sendInGmail = async () => {
     if (!editor || sending) return
@@ -1279,7 +1461,12 @@ const ComposeBox = memo(function ComposeBox({
     // Only replies stay on the thread; forwards and new emails start fresh.
     const isThreaded = Boolean(thread) && mode !== 'forward' && !isNew
 
+    // Stop autosave from racing the send (it would leave an orphaned draft), and
+    // let any in-flight save settle so we know the draft id to clean up.
+    sentRef.current = true
+    if (autosaveTimer.current) window.clearTimeout(autosaveTimer.current)
     setSending(true)
+    await waitForSaveIdle()
     try {
       const result = await window.ipc.invoke('gmail:sendReply', {
         threadId: isThreaded ? thread?.threadId : undefined,
@@ -1296,12 +1483,22 @@ const ComposeBox = memo(function ComposeBox({
           : undefined,
       })
       if (result.error) {
+        sentRef.current = false // allow autosave to resume on a failed send
         toast(`Send failed: ${result.error}`, 'error')
         return
       }
+      // Gmail only auto-cleans drafts on a threaded send; remove any draft we
+      // autosaved for a brand-new message so it doesn't linger after sending.
+      const leftover = draftIdRef.current
+      if (leftover) {
+        draftIdRef.current = undefined
+        void window.ipc.invoke('gmail:deleteDraft', { draftId: leftover }).catch(() => {})
+      }
       toast('Sent.', 'success')
+      closedRef.current = true
       onClose()
     } catch (err) {
+      sentRef.current = false
       toast(`Send failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
     } finally {
       setSending(false)
@@ -1419,7 +1616,7 @@ const ComposeBox = memo(function ComposeBox({
           >{preset.label}</Button>
         ))}
       </div>
-      {(isNew || mode === 'forward') && (
+      {(isModal || mode === 'forward') && (
         <div className="flex min-h-8 items-center gap-2 border-b border-border px-3 text-sm">
           <span className="text-muted-foreground">Subject</span>
           <input
@@ -1431,7 +1628,7 @@ const ComposeBox = memo(function ComposeBox({
       )}
       <EditorContent
         editor={editor}
-        className={cn('w-full overflow-y-auto', isNew ? 'min-h-0 flex-1' : 'max-h-[360px]')}
+        className={cn('w-full overflow-y-auto', isModal ? 'min-h-0 flex-1' : 'max-h-[360px]')}
       />
       <input
         ref={fileInputRef}
@@ -1526,16 +1723,16 @@ const ComposeBox = memo(function ComposeBox({
           )}
         </div>
         {editor && <ComposeToolbar editor={editor} onOpenLink={openLink} />}
-        <Button type="button" variant="ghost" size="sm" className="text-muted-foreground" onClick={onClose}>
+        <Button type="button" variant="ghost" size="sm" className="text-muted-foreground" onClick={handleDiscard}>
           Discard
         </Button>
       </div>
     </>
   )
 
-  if (isNew) {
+  if (isModal) {
     return (
-      <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <Dialog open onOpenChange={(open) => { if (!open) handleClose() }}>
         <DialogContent
           showCloseButton={false}
           aria-describedby={undefined}
@@ -1548,7 +1745,7 @@ const ComposeBox = memo(function ComposeBox({
               variant="ghost"
               size="icon-sm"
               className="size-7 text-muted-foreground"
-              onClick={onClose}
+              onClick={handleClose}
               aria-label="Close compose"
             >
               <X className="size-4" />
@@ -1569,7 +1766,7 @@ const ComposeBox = memo(function ComposeBox({
           variant="ghost"
           size="icon-xs"
           className="text-muted-foreground"
-          onClick={onClose}
+          onClick={handleClose}
           aria-label="Close compose"
         >
           <X className="size-3.5" />
@@ -1731,6 +1928,8 @@ const initialSectionState: SectionState = {
 // panels and coming back doesn't reload from scratch.
 let persistedImportant: SectionState | null = null
 let persistedOther: SectionState | null = null
+// Last-loaded drafts, kept across EmailView remounts so reopening is instant.
+let persistedDrafts: GmailThread[] | null = null
 
 function clearLoadingFlag(state: SectionState | null): SectionState {
   if (!state) return initialSectionState
@@ -1765,9 +1964,85 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   const [composeOpen, setComposeOpen] = useState(false)
   // Stable so the open composer isn't re-rendered on every inbox sync tick.
   const closeCompose = useCallback(() => setComposeOpen(false), [])
+  // Inbox vs Drafts. Drafts are fetched live (they're not in the inbox cache).
+  const [view, setView] = useState<'inbox' | 'drafts'>('inbox')
+  const [drafts, setDrafts] = useState<GmailThread[]>(() => persistedDrafts ?? [])
+  const [draftsLoading, setDraftsLoading] = useState(false)
+  const [draftsError, setDraftsError] = useState<string | null>(null)
+  const [editingDraft, setEditingDraft] = useState<GmailThread | null>(null)
+  // Server-side search across the whole Gmail mailbox (results indexed locally).
+  const [searchResults, setSearchResults] = useState<GmailThread[]>([])
+  const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+  const searchEpoch = useRef(0)
   // Gmail sync uses the native Google OAuth connection.
   const [emailConnection, setEmailConnection] = useState<GmailConnectionStatus | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
+
+  const loadDrafts = useCallback(async () => {
+    setDraftsLoading(true)
+    setDraftsError(null)
+    try {
+      const res = await window.ipc.invoke('gmail:getDrafts', {})
+      if (res.error) setDraftsError(res.error)
+      setDrafts(res.threads ?? [])
+    } catch (err) {
+      setDraftsError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setDraftsLoading(false)
+    }
+  }, [])
+
+  // Load drafts when the Drafts view is opened.
+  useEffect(() => {
+    if (view === 'drafts') void loadDrafts()
+  }, [view, loadDrafts])
+
+  // Debounced full-mailbox search. Each keystroke bumps an epoch so stale
+  // responses are ignored; an empty query clears results.
+  useEffect(() => {
+    const q = query.trim()
+    searchEpoch.current += 1
+    const epoch = searchEpoch.current
+    if (!q) {
+      setSearchResults([])
+      setSearchError(null)
+      setSearching(false)
+      return
+    }
+    setSearching(true)
+    const handle = window.setTimeout(async () => {
+      try {
+        const res = await window.ipc.invoke('gmail:search', { query: q, limit: 100 })
+        if (searchEpoch.current !== epoch) return
+        setSearchError(res.error ?? null)
+        setSearchResults(res.threads ?? [])
+      } catch (err) {
+        if (searchEpoch.current === epoch) setSearchError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (searchEpoch.current === epoch) setSearching(false)
+      }
+    }, 400)
+    return () => window.clearTimeout(handle)
+  }, [query])
+
+  const deleteDraftAction = useCallback(async (thread: GmailThread) => {
+    const id = thread.draftId
+    if (!id) return
+    setDrafts((prev) => prev.filter((d) => d.draftId !== id))
+    try {
+      await window.ipc.invoke('gmail:deleteDraft', { draftId: id })
+    } catch (err) {
+      toast(`Could not delete draft: ${err instanceof Error ? err.message : String(err)}`, 'error')
+      void loadDrafts()
+    }
+  }, [loadDrafts])
+
+  // Closing the draft composer may have edited/sent/deleted it — refresh.
+  const closeDraftEditor = useCallback(() => {
+    setEditingDraft(null)
+    void loadDrafts()
+  }, [loadDrafts])
 
   useEffect(() => {
     let cancelled = false
@@ -1800,7 +2075,7 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'n' || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey || e.isComposing) return
-      if (composeOpen || settingsOpen) return
+      if (composeOpen || settingsOpen || editingDraft) return
       const target = e.target as HTMLElement | null
       if (
         target &&
@@ -1816,10 +2091,11 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [composeOpen, settingsOpen])
+  }, [composeOpen, settingsOpen, editingDraft])
 
   useEffect(() => { persistedImportant = important }, [important])
   useEffect(() => { persistedOther = other }, [other])
+  useEffect(() => { persistedDrafts = drafts }, [drafts])
 
   const setSection = useCallback((section: InboxSection, updater: (prev: SectionState) => SectionState) => {
     if (section === 'important') setImportant(updater)
@@ -1846,19 +2122,38 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     setOpenedThreadIds((prev) => prev.filter((id) => id !== threadId))
   }, [])
 
-  const markThreadReadAction = useCallback(async (threadId: string) => {
+  const markThreadReadAction = useCallback(async (threadId: string, read: boolean = true) => {
     updateThreadInState(threadId, (t) => ({
       ...t,
-      unread: false,
-      messages: t.messages.map((m) => ({ ...m, unread: false })),
+      unread: !read,
+      messages: t.messages.map((m) => ({ ...m, unread: !read })),
     }))
     try {
-      const result = await window.ipc.invoke('gmail:markThreadRead', { threadId })
+      const result = await window.ipc.invoke('gmail:markThreadRead', { threadId, read })
       if (!result.ok && result.error) console.warn('[Gmail] mark-read failed:', result.error)
     } catch (err) {
       console.warn('[Gmail] mark-read failed:', err)
     }
   }, [updateThreadInState])
+
+  // Toggle the read state of a whole category — server-side across the entire
+  // category, not just the rows currently loaded. Optimistically flips the UI.
+  const markSectionReadAction = useCallback(async (section: InboxSection, read: boolean) => {
+    setSection(section, (prev) => ({
+      ...prev,
+      threads: prev.threads.map((t) => ({
+        ...t,
+        unread: !read,
+        messages: t.messages.map((m) => ({ ...m, unread: !read })),
+      })),
+    }))
+    try {
+      const result = await window.ipc.invoke('gmail:markSectionRead', { section, read })
+      if (!result.ok && result.error) toast(`Could not update read state: ${result.error}`, 'error')
+    } catch (err) {
+      toast(`Could not update read state: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setSection])
 
   const archiveThreadAction = useCallback(async (threadId: string) => {
     try {
@@ -2151,6 +2446,9 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
 
   const visibleImportant = useMemo(() => filterThreads(important.threads), [important.threads, filterThreads])
   const visibleOther = useMemo(() => filterThreads(other.threads), [other.threads, filterThreads])
+  const visibleDrafts = useMemo(() => filterThreads(drafts), [drafts, filterThreads])
+  const importantHasUnread = important.threads.some((t) => t.unread)
+  const otherHasUnread = other.threads.some((t) => t.unread)
 
   const hasAny = important.threads.length > 0 || other.threads.length > 0
   const initialLoading = !hasAny && refreshing
@@ -2186,17 +2484,15 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
             <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
           </button>
           <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
-            {isUnread && (
-              <button
-                type="button"
-                className="gmail-row-action"
-                title="Mark as read"
-                aria-label="Mark as read"
-                onClick={(e) => { stop(e); void markThreadReadAction(thread.threadId) }}
-              >
-                <CheckCheck size={15} />
-              </button>
-            )}
+            <button
+              type="button"
+              className="gmail-row-action"
+              title={isUnread ? 'Mark as read' : 'Mark as unread'}
+              aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
+              onClick={(e) => { stop(e); void markThreadReadAction(thread.threadId, isUnread) }}
+            >
+              {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
+            </button>
             <button
               type="button"
               className="gmail-row-action"
@@ -2228,6 +2524,41 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     )
   }
 
+  const renderDraftRow = (thread: GmailThread) => {
+    const stop = (e: React.MouseEvent | React.KeyboardEvent) => { e.stopPropagation() }
+    const recipient = thread.to ? extractName(thread.to) : 'No recipient'
+    return (
+      <div key={thread.draftId || thread.threadId} className="gmail-row-group">
+        <div className="gmail-row-shell">
+          <button
+            type="button"
+            className="gmail-row"
+            onClick={() => setEditingDraft(thread)}
+          >
+            <span className="gmail-row-dot" aria-hidden />
+            <span className="gmail-row-sender">To: {recipient}</span>
+            <span className="gmail-row-content">
+              <strong>{thread.subject || '(No subject)'}</strong>
+              <span>{snippet(thread.gmail_draft || thread.latest_email)}</span>
+            </span>
+            <span className="gmail-row-date">{formatInboxTime(thread.date)}</span>
+          </button>
+          <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
+            <button
+              type="button"
+              className="gmail-row-action gmail-row-action-danger"
+              title="Delete draft"
+              aria-label="Delete draft"
+              onClick={(e) => { stop(e); void deleteDraftAction(thread) }}
+            >
+              <Trash2 size={15} />
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="gmail-shell">
       <div className="gmail-main">
@@ -2237,12 +2568,29 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search loaded mail"
+              placeholder="Search all mail"
             />
           </div>
           <div className="gmail-topbar-actions">
-            <button type="button" className="gmail-icon-button" onClick={() => void refresh()} aria-label="Refresh">
-              {refreshing ? <LoaderIcon size={18} className="animate-spin" /> : <RefreshCw size={18} />}
+            <div className="flex items-center rounded-md border border-border p-0.5 text-xs font-medium">
+              <button
+                type="button"
+                className={cn('rounded px-2.5 py-1 transition-colors', view === 'inbox' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground')}
+                onClick={() => setView('inbox')}
+              >Inbox</button>
+              <button
+                type="button"
+                className={cn('rounded px-2.5 py-1 transition-colors', view === 'drafts' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground')}
+                onClick={() => setView('drafts')}
+              >Drafts{drafts.length > 0 ? ` (${drafts.length})` : ''}</button>
+            </div>
+            <button
+              type="button"
+              className="gmail-icon-button"
+              onClick={() => { if (view === 'drafts') void loadDrafts(); else void refresh() }}
+              aria-label="Refresh"
+            >
+              {(view === 'drafts' ? draftsLoading : refreshing) ? <LoaderIcon size={18} className="animate-spin" /> : <RefreshCw size={18} />}
             </button>
             <button type="button" className="gmail-icon-button" onClick={() => setComposeOpen(true)} aria-label="Compose new email">
               <SquarePen size={18} />
@@ -2250,7 +2598,43 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
           </div>
         </div>
 
-        {error && !hasAny ? (
+        {query.trim() ? (
+          searchError && searchResults.length === 0 ? (
+            <div className="gmail-empty-state">Could not search: {searchError}</div>
+          ) : searchResults.length > 0 ? (
+            <div className="gmail-list" aria-label="Search results">
+              <section className="gmail-section">
+                <div className="gmail-list-header">
+                  <span>Search results</span>
+                  <span>{searchResults.length} thread{searchResults.length === 1 ? '' : 's'}</span>
+                </div>
+                {searchResults.map(renderRow)}
+              </section>
+            </div>
+          ) : (
+            <div className="gmail-empty-state">
+              {searching ? 'Searching all mail…' : `No results for “${query.trim()}”.`}
+            </div>
+          )
+        ) : view === 'drafts' ? (
+          draftsError && drafts.length === 0 ? (
+            <div className="gmail-empty-state">Could not load drafts: {draftsError}</div>
+          ) : drafts.length > 0 ? (
+            <div className="gmail-list" aria-label="Drafts">
+              <section className="gmail-section">
+                <div className="gmail-list-header">
+                  <span>Drafts</span>
+                  <span>{drafts.length} draft{drafts.length === 1 ? '' : 's'}</span>
+                </div>
+                {visibleDrafts.map(renderDraftRow)}
+              </section>
+            </div>
+          ) : (
+            <div className="gmail-empty-state">
+              {draftsLoading ? 'Loading drafts…' : 'No drafts yet.'}
+            </div>
+          )
+        ) : error && !hasAny ? (
           <div className="gmail-empty-state">Could not load mail: {error}</div>
         ) : hasAny ? (
           <div className="gmail-list" aria-label="Recent emails">
@@ -2258,9 +2642,19 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Important</span>
-                  <span>
-                    {important.threads.length}{important.hasReachedEnd ? '' : '+'} thread{important.threads.length === 1 ? '' : 's'}
-                  </span>
+                  <div className="flex items-center gap-2.5">
+                    <div className="flex items-center gap-1.5" title={importantHasUnread ? 'Mark all in Important as read' : 'Mark all in Important as unread'}>
+                      <span className="text-xs text-muted-foreground">Read</span>
+                      <Switch
+                        checked={!importantHasUnread}
+                        onCheckedChange={(checked) => void markSectionReadAction('important', checked)}
+                        aria-label="Mark all of Important read or unread"
+                      />
+                    </div>
+                    <span>
+                      {important.threads.length}{important.hasReachedEnd ? '' : '+'} thread{important.threads.length === 1 ? '' : 's'}
+                    </span>
+                  </div>
                 </div>
                 {visibleImportant.map(renderRow)}
                 {!important.hasReachedEnd && (
@@ -2276,9 +2670,19 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Everything else</span>
-                  <span>
-                    {other.threads.length}{other.hasReachedEnd ? '' : '+'} thread{other.threads.length === 1 ? '' : 's'}
-                  </span>
+                  <div className="flex items-center gap-2.5">
+                    <div className="flex items-center gap-1.5" title={otherHasUnread ? 'Mark all in Everything else as read' : 'Mark all in Everything else as unread'}>
+                      <span className="text-xs text-muted-foreground">Read</span>
+                      <Switch
+                        checked={!otherHasUnread}
+                        onCheckedChange={(checked) => void markSectionReadAction('other', checked)}
+                        aria-label="Mark all of Everything else read or unread"
+                      />
+                    </div>
+                    <span>
+                      {other.threads.length}{other.hasReachedEnd ? '' : '+'} thread{other.threads.length === 1 ? '' : 's'}
+                    </span>
+                  </div>
                 </div>
                 {visibleOther.map(renderRow)}
                 {!other.hasReachedEnd && (
@@ -2315,6 +2719,14 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
         )}
       </div>
       {composeOpen && <ComposeBox mode="new" onClose={closeCompose} />}
+      {editingDraft && (
+        <ComposeBox
+          mode="draft"
+          thread={editingDraft}
+          selfEmail={emailConnection?.email ?? ''}
+          onClose={closeDraftEditor}
+        />
+      )}
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} defaultTab="connections" />
     </div>
   )

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -551,6 +551,19 @@ function MessageAttachments({ attachments }: { attachments: NonNullable<GmailThr
 
 type ComposeMode = 'reply' | 'replyAll' | 'forward' | 'new' | 'draft'
 
+// Platform-aware modifier: Cmd on macOS, Ctrl on Windows/Linux (App.tsx pattern).
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
+
+// True when a keyboard event originated in a text-entry context, so
+// single-letter shortcuts must stay inert.
+function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  return Boolean(
+    el &&
+    (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable)
+  )
+}
+
 function ComposeToolbarButton({
   editor,
   command,
@@ -724,12 +737,15 @@ function RecipientField({
   onChange,
   autoFocus,
   trailing,
+  focusSignal,
 }: {
   label: string
   value: string[]
   onChange: (next: string[]) => void
   autoFocus?: boolean
   trailing?: React.ReactNode
+  /** Bump to move focus into this field (e.g. after a Cc/Bcc shortcut). */
+  focusSignal?: number
 }) {
   const [draft, setDraft] = useState('')
   const [suggestions, setSuggestions] = useState<ContactSuggestion[]>([])
@@ -744,6 +760,10 @@ function RecipientField({
   useEffect(() => {
     if (autoFocus) inputRef.current?.focus()
   }, [autoFocus])
+
+  useEffect(() => {
+    if (focusSignal) inputRef.current?.focus()
+  }, [focusSignal])
 
   const excludeEmails = useMemo(
     () => value.map((token) => extractAddress(token).toLowerCase()).filter(Boolean),
@@ -803,6 +823,12 @@ function RecipientField({
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const hasSuggestions = suggestions.length > 0
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      // Cmd/Ctrl+Enter is "send" — commit any half-typed address on the way
+      // and let the event bubble to the composer's send handler.
+      if (draft.trim()) commit(draft)
+      return
+    }
     if (event.key === 'ArrowDown' && hasSuggestions) {
       event.preventDefault()
       setActiveIndex((i) => (i + 1) % suggestions.length)
@@ -815,6 +841,7 @@ function RecipientField({
     }
     if (event.key === 'Escape' && hasSuggestions) {
       event.preventDefault()
+      event.stopPropagation()
       setSuggestions([])
       return
     }
@@ -846,7 +873,10 @@ function RecipientField({
   const showSuggestions = isFocused && suggestions.length > 0
 
   return (
-    <div className="flex items-start gap-2 border-b border-border px-3 py-1.5 text-sm">
+    <div
+      className="flex items-start gap-2 border-b border-border px-3 py-1.5 text-sm"
+      data-suggestions-open={showSuggestions || undefined}
+    >
       <span className="min-w-7 pt-1.5 text-muted-foreground">{label}</span>
       <div className="relative flex min-w-0 flex-1 flex-wrap items-center gap-1" ref={fieldRef}>
         {value.map((token, index) => (
@@ -1047,6 +1077,9 @@ const ComposeBox = memo(function ComposeBox({
   const [bccList, setBccList] = useState<string[]>([])
   const [showCc, setShowCc] = useState<boolean>(initialRecipients.cc.length > 0)
   const [showBcc, setShowBcc] = useState<boolean>(false)
+  // Bumped by the Cc/Bcc shortcuts so the freshly revealed field grabs focus.
+  const [ccFocusSignal, setCcFocusSignal] = useState(0)
+  const [bccFocusSignal, setBccFocusSignal] = useState(0)
   const [subject, setSubject] = useState<string>(() => (thread ? composeSubject(mode, thread.subject) : ''))
   const modeLabel = mode === 'draft' ? 'Draft' : isNew ? 'New message' : mode === 'forward' ? 'Forward' : mode === 'replyAll' ? 'Reply All' : 'Reply'
 
@@ -1067,6 +1100,10 @@ const ComposeBox = memo(function ComposeBox({
       .join('')
   }, [mode, thread])
 
+  // Ref so the Tiptap keydown handler (captured once at editor creation)
+  // always calls the latest send closure; assigned below sendInGmail.
+  const sendRef = useRef<() => void>(() => {})
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({ link: false }),
@@ -1077,6 +1114,13 @@ const ComposeBox = memo(function ComposeBox({
     ],
     editorProps: {
       attributes: { class: 'compose-content' },
+      handleKeyDown: (_view, event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === 'Enter' && !event.shiftKey) {
+          sendRef.current()
+          return true
+        }
+        return false
+      },
     },
     content: initialContent,
   })
@@ -1520,6 +1564,44 @@ const ComposeBox = memo(function ComposeBox({
       setSending(false)
     }
   }
+  sendRef.current = () => { void sendInGmail() }
+
+  // Composer-level shortcuts, on the wrapper so they work from any field.
+  // Inner handlers (recipient menu, link bar, AI Enter) preventDefault first
+  // and keep priority via the defaultPrevented check.
+  const onComposerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.defaultPrevented) return
+    const mod = e.metaKey || e.ctrlKey
+    if (mod && e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      e.stopPropagation()
+      // Deferred one tick: a recipient field may have just committed a
+      // half-typed address, and send must read the re-rendered list.
+      window.setTimeout(() => sendRef.current(), 0)
+      return
+    }
+    if (mod && e.shiftKey && e.key.toLowerCase() === 'c') {
+      e.preventDefault()
+      e.stopPropagation()
+      setShowCc(true)
+      setCcFocusSignal((n) => n + 1)
+      return
+    }
+    if (mod && e.shiftKey && e.key.toLowerCase() === 'b') {
+      e.preventDefault()
+      e.stopPropagation()
+      setShowBcc(true)
+      setBccFocusSignal((n) => n + 1)
+      return
+    }
+    // The modal variant closes via Radix's own Escape handling.
+    if (!isModal && e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
+      if (linkOpen) cancelLink()
+      else handleClose()
+    }
+  }
 
   const refineWithCopilot = () => {
     if (!editor || !thread) return
@@ -1578,8 +1660,8 @@ const ComposeBox = memo(function ComposeBox({
           </div>
         }
       />
-      {showCc && <RecipientField label="Cc" value={ccList} onChange={setCcList} />}
-      {showBcc && <RecipientField label="Bcc" value={bccList} onChange={setBccList} />}
+      {showCc && <RecipientField label="Cc" value={ccList} onChange={setCcList} focusSignal={ccFocusSignal} />}
+      {showBcc && <RecipientField label="Bcc" value={bccList} onChange={setBccList} focusSignal={bccFocusSignal} />}
       <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         <Input
           className="h-8"
@@ -1592,7 +1674,8 @@ const ComposeBox = memo(function ComposeBox({
               : 'Describe your reply and let AI write it…'}
           disabled={generating}
           onKeyDown={(event) => {
-            if (event.key === 'Enter') {
+            // Plain Enter runs the AI writer; Cmd/Ctrl+Enter bubbles to send.
+            if (event.key === 'Enter' && !event.metaKey && !event.ctrlKey) {
               event.preventDefault()
               void runAiBar()
             }
@@ -1753,6 +1836,19 @@ const ComposeBox = memo(function ComposeBox({
           showCloseButton={false}
           aria-describedby={undefined}
           className="flex h-[min(720px,calc(100vh-4rem))] flex-col gap-0 overflow-hidden p-0 font-sans sm:max-w-[840px]"
+          onKeyDown={onComposerKeyDown}
+          onEscapeKeyDown={(event) => {
+            // Radix's Escape runs document-capture, before the inner fields
+            // can claim it — let the link bar and an open recipient-suggestion
+            // menu win; only a bare Escape closes the whole composer.
+            if (linkOpen) {
+              event.preventDefault()
+              cancelLink()
+              return
+            }
+            const target = event.target as HTMLElement | null
+            if (target?.closest('[data-suggestions-open]')) event.preventDefault()
+          }}
         >
           <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-3">
             <DialogTitle className="flex-1 text-sm font-medium text-foreground">{modeLabel}</DialogTitle>
@@ -1774,7 +1870,10 @@ const ComposeBox = memo(function ComposeBox({
   }
 
   return (
-    <div className="ml-10 max-w-[720px] overflow-hidden rounded-lg border border-border bg-background font-sans">
+    <div
+      className="gmail-compose-inline ml-10 max-w-[720px] overflow-hidden rounded-lg border border-border bg-background font-sans"
+      onKeyDown={onComposerKeyDown}
+    >
       <div className="flex h-8 items-center justify-between border-b border-border px-3">
         <span className="text-xs font-medium text-muted-foreground">{modeLabel}</span>
         <Button
@@ -1797,10 +1896,16 @@ function ThreadDetail({
   thread,
   onClose,
   hidden,
+  keysDisabled,
+  onComposingChange,
 }: {
   thread: GmailThread
   onClose: () => void
   hidden?: boolean
+  /** True while a dialog is open above the inbox; suspends the reply keys. */
+  keysDisabled?: boolean
+  /** Reports whether the inline composer is open, so list shortcuts pause. */
+  onComposingChange?: (composing: boolean) => void
 }) {
   const [composeMode, setComposeMode] = useState<ComposeMode | null>(null)
   const [selfEmail, setSelfEmail] = useState<string>('')
@@ -1837,6 +1942,46 @@ function ThreadDetail({
       return next
     })
   }, [])
+
+  // Let EmailView pause its list shortcuts while our composer is open. The
+  // cleanup resets on hide/unmount so a hidden-but-mounted detail (up to 5 are
+  // kept alive) can't block them.
+  useEffect(() => {
+    if (hidden) return
+    onComposingChange?.(composeMode !== null)
+    return () => onComposingChange?.(false)
+  }, [hidden, composeMode, onComposingChange])
+
+  // Superhuman-style reply keys for the visible thread. Scoped by `hidden` so
+  // only the on-screen ThreadDetail listens. Escape closes the inline composer
+  // first; with none open it falls through to EmailView's close-thread.
+  useEffect(() => {
+    if (hidden || keysDisabled) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.isComposing || e.defaultPrevented) return
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
+      if (e.key === 'Escape') {
+        if (composeMode !== null) {
+          e.preventDefault()
+          setComposeMode(null)
+        }
+        return
+      }
+      if (composeMode !== null || isEditableTarget(e.target)) return
+      if (e.key === 'r') {
+        e.preventDefault()
+        setComposeMode('reply')
+      } else if (e.key === 'a') {
+        e.preventDefault()
+        setComposeMode(canReplyAll ? 'replyAll' : 'reply')
+      } else if (e.key === 'f') {
+        e.preventDefault()
+        setComposeMode('forward')
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [hidden, keysDisabled, composeMode, canReplyAll])
 
   return (
     <div className={cn('gmail-detail gmail-detail-inline', hidden && 'gmail-detail-hidden')}>
@@ -1922,8 +2067,200 @@ function ThreadDetail({
   )
 }
 
+// One inbox/search row (plus its kept-alive ThreadDetail). Memoized so cursor
+// moves and page appends only re-render the rows whose props actually changed
+// — re-rendering the whole list mid-scroll is what janks the frame.
+const ThreadRow = memo(function ThreadRow({
+  thread,
+  isSelected,
+  isFocused,
+  isMounted,
+  isLeaving,
+  keysDisabled,
+  onToggle,
+  onMarkRead,
+  onArchive,
+  onTrash,
+  onHoverIn,
+  onHoverOut,
+  onCloseThread,
+  onComposingChange,
+}: {
+  thread: GmailThread
+  isSelected: boolean
+  isFocused: boolean
+  isMounted: boolean
+  isLeaving: boolean
+  keysDisabled: boolean
+  onToggle: (thread: GmailThread) => void
+  onMarkRead: (threadId: string, read?: boolean) => Promise<void>
+  onArchive: (threadId: string) => Promise<void>
+  onTrash: (threadId: string) => Promise<void>
+  onHoverIn: (thread: GmailThread) => void
+  onHoverOut: () => void
+  onCloseThread: () => void
+  onComposingChange: (composing: boolean) => void
+}) {
+  const latest = latestMessage(thread)
+  const isUnread = thread.unread === true
+  const stop = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation()
+  }
+  return (
+    <div className={cn('gmail-row-group', !isMounted && 'gmail-row-group-cv', isLeaving && 'gmail-row-group-leaving')}>
+      <div
+        className={cn('gmail-row-shell', isSelected && 'gmail-row-shell-selected')}
+        data-thread-id={thread.threadId}
+        onMouseEnter={() => onHoverIn(thread)}
+        onMouseLeave={onHoverOut}
+      >
+        <button
+          type="button"
+          className={cn('gmail-row', isSelected && 'gmail-row-selected', isUnread && 'gmail-row-unread', isFocused && 'gmail-row-focused')}
+          onClick={() => onToggle(thread)}
+        >
+          <span className="gmail-row-dot" aria-hidden />
+          <span className="gmail-row-sender">{extractName(latest?.from || thread.from)}</span>
+          <span className="gmail-row-content">
+            <strong>{thread.summary || thread.subject || '(No subject)'}</strong>
+            <span>{thread.summary ? thread.subject : snippet(latest?.body || thread.latest_email)}</span>
+          </span>
+          <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
+        </button>
+        <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
+          <button
+            type="button"
+            className="gmail-row-action"
+            title={isUnread ? 'Mark as read' : 'Mark as unread'}
+            aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
+            onClick={(e) => { stop(e); void onMarkRead(thread.threadId, isUnread) }}
+          >
+            {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
+          </button>
+          <button
+            type="button"
+            className="gmail-row-action"
+            title="Archive"
+            aria-label="Archive"
+            onClick={(e) => { stop(e); void onArchive(thread.threadId) }}
+          >
+            <Archive size={15} />
+          </button>
+          <button
+            type="button"
+            className="gmail-row-action gmail-row-action-danger"
+            title="Delete"
+            aria-label="Delete"
+            onClick={(e) => { stop(e); void onTrash(thread.threadId) }}
+          >
+            <Trash2 size={15} />
+          </button>
+        </div>
+      </div>
+      {/* Drop the detail as soon as the row starts leaving — the collapse
+          keyframe assumes row height, and the thread is being removed anyway. */}
+      {isMounted && !isLeaving && (
+        <ThreadDetail
+          thread={thread}
+          onClose={onCloseThread}
+          hidden={!isSelected}
+          keysDisabled={keysDisabled}
+          onComposingChange={onComposingChange}
+        />
+      )}
+    </div>
+  )
+})
+
+function ShortcutKey({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-[11px] font-medium text-foreground">
+      {children}
+    </kbd>
+  )
+}
+
+// One shortcut line: `combo` keys render as adjacent chips (a chord or a
+// two-key sequence); `alt` is an equivalent alternative shown after "or".
+function ShortcutRow({ combo, alt, label }: { combo: string[]; alt?: string[]; label: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-1">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="flex shrink-0 items-center gap-1">
+        {combo.map((key) => <ShortcutKey key={key}>{key}</ShortcutKey>)}
+        {alt && (
+          <>
+            <span className="px-0.5 text-xs text-muted-foreground">or</span>
+            {alt.map((key) => <ShortcutKey key={key}>{key}</ShortcutKey>)}
+          </>
+        )}
+      </span>
+    </div>
+  )
+}
+
+function ShortcutSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+// The "?" cheat sheet. Static list — keep in sync with the handlers in
+// EmailView, ThreadDetail, and ComposeBox.
+function ShortcutsHelpDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  const mod = isMac ? '⌘' : 'Ctrl'
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent aria-describedby={undefined} className="font-sans sm:max-w-[620px]">
+        <DialogTitle className="text-base font-semibold">Keyboard shortcuts</DialogTitle>
+        <div className="grid grid-cols-1 gap-x-10 gap-y-5 sm:grid-cols-2">
+          <ShortcutSection title="Inbox">
+            <ShortcutRow combo={['J']} alt={['↓']} label="Next thread" />
+            <ShortcutRow combo={['K']} alt={['↑']} label="Previous thread" />
+            <ShortcutRow combo={['Enter']} alt={['O']} label="Open / close thread" />
+            <ShortcutRow combo={['Esc']} label="Close thread / clear search" />
+            <ShortcutRow combo={['E']} label="Archive" />
+            <ShortcutRow combo={['#']} label="Move to trash" />
+            <ShortcutRow combo={['U']} label="Mark read / unread" />
+            <ShortcutRow combo={['C']} alt={['N']} label="New message" />
+            <ShortcutRow combo={['/']} label="Search" />
+            <ShortcutRow combo={['G', 'I']} label="Go to inbox" />
+            <ShortcutRow combo={['G', 'D']} label="Go to drafts" />
+            <ShortcutRow combo={['?']} label="Keyboard shortcuts" />
+          </ShortcutSection>
+          <div className="flex flex-col gap-5">
+            <ShortcutSection title="Thread">
+              <ShortcutRow combo={['R']} label="Reply" />
+              <ShortcutRow combo={['A']} label="Reply all" />
+              <ShortcutRow combo={['F']} label="Forward" />
+            </ShortcutSection>
+            <ShortcutSection title="Composer">
+              <ShortcutRow combo={[mod, 'Enter']} label="Send" />
+              <ShortcutRow combo={[mod, 'Shift', 'C']} label="Add Cc" />
+              <ShortcutRow combo={[mod, 'Shift', 'B']} label="Add Bcc" />
+              <ShortcutRow combo={['Esc']} label="Close (saves draft)" />
+            </ShortcutSection>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 const MAX_KEPT_OPEN = 5
 const PAGE_SIZE = 25
+// Duration of the row slide-out on archive/trash — matches gmail-row-leave.
+const ROW_LEAVE_MS = 160
+// Sticky .gmail-list-header height — rows scrolled to the top stay clear of it.
+const LIST_STICKY_HEADER_PX = 32
+
+function listScrollerFor(row: HTMLElement): HTMLElement | null {
+  const list = row.closest('.gmail-list')
+  return list instanceof HTMLElement ? list : null
+}
 type InboxSection = 'important' | 'other'
 
 interface SectionState {
@@ -1967,6 +2304,7 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   const [openedThreadIds, setOpenedThreadIds] = useState<string[]>(initialThreadId ? [initialThreadId] : [])
   useEffect(() => {
     setSelectedThreadId(initialThreadId ?? null)
+    setFocusedThreadId(initialThreadId ?? null)
     if (initialThreadId) {
       setOpenedThreadIds((prev) => {
         const without = prev.filter((id) => id !== initialThreadId)
@@ -1996,6 +2334,31 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   // Gmail sync uses the native Google OAuth connection.
   const [emailConnection, setEmailConnection] = useState<GmailConnectionStatus | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  // Keyboard navigation: the j/k focus cursor over the visible rows, plus the
+  // "?" shortcuts overlay. lastFocusedIndexRef remembers the cursor's position
+  // so it can re-anchor when the focused row disappears (archive/trash/reload).
+  const [focusedThreadId, setFocusedThreadId] = useState<string | null>(null)
+  const [helpOpen, setHelpOpen] = useState(false)
+  // Set while the visible ThreadDetail's inline composer is open; list
+  // shortcuts stay inert so typing a reply can't archive threads.
+  const [activeThreadComposing, setActiveThreadComposing] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const lastFocusedIndexRef = useRef(0)
+  const listModeRef = useRef<string | null>(null)
+  // Timestamp of a pending "g" for the two-key g→i / g→d sequences.
+  const gPendingRef = useRef(0)
+  // Rows currently animating out (archive/trash/draft-delete in flight).
+  const [leavingThreadIds, setLeavingThreadIds] = useState<ReadonlySet<string>>(() => new Set())
+  const markLeaving = useCallback((rowId: string, leaving: boolean) => {
+    setLeavingThreadIds((prev) => {
+      if (prev.has(rowId) === leaving) return prev
+      const next = new Set(prev)
+      if (leaving) next.add(rowId)
+      else next.delete(rowId)
+      return next
+    })
+  }, [])
 
   const loadDrafts = useCallback(async () => {
     setDraftsLoading(true)
@@ -2057,14 +2420,18 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   const deleteDraftAction = useCallback(async (thread: GmailThread) => {
     const id = thread.draftId
     if (!id) return
+    // Slide the row out before dropping it from the list.
+    markLeaving(id, true)
+    await new Promise((resolve) => window.setTimeout(resolve, ROW_LEAVE_MS))
     setDrafts((prev) => prev.filter((d) => d.draftId !== id))
+    markLeaving(id, false)
     try {
       await window.ipc.invoke('gmail:deleteDraft', { draftId: id })
     } catch (err) {
       toast(`Could not delete draft: ${err instanceof Error ? err.message : String(err)}`, 'error')
       void loadDrafts()
     }
-  }, [loadDrafts])
+  }, [loadDrafts, markLeaving])
 
   // Closing the draft composer may have edited/sent/deleted it — refresh.
   const closeDraftEditor = useCallback(() => {
@@ -2097,30 +2464,6 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     }
   }, [])
 
-  // Gmail-style "n" to start a new message. EmailView only mounts while the
-  // inbox is open, so this is naturally scoped to that view. Ignored while
-  // typing in any field or when a dialog (compose/settings) is already up.
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'n' || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey || e.isComposing) return
-      if (composeOpen || settingsOpen || editingDraft) return
-      const target = e.target as HTMLElement | null
-      if (
-        target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.tagName === 'SELECT' ||
-          target.isContentEditable)
-      ) {
-        return
-      }
-      e.preventDefault()
-      setComposeOpen(true)
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [composeOpen, settingsOpen, editingDraft])
-
   useEffect(() => { persistedImportant = important }, [important])
   useEffect(() => { persistedOther = other }, [other])
   useEffect(() => { persistedDrafts = drafts }, [drafts])
@@ -2137,6 +2480,7 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     })
     setImportant(mapSection)
     setOther(mapSection)
+    setSearchResults((prev) => prev.map((t) => (t.threadId === threadId ? updater(t) : t)))
   }, [])
 
   const removeThreadFromState = useCallback((threadId: string) => {
@@ -2146,6 +2490,7 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
     })
     setImportant(filterSection)
     setOther(filterSection)
+    setSearchResults((prev) => prev.filter((t) => t.threadId !== threadId))
     setSelectedThreadId((current) => (current === threadId ? null : current))
     setOpenedThreadIds((prev) => prev.filter((id) => id !== threadId))
   }, [])
@@ -2197,8 +2542,14 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   }, [markSectionReadAction])
 
   const archiveThreadAction = useCallback(async (threadId: string) => {
+    // Start the slide-out right away; the row is removed once both the IPC
+    // and the animation have finished. A failure clears the flag → snap back.
+    markLeaving(threadId, true)
     try {
-      const result = await window.ipc.invoke('gmail:archiveThread', { threadId })
+      const [result] = await Promise.all([
+        window.ipc.invoke('gmail:archiveThread', { threadId }),
+        new Promise((resolve) => window.setTimeout(resolve, ROW_LEAVE_MS)),
+      ])
       if (result.ok) {
         removeThreadFromState(threadId)
       } else if (result.error) {
@@ -2206,12 +2557,18 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
       }
     } catch (err) {
       toast(`Archive failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    } finally {
+      markLeaving(threadId, false)
     }
-  }, [removeThreadFromState])
+  }, [removeThreadFromState, markLeaving])
 
   const trashThreadAction = useCallback(async (threadId: string) => {
+    markLeaving(threadId, true)
     try {
-      const result = await window.ipc.invoke('gmail:trashThread', { threadId })
+      const [result] = await Promise.all([
+        window.ipc.invoke('gmail:trashThread', { threadId }),
+        new Promise((resolve) => window.setTimeout(resolve, ROW_LEAVE_MS)),
+      ])
       if (result.ok) {
         removeThreadFromState(threadId)
       } else if (result.error) {
@@ -2219,10 +2576,13 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
       }
     } catch (err) {
       toast(`Delete failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    } finally {
+      markLeaving(threadId, false)
     }
-  }, [removeThreadFromState])
+  }, [removeThreadFromState, markLeaving])
 
   const toggleThread = useCallback((thread: GmailThread) => {
+    setFocusedThreadId(thread.threadId)
     setSelectedThreadId((current) => {
       const next = current === thread.threadId ? null : thread.threadId
       if (next) {
@@ -2489,89 +2849,295 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   const visibleOther = useMemo(() => filterThreads(other.threads), [other.threads, filterThreads])
   const visibleDrafts = useMemo(() => filterThreads(drafts), [drafts, filterThreads])
 
+  // ── Keyboard shortcuts (Superhuman-style) ───────────────────────────────────
+  // EmailView only mounts while the email tab is open, so these are naturally
+  // scoped to that view. Single-letter keys stay inert while typing in any
+  // field, while a dialog is up, or while the inline reply composer is open.
+
+  const listMode: 'search' | 'drafts' | 'inbox' = query.trim() ? 'search' : view === 'drafts' ? 'drafts' : 'inbox'
+  const anyModalOpen = composeOpen || settingsOpen || Boolean(editingDraft) || helpOpen
+
+  // Row identity for the focus cursor — must match each row's data-thread-id.
+  const rowIdOf = useCallback((thread: GmailThread) => (
+    listMode === 'drafts' ? (thread.draftId || thread.threadId) : thread.threadId
+  ), [listMode])
+
+  // Flattened, ordered list of the rows currently on screen — the domain of
+  // the j/k cursor. Mirrors the render branches below: search results, drafts,
+  // or Important followed by Everything else (which only renders once
+  // Important is exhausted).
+  const visibleList = useMemo<GmailThread[]>(() => {
+    if (query.trim()) return searchResults
+    if (view === 'drafts') return visibleDrafts
+    if (important.hasReachedEnd && other.threads.length > 0) return [...visibleImportant, ...visibleOther]
+    return visibleImportant
+  }, [query, searchResults, view, visibleDrafts, visibleImportant, visibleOther, important.hasReachedEnd, other.threads.length])
+
+  // Keep the cursor valid as the list changes: switching between inbox,
+  // search, and drafts resets it; if the focused row vanished (archived,
+  // trashed, or replaced by a live reload), re-anchor to the same position.
+  useEffect(() => {
+    if (listModeRef.current !== listMode) {
+      const isFirstRun = listModeRef.current === null
+      listModeRef.current = listMode
+      if (!isFirstRun) {
+        lastFocusedIndexRef.current = 0
+        setFocusedThreadId(null)
+        return
+      }
+    }
+    if (!focusedThreadId || visibleList.length === 0) return
+    const idx = visibleList.findIndex((t) => rowIdOf(t) === focusedThreadId)
+    if (idx >= 0) {
+      lastFocusedIndexRef.current = idx
+      return
+    }
+    const fallback = visibleList[Math.min(lastFocusedIndexRef.current, visibleList.length - 1)]
+    setFocusedThreadId(fallback ? rowIdOf(fallback) : null)
+  }, [visibleList, focusedThreadId, listMode, rowIdOf])
+
+  // ── Smooth list scrolling ──────────────────────────────────────────────────
+  // Short ease-out scroll instead of native behavior:'smooth' — it finishes in
+  // ~140ms and retargets cleanly under key-repeat, where the native animation
+  // lags behind and rubber-bands.
+  const scrollAnimRef = useRef<number | null>(null)
+  const smoothScrollTo = useCallback((container: HTMLElement, top: number) => {
+    if (scrollAnimRef.current !== null) window.cancelAnimationFrame(scrollAnimRef.current)
+    const from = container.scrollTop
+    const max = container.scrollHeight - container.clientHeight
+    const target = Math.min(Math.max(top, 0), max)
+    const delta = target - from
+    if (delta === 0) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      container.scrollTop = target
+      return
+    }
+    const start = performance.now()
+    const duration = 140
+    const step = (now: number) => {
+      const t = Math.min(1, (now - start) / duration)
+      const eased = 1 - (1 - t) ** 3
+      container.scrollTop = from + delta * eased
+      scrollAnimRef.current = t < 1 ? window.requestAnimationFrame(step) : null
+    }
+    scrollAnimRef.current = window.requestAnimationFrame(step)
+  }, [])
+
+  useEffect(() => () => {
+    if (scrollAnimRef.current !== null) window.cancelAnimationFrame(scrollAnimRef.current)
+  }, [])
+
+  const rowElementFor = useCallback((rowId: string) => {
+    const el = rootRef.current?.querySelector(`[data-thread-id="${CSS.escape(rowId)}"]`)
+    return el instanceof HTMLElement ? el : null
+  }, [])
+
+  // Keep the focused row on screen during keyboard navigation — "nearest"
+  // semantics with the animated scroll, minding the sticky section header.
+  useEffect(() => {
+    if (!focusedThreadId) return
+    const row = rowElementFor(focusedThreadId)
+    const list = row ? listScrollerFor(row) : null
+    if (!row || !list) return
+    const listRect = list.getBoundingClientRect()
+    const rowRect = row.getBoundingClientRect()
+    const topEdge = listRect.top + LIST_STICKY_HEADER_PX
+    if (rowRect.top < topEdge) {
+      smoothScrollTo(list, list.scrollTop + rowRect.top - topEdge)
+    } else if (rowRect.bottom > listRect.bottom) {
+      smoothScrollTo(list, list.scrollTop + rowRect.bottom - listRect.bottom)
+    }
+  }, [focusedThreadId, rowElementFor, smoothScrollTo])
+
+  // Opening a thread glides its row to the top of the list so the expanded
+  // conversation gets the full viewport. Runs after the focus effect above and
+  // cancels its animation via the shared ref, so on open this scroll wins.
+  useEffect(() => {
+    if (!selectedThreadId) return
+    const row = rowElementFor(selectedThreadId)
+    const list = row ? listScrollerFor(row) : null
+    if (!row || !list) return
+    const rowTop = list.scrollTop + row.getBoundingClientRect().top - list.getBoundingClientRect().top
+    smoothScrollTo(list, rowTop - LIST_STICKY_HEADER_PX)
+  }, [selectedThreadId, rowElementFor, smoothScrollTo])
+
+  // While the list is scrolling, flag the shell so CSS turns off row pointer
+  // events (see .gmail-shell[data-scrolling]) — otherwise every row passing
+  // under the cursor restyles for :hover and schedules a prefetch timer,
+  // stealing frame time. The attribute is toggled straight on the DOM node so
+  // scrolling itself never causes a React render.
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    let timer: number | null = null
+    const onScroll = (event: Event) => {
+      const target = event.target
+      if (!(target instanceof Element) || !target.classList.contains('gmail-list')) return
+      if (timer === null) root.setAttribute('data-scrolling', '')
+      else window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        timer = null
+        root.removeAttribute('data-scrolling')
+      }, 150)
+    }
+    // Capture phase: scroll events don't bubble, so listen above the scroller.
+    root.addEventListener('scroll', onScroll, { capture: true, passive: true })
+    return () => {
+      root.removeEventListener('scroll', onScroll, { capture: true })
+      if (timer !== null) window.clearTimeout(timer)
+    }
+  }, [])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.isComposing || e.defaultPrevented) return
+      // All list keys are unmodified. Shift is allowed through because "#" and
+      // "?" need it; shifted letters produce uppercase e.key and match nothing.
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      const inEditable = isEditableTarget(e.target)
+
+      if (e.key === 'Escape') {
+        // The search input, recipient fields, and composers own their Escape;
+        // this level only closes the open thread or clears the search.
+        if (inEditable || anyModalOpen || activeThreadComposing) return
+        if (selectedThreadId) {
+          e.preventDefault()
+          setSelectedThreadId(null)
+          return
+        }
+        if (query.trim()) {
+          e.preventDefault()
+          setQuery('')
+        }
+        return
+      }
+
+      if (inEditable || anyModalOpen || activeThreadComposing) return
+
+      // Two-key "go to" sequences: g then i (inbox) / g then d (drafts).
+      if (gPendingRef.current && Date.now() - gPendingRef.current < 1000) {
+        gPendingRef.current = 0
+        if (e.key === 'i' || e.key === 'd') {
+          e.preventDefault()
+          setQuery('')
+          setView(e.key === 'i' ? 'inbox' : 'drafts')
+          return
+        }
+        // Any other key cancels the sequence and is handled normally below.
+      }
+      if (e.key === 'g') {
+        gPendingRef.current = Date.now()
+        return
+      }
+
+      const focusedIndex = focusedThreadId
+        ? visibleList.findIndex((t) => rowIdOf(t) === focusedThreadId)
+        : -1
+
+      const moveFocus = (delta: number) => {
+        if (visibleList.length === 0) return
+        e.preventDefault() // stop arrow keys from also scrolling the list
+        const next = visibleList[Math.min(Math.max(focusedIndex + delta, 0), visibleList.length - 1)]
+        if (next) setFocusedThreadId(rowIdOf(next))
+      }
+
+      switch (e.key) {
+        case 'j':
+        case 'ArrowDown':
+          moveFocus(1)
+          return
+        case 'k':
+        case 'ArrowUp':
+          moveFocus(-1)
+          return
+        case 'Enter':
+        case 'o': {
+          const focused = focusedIndex >= 0 ? visibleList[focusedIndex] : undefined
+          if (!focused) return
+          e.preventDefault()
+          if (listMode === 'drafts') setEditingDraft(focused)
+          else toggleThread(focused)
+          return
+        }
+        case 'c':
+        case 'n':
+          e.preventDefault()
+          setComposeOpen(true)
+          return
+        case '/':
+          e.preventDefault()
+          searchInputRef.current?.focus()
+          return
+        case '?':
+          e.preventDefault()
+          setHelpOpen(true)
+          return
+        case 'e':
+        case '#':
+        case 'u': {
+          if (listMode === 'drafts') return // drafts have no archive/trash/read state
+          // The open thread takes precedence over the cursor.
+          const targetId = selectedThreadId ?? (focusedIndex >= 0 ? visibleList[focusedIndex]?.threadId : undefined)
+          const target = targetId ? visibleList.find((t) => t.threadId === targetId) : undefined
+          if (!target) return
+          e.preventDefault()
+          if (e.key === 'u') void markThreadReadAction(target.threadId, target.unread === true)
+          else if (e.key === 'e') void archiveThreadAction(target.threadId)
+          else void trashThreadAction(target.threadId)
+          return
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [
+    visibleList, focusedThreadId, selectedThreadId, query, listMode, anyModalOpen,
+    activeThreadComposing, rowIdOf, toggleThread, markThreadReadAction,
+    archiveThreadAction, trashThreadAction,
+  ])
+
   const hasAny = important.threads.length > 0 || other.threads.length > 0
   const initialLoading = !hasAny && refreshing
   const needsEmailConnect = emailConnection?.connected === false
   const needsEmailReconnect = emailConnection?.connected === true && !emailConnection.hasRequiredScope
 
+  const closeThread = useCallback(() => setSelectedThreadId(null), [])
+
   const renderRow = (thread: GmailThread) => {
-    const latest = latestMessage(thread)
-    const isSelected = thread.threadId === selectedThreadId
-    const isUnread = thread.unread === true
     const isMounted = openedThreadIds.includes(thread.threadId)
-    const stop = (e: React.MouseEvent | React.KeyboardEvent) => {
-      e.stopPropagation()
-    }
     return (
-      <div key={thread.threadId} className="gmail-row-group">
-        <div
-          className={cn('gmail-row-shell', isSelected && 'gmail-row-shell-selected')}
-          onMouseEnter={() => scheduleHoverPrefetch(thread)}
-          onMouseLeave={cancelHoverPrefetch}
-        >
-          <button
-            type="button"
-            className={cn('gmail-row', isSelected && 'gmail-row-selected', isUnread && 'gmail-row-unread')}
-            onClick={() => toggleThread(thread)}
-          >
-            <span className="gmail-row-dot" aria-hidden />
-            <span className="gmail-row-sender">{extractName(latest?.from || thread.from)}</span>
-            <span className="gmail-row-content">
-              <strong>{thread.summary || thread.subject || '(No subject)'}</strong>
-              <span>{thread.summary ? thread.subject : snippet(latest?.body || thread.latest_email)}</span>
-            </span>
-            <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
-          </button>
-          <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
-            <button
-              type="button"
-              className="gmail-row-action"
-              title={isUnread ? 'Mark as read' : 'Mark as unread'}
-              aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
-              onClick={(e) => { stop(e); void markThreadReadAction(thread.threadId, isUnread) }}
-            >
-              {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
-            </button>
-            <button
-              type="button"
-              className="gmail-row-action"
-              title="Archive"
-              aria-label="Archive"
-              onClick={(e) => { stop(e); void archiveThreadAction(thread.threadId) }}
-            >
-              <Archive size={15} />
-            </button>
-            <button
-              type="button"
-              className="gmail-row-action gmail-row-action-danger"
-              title="Delete"
-              aria-label="Delete"
-              onClick={(e) => { stop(e); void trashThreadAction(thread.threadId) }}
-            >
-              <Trash2 size={15} />
-            </button>
-          </div>
-        </div>
-        {isMounted && (
-          <ThreadDetail
-            thread={thread}
-            onClose={() => setSelectedThreadId(null)}
-            hidden={!isSelected}
-          />
-        )}
-      </div>
+      <ThreadRow
+        key={thread.threadId}
+        thread={thread}
+        isSelected={thread.threadId === selectedThreadId}
+        isFocused={thread.threadId === focusedThreadId}
+        isMounted={isMounted}
+        isLeaving={leavingThreadIds.has(thread.threadId)}
+        keysDisabled={isMounted && anyModalOpen}
+        onToggle={toggleThread}
+        onMarkRead={markThreadReadAction}
+        onArchive={archiveThreadAction}
+        onTrash={trashThreadAction}
+        onHoverIn={scheduleHoverPrefetch}
+        onHoverOut={cancelHoverPrefetch}
+        onCloseThread={closeThread}
+        onComposingChange={setActiveThreadComposing}
+      />
     )
   }
 
   const renderDraftRow = (thread: GmailThread) => {
     const stop = (e: React.MouseEvent | React.KeyboardEvent) => { e.stopPropagation() }
     const recipient = thread.to ? extractName(thread.to) : 'No recipient'
+    const rowId = thread.draftId || thread.threadId
+    const isFocused = rowId === focusedThreadId
+    const isLeaving = leavingThreadIds.has(rowId)
     return (
-      <div key={thread.draftId || thread.threadId} className="gmail-row-group">
-        <div className="gmail-row-shell">
+      <div key={rowId} className={cn('gmail-row-group', 'gmail-row-group-cv', isLeaving && 'gmail-row-group-leaving')}>
+        <div className="gmail-row-shell" data-thread-id={rowId}>
           <button
             type="button"
-            className="gmail-row"
+            className={cn('gmail-row', isFocused && 'gmail-row-focused')}
             onClick={() => setEditingDraft(thread)}
           >
             <span className="gmail-row-dot" aria-hidden />
@@ -2599,15 +3165,23 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
   }
 
   return (
-    <div className="gmail-shell">
+    <div className="gmail-shell" ref={rootRef}>
       <div className="gmail-main">
         <div className="gmail-topbar">
           <div className="gmail-search">
             <Search size={18} />
             <input
+              ref={searchInputRef}
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search all mail"
+              onKeyDown={(event) => {
+                if (event.key !== 'Escape') return
+                event.preventDefault()
+                event.stopPropagation()
+                if (query) setQuery('')
+                else event.currentTarget.blur()
+              }}
             />
             {query && (
               <button
@@ -2768,6 +3342,7 @@ export function EmailView({ initialThreadId, threadIdVersion }: EmailViewProps =
         />
       )}
       <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} defaultTab="connections" />
+      <ShortcutsHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
     </div>
   )
 }

--- a/apps/x/packages/core/src/config/config.ts
+++ b/apps/x/packages/core/src/config/config.ts
@@ -44,6 +44,17 @@ function ensureDefaultConfigs() {
             configured: false
         }, null, 2));
     }
+
+    // Create gmail_sync.json with the default onboarding email count if it
+    // doesn't exist, so the "how many emails to backfill" setting is
+    // discoverable and editable. Keep the default in sync with
+    // DEFAULT_MAX_EMAILS in gmail_sync_config.ts.
+    const gmailSyncConfig = path.join(WorkDir, "config", "gmail_sync.json");
+    if (!fs.existsSync(gmailSyncConfig)) {
+        fs.writeFileSync(gmailSyncConfig, JSON.stringify({
+            maxEmails: 500
+        }, null, 2));
+    }
 }
 
 ensureDirs();

--- a/apps/x/packages/core/src/config/gmail_sync_config.ts
+++ b/apps/x/packages/core/src/config/gmail_sync_config.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import { WorkDir } from './config.js';
+
+const CONFIG_FILE = path.join(WorkDir, 'config', 'gmail_sync.json');
+
+/**
+ * How many of the newest email threads the initial (onboarding) / recovery
+ * Gmail sync pulls down. This bounds the sync by a COUNT of recent threads
+ * rather than a fixed date window, so a fresh account backfills its most recent
+ * `maxEmails` emails even when they span more than a week.
+ */
+export const DEFAULT_MAX_EMAILS = 500;
+
+// Guard rails: at least one email, and a hard ceiling so a misconfigured value
+// can't trigger a runaway onboarding sync (each thread costs a threads.get plus
+// an LLM classification).
+const MIN_MAX_EMAILS = 1;
+const MAX_MAX_EMAILS = 5000;
+
+interface GmailSyncConfig {
+    maxEmails: number;
+}
+
+function clampMaxEmails(value: number): number {
+    return Math.max(MIN_MAX_EMAILS, Math.min(MAX_MAX_EMAILS, Math.floor(value)));
+}
+
+/**
+ * Read the configured max email count for the onboarding/full sync.
+ * Falls back to {@link DEFAULT_MAX_EMAILS} when the file is missing, malformed,
+ * or holds an out-of-range value.
+ */
+export function getMaxEmails(): number {
+    try {
+        if (fs.existsSync(CONFIG_FILE)) {
+            const raw = fs.readFileSync(CONFIG_FILE, 'utf-8');
+            const parsed = JSON.parse(raw) as Partial<GmailSyncConfig>;
+            const value = Number(parsed?.maxEmails);
+            if (Number.isFinite(value) && value > 0) {
+                return clampMaxEmails(value);
+            }
+        }
+    } catch (err) {
+        console.warn('[GmailSyncConfig] Failed to read gmail_sync.json:', err);
+    }
+    return DEFAULT_MAX_EMAILS;
+}
+
+/**
+ * Persist the max email count used by the onboarding/full sync. The value is
+ * clamped into the supported range before writing.
+ */
+export function setMaxEmails(maxEmails: number): void {
+    const configDir = path.dirname(CONFIG_FILE);
+    if (!fs.existsSync(configDir)) {
+        fs.mkdirSync(configDir, { recursive: true });
+    }
+    const config: GmailSyncConfig = { maxEmails: clampMaxEmails(maxEmails) };
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}

--- a/apps/x/packages/core/src/config/gmail_sync_config.ts
+++ b/apps/x/packages/core/src/config/gmail_sync_config.ts
@@ -20,10 +20,37 @@ const MAX_MAX_EMAILS = 5000;
 
 interface GmailSyncConfig {
     maxEmails: number;
+    /**
+     * When true, threads the classifier labels as "Everything else" are
+     * automatically marked read as they arrive during sync. Toggling this on
+     * only governs FUTURE mail; existing threads are marked read separately at
+     * toggle time (and are never touched when this is turned off).
+     */
+    autoReadEverythingElse?: boolean;
 }
 
 function clampMaxEmails(value: number): number {
     return Math.max(MIN_MAX_EMAILS, Math.min(MAX_MAX_EMAILS, Math.floor(value)));
+}
+
+function readConfig(): Partial<GmailSyncConfig> {
+    try {
+        if (fs.existsSync(CONFIG_FILE)) {
+            const raw = fs.readFileSync(CONFIG_FILE, 'utf-8');
+            return JSON.parse(raw) as Partial<GmailSyncConfig>;
+        }
+    } catch (err) {
+        console.warn('[GmailSyncConfig] Failed to read gmail_sync.json:', err);
+    }
+    return {};
+}
+
+function writeConfig(config: Partial<GmailSyncConfig>): void {
+    const configDir = path.dirname(CONFIG_FILE);
+    if (!fs.existsSync(configDir)) {
+        fs.mkdirSync(configDir, { recursive: true });
+    }
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
 }
 
 /**
@@ -32,17 +59,9 @@ function clampMaxEmails(value: number): number {
  * or holds an out-of-range value.
  */
 export function getMaxEmails(): number {
-    try {
-        if (fs.existsSync(CONFIG_FILE)) {
-            const raw = fs.readFileSync(CONFIG_FILE, 'utf-8');
-            const parsed = JSON.parse(raw) as Partial<GmailSyncConfig>;
-            const value = Number(parsed?.maxEmails);
-            if (Number.isFinite(value) && value > 0) {
-                return clampMaxEmails(value);
-            }
-        }
-    } catch (err) {
-        console.warn('[GmailSyncConfig] Failed to read gmail_sync.json:', err);
+    const value = Number(readConfig()?.maxEmails);
+    if (Number.isFinite(value) && value > 0) {
+        return clampMaxEmails(value);
     }
     return DEFAULT_MAX_EMAILS;
 }
@@ -52,10 +71,18 @@ export function getMaxEmails(): number {
  * clamped into the supported range before writing.
  */
 export function setMaxEmails(maxEmails: number): void {
-    const configDir = path.dirname(CONFIG_FILE);
-    if (!fs.existsSync(configDir)) {
-        fs.mkdirSync(configDir, { recursive: true });
-    }
-    const config: GmailSyncConfig = { maxEmails: clampMaxEmails(maxEmails) };
-    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+    writeConfig({ ...readConfig(), maxEmails: clampMaxEmails(maxEmails) });
+}
+
+/**
+ * Whether newly-arriving "Everything else" threads should be auto-marked read
+ * during sync. Defaults to false (off) when unset.
+ */
+export function getAutoReadEverythingElse(): boolean {
+    return readConfig()?.autoReadEverythingElse === true;
+}
+
+/** Persist the "auto-mark Everything else as read" preference. */
+export function setAutoReadEverythingElse(enabled: boolean): void {
+    writeConfig({ ...readConfig(), autoReadEverythingElse: enabled });
 }

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -4,7 +4,7 @@ import { google, gmail_v1 as gmail } from 'googleapis';
 import { NodeHtmlMarkdown } from 'node-html-markdown'
 import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
-import { getMaxEmails } from '../config/gmail_sync_config.js';
+import { getMaxEmails, getAutoReadEverythingElse } from '../config/gmail_sync_config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
 import { serviceLogger, type ServiceRunContext } from '../services/service_logger.js';
 import { limitEventItems } from './limit_event_items.js';
@@ -303,6 +303,8 @@ export interface GmailThreadSnapshot {
             mimeType?: string;
             sizeBytes?: number;
             savedPath: string;
+            messageId?: string;
+            attachmentId?: string;
         }>;
         messageIdHeader?: string;
         isDraft?: boolean;
@@ -458,6 +460,10 @@ interface ExtractedAttachment {
     mimeType?: string;
     sizeBytes?: number;
     savedPath: string;
+    // Gmail identifiers needed to fetch the attachment on demand (e.g. when a
+    // search result's attachment hasn't been downloaded to disk yet).
+    messageId?: string;
+    attachmentId?: string;
 }
 
 /**
@@ -494,6 +500,8 @@ function extractAttachments(msgId: string, payload: gmail.Schema$MessagePart, ht
                     mimeType: part.mimeType ?? undefined,
                     sizeBytes: typeof part.body?.size === 'number' ? part.body.size : undefined,
                     savedPath: `gmail_sync/attachments/${safeName}`,
+                    messageId: msgId,
+                    attachmentId: attId,
                 });
             }
         }
@@ -921,6 +929,23 @@ async function buildAndCacheSnapshot(
         console.warn(`[Gmail] classify failed for ${threadId}:`, err);
     }
 
+    // Auto-mark newly-classified "Everything else" mail as read when the user
+    // has opted in. Governs future mail only — existing threads are handled at
+    // toggle time via markSectionRead.
+    if (snapshot.importance === 'other' && snapshot.unread && getAutoReadEverythingElse()) {
+        try {
+            await gmailClient.users.threads.modify({
+                userId: 'me',
+                id: threadId,
+                requestBody: { removeLabelIds: ['UNREAD'] },
+            });
+            for (const m of snapshot.messages) m.unread = false;
+            snapshot.unread = false;
+        } catch (err) {
+            console.warn(`[Gmail] auto-read (Everything else) failed for ${threadId}:`, err);
+        }
+    }
+
     if (threadData.historyId) {
         writeCachedSnapshot(threadId, threadData.historyId, snapshot);
     }
@@ -1048,6 +1073,83 @@ async function saveAttachment(gmail: gmail.Gmail, userId: string, msgId: string,
         console.error(`Error saving attachment ${filename}:`, e);
     }
     return null;
+}
+
+export interface DownloadAttachmentResult {
+    ok: boolean;
+    error?: string;
+}
+
+/**
+ * Ensure an attachment referenced by a snapshot exists on disk, downloading it
+ * on demand when it doesn't. Inbox attachments are saved during sync, but
+ * search results build snapshots without downloading, so opening one of their
+ * attachments needs this. `savedPath` is the workspace-relative path stored on
+ * the attachment; `attachmentId` (when supplied) is tried first, falling back
+ * to re-fetching the message and locating the part by filename — attachment ids
+ * can go stale on a cached snapshot, whereas the file name is stable.
+ */
+export async function downloadAttachment(args: {
+    messageId: string;
+    savedPath: string;
+    attachmentId?: string;
+}): Promise<DownloadAttachmentResult> {
+    try {
+        const { messageId, savedPath, attachmentId } = args;
+        if (!messageId || !savedPath) return { ok: false, error: 'Missing attachment reference.' };
+
+        const absPath = path.join(WorkDir, savedPath);
+        if (fs.existsSync(absPath)) return { ok: true };
+
+        const gmailClient = await getGmailClientOrThrow();
+        const dir = path.dirname(absPath);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+        const fetchData = async (attId: string): Promise<string | null> => {
+            const res = await gmailClient.users.messages.attachments.get({
+                userId: 'me',
+                messageId,
+                id: attId,
+            });
+            return res.data.data ?? null;
+        };
+
+        let data: string | null = null;
+        if (attachmentId) {
+            try {
+                data = await fetchData(attachmentId);
+            } catch (err) {
+                console.warn(`[Gmail] attachment fetch by id failed for ${messageId}, retrying by filename:`, err);
+            }
+        }
+
+        if (!data) {
+            // Re-fetch the message and locate the attachment part whose derived
+            // saved name matches the requested savedPath.
+            const wanted = path.basename(savedPath);
+            const msg = await gmailClient.users.messages.get({ userId: 'me', id: messageId, format: 'full' });
+            let foundAttId: string | undefined;
+            const walk = (part: gmail.Schema$MessagePart): void => {
+                if (foundAttId) return;
+                const fn = part.filename;
+                const attId = part.body?.attachmentId;
+                if (fn && attId && `${messageId}_${cleanFilename(fn)}` === wanted) {
+                    foundAttId = attId;
+                    return;
+                }
+                if (part.parts) for (const sub of part.parts) walk(sub);
+            };
+            if (msg.data.payload) walk(msg.data.payload);
+            if (!foundAttId) return { ok: false, error: 'Attachment not found in message.' };
+            data = await fetchData(foundAttId);
+        }
+
+        if (!data) return { ok: false, error: 'Attachment had no data.' };
+        fs.writeFileSync(absPath, Buffer.from(data, 'base64'));
+        return { ok: true };
+    } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
 }
 
 // --- Sync Logic ---

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -4,6 +4,7 @@ import { google, gmail_v1 as gmail } from 'googleapis';
 import { NodeHtmlMarkdown } from 'node-html-markdown'
 import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
+import { getMaxEmails } from '../config/gmail_sync_config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
 import { serviceLogger, type ServiceRunContext } from '../services/service_logger.js';
 import { limitEventItems } from './limit_event_items.js';
@@ -15,6 +16,10 @@ import { notifyIfEnabled } from '../application/notification/notifier.js';
 const SYNC_DIR = path.join(WorkDir, 'gmail_sync');
 const LEGACY_CACHE_DIR = path.join(SYNC_DIR, 'cache');
 const CACHE_DIR = path.join(WorkDir, 'inbox_lists');
+// Local index of full-text search results. Kept separate from inbox_lists/ so it
+// never leaks non-inbox threads into the inbox view. Grows as you search; we
+// don't prune it (the user wants a durable local index).
+const SEARCH_CACHE_DIR = path.join(WorkDir, 'search_index');
 
 (function migrateLegacyCacheDir() {
     try {
@@ -95,6 +100,35 @@ function deleteCachedSnapshot(threadId: string): void {
     }
 }
 
+// Local search index — same on-disk shape as the inbox cache, separate dir.
+function searchCachePath(threadId: string): string {
+    return path.join(SEARCH_CACHE_DIR, `${encodeURIComponent(threadId)}.json`);
+}
+
+function readSearchSnapshot(threadId: string): SnapshotCacheEntry | null {
+    try {
+        const raw = fs.readFileSync(searchCachePath(threadId), 'utf-8');
+        return JSON.parse(raw) as SnapshotCacheEntry;
+    } catch {
+        return null;
+    }
+}
+
+function writeSearchSnapshot(threadId: string, historyId: string, snapshot: GmailThreadSnapshot): void {
+    try {
+        if (!fs.existsSync(SEARCH_CACHE_DIR)) fs.mkdirSync(SEARCH_CACHE_DIR, { recursive: true });
+        const entry: SnapshotCacheEntry = {
+            historyId,
+            fetchedAt: new Date().toISOString(),
+            parserVersion: SNAPSHOT_PARSER_VERSION,
+            snapshot,
+        };
+        fs.writeFileSync(searchCachePath(threadId), JSON.stringify(entry), 'utf-8');
+    } catch (err) {
+        console.warn(`[Gmail search index] write failed for ${threadId}:`, err);
+    }
+}
+
 async function getGmailClientOrThrow() {
     const auth = await GoogleClientFactory.getClient();
     if (!auth) throw new Error('Gmail is not connected.');
@@ -132,19 +166,19 @@ export async function trashThread(threadId: string): Promise<ThreadActionResult>
     }
 }
 
-export async function markThreadRead(threadId: string): Promise<ThreadActionResult> {
+export async function markThreadRead(threadId: string, read: boolean = true): Promise<ThreadActionResult> {
     try {
         const gmailClient = await getGmailClientOrThrow();
         await gmailClient.users.threads.modify({
             userId: 'me',
             id: threadId,
-            requestBody: { removeLabelIds: ['UNREAD'] },
+            requestBody: read ? { removeLabelIds: ['UNREAD'] } : { addLabelIds: ['UNREAD'] },
         });
-        // Update local cache: clear unread on all messages in the thread.
+        // Mirror the new read state onto every message in the cached thread.
         const cached = readCachedSnapshot(threadId);
         if (cached) {
-            for (const m of cached.snapshot.messages) m.unread = false;
-            cached.snapshot.unread = false;
+            for (const m of cached.snapshot.messages) m.unread = !read;
+            cached.snapshot.unread = !read;
             try {
                 fs.writeFileSync(cachePath(threadId), JSON.stringify(cached), 'utf-8');
             } catch (err) {
@@ -154,6 +188,81 @@ export async function markThreadRead(threadId: string): Promise<ThreadActionResu
         return { ok: true };
     } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+}
+
+export interface MarkSectionReadResult {
+    ok: boolean;
+    count: number;
+    error?: string;
+}
+
+/**
+ * Toggle the read state of every thread in a category ('important' or 'other')
+ * on the server. The category is our local AI classification, so the set is read
+ * from the inbox cache; the change is applied on Gmail via a chunked
+ * messages.batchModify (UNREAD removed when read=true, added when read=false),
+ * then mirrored into the local cache. Only threads that actually need the change
+ * are touched.
+ */
+export async function markSectionRead(
+    section: 'important' | 'other',
+    read: boolean = true,
+): Promise<MarkSectionReadResult> {
+    try {
+        const gmailClient = await getGmailClientOrThrow();
+
+        // Gather threads in this category that still need the change.
+        const targets: { file: string; entry: SnapshotCacheEntry; messageIds: string[] }[] = [];
+        if (fs.existsSync(CACHE_DIR)) {
+            let names: string[] = [];
+            try { names = fs.readdirSync(CACHE_DIR); } catch { names = []; }
+            for (const name of names) {
+                if (!name.endsWith('.json')) continue;
+                const file = path.join(CACHE_DIR, name);
+                let entry: SnapshotCacheEntry;
+                try { entry = JSON.parse(fs.readFileSync(file, 'utf-8')) as SnapshotCacheEntry; } catch { continue; }
+                const snap = entry?.snapshot;
+                if (!snap) continue;
+                const isUnread = snap.unread === true;
+                // Marking read: skip already-read. Marking unread: skip already-unread.
+                if (read ? !isUnread : isUnread) continue;
+                // Mirror snapshotImportance: missing importance counts as 'important'.
+                const importance = snap.importance === 'other' ? 'other' : 'important';
+                if (importance !== section) continue;
+                const messageIds = snap.messages.map((m) => m.id).filter((id): id is string => Boolean(id));
+                targets.push({ file, entry, messageIds });
+            }
+        }
+
+        if (targets.length === 0) return { ok: true, count: 0 };
+
+        // Apply on Gmail (batchModify caps at 1000 message ids per call).
+        const allMessageIds = targets.flatMap((t) => t.messageIds);
+        const labelChange = read ? { removeLabelIds: ['UNREAD'] } : { addLabelIds: ['UNREAD'] };
+        for (let i = 0; i < allMessageIds.length; i += 1000) {
+            const ids = allMessageIds.slice(i, i + 1000);
+            if (ids.length === 0) continue;
+            await gmailClient.users.messages.batchModify({
+                userId: 'me',
+                requestBody: { ids, ...labelChange },
+            });
+        }
+
+        // Mirror into the local cache so the UI updates without a full resync.
+        for (const t of targets) {
+            for (const m of t.entry.snapshot.messages) m.unread = !read;
+            t.entry.snapshot.unread = !read;
+            try {
+                fs.writeFileSync(t.file, JSON.stringify(t.entry), 'utf-8');
+            } catch (err) {
+                console.warn(`[Gmail cache] markSectionRead write failed:`, err);
+            }
+        }
+
+        return { ok: true, count: targets.length };
+    } catch (err) {
+        return { ok: false, count: 0, error: err instanceof Error ? err.message : String(err) };
     }
 }
 
@@ -176,6 +285,8 @@ export interface GmailThreadSnapshot {
     importance?: 'important' | 'other';
     draft_response?: string;
     gmail_draft?: string;
+    /** Gmail-side draft id, present on entries from listDraftThreads. */
+    draftId?: string;
     messages: Array<{
         id?: string;
         from?: string;
@@ -194,6 +305,7 @@ export interface GmailThreadSnapshot {
             savedPath: string;
         }>;
         messageIdHeader?: string;
+        isDraft?: boolean;
     }>;
 }
 
@@ -792,6 +904,45 @@ async function buildAndCacheSnapshot(
     ) {
         return cached.snapshot;
     }
+    const snapshot = await parseThreadSnapshot(threadId, threadData, gmailClient);
+    if (!snapshot) return null;
+
+    try {
+        const userEmail = await getUserEmail(auth);
+        const skipDraft = (snapshot.gmail_draft?.length ?? 0) > 0;
+        const classification = await classifyThread(snapshot, userEmail, { skipDraft });
+        snapshot.importance = classification.importance;
+        if (classification.summary) snapshot.summary = classification.summary;
+        if (classification.draftResponse) {
+            const draftResponse = stripGmailQuotedReplyText(classification.draftResponse);
+            if (draftResponse) snapshot.draft_response = draftResponse;
+        }
+    } catch (err) {
+        console.warn(`[Gmail] classify failed for ${threadId}:`, err);
+    }
+
+    if (threadData.historyId) {
+        writeCachedSnapshot(threadId, threadData.historyId, snapshot);
+    }
+
+    return snapshot;
+}
+
+/**
+ * Parse a threads.get response into a snapshot WITHOUT AI classification or
+ * caching — the shared core of buildAndCacheSnapshot, also used by search (which
+ * doesn't need importance/summary). Returns null when there are no visible
+ * (non-draft) messages.
+ */
+async function parseThreadSnapshot(
+    threadId: string,
+    threadData: gmail.Schema$Thread,
+    gmailClient: gmail.Gmail,
+): Promise<GmailThreadSnapshot | null> {
+    const messages = threadData.messages;
+    if (!messages || messages.length === 0) return null;
+
+    const cached = readCachedSnapshot(threadId);
     const heightCarryover = new Map<string, number>();
     if (cached) {
         for (const m of cached.snapshot.messages) {
@@ -855,7 +1006,7 @@ async function buildAndCacheSnapshot(
         .filter(Boolean)
         .join('\n\n');
 
-    const snapshot: GmailThreadSnapshot = {
+    return {
         threadId,
         threadUrl: `https://mail.google.com/mail/u/0/#all/${threadId}`,
         subject: latest.subject || visibleMessages[0]?.subject,
@@ -868,26 +1019,6 @@ async function buildAndCacheSnapshot(
         messages: visibleMessages,
         gmail_draft: latestDraftBody || undefined,
     };
-
-    try {
-        const userEmail = await getUserEmail(auth);
-        const skipDraft = latestDraftBody.length > 0;
-        const classification = await classifyThread(snapshot, userEmail, { skipDraft });
-        snapshot.importance = classification.importance;
-        if (classification.summary) snapshot.summary = classification.summary;
-        if (classification.draftResponse) {
-            const draftResponse = stripGmailQuotedReplyText(classification.draftResponse);
-            if (draftResponse) snapshot.draft_response = draftResponse;
-        }
-    } catch (err) {
-        console.warn(`[Gmail] classify failed for ${threadId}:`, err);
-    }
-
-    if (threadData.historyId) {
-        writeCachedSnapshot(threadId, threadData.historyId, snapshot);
-    }
-
-    return snapshot;
 }
 
 async function saveAttachment(gmail: gmail.Gmail, userId: string, msgId: string, part: gmail.Schema$MessagePart, attachmentsDir: string): Promise<string | null> {
@@ -1148,24 +1279,29 @@ async function backfillMissingRecentThreads(
 async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: string, stateFile: string, lookbackDays: number) {
     const gmail = google.gmail({ version: 'v1', auth });
 
-    // If the state file holds a last_sync timestamp (e.g. left over from a
-    // prior Composio sync, or from a previous successful native sync that
-    // we're falling back to after a history.list 404), use that as the
-    // floor — but never reach back further than lookbackDays. This caps the
-    // window at "1 week at most": if last_sync is within the lookback window
-    // we resume from it (a smaller window), otherwise we clamp to lookbackDays
-    // ago. Mail older than the cap that arrived during a long offline gap is
-    // intentionally skipped rather than backfilled.
+    // The onboarding / recovery fetch is bounded by a COUNT of the most recent
+    // threads (maxEmails, configurable — default 500), not by a fixed date
+    // window. So a fresh account pulls its newest `maxEmails` emails even when
+    // they span more than a week.
+    //
+    // When we can resume after a previous successful sync (a last_sync within
+    // the lookback window — e.g. the history.list 404 fallback, or a prior
+    // Composio sync), we still floor the query at last_sync so only genuinely
+    // new mail is re-walked, and the count cap acts purely as a safety bound.
+    // With no resumable last_sync (first connect, or a gap longer than the
+    // lookback window) we drop the date floor entirely and just take the newest
+    // `maxEmails` threads.
+    const maxEmails = getMaxEmails();
     const state = loadState(stateFile);
     const lookbackFloor = new Date();
     lookbackFloor.setDate(lookbackFloor.getDate() - lookbackDays);
-    let pastDate: Date;
-    if (state.last_sync && new Date(state.last_sync) > lookbackFloor) {
-        pastDate = new Date(state.last_sync);
-        console.log(`Performing full sync from last_sync=${state.last_sync}...`);
+    const resumeFrom = state.last_sync && new Date(state.last_sync) > lookbackFloor
+        ? new Date(state.last_sync)
+        : null;
+    if (resumeFrom) {
+        console.log(`Performing full sync from last_sync=${state.last_sync} (max ${maxEmails} threads)...`);
     } else {
-        pastDate = lookbackFloor;
-        console.log(`Performing full sync of last ${lookbackDays} days...`);
+        console.log(`Performing full sync of the newest ${maxEmails} threads...`);
     }
 
     let run: ServiceRunContext | null = null;
@@ -1180,19 +1316,24 @@ async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: str
     };
 
     try {
-        const dateQuery = pastDate.toISOString().split('T')[0].replace(/-/g, '/');
+        const baseQuery = '-in:spam -in:trash';
+        const q = resumeFrom
+            ? `after:${resumeFrom.toISOString().split('T')[0].replace(/-/g, '/')} ${baseQuery}`
+            : baseQuery;
 
         // Get History ID
         const profile = await gmail.users.getProfile({ userId: 'me' });
         const currentHistoryId = profile.data.historyId!;
 
+        // Gmail returns threads newest-first, so paginating until we've collected
+        // maxEmails ids yields the most recent maxEmails threads.
         const threadIds: string[] = [];
         let pageToken: string | undefined;
         do {
             const res = await gmail.users.threads.list({
                 userId: 'me',
-                q: `after:${dateQuery} -in:spam -in:trash`,
-                maxResults: 500,
+                q,
+                maxResults: Math.min(500, maxEmails),
                 pageToken
             });
 
@@ -1205,7 +1346,9 @@ async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: str
                 }
             }
             pageToken = res.data.nextPageToken ?? undefined;
-        } while (pageToken);
+        } while (pageToken && threadIds.length < maxEmails);
+
+        if (threadIds.length > maxEmails) threadIds.length = maxEmails;
 
         if (threadIds.length === 0) {
             saveState(currentHistoryId, stateFile);
@@ -1434,10 +1577,10 @@ async function performSync() {
         // partial-sync on subsequent calls.
         const cacheMissing = !fs.existsSync(CACHE_DIR) || fs.readdirSync(CACHE_DIR).length === 0;
         // partialSync replays *every* messageAdded since the stored historyId,
-        // regardless of date — so after a long offline gap a still-valid
-        // historyId would pull the entire gap (e.g. 3 weeks). To honor the
-        // "1 week at most" cap, bypass it when last_sync is older than the
-        // lookback window and run a (date-clamped) fullSync instead.
+        // regardless of date/count — so after a long offline gap a still-valid
+        // historyId would pull the entire gap (e.g. 3 weeks). When last_sync is
+        // older than the lookback window, bypass it and run fullSync instead,
+        // which is count-bounded (the newest maxEmails threads).
         const gapMs = state.last_sync ? Date.now() - new Date(state.last_sync).getTime() : 0;
         const gapTooLarge = gapMs > LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
         if (!state.historyId) {
@@ -1447,7 +1590,7 @@ async function performSync() {
             console.log("History ID present but inbox cache empty — running full sync to backfill snapshots...");
             await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);
         } else if (gapTooLarge) {
-            console.log(`Last sync older than ${LOOKBACK_DAYS} days — running full sync clamped to the lookback window instead of partial sync...`);
+            console.log(`Last sync older than ${LOOKBACK_DAYS} days — running count-bounded full sync instead of partial sync...`);
             await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);
         } else {
             console.log("History ID found, starting partial sync...");
@@ -1482,6 +1625,19 @@ export interface SendReplyOptions {
 
 export interface SendReplyResult {
     messageId?: string;
+    error?: string;
+}
+
+export interface SaveDraftOptions extends Omit<SendReplyOptions, 'to'> {
+    /** Recipient may be blank while a draft is still being written. */
+    to?: string;
+    /** Existing Gmail draft to update; omitted on first save (creates a new one). */
+    draftId?: string;
+}
+
+export interface SaveDraftResult {
+    /** The Gmail-side draft id, to be passed back on subsequent saves. */
+    draftId?: string;
     error?: string;
 }
 
@@ -1588,6 +1744,88 @@ function sanitizeAttachmentName(name: string): string {
     return (name || 'attachment').replace(/[\r\n"\\]/g, '_').trim() || 'attachment';
 }
 
+// Build the raw (base64url) RFC 2822 message shared by both send and draft-save.
+// Recipient headers are omitted when blank, so an in-progress draft with no
+// `To` yet still produces a valid message. `isEmpty` lets callers reject a
+// whitespace-only body without re-parsing the result.
+function buildRawMimeMessage(opts: SaveDraftOptions, userEmail: string): { raw: string; isEmpty: boolean } {
+    const safeTo = opts.to?.trim() ? requireSafeHeaderValue('To', opts.to) : undefined;
+    const safeCc = opts.cc?.trim() ? requireSafeHeaderValue('Cc', opts.cc) : undefined;
+    const safeBcc = opts.bcc?.trim() ? requireSafeHeaderValue('Bcc', opts.bcc) : undefined;
+    const safeInReplyTo = opts.inReplyTo ? requireSafeHeaderValue('In-Reply-To', opts.inReplyTo) : undefined;
+    const safeReferences = opts.references ? requireSafeHeaderValue('References', opts.references) : undefined;
+    const replyBody = opts.threadId
+        ? sanitizeReplyBodyForGmailReply(opts.bodyHtml, opts.bodyText)
+        : { bodyHtml: opts.bodyHtml.trim(), bodyText: opts.bodyText.trim() };
+    const isEmpty = !replyBody.bodyText.trim();
+
+    const seed = `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    const altBoundary = `alt_${seed}`;
+    const attachments = (opts.attachments ?? []).filter((a) => a.contentBase64);
+
+    const headers: string[] = [];
+    headers.push(`From: ${requireSafeHeaderValue('From', userEmail)}`);
+    if (safeTo) headers.push(`To: ${safeTo}`);
+    if (safeCc) headers.push(`Cc: ${safeCc}`);
+    if (safeBcc) headers.push(`Bcc: ${safeBcc}`);
+    headers.push(`Subject: ${encodeRfc2047(opts.subject)}`);
+    if (safeInReplyTo) headers.push(`In-Reply-To: ${safeInReplyTo}`);
+    if (safeReferences) headers.push(`References: ${safeReferences}`);
+    headers.push('MIME-Version: 1.0');
+
+    // The text+html body as a self-contained multipart/alternative block.
+    const altParts: string[] = [];
+    altParts.push(`--${altBoundary}`);
+    altParts.push('Content-Type: text/plain; charset="UTF-8"');
+    altParts.push('Content-Transfer-Encoding: base64');
+    altParts.push('');
+    altParts.push(encodeMimeBase64(replyBody.bodyText));
+    altParts.push('');
+    altParts.push(`--${altBoundary}`);
+    altParts.push('Content-Type: text/html; charset="UTF-8"');
+    altParts.push('Content-Transfer-Encoding: base64');
+    altParts.push('');
+    altParts.push(encodeMimeBase64(replyBody.bodyHtml));
+    altParts.push('');
+    altParts.push(`--${altBoundary}--`);
+
+    let body: string;
+    if (attachments.length) {
+        // Wrap the alternative body plus each attachment in a multipart/mixed.
+        const mixedBoundary = `mixed_${seed}`;
+        headers.push(`Content-Type: multipart/mixed; boundary="${mixedBoundary}"`);
+        const mixed: string[] = [];
+        mixed.push(`--${mixedBoundary}`);
+        mixed.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`);
+        mixed.push('');
+        mixed.push(altParts.join('\r\n'));
+        for (const att of attachments) {
+            const name = sanitizeAttachmentName(att.filename);
+            const mime = sanitizeAttachmentName(att.mimeType) || 'application/octet-stream';
+            mixed.push(`--${mixedBoundary}`);
+            mixed.push(`Content-Type: ${mime}; name="${name}"`);
+            mixed.push('Content-Transfer-Encoding: base64');
+            mixed.push(`Content-Disposition: attachment; filename="${name}"`);
+            mixed.push('');
+            mixed.push(wrapBase64(att.contentBase64));
+            mixed.push('');
+        }
+        mixed.push(`--${mixedBoundary}--`);
+        body = mixed.join('\r\n');
+    } else {
+        headers.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`);
+        body = altParts.join('\r\n');
+    }
+
+    const message = `${headers.join('\r\n')}\r\n\r\n${body}`;
+    const raw = Buffer.from(message, 'utf8')
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+    return { raw, isEmpty };
+}
+
 export async function sendThreadReply(opts: SendReplyOptions): Promise<SendReplyResult> {
     try {
         const auth = await GoogleClientFactory.getClient();
@@ -1597,82 +1835,11 @@ export async function sendThreadReply(opts: SendReplyOptions): Promise<SendReply
         const userEmail = await getUserEmail(auth);
         if (!userEmail) return { error: 'Could not determine your Gmail address.' };
 
-        const safeTo = requireSafeHeaderValue('To', opts.to);
-        const safeCc = opts.cc?.trim() ? requireSafeHeaderValue('Cc', opts.cc) : undefined;
-        const safeBcc = opts.bcc?.trim() ? requireSafeHeaderValue('Bcc', opts.bcc) : undefined;
-        const safeInReplyTo = opts.inReplyTo ? requireSafeHeaderValue('In-Reply-To', opts.inReplyTo) : undefined;
-        const safeReferences = opts.references ? requireSafeHeaderValue('References', opts.references) : undefined;
-        const replyBody = opts.threadId
-            ? sanitizeReplyBodyForGmailReply(opts.bodyHtml, opts.bodyText)
-            : { bodyHtml: opts.bodyHtml.trim(), bodyText: opts.bodyText.trim() };
-        if (!replyBody.bodyText.trim()) return { error: 'Draft is empty.' };
+        if (!opts.to?.trim()) return { error: 'Add at least one recipient.' };
+        const built = buildRawMimeMessage(opts, userEmail);
+        if (built.isEmpty) return { error: 'Draft is empty.' };
 
-        const seed = `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-        const altBoundary = `alt_${seed}`;
-        const attachments = (opts.attachments ?? []).filter((a) => a.contentBase64);
-
-        const headers: string[] = [];
-        headers.push(`From: ${requireSafeHeaderValue('From', userEmail)}`);
-        headers.push(`To: ${safeTo}`);
-        if (safeCc) headers.push(`Cc: ${safeCc}`);
-        if (safeBcc) headers.push(`Bcc: ${safeBcc}`);
-        headers.push(`Subject: ${encodeRfc2047(opts.subject)}`);
-        if (safeInReplyTo) headers.push(`In-Reply-To: ${safeInReplyTo}`);
-        if (safeReferences) headers.push(`References: ${safeReferences}`);
-        headers.push('MIME-Version: 1.0');
-
-        // The text+html body as a self-contained multipart/alternative block.
-        const altParts: string[] = [];
-        altParts.push(`--${altBoundary}`);
-        altParts.push('Content-Type: text/plain; charset="UTF-8"');
-        altParts.push('Content-Transfer-Encoding: base64');
-        altParts.push('');
-        altParts.push(encodeMimeBase64(replyBody.bodyText));
-        altParts.push('');
-        altParts.push(`--${altBoundary}`);
-        altParts.push('Content-Type: text/html; charset="UTF-8"');
-        altParts.push('Content-Transfer-Encoding: base64');
-        altParts.push('');
-        altParts.push(encodeMimeBase64(replyBody.bodyHtml));
-        altParts.push('');
-        altParts.push(`--${altBoundary}--`);
-
-        let body: string;
-        if (attachments.length) {
-            // Wrap the alternative body plus each attachment in a multipart/mixed.
-            const mixedBoundary = `mixed_${seed}`;
-            headers.push(`Content-Type: multipart/mixed; boundary="${mixedBoundary}"`);
-            const mixed: string[] = [];
-            mixed.push(`--${mixedBoundary}`);
-            mixed.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`);
-            mixed.push('');
-            mixed.push(altParts.join('\r\n'));
-            for (const att of attachments) {
-                const name = sanitizeAttachmentName(att.filename);
-                const mime = sanitizeAttachmentName(att.mimeType) || 'application/octet-stream';
-                mixed.push(`--${mixedBoundary}`);
-                mixed.push(`Content-Type: ${mime}; name="${name}"`);
-                mixed.push('Content-Transfer-Encoding: base64');
-                mixed.push(`Content-Disposition: attachment; filename="${name}"`);
-                mixed.push('');
-                mixed.push(wrapBase64(att.contentBase64));
-                mixed.push('');
-            }
-            mixed.push(`--${mixedBoundary}--`);
-            body = mixed.join('\r\n');
-        } else {
-            headers.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`);
-            body = altParts.join('\r\n');
-        }
-
-        const message = `${headers.join('\r\n')}\r\n\r\n${body}`;
-        const raw = Buffer.from(message, 'utf8')
-            .toString('base64')
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-
-        const requestBody: gmail.Schema$Message = { raw };
+        const requestBody: gmail.Schema$Message = { raw: built.raw };
         if (opts.threadId) requestBody.threadId = opts.threadId;
 
         const res = await gmailClient.users.messages.send({
@@ -1703,6 +1870,265 @@ export async function sendThreadReply(opts: SendReplyOptions): Promise<SendReply
         return { messageId: res.data.id || undefined };
     } catch (err) {
         return { error: err instanceof Error ? err.message : String(err) };
+    }
+}
+
+/**
+ * Save the composer's contents as a Gmail draft. Drafts created here live in the
+ * user's real Gmail account, so they show up in the Drafts folder of every Gmail
+ * client and sync back down via the normal history sync (the `gmail_draft` field).
+ *
+ * Passing `draftId` updates that existing draft in place. If it's omitted but a
+ * draft already exists for `threadId` (e.g. a reply opened in a new session),
+ * that draft is reused instead of creating a duplicate. A stale `draftId`
+ * (deleted/sent elsewhere) falls back to creating a fresh draft.
+ */
+export async function saveThreadDraft(opts: SaveDraftOptions): Promise<SaveDraftResult> {
+    try {
+        const auth = await GoogleClientFactory.getClient();
+        if (!auth) return { error: 'Gmail is not connected.' };
+
+        const gmailClient = google.gmail({ version: 'v1', auth });
+        const userEmail = await getUserEmail(auth);
+        if (!userEmail) return { error: 'Could not determine your Gmail address.' };
+
+        const built = buildRawMimeMessage(opts, userEmail);
+        if (built.isEmpty) return { error: 'Draft is empty.' };
+
+        const message: gmail.Schema$Message = { raw: built.raw };
+        if (opts.threadId) message.threadId = opts.threadId;
+
+        // Resolve which draft to update: explicit id wins; otherwise reuse an
+        // existing draft on the same thread so replies don't pile up duplicates.
+        let draftId = opts.draftId;
+        if (!draftId && opts.threadId) {
+            try {
+                const drafts = await gmailClient.users.drafts.list({ userId: 'me' });
+                const existing = (drafts.data.drafts || []).find(
+                    (d) => d.message?.threadId === opts.threadId && d.id
+                );
+                if (existing?.id) draftId = existing.id;
+            } catch {
+                // Listing failed — fall through and create a new draft.
+            }
+        }
+
+        let res;
+        if (draftId) {
+            try {
+                res = await gmailClient.users.drafts.update({
+                    userId: 'me',
+                    id: draftId,
+                    requestBody: { message },
+                });
+            } catch {
+                // The draft was likely deleted or already sent; start a new one.
+                res = await gmailClient.users.drafts.create({ userId: 'me', requestBody: { message } });
+            }
+        } else {
+            res = await gmailClient.users.drafts.create({ userId: 'me', requestBody: { message } });
+        }
+
+        // Wake the sync loop so the local cache reflects the draft.
+        triggerSync();
+
+        return { draftId: res.data.id || undefined };
+    } catch (err) {
+        return { error: err instanceof Error ? err.message : String(err) };
+    }
+}
+
+/** Delete a Gmail draft by id. A missing draft is treated as success. */
+export async function deleteThreadDraft(draftId: string): Promise<{ ok: boolean; error?: string }> {
+    try {
+        const auth = await GoogleClientFactory.getClient();
+        if (!auth) return { ok: false, error: 'Gmail is not connected.' };
+
+        const gmailClient = google.gmail({ version: 'v1', auth });
+        await gmailClient.users.drafts.delete({ userId: 'me', id: draftId });
+        triggerSync();
+        return { ok: true };
+    } catch (err) {
+        const code = (err as { code?: number; response?: { status?: number } })?.code
+            ?? (err as { response?: { status?: number } })?.response?.status;
+        // Already gone (sent/deleted) — nothing to do.
+        if (code === 404 || code === 410) return { ok: true };
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+}
+
+// In-memory cache of built draft snapshots, keyed by draftId and validated by
+// the draft's underlying message id. Gmail assigns a fresh message id whenever a
+// draft is updated (locally via saveThreadDraft or in another client), so an
+// unchanged message id means the parsed snapshot can be reused — we skip the
+// per-draft drafts.get + body parse, mirroring listInboxPage's mtime cache.
+interface DraftCacheEntry {
+    messageId: string;
+    snapshot: GmailThreadSnapshot;
+}
+const draftListCache = new Map<string, DraftCacheEntry>();
+
+// Fetch one draft and parse it into a lightweight snapshot for the Drafts view.
+async function buildDraftSnapshot(
+    gmailClient: gmail.Gmail,
+    draftId: string,
+): Promise<GmailThreadSnapshot | null> {
+    const full = await gmailClient.users.drafts.get({ userId: 'me', id: draftId, format: 'full' });
+    const msg = full.data.message;
+    if (!msg) return null;
+
+    const headers = msg.payload?.headers || [];
+    const parts = msg.payload ? extractBodyParts(msg.payload) : { text: '', html: '' };
+    const rawBody = msg.payload ? normalizeBody(getBody(msg.payload)) : '';
+    const body = stripGmailQuotedReplyText(rawBody);
+    const subject = headerValue(headers, 'Subject') || '';
+    const from = headerValue(headers, 'From') || '';
+    const to = headerValue(headers, 'To') || '';
+    const cc = headerValue(headers, 'Cc') || '';
+    const date = headerValue(headers, 'Date') || '';
+    const threadId = msg.threadId || draftId;
+    const messageIdHeader =
+        headerValue(headers, 'Message-ID') || headerValue(headers, 'Message-Id') || undefined;
+
+    return {
+        threadId,
+        threadUrl: `https://mail.google.com/mail/u/0/#drafts?compose=${draftId}`,
+        subject,
+        from,
+        to,
+        date,
+        latest_email: body,
+        gmail_draft: body || undefined,
+        draftId,
+        unread: false,
+        messages: [{
+            id: msg.id || undefined,
+            from,
+            to,
+            cc: cc || undefined,
+            date,
+            subject,
+            body,
+            bodyHtml: parts.html || undefined,
+            messageIdHeader,
+            isDraft: true,
+        }],
+    };
+}
+
+/**
+ * List the account's Gmail drafts (reply drafts and standalone new-message
+ * drafts) as lightweight thread snapshots for the Drafts view. Drafts aren't
+ * part of the INBOX snapshot cache, so we read them from the Gmail API — but a
+ * cheap drafts.list (ids only) lets us reuse already-parsed snapshots for
+ * unchanged drafts and only drafts.get the new/edited ones. No AI
+ * classification; recipients/subject/body come straight off the draft message.
+ */
+export async function listDraftThreads(): Promise<{ threads: GmailThreadSnapshot[]; error?: string }> {
+    try {
+        const auth = await GoogleClientFactory.getClient();
+        if (!auth) {
+            draftListCache.clear();
+            return { threads: [], error: 'Gmail is not connected.' };
+        }
+
+        const gmailClient = google.gmail({ version: 'v1', auth });
+        const list = await gmailClient.users.drafts.list({ userId: 'me', maxResults: 50 });
+        const drafts = list.data.drafts || [];
+
+        const seen = new Set<string>();
+        const built = await Promise.all(drafts.map(async (d) => {
+            if (!d.id) return null;
+            seen.add(d.id);
+            const messageId = d.message?.id || '';
+            const cached = draftListCache.get(d.id);
+            // Reuse the cached snapshot when the draft's message id is unchanged.
+            if (cached && messageId && cached.messageId === messageId) {
+                return cached.snapshot;
+            }
+            try {
+                const snapshot = await buildDraftSnapshot(gmailClient, d.id);
+                if (snapshot) draftListCache.set(d.id, { messageId, snapshot });
+                return snapshot;
+            } catch (err) {
+                console.warn('[Gmail] draft fetch failed:', err);
+                // Fall back to a stale cached copy if we have one.
+                return cached?.snapshot ?? null;
+            }
+        }));
+
+        // Evict cache entries for drafts that no longer exist (sent/deleted).
+        for (const key of draftListCache.keys()) {
+            if (!seen.has(key)) draftListCache.delete(key);
+        }
+
+        const threads = built.filter((s): s is GmailThreadSnapshot => s !== null);
+        // Newest first.
+        threads.sort((a, b) => {
+            const da = a.date ? Date.parse(a.date) : 0;
+            const db = b.date ? Date.parse(b.date) : 0;
+            return (Number.isFinite(db) ? db : 0) - (Number.isFinite(da) ? da : 0);
+        });
+        return { threads };
+    } catch (err) {
+        return { threads: [], error: err instanceof Error ? err.message : String(err) };
+    }
+}
+
+export interface SearchResult {
+    threads: GmailThreadSnapshot[];
+    error?: string;
+}
+
+/**
+ * Full-text search across the ENTIRE Gmail mailbox (not just locally-synced
+ * mail) using Gmail's `q` query. Each matching thread is parsed into a snapshot
+ * and written to the local search index so repeat searches — and opening a
+ * result — are instant. Reuses the inbox cache when a thread is already synced
+ * there. No AI classification.
+ */
+export async function searchThreads(query: string, opts: { limit?: number } = {}): Promise<SearchResult> {
+    const q = query.trim();
+    if (!q) return { threads: [] };
+    try {
+        const auth = await GoogleClientFactory.getClient();
+        if (!auth) return { threads: [], error: 'Gmail is not connected.' };
+
+        const gmailClient = google.gmail({ version: 'v1', auth });
+        // Generous cap so the index isn't artificially small (Gmail allows 500).
+        const limit = Math.max(1, Math.min(200, opts.limit ?? 100));
+        const list = await gmailClient.users.threads.list({ userId: 'me', q, maxResults: limit });
+        const ids = (list.data.threads || [])
+            .map((t) => t.id)
+            .filter((id): id is string => Boolean(id));
+
+        const built = await Promise.all(ids.map(async (threadId) => {
+            // Prefer the inbox snapshot (kept fresh by sync), then the search index.
+            const inboxCached = readCachedSnapshot(threadId);
+            if (inboxCached?.snapshot) return inboxCached.snapshot;
+            const indexed = readSearchSnapshot(threadId);
+            if (indexed?.snapshot) return indexed.snapshot;
+            try {
+                const threadData = await gmailClient.users.threads.get({ userId: 'me', id: threadId, format: 'full' });
+                const snapshot = await parseThreadSnapshot(threadId, threadData.data, gmailClient);
+                if (snapshot) writeSearchSnapshot(threadId, threadData.data.historyId || '', snapshot);
+                return snapshot;
+            } catch (err) {
+                console.warn(`[Gmail search] fetch failed for ${threadId}:`, err);
+                return null;
+            }
+        }));
+
+        const threads = built.filter((s): s is GmailThreadSnapshot => s !== null);
+        // Newest first.
+        threads.sort((a, b) => {
+            const da = a.date ? Date.parse(a.date) : 0;
+            const db = b.date ? Date.parse(b.date) : 0;
+            return (Number.isFinite(db) ? db : 0) - (Number.isFinite(da) ? da : 0);
+        });
+        return { threads };
+    } catch (err) {
+        return { threads: [], error: err instanceof Error ? err.message : String(err) };
     }
 }
 

--- a/apps/x/packages/shared/src/blocks.ts
+++ b/apps/x/packages/shared/src/blocks.ts
@@ -124,6 +124,8 @@ export const GmailThreadMessageSchema = z.object({
   bodyHeight: z.number().int().positive().optional(),
   attachments: z.array(GmailAttachmentSchema).optional(),
   messageIdHeader: z.string().optional(),
+  // Set on the unsent draft message within a thread (used by the Drafts view).
+  isDraft: z.boolean().optional(),
 });
 
 export type GmailThreadMessage = z.infer<typeof GmailThreadMessageSchema>;
@@ -134,6 +136,9 @@ export const GmailThreadSchema = EmailBlockSchema.extend({
   unread: z.boolean().optional(),
   importance: z.enum(['important', 'other']).optional(),
   gmail_draft: z.string().optional(),
+  // Gmail-side draft id, present on entries returned by the Drafts list so the
+  // composer can update/delete that exact draft.
+  draftId: z.string().optional(),
   messages: z.array(GmailThreadMessageSchema),
 });
 

--- a/apps/x/packages/shared/src/blocks.ts
+++ b/apps/x/packages/shared/src/blocks.ts
@@ -107,6 +107,10 @@ export const GmailAttachmentSchema = z.object({
   mimeType: z.string().optional(),
   sizeBytes: z.number().int().nonnegative().optional(),
   savedPath: z.string(),
+  // Gmail identifiers used to fetch the attachment on demand when it hasn't
+  // been downloaded to disk yet (e.g. attachments on search results).
+  messageId: z.string().optional(),
+  attachmentId: z.string().optional(),
 });
 
 export type GmailAttachment = z.infer<typeof GmailAttachmentSchema>;

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -292,6 +292,22 @@ const ipcSchemas = {
     req: z.object({ section: z.enum(['important', 'other']), read: z.boolean() }),
     res: z.object({ ok: z.boolean(), count: z.number().int().nonnegative(), error: z.string().optional() }),
   },
+  'gmail:downloadAttachment': {
+    req: z.object({
+      messageId: z.string().min(1),
+      savedPath: z.string().min(1),
+      attachmentId: z.string().optional(),
+    }),
+    res: z.object({ ok: z.boolean(), error: z.string().optional() }),
+  },
+  'gmail:getAutoReadEverythingElse': {
+    req: z.object({}),
+    res: z.object({ enabled: z.boolean() }),
+  },
+  'gmail:setAutoReadEverythingElse': {
+    req: z.object({ enabled: z.boolean() }),
+    res: z.object({}),
+  },
   'gmail:saveMessageHeight': {
     req: z.object({
       threadId: z.string().min(1),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -205,6 +205,56 @@ const ipcSchemas = {
       error: z.string().optional(),
     }),
   },
+  'gmail:saveDraft': {
+    req: z.object({
+      // Existing Gmail draft to update; omitted on first save (creates a new one).
+      draftId: z.string().min(1).optional(),
+      threadId: z.string().min(1).optional(),
+      // Recipients may be blank for a draft (unlike a send).
+      to: z.string().optional(),
+      cc: z.string().optional(),
+      bcc: z.string().optional(),
+      subject: z.string(),
+      bodyHtml: z.string(),
+      bodyText: z.string(),
+      inReplyTo: z.string().optional(),
+      references: z.string().optional(),
+      attachments: z
+        .array(
+          z.object({
+            filename: z.string(),
+            mimeType: z.string(),
+            contentBase64: z.string(),
+          }),
+        )
+        .optional(),
+    }),
+    res: z.object({
+      draftId: z.string().optional(),
+      error: z.string().optional(),
+    }),
+  },
+  'gmail:deleteDraft': {
+    req: z.object({ draftId: z.string().min(1) }),
+    res: z.object({ ok: z.boolean(), error: z.string().optional() }),
+  },
+  'gmail:getDrafts': {
+    req: z.object({}),
+    res: z.object({
+      threads: z.array(GmailThreadSchema),
+      error: z.string().optional(),
+    }),
+  },
+  'gmail:search': {
+    req: z.object({
+      query: z.string(),
+      limit: z.number().int().positive().optional(),
+    }),
+    res: z.object({
+      threads: z.array(GmailThreadSchema),
+      error: z.string().optional(),
+    }),
+  },
   'gmail:getConnectionStatus': {
     req: z.object({}),
     res: z.object({
@@ -235,8 +285,12 @@ const ipcSchemas = {
     res: z.object({ ok: z.boolean(), error: z.string().optional() }),
   },
   'gmail:markThreadRead': {
-    req: z.object({ threadId: z.string().min(1) }),
+    req: z.object({ threadId: z.string().min(1), read: z.boolean().optional() }),
     res: z.object({ ok: z.boolean(), error: z.string().optional() }),
+  },
+  'gmail:markSectionRead': {
+    req: z.object({ section: z.enum(['important', 'other']), read: z.boolean() }),
+    res: z.object({ ok: z.boolean(), count: z.number().int().nonnegative(), error: z.string().optional() }),
   },
   'gmail:saveMessageHeight': {
     req: z.object({


### PR DESCRIPTION
## Summary

Turns the built-in Gmail client into a fast, keyboard-driven email experience, and rounds out core mail features: real Gmail drafts with autosave, search, bulk read/unread, and a configurable sync backfill.

### ⌨️ Superhuman-style keyboard shortcuts
- **List**: `j`/`k` (or arrows) move a visible cursor with smooth cursor-follow scrolling, `Enter`/`o` open, `e` archive, `#` trash, `u` read toggle, `c`/`n` compose, `/` search, `g`+`i` / `g`+`d` switch views, `?` help overlay. With a thread open, `e`/`#`/`u` act on that thread.
- **Thread**: `r` reply, `a` reply-all (falls back to reply when there's no one else), `f` forward. Only the visible thread listens.
- **Composer**: `Cmd/Ctrl+Enter` sends (commits half-typed recipients first), `Cmd/Ctrl+Shift+C`/`B` reveal+focus Cc/Bcc, `Esc` closes with the draft preserved.
- **Layered Escape**: closes exactly one layer top-down (suggestion menu → link bar → composer → thread → search) — fixes Esc tearing down the whole compose modal while a menu was open.
- Guard rails: unmodified keys only, ignored while typing / in modals / mid-IME composition.

### 📝 Drafts (Gmail-backed)
- Composer autosaves to a real Gmail draft (debounced ~1.5s), reuses the thread's existing draft so edits update in place, flushes a final save on close, deletes on discard.
- Drafts view with list/edit/delete; new core helpers (`saveThreadDraft`, `deleteThreadDraft`, `listDraftThreads`) and IPC channels (`gmail:saveDraft`, `gmail:deleteDraft`, `gmail:getDrafts`).

### 🔍 Search
- `searchThreads(query)` backed by an on-disk snapshot cache; shared parse core (`parseThreadSnapshot`) reused by sync and search.
- Clear button on the search box; stale search-result rows fixed on archive/read actions.
- Search-result attachments download on demand before opening — fixes Linux where `xdg-open` reports success on a missing file so the old open-then-download fallback never fired.

### ✅ Read state
- `markThreadRead` now toggles read/unread; new `markSectionRead` for bulk section actions.
- "Everything else" gets a **Mark as read** preference: on marks all current and future mail read; off stops auto-reading future mail without touching existing threads. Read toggle removed from Important.

### ⚙️ Configurable backfill
- Onboarding/recovery sync bounded by thread count instead of a fixed 7-day window: `~/.rowboat/config/gmail_sync.json`, default 500, clamped 1–5000.

### ⚡ Performance & polish
- `content-visibility` row virtualization, memoized `ThreadRow` (cursor moves and page appends only re-render affected rows), pointer-events suppressed while scrolling.
- 160ms row slide-out on archive/trash/draft-delete with snap-back on failure; fast thread-detail and inline-composer open transitions; 140ms ease-out animated scrolling (respects `prefers-reduced-motion`).

## Test plan
- [ ] `j`/`k`/`Enter`/`e`/`#`/`u` triage flow in inbox; `?` overlay lists all bindings
- [ ] `r`/`a`/`f` from an open thread; `a` falls back to reply on 1:1 threads
- [ ] `Cmd/Ctrl+Enter` sends with a half-typed recipient still in the To field
- [ ] Esc layering: suggestion menu → link bar → composer → thread → search
- [ ] Draft autosave while typing, edit-in-place, final save on close, delete on discard
- [ ] Search, clear button, archive/read from search results, attachment open on Linux
- [ ] "Everything else" mark-as-read preference on/off behavior
- [ ] Backfill honors `gmail_sync.json` maxEmails

🤖 Generated with [Claude Code](https://claude.com/claude-code)