### PR TITLE
fix: surface Ollama's real error message instead of bare HTTP statusText

### DIFF
--- a/apps/x/packages/core/src/models/local.test.ts
+++ b/apps/x/packages/core/src/models/local.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { makeOllamaThinkFetch, resolveThinkValue } from "./local.js";
+import { makeOllamaThinkFetch, resolveThinkValue, rewrapOllamaErrorBody } from "./local.js";
 
 describe("resolveThinkValue", () => {
     it("passes effort levels straight through for gpt-oss variants", () => {
@@ -19,6 +19,27 @@ describe("resolveThinkValue", () => {
     it("strips think for models without the thinking capability", () => {
         expect(resolveThinkValue("llama3.2:3b", "low", false)).toBeUndefined();
         expect(resolveThinkValue("llama3.2:3b", "high", false)).toBeUndefined();
+    });
+});
+
+describe("rewrapOllamaErrorBody", () => {
+    it("rewraps Ollama's plain-string error shape", () => {
+        expect(rewrapOllamaErrorBody('{"error":"model \'x\' not found"}'))
+            .toBe('{"error":{"message":"model \'x\' not found"}}');
+    });
+
+    it("leaves already-nested errors untouched", () => {
+        expect(rewrapOllamaErrorBody('{"error":{"message":"x"}}')).toBeUndefined();
+    });
+
+    it("leaves non-JSON bodies untouched", () => {
+        expect(rewrapOllamaErrorBody("<html>bad gateway</html>")).toBeUndefined();
+    });
+
+    it("leaves JSON without a string error field untouched", () => {
+        expect(rewrapOllamaErrorBody('{"message":"x"}')).toBeUndefined();
+        expect(rewrapOllamaErrorBody('{"error":42}')).toBeUndefined();
+        expect(rewrapOllamaErrorBody("null")).toBeUndefined();
     });
 });
 
@@ -77,5 +98,33 @@ describe("makeOllamaThinkFetch", () => {
         }
         // Non-chat request passed through with no body rewrite.
         expect(calls.some((c) => c.url.endsWith("/api/tags"))).toBe(true);
+    });
+
+    it("rewraps plain-string error bodies on failed responses, keeping the status", async () => {
+        vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            if (url.endsWith("/api/show")) {
+                return new Response(JSON.stringify({ capabilities: ["completion"] }), { status: 200 });
+            }
+            return new Response(JSON.stringify({ error: "boom" }), { status: 400, statusText: "Bad Request" });
+        }));
+        const wrapped = makeOllamaThinkFetch("low");
+        const res = await wrapped("http://localhost:11434/api/chat", {
+            method: "POST",
+            body: JSON.stringify({ model: "llama3.2:3b", think: false, messages: [] }),
+        });
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: { message: "boom" } });
+    });
+
+    it("returns successful responses untouched", async () => {
+        stubFetch(["completion"]);
+        const wrapped = makeOllamaThinkFetch("low");
+        const res = await wrapped("http://localhost:11434/api/chat", {
+            method: "POST",
+            body: JSON.stringify({ model: "llama3.2:3b", messages: [] }),
+        });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({});
     });
 });

--- a/apps/x/packages/core/src/models/local.ts
+++ b/apps/x/packages/core/src/models/local.ts
@@ -84,12 +84,43 @@ export function resolveThinkValue(
     }
 }
 
+// Ollama replies with {"error":"<string>"}; ollama-ai-provider-v2 expects
+// OpenAI-style {"error":{"message":...}} and falls back to the bare HTTP
+// statusText when parsing fails -- the real reason gets swallowed (#696).
+// Rewrap so the provider surfaces the actual message. Returns undefined
+// when the body isn't in Ollama's plain-string error shape.
+export function rewrapOllamaErrorBody(text: string): string | undefined {
+    try {
+        const parsed = JSON.parse(text) as unknown;
+        if (parsed && typeof parsed === "object" && typeof (parsed as { error?: unknown }).error === "string") {
+            return JSON.stringify({ error: { message: (parsed as { error: string }).error } });
+        }
+    } catch {
+        // not JSON -- leave untouched
+    }
+    return undefined;
+}
+
+async function rewrapErrorResponse(res: Response): Promise<Response> {
+    const text = await res.text();
+    const headers = new Headers(res.headers);
+    // The body may have grown; let the runtime recompute the length.
+    headers.delete("content-length");
+    return new Response(rewrapOllamaErrorBody(text) ?? text, {
+        status: res.status,
+        statusText: res.statusText,
+        headers,
+    });
+}
+
 // The ollama-ai-provider-v2 request builder always writes `think: false`
 // (its providerOptions schema is boolean-only), so effort can only be set by
 // rewriting the wire request. This wraps fetch for createOllama: /api/chat
 // bodies get `think` set per resolveThinkValue; every other request passes
 // through untouched. Thinking capability is probed once per model via
-// /api/show and cached for the process lifetime.
+// /api/show and cached for the process lifetime. Failed responses get their
+// error body rewrapped (see rewrapOllamaErrorBody) so the provider surfaces
+// Ollama's actual error message instead of the HTTP statusText.
 export function makeOllamaThinkFetch(
     effort: ReasoningEffort,
 ): typeof fetch {
@@ -117,6 +148,7 @@ export function makeOllamaThinkFetch(
     };
 
     return async (input, init) => {
+        let finalInit = init;
         try {
             const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
             const isChat = /\/api\/chat(\?.*)?$/.test(url);
@@ -130,11 +162,12 @@ export function makeOllamaThinkFetch(
                 } else {
                     parsed.think = think;
                 }
-                return fetch(input, { ...init, body: JSON.stringify(parsed) });
+                finalInit = { ...init, body: JSON.stringify(parsed) };
             }
         } catch {
             // Malformed body or URL — send the original request unchanged.
         }
-        return fetch(input, init);
+        const res = await fetch(input, finalInit);
+        return res.ok ? res : rewrapErrorResponse(res);
     };
 }


