### PR TITLE
fix(x): show chat timestamps in the user's local timezone

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -3049,7 +3049,18 @@ function App() {
         ...(chatMaxModelCalls !== undefined ? { maxModelCalls: chatMaxModelCalls } : {}),
       }
       const userMessageContextFor = (middlePane: Awaited<ReturnType<typeof buildMiddlePaneContext>>) => ({
-        currentDateTime: new Date().toISOString(),
+        // Local wall-clock with explicit timezone, never toISOString: the model
+        // adopts this as its time frame, so a UTC "now" makes it quote email
+        // timestamps (which carry their own offsets) in UTC instead of local.
+        currentDateTime: `${new Date().toLocaleString('en-US', {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          timeZoneName: 'short',
+        })} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`,
         middlePane: middlePane ?? { kind: 'empty' as const },
       })
 

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -13,6 +13,7 @@ import { classifyThread, getUserEmail, type EmailCategory } from './classify_thr
 import { recordImportanceCorrection } from './email_importance_feedback.js';
 import { recordCategoryCorrection } from './email_category_feedback.js';
 import { notifyIfEnabled } from '../application/notification/notifier.js';
+import { formatTimestampForModel } from '@x/shared/dist/time.js';
 
 // Configuration
 const SYNC_DIR = path.join(WorkDir, 'gmail_sync');
