### PR TITLE
Add camera usage string to Info.plist

### DIFF
--- a/apps/x/apps/main/forge.config.cjs
+++ b/apps/x/apps/main/forge.config.cjs
@@ -199,6 +199,7 @@ module.exports = {
         ],
         extendInfo: {
             NSAudioCaptureUsageDescription: 'Rowboat needs access to system audio to transcribe meetings from other apps (Zoom, Meet, etc.)',
+            NSCameraUsageDescription: 'Rowboat uses your camera in video chat mode so the assistant can see you and give feedback (e.g. pitch practice).',
         },
         osxSign: {
             batchCodesignCalls: true,


### PR DESCRIPTION
Adds `NSCameraUsageDescription` to the packaged app's Info.plist — required for camera access in the video call feature merged in #663. Without it, packaged macOS builds crash on first `getUserMedia({video})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)