### PR TITLE
fix(x): grant first_app_built credit for copilot-built apps

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1814,6 +1814,13 @@ export function setupIpcHandlers() {
         lastAppsFingerprint = fingerprint;
         invalidateCopilotInstructionsCache();
       }
+      // The copilot builds apps by writing the folder directly — apps:create is
+      // never on that path — so the first-app reward triggers off observed
+      // state instead: a valid non-installed app means the user built one.
+      // Cheap on repeat polls (maybeActivateCredit short-circuits once claimed).
+      if (apps.some((a) => a.kind === 'local' && a.status === 'ok')) {
+        void maybeActivateCredit('first_app_built');
+      }
       return {
         serverRunning: status.running,
         ...(status.error ? { serverError: status.error } : {}),


### PR DESCRIPTION
## Problem

The `first_app_built` reward only fired in the `apps:create` IPC handler, but no UI path invokes it — the copilot builds apps by writing the folder to `~/.rowboat/apps/` directly. So building an app never granted the credit (all other rewards worked).

## Fix

Fire `maybeActivateCredit('first_app_built')` from the `apps:list` handler, off observed state: any valid non-installed app (`kind: 'local'`) means the user built one.

- Catalog installs don't count — they carry `.rowboat-install.json` and index as `kind: 'installed'`.
- Repeat polls are cheap: after the grant, the call short-circuits on the local claimed file before any flag/billing/network work (same pattern as the other rewards).
- The `apps:create` trigger is left in place; it's harmless and correct if that path is ever used.

## Testing

Verified on a fresh account against staging: built an app via copilot, credit granted on the next apps poll. Typecheck clean; the existing lint errors on main are in unrelated files.

Note: existing users who built an app before this feature get the credit on their first poll after updating — fair, and the backend enforces once-per-user regardless.