### PR TITLE
feat(x): image generation — generate-image tool, chat rendering, BYOK + gateway support

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -63,6 +63,7 @@ import { TurnActivityIndicator } from '@/components/turn-activity-indicator';
 import { useSmoothedText } from './hooks/useSmoothedText';
 import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool';
 import { WebSearchResult } from '@/components/ai-elements/web-search-result';
+import { GeneratedImageCard } from '@/components/ai-elements/generated-image-card';
 import { AppActionCard } from '@/components/ai-elements/app-action-card';
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card';
 import { PermissionRequest } from '@/components/ai-elements/permission-request';
@@ -107,6 +108,7 @@ import {
   type ToolCall,
   createEmptyChatTabViewState,
   getWebSearchCardData,
+  getGeneratedImageCardData,
   getAppActionCardData,
   getComposioConnectCardData,
   getToolDisplayName,
@@ -6085,6 +6087,18 @@ function App() {
             results={webSearchData.results}
             status={item.status}
             title={webSearchData.title}
+          />
+        )
+      }
+      const generatedImageData = getGeneratedImageCardData(item)
+      if (generatedImageData) {
+        return (
+          <GeneratedImageCard
+            key={item.id}
+            prompt={generatedImageData.prompt}
+            path={generatedImageData.path}
+            error={generatedImageData.error}
+            status={item.status}
           />
         )
       }

