### PR TITLE
fix(x): never record a repository failure as a tool's own error result

### DIFF
--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -45,6 +45,8 @@ import type {
 // Fixtures
 // ---------------------------------------------------------------------------
 
+type TEvent = z.infer<typeof TurnEvent>;
+
 const TS = "2026-07-02T10:00:00Z";
 
 const echoDescriptor: z.infer<typeof ToolDescriptor> = {
@@ -2227,6 +2229,215 @@ describe("concurrent sync tool execution (10.5)", () => {
         // The turn stays readable and re-advanceable.
         const again = await advanceAndSettle(runtime, turnId);
         expect(again.outcome?.status).toBe("completed");
+    });
+});
+
+// Fails appends whose batch matches the predicate; counts the failures.
+class FailingAppendRepo extends InMemoryTurnRepo {
+    failWhen?: (events: TEvent[]) => boolean;
+    failures = 0;
+
+    override async append(turnId: string, events: TEvent[]): Promise<void> {
+        if (this.failWhen?.(events)) {
+            this.failures += 1;
+            throw new Error("disk full");
+        }
+        return super.append(turnId, events);
+    }
+}
+
+describe("sync tool result append failures (21.4)", () => {
+    const isSyncSuccessResult = (events: TEvent[]) =>
+        events.some(
+            (e) =>
+                e.type === "tool_result" &&
+                e.source === "sync" &&
+                e.result.isError === false,
+        );
+
+    it("rejects as infrastructure instead of recording a false tool error, then recovers honestly", async () => {
+        const executed: unknown[] = [];
+        const repo = new FailingAppendRepo();
+        repo.failWhen = isSyncSuccessResult;
+        const { runtime } = makeRuntime({
+            repo,
+            tools: [
+                syncTool(echoDescriptor, async (input) => {
+                    executed.push(input);
+                    return { output: "sent", isError: false };
+                }),
+                ...defaultTools.slice(1),
+            ],
+            models: [
+                respond(
+                    completedResp(assistantCalls(toolCallPart("A", "echo"))),
+                ),
+                respond(completedResp(assistantText("done"))),
+            ],
+        });
+        const turnId = await newTurn(runtime);
+
+        // The tool ran (side effect happened) but its result could not be
+        // persisted: the invocation rejects as infrastructure, and the log
+        // must NOT contain a fabricated error result claiming the tool
+        // failed.
+        const first = await advanceAndSettle(runtime, turnId);
+        expect(first.outcome).toBeUndefined();
+        expect(String(first.error)).toContain("disk full");
+        expect(repo.failures).toBe(1);
+        expect(executed).toHaveLength(1);
+        let log = await persisted(repo, turnId);
+        expect(typesOf(log)).toEqual([
+            "turn_created",
+            "model_call_requested",
+            "model_call_completed",
+            "tool_invocation_requested",
+        ]);
+
+        // Recovery: the interrupted invocation is closed with the honest
+        // indeterminate result — never re-executed — and the turn continues
+        // to completion.
+        repo.failWhen = undefined;
+        const second = await advanceAndSettle(runtime, turnId);
+        expect(second.outcome?.status).toBe("completed");
+        expect(executed).toHaveLength(1);
+        log = await persisted(repo, turnId);
+        const result = log.find((e) => e.type === "tool_result");
+        expect(result).toMatchObject({
+            source: "runtime",
+            result: {
+                output: "Tool execution was interrupted; its outcome is unknown and it was not retried.",
+                isError: true,
+            },
+        });
+        expect(typesOf(log)).toContain("turn_completed");
+    });
+
+    it("one tool's failed result append does not disturb a committed sibling result", async () => {
+        const slowDescriptor: z.infer<typeof ToolDescriptor> = {
+            toolId: "tool.slow",
+            name: "slow",
+            description: "Slow tool",
+            inputSchema: {},
+            execution: "sync",
+            requiresHuman: false,
+        };
+        const agent: z.infer<typeof ResolvedAgent> = {
+            ...defaultAgent,
+            tools: [echoDescriptor, slowDescriptor],
+        };
+        const executions: string[] = [];
+        const repo = new FailingAppendRepo();
+        // Fail only echo's SUCCESS result; slow's must commit. (Old code
+        // would then durably record echo as failed via the catch path — the
+        // recovery assertions below reject that fabrication.)
+        repo.failWhen = (events) =>
+            events.some(
+                (e) =>
+                    e.type === "tool_result" &&
+                    e.source === "sync" &&
+                    e.toolCallId === "E" &&
+                    e.result.isError === false,
+            );
+        const { runtime } = makeRuntime({
+            repo,
+            agent,
+            tools: [
+                syncTool(echoDescriptor, async () => {
+                    executions.push("echo");
+                    return { output: "e-done", isError: false };
+                }),
+                syncTool(slowDescriptor, async () => {
+                    executions.push("slow");
+                    return { output: "s-done", isError: false };
+                }),
+            ],
+            models: [
+                respond(
+                    completedResp(
+                        assistantCalls(
+                            toolCallPart("E", "echo"),
+                            toolCallPart("S", "slow"),
+                        ),
+                    ),
+                ),
+                respond(completedResp(assistantText("done"))),
+            ],
+        });
+        const turnId = await newTurn(runtime);
+
+        const first = await advanceAndSettle(runtime, turnId);
+        expect(first.outcome).toBeUndefined();
+        expect(String(first.error)).toContain("disk full");
+        let log = await persisted(repo, turnId);
+        // Both invocations durable; exactly the sibling's result committed
+        // (the append chain stays alive after a failed commit).
+        const results = log.filter((e) => e.type === "tool_result");
+        expect(results).toHaveLength(1);
+        expect(results[0]).toMatchObject({
+            toolCallId: "S",
+            result: { output: "s-done", isError: false },
+        });
+
+        // Recovery: echo closes as indeterminate, slow's real result is
+        // preserved, neither re-executes, and the batch reaches the model
+        // in source order.
+        repo.failWhen = undefined;
+        const second = await advanceAndSettle(runtime, turnId);
+        expect(second.outcome?.status).toBe("completed");
+        expect(executions.sort()).toEqual(["echo", "slow"]);
+        log = await persisted(repo, turnId);
+        const byId = new Map(
+            log
+                .filter((e) => e.type === "tool_result")
+                .map((e) => [e.toolCallId, e]),
+        );
+        expect(byId.get("E")).toMatchObject({
+            source: "runtime",
+            result: { isError: true },
+        });
+        expect(byId.get("S")).toMatchObject({
+            source: "sync",
+            result: { output: "s-done", isError: false },
+        });
+        const followUp = log.find(
+            (e) => e.type === "model_call_requested" && e.modelCallIndex === 1,
+        );
+        expect(followUp).toMatchObject({
+            request: {
+                messages: ["assistant:0", "toolResult:E", "toolResult:S"],
+            },
+        });
+    });
+
+    it("a tool returning an unparseable result is a tool error, not infrastructure", async () => {
+        const { runtime, repo } = makeRuntime({
+            tools: [
+                syncTool(
+                    echoDescriptor,
+                    async () =>
+                        "garbage" as unknown as Awaited<
+                            ReturnType<SyncRuntimeTool["execute"]>
+                        >,
+                ),
+                ...defaultTools.slice(1),
+            ],
+            models: [
+                respond(
+                    completedResp(assistantCalls(toolCallPart("A", "echo"))),
+                ),
+                respond(completedResp(assistantText("done"))),
+            ],
+        });
+        const turnId = await newTurn(runtime);
+        const { outcome } = await advanceAndSettle(runtime, turnId);
+        expect(outcome?.status).toBe("completed");
+        const log = await persisted(repo, turnId);
+        const result = log.find((e) => e.type === "tool_result");
+        expect(result).toMatchObject({
+            source: "sync",
+            result: { isError: true },
+        });
     });
 });
 

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -888,7 +888,13 @@ class TurnAdvance {
         tc: ToolCallState,
         syncTool: SyncRuntimeTool,
     ): Promise<void> {
-        let settled: z.infer<typeof ToolResultData> | undefined;
+        // The try covers tool execution only (including parsing its return —
+        // a tool returning garbage is a tool error). The success-result
+        // append stays OUTSIDE: a repository failure there must reject the
+        // invocation as infrastructure, never masquerade as a failed tool —
+        // the side effect already happened, and a durable false error would
+        // invite the model to retry it (§21.4).
+        let settled: z.infer<typeof ToolResultData>;
         try {
             const result = await syncTool.execute(tc.input, {
                 turnId: this.turnId,
@@ -906,15 +912,6 @@ class TurnAdvance {
                 },
             });
             settled = ToolResultData.parse(result);
-            await this.append({
-                type: "tool_result",
-                turnId: this.turnId,
-                ts: this.now(),
-                toolCallId: tc.toolCallId,
-                toolName: tc.toolName,
-                source: "sync",
-                result: settled,
-            });
         } catch (error) {
             if (this.signal.aborted) {
                 await this.append(
@@ -936,6 +933,15 @@ class TurnAdvance {
             });
             return;
         }
+        await this.append({
+            type: "tool_result",
+            turnId: this.turnId,
+            ts: this.now(),
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+            source: "sync",
+            result: settled,
+        });
         await this.maybeExtendTools(tc, settled);
     }
 


### PR DESCRIPTION
## Problem

In `executeSyncTool`, the success-result append lived inside the try whose catch appends an **error** tool result. So this sequence:

1. tool executes successfully — the side effect happens (email sent, issue created),
2. the append of its success result fails transiently (disk pressure, EMFILE),

…durably recorded the *tool* as failed, with the repository error as its output. The model then reads that error on the next call and may **retry the side effect**. This is durable false history and violates the spec's own rule (§21.4: repository failures reject the execution, never masquerade as tool outcomes; §26.6: infrastructure errors do not append false events).

## Fix

The try now covers `execute()` + `ToolResultData.parse()` only (a tool returning unparseable garbage is still legitimately a tool error). The success append moves outside the try:

- if it fails, the error propagates as infrastructure — the invocation rejects, the file keeps the invocation **without** a result;
- the existing §23 recovery row then closes it honestly on the next advance: *"Tool execution was interrupted; its outcome is unknown and it was not retried"* — and never re-executes.

No new machinery; the spec already described this behavior, the code just violated it. No doc change needed.

## Tests (3 new)

- **Core case**: repo fake fails exactly the success-result append → outcome rejects with the repo error, the log contains the invocation and **no fabricated error result**, recovery yields the indeterminate runtime result, the tool is not re-executed, and the turn completes.
- **Sibling isolation**: two concurrent tools, only one's success append fails → the sibling's committed result survives, recovery closes only the interrupted one, both reach the model in source order.
- **Parse failure**: a tool returning garbage is a sync tool error (turn continues), not infrastructure.

Verified discriminating: the two repo tests **fail against the old code** (checked via stash).

## Verification

- full `@x/core` suite: 436/436
- `npm run typecheck` passes; eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)