### PR TITLE
feat(knowledge): chat research compounds into the Brain (update-only)

### DIFF
--- a/apps/x/packages/core/src/application/assistant/instructions.ts
+++ b/apps/x/packages/core/src/application/assistant/instructions.ts
@@ -152,6 +152,15 @@ Use the \`save-to-memory\` tool to note things worth remembering about the user.
 - Things already in the knowledge graph
 - Information you can derive from reading their notes
 
+## Saving Research Conclusions (offer, never auto-save)
+
+When a conversation produces a **durable research artifact** — a decision, a shortlist, a comparison with a clear winner, a curated set of findings the user reacted positively to — offer ONCE: "Want me to save this to your Brain?" Never auto-save, never re-ask after a decline, and never offer for open-ended exploring that reached no landing point.
+
+On yes, write a note at \`knowledge/Notes/Research/<Topic> — <YYYY-MM-DD>.md\` with frontmatter \`source: chat-research\`. Content rules:
+- Dated conclusions and what remains open: "(2026-07-05) Shortlisted X and Y; unresolved: pricing at scale"
+- "Researched X" never becomes "chose X" — record what was actually concluded
+- If the research was ABOUT a person/org/project that has a note in the Brain, add a \`[[Folder/Name]]\` link to it (the graph pipeline separately enriches that entity's note from this conversation — you don't need to edit the entity note yourself)
+
 ## Memory That Compounds
 Unlike other AI assistants that start cold every session, you have access to a live knowledge graph that updates itself from Gmail, calendar, and meeting notes (Google Meet, Granola, Fireflies). This isn't just summaries - it's structured extraction of decisions, commitments, open questions, and context, routed to long-lived notes for each person, project, and topic.
 

--- a/apps/x/packages/core/src/knowledge/agent_notes.ts
+++ b/apps/x/packages/core/src/knowledge/agent_notes.ts
@@ -256,7 +256,11 @@ async function processAgentNotes(): Promise<void> {
         for (const runFile of runsToProcess) {
             const messages = extractConversationMessages(path.join(RUNS_DIR, runFile));
             if (messages.length === 0) continue;
-            conversationText += `\n--- Conversation ---\n`;
+            // Run id + date let the agent write chat-digest artifacts
+            // (knowledge_sources/chats/<runId>.md) with provenance.
+            const runId = runFile.replace(/\.jsonl$/, '');
+            const dateMatch = runId.match(/^(\d{4}-\d{2}-\d{2})/);
+            conversationText += `\n--- Conversation (runId: ${runId}, date: ${dateMatch ? dateMatch[1] : 'unknown'}) ---\n`;
             for (const msg of messages) {
                 conversationText += `${msg.role}: ${msg.text}\n\n`;
             }

--- a/apps/x/packages/core/src/knowledge/agent_notes_agent.ts
+++ b/apps/x/packages/core/src/knowledge/agent_notes_agent.ts
@@ -35,7 +35,61 @@ The Agent Notes folder contains markdown files that capture what you've learned 
 You will receive a message containing some combination of:
 1. **Emails sent by the user** — Analyze their writing style and update \`style/email.md\`. Do NOT put style observations in \`user.md\`.
 2. **Inbox entries** — Notes the assistant saved during conversations via save-to-memory. Route each to the appropriate file. General preferences go to \`preferences.md\`. Topic-specific preferences get their own file.
-3. **Copilot conversations** — User and assistant messages from recent chats. Extract lasting facts about the user and append timestamped entries to \`user.md\`.
+3. **Copilot conversations** — User and assistant messages from recent chats. Three extractions per conversation:
+   a. Lasting facts about the user → timestamped entries in \`user.md\` (as before).
+   b. **Chat digest** (see "Chat Digests" below) — when the conversation substantively discusses entities or is a real research session, write a digest artifact so the knowledge graph can enrich EXISTING entity notes. This is how pre-meeting research ends up on the person's note.
+   c. **Research ledger + cards** (see "Research Themes" below) — when the conversation is substantive research on a theme with no entity note, log it and maintain suggestion cards.
+
+## Chat Digests (feeds the knowledge graph — update-only)
+
+For each conversation that clears the bar, write ONE digest file: \`knowledge_sources/chats/<runId>.md\` (runId and date are in the conversation header; use file-writeText; create the directory if needed).
+
+**The bar (skip the digest entirely when none of these hold):**
+- The user researched, planned around, or made decisions about a specific person, organization, project, or topic — the entity was a SUBJECT of the session, not a passing mention.
+- Or the session produced concrete findings/decisions about such an entity.
+Skip: casual Q&A, coding/debugging sessions, one-off tasks (write a story, draft an email), and sessions whose entities are only passing references.
+
+**Digest format:**
+\`\`\`markdown
+---
+source: chat
+run_id: <runId>
+session_date: "<date>"
+---
+# Chat digest: <one-line topic>
+
+## Entities discussed
+- <Name> (<person|organization|project|topic>) — <why they were the subject>
+
+## Findings
+- (web research) <finding the assistant surfaced from the web>
+- (user said) <thing the user stated as fact>
+
+## Decisions / intents
+- <decisions made or stated intents, if any>
+
+## Open questions
+- <what remained unresolved, if any>
+\`\`\`
+
+**Rules:**
+- ≤3 entities per digest; pick the real subjects.
+- **Mark every finding's provenance**: \`(web research)\` for things the assistant found online, \`(user said)\` for the user's own statements. Never mix them up — downstream trust depends on it.
+- Findings are facts stated in the conversation — never your own additions.
+- One digest per conversation, never rewrite an existing digest.
+
+## Research Themes (ledger + suggestion cards)
+
+For conversations that are substantive research on a theme with **no existing entity note** (e.g. "vector database selection" — check nothing obvious matches in \`knowledge/\`):
+
+1. **Ledger**: append one line to \`knowledge/Agent Notes/research-log.md\`:
+   \`- [<date>] <theme> — <one-line state: what was explored, what's open> (run: <runId>)\`
+   Keep the file ≤60 lines; prune the oldest lines when over.
+2. **Promotion to a research note (mechanical rule)**: after appending, count the ledger lines for this theme. If it appears in **≥2 distinct sessions within the last 14 days** (or 1 session where the user stated explicit forward intent — quote it), create or update a living note at \`knowledge/Notes/Research/<Theme>.md\`:
+   - Frontmatter: \`source: chat-research\`, \`last_update: "<date>"\`
+   - Body: a dated running state — what's been explored across sessions, current shortlist/leaning, open questions. Update in place on later sessions (newest state first); never lose earlier dated entries.
+   - Create the \`Notes/Research/\` directory if needed. These are user documents — never delete one; staleness is fine.
+3. Note copy is factual and dated. "Researched X" never becomes "decided X". Time words must be true as of the current timestamp.
 
 ## What Goes Where — Be Strict
 

--- a/apps/x/packages/core/src/knowledge/build_graph.ts
+++ b/apps/x/packages/core/src/knowledge/build_graph.ts
@@ -47,6 +47,12 @@ function getEnabledFileSources(): KnowledgeSourceConfig[] {
 // Voice memos are now created directly in knowledge/Voice Memos/<date>/
 const VOICE_MEMOS_KNOWLEDGE_DIR = path.join(NOTES_OUTPUT_DIR, 'Voice Memos');
 
+// Chat digest artifacts, written by the agent-notes pass from copilot
+// conversations (see agent_notes_agent.ts "Chat Digests"). Processed as an
+// UPDATE-ONLY source: chats can enrich entities that already have notes but
+// never create new ones (see chatSourceBanner).
+const CHAT_DIGESTS_DIR = path.join(WorkDir, 'knowledge_sources', 'chats');
+
 /**
  * Check if email frontmatter contains any noise/skip tags. Returns true if the
  * email should be skipped.
@@ -321,6 +327,18 @@ export function emailReplyGateBanner(filePath: string, content: string): string 
 }
 
 /**
+ * Computed banner for chat-digest sources: chats are update-only, enforced the
+ * same way as the email reply gate — a system-stamped instruction the model
+ * cannot re-derive or argue with. Chats never create nodes; they enrich
+ * entities that already earned one.
+ */
+export function chatSourceBanner(filePath: string): string | null {
+    const segments = filePath.split(path.sep);
+    if (!(segments.includes('knowledge_sources') && segments.includes('chats'))) return null;
+    return `> **CHAT SOURCE (computed by the system, authoritative): this digest comes from the owner's copilot conversation — UPDATE-ONLY.** Resolve each entity against the knowledge index. Entities WITH an existing note: append the chat activity, dated findings (keep their provenance markers — "(web research)" facts never overwrite facts learned from direct email/meeting interaction), and assistant notes where useful. Entities WITHOUT an existing note: skip them entirely — no new note of any type, no suggestion card from this file. If no mentioned entity resolves to an existing note, reply SKIP.`;
+}
+
+/**
  * Run note creation agent on a batch of files to extract entities and create/update notes
  */
 async function createNotesFromBatch(
@@ -365,7 +383,7 @@ async function createNotesFromBatch(
         // Pass workspace-relative path so the agent can link back to meeting notes
         const relativePath = path.relative(WorkDir, file.path);
         message += `## Source File ${idx + 1}: ${relativePath}\n\n`;
-        const gateBanner = emailReplyGateBanner(file.path, file.content);
+        const gateBanner = emailReplyGateBanner(file.path, file.content) ?? chatSourceBanner(file.path);
         if (gateBanner) {
             message += gateBanner + `\n\n`;
         }
@@ -739,7 +757,10 @@ export async function processAllSources(): Promise<void> {
     }
 
     const state = loadState();
-    const folderChanges: { source: KnowledgeSourceConfig; sourceDir: string; files: string[] }[] = [];
+    // Only `id` is read after collection (provider gating happens above at
+    // push time), so synthetic sources like chat digests fit without faking a
+    // full KnowledgeSourceConfig.
+    const folderChanges: { source: { id: string }; sourceDir: string; files: string[] }[] = [];
     const countsByFolder: Record<string, number> = {};
     const allFiles: string[] = [];
     const fileSources = getEnabledFileSources();
@@ -785,6 +806,22 @@ export async function processAllSources(): Promise<void> {
             console.error(`[GraphBuilder] Error processing ${source.id}:`, error);
             // Continue with other folders even if one fails
         }
+    }
+
+    // Chat digests — explicit synthetic source (not in the sources repo, like
+    // voice memos). Update-only enforcement happens via chatSourceBanner.
+    try {
+        if (fs.existsSync(CHAT_DIGESTS_DIR)) {
+            const chatFiles = getFilesToProcess(CHAT_DIGESTS_DIR, state);
+            if (chatFiles.length > 0) {
+                console.log(`[GraphBuilder] Found ${chatFiles.length} new chat digest(s)`);
+                folderChanges.push({ source: { id: 'chat_digests' }, sourceDir: CHAT_DIGESTS_DIR, files: chatFiles });
+                countsByFolder['chat_digests'] = chatFiles.length;
+                allFiles.push(...chatFiles);
+            }
+        }
+    } catch (error) {
+        console.error('[GraphBuilder] Error scanning chat digests:', error);
     }
 
     if (allFiles.length > 0) {

--- a/apps/x/packages/core/src/knowledge/note_creation.ts
+++ b/apps/x/packages/core/src/knowledge/note_creation.ts
@@ -238,12 +238,18 @@ file-readText({ path: "{source_file}" })
 - Source file path is under \`knowledge_sources/<provider>/\`
 - Contains issue, PR, task, ticket, comment, status, or project metadata
 
+**Chat digest indicators:**
+- YAML frontmatter has \`source: chat\`
+- Source file path is under \`knowledge_sources/chats/\`
+- Carries a system-stamped CHAT SOURCE banner in the message
+
 **Set processing mode:**
 - \`source_type = "meeting"\` → Can create new notes
 - \`source_type = "email"\` → Can create notes if personalized and relevant
 - \`source_type = "voice_memo"\` → Can create new notes (treat like meetings)
 - \`source_type = "slack"\` → Prefer updating existing project/person/topic notes; create new notes only for clear durable entities
 - \`source_type = "connected_tool"\` → Prefer updating existing project/topic notes; create new notes only for durable projects, organizations, repositories, issues, or initiatives
+- \`source_type = "chat"\` → **STRICTLY UPDATE-ONLY** (see "Chat Digests" below): enrich entities that already have notes; never create any note or suggestion card from a chat digest
 
 ---
 
@@ -304,6 +310,18 @@ Process artifacts from GitHub, Linear, Jira, and similar tools when they carry p
 - Comments that clarify requirements, decisions, blockers, or commitments
 
 Skip routine metadata churn and duplicated notifications unless they change durable knowledge.
+
+## For Chat Digests (source: chat) — STRICTLY UPDATE-ONLY
+
+Chat digests summarize the owner's own copilot conversations (e.g. researching a person before a meeting). The owner's research about an entity that already earned a note belongs ON that note — but chats NEVER create notes.
+
+- Resolve each entity in "## Entities discussed" against the knowledge index. **Only confidently resolved entities with an existing note are touched.** Ambiguous or unresolved → skip that entity silently.
+- For each resolved entity:
+  - Activity line: \`**{session_date}** (chat): Researched {entity} ahead of {context} — {one-line gist}.\`
+  - Findings → dated Key facts **keeping their provenance markers**: \`- ({session_date}, web research) Acme raised a $30M Series B\` or \`- ({session_date}, user said) …\`
+  - **Trust hierarchy:** \`(web research)\` facts NEVER overwrite facts learned from direct interaction (email/meeting) — a conflict is recorded as "(web says X; our correspondence says Y)". \`(user said)\` facts rank above web research but below direct interaction with the entity themself.
+  - Add an Assistant note only for durable assistant-relevant context (e.g. what the owner prepped for).
+- If NO entity resolves to an existing note: reply SKIP. Do not create notes, do not add suggestion cards — node-less research themes are handled elsewhere.
 
 ## For Emails — Read YAML Frontmatter
 
@@ -1048,6 +1066,11 @@ This applies everywhere, including \`## Assistant notes\` lines ("The owner redu
 **2025-01-15** (email): [[People/Sarah Chen]] sent pricing proposal for [[Projects/Acme Integration]]. [View thread](https://mail.google.com/mail/#inbox/18d5a3b2c1e4f567)
 \`\`\`
 
+**For chat digests:** No external link; the session date and gist suffice:
+\`\`\`
+**2026-07-05** (chat): Researched [[People/Sarah Chen]] ahead of Tuesday's meeting — funding, product line, recent talk.
+\`\`\`
+
 **For voice memos:** Include a link to the voice memo file using the Path field:
 \`\`\`
 **2025-01-15** (voice memo): Discussed [[Projects/Acme Integration]] timeline. See [[Voice Memos/2025-01-15/voice-memo-2025-01-15T10-30-00-000Z]]
@@ -1312,6 +1335,7 @@ ${renderNoteTypesBlock()}
 | Email (create label + user replied in thread) | Yes | Yes | Yes |
 | Email (create label, purely inbound — no user reply) | Update-only (no new People/Org notes) | Yes | Yes |
 | Email (only skip labels) | No (SKIP) | No | No |
+| Chat digest (source: chat) | Never | Yes — resolved existing entities only | Yes |
 
 **Email Reply Gate:** New canonical People/Organization notes from an email require the user to have replied at least once in the thread (a \`### From:\` matching \`user.email\` or \`@user.domain\`). Purely inbound threads update existing notes only. Calendar invites for a scheduled meeting are exempt.
 


### PR DESCRIPTION
Copilot conversations now enrich the knowledge graph without ever creating nodes. Three tiers (spec: apps/x/CHAT_RESEARCH_MEMORY.md):

- Tier 0: the agent-notes pass emits chat digests (knowledge_sources/chats/<runId>.md) for sessions that substantively discuss known entities; the graph builder processes them as a new source_type "chat" carrying a system-computed UPDATE-ONLY banner (chatSourceBanner, same mechanical-gate pattern as the email reply gate). Findings carry provenance — (web research) facts never overwrite facts from direct interaction.
- Tier 1: the copilot offers once to save research conclusions to knowledge/Notes/Research/<Topic> — <date>.md; never auto-saves.
- Tier 2: recurring node-less themes accrue in the Agent Notes/research-log.md ledger; >=2 sessions in 14 days promotes a living note in knowledge/Notes/Research/ (suggested-topics UI is legacy and no longer targeted).

Conversation headers in the agent-notes pass now include runId + date so digests get provenance.