### PR TITLE
fix(x): resolve baileys build approval placeholder blocking package build

### DIFF
--- a/apps/x/pnpm-workspace.yaml
+++ b/apps/x/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 allowBuilds:
-  baileys: set this to true or false
+  baileys: true
   core-js: true
   electron: true
   electron-winstaller: true


### PR DESCRIPTION
## Problem

Running \`npm run package\` in \`apps/x/apps/main\` fails during Electron Forge's \`generateAssets\` hook:

\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: baileys@7.0.0-rc13
[ERROR] Command failed with exit code 1: pnpm install
\`\`\`

The mobile-channels feature (#665) added \`baileys\`, whose install-time scripts (\`preinstall\`, \`prepare\`) require build approval. The \`allowBuilds\` block in \`apps/x/pnpm-workspace.yaml\` was left with a literal placeholder:

\`\`\`yaml
allowBuilds:
  baileys: set this to true or false
\`\`\`

pnpm 11 treats an unresolved build decision as a **hard error** (non-zero exit), which aborts \`pnpm install\` and, in turn, the Forge packaging hook. This breaks \`npm run package\` on \`dev\` for everyone.

## Fix

Set \`baileys: true\`, matching the companion \`onlyBuiltDependencies\` entry and the intent of commit \`c1b5291f\` ("approve baileys build").

## Verification

\`pnpm install\` now completes cleanly — baileys \`preinstall\` runs and exits 0:

\`\`\`
.../node_modules/baileys preinstall\$ node ./engine-requirements.js
.../node_modules/baileys preinstall: Done
Done in 1.4s using pnpm v11.7.0
\`\`\`