### PR TITLE
feat(core): elide oversized historic tool results from model context

### DIFF
--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -393,14 +393,18 @@ Rules:
 The app wires the resolver through a decorator (`context-elision.ts`) that
 applies transmit-time elision to the materialized prefix: tool results from
 prior turns above a size threshold are replaced with a short placeholder
-telling the model to re-run the tool if it needs the output. The durable log
-is untouched; only the transmitted bytes change. Elision is a pure function
-of each message, so resolved prefixes stay byte-stable across calls (provider
-prefix caches keep working), and the current turn's own in-flight tool
-results never pass through the resolver, so they are always sent verbatim.
-Policy lives in `config/context.json` (`elideHistoricToolResults`, default
-true; `elideHistoricToolResultsThresholdChars`, default 10000). The inspect
-CLI composes through the same decorated resolver.
+telling the model to re-run the tool if it needs the output, and inline
+image parts from prior turns (video-mode webcam and screen-share frames) are
+replaced with a text part recording how many frames of each kind were
+dropped. The durable log is untouched; only the transmitted bytes change.
+Elision is a pure function of each message, so resolved prefixes stay
+byte-stable across calls (provider prefix caches keep working), and the
+current turn's own messages never pass through the resolver, so in-flight
+tool results and just-captured frames are always sent verbatim. Policy lives
+in `config/context.json` (`elideHistoricToolResults`, default true;
+`elideHistoricToolResultsThresholdChars`, default 10000;
+`elideHistoricImages`, default true). The inspect CLI composes through the
+same decorated resolver.
 
 ### 6.7 Agent snapshot inheritance
 

--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -393,18 +393,21 @@ Rules:
 The app wires the resolver through a decorator (`context-elision.ts`) that
 applies transmit-time elision to the materialized prefix: tool results from
 prior turns above a size threshold are replaced with a short placeholder
-telling the model to re-run the tool if it needs the output, and inline
-image parts from prior turns (video-mode webcam and screen-share frames) are
+telling the model to re-run the tool if it needs the output; inline image
+parts from prior turns (video-mode webcam and screen-share frames) are
 replaced with a text part recording how many frames of each kind were
-dropped. The durable log is untouched; only the transmitted bytes change.
+dropped; and middle-pane note snapshots on prior-turn user messages keep
+their kind and path but have their content replaced with a placeholder
+pointing at the still-readable file. The durable log is untouched; only the
+transmitted bytes change.
 Elision is a pure function of each message, so resolved prefixes stay
 byte-stable across calls (provider prefix caches keep working), and the
 current turn's own messages never pass through the resolver, so in-flight
 tool results and just-captured frames are always sent verbatim. Policy lives
 in `config/context.json` (`elideHistoricToolResults`, default true;
 `elideHistoricToolResultsThresholdChars`, default 10000;
-`elideHistoricImages`, default true). The inspect CLI composes through the
-same decorated resolver.
+`elideHistoricImages`, default true; `elideHistoricMiddlePaneContent`,
+default true). The inspect CLI composes through the same decorated resolver.
 
 ### 6.7 Agent snapshot inheritance
 

--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -390,6 +390,18 @@ Rules:
   It rejects the execution and does not append `turn_failed`.
 - The reducer treats `context` as opaque data and never resolves references.
 
+The app wires the resolver through a decorator (`context-elision.ts`) that
+applies transmit-time elision to the materialized prefix: tool results from
+prior turns above a size threshold are replaced with a short placeholder
+telling the model to re-run the tool if it needs the output. The durable log
+is untouched; only the transmitted bytes change. Elision is a pure function
+of each message, so resolved prefixes stay byte-stable across calls (provider
+prefix caches keep working), and the current turn's own in-flight tool
+results never pass through the resolver, so they are always sent verbatim.
+Policy lives in `config/context.json` (`elideHistoricToolResults`, default
+true; `elideHistoricToolResultsThresholdChars`, default 10000). The inspect
+CLI composes through the same decorated resolver.
+
 ### 6.7 Agent snapshot inheritance
 
 Session turns whose resolved system prompt and tool set are byte-identical

--- a/apps/x/packages/core/src/di/container.ts
+++ b/apps/x/packages/core/src/di/container.ts
@@ -31,7 +31,8 @@ import type { INotificationService } from "../application/notification/service.j
 import { SystemClock, type IClock } from "../turns/clock.js";
 import { FSTurnRepo } from "../turns/fs-repo.js";
 import type { ITurnRepo } from "../turns/repo.js";
-import { TurnRepoContextResolver, type IContextResolver } from "../turns/context-resolver.js";
+import type { IContextResolver } from "../turns/context-resolver.js";
+import { createContextResolver } from "../turns/context-elision.js";
 import { EmitterTurnLifecycleBus, type ITurnLifecycleBus } from "../turns/bus.js";
 import { RealUsageReporter } from "../turns/bridges/real-usage-reporter.js";
 import type { IUsageReporter } from "../turns/usage-reporter.js";
