### PR TITLE
fix(uploads): prevent path traversal in /api/uploads/[fileId] route

### DIFF
--- a/apps/rowboat/app/api/uploads/[fileId]/route.ts
+++ b/apps/rowboat/app/api/uploads/[fileId]/route.ts
@@ -9,6 +9,26 @@ const UPLOADS_DIR = process.env.RAG_UPLOADS_DIR || '/uploads';
 
 const dataSourceDocsRepository = container.resolve<IDataSourceDocsRepository>('dataSourceDocsRepository');
 
+/**
+ * Resolve a user-supplied file identifier to an absolute path constrained to
+ * UPLOADS_DIR. Returns null if the resulting path would escape the uploads
+ * directory (e.g. via `..` traversal or an absolute path).
+ */
+function resolveUploadPath(fileId: string): string | null {
+    // Reject path separators and NUL bytes outright — fileIds are meant to be
+    // opaque single-segment identifiers.
+    if (!fileId || fileId.includes('\0') || fileId.includes('/') || fileId.includes('\\')) {
+        return null;
+    }
+    const uploadsRoot = path.resolve(UPLOADS_DIR);
+    const resolved = path.resolve(uploadsRoot, fileId);
+    // Ensure the resolved path is strictly contained within uploadsRoot.
+    if (resolved !== uploadsRoot && !resolved.startsWith(uploadsRoot + path.sep)) {
+        return null;
+    }
+    return resolved;
+}
+
 // PUT endpoint to handle file uploads
 export async function PUT(request: NextRequest, props: { params: Promise<{ fileId: string }> }) {
     const params = await props.params;
@@ -17,7 +37,10 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ fileI
         return NextResponse.json({ error: 'Missing file ID' }, { status: 400 });
     }
 
