### PR TITLE
fix: add explicit parentheses in handoff filter precedence

### DIFF
--- a/apps/rowboat/src/application/lib/agents-runtime/agent-handoffs.ts
+++ b/apps/rowboat/src/application/lib/agents-runtime/agent-handoffs.ts
@@ -69,7 +69,7 @@ function filterForPipeline(data: HandoffInputData): HandoffInputData {
         preHandoffItems: data.preHandoffItems.filter(item => 
             !item.type || 
             item.type === 'message' || 
-            item.type === 'tool_call' && item.name?.includes('pipeline')
+            (item.type === 'tool_call' && item.name?.includes('pipeline'))
         )
     };
 }


### PR DESCRIPTION
The \`preHandoffItems\` filter had a condition where \`&&\` binds tighter than \`||\`:

\`\`\`js
item.type === 'tool_call' && item.name?.includes('pipeline')
\`\`\`

This happened to work correctly by coincidence (the \`||\` cases above it caught the other types), but the grouping was ambiguous and easy to misread. Added explicit parentheses around the \`&&\` clause so the intent is clear and future edits don't accidentally change the logic.