### PR TITLE
Fix double unsubscribe removing other bus handlers

### DIFF
--- a/apps/x/packages/core/src/application/lib/bus.test.ts
+++ b/apps/x/packages/core/src/application/lib/bus.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import z from "zod";
+import { RunEvent } from "@x/shared/dist/runs.js";
+import { InMemoryBus } from "./bus.js";
+
+function makeEvent(runId: string): z.infer<typeof RunEvent> {
+    return {
+        type: "run-processing-start",
+        runId,
+        subflow: [],
+    };
+}
+
+describe("InMemoryBus", () => {
+    it("keeps other handlers subscribed when a handler is unsubscribed twice", async () => {
+        const bus = new InMemoryBus();
+        const runId = "run-1";
+
+        const receivedByA: z.infer<typeof RunEvent>[] = [];
+        const receivedByB: z.infer<typeof RunEvent>[] = [];
+
+        const unsubscribeA = await bus.subscribe(runId, async (event) => {
+            receivedByA.push(event);
+        });
+        await bus.subscribe(runId, async (event) => {
+            receivedByB.push(event);
+        });
+
+        // Double-unsubscribe of A must be a no-op the second time. The buggy
+        // implementation ran splice(indexOf(A), 1) where indexOf(A) === -1 on
+        // the second call, which removed the last handler (B) instead.
+        unsubscribeA();
+        unsubscribeA();
+
+        await bus.publish(makeEvent(runId));
+
+        expect(receivedByA).toHaveLength(0);
+        expect(receivedByB).toHaveLength(1);
+    });
+});

--- a/apps/x/packages/core/src/application/lib/bus.ts
+++ b/apps/x/packages/core/src/application/lib/bus.ts
@@ -29,7 +29,10 @@ export class InMemoryBus implements IBus {
         }
         this.subscribers.get(runId)!.push(handler);
         return () => {
-            this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
+            const handlers = this.subscribers.get(runId);
+            if (!handlers) return;
+            const idx = handlers.indexOf(handler);
+            if (idx >= 0) handlers.splice(idx, 1);
         };
     }
 }


### PR DESCRIPTION
## Summary

`InMemoryBus.subscribe()` returned an unsubscribe closure that removed the handler with an unguarded `splice`:

```ts
this.subscribers.get(runId)!.splice(this.subscribers.get(runId)!.indexOf(handler), 1);
```

When the handler was no longer present — e.g. `unsubscribe()` called twice — `indexOf` returned `-1`, so `splice(-1, 1)` removed the **last** subscriber for that `runId` instead. That silently drops a live, unrelated handler, which stops receiving run events.

The fix guards the index before splicing, matching the pattern already used by the other buses in this package (e.g. `background-tasks/bus.ts`):

```ts
return () => {
    const handlers = this.subscribers.get(runId);
    if (!handlers) return;
    const idx = handlers.indexOf(handler);
    if (idx >= 0) handlers.splice(idx, 1);
};
```

Fixes #491.

## Testing

Added a focused regression test at `apps/x/packages/core/src/application/lib/bus.test.ts`:

- Subscribes handlers A and B to the same `runId`.
- Calls A's unsubscribe function **twice**, then publishes an event.
- Asserts B still receives the event and A does not.

Behavior:

- **Before the fix:** the test fails — the second `unsubscribe()` call runs `splice(-1, 1)` and removes B, so B receives nothing (`AssertionError: expected [] to have a length of 1 but got +0`).
- **After the fix:** the test passes — the double-unsubscribe is a no-op and B still receives the event.

Commands run:

- `vitest run src/application/lib/bus.test.ts` → 1 passed (was 1 failed before the fix)
- `pnpm typecheck` → clean, exit 0

## Scope

- Only `apps/x/packages/core/src/application/lib/bus.ts` and its new test file are touched.
- The identical bug in the CLI's `apps/cli/src/application/lib/bus.ts` (#492) was **intentionally left untouched** — not in scope for this PR.
- No unrelated refactors or cleanup.