-    const filePath = path.join(UPLOADS_DIR, fileId);
+    const filePath = resolveUploadPath(fileId);
+    if (!filePath) {
+        return NextResponse.json({ error: 'Invalid file ID' }, { status: 400 });
+    }
 
     try {
         const data = await request.arrayBuffer();
@@ -54,8 +77,12 @@ export async function GET(request: NextRequest, props: { params: Promise<{ fileI
     const fileName = doc.data.name;
 
     try {
-        // strip uploads dir from path
-        const filePath = path.join(UPLOADS_DIR, doc.data.path.split('/api/uploads/')[1]);
+        // strip uploads dir from path and validate containment
+        const rawSegment = doc.data.path.split('/api/uploads/')[1];
+        const filePath = rawSegment ? resolveUploadPath(rawSegment) : null;
+        if (!filePath) {
+            return NextResponse.json({ error: 'File not found' }, { status: 404 });
+        }
 
         // Check if file exists
         await fs.access(filePath);


### PR DESCRIPTION
## Summary

`apps/rowboat/app/api/uploads/[fileId]/route.ts` used the raw `fileId` route parameter directly in `path.join(UPLOADS_DIR, fileId)` for both `PUT` (write) and `GET` (read). Because `path.join` normalizes `..` sequences, a request such as `PUT /api/uploads/..%2F..%2Fetc%2Fpasswd_backup` writes attacker-controlled bytes anywhere the Node process can reach, and the symmetric issue lets `GET` be steered by a `doc.data.path` value into reading files outside the uploads directory.

- **CWE**: CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **Affected file**: `apps/rowboat/app/api/uploads/[fileId]/route.ts` (`PUT` and `GET` handlers)
- **Impact**: Arbitrary file write / arbitrary file read on the server hosting Rowboat, constrained only by the Node process's filesystem permissions. On the shipped Docker image the process has read access to app source, env-file contents, and other config outside the uploads volume.
- **Data flow**: `request.nextUrl.pathname` → dynamic segment `[fileId]` → `params.fileId` → `path.join(UPLOADS_DIR, fileId)` → `fs.writeFile` / `fs.createReadStream`. No validation between source and sink.

## Reachability / auth

`apps/rowboat/middleware.ts` matches `/api/*` early and returns a response that only sets CORS headers — it does **not** invoke `authCheck` for API routes. Concretely:

```ts
if (request.nextUrl.pathname.startsWith('/api/')) {
    // ... CORS-only response, no auth ...
    return response;
}
```

`authCheck` is applied only to `/projects`, `/billing`, and `/onboarding`, and even then only when `USE_AUTH=true`. So `PUT /api/uploads/<anything>` is reachable by any unauthenticated client that can reach the server.

## Fix

Add a small helper that treats `fileId` as an opaque single path segment and rejects anything that could escape `UPLOADS_DIR`:

```ts
function resolveUploadPath(fileId: string): string | null {
    if (!fileId || fileId.includes('\0') || fileId.includes('/') || fileId.includes('\\')) {
        return null;
    }
    const uploadsRoot = path.resolve(UPLOADS_DIR);
    const resolved = path.resolve(uploadsRoot, fileId);
    if (resolved !== uploadsRoot && !resolved.startsWith(uploadsRoot + path.sep)) {
        return null;
    }
    return resolved;
}
```

Both `PUT` and `GET` now route through this helper. The `GET` handler additionally applies it to the segment extracted from `doc.data.path`, so a poisoned database record cannot steer reads outside the uploads directory either. Invalid IDs return `400 Invalid file ID` (PUT) or `404 File not found` (GET), matching the existing error shapes.

Rationale for the specific checks:

- Explicit rejection of `/`, `\`, and NUL means we don't rely solely on `path.join`/`path.resolve` normalization semantics (which vary between platforms and have historically been the source of bypasses like `..%2F` and mixed-separator payloads on Windows).
- `path.resolve(uploadsRoot, fileId)` followed by a `startsWith(uploadsRoot + path.sep)` check is the standard containment pattern.
- `UPLOADS_DIR` is resolved once via `path.resolve`, so the containment check is stable even if `UPLOADS_DIR` is set to a relative path in a dev environment.

## Proof of concept

Against a locally running Rowboat instance (`docker compose up` from the repo root, defaults):

```bash
# Before the fix — writes /tmp/pwned inside the container
curl -X PUT --data 'owned' \
  'http://localhost:3000/api/uploads/..%2F..%2F..%2Ftmp%2Fpwned'
# -> {"success":true}
# Inside the container: cat /tmp/pwned  ->  owned

# After the fix — rejected before touching the filesystem
curl -X PUT --data 'owned' \
  'http://localhost:3000/api/uploads/..%2F..%2F..%2Ftmp%2Fpwned'
# -> {"error":"Invalid file ID"}   (HTTP 400)

# Legitimate uploads still work
curl -X PUT --data 'hello' \
  'http://localhost:3000/api/uploads/abc123'
# -> {"success":true}
```

Because Next.js decodes the dynamic segment before it reaches the handler, `..%2F..%2F..%2Ftmp%2Fpwned` becomes the literal string `../../../tmp/pwned` inside `params.fileId`, which `path.join` collapses relative to `UPLOADS_DIR`.

## Testing

Unit-level checks against `resolveUploadPath` with `UPLOADS_DIR=/uploads`:

| Input | Expected | Result |
|---|---|---|
| `"abc123"` | `/uploads/abc123` | ✅ |
| `"../etc/passwd"` | `null` (contains `/`) | ✅ |
| `"..%2Fetc%2Fpasswd"` (post-decode: `../etc/passwd`) | `null` | ✅ |
| `"..\\windows\\win.ini"` | `null` (contains `\`) | ✅ |
| `"foo\0.txt"` | `null` (NUL) | ✅ |
| `"/etc/passwd"` | `null` | ✅ |
| `""` | `null` | ✅ |
| `".."` | `null` (would resolve to `/`) | ✅ |
| `"file with spaces.pdf"` | `/uploads/file with spaces.pdf` | ✅ |

Manual end-to-end: PUT then GET of a normal `fileId` round-trips a file unchanged; traversal payloads are consistently rejected with the documented error shapes; existing docs whose `data.path` contains `/api/uploads/<id>` continue to resolve.

## Adversarial review

Before submitting, we tried to disprove the finding:

- **Is there middleware auth we missed?** `apps/rowboat/middleware.ts` is the only Next.js middleware in the app; it explicitly short-circuits `/api/*` to a CORS-only response before any auth check, so the "no auth required" claim holds independent of the `USE_AUTH` flag.
- **Does `path.join` already refuse traversal?** It does not. `path.join('/uploads', '../../../tmp/pwned')` returns `/tmp/pwned` on both Linux and macOS — normalization collapses the `..` segments rather than rejecting them.
- **Is `UPLOADS_DIR` a throwaway tmpfs?** In the shipped Docker Compose setup it's a bind-mounted volume alongside the app process, which has read access to source, env, and config elsewhere in the container. The write primitive suffices to overwrite files that get executed or re-read later; the symmetric arbitrary-read via `GET` is a straightforward information-disclosure primitive on its own.
- **Would a reverse proxy / WAF catch this?** Not reliably — the payload is a well-formed URL segment with no `../` visible in the path structure until Next.js decodes it, and self-hosters commonly deploy without a WAF in front.

The finding stands; the fix is minimal and confined to one file.