### PR TITLE
fix(x): meeting detection blind when Siri holds the mic + capture review findings

### DIFF
--- a/apps/x/apps/main/src/deeplink.ts
+++ b/apps/x/apps/main/src/deeplink.ts
@@ -2,6 +2,7 @@ import { BrowserWindow } from "electron";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { WorkDir } from "@x/core/dist/config/config.js";
+import { markPendingTakeMeetingNotes } from "./tray.js";
 
 export const DEEP_LINK_SCHEME = "rowboat";
 const URL_PREFIX = `${DEEP_LINK_SCHEME}://`;
@@ -9,9 +10,18 @@ const ACTION_HOST = "action";
 
 let pendingUrl: string | null = null;
 let mainWindowRef: BrowserWindow | null = null;
+// Registered by main.ts (showApp): creates/reveals the main window. The app
+// can be alive with NO window (tray-resident) when a notification is
+// clicked — deep links must be able to bring the window back, and importing
+// main.ts from here would be a cycle.
+let revealAppRef: (() => void) | null = null;
 
 export function setMainWindowForDeepLinks(win: BrowserWindow | null): void {
     mainWindowRef = win;
+}
+
+export function setRevealAppForDeepLinks(reveal: () => void): void {
+    revealAppRef = reveal;
 }
 
 export function consumePendingDeepLink(): string | null {
@@ -54,7 +64,12 @@ export function dispatchDeepLink(url: string): void {
     pendingUrl = url;
 
     const win = mainWindowRef;
-    if (!win || win.isDestroyed()) return;
+    if (!win || win.isDestroyed()) {
+        // Tray-resident with no window: create/reveal one — the fresh
+        // renderer drains pendingUrl on mount.
+        revealAppRef?.();
+        return;
+    }
     focusWindow(win);
 
     if (win.webContents.isLoading()) return;
@@ -94,10 +109,6 @@ async function dispatchAction(url: string): Promise<void> {
 }
 
 async function handleTakeMeetingNotes(eventId: string, openMeeting: boolean): Promise<void> {
-    const win = mainWindowRef;
-    if (!win || win.isDestroyed()) return;
-    focusWindow(win);
-
     const filePath = path.join(WorkDir, "calendar_sync", `${eventId}.json`);
     let event: unknown;
     try {
@@ -108,15 +119,21 @@ async function handleTakeMeetingNotes(eventId: string, openMeeting: boolean): Pr
         return;
     }
 
-    const payload = { event, openMeeting };
+    // The real calendar_sync path lets the summarizer resolve attendees.
+    const payload = { event, openMeeting, source: `calendar_sync/${eventId}.json` };
 
-    if (win.webContents.isLoading()) {
-        win.webContents.once("did-finish-load", () => {
-            win.webContents.send("app:takeMeetingNotes", payload);
-        });
+    const win = mainWindowRef;
+    if (!win || win.isDestroyed() || win.webContents.isLoading()) {
+        // No window (tray-resident), or a fresh window whose renderer hasn't
+        // registered listeners yet (a did-finish-load push races React's
+        // mount) — park the payload for the renderer's mount-time drain and
+        // make sure a window is coming.
+        markPendingTakeMeetingNotes(payload);
+        revealAppRef?.();
         return;
     }
 
+    focusWindow(win);
     win.webContents.send("app:takeMeetingNotes", payload);
 }
 

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -69,7 +69,7 @@ import { loadNotificationSettings, saveNotificationSettings } from '@x/core/dist
 import { saveAppSettings } from '@x/core/dist/config/app_settings.js';
 import { setSelfCaptureActive } from '@x/core/dist/meetings/detector.js';
 import { notifyIfEnabled } from '@x/core/dist/application/notification/notifier.js';
-import { consumePendingToggleMeetingNotes, setTrayRecordingState } from './tray.js';
+import { consumePendingTakeMeetingNotes, consumePendingToggleMeetingNotes, setTrayRecordingState } from './tray.js';
 import { closeMeetingPopup, getMeetingPopupPayload, handleMeetingPopupAction } from './meeting-popup.js';
 
 // Ambient meeting detection must ignore Rowboat's own mic use: meeting
@@ -79,6 +79,20 @@ let meetingRecordingActive = false;
 let voiceCallActive = false;
 function updateSelfCaptureState() {
   setSelfCaptureActive(meetingRecordingActive || voiceCallActive);
+}
+
+/**
+ * Forget all renderer-reported capture state. Called when the main window
+ * closes or its renderer dies: the process that owned the capture is gone
+ * and will never send recording:false — without this, the tray stays on
+ * "Stop recording", popup Take Notes clicks are swallowed, and ambient
+ * detection stays suppressed until app restart.
+ */
+export function resetCaptureState(): void {
+  meetingRecordingActive = false;
+  voiceCallActive = false;
+  updateSelfCaptureState();
+  setTrayRecordingState(false);
 }
 import * as composioHandler from './composio-handler.js';
 import * as appsIndexer from '@x/core/dist/apps/indexer.js';
@@ -447,7 +461,7 @@ function findMainAppWindow(): BrowserWindow | undefined {
     if (w === videoPopoutWin || w.isDestroyed()) return false;
     const url = w.webContents.getURL();
     const isAppWindow = url.startsWith('app://') || url.startsWith('http://localhost');
-    return isAppWindow && !url.includes('#video-popout');
+    return isAppWindow && !url.includes('#video-popout') && !url.includes('#meeting-detected');
   });
 }
 
@@ -885,7 +899,10 @@ export function setupIpcHandlers() {
       return {};
     },
     'app:consumePendingTrayCommand': async () => {
-      return { toggleMeetingNotes: consumePendingToggleMeetingNotes() };
+      return {
+        toggleMeetingNotes: consumePendingToggleMeetingNotes(),
+        takeMeetingNotes: consumePendingTakeMeetingNotes() ?? undefined,
+      };
     },
     'app:getLoginItemSettings': async () => {
       // Dev builds never register a login item (it would point at the dev
@@ -2317,15 +2334,17 @@ export function setupIpcHandlers() {
       }
       return {};
     },
-    'app:focusMainWindow': async () => {
+    'app:focusMainWindow': async (_event, args) => {
       const main = findMainAppWindow();
       if (main) {
         if (main.isMinimized()) main.restore();
         main.show();
         main.focus();
-        // The user is typically in another app (e.g. just left a meeting) —
-        // a plain focus() won't take the foreground from it.
-        app.focus({ steal: true });
+        // Stealing the OS foreground is opt-in: right for the post-meeting
+        // notes redirect (the user just left a call), wrong for ambient
+        // callers like in-call assistant navigation, where yanking focus
+        // mid-keystroke from the app the user is working in is hostile.
+        if (args?.steal) app.focus({ steal: true });
       }
       return {};
     },

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -1,8 +1,8 @@
 import { app, BrowserWindow, desktopCapturer, dialog, protocol, net, shell, session, safeStorage, type Session } from "electron";
 import path from "node:path";
-import os from "node:os";
 import {
   setupIpcHandlers,
+  resetCaptureState,
   startRunsWatcher, startSessionsWatcher, startTurnEventsWatcher, markSessionsIndexReady,
   startCodeRunFeedWatcher,
   startChannelsWatcher,
@@ -63,12 +63,19 @@ import {
   dispatchUrl,
   extractDeepLinkFromArgv,
   setMainWindowForDeepLinks,
+  setRevealAppForDeepLinks,
 } from "./deeplink.js";
 import { disconnectGoogleIfScopesStale } from "./oauth-handler.js";
 import { startModelsDevRefresh } from "@x/core/dist/models/models-dev.js";
 import { loadAppSettings, saveAppSettings } from "@x/core/dist/config/app_settings.js";
 import { init as initMeetingDetection } from "@x/core/dist/meetings/detector.js";
-import { createAppTray, hasTray, isRecordingActive, markPendingToggleMeetingNotes } from "./tray.js";
+import {
+  createAppTray,
+  hasTray,
+  isRecordingActive,
+  markPendingTakeMeetingNotes,
+  markPendingToggleMeetingNotes,
+} from "./tray.js";
 import { initMeetingPopup, showMeetingPopup } from "./meeting-popup.js";
 
 // Captured as early as possible so it reflects actual process start. Used to
@@ -136,6 +143,10 @@ app.on("open-url", (event, url) => {
 app.on("second-instance", (_event, argv) => {
   const url = extractDeepLinkFromArgv(argv);
   if (url) dispatchUrl(url);
+  // A second launch is the user asking for the app. With the tray keeping
+  // the process alive after the window closes (Windows/Linux especially),
+  // this is the only path that can reopen the window on those platforms.
+  showApp();
 });
 
 // Fix PATH for packaged Electron apps on macOS/Linux.
@@ -322,21 +333,36 @@ function showApp(): void {
  * Used to start with the window hidden so login launches are invisible.
  *
  * - Windows: our login item registers with an explicit --hidden arg.
- * - macOS: wasOpenedAtLogin when available. On macOS 13+ (SMAppService)
- *   Electron doesn't reliably populate it (electron#37244), so fall back to
- *   a heuristic: a packaged launch while registered as a login item within
- *   two minutes of boot is treated as a login launch.
+ * - macOS: wasOpenedAtLogin only. On macOS 13+ (SMAppService) Electron may
+ *   not populate it (electron#37244) — a login launch then shows the window,
+ *   which is the acceptable failure direction. The previous uptime<120s
+ *   heuristic failed the other way: a MANUAL launch right after boot started
+ *   hidden and looked like the app didn't open at all.
  */
 function wasLaunchedAtLogin(): boolean {
   if (process.argv.includes("--hidden")) return true;
   if (process.platform !== "darwin" || !app.isPackaged) return false;
   try {
-    const settings = app.getLoginItemSettings();
-    if (settings.wasOpenedAtLogin) return true;
-    return settings.openAtLogin && os.uptime() < 120;
+    return app.getLoginItemSettings().wasOpenedAtLogin === true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Deliver a take-meeting-notes payload to the renderer. On a freshly created
+ * (or still-loading) window a push races the renderer's listener
+ * registration — React subscribes after mount, later than did-finish-load —
+ * so the payload is parked and the renderer pulls it on mount instead (same
+ * pattern as pending deep links and tray toggles).
+ */
+function sendTakeMeetingNotes(payload: { event: unknown; openMeeting: boolean; source?: string }): void {
+  const win = mainWindow;
+  if (!win || win.isDestroyed() || win.webContents.isLoading()) {
+    markPendingTakeMeetingNotes(payload);
+    return;
+  }
+  win.webContents.send("app:takeMeetingNotes", payload);
 }
 
 function createWindow(options: { startHidden?: boolean } = {}) {
@@ -371,6 +397,15 @@ function createWindow(options: { startHidden?: boolean } = {}) {
   win.on("closed", () => {
     if (mainWindow === win) mainWindow = null;
     setMainWindowForDeepLinks(null);
+    // The renderer owned any active capture — it died with the window and
+    // can never send recording:false. Without this reset the tray stays on
+    // "Stop recording", future popup Take Notes clicks are swallowed, and
+    // ambient detection stays suppressed until app restart.
+    resetCaptureState();
+  });
+  win.webContents.on("render-process-gone", () => {
+    // Same invariant on a crashed renderer that leaves the window up.
+    resetCaptureState();
   });
 
   // Show window when content is ready to prevent blank screen.
@@ -519,6 +554,9 @@ app.whenReady().then(async () => {
   }
 
   createWindow({ startHidden: wasLaunchedAtLogin() });
+  // Deep links / notification clicks must be able to reveal (or recreate)
+  // the window when the app is tray-resident with none open.
+  setRevealAppForDeepLinks(showApp);
 
   // Menu bar icon: open the app / start-stop meeting notes without the
   // window. If the renderer isn't ready to receive the toggle (window closed
@@ -548,20 +586,16 @@ app.whenReady().then(async () => {
       // The user may have started recording between popup and click —
       // sending the take-notes flow then would toggle it OFF.
       if (isRecordingActive()) return;
-      const payload = {
+      sendTakeMeetingNotes({
         event: meeting.calendarEvent ?? { summary: meeting.noteTitle },
         openMeeting: false,
-        source: "detected",
-      };
-      const win = mainWindow;
-      if (!win || win.isDestroyed()) return;
-      if (win.webContents.isLoading()) {
-        win.webContents.once("did-finish-load", () => {
-          if (!win.isDestroyed()) win.webContents.send("app:takeMeetingNotes", payload);
-        });
-        return;
-      }
-      win.webContents.send("app:takeMeetingNotes", payload);
+        // A matched event carries its calendar_sync path so the summarizer
+        // can resolve attendees/organizer; ad-hoc detections are marked
+        // 'detected' and never masquerade as calendar data downstream.
+        source: meeting.calendarEvent
+          ? meeting.calendarEventSource ?? "calendar-sync"
+          : "detected",
+      });
     },
   });
   initMeetingDetection({

--- a/apps/x/apps/main/src/tray.ts
+++ b/apps/x/apps/main/src/tray.ts
@@ -40,6 +40,22 @@ export function consumePendingToggleMeetingNotes(): boolean {
   return value;
 }
 
+// A take-meeting-notes payload (detection popup / calendar notification)
+// that couldn't be delivered: pushes race the renderer's listener
+// registration on a freshly created window, so the renderer pulls this on
+// mount instead.
+let pendingTakeMeetingNotes: unknown | null = null;
+
+export function markPendingTakeMeetingNotes(payload: unknown): void {
+  pendingTakeMeetingNotes = payload;
+}
+
+export function consumePendingTakeMeetingNotes(): unknown | null {
+  const value = pendingTakeMeetingNotes;
+  pendingTakeMeetingNotes = null;
+  return value;
+}
+
 function buildTrayIcon() {
   const icon = nativeImage.createEmpty();
   icon.addRepresentation({

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -687,6 +687,45 @@ function viewStatesEqual(a: ViewState, b: ViewState): boolean {
  *   live-notes:       ?type=live-notes
  *   email:            ?type=email
  */
+interface TakeMeetingNotesPayload {
+  event: unknown
+  openMeeting?: boolean
+  source?: string
+}
+
+// Start the take-meeting-notes flow from a main-process payload (calendar
+// notification click or detection popup). Module-level so both the live IPC
+// push and the mount-time pending drain share one implementation. When
+// `openMeeting` is true, also opens the meeting URL in the system browser.
+function handleTakeMeetingNotesPayload({ event, openMeeting, source }: TakeMeetingNotesPayload) {
+  const e = event as {
+    summary?: string
+    start?: { dateTime?: string; date?: string; timeZone?: string }
+    end?: { dateTime?: string; date?: string; timeZone?: string }
+    location?: string
+    htmlLink?: string
+    hangoutLink?: string
+    conferenceData?: { entryPoints?: Array<{ entryPointType?: string; uri?: string }> }
+  }
+  if (!e || typeof e !== 'object') return
+  const conferenceLink = extractConferenceLink(e as Record<string, unknown>)
+  if (openMeeting && conferenceLink) {
+    window.open(conferenceLink, '_blank')
+  } else if (openMeeting) {
+    console.warn('[take-meeting-notes] openMeeting requested but event has no conference link', e)
+  }
+  window.__pendingCalendarEvent = {
+    summary: e.summary,
+    start: e.start,
+    end: e.end,
+    location: e.location,
+    htmlLink: e.htmlLink,
+    conferenceLink,
+    source: source ?? 'calendar-sync',
+  }
+  window.dispatchEvent(new Event('calendar-block:join-meeting'))
+}
+
 function parseDeepLink(input: string): ViewState | null {
   const SCHEME = 'rowboat://'
   if (!input.startsWith(SCHEME)) return null
@@ -1105,7 +1144,14 @@ function App() {
   const practiceModeRef = useRef(false)
 
   const handleToggleMeetingRef = useRef<(() => void) | undefined>(undefined)
+  // Why the recording stopped — decides the post-summary behavior. A
+  // call-end or manual stop foregrounds Rowboat on the finished note; a
+  // silence-backstop stop (user forgot a recording was running, possibly
+  // long ago) must never yank focus — the background notification is the
+  // re-entry point there.
+  const meetingStopReasonRef = useRef<'manual' | 'silence' | 'call-ended'>('manual')
   const meetingTranscription = useMeetingTranscription(() => {
+    meetingStopReasonRef.current = 'silence'
     handleToggleMeetingRef.current?.()
   })
 
@@ -1123,6 +1169,7 @@ function App() {
   useEffect(() => {
     if (meetingTranscription.state !== 'recording') return
     return window.ipc.on('meeting:externalCallEnded', () => {
+      meetingStopReasonRef.current = 'call-ended'
       handleToggleMeetingRef.current?.()
     })
   }, [meetingTranscription.state])
@@ -4735,49 +4782,29 @@ function App() {
   }, [])
 
   // Tray menu "Start/Stop meeting notes": same toggle as the Meetings header
-  // button. Also drains a toggle parked while the window was closed/loading
-  // (mirrors the pending deep-link pull above).
+  // button. Also drains commands parked while the window was closed/loading
+  // (mirrors the pending deep-link pull above): the toggle flag AND any
+  // take-meeting-notes payload whose push would have raced this mount.
   useEffect(() => {
-    void window.ipc.invoke('app:consumePendingTrayCommand', null).then(({ toggleMeetingNotes }) => {
-      if (toggleMeetingNotes) handleToggleMeetingRef.current?.()
+    void window.ipc.invoke('app:consumePendingTrayCommand', null).then(({ toggleMeetingNotes, takeMeetingNotes }) => {
+      if (takeMeetingNotes) {
+        handleTakeMeetingNotesPayload(takeMeetingNotes as TakeMeetingNotesPayload)
+      }
+      if (toggleMeetingNotes) {
+        meetingStopReasonRef.current = 'manual'
+        handleToggleMeetingRef.current?.()
+      }
     })
     return window.ipc.on('app:toggleMeetingNotes', () => {
+      meetingStopReasonRef.current = 'manual'
       handleToggleMeetingRef.current?.()
     })
   }, [])
 
-  // Triggered by main when the user clicks a calendar-meeting notification.
-  // Reuses the same flow as the in-app "Join meeting & take notes" button.
-  // When `openMeeting` is true, also opens the meeting URL in the system browser.
+  // Triggered by main when the user clicks a calendar-meeting notification
+  // or the detection popup's Take Notes (pushed live, or drained above).
   useEffect(() => {
-    return window.ipc.on('app:takeMeetingNotes', ({ event, openMeeting, source }) => {
-      const e = event as {
-        summary?: string
-        start?: { dateTime?: string; date?: string; timeZone?: string }
-        end?: { dateTime?: string; date?: string; timeZone?: string }
-        location?: string
-        htmlLink?: string
-        hangoutLink?: string
-        conferenceData?: { entryPoints?: Array<{ entryPointType?: string; uri?: string }> }
-      }
-      if (!e || typeof e !== 'object') return
-      const conferenceLink = extractConferenceLink(e as Record<string, unknown>)
-      if (openMeeting && conferenceLink) {
-        window.open(conferenceLink, '_blank')
-      } else if (openMeeting) {
-        console.warn('[take-meeting-notes] openMeeting requested but event has no conference link', e)
-      }
-      window.__pendingCalendarEvent = {
-        summary: e.summary,
-        start: e.start,
-        end: e.end,
-        location: e.location,
-        htmlLink: e.htmlLink,
-        conferenceLink,
-        source: source ?? 'calendar-sync',
-      }
-      window.dispatchEvent(new Event('calendar-block:join-meeting'))
-    })
+    return window.ipc.on('app:takeMeetingNotes', handleTakeMeetingNotesPayload)
   }, [])
 
   const handleBaseConfigChange = useCallback((path: string, config: BaseConfig) => {
@@ -5714,10 +5741,15 @@ function App() {
               // Refresh the file view
               await handleVoiceNoteCreated(notePath)
               // Notes are done — bring Rowboat to the foreground on the
-              // finished note (the post-call "redirect"). The notification
-              // below is background-only, so it only fires if the focus
-              // grab didn't take.
-              void window.ipc.invoke('app:focusMainWindow', null).catch(() => {})
+              // finished note (the post-call "redirect"), but only for stops
+              // the user is expecting NOW (hang-up detection or a manual
+              // stop). A silence-backstop stop fires with zero user action,
+              // possibly long after the user forgot the recording — stealing
+              // focus then is hostile; the background-only notification
+              // below is the re-entry point in every case.
+              if (meetingStopReasonRef.current !== 'silence') {
+                void window.ipc.invoke('app:focusMainWindow', { steal: true }).catch(() => {})
+              }
               void window.ipc
                 .invoke('meeting:notifyNotesReady', { notePath, title: noteTitle })
                 .catch(() => { /* notification is best-effort */ })
@@ -5729,6 +5761,7 @@ function App() {
         }
         setMeetingSummarizing(false)
         meetingNotePathRef.current = null
+        meetingStopReasonRef.current = 'manual'
       }
     } else if (meetingTranscription.state === 'idle') {
       // On macOS, check screen recording permission before starting

--- a/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
+++ b/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
@@ -99,7 +99,12 @@ function formatTranscript(entries: TranscriptEntry[], date: string, calendarEven
         `title: ${noteTitle}`,
         `date: "${date}"`,
     ];
-    if (calendarEvent) {
+    // Ad-hoc detected meetings carry a synthetic event that only names the
+    // note ("Slack huddle") — it is NOT calendar data. Writing it as
+    // calendar_event would make the summarizer treat it as a real linked
+    // event with zero attendees, whose prompt rules then strip every
+    // speaker name from the notes.
+    if (calendarEvent && calendarEvent.source !== 'detected') {
         // Serialize as a JSON string on one line — the frontmatter system
         // only supports flat key: value pairs, not nested YAML objects.
         const eventObj: Record<string, string> = {}

--- a/apps/x/packages/core/src/meetings/detector.ts
+++ b/apps/x/packages/core/src/meetings/detector.ts
@@ -262,10 +262,29 @@ function spawnHelper(helperPath: string): void {
     });
 }
 
+/**
+ * Is the mic being used by something that could be a meeting? With owner
+ * attribution (macOS 14.4+), only call-capable owners count — system daemons
+ * like corespeechd ("Hey Siri" keeps a permanent low-power mic tap open),
+ * dictation, or audio recorders neither start the detection debounce nor
+ * claim the once-per-session slot. Keying the session on raw mic-in-use
+ * shipped a bug where Siri's always-on tap claimed the session at launch and
+ * never released it, so real meetings never prompted. Without attribution,
+ * fall back to raw device state.
+ */
+function meetingRelevantMicInUse(): boolean {
+    if (!micInUse) return false;
+    if (micOwners.length === 0) return true;
+    return micOwners.some((owner) => {
+        const match = matchOwner(owner);
+        return match !== null && match !== "self";
+    });
+}
+
 function tick(onDetected: DetectorOptions["onDetected"]): void {
     const now = Date.now();
 
-    if (!micInUse) {
+    if (!meetingRelevantMicInUse()) {
         micInUseSince = null;
         if (micIdleSince === null) micIdleSince = now;
         if (sessionNotified && now - micIdleSince >= MIC_SESSION_RESET_MS) {

--- a/apps/x/packages/core/src/meetings/detector.ts
+++ b/apps/x/packages/core/src/meetings/detector.ts
@@ -43,9 +43,10 @@ const MIC_SESSION_RESET_MS = 30_000;
 // (Granola merges ad-hoc calls within 15 minutes of a scheduled event).
 const CALENDAR_MERGE_LEAD_MS = 15 * 60_000;
 // While recording, the meeting app must be off the mic this long before we
-// call the meeting over. Kept short so notes arrive right after hang-up;
-// only guards against sub-poll device churn, not full reconnects.
-const CALL_END_GRACE_MS = 1_000;
+// call the meeting over. Long enough to survive an input-device switch
+// (AirPods in/out tears down and rebuilds the app's audio engine, often >1s)
+// while still wrapping up within seconds of a real hang-up.
+const CALL_END_GRACE_MS = 5_000;
 const CALENDAR_SYNC_DIR = path.join(WorkDir, "calendar_sync");
 const HELPER_MAX_RESTARTS = 3;
 
@@ -61,6 +62,12 @@ export interface DetectedMeeting {
     noteTitle: string;
     /** Raw calendar event JSON when a nearby event matched. */
     calendarEvent?: Record<string, unknown>;
+    /**
+     * WorkDir-relative path of the matched event's calendar_sync JSON —
+     * downstream (note frontmatter → summarizer) uses it to load attendees
+     * and organizer. Only set when calendarEvent is.
+     */
+    calendarEventSource?: string;
 }
 
 interface PlatformMatch {
@@ -86,20 +93,14 @@ const BUNDLE_MATCHERS: Array<{ prefix: string; app: string; kind: DetectedMeetin
     { prefix: "org.mozilla.firefox", app: "Firefox", kind: "meeting" },
     { prefix: "com.brave.browser", app: "Brave Browser", kind: "meeting" },
     { prefix: "com.microsoft.edgemac", app: "Microsoft Edge", kind: "meeting" },
+    // Dia before Arc: both are The Browser Company bundles, so the more
+    // specific prefix must win.
+    { prefix: "company.thebrowser.dia", app: "Dia", kind: "meeting" },
     { prefix: "company.thebrowser", app: "Arc", kind: "meeting" },
 ];
 
 // Rowboat's own capture (and the dev Electron shell) — never a "meeting".
 const SELF_BUNDLE_PREFIXES = ["com.rowboat", "com.github.electron"];
-
-const BROWSER_APPS = new Set([
-    "Google Chrome",
-    "Safari",
-    "Firefox",
-    "Brave Browser",
-    "Microsoft Edge",
-    "Arc",
-]);
 
 // Process-name fallbacks (case-insensitive prefix on the executable
 // basename): used when an owner has no bundle ID, and by the pre-14.4
@@ -125,6 +126,11 @@ const BROWSERS = [
     "Dia",
     "Comet",
 ];
+
+// Single source of truth for "is this app a browser": derived, so a browser
+// added to BROWSERS can never silently count as a dedicated meeting app in
+// the attribution preference.
+const BROWSER_APPS = new Set(BROWSERS);
 
 const KIND_TITLES: Record<DetectedMeetingKind, string> = {
     huddle: "Huddle detected",
@@ -171,6 +177,11 @@ let callEndFired = false;
  * prompt about our own audio.
  */
 export function setSelfCaptureActive(active: boolean): void {
+    // No-op invokes (e.g. an assistant voice-state flicker while a meeting
+    // recording keeps the combined state true) must not touch the armed
+    // call-end watch — a reset landing after the meeting app's last mic
+    // release would make re-arming impossible and silently kill auto-stop.
+    if (active === selfCaptureActive) return;
     selfCaptureActive = active;
     // Fresh capture session — re-arm call-end tracking.
     externalAppSeen = false;
@@ -368,16 +379,18 @@ async function detect(onDetected: DetectorOptions["onDetected"]): Promise<void> 
         return;
     }
 
-    const calendarEvent = await findNearbyCalendarEvent();
+    const nearby = await findNearbyCalendarEvent();
     const eventSummary =
-        typeof calendarEvent?.summary === "string" ? calendarEvent.summary.trim() : "";
+        typeof nearby?.event.summary === "string" ? nearby.event.summary.trim() : "";
 
     const meeting: DetectedMeeting = {
         kind: source.kind,
         title: KIND_TITLES[source.kind],
         appName: source.app,
         noteTitle: eventSummary || defaultNoteTitle(source),
-        ...(calendarEvent ? { calendarEvent } : {}),
+        ...(nearby
+            ? { calendarEvent: nearby.event, calendarEventSource: nearby.sourcePath }
+            : {}),
     };
 
     console.log(
@@ -390,9 +403,7 @@ async function detect(onDetected: DetectorOptions["onDetected"]): Promise<void> 
 function defaultNoteTitle(source: PlatformMatch): string {
     if (source.kind === "huddle") return `${source.app} huddle`;
     if (source.kind === "call") return `${source.app} call`;
-    return BROWSER_APPS.has(source.app) || BROWSERS.includes(source.app)
-        ? "Meeting"
-        : `${source.app} meeting`;
+    return BROWSER_APPS.has(source.app) ? "Meeting" : `${source.app} meeting`;
 }
 
 /** Match a mic owner to a platform (or to Rowboat itself). */
@@ -500,7 +511,11 @@ interface CalendarEvent {
  * before its start through its end. Skips all-day, cancelled, and
  * self-declined events. Ties go to the event that started most recently.
  */
-async function findNearbyCalendarEvent(): Promise<CalendarEvent | null> {
+async function findNearbyCalendarEvent(): Promise<{
+    event: CalendarEvent;
+    /** WorkDir-relative path to the event's calendar_sync JSON. */
+    sourcePath: string;
+} | null> {
     let files: string[];
     try {
         files = await fs.readdir(CALENDAR_SYNC_DIR);
@@ -509,7 +524,7 @@ async function findNearbyCalendarEvent(): Promise<CalendarEvent | null> {
     }
 
     const now = Date.now();
-    let best: { event: CalendarEvent; startMs: number } | null = null;
+    let best: { event: CalendarEvent; sourcePath: string; startMs: number } | null = null;
 
     for (const name of files) {
         if (!name.endsWith(".json") || name.startsWith("sync_state")) continue;
@@ -531,8 +546,10 @@ async function findNearbyCalendarEvent(): Promise<CalendarEvent | null> {
         const endMs = endStr ? Date.parse(endStr) : startMs + 60 * 60_000;
 
         if (now < startMs - CALENDAR_MERGE_LEAD_MS || now > endMs) continue;
-        if (!best || startMs > best.startMs) best = { event, startMs };
+        if (!best || startMs > best.startMs) {
+            best = { event, sourcePath: `calendar_sync/${name}`, startMs };
+        }
     }
 
-    return best?.event ?? null;
+    return best ? { event: best.event, sourcePath: best.sourcePath } : null;
 }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -792,7 +792,10 @@ const ipcSchemas = {
   // Bring the main app window to the foreground (e.g. the assistant navigated
   // the UI during a call while the user was in another app).
   'app:focusMainWindow': {
-    req: z.null(),
+    // steal: also take the OS foreground from another app. Opt-in — right
+    // for the post-meeting notes redirect, wrong for ambient callers like
+    // in-call assistant navigation.
+    req: z.union([z.null(), z.object({ steal: z.boolean().optional() })]),
     res: z.object({}),
   },
   'app:takeMeetingNotes': {
@@ -851,6 +854,10 @@ const ipcSchemas = {
     req: z.null(),
     res: z.object({
       toggleMeetingNotes: z.boolean(),
+      // A parked app:takeMeetingNotes payload ({event, openMeeting, source})
+      // that couldn't be pushed — pushes race listener registration on a
+      // freshly created window.
+      takeMeetingNotes: z.unknown().optional(),
     }),
   },
   // Main → renderer: tray menu "Start/Stop meeting notes" — runs the same


### PR DESCRIPTION
## Two fixes for v0.7.6

### 1. Meeting detection blind when Siri/dictation holds the mic (the v0.7.5 report)

`corespeechd` ("Hey Siri") keeps a permanent low-power mic tap open. The detector's once-per-session logic keyed on raw mic-in-use, so it claimed the session at launch (owner matched no meeting app → silent) and never re-armed (mic never idle 30s). Real meetings then never prompted. Fixed by keying the debounce/session on meeting-relevant mic owners only; system daemons and recorders are now invisible to detection.

### 2. The 10 confirmed findings from the pre-merge review of #748

- **Notes quality (worst):** ad-hoc detected meetings fabricated a calendar event with no attendees — the summarizer's prompt rules then stripped every speaker name from the notes; matched real events lost attendee resolution because their source path was overwritten with 'detected'. Ad-hoc notes no longer write calendar_event frontmatter; matched events (and now the calendar-notification deep-link path too) carry their true calendar_sync path.
- **Resident-mode delivery:** popup Take Notes / notification clicks were lost when the window was closed or freshly created (push raced React listener registration). Payloads now park and drain on renderer mount; deep links reveal/create the window.
- **Stale capture state:** window close or renderer crash mid-recording left the tray stuck on 'Stop recording', swallowed future popups, suppressed detection — and the stale Stop started a NEW recording. Main resets capture state on closed/render-process-gone.
- **Call-end robustness:** grace 1s → 5s (AirPods/device switches release the mic >1s mid-call and falsely ended meetings, unrecoverably); no-op self-capture updates no longer reset the armed call-end watch (assistant voice flicker could kill auto-stop).
- **Focus scoping:** steal is opt-in — post-meeting redirect steals, in-call assistant navigation doesn't, silence-backstop stops don't foreground at all.
- **Window lifecycle:** second-instance relaunch reveals the window (Windows/Linux tray-resident relaunch did nothing); the uptime<120s login heuristic is gone (manual launch right after boot started hidden); findMainAppWindow excludes the detection popup.
- **Detector hygiene:** single browser list (Comet/Dia could out-rank Zoom in attribution); Dia bundle prefix before Arc's.

## Testing
- Typecheck/lint clean; dev boot verified.
- End-to-end verified on a Siri-enabled Mac (the v0.7.5 repro machine): detection prompts with corespeechd on the mic.