### PR TITLE
feat(models): switch signed-in default model to Gemini 3.5 Flash

### DIFF
--- a/apps/x/packages/core/src/models/defaults.ts
+++ b/apps/x/packages/core/src/models/defaults.ts
@@ -4,7 +4,7 @@ import { IModelConfigRepo } from "./repo.js";
 import { isSignedIn } from "../account/account.js";
 import container from "../di/container.js";
 
-const SIGNED_IN_DEFAULT_MODEL = "anthropic/claude-opus-4.7";
+const SIGNED_IN_DEFAULT_MODEL = "google/gemini-3.5-flash";
 const SIGNED_IN_DEFAULT_PROVIDER = "rowboat";
 // KG note-creation historically failed on identity (self-notes, perspective
 // flips, misread outbound email) — root cause was the owner block never being


### PR DESCRIPTION
## Summary
- Changes `SIGNED_IN_DEFAULT_MODEL` in `packages/core/src/models/defaults.ts` from `anthropic/claude-opus-4.7` to `google/gemini-3.5-flash` (still served via the `rowboat` gateway provider).
- BYOK mode is unaffected — signed-out users keep whatever is in `~/.rowboat/config/models.json` (e.g. `gpt-5.4`).

## Notes
- Per-category signed-in models (KG, live notes, auto-permission) remain on `gemini-3.1-flash-lite`; meeting notes follows the new default automatically.
- An explicit `defaultSelection` chosen by the user in settings still takes precedence over this fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)