### PR TITLE
feat(x): scrollable release-notes box on the update card, notes on Windows too

### DIFF
--- a/apps/x/apps/main/src/updater.ts
+++ b/apps/x/apps/main/src/updater.ts
@@ -1,4 +1,4 @@
-import { app, autoUpdater, nativeImage, BrowserWindow } from "electron";
+import { app, autoUpdater, net, nativeImage, BrowserWindow } from "electron";
 import { capture } from "@x/core/dist/analytics/posthog.js";
 import type { ipc } from "@x/shared";
 
@@ -90,6 +90,12 @@ export function initUpdater(): void {
       releaseNotes: releaseNotes || undefined,
     });
     showReadyBadge();
+    // Squirrel.Windows never carries notes, and Squirrel.Mac's copy is a
+    // snapshot from download time — stale when the release body is edited
+    // after publish (update.electronjs.org caching widens that window).
+    // Refresh from the GitHub API; on failure the snapshot (or the card's
+    // static fallback line) stands.
+    void backfillReleaseNotes(releaseName || undefined);
   });
   autoUpdater.on("error", (err) => {
     setStatus({ state: "error", error: err.message, lastCheckedAt: status.lastCheckedAt });
@@ -108,6 +114,30 @@ export function initUpdater(): void {
   // update is already staged.
   checkForUpdates();
   setInterval(checkForUpdates, CHECK_INTERVAL_MS);
+}
+
+/**
+ * Replace the staged update's release notes with the current GitHub release
+ * body. releaseName is "0.7.7" from Squirrel.Windows and "v0.7.7" from
+ * Squirrel.Mac — normalize to the tag form.
+ */
+async function backfillReleaseNotes(releaseName: string | undefined): Promise<void> {
+  if (!releaseName) return;
+  try {
+    const tag = `v${releaseName.replace(/^v/, "")}`;
+    const res = await net.fetch(`https://api.github.com/repos/${REPO}/releases/tags/${tag}`, {
+      headers: { Accept: "application/vnd.github+json", "User-Agent": "Rowboat" },
+    });
+    if (!res.ok) return;
+    const { body } = (await res.json()) as { body?: string };
+    const notes = body?.trim();
+    // Re-check the state: the fetch raced user actions (quitAndInstall).
+    if (notes && status.state === "ready" && status.newVersion === releaseName) {
+      setStatus({ ...status, releaseNotes: notes });
+    }
+  } catch {
+    // Offline or rate-limited — the Squirrel snapshot / fallback line stands.
+  }
 }
 
 /**

--- a/apps/x/apps/renderer/src/components/update-card.tsx
+++ b/apps/x/apps/renderer/src/components/update-card.tsx
@@ -55,6 +55,11 @@ export function UpdateCard() {
   if (!visible || status?.state !== "ready") return null
 
   const releaseUrl = version ? `${RELEASES_URL}/tag/v${version}` : `${RELEASES_URL}/latest`
+  // Release bodies usually open with their own "What's new" heading, which
+  // would duplicate the card's label above the box — drop it.
+  const releaseNotes = status.releaseNotes
+    ?.replace(/^\s*#{1,6}[ \t]*what[’']?s new[ \t]*\r?\n+/i, "")
+    .trim()
 
   return (
     <div
@@ -81,10 +86,13 @@ export function UpdateCard() {
       </p>
       <div className="mt-3">
         <h5 className="text-xs font-semibold">What&apos;s new</h5>
-        {status.releaseNotes ? (
-          <div className="mt-1.5 max-h-56 overflow-y-auto">
+        {releaseNotes ? (
+          // A bordered, fixed-height scroll box (not a bare max-h clip): the
+          // frame and inset scrollbar signal there is more content below the
+          // fold on every platform.
+          <div className="mt-1.5 max-h-56 overflow-y-auto overscroll-contain rounded-md border border-border/60 bg-muted/30 p-2.5">
             <Streamdown className="prose prose-sm dark:prose-invert max-w-none text-xs [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-              {status.releaseNotes}
+              {releaseNotes}
             </Streamdown>
           </div>
         ) : (


### PR DESCRIPTION
## Summary

The update card's release-notes pane had two problems:

- It was a bare `max-h` clip — nothing signalled that more content sat below the fold.
- **Windows users never saw release notes at all**: Squirrel.Windows doesn't supply them, so the card always showed the static fallback line. Squirrel.Mac isn't much better in the edit-after-publish window — it snapshots the release body at download time, which is how v0.7.7 shipped a card showing two paragraphs of a ten-item release.

## Changes

- Render the notes in a bordered, inset scroll box (`max-h` + `overflow-y`) so the frame and scrollbar make overflow visible on both platforms.
- Backfill the notes from the GitHub release body after `update-downloaded`: gives Windows notes for the first time and replaces macOS's stale snapshot with the current body. On fetch failure the snapshot (or the fallback line) stands.
- Strip the release body's leading "What's new" heading, which duplicated the card's own label.

## Test plan

- [ ] macOS: trigger an update, confirm notes render in the scroll box and reflect the current GitHub release body
- [x] Windows: trigger an update, confirm notes appear (previously only the fallback line)
- [ ] Simulate GitHub fetch failure, confirm the snapshot/fallback text still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