@@ -117,7 +118,9 @@ container.register({
     turnsRootDir: asValue(path.join(WorkDir, "storage", "turns")),
     sessionsRootDir: asValue(path.join(WorkDir, "storage", "sessions")),
     turnRepo: asClass<ITurnRepo>(FSTurnRepo).singleton(),
-    contextResolver: asClass<IContextResolver>(TurnRepoContextResolver).singleton(),
+    contextResolver: asFunction<IContextResolver>(({ turnRepo }) =>
+        createContextResolver({ turnRepo }),
+    ).singleton(),
     lifecycleBus: asClass<ITurnLifecycleBus>(EmitterTurnLifecycleBus).singleton(),
     usageReporter: asClass<IUsageReporter>(RealUsageReporter).singleton(),
     agentResolver: asFunction<IAgentResolver>(() => new RealAgentResolver()).singleton(),

--- a/apps/x/packages/core/src/turns/context-elision.test.ts
+++ b/apps/x/packages/core/src/turns/context-elision.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import type { z } from "zod";
+import type { TurnContext, TurnEvent } from "@x/shared/dist/turns.js";
+import {
+    ElidingContextResolver,
+    elideHistoricToolResults,
+} from "./context-elision.js";
+import { TurnRepoContextResolver } from "./context-resolver.js";
+import { InMemoryTurnRepo } from "./in-memory-turn-repo.js";
+
+type TEvent = z.infer<typeof TurnEvent>;
+
+function user(text: string) {
+    return { role: "user" as const, content: text };
+}
+
+function assistant(text: string) {
+    return { role: "assistant" as const, content: text };
+}
+
+function toolMsg(content: string, toolName = "file-readText") {
+    return {
+        role: "tool" as const,
+        content,
+        toolCallId: "tc1",
+        toolName,
+    };
+}
+
+// A completed turn containing one tool round trip whose result has the given
+// output, followed by a final text response.
+function toolTurnLog(
+    turnId: string,
+    context: z.infer<typeof TurnContext>,
+    toolOutput: string,
+): TEvent[] {
+    const ts = "2026-07-02T10:00:00Z";
+    const echo = {
+        toolId: "tool.echo",
+        name: "echo",
+        description: "Echo",
+        inputSchema: {},
+        execution: "sync" as const,
+        requiresHuman: false,
+    };
+    const call = {
+        role: "assistant" as const,
+        content: [
+            {
+                type: "tool-call" as const,
+                toolCallId: "tc1",
+                toolName: "echo",
+                arguments: {},
+            },
+        ],
+    };
+    return [
+        {
+            type: "turn_created",
+            schemaVersion: 1,
+            turnId,
+            ts,
+            sessionId: "sess-1",
+            agent: {
+                requested: { agentId: "copilot" },
+                resolved: {
+                    agentId: "copilot",
+                    systemPrompt: "SYS",
+                    model: { provider: "fake", model: "m" },
+                    tools: [echo],
+                },
+            },
+            context,
+            input: user("do it"),
+            config: {
+                autoPermission: false,
+                humanAvailable: true,
+                maxModelCalls: 20,
+            },
+        },
+        {
+            type: "model_call_requested",
+            turnId,
+            ts,
+            modelCallIndex: 0,
+            request: {
+                ...(Array.isArray(context) ? {} : { contextRef: context }),
+                messages:
+                    Array.isArray(context) && context.length > 0
+                        ? ["context", "input"]
+                        : ["input"],
+                parameters: {},
+            },
+        },
+        {
+            type: "model_call_completed",
+            turnId,
+            ts,
+            modelCallIndex: 0,
+            message: call,
+            finishReason: "tool-calls",
+            usage: {},
+        },
+        {
+            type: "tool_invocation_requested",
+            turnId,
+            ts,
+            toolCallId: "tc1",
+            toolId: "tool.echo",
+            toolName: "echo",
+            execution: "sync",
+            input: {},
+        },
+        {
+            type: "tool_result",
+            turnId,
+            ts,
+            toolCallId: "tc1",
+            toolName: "echo",
+            source: "sync",
+            result: { output: toolOutput, isError: false },
+        },
+        {
+            type: "model_call_requested",
+            turnId,
+            ts,
+            modelCallIndex: 1,
+            request: {
+                messages: ["assistant:0", "toolResult:tc1"],
+                parameters: {},
+            },
+        },
+        {
+            type: "model_call_completed",
+            turnId,
+            ts,
+            modelCallIndex: 1,
+            message: assistant("done"),
+            finishReason: "stop",
+            usage: {},
+        },
+        {
+            type: "turn_completed",
+            turnId,
+            ts,
+            output: assistant("done"),
+            finishReason: "stop",
+            usage: {},
+        },
+    ];
+}
+
+const T1 = "2026-07-02T10-00-00Z-0000001-000";
+
+describe("elideHistoricToolResults", () => {
+    it("replaces tool results above the threshold with a placeholder", () => {
+        const big = "x".repeat(101);
+        const elided = elideHistoricToolResults([toolMsg(big)], 100);
+        expect(elided).toHaveLength(1);
+        expect(elided[0]).toMatchObject({
+            role: "tool",
+            toolCallId: "tc1",
+            toolName: "file-readText",
+        });
+        expect(elided[0].content).toContain("elided");
+        expect(elided[0].content).toContain("file-readText");
+        expect(elided[0].content).toContain("101");
+    });
+
+    it("keeps tool results at or below the threshold verbatim", () => {
+        const exact = toolMsg("x".repeat(100));
+        expect(elideHistoricToolResults([exact], 100)).toEqual([exact]);
+    });
+
+    it("leaves non-tool messages untouched", () => {
+        const messages = [user("q".repeat(500)), assistant("a".repeat(500))];
+        expect(elideHistoricToolResults(messages, 100)).toEqual(messages);
+    });
+
+    it("is idempotent at realistic thresholds (placeholder is well under them)", () => {
+        const once = elideHistoricToolResults([toolMsg("x".repeat(5000))], 1000);
+        expect(once[0].content.length).toBeLessThan(1000);
+        expect(elideHistoricToolResults(once, 1000)).toEqual(once);
+    });
+
+    it("is deterministic for the same input", () => {
+        const messages = [toolMsg("x".repeat(5000)), user("q"), assistant("a")];
+        expect(elideHistoricToolResults(messages, 100)).toEqual(
+            elideHistoricToolResults(messages, 100),
+        );
+    });
+});
+
+describe("ElidingContextResolver", () => {
+    function resolver(
+        repo: InMemoryTurnRepo,
+        policy: { enabled: boolean; thresholdChars: number },
+    ) {
+        return new ElidingContextResolver({
+            inner: new TurnRepoContextResolver({ turnRepo: repo }),
+            loadPolicy: () => policy,
+        });
+    }
+
+    it("elides oversized tool results in the resolved prefix", async () => {
+        const repo = new InMemoryTurnRepo();
+        repo.seed(toolTurnLog(T1, [], "x".repeat(200)));
+        const resolved = await resolver(repo, {
+            enabled: true,
+            thresholdChars: 100,
+        }).resolve({ previousTurnId: T1 });
+        const tool = resolved.find((m) => m.role === "tool");
+        expect(tool?.content).toContain("elided");
+        // The rest of the transcript is intact.
+        expect(resolved.map((m) => m.role)).toEqual([
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+        ]);
+    });
+
+    it("returns the prefix unchanged when the policy is disabled", async () => {
+        const repo = new InMemoryTurnRepo();
+        const output = "x".repeat(200);
+        repo.seed(toolTurnLog(T1, [], output));
+        const resolved = await resolver(repo, {
+            enabled: false,
+            thresholdChars: 100,
+        }).resolve({ previousTurnId: T1 });
+        const tool = resolved.find((m) => m.role === "tool");
+        expect(tool?.content).toBe(output);
+    });
+
+    it("keeps small tool results verbatim when enabled", async () => {
+        const repo = new InMemoryTurnRepo();
+        repo.seed(toolTurnLog(T1, [], "small"));
+        const resolved = await resolver(repo, {
+            enabled: true,
+            thresholdChars: 100,
+        }).resolve({ previousTurnId: T1 });
+        const tool = resolved.find((m) => m.role === "tool");
+        expect(tool?.content).toBe("small");
+    });
+});

--- a/apps/x/packages/core/src/turns/context-elision.test.ts
+++ b/apps/x/packages/core/src/turns/context-elision.test.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import type { TurnContext, TurnEvent } from "@x/shared/dist/turns.js";
 import {
     ElidingContextResolver,
+    elideHistoricImages,
     elideHistoricToolResults,
 } from "./context-elision.js";
 import { TurnRepoContextResolver } from "./context-resolver.js";
@@ -150,6 +151,16 @@ function toolTurnLog(
     ];
 }
 
+function frame(source: "camera" | "screen") {
+    return {
+        type: "image" as const,
+        data: "aGVsbG8=".repeat(50),
+        mediaType: "image/jpeg",
+        source,
+        capturedAt: "2026-07-02T10:00:00Z",
+    };
+}
+
 const T1 = "2026-07-02T10-00-00Z-0000001-000";
 
 describe("elideHistoricToolResults", () => {
@@ -191,10 +202,56 @@ describe("elideHistoricToolResults", () => {
     });
 });
 
+describe("elideHistoricImages", () => {
+    it("replaces image parts with a labeled placeholder, keeping other parts", () => {
+        const message = {
+            role: "user" as const,
+            content: [
+                { type: "text" as const, text: "how do I look?" },
+                frame("camera"),
+                frame("camera"),
+                frame("screen"),
+            ],
+        };
+        const [elided] = elideHistoricImages([message]);
+        if (typeof elided.content === "string" || elided.role !== "user") {
+            throw new Error("expected user message with parts");
+        }
+        expect(elided.content.filter((p) => p.type === "image")).toHaveLength(0);
+        expect(elided.content[0]).toEqual({ type: "text", text: "how do I look?" });
+        const placeholder = elided.content[elided.content.length - 1];
+        if (placeholder.type !== "text") throw new Error("expected text placeholder");
+        expect(placeholder.text).toContain("2 webcam frames");
+        expect(placeholder.text).toContain("1 screen-share frame");
+    });
+
+    it("leaves string-content and image-free user messages untouched", () => {
+        const messages = [
+            user("plain"),
+            {
+                role: "user" as const,
+                content: [{ type: "text" as const, text: "no images" }],
+            },
+            assistant("a"),
+        ];
+        expect(elideHistoricImages(messages)).toEqual(messages);
+    });
+});
+
+const POLICY_OFF = {
+    toolResults: false,
+    toolResultThresholdChars: 100,
+    images: false,
+};
+
 describe("ElidingContextResolver", () => {
     function resolver(
         repo: InMemoryTurnRepo,
-        policy: { enabled: boolean; thresholdChars: number },
+        policy: {
+            toolResults: boolean;
+            toolResultThresholdChars: number;
+            images: boolean;
+        },
     ) {
         return new ElidingContextResolver({
             inner: new TurnRepoContextResolver({ turnRepo: repo }),
@@ -206,8 +263,8 @@ describe("ElidingContextResolver", () => {
         const repo = new InMemoryTurnRepo();
         repo.seed(toolTurnLog(T1, [], "x".repeat(200)));
         const resolved = await resolver(repo, {
-            enabled: true,
-            thresholdChars: 100,
+            ...POLICY_OFF,
+            toolResults: true,
         }).resolve({ previousTurnId: T1 });
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toContain("elided");
@@ -224,10 +281,9 @@ describe("ElidingContextResolver", () => {
         const repo = new InMemoryTurnRepo();
         const output = "x".repeat(200);
         repo.seed(toolTurnLog(T1, [], output));
-        const resolved = await resolver(repo, {
-            enabled: false,
-            thresholdChars: 100,
-        }).resolve({ previousTurnId: T1 });
+        const resolved = await resolver(repo, POLICY_OFF).resolve({
+            previousTurnId: T1,
+        });
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toBe(output);
     });
@@ -236,10 +292,39 @@ describe("ElidingContextResolver", () => {
         const repo = new InMemoryTurnRepo();
         repo.seed(toolTurnLog(T1, [], "small"));
         const resolved = await resolver(repo, {
-            enabled: true,
-            thresholdChars: 100,
+            ...POLICY_OFF,
+            toolResults: true,
         }).resolve({ previousTurnId: T1 });
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toBe("small");
+    });
+
+    it("elides images in the resolved prefix when enabled", async () => {
+        const repo = new InMemoryTurnRepo();
+        const log = toolTurnLog(T1, [], "small").map((event) =>
+            event.type === "turn_created"
+                ? {
+                      ...event,
+                      input: {
+                          role: "user" as const,
+                          content: [
+                              { type: "text" as const, text: "watch me" },
+                              frame("camera"),
+                          ],
+                      },
+                  }
+                : event,
+        );
+        repo.seed(log);
+        const resolved = await resolver(repo, {
+            ...POLICY_OFF,
+            images: true,
+        }).resolve({ previousTurnId: T1 });
+        const input = resolved[0];
+        if (input.role !== "user" || typeof input.content === "string") {
+            throw new Error("expected user message with parts");
+        }
+        expect(input.content.some((p) => p.type === "image")).toBe(false);
+        expect(JSON.stringify(input.content)).toContain("1 webcam frame");
     });
 });

--- a/apps/x/packages/core/src/turns/context-elision.test.ts
+++ b/apps/x/packages/core/src/turns/context-elision.test.ts
@@ -4,6 +4,7 @@ import type { TurnContext, TurnEvent } from "@x/shared/dist/turns.js";
 import {
     ElidingContextResolver,
     elideHistoricImages,
+    elideHistoricMiddlePaneContent,
     elideHistoricToolResults,
 } from "./context-elision.js";
 import { TurnRepoContextResolver } from "./context-resolver.js";
@@ -238,10 +239,60 @@ describe("elideHistoricImages", () => {
     });
 });
 
+function noteMessage(content: string) {
+    return {
+        role: "user" as const,
+        content: "make this punchier",
+        userMessageContext: {
+            currentDateTime: "Thursday, July 2, 2026 at 10:00 AM GMT",
+            middlePane: {
+                kind: "note" as const,
+                path: "knowledge/Notes/Draft.md",
+                content,
+            },
+        },
+    };
+}
+
+describe("elideHistoricMiddlePaneContent", () => {
+    it("replaces large note snapshots, keeping kind and path", () => {
+        const [elided] = elideHistoricMiddlePaneContent([
+            noteMessage("n".repeat(600)),
+        ]);
+        if (elided.role !== "user") throw new Error("expected user message");
+        const middlePane = elided.userMessageContext?.middlePane;
+        if (middlePane?.kind !== "note") throw new Error("expected note pane");
+        expect(middlePane.path).toBe("knowledge/Notes/Draft.md");
+        expect(middlePane.content).toContain("omitted from history");
+        expect(middlePane.content).toContain("600");
+        expect(elided.userMessageContext?.currentDateTime).toBeDefined();
+        expect(elided.content).toBe("make this punchier");
+    });
+
+    it("keeps small notes and non-note panes untouched", () => {
+        const small = noteMessage("short todo list");
+        const browser = {
+            role: "user" as const,
+            content: "what is this page?",
+            userMessageContext: {
+                middlePane: {
+                    kind: "browser" as const,
+                    url: "https://example.com",
+                    title: "Example",
+                },
+            },
+        };
+        const plain = user("no context at all");
+        const messages = [small, browser, plain];
+        expect(elideHistoricMiddlePaneContent(messages)).toEqual(messages);
+    });
+});
+
 const POLICY_OFF = {
     toolResults: false,
     toolResultThresholdChars: 100,
     images: false,
+    middlePaneContent: false,
 };
 
 describe("ElidingContextResolver", () => {
@@ -326,5 +377,24 @@ describe("ElidingContextResolver", () => {
         }
         expect(input.content.some((p) => p.type === "image")).toBe(false);
         expect(JSON.stringify(input.content)).toContain("1 webcam frame");
+    });
+
+    it("elides middle-pane note snapshots in the resolved prefix when enabled", async () => {
+        const repo = new InMemoryTurnRepo();
+        const log = toolTurnLog(T1, [], "small").map((event) =>
+            event.type === "turn_created"
+                ? { ...event, input: noteMessage("n".repeat(600)) }
+                : event,
+        );
+        repo.seed(log);
+        const resolved = await resolver(repo, {
+            ...POLICY_OFF,
+            middlePaneContent: true,
+        }).resolve({ previousTurnId: T1 });
+        const input = resolved[0];
+        if (input.role !== "user") throw new Error("expected user message");
+        const middlePane = input.userMessageContext?.middlePane;
+        if (middlePane?.kind !== "note") throw new Error("expected note pane");
+        expect(middlePane.content).toContain("omitted from history");
     });
 });

--- a/apps/x/packages/core/src/turns/context-elision.ts
+++ b/apps/x/packages/core/src/turns/context-elision.ts
@@ -12,29 +12,41 @@ import type { IContextResolver } from "./context-resolver.js";
 import { TurnRepoContextResolver } from "./context-resolver.js";
 import type { ITurnRepo } from "./repo.js";
 
-// Transmit-time elision of historic tool results (the cross-turn prefix
-// only — the current turn's own messages never pass through the resolver, so
-// in-flight tool results are always sent verbatim). Large tool outputs from
-// earlier turns (skill loads, file reads, HTTP fetches) dominate resent
-// context; the model rarely needs them verbatim and can re-run the tool when
-// it does. Elision is a pure function of each message's content, so resolved
-// prefixes stay byte-stable across calls and turns (provider prefix caches
-// keep working), and the durable JSONL log is untouched — only the
-// transmitted bytes change.
+// Transmit-time elision of historic context (the cross-turn prefix only —
+// the current turn's own messages never pass through the resolver, so
+// in-flight tool results and just-captured frames are always sent verbatim).
+//
+// Two policies, both on by default:
+//   - Tool results: large tool outputs from earlier turns (skill loads, file
+//     reads, HTTP fetches) dominate resent context; the model rarely needs
+//     them verbatim and can re-run the tool when it does.
+//   - Inline images: video-mode webcam and screen-share frames matter for
+//     the response they were captured for; afterwards the assistant's own
+//     text carries the takeaway, and fresh frames arrive with every new call
+//     message. Unlike tool results they cannot be re-fetched, so the
+//     placeholder only records what was there.
+//
+// Elision is a pure function of each message's content, so resolved prefixes
+// stay byte-stable across calls and turns (provider prefix caches keep
+// working), and the durable JSONL log is untouched — only the transmitted
+// bytes change.
 
-export interface ToolResultElisionPolicy {
-    enabled: boolean;
-    thresholdChars: number;
+export interface ElisionPolicy {
+    toolResults: boolean;
+    toolResultThresholdChars: number;
+    images: boolean;
 }
 
-export const DEFAULT_ELISION_POLICY: ToolResultElisionPolicy = {
-    enabled: true,
-    thresholdChars: 10_000,
+export const DEFAULT_ELISION_POLICY: ElisionPolicy = {
+    toolResults: true,
+    toolResultThresholdChars: 10_000,
+    images: true,
 };
 
 const ContextConfig = z.object({
     elideHistoricToolResults: z.boolean().optional(),
     elideHistoricToolResultsThresholdChars: z.number().int().min(0).optional(),
+    elideHistoricImages: z.boolean().optional(),
 });
 
 const CONTEXT_CONFIG_PATH = path.join(WorkDir, "config", "context.json");
@@ -42,7 +54,7 @@ const CONTEXT_CONFIG_PATH = path.join(WorkDir, "config", "context.json");
 // Read the elision policy from config/context.json, falling back to defaults
 // for missing keys or an unreadable file. Read per resolve so a config edit
 // applies to the next turn without a restart.
-export function loadElisionPolicy(): ToolResultElisionPolicy {
+export function loadElisionPolicy(): ElisionPolicy {
     try {
         if (!fs.existsSync(CONTEXT_CONFIG_PATH)) {
             return DEFAULT_ELISION_POLICY;
@@ -50,12 +62,14 @@ export function loadElisionPolicy(): ToolResultElisionPolicy {
         const raw = fs.readFileSync(CONTEXT_CONFIG_PATH, "utf-8");
         const parsed = ContextConfig.parse(JSON.parse(raw));
         return {
-            enabled:
+            toolResults:
                 parsed.elideHistoricToolResults ??
-                DEFAULT_ELISION_POLICY.enabled,
-            thresholdChars:
+                DEFAULT_ELISION_POLICY.toolResults,
+            toolResultThresholdChars:
                 parsed.elideHistoricToolResultsThresholdChars ??
-                DEFAULT_ELISION_POLICY.thresholdChars,
+                DEFAULT_ELISION_POLICY.toolResultThresholdChars,
+            images:
+                parsed.elideHistoricImages ?? DEFAULT_ELISION_POLICY.images,
         };
     } catch {
         return DEFAULT_ELISION_POLICY;
@@ -80,18 +94,48 @@ export function elideHistoricToolResults(
     });
 }
 
+export function elideHistoricImages(
+    messages: Array<z.infer<typeof ConversationMessage>>,
+): Array<z.infer<typeof ConversationMessage>> {
+    return messages.map((message) => {
+        if (message.role !== "user" || typeof message.content === "string") {
+            return message;
+        }
+        const images = message.content.filter((part) => part.type === "image");
+        if (images.length === 0) {
+            return message;
+        }
+        const camera = images.filter((part) => part.source !== "screen").length;
+        const screen = images.length - camera;
+        const kinds = [
+            ...(camera > 0 ? [`${camera} webcam frame${camera === 1 ? "" : "s"}`] : []),
+            ...(screen > 0 ? [`${screen} screen-share frame${screen === 1 ? "" : "s"}`] : []),
+        ].join(" and ");
+        return {
+            ...message,
+            content: [
+                ...message.content.filter((part) => part.type !== "image"),
+                {
+                    type: "text" as const,
+                    text: `[Omitted from history to save context: ${kinds} captured while this message was composed. The assistant saw them when responding to this message.]`,
+                },
+            ],
+        };
+    });
+}
+
 // IContextResolver decorator: applies the elision policy to the materialized
 // cross-turn prefix. Agent snapshot resolution is delegated untouched.
 export class ElidingContextResolver implements IContextResolver {
     private readonly inner: IContextResolver;
-    private readonly loadPolicy: () => ToolResultElisionPolicy;
+    private readonly loadPolicy: () => ElisionPolicy;
 
     constructor({
         inner,
         loadPolicy,
     }: {
         inner: IContextResolver;
-        loadPolicy?: () => ToolResultElisionPolicy;
+        loadPolicy?: () => ElisionPolicy;
     }) {
         this.inner = inner;
         this.loadPolicy = loadPolicy ?? loadElisionPolicy;
@@ -100,12 +144,18 @@ export class ElidingContextResolver implements IContextResolver {
     async resolve(
         context: z.infer<typeof TurnContext>,
     ): Promise<Array<z.infer<typeof ConversationMessage>>> {
-        const prefix = await this.inner.resolve(context);
+        let prefix = await this.inner.resolve(context);
         const policy = this.loadPolicy();
-        if (!policy.enabled) {
-            return prefix;
+        if (policy.toolResults) {
+            prefix = elideHistoricToolResults(
+                prefix,
+                policy.toolResultThresholdChars,
+            );
         }
-        return elideHistoricToolResults(prefix, policy.thresholdChars);
+        if (policy.images) {
+            prefix = elideHistoricImages(prefix);
+        }
+        return prefix;
     }
 
     resolveAgent(

--- a/apps/x/packages/core/src/turns/context-elision.ts
+++ b/apps/x/packages/core/src/turns/context-elision.ts
@@ -25,6 +25,11 @@ import type { ITurnRepo } from "./repo.js";
 //     text carries the takeaway, and fresh frames arrive with every new call
 //     message. Unlike tool results they cannot be re-fetched, so the
 //     placeholder only records what was there.
+//   - Middle-pane note content: every user message sent while a note is
+//     open carries a full snapshot of that note in userMessageContext. Only
+//     the newest snapshot matters (the system prompt already tells the model
+//     later middle-pane context overrides earlier), and the current file is
+//     always re-readable at the recorded path.
 //
 // Elision is a pure function of each message's content, so resolved prefixes
 // stay byte-stable across calls and turns (provider prefix caches keep
@@ -35,18 +40,25 @@ export interface ElisionPolicy {
     toolResults: boolean;
     toolResultThresholdChars: number;
     images: boolean;
+    middlePaneContent: boolean;
 }
 
 export const DEFAULT_ELISION_POLICY: ElisionPolicy = {
     toolResults: true,
     toolResultThresholdChars: 10_000,
     images: true,
+    middlePaneContent: true,
 };
+
+// Notes smaller than this stay verbatim in history: below the floor the
+// placeholder saves nothing and a short note may carry useful context.
+const MIDDLE_PANE_CONTENT_FLOOR_CHARS = 500;
 
 const ContextConfig = z.object({
     elideHistoricToolResults: z.boolean().optional(),
     elideHistoricToolResultsThresholdChars: z.number().int().min(0).optional(),
     elideHistoricImages: z.boolean().optional(),
+    elideHistoricMiddlePaneContent: z.boolean().optional(),
 });
 
 const CONTEXT_CONFIG_PATH = path.join(WorkDir, "config", "context.json");
@@ -70,6 +82,9 @@ export function loadElisionPolicy(): ElisionPolicy {
                 DEFAULT_ELISION_POLICY.toolResultThresholdChars,
             images:
                 parsed.elideHistoricImages ?? DEFAULT_ELISION_POLICY.images,
+            middlePaneContent:
+                parsed.elideHistoricMiddlePaneContent ??
+                DEFAULT_ELISION_POLICY.middlePaneContent,
         };
     } catch {
         return DEFAULT_ELISION_POLICY;
@@ -124,6 +139,34 @@ export function elideHistoricImages(
     });
 }
 
+export function elideHistoricMiddlePaneContent(
+    messages: Array<z.infer<typeof ConversationMessage>>,
+): Array<z.infer<typeof ConversationMessage>> {
+    return messages.map((message) => {
+        if (message.role !== "user") {
+            return message;
+        }
+        const middlePane = message.userMessageContext?.middlePane;
+        if (
+            !middlePane ||
+            middlePane.kind !== "note" ||
+            middlePane.content.length <= MIDDLE_PANE_CONTENT_FLOOR_CHARS
+        ) {
+            return message;
+        }
+        return {
+            ...message,
+            userMessageContext: {
+                ...message.userMessageContext,
+                middlePane: {
+                    ...middlePane,
+                    content: `[Note content (${middlePane.content.length} characters) omitted from history to save context. This snapshot is stale; read the file at the path above if its content is needed now.]`,
+                },
+            },
+        };
+    });
+}
+
 // IContextResolver decorator: applies the elision policy to the materialized
 // cross-turn prefix. Agent snapshot resolution is delegated untouched.
 export class ElidingContextResolver implements IContextResolver {
@@ -154,6 +197,9 @@ export class ElidingContextResolver implements IContextResolver {
         }
         if (policy.images) {
             prefix = elideHistoricImages(prefix);
+        }
+        if (policy.middlePaneContent) {
+            prefix = elideHistoricMiddlePaneContent(prefix);
         }
         return prefix;
     }

--- a/apps/x/packages/core/src/turns/context-elision.ts
+++ b/apps/x/packages/core/src/turns/context-elision.ts
@@ -1,0 +1,129 @@
+import fs from "fs";
+import path from "path";
+import { z } from "zod";
+import type {
+    ConversationMessage,
+    ResolvedAgent,
+    ResolvedAgentSnapshot,
+    TurnContext,
+} from "@x/shared/dist/turns.js";
+import { WorkDir } from "../config/config.js";
+import type { IContextResolver } from "./context-resolver.js";
+import { TurnRepoContextResolver } from "./context-resolver.js";
+import type { ITurnRepo } from "./repo.js";
+
+// Transmit-time elision of historic tool results (the cross-turn prefix
+// only — the current turn's own messages never pass through the resolver, so
+// in-flight tool results are always sent verbatim). Large tool outputs from
+// earlier turns (skill loads, file reads, HTTP fetches) dominate resent
+// context; the model rarely needs them verbatim and can re-run the tool when
+// it does. Elision is a pure function of each message's content, so resolved
+// prefixes stay byte-stable across calls and turns (provider prefix caches
+// keep working), and the durable JSONL log is untouched — only the
+// transmitted bytes change.
+
+export interface ToolResultElisionPolicy {
+    enabled: boolean;
+    thresholdChars: number;
+}
+
+export const DEFAULT_ELISION_POLICY: ToolResultElisionPolicy = {
+    enabled: true,
+    thresholdChars: 10_000,
+};
+
+const ContextConfig = z.object({
+    elideHistoricToolResults: z.boolean().optional(),
+    elideHistoricToolResultsThresholdChars: z.number().int().min(0).optional(),
+});
+
+const CONTEXT_CONFIG_PATH = path.join(WorkDir, "config", "context.json");
+
+// Read the elision policy from config/context.json, falling back to defaults
+// for missing keys or an unreadable file. Read per resolve so a config edit
+// applies to the next turn without a restart.
+export function loadElisionPolicy(): ToolResultElisionPolicy {
+    try {
+        if (!fs.existsSync(CONTEXT_CONFIG_PATH)) {
+            return DEFAULT_ELISION_POLICY;
+        }
+        const raw = fs.readFileSync(CONTEXT_CONFIG_PATH, "utf-8");
+        const parsed = ContextConfig.parse(JSON.parse(raw));
+        return {
+            enabled:
+                parsed.elideHistoricToolResults ??
+                DEFAULT_ELISION_POLICY.enabled,
+            thresholdChars:
+                parsed.elideHistoricToolResultsThresholdChars ??
+                DEFAULT_ELISION_POLICY.thresholdChars,
+        };
+    } catch {
+        return DEFAULT_ELISION_POLICY;
+    }
+}
+
+export function elideHistoricToolResults(
+    messages: Array<z.infer<typeof ConversationMessage>>,
+    thresholdChars: number,
+): Array<z.infer<typeof ConversationMessage>> {
+    return messages.map((message) => {
+        if (
+            message.role !== "tool" ||
+            message.content.length <= thresholdChars
+        ) {
+            return message;
+        }
+        return {
+            ...message,
+            content: `[Tool result elided to save context: "${message.toolName}" returned ${message.content.length} characters in an earlier turn. Call the tool again if you need this output now.]`,
+        };
+    });
+}
+
+// IContextResolver decorator: applies the elision policy to the materialized
+// cross-turn prefix. Agent snapshot resolution is delegated untouched.
+export class ElidingContextResolver implements IContextResolver {
+    private readonly inner: IContextResolver;
+    private readonly loadPolicy: () => ToolResultElisionPolicy;
+
+    constructor({
+        inner,
+        loadPolicy,
+    }: {
+        inner: IContextResolver;
+        loadPolicy?: () => ToolResultElisionPolicy;
+    }) {
+        this.inner = inner;
+        this.loadPolicy = loadPolicy ?? loadElisionPolicy;
+    }
+
+    async resolve(
+        context: z.infer<typeof TurnContext>,
+    ): Promise<Array<z.infer<typeof ConversationMessage>>> {
+        const prefix = await this.inner.resolve(context);
+        const policy = this.loadPolicy();
+        if (!policy.enabled) {
+            return prefix;
+        }
+        return elideHistoricToolResults(prefix, policy.thresholdChars);
+    }
+
+    resolveAgent(
+        resolved: z.infer<typeof ResolvedAgentSnapshot>,
+    ): Promise<z.infer<typeof ResolvedAgent>> {
+        return this.inner.resolveAgent(resolved);
+    }
+}
+
+// The one context resolver the app should construct (DI container and the
+// inspect CLI both use this), so the debug view reproduces the same bytes
+// the loop transmits.
+export function createContextResolver({
+    turnRepo,
+}: {
+    turnRepo: ITurnRepo;
+}): IContextResolver {
+    return new ElidingContextResolver({
+        inner: new TurnRepoContextResolver({ turnRepo }),
+    });
+}

--- a/apps/x/packages/core/src/turns/inspect-cli.ts
+++ b/apps/x/packages/core/src/turns/inspect-cli.ts
@@ -27,7 +27,7 @@ import { convertFromMessages } from "../agents/runtime.js";
 import { WorkDir } from "../config/config.js";
 import { FSSessionRepo } from "../sessions/fs-repo.js";
 import { composeModelRequest } from "./compose-model-request.js";
-import { TurnRepoContextResolver } from "./context-resolver.js";
+import { createContextResolver } from "./context-elision.js";
 import { FSTurnRepo } from "./fs-repo.js";
 
 const turnRepo = new FSTurnRepo({
@@ -36,7 +36,7 @@ const turnRepo = new FSTurnRepo({
 const sessionRepo = new FSSessionRepo({
     sessionsRootDir: path.join(WorkDir, "storage", "sessions"),
 });
-const resolver = new TurnRepoContextResolver({ turnRepo });
+const resolver = createContextResolver({ turnRepo });
 const encode = (messages: Parameters<typeof convertFromMessages>[0]) =>
     convertFromMessages(messages) as unknown as JsonValue[];
 


### PR DESCRIPTION
## Problem

Users are burning through credits after a single chat. The turn runtime resends the **entire conversation** to the provider on every model step: the loop runs one `streamText` call per step, and each request is rebuilt as system prompt + all tool schemas + the full transcript of every prior turn (context is a reference chain to the previous turn, materialized by `TurnRepoContextResolver`).

The dominant avoidable cost in that resent transcript is **stale tool results**. Nothing in the turn path truncates tool output, so one-shot payloads enter the transcript and are retransmitted on every subsequent model call for the rest of the session:

- `loadSkill` returns the entire guidance string — `create-presentations` alone is ~117KB (~30k tokens)
- `file-readText` defaults to 2,000 lines
- `httpFetch` allows up to 200,000 chars (~50k tokens)
- MCP tools return unbounded JSON

A model almost never needs these verbatim in later turns — and when it does, re-running the tool is both natural and correct.

## Change

A new decorator over the context resolver applies **transmit-time elision**: when the cross-turn prefix is materialized, tool results from prior turns whose content exceeds a size threshold are replaced with a short placeholder:

> `[Tool result elided to save context: "file-readText" returned 15000 characters in an earlier turn. Call the tool again if you need this output now.]`

### Key properties

- **The durable log is untouched.** Elision happens only when the prefix is materialized for transmission. The JSONL event log, UI reconstruction, and crash recovery are unaffected — only the bytes sent to the provider change.
- **The current turn is never elided.** In-flight tool results ride `requestMessagesFor` (the turn's own events), which doesn't pass through the resolver. The model always sees the full output of tools it just called.
- **Byte-stable prefixes.** Elision is a pure function of each message's content, so the same durable state always produces the same transmitted bytes — deterministic recomposition still holds, and provider prefix caches keep working (no moving window).
- **Debug view still equals wire bytes.** The DI container and the `npm run inspect` CLI both construct the resolver through one factory (`createContextResolver`), so the inspector reproduces exactly what the loop transmits.

### Configuration

`~/.rowboat/config/context.json`, read per resolve (no restart needed):

```json
{
  "elideHistoricToolResults": true,
  "elideHistoricToolResultsThresholdChars": 10000
}
```

Defaults: **enabled**, threshold 10,000 chars (~2.5k tokens). Small tool results (success flags, short lookups) always survive. A missing or malformed config file falls back to defaults.

## Files

- `packages/core/src/turns/context-elision.ts` — new: pure `elideHistoricToolResults()`, `ElidingContextResolver` (an `IContextResolver` decorator), config loader, and the `createContextResolver` factory
- `packages/core/src/di/container.ts` — `contextResolver` registration now builds through the factory
- `packages/core/src/turns/inspect-cli.ts` — same factory, keeping debug output identical to transmitted bytes
- `packages/core/src/turns/context-elision.test.ts` — new: threshold boundary, placeholder content, disabled policy, determinism/idempotency, and resolver-level tests over a seeded turn log with a tool round trip
- `packages/core/docs/turn-runtime-design.md` — §6.6 note documenting the decorator and policy

## Verification

Beyond unit tests (115 turns tests green), verified end-to-end against the built dist with a synthetic workdir (turn A holding a 15,000-char tool result, turn B referencing it):

- Turn B's composed payload (via `npm run inspect`, the exact wire path) carries the placeholder; surrounding messages verbatim
- Turn A's own model call still sends the full 15,000 chars (in-flight results untouched)
- `elideHistoricToolResults: false` restores full content; threshold 20,000 keeps the 15k result; garbage in `context.json` falls back to defaults without crashing
- Resolving `contextResolver` from the real DI container constructs `ElidingContextResolver` and elides correctly

## Trade-off and follow-ups

If a user follows up on old tool output, the model re-runs the tool — one extra round trip for a fresh, correct result. Skill guidance loaded in an earlier turn is the case to watch: the model may need to re-load a skill mid-session (the placeholder tells it to).

This is the first of the planned context-cost levers; next up are pruning historic video-call frames in `convertFromMessages` and Anthropic `cacheControl` breakpoints in `RealModelRegistry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)