@@ -365,33 +366,6 @@ export const NEW_EMAIL_MAX_AGE_MS = 5 * 60 * 1000;
  */
 export function isEmailTooOldToNotify(dateMs: number, now: number = Date.now()): boolean {
     return dateMs > 0 && now - dateMs > NEW_EMAIL_MAX_AGE_MS;
-}
-
-/**
- * Format a raw email `Date:` header into the user's local timezone for any text
- * shown to the LLM (tool output, knowledge markdown, thread summaries). Email
- * headers carry their own offset (marketing mail is typically `+0000`); handed
- * to the model raw, it quotes them verbatim in UTC instead of converting to
- * local time — e.g. a 1:06 PM IST email described as "7:36 AM" in chat. Runs in
- * the main process, so `toLocaleString` uses the desktop's system timezone.
- *
- * NOT for the structured `date` field on snapshots/messages — the renderer
- * parses that with `new Date(...)`, so it must stay a raw parseable header.
- * Non-date input (e.g. 'Unknown', '') is returned unchanged.
- */
-export function formatEmailDateLocal(raw: string | undefined | null): string {
-    if (!raw) return '';
-    const parsed = new Date(raw);
-    if (Number.isNaN(parsed.getTime())) return raw;
-    return parsed.toLocaleString('en-US', {
-        weekday: 'short',
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZoneName: 'short',
-    });
 }
 
 /**
@@ -1184,7 +1158,7 @@ async function parseThreadSnapshot(
     const earlier = visibleMessages.slice(0, -1);
     const earlierSummary = earlier
         .map((msg) => {
-            const date = msg.date ? ` (${formatEmailDateLocal(msg.date)})` : '';
+            const date = msg.date ? ` (${formatTimestampForModel(msg.date)})` : '';
             const body = msg.body.replace(/\s+/g, ' ').slice(0, 500).trim();
             return `${msg.from}${date}: ${body}`;
         })
@@ -1357,7 +1331,7 @@ async function processThread(auth: OAuth2Client, threadId: string, syncDir: stri
             const date = headers.find(h => h.name === 'Date')?.value || 'Unknown';
 
             mdContent += `### From: ${from}\n`;
-            mdContent += `**Date:** ${formatEmailDateLocal(date)}\n\n`;
+            mdContent += `**Date:** ${formatTimestampForModel(date)}\n\n`;
 
             if (msg.payload) {
                 const body = getBody(msg.payload);

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -368,6 +368,33 @@ export function isEmailTooOldToNotify(dateMs: number, now: number = Date.now()):
 }
 
 /**
+ * Format a raw email `Date:` header into the user's local timezone for any text
+ * shown to the LLM (tool output, knowledge markdown, thread summaries). Email
+ * headers carry their own offset (marketing mail is typically `+0000`); handed
+ * to the model raw, it quotes them verbatim in UTC instead of converting to
+ * local time — e.g. a 1:06 PM IST email described as "7:36 AM" in chat. Runs in
+ * the main process, so `toLocaleString` uses the desktop's system timezone.
+ *
+ * NOT for the structured `date` field on snapshots/messages — the renderer
+ * parses that with `new Date(...)`, so it must stay a raw parseable header.
+ * Non-date input (e.g. 'Unknown', '') is returned unchanged.
+ */
+export function formatEmailDateLocal(raw: string | undefined | null): string {
+    if (!raw) return '';
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) return raw;
+    return parsed.toLocaleString('en-US', {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZoneName: 'short',
+    });
+}
+
+/**
  * Fire one OS notification per genuinely-new email thread. Only ever called
  * from the partial-sync (incremental) path, so the first-time connect — which
  * goes through fullSync — never notifies. Suppressed while the app is focused,
@@ -1157,7 +1184,7 @@ async function parseThreadSnapshot(
     const earlier = visibleMessages.slice(0, -1);
     const earlierSummary = earlier
         .map((msg) => {
-            const date = msg.date ? ` (${msg.date})` : '';
+            const date = msg.date ? ` (${formatEmailDateLocal(msg.date)})` : '';
             const body = msg.body.replace(/\s+/g, ' ').slice(0, 500).trim();
             return `${msg.from}${date}: ${body}`;
         })
@@ -1330,7 +1357,7 @@ async function processThread(auth: OAuth2Client, threadId: string, syncDir: stri
             const date = headers.find(h => h.name === 'Date')?.value || 'Unknown';
 
             mdContent += `### From: ${from}\n`;
-            mdContent += `**Date:** ${date}\n\n`;
+            mdContent += `**Date:** ${formatEmailDateLocal(date)}\n\n`;
 
             if (msg.payload) {
                 const body = getBody(msg.payload);

--- a/apps/x/packages/core/src/runtime/assembly/__snapshots__/compose-instructions.test.ts.snap
+++ b/apps/x/packages/core/src/runtime/assembly/__snapshots__/compose-instructions.test.ts.snap
@@ -6,7 +6,7 @@ exports[`composeSystemInstructions golden bytes > agent notes 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -27,7 +27,7 @@ exports[`composeSystemInstructions golden bytes > base: no modes active 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -44,7 +44,7 @@ exports[`composeSystemInstructions golden bytes > coach mode 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -72,7 +72,7 @@ exports[`composeSystemInstructions golden bytes > code mode claude with cwd 1`] 
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -105,7 +105,7 @@ exports[`composeSystemInstructions golden bytes > code mode codex without cwd 1`
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -138,7 +138,7 @@ exports[`composeSystemInstructions golden bytes > everything on 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -285,7 +285,7 @@ exports[`composeSystemInstructions golden bytes > search enabled 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -305,7 +305,7 @@ exports[`composeSystemInstructions golden bytes > video mode 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -346,7 +346,7 @@ exports[`composeSystemInstructions golden bytes > voice input 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -368,7 +368,7 @@ exports[`composeSystemInstructions golden bytes > voice output full 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -430,7 +430,7 @@ exports[`composeSystemInstructions golden bytes > voice output summary 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 
@@ -495,7 +495,7 @@ exports[`composeSystemInstructions golden bytes > work directory 1`] = `
 # Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 

--- a/apps/x/packages/core/src/runtime/assembly/compose-instructions.ts
+++ b/apps/x/packages/core/src/runtime/assembly/compose-instructions.ts
@@ -25,7 +25,7 @@ const PROMPT_CAPABILITIES = [
 const USER_CONTEXT_SYSTEM_INSTRUCTIONS = `# Hidden User Context
 User messages may include a hidden "# User Context" section before "# User Message". Treat it as runtime metadata captured when that specific user message was sent. The actual user-authored text starts under "# User Message".
 
-Use "Current date and time" for temporal reasoning.
+Use "Current date and time" for temporal reasoning; it reflects the user's local timezone. Always express dates and times in that local timezone: timestamps inside emails, web content, or tool output may carry other offsets (often UTC) — convert those to local time before repeating them.
 
 If Middle pane context is present, it reflects what the user had open at the time of that specific message and overrides earlier middle-pane references. If the conversation history references a different note or browser page, the user had since closed or navigated away from it. Do not treat earlier context as current.
 

--- a/apps/x/packages/core/src/runtime/tools/domains/app.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/app.ts
@@ -10,7 +10,7 @@ import * as files from "../../../filesystem/files.js";
 import { WorkDir } from "../../../config/config.js";
 import { RowboatAppManifestSchema } from "@x/shared/dist/rowboat-app.js";
 import { listApps } from "../../../apps/indexer.js";
-import { listImportantThreads, searchThreads } from "../../../knowledge/sync_gmail.js";
+import { listImportantThreads, searchThreads, formatEmailDateLocal } from "../../../knowledge/sync_gmail.js";
 import { listTasks as listBackgroundTasks } from "../../../background-tasks/fileops.js";
 import type { ISessions } from "../../sessions/api.js";
 import { BuiltinToolsSchema } from "../types.js";
@@ -113,7 +113,9 @@ export const appNavigationTools: z.infer<typeof BuiltinToolsSchema> = {
                                     threadId: t.threadId,
                                     subject: t.subject ?? '(no subject)',
                                     from: t.from ?? '',
-                                    date: t.date ?? '',
+                                    // Local-timezone string for the model, not the raw
+                                    // header — otherwise it quotes email times in UTC.
+                                    date: formatEmailDateLocal(t.date),
                                     unread: t.unread ?? false,
                                     summary: t.summary ? t.summary.slice(0, 200) : undefined,
                                 }));

--- a/apps/x/packages/core/src/runtime/tools/domains/app.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/app.ts
@@ -10,7 +10,8 @@ import * as files from "../../../filesystem/files.js";
 import { WorkDir } from "../../../config/config.js";
 import { RowboatAppManifestSchema } from "@x/shared/dist/rowboat-app.js";
 import { listApps } from "../../../apps/indexer.js";
-import { listImportantThreads, searchThreads, formatEmailDateLocal } from "../../../knowledge/sync_gmail.js";
+import { listImportantThreads, searchThreads } from "../../../knowledge/sync_gmail.js";
+import { formatTimestampForModel } from "@x/shared/dist/time.js";
 import { listTasks as listBackgroundTasks } from "../../../background-tasks/fileops.js";
 import type { ISessions } from "../../sessions/api.js";
 import { BuiltinToolsSchema } from "../types.js";
@@ -115,7 +116,7 @@ export const appNavigationTools: z.infer<typeof BuiltinToolsSchema> = {
                                     from: t.from ?? '',
                                     // Local-timezone string for the model, not the raw
                                     // header — otherwise it quotes email times in UTC.
-                                    date: formatEmailDateLocal(t.date),
+                                    date: formatTimestampForModel(t.date),
                                     unread: t.unread ?? false,
                                     summary: t.summary ? t.summary.slice(0, 200) : undefined,
                                 }));

--- a/apps/x/packages/shared/src/index.ts
+++ b/apps/x/packages/shared/src/index.ts
@@ -22,5 +22,6 @@ export * as notificationSettings from './notification-settings.js';
 export * as turnLimits from './turn-limits.js';
 export * as codeSessions from './code-sessions.js';
 export * as channels from './channels.js';
+export * as time from './time.js';
 export * as rowboatApp from './rowboat-app.js';
 export { PrefixLogger };

--- a/apps/x/packages/shared/src/time.ts
+++ b/apps/x/packages/shared/src/time.ts
@@ -1,0 +1,34 @@
+/**
+ * Format a timestamp into the user's local timezone for any text shown to the
+ * LLM (tool output, knowledge markdown, thread summaries). External sources
+ * carry their own offsets — email `Date:` headers are typically `+0000`, Slack
+ * uses epoch seconds, calendar APIs return UTC ISO strings. Handed to the model
+ * raw, it quotes them verbatim instead of converting — e.g. a 1:06 PM IST email
+ * described as "7:36 AM" in chat. Call this at every model-facing serialization
+ * boundary; the model's tendency to quote timestamps verbatim then produces
+ * correct output. The weekday is included because models are unreliable at
+ * day-of-week arithmetic. Uses the system timezone of the process it runs in.
+ *
+ * NOT for structured `date` fields that code later parses with `new Date(...)`
+ * — those must stay raw parseable values.
+ *
+ * Accepts a raw date string, epoch milliseconds, or a Date. Unparseable
+ * strings (e.g. 'Unknown') are returned unchanged; null/undefined and invalid
+ * Date/number inputs return ''.
+ */
+export function formatTimestampForModel(raw: string | number | Date | undefined | null): string {
+    if (raw === undefined || raw === null || raw === '') return '';
+    const parsed = raw instanceof Date ? raw : new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+        return typeof raw === 'string' ? raw : '';
+    }
+    return parsed.toLocaleString('en-US', {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZoneName: 'short',
+    });
+}


