### PR TITLE
fix(rag-worker): clear stale doc embeddings before upsert to prevent orphaned vectors

### DIFF
--- a/apps/rowboat/app/scripts/rag-worker.ts
+++ b/apps/rowboat/app/scripts/rag-worker.ts
@@ -47,6 +47,37 @@ const splitter = new RecursiveCharacterTextSplitter({
 // Configure Google Gemini API
 const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY || '');
 
+// Remove any existing points for this doc so that retries of a failed or
+// partially-completed run do not leave orphaned vectors behind (#603).
+// Point IDs are random UUIDs, so a re-run would otherwise upsert a full
+// duplicate set of chunks alongside the old ones.
+async function deleteDocEmbeddings(projectId: string, sourceId: string, docId: string): Promise<void> {
+    await qdrantClient.delete("embeddings", {
+        filter: {
+            must: [
+                {
+                    key: "projectId",
+                    match: {
+                        value: projectId,
+                    }
+                },
+                {
+                    key: "sourceId",
+                    match: {
+                        value: sourceId,
+                    }
+                },
+                {
+                    key: "docId",
+                    match: {
+                        value: docId,
+                    }
+                }
+            ],
+        },
+    });
+}
+
 async function retryable<T>(fn: () => Promise<T>, maxAttempts: number = 3): Promise<T> {
     let attempts = 0;
     while (true) {
@@ -150,6 +181,10 @@ async function runProcessFilePipeline(_logger: PrefixLogger, usageTracker: Usage
         context: "rag.files.embedding_usage",
     });
 
+    // clear any points left over from a previous failed attempt (#603)
+    logger.log("Clearing existing embeddings for doc in Qdrant");
+    await deleteDocEmbeddings(job.projectId, job.id, doc.id);
+
     // store embeddings in qdrant
     logger.log("Storing embeddings in Qdrant");
     const points: z.infer<typeof EmbeddingRecord>[] = embeddings.map((embedding, i) => ({
@@ -219,6 +254,10 @@ async function runScrapePipeline(_logger: PrefixLogger, usageTracker: UsageTrack
         context: "rag.urls.embedding_usage",
     });
 
+    // clear any points left over from a previous failed attempt (#603)
+    logger.log("Clearing existing embeddings for doc in Qdrant");
+    await deleteDocEmbeddings(job.projectId, job.id, doc.id);
+
     // store embeddings in qdrant
     logger.log("Storing embeddings in Qdrant");
     const points: z.infer<typeof EmbeddingRecord>[] = embeddings.map((embedding, i) => ({
@@ -271,6 +310,10 @@ async function runProcessTextPipeline(_logger: PrefixLogger, usageTracker: Usage
         context: "rag.text.embedding_usage",
     });
 
+    // clear any points left over from a previous failed attempt (#603)
+    logger.log("Clearing existing embeddings for doc in Qdrant");
+    await deleteDocEmbeddings(job.projectId, job.id, doc.id);
+
     // store embeddings in qdrant
     logger.log("Storing embeddings in Qdrant");
     const points: z.infer<typeof EmbeddingRecord>[] = embeddings.map((embedding, i) => ({
@@ -304,30 +347,7 @@ async function runDeletionPipeline(_logger: PrefixLogger, job: z.infer<typeof Da
 
     // Delete embeddings from qdrant
     logger.log("Deleting embeddings from Qdrant");
-    await qdrantClient.delete("embeddings", {
-        filter: {
-            must: [
-                {
-                    key: "projectId",
-                    match: {
-                        value: job.projectId,
-                    }
-                },
-                {
-                    key: "sourceId",
-                    match: {
-                        value: job.id,
-                    }
-                },
-                {
-                    key: "docId",
-                    match: {
-                        value: doc.id,
-                    }
-                }
-            ],
-        },
-    });
+    await deleteDocEmbeddings(job.projectId, job.id, doc.id);
 
     // Delete docs from db
     logger.log("Deleting doc from db");


### PR DESCRIPTION
## Problem

Fixes #603

The three ingestion pipelines (file / text / URL) in `rag-worker.ts` generate Qdrant point IDs with `crypto.randomUUID()`, upsert the points, and then update the doc record in MongoDB. These are separate network calls with no cleanup between attempts.

Because docs with status `pending` **or** `error` are re-polled, any retry of a failed or partially-completed run (e.g. Qdrant upsert succeeded but the Mongo `updateByVersion` failed) re-embeds the doc and upserts a **full duplicate set of chunks under fresh random IDs**. The vectors from the previous attempt are never removed, so duplicates accumulate on every retry — bloating the collection and polluting RAG search results with duplicate/stale chunks.

## Fix

- Add a `deleteDocEmbeddings(projectId, sourceId, docId)` helper using the same filtered-delete pattern the worker already uses in `runDeletionPipeline`.
- Call it immediately before the Qdrant upsert in all three pipelines, making doc processing idempotent — a retry now *replaces* the previous attempt's points instead of stacking on top of them.
- Refactor `runDeletionPipeline` to reuse the helper (removes the duplicated inline filter).

## Why delete-before-upsert rather than deterministic point IDs

Deterministic IDs (e.g. hashing `docId + chunk index`) would make retries overwrite in place, but if a doc is later re-processed and yields **fewer** chunks, the leftover higher-index points would still linger. The scoped filtered delete handles every case (retry, re-process, content change) and reuses an existing pattern in the codebase.

## Testing notes

- Verified the filter shape matches the existing deletion paths (`projectId` + `sourceId` + `docId` must-clauses).
- `esbuild` parse check passes on the modified file.
- Happy to add a worker-level test if you can point me at the preferred harness for this script.