### PR TITLE
fix(x): hide grant-scope buttons where no grant persistence exists

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -3150,7 +3150,6 @@ function App() {
     toolCallId: string,
     subflow: string[],
     response: 'approve' | 'deny',
-    scope?: 'once' | 'session' | 'always',
   ) => {
     if (!runId) return
 
@@ -3159,7 +3158,6 @@ function App() {
       await sessionChat.respondToPermission(
         toolCallId,
         response === 'approve' ? 'allow' : 'deny',
-        scope ? { scope } : undefined,
       )
     } catch (error) {
       console.error('Failed to authorize permission:', error)
@@ -6834,8 +6832,6 @@ function App() {
                                               toolCall={permRequest.toolCall}
                                               permission={permRequest.permission}
                                               onApprove={() => handlePermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve')}
-                                              onApproveSession={() => handlePermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve', 'session')}
-                                              onApproveAlways={() => handlePermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve', 'always')}
                                               onDeny={() => handlePermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'deny')}
                                               isProcessing={isActive && activeIsWorking}
                                               response={response}

--- a/apps/x/apps/renderer/src/components/ai-elements/permission-request.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/permission-request.tsx
@@ -67,6 +67,13 @@ export const PermissionRequest = ({
   const isResponded = response !== null;
   const isApproved = response === 'approve';
 
+  // Scope actions ("Allow for Session"/"Always Allow") render only when the
+  // caller wires them: the legacy code-mode path persists grants, but the
+  // turns path has no grant persistence yet and must not show dead buttons.
+  const hasScopeActions =
+    Boolean(onApproveSession || onApproveAlways) &&
+    Boolean(command || filePermission);
+
   // Once a response is chosen, collapse the details to just the header.
   // Users can click the header to expand them again.
   const [expanded, setExpanded] = useState(false);
@@ -180,12 +187,12 @@ export const PermissionRequest = ({
                 size="sm"
                 onClick={onApprove}
                 disabled={isProcessing}
-                className={cn("flex-1", (command || filePermission) && "rounded-r-none")}
+                className={cn("flex-1", hasScopeActions && "rounded-r-none")}
               >
                 <CheckIcon className="size-4" />
                 Approve
               </Button>
-              {(command || filePermission) && (
+              {hasScopeActions && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -170,7 +170,7 @@ interface ChatSidebarProps {
   allPermissionRequests?: ChatTabViewState['allPermissionRequests']
   permissionResponses?: ChatTabViewState['permissionResponses']
   autoPermissionDecisions?: ChatTabViewState['autoPermissionDecisions']
-  onPermissionResponse?: (toolCallId: string, subflow: string[], response: PermissionResponse, scope?: 'once' | 'session' | 'always') => void
+  onPermissionResponse?: (toolCallId: string, subflow: string[], response: PermissionResponse) => void
   onAskHumanResponse?: (toolCallId: string, subflow: string[], response: string) => void
   isToolOpenForTab?: (tabId: string, toolId: string) => boolean
   onToolOpenChangeForTab?: (tabId: string, toolId: string, open: boolean) => void
@@ -706,8 +706,6 @@ export function ChatSidebar({
                                             toolCall={permRequest.toolCall}
                                             permission={permRequest.permission}
                                             onApprove={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve')}
-                                            onApproveSession={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve', 'session')}
-                                            onApproveAlways={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve', 'always')}
                                             onDeny={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'deny')}
                                             isProcessing={isActive && isProcessing && !isWaitingOnHuman}
                                             response={response}


### PR DESCRIPTION
## Problem

On the turns path (full-screen chat + side-pane), the permission card's dropdown offered **"Allow for Session"** and **"Always Allow"** — but the sessions layer never persists grants. The scope choice rode `respondToPermission` metadata that no consumer reads (the checker's session-grant inputs are deliberately empty, deferred). Both buttons behaved identically to "Approve once" while telling the user a standing grant was created — they'd get re-prompted next turn and reasonably conclude the app is broken.

Grant persistence proper is deferred by decision: there's no sound notion of grant keys yet (`executeCommand` parsing is not AST-based), and auto-permission mode — on by default — covers prompt fatigue meanwhile.

## Fix

- `PermissionRequest` renders the scope dropdown only when the caller actually wires `onApproveSession`/`onApproveAlways` (previously it rendered whenever the request was command/file-shaped, with undefined handlers as silent no-ops).
- The turns-path call sites (App.tsx, chat-sidebar.tsx) stop passing the scope handlers and drop the dead `scope` plumbing from their handler signatures.
- The **legacy code-mode chat keeps the buttons**: it routes through `runs:authorizePermission`, where grants genuinely persist (`addFileAccessGrant` / command session grants).

Net UI change: turns-path permission cards show plain Approve / Deny; code-mode chat is unchanged.

## Verification

- `npm run typecheck` passes; renderer tests 66/66
- eslint: no errors; the 8 App.tsx react-hooks warnings pre-exist on the unmodified file (verified via stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)