### PR TITLE
fix(workspace): scope the workspace watcher to whitelisted roots (EMFILE crash)

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -583,11 +583,12 @@ function handleWorkspaceChange(event: z.infer<typeof workspaceShared.WorkspaceCh
 
 /**
  * Start workspace watcher
- * Watches the configured workspace root recursively and emits change events to renderer
+ * Watches the user-facing workspace roots recursively and emits change events to renderer
  * 
  * This should be called once when the app starts (from main.ts).
- * The watcher runs as a main-process service and catches ALL filesystem changes
- * (both from IPC handlers and external changes like terminal/git).
+ * The watcher runs as a main-process service and catches all filesystem changes
+ * under the watched roots (both from IPC handlers and external changes like
+ * terminal/git).
  * 
  * Safe to call multiple times - guards against duplicate watchers.
  */

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, desktopCapturer, protocol, net, shell, session, safeStorage, type Session } from "electron";
+import { app, BrowserWindow, desktopCapturer, dialog, protocol, net, shell, session, safeStorage, type Session } from "electron";
 import path from "node:path";
 import {
   setupIpcHandlers,
@@ -73,6 +73,24 @@ const APP_LAUNCHED_AT = Date.now();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+// fs.watch failures (EMFILE fd exhaustion, ENOSPC watch limits) surface as
+// uncaught exceptions from Node's watcher internals, bypassing chokidar's
+// 'error' handlers. Watching is a degradable feature — log and keep running.
+// Everything else keeps Electron's default behavior (native error dialog),
+// which we replicate since registering any listener suppresses it.
+process.on('uncaughtException', (err) => {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if ((code === 'EMFILE' || code === 'ENOSPC') && (err?.stack ?? '').includes('FSWatcher')) {
+    console.error('[Main] file watcher error (non-fatal):', err);
+    return;
+  }
+  console.error('[Main] uncaught exception:', err);
+  dialog.showErrorBox(
+    'A JavaScript error occurred in the main process',
+    err?.stack ?? String(err),
+  );
+});
 
 // run this as early in the main process as possible
 if (started) app.quit();

--- a/apps/x/packages/core/src/apps/server.ts
+++ b/apps/x/packages/core/src/apps/server.ts
@@ -719,6 +719,12 @@ async function startWatcher(): Promise<void> {
     if (watcher) return;
     const w = chokidar.watch(APPS_DIR, {
         ignoreInitial: true,
+        // Installed apps may ship .git/node_modules trees — thousands of files
+        // no consumer renders, at one watch fd per file (chokidar v4, no fsevents).
+        ignored: (watchedPath: string) => {
+            const segments = path.relative(APPS_DIR, watchedPath).split(path.sep);
+            return segments.includes('.git') || segments.includes('node_modules');
+        },
         awaitWriteFinish: { stabilityThreshold: 180, pollInterval: 50 },
     });
     w.on('all', (eventName, absolutePath) => {

--- a/apps/x/packages/core/src/workspace/watcher.ts
+++ b/apps/x/packages/core/src/workspace/watcher.ts
@@ -9,10 +9,28 @@ import { Stats } from 'node:fs';
 
 export type WorkspaceChangeCallback = (event: z.infer<typeof WorkspaceChangeEvent>) => void;
 
+// The only WorkDir paths whose change events have a consumer (knowledge index
+// invalidation in main, and the tree/editor, live-notes, email, sidebar and
+// meetings views in the renderer). Everything else under WorkDir — runs-archive,
+// storage/turns, engines, logs, code-mode, ... — is internal state that grows
+// unboundedly with usage; chokidar v4 holds one OS watch handle per file, so
+// watching all of WorkDir exhausts the process fd limit (EMFILE crash) once
+// the workdir gets big enough.
+const WATCHED_ROOTS = [
+  'knowledge',
+  'bases',
+  'inbox_lists',
+  'gmail_sync',
+  'calendar_sync',
+  'bg-tasks',
+  'config/agent-schedule.json',
+];
+
 /**
  * Create a workspace watcher
- * Watches the configured workspace root recursively and emits change events via callback
- * 
+ * Watches the user-facing workspace roots (WATCHED_ROOTS) recursively and
+ * emits WorkDir-relative change events via callback.
+ *
  * Returns a watcher instance that can be closed.
  * The watcher emits events immediately without debouncing.
  * Debouncing and lifecycle management should be handled by the caller.
@@ -22,15 +40,13 @@ export async function createWorkspaceWatcher(
 ): Promise<FSWatcher> {
   await ensureWorkspaceRoot();
 
-  // Code-section session worktrees are full repo checkouts (thousands of files,
-  // possibly node_modules) living under WorkDir — watching them would flood the
-  // event stream and burn file handles, and nothing in the app renders them
-  // from workspace events.
-  const codeModeDir = path.join(WorkDir, 'code-mode');
-  const watcher = chokidar.watch(WorkDir, {
+  const roots = WATCHED_ROOTS.map((rel) => path.join(WorkDir, rel));
+  const watcher = chokidar.watch(roots, {
     ignoreInitial: true,
+    // knowledge/ is a git repo (version history) — its .git object store is
+    // thousands of files nothing renders, so keep it out of the watch set.
     ignored: (watchedPath: string) =>
-      watchedPath === codeModeDir || watchedPath.startsWith(codeModeDir + path.sep),
+      path.relative(WorkDir, watchedPath).split(path.sep).includes('.git'),
     awaitWriteFinish: {
       stabilityThreshold: 150,
       pollInterval: 50,

--- a/apps/x/packages/core/src/workspace/watcher.ts
+++ b/apps/x/packages/core/src/workspace/watcher.ts
@@ -16,20 +16,20 @@ export type WorkspaceChangeCallback = (event: z.infer<typeof WorkspaceChangeEven
 // unboundedly with usage; chokidar v4 holds one OS watch handle per file, so
 // watching all of WorkDir exhausts the process fd limit (EMFILE crash) once
 // the workdir gets big enough.
-const WATCHED_ROOTS = [
+const WATCHED_DIR_ROOTS = [
   'knowledge',
   'bases',
   'inbox_lists',
   'gmail_sync',
   'calendar_sync',
   'bg-tasks',
-  'config/agent-schedule.json',
 ];
+const WATCHED_FILE_ROOTS = ['config/agent-schedule.json'];
 
 /**
  * Create a workspace watcher
- * Watches the user-facing workspace roots (WATCHED_ROOTS) recursively and
- * emits WorkDir-relative change events via callback.
+ * Watches the user-facing workspace roots (WATCHED_DIR_ROOTS / WATCHED_FILE_ROOTS)
+ * recursively and emits WorkDir-relative change events via callback.
  *
  * Returns a watcher instance that can be closed.
  * The watcher emits events immediately without debouncing.
@@ -40,7 +40,18 @@ export async function createWorkspaceWatcher(
 ): Promise<FSWatcher> {
   await ensureWorkspaceRoot();
 
-  const roots = WATCHED_ROOTS.map((rel) => path.join(WorkDir, rel));
+  // chokidar v4 never picks up a watched directory that doesn't exist yet
+  // (a missing file is fine as long as its parent dir exists), so create the
+  // roots up front — otherwise e.g. calendar_sync/ appearing after app start
+  // would stay invisible until restart.
+  for (const rel of WATCHED_DIR_ROOTS) {
+    await fs.mkdir(path.join(WorkDir, rel), { recursive: true });
+  }
+  for (const rel of WATCHED_FILE_ROOTS) {
+    await fs.mkdir(path.dirname(path.join(WorkDir, rel)), { recursive: true });
+  }
+
+  const roots = [...WATCHED_DIR_ROOTS, ...WATCHED_FILE_ROOTS].map((rel) => path.join(WorkDir, rel));
   const watcher = chokidar.watch(roots, {
     ignoreInitial: true,
     // knowledge/ is a git repo (version history) — its .git object store is


### PR DESCRIPTION
## Problem

The app crashes with `Uncaught Exception: Error: EMFILE: too many open files, watch` (reported by Arjun; native error dialog on launch).

The workspace watcher watched **all of `~/.rowboat`** recursively. Chokidar v4 has no fsevents backend on macOS, so it holds **one OS watch handle (fd) per watched file/dir**. Internal state dirs (`runs-archive`, `storage/turns/**`, `engines`, ...) grow unboundedly with usage, so fd usage grows with usage history until it blows the process fd limit. Measured on a 1.1G workdir: **~20.5k open fds** held by the running app. Running the old watcher under a 256-fd limit (Arjun's) reproduces the crash immediately.

## Fix

- **Whitelist the workspace watcher.** Watch only the roots whose change events actually have consumers (traced every listener of `workspace:didChange` + the knowledge-index invalidation): `knowledge/`, `bases/`, `inbox_lists/`, `gmail_sync/`, `calendar_sync/`, `bg-tasks/`, `config/agent-schedule.json` — with `.git` ignored (`knowledge/` is a git repo).
- **Pre-create the watched dir roots.** chokidar v4 silently never watches a directory that doesn't exist at watch time, so e.g. `calendar_sync/` appearing after first launch would otherwise stay invisible until restart.
- **Harden the apps watcher.** Ignore `.git`/`node_modules` segments under `~/.rowboat/apps` so an installed app shipping either can't recreate the fd explosion. (The skills watcher already bounds itself with `depth: 1`.)
- **Degrade instead of crash.** fs.watch failures (EMFILE/ENOSPC) escape chokidar's `error` handler as uncaught exceptions from Node watcher internals — exactly the native dialog in the report. A process-level guard now logs watcher fd errors and keeps the app running; all other uncaught exceptions keep the default dialog behavior.

## Verification

- Standalone harness against a real workdir: **~20,950 watched entries → 380** (~363 fds).
- Running app: `lsof -p <pid> | grep -c .rowboat` went from **20,518 → ~40**.
- Behavior test: events fire for all whitelisted roots (incl. a root created after watcher start) and do **not** fire for `storage/` or `.git/`.
- Manual: external edits to knowledge files show up live in the editor/tree.
- `npm run deps` + eslint clean on all touched files; `tsc --noEmit` clean on main.