### PR TITLE
Improve apps/x CI coverage

### DIFF
--- a/.github/workflows/x-tests.yml
+++ b/.github/workflows/x-tests.yml
@@ -1,19 +1,14 @@
-name: apps/x tests
+name: rowboat
 
 on:
   pull_request:
-    paths:
-      - "apps/x/**"
-      - ".github/workflows/x-tests.yml"
   push:
     branches: [main]
-    paths:
-      - "apps/x/**"
-      - ".github/workflows/x-tests.yml"
   workflow_dispatch:
 
 jobs:
-  test:
+  apps-x-vitest:
+    name: apps/x Vitest suites
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -36,5 +31,33 @@ jobs:
 
       # Builds @x/shared (core/renderer tests import its dist), then runs
       # the shared, core, and renderer vitest suites in order.
-      - name: Run tests
+      - name: Run apps/x Vitest suites
         run: npm test
+
+  apps-x-electron-package:
+    name: apps/x Electron package smoke test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/x
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+          cache-dependency-path: apps/x/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Package Electron app without signing
+        env:
+          ROWBOAT_SKIP_CODE_SIGNING: "1"
+        run: npm run package
+        working-directory: apps/x/apps/main

--- a/apps/x/apps/main/forge.config.cjs
+++ b/apps/x/apps/main/forge.config.cjs
@@ -10,6 +10,7 @@ const pkg = require('./package.json');
 // but CI sets ROWBOAT_SKIP_PACMAN=1 to disable it explicitly — GitHub runners are
 // Ubuntu and shouldn't attempt to ship an Arch package.
 const SKIP_PACMAN = process.env.ROWBOAT_SKIP_PACMAN === '1';
+const SKIP_CODE_SIGNING = process.env.ROWBOAT_SKIP_CODE_SIGNING === '1';
 
 // Stage the ACP coding-adapters (@agentclientprotocol/*-acp) and their full
 // production dependency closure into the packaged app.
@@ -201,18 +202,20 @@ module.exports = {
             NSAudioCaptureUsageDescription: 'Rowboat needs access to system audio to transcribe meetings from other apps (Zoom, Meet, etc.)',
             NSCameraUsageDescription: 'Rowboat uses your camera in video chat mode so the assistant can see you and give feedback (e.g. pitch practice).',
         },
-        osxSign: {
-            batchCodesignCalls: true,
-            optionsForFile: () => ({
-                entitlements: path.join(__dirname, 'entitlements.plist'),
-                'entitlements-inherit': path.join(__dirname, 'entitlements.plist'),
-            }),
-        },
-        osxNotarize: {
-            appleId: process.env.APPLE_ID,
-            appleIdPassword: process.env.APPLE_PASSWORD,
-            teamId: process.env.APPLE_TEAM_ID
-        },
+        ...(SKIP_CODE_SIGNING ? {} : {
+            osxSign: {
+                batchCodesignCalls: true,
+                optionsForFile: () => ({
+                    entitlements: path.join(__dirname, 'entitlements.plist'),
+                    'entitlements-inherit': path.join(__dirname, 'entitlements.plist'),
+                }),
+            },
+            osxNotarize: {
+                appleId: process.env.APPLE_ID,
+                appleIdPassword: process.env.APPLE_PASSWORD,
+                teamId: process.env.APPLE_TEAM_ID
+            },
+        }),
         // Since we bundle the main process with esbuild, we don't need the workspace
         // node_modules. These settings prevent Forge's dependency walker (flora-colossus)
         // from trying to analyze/copy node_modules, which fails with pnpm's symlinked


### PR DESCRIPTION
## Summary
- Run the apps/x test workflow on every PR and push to main by removing path filters
- Add a PR Electron package job that runs npm run package from apps/x/apps/main
- Add ROWBOAT_SKIP_CODE_SIGNING so CI package validation can avoid signing/notarization config

## Validation
- npm test
- ROWBOAT_SKIP_CODE_SIGNING=1 npm run package
- git diff --check
- YAML parse via Ruby Psych