### PR TITLE
fix(mcp): forward configured headers to remote MCP transports

### DIFF
--- a/apps/cli/src/mcp/mcp.ts
+++ b/apps/cli/src/mcp/mcp.ts
@@ -40,11 +40,20 @@ async function getClient(serverName: string): Promise<Client> {
                 env: config.env,
             });
         } else {
+            // Forward any configured headers (e.g. Authorization) so
+            // auth-protected remote MCP servers can be reached.
+            const requestInit = config.headers
+                ? { headers: config.headers }
+                : undefined;
             try {
-                transport = new StreamableHTTPClientTransport(new URL(config.url));
+                transport = new StreamableHTTPClientTransport(new URL(config.url), {
+                    requestInit,
+                });
             } catch (error) {
                 // if that fails, try sse transport
-                transport = new SSEClientTransport(new URL(config.url));
+                transport = new SSEClientTransport(new URL(config.url), {
+                    requestInit,
+                });
             }
         }
 

--- a/apps/x/packages/core/src/mcp/mcp.ts
+++ b/apps/x/packages/core/src/mcp/mcp.ts
@@ -39,11 +39,20 @@ async function getClient(serverName: string): Promise<Client> {
                 env: config.env,
             });
         } else {
+            // Forward any configured headers (e.g. Authorization) so
+            // auth-protected remote MCP servers can be reached.
+            const requestInit = config.headers
+                ? { headers: config.headers }
+                : undefined;
             try {
-                transport = new StreamableHTTPClientTransport(new URL(config.url));
+                transport = new StreamableHTTPClientTransport(new URL(config.url), {
+                    requestInit,
+                });
             } catch {
                 // if that fails, try sse transport
-                transport = new SSEClientTransport(new URL(config.url));
+                transport = new SSEClientTransport(new URL(config.url), {
+                    requestInit,
+                });
             }
         }
 


### PR DESCRIPTION
The HTTP MCP server config schema has an optional `headers` field (`HttpMcpServerConfig` in both `apps/cli/src/mcp/schema.ts` and `apps/x/packages/shared/src/mcp.ts`), but `getClient` builds the transport with just `new StreamableHTTPClientTransport(new URL(config.url))` — the headers are never passed on. So any remote MCP server that needs an `Authorization` (or other) header from `config/mcp.json` can't be reached, and the connection just fails.

Passed the configured headers through as `requestInit.headers` on both the Streamable HTTP and the SSE fallback transport. Did the same in the CLI and the desktop core since both read the same config shape and had the same gap.

Related to #580 — that report is about connecting to auth-gated remote MCP servers via `config/mcp.json`; dropping the configured headers is part of why those connections don't go through.