### PR TITLE
fix(x): don't re-apply stale assistant email search on re-entering email view

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -4281,6 +4281,9 @@ function App() {
       setEmailInitialThreadId(threadId)
       setEmailThreadIdVersion((v) => v + 1)
     }
+    // Same reason as in navigateToView: a stale assistant-driven search must
+    // not repopulate the search box when the user re-enters the email view.
+    setEmailInitialSearchQuery(null)
     ensureEmailFileTab()
   }, [ensureEmailFileTab])
 
@@ -4455,6 +4458,10 @@ function App() {
         if (view.searchQuery) {
           setEmailInitialSearchQuery(view.searchQuery)
           setEmailSearchQueryVersion((v) => v + 1)
+        } else {
+          // Otherwise a past assistant-driven search would be re-applied on
+          // every re-entry, even after the user cleared the search box.
+          setEmailInitialSearchQuery(null)
         }
         ensureEmailFileTab()
         return


### PR DESCRIPTION
## Problem

Search in the email section resurrected itself: search for something (via the assistant's read-view email search), clear the search box, navigate to another section, come back — and the old search is applied again.

## Cause

When the assistant navigates to the email view with a search, the query is stored in `emailInitialSearchQuery` in `App.tsx` and passed to `EmailView`, whose mount effect loads it into the search box. The stored value was never cleared, and `EmailView` unmounts when you leave the section — so every re-entry remounted the view and re-injected the stale query, overriding whatever the user had done since.

## Fix

Clear the stored query on any email navigation that doesn't carry an explicit search:

- `navigateToView` email case: reset `emailInitialSearchQuery` to null when `view.searchQuery` is absent
- `openEmailView` (sidebar entry path): always reset it, since this path never sets a search

Deep-linked searches (assistant email search) still apply — exactly once, on the navigation that carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)