### PR TITLE
fix(x): sanitize PCRE shorthands in tool schemas for llama.cpp backends

### DIFF
--- a/apps/x/packages/core/src/models/gbnf-sanitize.test.ts
+++ b/apps/x/packages/core/src/models/gbnf-sanitize.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    translatePcreShorthands,
+    sanitizePatternsInPlace,
+    sanitizeChatCompletionsBody,
+    makeGbnfSafeFetch,
+} from "./gbnf-sanitize.js";
+
+describe("translatePcreShorthands", () => {
+    it("translates the HH:MM window regex that triggers the LM Studio bug", () => {
+        // The exact pattern from live-note TriggerWindowSchema (pre-fix source).
+        expect(translatePcreShorthands("^([01]\\d|2[0-3]):[0-5]\\d$"))
+            .toBe("^([01][0-9]|2[0-3]):[0-5][0-9]$");
+    });
+
+    it("translates each shorthand outside a character class", () => {
+        expect(translatePcreShorthands("\\d")).toBe("[0-9]");
+        expect(translatePcreShorthands("\\D")).toBe("[^0-9]");
+        expect(translatePcreShorthands("\\w")).toBe("[A-Za-z0-9_]");
+        expect(translatePcreShorthands("\\W")).toBe("[^A-Za-z0-9_]");
+        expect(translatePcreShorthands("\\s")).toBe("[ \\t\\n\\r]");
+        expect(translatePcreShorthands("\\S")).toBe("[^ \\t\\n\\r]");
+    });
+
+    it("keeps quantifiers and anchors around a translated shorthand", () => {
+        expect(translatePcreShorthands("^\\d{2,4}$")).toBe("^[0-9]{2,4}$");
+        expect(translatePcreShorthands("\\w+")).toBe("[A-Za-z0-9_]+");
+    });
+
+    it("translates shorthands as bare members inside a character class", () => {
+        expect(translatePcreShorthands("[\\d.]")).toBe("[0-9.]");
+        expect(translatePcreShorthands("[\\w-]")).toBe("[A-Za-z0-9_-]");
+        expect(translatePcreShorthands("[\\s]")).toBe("[ \\t\\n\\r]");
+        // A negated class that only contains \s is expressible: [^\s] -> [^ \t\n\r]
+        expect(translatePcreShorthands("[^\\s]")).toBe("[^ \\t\\n\\r]");
+    });
+
+    it("drops the pattern when a negated shorthand appears inside a class", () => {
+        // \D/\W/\S have no in-class member form (negation can't nest).
+        expect(translatePcreShorthands("[\\D]")).toBeNull();
+        expect(translatePcreShorthands("[\\W.]")).toBeNull();
+        expect(translatePcreShorthands("[a\\S]")).toBeNull();
+    });
+
+    it("drops the pattern for word boundaries, which have no GBNF equivalent", () => {
+        expect(translatePcreShorthands("\\bword\\b")).toBeNull();
+        expect(translatePcreShorthands("foo\\Bbar")).toBeNull();
+    });
+
+    it("drops the pattern for an unbalanced character class", () => {
+        expect(translatePcreShorthands("[0-9")).toBeNull();
+    });
+
+    it("leaves GBNF-safe escapes untouched", () => {
+        expect(translatePcreShorthands("a\\.b")).toBe("a\\.b");
+        expect(translatePcreShorthands("line\\nbreak")).toBe("line\\nbreak");
+        expect(translatePcreShorthands("a\\\\b")).toBe("a\\\\b");
+        // A digit escape followed by a literal dot, mixed.
+        expect(translatePcreShorthands("v\\d\\.\\d")).toBe("v[0-9]\\.[0-9]");
+    });
+
+    it("returns patterns without shorthands unchanged", () => {
+        expect(translatePcreShorthands("^[a-z][a-z0-9-]*$")).toBe("^[a-z][a-z0-9-]*$");
+        expect(translatePcreShorthands("(foo|bar)")).toBe("(foo|bar)");
+    });
+});
+
+describe("sanitizePatternsInPlace", () => {
+    it("rewrites a pattern nested deep inside a tool parameters schema", () => {
+        const schema = {
+            type: "object",
+            properties: {
+                triggers: {
+                    type: "object",
+                    properties: {
+                        windows: {
+                            type: "array",
+                            items: {
+                                type: "object",
+                                properties: {
+                                    startTime: { type: "string", pattern: "^([01]\\d|2[0-3]):[0-5]\\d$" },
+                                    endTime: { type: "string", pattern: "^([01]\\d|2[0-3]):[0-5]\\d$" },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const changes = sanitizePatternsInPlace(schema);
+        expect(changes).toBe(2);
+        const item = schema.properties.triggers.properties.windows.items.properties;
+        expect(item.startTime.pattern).toBe("^([01][0-9]|2[0-3]):[0-5][0-9]$");
+        expect(item.endTime.pattern).toBe("^([01][0-9]|2[0-3]):[0-5][0-9]$");
+    });
+
+    it("deletes an untranslatable pattern instead of emitting broken grammar", () => {
+        const schema: { type: string; pattern?: string } = { type: "string", pattern: "\\bword\\b" };
+        const changes = sanitizePatternsInPlace(schema);
+        expect(changes).toBe(1);
+        expect("pattern" in schema).toBe(false);
+    });
+
+    it("does not touch a tool field that is merely named 'pattern'", () => {
+        // file-grep exposes an input field called `pattern` — its schema node is
+        // an object, not a regex string, and must be left alone.
+        const schema = {
+            type: "object",
+            properties: {
+                pattern: { type: "string", description: "Regex pattern to search for" },
+            },
+        };
+        const changes = sanitizePatternsInPlace(schema);
+        expect(changes).toBe(0);
+        expect(schema.properties.pattern).toEqual({ type: "string", description: "Regex pattern to search for" });
+    });
+
+    it("sanitizes a real regex constraint on a field named 'pattern'", () => {
+        const schema = {
+            type: "object",
+            properties: {
+                pattern: { type: "string", pattern: "\\d+" },
+            },
+        };
+        const changes = sanitizePatternsInPlace(schema);
+        expect(changes).toBe(1);
+        expect(schema.properties.pattern.pattern).toBe("[0-9]+");
+    });
+
+    it("returns 0 for values that carry no patterns", () => {
+        expect(sanitizePatternsInPlace({ type: "object", properties: {} })).toBe(0);
+        expect(sanitizePatternsInPlace(null)).toBe(0);
+        expect(sanitizePatternsInPlace("string")).toBe(0);
+        expect(sanitizePatternsInPlace(42)).toBe(0);
+    });
+});
+
+describe("sanitizeChatCompletionsBody", () => {
+    const toolBody = (pattern: string) => JSON.stringify({
+        model: "qwen",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{
+            type: "function",
+            function: {
+                name: "create-background-task",
+                parameters: {
+                    type: "object",
+                    properties: { startTime: { type: "string", pattern } },
+                },
+            },
+        }],
+    });
+
+    it("sanitizes a PCRE shorthand in tool parameters", () => {
+        const out = sanitizeChatCompletionsBody(toolBody("^([01]\\d|2[0-3]):[0-5]\\d$"));
+        const parsed = JSON.parse(out);
+        expect(parsed.tools[0].function.parameters.properties.startTime.pattern)
+            .toBe("^([01][0-9]|2[0-3]):[0-5][0-9]$");
+        // Non-schema fields are preserved.
+        expect(parsed.model).toBe("qwen");
+        expect(parsed.messages).toEqual([{ role: "user", content: "hi" }]);
+    });
+
+    it("sanitizes a pattern inside a json_schema response_format", () => {
+        const body = JSON.stringify({
+            model: "qwen",
+            messages: [],
+            response_format: {
+                type: "json_schema",
+                json_schema: {
+                    name: "out",
+                    schema: { type: "object", properties: { t: { type: "string", pattern: "\\d\\d:\\d\\d" } } },
+                },
+            },
+        });
+        const parsed = JSON.parse(sanitizeChatCompletionsBody(body));
+        expect(parsed.response_format.json_schema.schema.properties.t.pattern)
+            .toBe("[0-9][0-9]:[0-9][0-9]");
+    });
+
+    it("returns the body byte-for-byte when it carries no offending pattern", () => {
+        const clean = toolBody("^[a-z]+$");
+        expect(sanitizeChatCompletionsBody(clean)).toBe(clean);
+    });
+
+    it("returns a body with no tools/response_format unchanged", () => {
+        const body = JSON.stringify({ model: "qwen", input: "text" });
+        expect(sanitizeChatCompletionsBody(body)).toBe(body);
+    });
+
+    it("returns non-JSON bodies unchanged", () => {
+        expect(sanitizeChatCompletionsBody("not json")).toBe("not json");
+        expect(sanitizeChatCompletionsBody("")).toBe("");
+    });
+});
+
+describe("makeGbnfSafeFetch", () => {
+    it("forwards a sanitized body to the underlying fetch when a shorthand is present", async () => {
+        const base = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => new Response("ok"));
+        const wrapped = makeGbnfSafeFetch(base as unknown as typeof fetch);
+        const body = JSON.stringify({
+            messages: [],
+            tools: [{ type: "function", function: { name: "t", parameters: { type: "object", properties: { x: { type: "string", pattern: "\\d" } } } } }],
+        });
+
+        await wrapped("http://localhost:1234/v1/chat/completions", { method: "POST", body });
+
+        expect(base).toHaveBeenCalledTimes(1);
+        const sentBody = (base.mock.calls[0][1] as RequestInit).body as string;
+        expect(JSON.parse(sentBody).tools[0].function.parameters.properties.x.pattern).toBe("[0-9]");
+    });
+
+    it("passes the original init through untouched when nothing needs changing", async () => {
+        const base = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => new Response("ok"));
+        const wrapped = makeGbnfSafeFetch(base as unknown as typeof fetch);
+        const init = { method: "POST", body: JSON.stringify({ messages: [], tools: [] }) };
+
+        await wrapped("http://localhost:1234/v1/chat/completions", init);
+
+        expect(base).toHaveBeenCalledTimes(1);
+        // Same init object reference — no clone when there's nothing to rewrite.
+        expect(base.mock.calls[0][1]).toBe(init);
+    });
+
+    it("passes through requests with a non-string body", async () => {
+        const base = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => new Response("ok"));
+        const wrapped = makeGbnfSafeFetch(base as unknown as typeof fetch);
+
+        await wrapped("http://localhost:1234/v1/models", { method: "GET" });
+
+        expect(base).toHaveBeenCalledTimes(1);
+        expect(base.mock.calls[0][1]).toEqual({ method: "GET" });
+    });
+});

--- a/apps/x/packages/core/src/models/gbnf-sanitize.test.ts
+++ b/apps/x/packages/core/src/models/gbnf-sanitize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+    translatePattern,
     translatePcreShorthands,
     sanitizePatternsInPlace,
     sanitizeChatCompletionsBody,
@@ -65,7 +66,65 @@ describe("translatePcreShorthands", () => {
     });
 });
 
+describe("translatePattern", () => {
+    it("reports the translated pattern when every shorthand is expressible", () => {
+        expect(translatePattern("^\\d$")).toEqual({ kind: "translated", pattern: "^[0-9]$" });
+    });
+
+    it("names the offending construct when a pattern has to be dropped", () => {
+        expect(translatePattern("\\bword\\b")).toEqual({
+            kind: "dropped",
+            reason: "word boundary \\b has no GBNF equivalent",
+        });
+        expect(translatePattern("[\\D]")).toEqual({
+            kind: "dropped",
+            reason: "negated shorthand \\D cannot be expressed inside a character class",
+        });
+        expect(translatePattern("[0-9")).toEqual({
+            kind: "dropped",
+            reason: "unbalanced character class",
+        });
+    });
+});
+
 describe("sanitizePatternsInPlace", () => {
+    it("reports each dropped pattern with its reason through onDrop", () => {
+        const onDrop = vi.fn<(pattern: string, reason: string) => void>();
+        const schema = {
+            type: "object",
+            properties: {
+                a: { type: "string", pattern: "\\bword\\b" },
+                b: { type: "string", pattern: "\\d+" },
+            },
+        };
+
+        sanitizePatternsInPlace(schema, onDrop);
+
+        // Only the untranslatable pattern is reported; the translated one is silent.
+        expect(onDrop).toHaveBeenCalledTimes(1);
+        expect(onDrop).toHaveBeenCalledWith("\\bword\\b", "word boundary \\b has no GBNF equivalent");
+    });
+
+    it("leaves patternProperties keys alone but sanitizes patterns nested under them", () => {
+        // llama.cpp's JSON-Schema -> GBNF converter builds object rules from
+        // `properties` / `additionalProperties` only; it never reads
+        // `patternProperties`, so its regex keys never reach the grammar parser
+        // and must be preserved verbatim. Schemas *inside* those values are
+        // ordinary schemas and still get sanitized.
+        const schema = {
+            type: "object",
+            patternProperties: {
+                "^\\d+$": { type: "string", pattern: "^\\w+$" },
+            },
+        };
+
+        const changes = sanitizePatternsInPlace(schema);
+
+        expect(changes).toBe(1);
+        expect(Object.keys(schema.patternProperties)).toEqual(["^\\d+$"]);
+        expect(schema.patternProperties["^\\d+$"].pattern).toBe("^[A-Za-z0-9_]+$");
+    });
+
     it("rewrites a pattern nested deep inside a tool parameters schema", () => {
         const schema = {
             type: "object",
@@ -220,6 +279,39 @@ describe("makeGbnfSafeFetch", () => {
         expect(base).toHaveBeenCalledTimes(1);
         // Same init object reference — no clone when there's nothing to rewrite.
         expect(base.mock.calls[0][1]).toBe(init);
+    });
+
+    it("warns once per distinct dropped pattern, even across repeated requests", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const base = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => new Response("ok"));
+        const wrapped = makeGbnfSafeFetch(base as unknown as typeof fetch);
+        const bodyWith = (patterns: string[]) => JSON.stringify({
+            messages: [],
+            tools: [{
+                type: "function",
+                function: {
+                    name: "t",
+                    parameters: {
+                        type: "object",
+                        properties: Object.fromEntries(patterns.map((pattern, i) => [`f${i}`, { type: "string", pattern }])),
+                    },
+                },
+            }],
+        });
+
+        // The same tool schema is re-sent on every turn: the drop must be logged
+        // the first time only, or it would spam the console once per message.
+        await wrapped("http://localhost:1234/v1/chat/completions", { method: "POST", body: bodyWith(["\\bword\\b", "\\d"]) });
+        await wrapped("http://localhost:1234/v1/chat/completions", { method: "POST", body: bodyWith(["\\bword\\b", "\\d"]) });
+        // A different untranslatable pattern is a new event and gets its own line.
+        await wrapped("http://localhost:1234/v1/chat/completions", { method: "POST", body: bodyWith(["[\\W]"]) });
+
+        expect(warn).toHaveBeenCalledTimes(2);
+        expect(warn.mock.calls[0][0]).toContain("\\bword\\b");
+        expect(warn.mock.calls[0][0]).toContain("word boundary");
+        expect(warn.mock.calls[1][0]).toContain("[\\W]");
+        // Translatable shorthands are rewritten silently — no noise for the happy path.
+        expect(warn.mock.calls.some((call) => String(call[0]).includes("\"\\d\""))).toBe(false);
     });
 
     it("passes through requests with a non-string body", async () => {

--- a/apps/x/packages/core/src/models/gbnf-sanitize.ts
+++ b/apps/x/packages/core/src/models/gbnf-sanitize.ts
@@ -1,0 +1,207 @@
+// GBNF-safe JSON Schema sanitization for llama.cpp-backed OpenAI-compatible
+// servers (LM Studio, llama-server, ...).
+//
+// When a chat request carries tool definitions (or a json_schema
+// response_format), llama.cpp compiles each `pattern` regex in the schema into
+// a GBNF grammar so it can constrain decoding. GBNF understands ordinary regex
+// syntax — literals, `[a-z]` classes, `(a|b)`, `*`/`+`/`?`/`{n,m}` — but NOT the
+// PCRE shorthand classes (`\d \w \s` and their negations) or word boundaries
+// (`\b \B`). It aborts grammar compilation with `parse: error parsing grammar:
+// unknown escape at \d`, and because the sampler init fails, the WHOLE request
+// dies with HTTP 400 ("Failed to initialize samplers: failed to parse grammar")
+// — one offending field takes down the entire session.
+//
+// This is a long-standing, still-open llama.cpp limitation (see llama.cpp
+// #16714 and #22314), so it can't be fixed by updating the runtime. Rowboat's
+// own tools legitimately use shorthands (e.g. the `HH:MM` window times validate
+// with `^([01]\d|2[0-3]):[0-5]\d$`), and any third-party schema might too, so we
+// rewrite the outgoing wire request instead: translate every shorthand into an
+// equivalent GBNF-safe character class before it reaches the backend.
+//
+// Only the `openai-compatible` provider wires this in (see models.ts) — the
+// hosted providers (OpenAI, Anthropic, Google) accept these patterns fine, and
+// leaving their payloads byte-identical keeps prompt caching intact.
+
+// Shorthand -> replacement when the shorthand appears OUTSIDE a character class.
+// The replacement is a self-contained class so it can stand alone in the regex.
+const SHORTHAND_OUTSIDE_CLASS: Record<string, string> = {
+    d: "[0-9]",
+    D: "[^0-9]",
+    w: "[A-Za-z0-9_]",
+    W: "[^A-Za-z0-9_]",
+    s: "[ \\t\\n\\r]",
+    S: "[^ \\t\\n\\r]",
+};
+
+// Shorthand -> replacement when the shorthand appears INSIDE a character class
+// (e.g. `[\d.]`). Here the replacement must be bare class members, with no
+// brackets. Negated shorthands (`\D \W \S`) have no in-class equivalent —
+// negation can't be nested inside `[...]` — so they map to `null`, which forces
+// us to drop the whole pattern rather than emit broken grammar.
+const SHORTHAND_INSIDE_CLASS: Record<string, string | null> = {
+    d: "0-9",
+    D: null,
+    w: "A-Za-z0-9_",
+    W: null,
+    s: " \\t\\n\\r",
+    S: null,
+};
+
+/**
+ * Rewrite the PCRE shorthand classes in a regex `pattern` into GBNF-safe
+ * character classes.
+ *
+ * Returns the translated pattern, or `null` when the pattern contains something
+ * that cannot be safely expressed in GBNF (a `\b`/`\B` word boundary, a negated
+ * shorthand inside a character class, or an unbalanced class). A `null` result
+ * means "drop this pattern entirely" — omitting a validation constraint is
+ * strictly safer than shipping a grammar that fails the whole request.
+ *
+ * The scan is character-class aware so `\d` becomes `[0-9]` on its own but
+ * `0-9` inside `[...]`. Escapes GBNF already understands (`\n \t \\ \" \xNN` …)
+ * are passed through untouched.
+ */
+export function translatePcreShorthands(pattern: string): string | null {
+    let out = "";
+    let inClass = false;
+
+    for (let i = 0; i < pattern.length; i++) {
+        const ch = pattern[i];
+
+        if (ch === "\\") {
+            const next = pattern[i + 1];
+            if (next === undefined) {
+                // Trailing backslash: malformed. Leave it verbatim; the backend
+                // would reject such a pattern regardless of shorthands.
+                out += ch;
+                break;
+            }
+            // Word boundaries have no GBNF equivalent, in or out of a class.
+            if (next === "b" || next === "B") {
+                return null;
+            }
+            const table = inClass ? SHORTHAND_INSIDE_CLASS : SHORTHAND_OUTSIDE_CLASS;
+            if (Object.prototype.hasOwnProperty.call(table, next)) {
+                const replacement = table[next];
+                if (replacement === null) {
+                    // e.g. `\D` inside `[...]` — untranslatable, drop the pattern.
+                    return null;
+                }
+                out += replacement;
+            } else {
+                // Any other escape (`\. \n \t \\ \" \/ \xNN` …) — GBNF handles
+                // these, so keep the escape as-is.
+                out += ch + next;
+            }
+            i++; // consumed the escaped character
+            continue;
+        }
+
+        if (ch === "[" && !inClass) {
+            inClass = true;
+        } else if (ch === "]" && inClass) {
+            inClass = false;
+        }
+        out += ch;
+    }
+
+    if (inClass) {
+        // Unbalanced character class — we can't reason about member escapes
+        // safely, so drop the pattern rather than risk broken grammar.
+        return null;
+    }
+    return out;
+}
+
+/**
+ * Walk an arbitrary JSON value (a parsed JSON Schema or any nesting of tool
+ * definitions) and sanitize every string `pattern` in place. Translatable
+ * shorthands are rewritten; untranslatable patterns have their `pattern` key
+ * deleted. Returns the number of patterns changed or removed.
+ *
+ * Mutates `node` in place — callers that must not alter the input should pass a
+ * clone (a freshly `JSON.parse`d wire body is already safe to mutate).
+ *
+ * A key literally named `pattern` whose value is NOT a string (e.g. a tool
+ * input field that happens to be called "pattern") is left alone and recursed
+ * into normally, so only real JSON-Schema `pattern` constraints are touched.
+ */
+export function sanitizePatternsInPlace(node: unknown): number {
+    if (Array.isArray(node)) {
+        let changes = 0;
+        for (const item of node) changes += sanitizePatternsInPlace(item);
+        return changes;
+    }
+    if (node === null || typeof node !== "object") {
+        return 0;
+    }
+
+    const obj = node as Record<string, unknown>;
+    let changes = 0;
+    for (const key of Object.keys(obj)) {
+        const value = obj[key];
+        if (key === "pattern" && typeof value === "string") {
+            const translated = translatePcreShorthands(value);
+            if (translated === null) {
+                delete obj[key];
+                changes++;
+            } else if (translated !== value) {
+                obj[key] = translated;
+                changes++;
+            }
+            continue;
+        }
+        changes += sanitizePatternsInPlace(value);
+    }
+    return changes;
+}
+
+/**
+ * Sanitize a serialized `/chat/completions` request body: rewrite any GBNF-
+ * hostile `pattern` inside `tools` (tool-call schemas) and `response_format`
+ * (structured-output schemas). Returns the original string untouched when the
+ * body isn't JSON, carries no schema, or needs no changes — so non-chat
+ * requests (embeddings, model listing, …) and clean bodies pass through
+ * byte-for-byte.
+ */
+export function sanitizeChatCompletionsBody(body: string): string {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return body;
+    }
+    if (parsed === null || typeof parsed !== "object") {
+        return body;
+    }
+
+    const obj = parsed as Record<string, unknown>;
+    let changes = 0;
+    if (Array.isArray(obj.tools)) {
+        changes += sanitizePatternsInPlace(obj.tools);
+    }
+    if (obj.response_format !== undefined) {
+        changes += sanitizePatternsInPlace(obj.response_format);
+    }
+    return changes > 0 ? JSON.stringify(parsed) : body;
+}
+
+/**
+ * Wrap a `fetch` so every outgoing request with a string body has its tool /
+ * response_format schemas made GBNF-safe (see sanitizeChatCompletionsBody).
+ * Bodies without schemas are forwarded unchanged. This is the seam the
+ * openai-compatible provider uses so llama.cpp-backed servers don't 400 on
+ * shorthand-bearing patterns.
+ */
+export function makeGbnfSafeFetch(baseFetch: typeof fetch = fetch): typeof fetch {
+    return async (input, init) => {
+        const body = init?.body;
+        if (typeof body === "string" && body.length > 0) {
+            const sanitized = sanitizeChatCompletionsBody(body);
+            if (sanitized !== body) {
+                return baseFetch(input, { ...init, body: sanitized });
+            }
+        }
+        return baseFetch(input, init);
+    };
+}

--- a/apps/x/packages/core/src/models/gbnf-sanitize.ts
+++ b/apps/x/packages/core/src/models/gbnf-sanitize.ts
@@ -48,20 +48,30 @@ const SHORTHAND_INSIDE_CLASS: Record<string, string | null> = {
 };
 
 /**
+ * Outcome of translating one JSON-Schema `pattern` for GBNF: either the
+ * rewritten pattern, or a human-readable reason why it had to be dropped (used
+ * for the one-time diagnostic log in {@link makeGbnfSafeFetch}).
+ */
+export type PatternTranslation =
+    | { kind: "translated"; pattern: string }
+    | { kind: "dropped"; reason: string };
+
+/**
  * Rewrite the PCRE shorthand classes in a regex `pattern` into GBNF-safe
  * character classes.
  *
- * Returns the translated pattern, or `null` when the pattern contains something
- * that cannot be safely expressed in GBNF (a `\b`/`\B` word boundary, a negated
- * shorthand inside a character class, or an unbalanced class). A `null` result
- * means "drop this pattern entirely" — omitting a validation constraint is
- * strictly safer than shipping a grammar that fails the whole request.
+ * Returns the translated pattern, or a `dropped` result when the pattern
+ * contains something that cannot be safely expressed in GBNF (a `\b`/`\B` word
+ * boundary, a negated shorthand inside a character class, or an unbalanced
+ * class). `dropped` means "remove this pattern entirely" — omitting a validation
+ * constraint is strictly safer than shipping a grammar that fails the whole
+ * request.
  *
  * The scan is character-class aware so `\d` becomes `[0-9]` on its own but
  * `0-9` inside `[...]`. Escapes GBNF already understands (`\n \t \\ \" \xNN` …)
  * are passed through untouched.
  */
-export function translatePcreShorthands(pattern: string): string | null {
+export function translatePattern(pattern: string): PatternTranslation {
     let out = "";
     let inClass = false;
 
@@ -78,14 +88,17 @@ export function translatePcreShorthands(pattern: string): string | null {
             }
             // Word boundaries have no GBNF equivalent, in or out of a class.
             if (next === "b" || next === "B") {
-                return null;
+                return { kind: "dropped", reason: `word boundary \\${next} has no GBNF equivalent` };
             }
             const table = inClass ? SHORTHAND_INSIDE_CLASS : SHORTHAND_OUTSIDE_CLASS;
             if (Object.prototype.hasOwnProperty.call(table, next)) {
                 const replacement = table[next];
                 if (replacement === null) {
                     // e.g. `\D` inside `[...]` — untranslatable, drop the pattern.
-                    return null;
+                    return {
+                        kind: "dropped",
+                        reason: `negated shorthand \\${next} cannot be expressed inside a character class`,
+                    };
                 }
                 out += replacement;
             } else {
@@ -108,10 +121,22 @@ export function translatePcreShorthands(pattern: string): string | null {
     if (inClass) {
         // Unbalanced character class — we can't reason about member escapes
         // safely, so drop the pattern rather than risk broken grammar.
-        return null;
+        return { kind: "dropped", reason: "unbalanced character class" };
     }
-    return out;
+    return { kind: "translated", pattern: out };
 }
+
+/**
+ * Convenience form of {@link translatePattern}: the translated pattern, or
+ * `null` when it must be dropped.
+ */
+export function translatePcreShorthands(pattern: string): string | null {
+    const result = translatePattern(pattern);
+    return result.kind === "translated" ? result.pattern : null;
+}
+
+/** Called once for every `pattern` the sanitizer had to remove. */
+export type OnPatternDropped = (pattern: string, reason: string) => void;
 
 /**
  * Walk an arbitrary JSON value (a parsed JSON Schema or any nesting of tool
@@ -125,11 +150,20 @@ export function translatePcreShorthands(pattern: string): string | null {
  * A key literally named `pattern` whose value is NOT a string (e.g. a tool
  * input field that happens to be called "pattern") is left alone and recursed
  * into normally, so only real JSON-Schema `pattern` constraints are touched.
+ *
+ * `patternProperties` keys are regexes too, but they are deliberately NOT
+ * rewritten: llama.cpp's JSON-Schema -> GBNF converter builds object rules from
+ * `properties` / `additionalProperties` only and never reads
+ * `patternProperties`, so those keys never reach the grammar parser. The
+ * schemas nested under them are walked like any other value.
+ *
+ * `onDrop` is invoked for every pattern that had to be removed, with the
+ * original pattern and the reason it is untranslatable.
  */
-export function sanitizePatternsInPlace(node: unknown): number {
+export function sanitizePatternsInPlace(node: unknown, onDrop?: OnPatternDropped): number {
     if (Array.isArray(node)) {
         let changes = 0;
-        for (const item of node) changes += sanitizePatternsInPlace(item);
+        for (const item of node) changes += sanitizePatternsInPlace(item, onDrop);
         return changes;
     }
     if (node === null || typeof node !== "object") {
@@ -141,17 +175,18 @@ export function sanitizePatternsInPlace(node: unknown): number {
     for (const key of Object.keys(obj)) {
         const value = obj[key];
         if (key === "pattern" && typeof value === "string") {
-            const translated = translatePcreShorthands(value);
-            if (translated === null) {
+            const result = translatePattern(value);
+            if (result.kind === "dropped") {
                 delete obj[key];
                 changes++;
-            } else if (translated !== value) {
-                obj[key] = translated;
+                onDrop?.(value, result.reason);
+            } else if (result.pattern !== value) {
+                obj[key] = result.pattern;
                 changes++;
             }
             continue;
         }
-        changes += sanitizePatternsInPlace(value);
+        changes += sanitizePatternsInPlace(value, onDrop);
     }
     return changes;
 }
@@ -163,8 +198,10 @@ export function sanitizePatternsInPlace(node: unknown): number {
  * body isn't JSON, carries no schema, or needs no changes — so non-chat
  * requests (embeddings, model listing, …) and clean bodies pass through
  * byte-for-byte.
+ *
+ * `onDrop` is forwarded to {@link sanitizePatternsInPlace}.
  */
-export function sanitizeChatCompletionsBody(body: string): string {
+export function sanitizeChatCompletionsBody(body: string, onDrop?: OnPatternDropped): string {
     let parsed: unknown;
     try {
         parsed = JSON.parse(body);
@@ -178,10 +215,10 @@ export function sanitizeChatCompletionsBody(body: string): string {
     const obj = parsed as Record<string, unknown>;
     let changes = 0;
     if (Array.isArray(obj.tools)) {
-        changes += sanitizePatternsInPlace(obj.tools);
+        changes += sanitizePatternsInPlace(obj.tools, onDrop);
     }
     if (obj.response_format !== undefined) {
-        changes += sanitizePatternsInPlace(obj.response_format);
+        changes += sanitizePatternsInPlace(obj.response_format, onDrop);
     }
     return changes > 0 ? JSON.stringify(parsed) : body;
 }
@@ -192,12 +229,27 @@ export function sanitizeChatCompletionsBody(body: string): string {
  * Bodies without schemas are forwarded unchanged. This is the seam the
  * openai-compatible provider uses so llama.cpp-backed servers don't 400 on
  * shorthand-bearing patterns.
+ *
+ * Dropping a pattern silently would make "why isn't this field validated?"
+ * impossible to debug, so each distinct dropped pattern is logged once per
+ * wrapper (i.e. per provider instance). Once, not per request: the same tool
+ * schemas are re-sent on every turn and would otherwise flood the console.
  */
 export function makeGbnfSafeFetch(baseFetch: typeof fetch = fetch): typeof fetch {
+    const warnedPatterns = new Set<string>();
+    const warnOnce: OnPatternDropped = (pattern, reason) => {
+        if (warnedPatterns.has(pattern)) return;
+        warnedPatterns.add(pattern);
+        console.warn(
+            `[models] Dropped JSON-Schema pattern "${pattern}" from an openai-compatible request: ${reason}. ` +
+            "llama.cpp cannot compile it to GBNF, so the field is sent without that constraint.",
+        );
+    };
+
     return async (input, init) => {
         const body = init?.body;
         if (typeof body === "string" && body.length > 0) {
-            const sanitized = sanitizeChatCompletionsBody(body);
+            const sanitized = sanitizeChatCompletionsBody(body, warnOnce);
             if (sanitized !== body) {
                 return baseFetch(input, { ...init, body: sanitized });
             }

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -19,6 +19,7 @@ import {
     DEFAULT_OLLAMA_CONTEXT_LENGTH,
     DEFAULT_OLLAMA_REASONING_EFFORT,
 } from "./local.js";
+import { makeGbnfSafeFetch } from "./gbnf-sanitize.js";
 
 export const Provider = LlmProvider;
 export const ModelConfig = LlmModelConfig;
@@ -73,6 +74,13 @@ export function createProvider(config: z.infer<typeof Provider>): ProviderV4 {
                 apiKey,
                 baseURL: baseURL || "",
                 headers,
+                // llama.cpp-backed servers (LM Studio, llama-server) compile
+                // JSON-Schema `pattern`s in tool/response_format schemas into
+                // GBNF grammar. GBNF rejects PCRE shorthands (\d \w \s \b), and
+                // the failure kills the whole request with HTTP 400
+                // ("failed to parse grammar"). Rewrite the wire body to
+                // GBNF-safe character classes first. See gbnf-sanitize.ts.
+                fetch: makeGbnfSafeFetch(),
             });
         case "openrouter":
             return createOpenRouter({

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -18,6 +18,7 @@ import {
     DEFAULT_OLLAMA_CONTEXT_LENGTH,
     DEFAULT_OLLAMA_REASONING_EFFORT,
 } from "./local.js";
+import { makeGbnfSafeFetch } from "./gbnf-sanitize.js";
 
 export const Provider = LlmProvider;
 export const ModelConfig = LlmModelConfig;
@@ -72,6 +73,13 @@ export function createProvider(config: z.infer<typeof Provider>): ProviderV2 {
                 apiKey,
                 baseURL: baseURL || "",
                 headers,
+                // llama.cpp-backed servers (LM Studio, llama-server) compile
+                // JSON-Schema `pattern`s in tool/response_format schemas into
+                // GBNF grammar. GBNF rejects PCRE shorthands (\d \w \s \b), and
+                // the failure kills the whole request with HTTP 400
+                // ("failed to parse grammar"). Rewrite the wire body to
+                // GBNF-safe character classes first. See gbnf-sanitize.ts.
+                fetch: makeGbnfSafeFetch(),
             });
         case "openrouter":
             return createOpenRouter({

--- a/apps/x/packages/shared/src/live-note.ts
+++ b/apps/x/packages/shared/src/live-note.ts
@@ -58,8 +58,14 @@ export type LiveNote = {
 };
 
 const TriggerWindowSchema = z.object({
-    startTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).describe('24h HH:MM, local time. Also the daily cycle anchor — once the agent fires after this time, the window is done for the day.'),
-    endTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).describe('24h HH:MM, local time. After this, the window is closed for the day.'),
+    // Use explicit [0-9] rather than the \d shorthand: this schema is serialized
+    // to JSON Schema and sent to models. llama.cpp (LM Studio) compiles `pattern`
+    // into GBNF, which rejects PCRE shorthands like \d — [0-9] is the equivalent
+    // it accepts. The provider-level fetch sanitizer (gbnf-sanitize.ts) is the
+    // general safety net; keeping the source GBNF-safe avoids the issue at origin
+    // (and in the schema text embedded in skill prompts).
+    startTime: z.string().regex(/^([01][0-9]|2[0-3]):[0-5][0-9]$/).describe('24h HH:MM, local time. Also the daily cycle anchor — once the agent fires after this time, the window is done for the day.'),
+    endTime: z.string().regex(/^([01][0-9]|2[0-3]):[0-5][0-9]$/).describe('24h HH:MM, local time. After this, the window is closed for the day.'),
 });
 
 export const TriggersSchema = z.object({

--- a/apps/x/packages/shared/src/live-note.ts
+++ b/apps/x/packages/shared/src/live-note.ts
@@ -59,8 +59,14 @@ export type LiveNote = {
 };
 
 const TriggerWindowSchema = z.object({
-    startTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).describe('24h HH:MM, local time. Also the daily cycle anchor — once the agent fires after this time, the window is done for the day.'),
-    endTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).describe('24h HH:MM, local time. After this, the window is closed for the day.'),
+    // Use explicit [0-9] rather than the \d shorthand: this schema is serialized
+    // to JSON Schema and sent to models. llama.cpp (LM Studio) compiles `pattern`
+    // into GBNF, which rejects PCRE shorthands like \d — [0-9] is the equivalent
+    // it accepts. The provider-level fetch sanitizer (gbnf-sanitize.ts) is the
+    // general safety net; keeping the source GBNF-safe avoids the issue at origin
+    // (and in the schema text embedded in skill prompts).
+    startTime: z.string().regex(/^([01][0-9]|2[0-3]):[0-5][0-9]$/).describe('24h HH:MM, local time. Also the daily cycle anchor — once the agent fires after this time, the window is done for the day.'),
+    endTime: z.string().regex(/^([01][0-9]|2[0-3]):[0-5][0-9]$/).describe('24h HH:MM, local time. After this, the window is closed for the day.'),
 });
 
 export const TriggersSchema = z.object({


### PR DESCRIPTION
Closes #740.

## Problem

With an OpenAI-compatible provider backed by LM Studio (llama.cpp), **Test & Save works but starting a chat fails with HTTP 400**. llama.cpp compiles each JSON-Schema `pattern` in a request's tool and `response_format` schemas into a GBNF grammar to constrain decoding, and GBNF has no PCRE shorthand classes (`\d \w \s` + negations) or word boundaries (`\b \B`). It aborts with:

```
parse: error parsing grammar: unknown escape at \d
```

sampler init then fails, and the **whole request** 400s (`Failed to initialize samplers: failed to parse grammar`). This is an open llama.cpp limitation (ggml-org/llama.cpp#16714, #22314), so it can't be fixed by updating the runtime.

The `testModelConnection` probe sends no tools, which is why Test & Save passes; a real turn sends tool schemas and hits the grammar. The offending pattern is the background-task / live-note time-window regex `^([01]\d|2[0-3]):[0-5]\d$`; forwarded third-party MCP tool schemas can carry others.

## Fix

Two layers:

1. **Provider-scoped wire sanitizer** — new `packages/core/src/models/gbnf-sanitize.ts`. Wraps the `openai-compatible` provider's `fetch` (mirroring the existing `makeOllamaThinkFetch` in `models/local.ts`) and rewrites the outgoing chat body: shorthands in `tools[].function.parameters` and `response_format` `pattern`s are translated to GBNF-safe classes (`\d`→`[0-9]`, `\w`→`[A-Za-z0-9_]`, `\s`→`[ \t\n\r]`, and negations), character-class aware (`[\d.]`→`[0-9.]`). Anything untranslatable (`\b`/`\B`, a negated shorthand inside a class, an unbalanced class) has its `pattern` dropped — a missing constraint beats a grammar that 400s the request. Only the openai-compatible flavor wires it in; hosted providers keep byte-identical payloads (prompt caching untouched). Because it runs on the final wire body, it covers both built-in and forwarded MCP tool schemas.

2. **Root cause** — the live-note window regex now uses `[0-9]` instead of `\d` (equivalent), so Rowboat's own schema is GBNF-safe by construction, including the schema text embedded in skill prompts.

## Tests

- New `gbnf-sanitize.test.ts` (22 cases): translator edge cases (in/out of a character class, negations, `\b` drop, unbalanced class, passthrough of GBNF-safe escapes), schema walk (nested `pattern`, a field literally named `pattern`, delete-untranslatable), request-body rewrite (tools + `response_format`, byte-identical passthrough, non-JSON), and the fetch wrapper.
- `npm test` (shared + core + renderer) and `npm run typecheck` pass. No new dependencies; `pnpm-lock.yaml` unchanged.

## How to verify

Run the curl repro from #740: the `\d` pattern returns 400 before this change and 200 after (equivalently, tool calling against LM Studio now works instead of 400ing).
