### PR TITLE
fix(x): default settings dialog tabs to scrollable

### DIFF
--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -2802,7 +2802,10 @@ export function SettingsDialog({ children, defaultTab = "account", open: control
             </div>
 
             {/* Content */}
-            <div className={cn("flex-1 px-6 pb-5 min-h-0", (activeTab === "models" || activeTab === "connections" || activeTab === "mobile" || activeTab === "account" || activeTab === "code-mode" || activeTab === "notifications" || activeTab === "advanced") ? "overflow-y-auto" : activeTab === "note-tagging" ? "overflow-hidden flex flex-col" : "overflow-hidden")}>
+            {/* JSON tabs render a full-height textarea (it scrolls itself);
+                note-tagging manages its own scroll region; everything else
+                scrolls here so tall tabs aren't clipped by the fixed dialog. */}
+            <div className={cn("flex-1 px-6 pb-5 min-h-0", isJsonTab ? "overflow-hidden" : activeTab === "note-tagging" ? "overflow-hidden flex flex-col" : "overflow-y-auto")}>
               {activeTab === "account" ? (
                 <AccountSettings dialogOpen={open} />
               ) : activeTab === "connections" ? (


### PR DESCRIPTION
## Summary
- Inverts the scroll logic for the settings dialog content area: tabs now scroll by default (`overflow-y-auto`), with explicit opt-outs instead of an allowlist.
- JSON editor tabs (`mcp`, `security`) stay `overflow-hidden` since they render a full-height textarea that scrolls itself; `note-tagging` keeps its own scroll region.

## Why
The previous condition enumerated every scrollable tab by name, so each new tab had to remember to add itself to the list or its content would be clipped by the fixed-height dialog. Defaulting to scrollable removes that footgun.

## Notes for review
- Behavior for existing tabs is unchanged: every previously-listed tab still gets `overflow-y-auto`, and `mcp`/`security`/`note-tagging` keep their previous overflow handling.
- Worth a quick manual pass over the settings tabs to confirm scroll behavior.