### PR DESCRIPTION
Chat replies show email timestamps in UTC instead of the user's local time. An email shown as **1:06 PM IST** in the inbox is described as **7:36 AM** in chat — the 5½-hour IST offset. Two root causes, fixed in two commits.

## 1. The model's "current time" was UTC
Every chat message embeds a "Current date and time" line for the model. `App.tsx` built it with `new Date().toISOString()` — a UTC instant with no timezone — so the model had no local frame of reference. Now built from local wall-clock via `toLocaleString` with an explicit `timeZoneName` and IANA zone, e.g. `Tuesday, July 22, 2026 at 5:47 PM GMT+5:30 (Asia/Kolkata)`. Matches what the legacy engine already did.

## 2. Email timestamps reached the model as raw sender-timezone headers
Even with a correct "now," email dates were serialized to the model as their raw RFC 2822 `Date:` headers (marketing mail is sent in `+0000`), so it quoted them verbatim in UTC. Added `formatEmailDateLocal()` and applied it at the three model-facing serialization points:

- the `read-view` email tool result (`app.ts`)
- the thread-summary line (`sync_gmail.ts`, also shown in the email card UI — now local)
- the gmail-sync knowledge markdown `**Date:**` field (`sync_gmail.ts`) — the "read a file" path

The structured `date` field on snapshots/messages is deliberately left raw: the renderer parses it with `new Date(...)` and formats client-side, so that path was already correct.

## Notes / scope
- The "now" fix affects **newly sent** messages; the email-date fix in knowledge markdown applies to **newly synced** emails (existing files keep raw dates until re-synced). Fresh tool reads (`read-view`) are correct immediately.
- Verified conversion: raw `Tue, 21 Jul 2026 07:36:00 +0000` → `Tue, Jul 21, 2026, 1:06 PM GMT+5:30` under `TZ=Asia/Kolkata`; non-date inputs (`Unknown`, empty) pass through unchanged.
- `npm run typecheck` passes.