### PR DESCRIPTION
## Summary

Ollama error responses were being swallowed by our provider stack: users saw only the bare HTTP status text ("Bad Request", "Not Found") no matter what actually went wrong. This PR rewraps Ollama's error bodies into the shape `ollama-ai-provider-v2` can parse, so the app surfaces Ollama's real error message. It directly addresses the "how can I debug this" half of #696 and makes every future Ollama bug report actionable.

Refs #696 (deliberately not `Fixes` — see "Relationship to #696").

## Problem & root cause

Ollama returns errors as a flat JSON string: `{"error":"model 'x' not found"}`. The `ollama-ai-provider-v2` error parser (`ollamaErrorDataSchema`) expects the OpenAI-style nested shape `{"error":{"message":"..."}}`. The schema mismatch makes parsing fail and the AI SDK falls back to the HTTP `statusText`. Verified live: a 404 for a nonexistent model produced `error.message === "Not Found"` even though `responseBody` contained the real reason. Result: every Ollama failure reaches the user as an opaque "Bad Request"/"Not Found".

## Relationship to #696

The reporter gets a 400 on every prompt with `gemma4:12b-mlx`. I could **not** reproduce that 400 on Ollama 0.31.2 (macOS, MLX engine) with the same model: tools, `think` on/off, explicit `num_ctx`, multi-turn tool round-trips and complex schemas all pass. Their underlying 400 is therefore most likely environment/version-specific.

What *is* reproducible — and app-side — is that whatever Ollama's real complaint is, we hide it. Two factors match the reported symptoms exactly:

1. `testModelConnection` pings without tools, while real chat always sends tools — so Settings "Test & Save" passes while every chat fails.
2. The real error is swallowed (this PR), so all the user can see is "Bad Request".

This PR intentionally does **not** claim to fix the reporter's 400; it makes the actual error visible so it can be diagnosed. I've asked the reporter for their `ollama --version` on the issue.

## What changed & how it works

All in `apps/x/packages/core/src/models/local.ts` (+ tests):

- New exported pure helper `rewrapOllamaErrorBody(text)`: if the body parses as `{error: string}`, returns it rewrapped as `{"error":{"message":<string>}}`; returns `undefined` for anything else (already-nested errors, non-JSON, non-string `error`), meaning "leave the body untouched".
- New private `rewrapErrorResponse(res)`: reads the failed response's text, applies the helper (falling back to the original text), and rebuilds a `Response` with the same `status`/`statusText` and a copy of the headers with `content-length` removed (body length may change; the runtime recomputes it).
- `makeOllamaThinkFetch`'s returned wrapper now funnels every request through a single fetch call site: the existing `think`-rewrite logic computes `finalInit` inside its try/catch, then `res.ok ? res : rewrapErrorResponse(res)`. Successful responses (incl. streaming) are returned untouched. The `/api/show` thinking-capability probe is unchanged.

## Design decisions

- **Fix at the fetch wrapper, not in the SDK error handler.** `makeOllamaThinkFetch` is already our single interception point for Ollama wire traffic (it exists to rewrite `think`). Rewrapping there lets the provider's own error parsing work as designed — no changes needed in `real-model-registry.ts` or UI error plumbing, and every consumer (chat, settings test, background agents) benefits automatically.
- **Merged the wrapper's two fetch call sites into one.** Previously the chat path returned `fetch(...)` inside the `try` and the passthrough ran after it. Post-processing both separately would require awaiting inside the `try`, where a network rejection would fall into the `catch` and fire the passthrough fetch — a duplicate request. A single call site removes that hazard and guarantees both paths get identical error handling.
- **`content-length` dropped, everything else preserved.** Rewrapping can change body length; recomputation is safest. `status`/`statusText`/`content-type` are preserved so status-based handling upstream is unaffected.
- **No double-wrap.** Already-nested bodies pass through untouched (tested), so this stays safe even if a future Ollama version adopts the nested shape.

## Files touched

- `apps/x/packages/core/src/models/local.ts` — helper + wrapper change
- `apps/x/packages/core/src/models/local.test.ts` — 6 new tests

## Testing & verification

- **Unit:** `npx vitest run src/models/local.test.ts` — 12/12 pass. New tests cover: rewrapping the plain-string shape; leaving already-nested / non-JSON / non-string-error / `null` bodies untouched; a stubbed 400 with `{"error":"boom"}` through the full wrapper coming back rewrapped with status still 400; a 200 passing through untouched.
- **Types:** `npx tsc --noEmit` in `packages/core` — changed files clean (one pre-existing unrelated error elsewhere).
- **Live against local Ollama 0.31.2:** requesting nonexistent model `does-not-exist:1b` now yields an error whose message contains `model 'does-not-exist:1b' not found` (previously just "Not Found"), status 404 preserved. Happy path with `gemma4:12b-mlx` unaffected.
- **In-app (dev build):** Settings → Models → Ollama with model `does-not-exist:1b` → Test & Save shows `model 'does-not-exist:1b' not found` in the UI (previously "Not Found").

## How to verify manually

1. `npm run deps && npm run dev` in `apps/x`.
2. Settings → Models → Ollama (Local), Base URL `http://localhost:11434`, model `does-not-exist:1b` → Test & Save → the error should name the model instead of just "Not Found".
3. Optional, reproduces the #696 symptom class end-to-end: `ollama pull gemma2:2b` (a model without tool support). Test & Save passes (the connection test sends no tools); then chat "hi" with it — the chat error should now state Ollama's real reason instead of bare "Bad Request".