--- a/apps/x/apps/renderer/src/components/ai-elements/generated-image-card.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/generated-image-card.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { ImageIcon, ImageOffIcon, LoaderIcon } from "lucide-react";
+
+interface GeneratedImageCardProps {
+  prompt: string;
+  /** Workspace-relative path of the generated image (present once completed). */
+  path?: string;
+  error?: string;
+  status: "pending" | "running" | "completed" | "error";
+}
+
+// Chat card for the generate-image builtin: spinner while the model paints,
+// then the image itself served over app://workspace (see main.ts protocol).
+export function GeneratedImageCard({ prompt, path, error, status }: GeneratedImageCardProps) {
+  const isRunning = status === "pending" || status === "running";
+  const failed = !isRunning && (!!error || !path);
+
+  if (isRunning || failed) {
+    return (
+      <div className="not-prose mb-4 flex w-full items-center gap-2.5 rounded-[28px] border bg-[var(--card-surface)] px-4 py-2.5 text-sm">
+        {isRunning ? (
+          <LoaderIcon className="size-4 shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <ImageOffIcon className="size-4 shrink-0 text-destructive" />
+        )}
+        <span className={cn("min-w-0 truncate", isRunning ? "text-muted-foreground" : "text-destructive")}>
+          {isRunning
+            ? `Generating image${prompt ? ` — ${prompt}` : "…"}`
+            : error || "Image generation failed"}
+        </span>
+      </div>
+    );
+  }
+
+  const src = `app://workspace/${path!.split("/").map(encodeURIComponent).join("/")}`;
+  return (
+    <div className="not-prose mb-4 w-fit max-w-full overflow-hidden rounded-2xl border bg-[var(--card-surface)]">
+      <img
+        src={src}
+        alt={prompt || "Generated image"}
+        className="block max-h-96 max-w-full object-contain"
+      />
+      {prompt && (
+        <div className="flex items-center gap-1.5 border-t px-3 py-1.5 text-xs text-muted-foreground">
+          <ImageIcon className="size-3 shrink-0" />
+          <span className="truncate">{prompt}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -21,6 +21,7 @@ import { TurnActivityIndicator } from '@/components/turn-activity-indicator'
 import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
 import { WebSearchResult } from '@/components/ai-elements/web-search-result'
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card'
+import { GeneratedImageCard } from '@/components/ai-elements/generated-image-card'
 import { PermissionRequest } from '@/components/ai-elements/permission-request'
 import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
 import { TerminalOutput } from '@/components/terminal-output'
@@ -45,6 +46,7 @@ import {
   createEmptyChatTabViewState,
   getWebSearchCardData,
   getComposioConnectCardData,
+  getGeneratedImageCardData,
   getToolDisplayName,
   getToolErrorText,
   groupConversationItems,
@@ -449,6 +451,18 @@ export function ChatSidebar({
             results={webSearchData.results}
             status={item.status}
             title={webSearchData.title}
+          />
+        )
+      }
+      const generatedImageData = getGeneratedImageCardData(item)
+      if (generatedImageData) {
+        return (
+          <GeneratedImageCard
+            key={item.id}
+            prompt={generatedImageData.prompt}
+            path={generatedImageData.path}
+            error={generatedImageData.error}
+            status={item.status}
           />
         )
       }

--- a/apps/x/apps/renderer/src/lib/chat-conversation.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.ts
@@ -204,6 +204,27 @@ export const getWebSearchCardData = (tool: ToolCall): WebSearchCardData | null =
   return null
 }
 
+// Generated-image card data (the generate-image builtin)
+export type GeneratedImageCardData = {
+  prompt: string
+  /** Workspace-relative path of the generated image; undefined while running or on failure. */
+  path?: string
+  error?: string
+}
+
+export const getGeneratedImageCardData = (tool: ToolCall): GeneratedImageCardData | null => {
+  if (tool.name !== 'generate-image') return null
+  const input = normalizeToolInput(tool.input) as Record<string, unknown> | undefined
+  const result = tool.result as Record<string, unknown> | undefined
+  return {
+    prompt: (input?.prompt as string) || '',
+    ...(result?.success && typeof result.path === 'string' ? { path: result.path } : {}),
+    ...(result && result.success !== true
+      ? { error: (result.error as string) || 'Image generation failed' }
+      : {}),
+  }
+}
+
 // App navigation action card data
 export type AppActionCardData = {
   action: string
@@ -609,6 +630,7 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   'composio-search-tools': 'Searching tools',
   'composio-execute-tool': 'Running tool',
   'composio-connect-toolkit': 'Connecting service',
+  'generate-image': 'Generating image',
 }
 
 /**
@@ -705,6 +727,7 @@ const isPlainToolCall = (item: ConversationItem): item is ToolCall => {
   if (getWebSearchCardData(item)) return false
   if (getComposioConnectCardData(item)) return false
   if (getAppActionCardData(item)) return false
+  if (getGeneratedImageCardData(item)) return false
   return true
 }
 

--- a/apps/x/packages/core/src/images/images.ts
+++ b/apps/x/packages/core/src/images/images.ts
@@ -1,0 +1,275 @@
+// Image generation as a standalone capability — the TTS/ASR pattern
+// (voice/voice.ts), NOT another LLM. Image models never enter the model
+// registry, the model picker, or models.json:
+//
+// - Signed in: a dedicated proxy endpoint (`/v1/images/generations`, bearer
+//   auth), where the backend owns the model choice — mirroring
+//   `/v1/voice/text-to-speech/<voiceId>`.
+// - BYOK: `~/.rowboat/config/image-generation.json` with the vendor, its own
+//   API key, and the model to use — mirroring elevenlabs.json/exa-search.json.
+//
+// An explicit BYOK config wins over the signed-in proxy (it's a deliberate
+// user choice, like defaultSelection for chat models); unset + signed-in
+// falls through to the proxy's curated model.
+
+import { generateImage, generateText, type ModelMessage } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { isSignedIn } from "../account/account.js";
+import { getAccessToken } from "../auth/tokens.js";
+import { getCurrentUseCase } from "../analytics/use_case.js";
+import { WorkDir } from "../config/config.js";
+import { API_URL } from "../config/env.js";
+
+export const GENERATED_IMAGES_DIR = "generated-images";
+
+const CONFIG_FILENAME = "image-generation.json";
+const IMAGE_GEN_PROVIDERS = ["gemini", "openrouter", "openai"] as const;
+export type ImageGenProvider = (typeof IMAGE_GEN_PROVIDERS)[number];
+
+export interface ImageGenConfig {
+    provider: ImageGenProvider;
+    apiKey: string;
+    model: string;
+}
+
+function configPath(): string {
+    return path.join(WorkDir, "config", CONFIG_FILENAME);
+}
+
+/** The BYOK image-generation config, or null when absent/incomplete. */
+export async function getImageGenConfig(): Promise<ImageGenConfig | null> {
+    try {
+        const raw = await fs.readFile(configPath(), "utf8");
+        const parsed = JSON.parse(raw) as Partial<ImageGenConfig>;
+        if (
+            typeof parsed.apiKey === "string" && parsed.apiKey &&
+            typeof parsed.model === "string" && parsed.model &&
+            IMAGE_GEN_PROVIDERS.includes(parsed.provider as ImageGenProvider)
+        ) {
+            return { provider: parsed.provider as ImageGenProvider, apiKey: parsed.apiKey, model: parsed.model };
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/** Availability gate for the generate-image tool and its skill. */
+export async function isImageGenerationAvailable(): Promise<boolean> {
+    if (await getImageGenConfig()) return true;
+    return isSignedIn();
+}
+
+export interface GenerateImageArgs {
+    prompt: string;
+    /** Source images (already read + permission-checked) for edit/remix prompts. */
+    sourceImages?: Array<{ bytes: Uint8Array; mediaType: string }>;
+    abortSignal?: AbortSignal;
+}
+
+export interface GenerateImageOutcome {
+    /** Workspace-relative path of the saved image. */
+    relPath: string;
+    /** Absolute path of the saved image. */
+    absPath: string;
+    mediaType: string;
+    /** "rowboat" for the signed-in proxy, otherwise the BYOK vendor. */
+    provider: string;
+    /** Model id when known (BYOK config, or reported by the proxy). */
+    model?: string;
+    /** Any text the model returned alongside the image. */
+    text?: string;
+    /** Token usage when the vendor reports it (chat-modality paths). */
+    usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+}
+
+const EXT_BY_MEDIA_TYPE: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+};
+
+function fileNameForPrompt(prompt: string, mediaType: string): string {
+    const slug = prompt
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 48) || "image";
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const ext = EXT_BY_MEDIA_TYPE[mediaType] ?? "png";
+    return `${slug}-${stamp}.${ext}`;
+}
+
+async function saveImage(bytes: Uint8Array, mediaType: string, prompt: string): Promise<{ relPath: string; absPath: string }> {
+    const dir = path.join(WorkDir, GENERATED_IMAGES_DIR);
+    await fs.mkdir(dir, { recursive: true });
+    const fileName = fileNameForPrompt(prompt, mediaType);
+    const absPath = path.join(dir, fileName);
+    await fs.writeFile(absPath, bytes);
+    return { relPath: `${GENERATED_IMAGES_DIR}/${fileName}`, absPath };
+}
+
+type RawGeneration = {
+    bytes: Uint8Array;
+    mediaType: string;
+    provider: string;
+    model?: string;
+    text?: string;
+    usage?: GenerateImageOutcome["usage"];
+};
+
+// ---- Signed-in proxy path ----
+
+interface ProxyResponse {
+    image?: { mediaType?: string; dataBase64?: string };
+    model?: string;
+}
+
+async function generateViaProxy(args: GenerateImageArgs): Promise<RawGeneration> {
+    const accessToken = await getAccessToken();
+    // Same attribution headers the LLM gateway sends (gateway.ts authedFetch):
+    // the backend stamps them onto its billing/generation records.
+    const ctx = getCurrentUseCase();
+    const response = await fetch(`${API_URL}/v1/images/generations`, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+            ...(ctx?.useCase ? { "x-rowboat-use-case": ctx.useCase } : {}),
+            ...(ctx?.subUseCase ? { "x-rowboat-sub-use-case": ctx.subUseCase } : {}),
+            ...(ctx?.agentName ? { "x-rowboat-agent-name": ctx.agentName } : {}),
+        },
+        body: JSON.stringify({
+            prompt: args.prompt,
+            ...(args.sourceImages?.length
+                ? {
+                    sourceImages: args.sourceImages.map((img) => ({
+                        mediaType: img.mediaType,
+                        dataBase64: Buffer.from(img.bytes).toString("base64"),
+                    })),
+                }
+                : {}),
+        }),
+        signal: args.abortSignal ?? null,
+    });
+    if (!response.ok) {
+        const errText = await response.text().catch(() => "Unknown error");
+        throw new Error(`Image generation API error ${response.status}: ${errText.slice(0, 300)}`);
+    }
+    const body = await response.json() as ProxyResponse;
+    if (!body.image?.dataBase64) {
+        throw new Error("Image generation API returned no image");
+    }
+    return {
+        bytes: new Uint8Array(Buffer.from(body.image.dataBase64, "base64")),
+        mediaType: body.image.mediaType || "image/png",
+        provider: "rowboat",
+        ...(body.model ? { model: body.model } : {}),
+    };
+}
+
+// ---- BYOK vendor paths ----
+
+// Gemini image models (Nano Banana) and OpenRouter-routed image models are
+// chat models that return images as file parts from an ordinary completion.
+async function generateViaChatModalities(config: ImageGenConfig, args: GenerateImageArgs): Promise<RawGeneration> {
+    const model = config.provider === "gemini"
+        ? createGoogleGenerativeAI({ apiKey: config.apiKey }).languageModel(config.model)
+        : createOpenRouter({ apiKey: config.apiKey }).languageModel(config.model);
+    const providerOptions: Record<string, Record<string, string[]>> = config.provider === "gemini"
+        ? { google: { responseModalities: ["TEXT", "IMAGE"] } }
+        // Spread verbatim into the /chat/completions body by the OpenRouter provider.
+        : { openrouter: { modalities: ["image", "text"] } };
+    const messages: ModelMessage[] = [{
+        role: "user",
+        content: [
+            { type: "text", text: args.prompt },
+            ...(args.sourceImages ?? []).map((img) => ({
+                type: "image" as const,
+                image: img.bytes,
+                mediaType: img.mediaType,
+            })),
+        ],
+    }];
+    const result = await generateText({
+        model,
+        messages,
+        providerOptions,
+        abortSignal: args.abortSignal,
+    });
+    const image = result.files.find((f) => f.mediaType.startsWith("image/"));
+    if (!image) {
+        const detail = result.text?.trim();
+        throw new Error(
+            `Model ${config.model} returned no image${detail ? ` (model said: ${detail.slice(0, 300)})` : ""}. ` +
+            `Make sure the "model" in ${CONFIG_FILENAME} is an image-generation model.`,
+        );
+    }
+    return {
+        bytes: image.uint8Array,
+        mediaType: image.mediaType,
+        provider: config.provider,
+        model: config.model,
+        text: result.text?.trim() || undefined,
+        usage: result.usage,
+    };
+}
+
+async function generateViaOpenAI(config: ImageGenConfig, args: GenerateImageArgs): Promise<RawGeneration> {
+    if (args.sourceImages?.length) {
+        throw new Error(
+            "The 'openai' image provider does not accept source images here. " +
+            "Use the 'gemini' or 'openrouter' provider for image editing.",
+        );
+    }
+    const { image } = await generateImage({
+        model: createOpenAI({ apiKey: config.apiKey }).imageModel(config.model),
+        prompt: args.prompt,
+        abortSignal: args.abortSignal,
+    });
+    return {
+        bytes: image.uint8Array,
+        mediaType: image.mediaType,
+        provider: config.provider,
+        model: config.model,
+    };
+}
+
+/**
+ * Generate one image and save it under `<workspace>/generated-images/`.
+ * Throws when image generation is unavailable (signed out and no BYOK
+ * config) or the vendor returns no image.
+ */
+export async function generateImageToWorkspace(args: GenerateImageArgs): Promise<GenerateImageOutcome> {
+    const config = await getImageGenConfig();
+    let generated: RawGeneration;
+    if (config) {
+        generated = config.provider === "openai"
+            ? await generateViaOpenAI(config, args)
+            : await generateViaChatModalities(config, args);
+    } else if (await isSignedIn()) {
+        generated = await generateViaProxy(args);
+    } else {
+        throw new Error(
+            `Image generation not configured. Create ${configPath()} with ` +
+            `{ "provider": "gemini" | "openrouter" | "openai", "apiKey": "<your-key>", "model": "<image model id>" } ` +
+            `or sign in to Rowboat.`,
+        );
+    }
+
+    const { relPath, absPath } = await saveImage(generated.bytes, generated.mediaType, args.prompt);
+    return {
+        relPath,
+        absPath,
+        mediaType: generated.mediaType,
+        provider: generated.provider,
+        ...(generated.model ? { model: generated.model } : {}),
+        ...(generated.text ? { text: generated.text } : {}),
+        ...(generated.usage ? { usage: generated.usage } : {}),
+    };
+}

--- a/apps/x/packages/core/src/runtime/assembly/permission-metadata.ts
+++ b/apps/x/packages/core/src/runtime/assembly/permission-metadata.ts
@@ -70,6 +70,14 @@ function filePermissionTargets(toolName: string, args: Record<string, unknown>):
         }
         case 'file-remove':
             return pathArg ? { operation: 'delete', paths: [pathArg] } : null;
+        case 'generate-image': {
+            // Output always lands inside the workspace; only reading source
+            // images (from e.g. Desktop) can cross the boundary.
+            const sources = Array.isArray(args.sourceImagePaths)
+                ? args.sourceImagePaths.filter((p): p is string => typeof p === 'string')
+                : [];
+            return sources.length ? { operation: 'read', paths: sources } : null;
+        }
         default:
             return null;
     }

--- a/apps/x/packages/core/src/runtime/assembly/skills/generate-images/skill.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/generate-images/skill.ts
@@ -1,0 +1,37 @@
+export const skill = String.raw`
+# Generate Images
+
+Load this skill when the user asks you to create, generate, edit, or remix an image — illustrations, logos, mockups, photos, diagrams-as-art, profile pictures, social cards, and so on.
+
+## The tool: \`generate-image\`
+
+Generates one image with the user's configured image model and saves it under \`generated-images/\` in the workspace.
+
+### Parameters
+- **\`prompt\`** (required) — what to generate. Be concrete: subject, style, composition, colors, lighting, mood. For edits, describe the change relative to the source images.
+- **\`sourceImagePaths\`** (optional) — existing images (png/jpg/webp/gif) to edit or remix. Accepts workspace-relative, absolute, or \`~/\` paths — e.g. an attachment the user dropped into chat, or a previously generated image.
+
+### Result
+Returns \`{ success, path, absolutePath }\` where \`path\` is workspace-relative (e.g. \`generated-images/sunset-cabin-….png\`).
+
+- **In chat, the image is displayed to the user automatically** as part of the tool result — do NOT repeat it as a markdown image in your reply. Just describe what you made in a short sentence.
+- **In notes / HTML artifacts** (background tasks, live notes), embed the image yourself with a path that is relative to the file you're writing — e.g. from \`bg-tasks/<slug>/index.html\` the generated image is \`../../generated-images/<file>.png\`.
+
+## Iterating
+
+Image generation is iterative by nature. When the user asks for tweaks ("make it darker", "remove the text"), call \`generate-image\` again with the previous output as a source image:
+
+\`\`\`json
+{
+  "prompt": "Same scene, but at night with warm window lighting",
+  "sourceImagePaths": ["generated-images/sunset-cabin-2026-07-16T....png"]
+}
+\`\`\`
+
+## Anti-patterns
+- **Don't generate unprompted.** Only call the tool when the user asked for an image (or a background task's instructions clearly require one).
+- **Don't batch speculative variations.** Generate one image, let the user react, then iterate. Each call costs real money.
+- **Don't re-embed the chat result.** The UI already renders it; a duplicate markdown embed shows the image twice.
+`;
+
+export default skill;

--- a/apps/x/packages/core/src/runtime/assembly/skills/index.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/index.ts
@@ -29,6 +29,7 @@ import backgroundTaskSkill from "./background-task/skill.js";
 import notifyUserSkill from "./notify-user/skill.js";
 import appsSkill from "./apps/skill.js";
 import slackSkill from "./slack/skill.js";
+import generateImagesSkill from "./generate-images/skill.js";
 
 const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CATALOG_PREFIX = "src/runtime/assembly/skills";
@@ -191,6 +192,22 @@ const definitions: SkillDefinition[] = [
     title: "Slack",
     summary: "Read, search, and send Slack messages via the agent-slack CLI — catch up on channels, summarize threads, list users. Load FIRST for ANY Slack request; Slack is connected natively, never through Composio.",
     content: slackSkill,
+  },
+  {
+    id: "generate-images",
+    // Hidden until image generation is usable: signed in (gateway proxy) or
+    // a BYOK config/image-generation.json. Imported lazily to keep this
+    // module free of back-edges into heavier layers (a static import of
+    // models/defaults.ts from here once cycled through the DI container into
+    // the tool catalog, which imports this file).
+    availability: async () => {
+      const { isImageGenerationAvailable } = await import("../../../images/images.js");
+      return isImageGenerationAvailable();
+    },
+    title: "Generate Images",
+    summary: "Create, edit, or remix images from a text prompt with the configured image model. Load when the user asks for an image — illustration, logo, mockup, photo edit, etc.",
+    content: generateImagesSkill,
+    tools: ["generate-image"],
   },
   {
     id: "notify-user",

--- a/apps/x/packages/core/src/runtime/tools/catalog.test.ts
+++ b/apps/x/packages/core/src/runtime/tools/catalog.test.ts
@@ -202,6 +202,7 @@ const HISTORICAL_KEY_ORDER = [
     "run-background-task-agent",
     "launch-code-task",
     "notify-user",
+    "generate-image",
     "spawn-agent",
 ];
 
@@ -239,6 +240,7 @@ describe("BuiltinTools permission audit", () => {
             addMcpServer: "prompt",
             executeMcpTool: "mcp-execute",
             "composio-execute-tool": "composio-execute",
+            "generate-image": "file-boundary",
         });
     });
 });

