### PR TITLE
Group consecutive web searches into a collapsible container

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -62,7 +62,10 @@ import {
 import { TurnActivityIndicator } from '@/components/turn-activity-indicator';
 import { useSmoothedText } from './hooks/useSmoothedText';
 import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool';
-import { WebSearchResult } from '@/components/ai-elements/web-search-result';
+import {
+  WebSearchGroupResult,
+  WebSearchResult,
+} from '@/components/ai-elements/web-search-result';
 import { AppActionCard } from '@/components/ai-elements/app-action-card';
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card';
 import { PermissionRequest } from '@/components/ai-elements/permission-request';
@@ -117,6 +120,7 @@ import {
   isErrorMessage,
   isToolCall,
   isToolGroup,
+  isWebSearchGroup,
   isTurnUsageMessage,
   normalizeToolInput,
   normalizeToolOutput,
@@ -6904,6 +6908,14 @@ function App() {
                                   tabState.conversation,
                                   (id) => !!tabState.allPermissionRequests.get(id) || !!tabState.autoPermissionDecisions.get(id)
                                 ).map(item => {
+                                  if (isWebSearchGroup(item)) {
+                                    return (
+                                      <WebSearchGroupResult
+                                        key={item.groupId}
+                                        searches={item.items}
+                                      />
+                                    )
+                                  }
                                   if (isToolGroup(item)) {
                                     return (
                                       <ToolGroupComponent

--- a/apps/x/apps/renderer/src/components/ai-elements/web-search-result.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/web-search-result.tsx
@@ -10,15 +10,22 @@ import {
   ChevronDownIcon,
   GlobeIcon,
   LoaderIcon,
+  XCircleIcon,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
+import {
+  getWebSearchCardData,
+  getWebSearchGroupStatus,
+  type ToolCall,
+} from "@/lib/chat-conversation";
 
 interface WebSearchResultProps {
   query: string;
   results: Array<{ title: string; url: string; description: string }>;
   status: "pending" | "running" | "completed" | "error";
   title?: string;
+  className?: string;
 }
 
 // How long each fetched website stays on the rolling header before the
@@ -92,7 +99,13 @@ function buildSearchedSummary(domains: string[]): React.ReactNode {
 
 type RollPhase = "searching" | "rolling" | "settled";
 
-export function WebSearchResult({ query, results, status, title = "Searched the web" }: WebSearchResultProps) {
+export function WebSearchResult({
+  query,
+  results,
+  status,
+  title = "Searched the web",
+  className,
+}: WebSearchResultProps) {
   const isRunning = status === "pending" || status === "running";
   const [open, setOpen] = useState(false);
 
@@ -201,7 +214,10 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
     <Collapsible
       open={open}
       onOpenChange={setOpen}
-      className="not-prose mb-4 w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30"
+      className={cn(
+        "not-prose mb-4 w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30",
+        className,
+      )}
     >
       <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-2.5">
         {/* Rolling header: clipped, fixed height so sliding lines stay contained */}
@@ -277,6 +293,88 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
               <span>Searching...</span>
             </div>
           )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+interface WebSearchGroupResultProps {
+  searches: ToolCall[];
+}
+
+export function WebSearchGroupResult({
+  searches,
+}: WebSearchGroupResultProps) {
+  const [open, setOpen] = useState(false);
+  const status = getWebSearchGroupStatus(searches);
+  const queryCount = searches.length;
+
+  const label =
+    status === "running"
+      ? "Searching the web…"
+      : status === "error"
+        ? "Web search finished with errors"
+        : "Searched the web";
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="not-prose mb-4 w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30"
+    >
+      <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {status === "running" ? (
+            <LoaderIcon className="size-4 shrink-0 animate-spin text-muted-foreground" />
+          ) : status === "error" ? (
+            <XCircleIcon className="size-4 shrink-0 text-red-600" />
+          ) : (
+            <GlobeIcon className="size-4 shrink-0 text-muted-foreground" />
+          )}
+
+          <span className="truncate text-left text-sm font-medium">
+            {label}
+          </span>
+
+          <span className="shrink-0 text-xs text-muted-foreground">
+            ({queryCount} {queryCount === 1 ? "query" : "queries"})
+          </span>
+        </div>
+
+        <ChevronDownIcon
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="overflow-hidden data-[state=open]:animate-[collapsible-down_0.09s_ease-out] data-[state=closed]:animate-[collapsible-up_0.08s_ease-in]">
+        <div className="flex flex-col gap-3 p-2">
+          {searches.map((search) => {
+            const data = getWebSearchCardData(search);
+            if (!data) return null;
+
+            return (
+              <div key={search.id} className="space-y-1.5">
+                <div className="flex min-w-0 items-center gap-2 px-2 text-sm text-muted-foreground">
+                  <GlobeIcon className="size-3.5 shrink-0" />
+                  <span className="truncate">
+                    {data.query || "Untitled query"}
+                  </span>
+                </div>
+
+                <WebSearchResult
+                  query={data.query}
+                  results={data.results}
+                  status={search.status}
+                  title={data.title}
+                  className="mb-0 rounded-[20px] border-border/60 bg-transparent"
+                />
+              </div>
+            );
+          })}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -19,7 +19,10 @@ import {
 } from '@/components/ai-elements/message'
 import { TurnActivityIndicator } from '@/components/turn-activity-indicator'
 import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
-import { WebSearchResult } from '@/components/ai-elements/web-search-result'
+import {
+  WebSearchGroupResult,
+  WebSearchResult,
+} from '@/components/ai-elements/web-search-result'
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card'
 import { PermissionRequest } from '@/components/ai-elements/permission-request'
 import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
@@ -52,6 +55,7 @@ import {
   isErrorMessage,
   isToolCall,
   isToolGroup,
+  isWebSearchGroup,
   isTurnUsageMessage,
   normalizeToolInput,
   normalizeToolOutput,
@@ -666,6 +670,14 @@ export function ChatSidebar({
                                 tabState.conversation,
                                 (id) => !!tabState.allPermissionRequests.get(id) || !!tabState.autoPermissionDecisions.get(id)
                               ).map((item) => {
+                                if (isWebSearchGroup(item)) {
+                                  return (
+                                    <WebSearchGroupResult
+                                      key={item.groupId}
+                                      searches={item.items}
+                                    />
+                                  )
+                                }
                                 if (isToolGroup(item)) {
                                   return (
                                     <ToolGroupComponent

--- a/apps/x/apps/renderer/src/components/code/code-chat.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-chat.tsx
@@ -10,11 +10,21 @@ import { Conversation, ConversationContent, ConversationScrollButton } from '@/c
 import { MessageResponse } from '@/components/ai-elements/message'
 import { Shimmer } from '@/components/ai-elements/shimmer'
 import { Tool, ToolContent, ToolHeader } from '@/components/ai-elements/tool'
-import { toToolState, getToolDisplayName, getToolErrorText, getWebSearchCardData, type ToolCall } from '@/lib/chat-conversation'
+import {
+  toToolState,
+  getToolDisplayName,
+  getToolErrorText,
+  getWebSearchCardData,
+  type ToolCall,
+  type WebSearchGroup,
+} from '@/lib/chat-conversation'
 import { CodeRunPermissionRequest, CodingRunTimeline } from '@/components/coding-run'
 import { PermissionRequest } from '@/components/ai-elements/permission-request'
 import { AskHumanRequest } from '@/components/ai-elements/ask-human-request'
-import { WebSearchResult } from '@/components/ai-elements/web-search-result'
+import {
+  WebSearchGroupResult,
+  WebSearchResult,
+} from '@/components/ai-elements/web-search-result'
 import { useVoiceMode } from '@/hooks/useVoiceMode'
 import { useCodeChat, isDirectTurn, isChatToolCall, isChatErrorMessage, type CodeChatItem } from './use-code-chat'
 
@@ -97,6 +107,60 @@ function RowboatToolCall({ item, onOpenDiff }: { item: ToolCall; onOpenDiff: (pa
       <span className="truncate">{getToolDisplayName(item)}</span>
     </div>
   )
+}
+
+type GroupedCodeChatItem = CodeChatItem | WebSearchGroup
+
+const isCodeChatWebSearch = (
+  item: CodeChatItem
+): item is ToolCall =>
+  isChatToolCall(item) &&
+  getWebSearchCardData(item) !== null
+
+const isCodeChatWebSearchGroup = (
+  item: GroupedCodeChatItem
+): item is WebSearchGroup =>
+  'type' in item && item.type === 'web-search-group'
+
+function groupCodeChatItems(
+  items: CodeChatItem[]
+): GroupedCodeChatItem[] {
+  const result: GroupedCodeChatItem[] = []
+  let index = 0
+
+  while (index < items.length) {
+    const item = items[index]
+
+    if (isCodeChatWebSearch(item)) {
+      const searches: ToolCall[] = [item]
+      index++
+
+      while (
+        index < items.length &&
+        isCodeChatWebSearch(items[index])
+      ) {
+        searches.push(items[index] as ToolCall)
+        index++
+      }
+
+      if (searches.length === 1) {
+        result.push(searches[0])
+      } else {
+        result.push({
+          type: 'web-search-group',
+          items: searches,
+          groupId: searches[0].id,
+        })
+      }
+
+      continue
+    }
+
+    result.push(item)
+    index++
+  }
+
+  return result
 }
 
 function ChatItem({ item, onOpenDiff }: { item: CodeChatItem; onOpenDiff: (path: string) => void }) {
@@ -290,9 +354,24 @@ export function CodeChat({
               </p>
             </div>
           )}
-          {items.map((item) => (
-            <ChatItem key={item.id} item={item} onOpenDiff={onOpenDiff} />
-          ))}
+          {groupCodeChatItems(items).map((item) => {
+            if (isCodeChatWebSearchGroup(item)) {
+              return (
+                <WebSearchGroupResult
+                  key={item.groupId}
+                  searches={item.items}
+                />
+              )
+            }
+
+            return (
+              <ChatItem
+                key={item.id}
+                item={item}
+                onOpenDiff={onOpenDiff}
+              />
+            )
+          })}
           {liveText && (
             <div className="min-w-0 max-w-none break-words text-sm">
               <MessageResponse>{liveText.replace(/<\/?voice>/g, '')}</MessageResponse>

--- a/apps/x/apps/renderer/src/lib/chat-conversation.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+  groupConversationItems,
+  getWebSearchGroupStatus,
+  isWebSearchGroup,
+  type ChatMessage,
+  type ToolCall,
+} from './chat-conversation'
+
+const makeWebSearch = (id: string, query: string): ToolCall => ({
+  id,
+  name: 'web-search',
+  input: { query },
+  result: { results: [] },
+  status: 'completed',
+  timestamp: 1,
+})
+
+describe('getWebSearchGroupStatus', () => {
+  it('stays running while any query is pending or running', () => {
+    const completed = makeWebSearch('search-1', 'React testing')
+    const failed = { ...makeWebSearch('search-2', 'Vitest mocks'), status: 'error' as const }
+    const running = { ...makeWebSearch('search-3', 'Testing hooks'), status: 'running' as const }
+
+    expect(getWebSearchGroupStatus([completed, failed, running])).toBe('running')
+  })
+
+  it('reports an error after all queries settle if any failed', () => {
+    const completed = makeWebSearch('search-1', 'React testing')
+    const failed = { ...makeWebSearch('search-2', 'Vitest mocks'), status: 'error' as const }
+
+    expect(getWebSearchGroupStatus([completed, failed])).toBe('error')
+  })
+
+  it('reports completion when every query completed', () => {
+    expect(getWebSearchGroupStatus([
+      makeWebSearch('search-1', 'React testing'),
+      makeWebSearch('search-2', 'Vitest mocks'),
+    ])).toBe('completed')
+  })
+})
+
+const makeTool = (id: string, name = 'file-readText'): ToolCall => ({
+  id,
+  name,
+  input: {},
+  status: 'completed',
+  timestamp: 1,
+})
+
+const makeMessage = (id: string): ChatMessage => ({
+  id,
+  role: 'assistant',
+  content: 'Done',
+  timestamp: 1,
+})
+
+const group = (items: Array<ToolCall | ChatMessage>) =>
+  groupConversationItems(items, () => false)
+
+describe('groupConversationItems web searches', () => {
+  it('keeps a single web search as its existing standalone card', () => {
+    const search = makeWebSearch('search-1', 'React testing')
+
+    expect(group([search])).toEqual([search])
+  })
+
+  it('groups two or more consecutive web searches', () => {
+    const first = makeWebSearch('search-1', 'React testing')
+    const second = makeWebSearch('search-2', 'Vitest mocks')
+    const third = makeWebSearch('search-3', 'Testing hooks')
+    const [result] = group([first, second, third])
+
+    expect(isWebSearchGroup(result)).toBe(true)
+    if (!isWebSearchGroup(result)) throw new Error('Expected a web-search group')
+    expect(result.groupId).toBe(first.id)
+    expect(result.items).toEqual([first, second, third])
+  })
+
+  it('ends a web-search group at a message boundary', () => {
+    const first = makeWebSearch('search-1', 'React testing')
+    const second = makeWebSearch('search-2', 'Vitest mocks')
+    const message = makeMessage('message-1')
+    const third = makeWebSearch('search-3', 'Testing hooks')
+
+    const result = group([first, second, message, third])
+
+    expect(result).toHaveLength(3)
+    expect(isWebSearchGroup(result[0])).toBe(true)
+    expect(result[1]).toBe(message)
+    expect(result[2]).toBe(third)
+  })
+
+  it('ends a web-search group at a different tool call', () => {
+    const first = makeWebSearch('search-1', 'React testing')
+    const second = makeWebSearch('search-2', 'Vitest mocks')
+    const fileTool = makeTool('tool-1')
+    const third = makeWebSearch('search-3', 'Testing hooks')
+
+    const result = group([first, second, fileTool, third])
+
+    expect(result).toHaveLength(3)
+    expect(isWebSearchGroup(result[0])).toBe(true)
+    expect(result[1]).toBe(fileTool)
+    expect(result[2]).toBe(third)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/chat-conversation.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.ts
@@ -46,6 +46,28 @@ export interface ToolCall {
   subAgent?: { childTurnId: string; agentName: string; task: string }
 }
 
+export type WebSearchGroupStatus = 'running' | 'completed' | 'error'
+
+export const getWebSearchGroupStatus = (
+  searches: ToolCall[]
+): WebSearchGroupStatus => {
+  if (
+    searches.some(
+      search =>
+        search.status === 'pending' ||
+        search.status === 'running'
+    )
+  ) {
+    return 'running'
+  }
+
+  if (searches.some(search => search.status === 'error')) {
+    return 'error'
+  }
+
+  return 'completed'
+}
+
 export interface ErrorMessage {
   id: string
   kind: 'error'
@@ -693,10 +715,22 @@ export type ToolGroup = {
   groupId: string
 }
 
-export type GroupedConversationItem = ConversationItem | ToolGroup
+export type WebSearchGroup = {
+  type: 'web-search-group'
+  items: ToolCall[]
+  groupId: string
+}
+
+export type GroupedConversationItem = ConversationItem | ToolGroup | WebSearchGroup
 
 export const isToolGroup = (item: GroupedConversationItem): item is ToolGroup =>
   'type' in item && (item as ToolGroup).type === 'tool-group'
+
+export const isWebSearchGroup = (item: GroupedConversationItem): item is WebSearchGroup =>
+  'type' in item && (item as WebSearchGroup).type === 'web-search-group'
+
+const isWebSearchToolCall = (item: ConversationItem): item is ToolCall =>
+  isToolCall(item) && getWebSearchCardData(item) !== null
 
 const isPlainToolCall = (item: ConversationItem): item is ToolCall => {
   if (!isToolCall(item)) return false
@@ -717,7 +751,22 @@ export const groupConversationItems = (
 
   while (i < items.length) {
     const item = items[i]
-    if (isPlainToolCall(item) && !hasPermissionRequest(item.id)) {
+    if (isWebSearchToolCall(item)) {
+      const group: ToolCall[] = [item]
+      i++
+      while (
+        i < items.length &&
+        isWebSearchToolCall(items[i] as ConversationItem)
+      ) {
+        group.push(items[i] as ToolCall)
+        i++
+      }
+      if (group.length === 1) {
+        result.push(group[0])
+      } else {
+        result.push({ type: 'web-search-group', items: group, groupId: group[0].id })
+      }
+    } else if (isPlainToolCall(item) && !hasPermissionRequest(item.id)) {
       const group: ToolCall[] = [item]
       i++
       while (


### PR DESCRIPTION
## Summary

This PR improves the chat experience by grouping consecutive web-search tool calls into a single collapsible container.

### What changed

- Groups two or more adjacent web searches into one container
- Shows the total query count in the group header
- Displays aggregated running, completed, and error states
- Reveals individual queries and their existing search results when expanded
- Preserves the original card for a single web search
- Stops grouping when a message or different tool appears
- Supports the main chat, chat sidebar, and code chat
- Adds focused tests for grouping boundaries and mixed statuses

## Before

Consecutive web searches were rendered as separate cards, creating unnecessary vertical clutter.

<img width="880" height="496" alt="Screenshot 2026-07-23 at 9 35 31 AM" src="https://github.com/user-attachments/assets/00f9c4a6-0a9b-43cf-aff2-30546cd55caa" />



## After

### Collapsed

<img width="1456" height="933" alt="Screenshot 2026-07-23 at 9 38 41 AM" src="https://github.com/user-attachments/assets/129f6081-65cf-48da-ad03-0bebe644861e" />



### Expanded

<img width="1435" height="1041" alt="Screenshot 2026-07-23 at 9 38 50 AM" src="https://github.com/user-attachments/assets/3e04c7a1-33b9-476f-a6e8-4d8d58e5608e" />



## Testing

- `npm run typecheck`
- `npm test`
- Verified multiple consecutive searches are grouped
- Verified the group expands to show every query and its sources
- Verified result cards and links continue to work
- Verified a single search retains the original standalone card
- Verified grouping boundaries with messages and other tool calls

Closes #764