--- a/apps/x/packages/core/src/runtime/tools/catalog.ts
+++ b/apps/x/packages/core/src/runtime/tools/catalog.ts
@@ -22,6 +22,7 @@ import { modelTools } from "./domains/models.js";
 import { liveNoteTools } from "./domains/live-note.js";
 import { backgroundTaskTools } from "./domains/background-tasks.js";
 import { notificationTools } from "./domains/notifications.js";
+import { imageTools } from "./domains/images.js";
 import { BuiltinToolsSchema } from "./types.js";
 export { coalesceCodeRunEvents } from "./domains/code.js";
 
@@ -94,6 +95,7 @@ export const BuiltinTools: z.infer<typeof BuiltinToolsSchema> = {
     ...backgroundTaskTools,
     ...codeTaskTools,
     ...notificationTools,
+    ...imageTools,
 
     [SPAWN_AGENT_TOOL_NAME]: {
         permission: "none",

--- a/apps/x/packages/core/src/runtime/tools/domains/images.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/images.ts
@@ -1,0 +1,88 @@
+// Builtin tools: image-generation domain.
+
+import { z } from "zod";
+import * as files from "../../../filesystem/files.js";
+import { isImageGenerationAvailable, generateImageToWorkspace } from "../../../images/images.js";
+import { captureLlmUsage } from "../../../analytics/usage.js";
+import { getCurrentUseCase, withUseCase } from "../../../analytics/use_case.js";
+import { BuiltinToolsSchema } from "../types.js";
+import type { ToolContext } from "../exec-tool.js";
+
+const SOURCE_IMAGE_MIME_BY_EXT: Record<string, string> = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+};
+
+export const imageTools: z.infer<typeof BuiltinToolsSchema> = {
+    'generate-image': {
+        // file-boundary: reading sourceImagePaths outside the workspace
+        // requires the same grant as file-readText (see permission-metadata).
+        permission: "file-boundary",
+        description: 'Generate an image from a text prompt with the configured image model, or edit/remix existing images by passing them as sourceImagePaths. The image is saved under generated-images/ in the workspace and returned as a path. In chat the result is shown to the user automatically — do NOT re-embed it in your reply. In notes or HTML artifacts, reference the returned path (relative to the workspace root).',
+        inputSchema: z.object({
+            prompt: z.string().min(1).describe('What to generate. Be specific about subject, style, composition, and lighting; for edits, describe the change to make to the source images.'),
+            sourceImagePaths: z.array(z.string()).optional().describe('Optional existing images (png/jpg/webp/gif) to edit or remix. Absolute, ~/..., or workspace-relative paths.'),
+        }),
+        isAvailable: isImageGenerationAvailable,
+        execute: async (
+            { prompt, sourceImagePaths }: { prompt: string; sourceImagePaths?: string[] },
+            toolCtx?: ToolContext,
+        ) => {
+            try {
+                const sourceImages: Array<{ bytes: Uint8Array; mediaType: string }> = [];
+                for (const sourcePath of sourceImagePaths ?? []) {
+                    const ext = sourcePath.slice(sourcePath.lastIndexOf('.')).toLowerCase();
+                    const mediaType = SOURCE_IMAGE_MIME_BY_EXT[ext];
+                    if (!mediaType) {
+                        return {
+                            success: false,
+                            error: `Unsupported source image format '${ext || sourcePath}'. Supported: ${Object.keys(SOURCE_IMAGE_MIME_BY_EXT).join(', ')}`,
+                        };
+                    }
+                    const { buffer } = await files.readBuffer(sourcePath);
+                    sourceImages.push({ bytes: new Uint8Array(buffer), mediaType });
+                }
+
+                const ctx = getCurrentUseCase();
+                const result = await withUseCase({
+                    useCase: ctx?.useCase ?? 'copilot_chat',
+                    subUseCase: 'image_generation',
+                    ...(ctx?.agentName ? { agentName: ctx.agentName } : {}),
+                }, () => generateImageToWorkspace({
+                    prompt,
+                    ...(sourceImages.length > 0 ? { sourceImages } : {}),
+                    abortSignal: toolCtx?.signal,
+                }));
+
+                if (result.usage) {
+                    captureLlmUsage({
+                        useCase: ctx?.useCase ?? 'copilot_chat',
+                        subUseCase: 'image_generation',
+                        ...(ctx?.agentName ? { agentName: ctx.agentName } : {}),
+                        model: result.model ?? 'unknown',
+                        provider: result.provider,
+                        usage: result.usage,
+                    });
+                }
+
+                return {
+                    success: true,
+                    path: result.relPath,
+                    absolutePath: result.absPath,
+                    mediaType: result.mediaType,
+                    provider: result.provider,
+                    ...(result.model ? { model: result.model } : {}),
+                    ...(result.text ? { modelNote: result.text } : {}),
+                };
+            } catch (error) {
+                return {
+                    success: false,
+                    error: error instanceof Error ? error.message : 'Unknown error',
+                };
+            }
+        },
+    },
+};


### PR DESCRIPTION
## What

Adds image generation to the desktop app as a **standalone capability following the TTS/ASR pattern** (`voice/voice.ts`) — image models are a separate API, never another LLM. They don't enter the model registry, `models.json`, `listGatewayModels`, or the model picker.

### Core (`packages/core/src/images/images.ts`)
- **Signed-in**: POSTs to a dedicated proxy endpoint `POST /v1/images/generations` (bearer auth + use-case attribution headers, mirrors `/v1/voice/text-to-speech`). The backend owns the model choice.
- **BYOK**: `~/.rowboat/config/image-generation.json` with `{ "provider": "gemini" | "openrouter" | "openai", "apiKey": "…", "model": "…" }` (mirrors `elevenlabs.json` / `exa-search.json`). Gemini/OpenRouter generate via chat modalities and support source-image editing; OpenAI uses the dedicated images API (generation only). An explicit BYOK config wins over the signed-in proxy.
- Output is saved to `~/.rowboat/generated-images/`.

### Tool + skill
- New `generate-image` builtin (`prompt` + optional `sourceImagePaths` for edit/remix). Permission is `file-boundary`: prompts only when a source image is read from outside the workspace, exactly like `file-readText`.
- Background agents pick it up automatically (they attach all builtins).
- The copilot gets it via a new `generate-images` skill, availability-gated (hidden unless signed in or BYOK-configured).

### Chat UI
- `GeneratedImageCard` replaces the raw tool card in both chat surfaces: spinner with the prompt while generating, then the image itself (served via `app://workspace/`), plus an error state.

## Backend (separate, not in this repo)
Requires `POST /v1/images/generations` on rowboatx-backend:
```
Request:  { prompt: string, sourceImages?: [{ mediaType, dataBase64 }] }
Response: { image: { mediaType, dataBase64 }, model? }
```
Suggested implementation: OpenRouter chat completions with `modalities: ["image","text"]` + `IMAGE_GEN_MODEL` env (e.g. `google/gemini-2.5-flash-image`), recording the generation id in `billing_generations` so the existing usage-reconciler bills actual cost. Because the endpoint is not under `/llm`, the LLM allowlist and `/llm/models` (→ the model picker) are untouched. Until the endpoint ships, signed-in-only users get a clean tool error; BYOK works today.

## Testing
- `npm run deps`, `npm run typecheck`, `npm run lint` (only pre-existing lint errors), full core suite: 480/480 passing — including the pinned catalog key-order and permission-audit tests, updated in the same commit.
- Not yet exercised against a live model/endpoint; BYOK smoke test: create `~/.rowboat/config/image-generation.json` and ask the copilot for an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)