### PR TITLE
test: add unit tests for frontmatter, prefix-logger, and MCP tools

### DIFF
--- a/apps/x/packages/core/src/runtime/tools/domains/mcp.test.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/mcp.test.ts
@@ -1,0 +1,331 @@
+/**
+ * MCP Eval Test Harness
+ *
+ * Mock-based evaluation suite for the builtin MCP tool domain.
+ * Tests that the four builtin MCP tools (executeMcpTool, listMcpTools,
+ * listMcpServers, addMcpServer) parse inputs, validate schemas, and
+ * surface errors correctly — without requiring a live MCP server.
+ *
+ * These tests mock the real MCP client functions (executeTool, listTools,
+ * listServers) and the config repo (IMcpConfigRepo) so the evaluation
+ * harness is deterministic, fast, and CI-friendly.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mcpTools } from "./mcp.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.mock factory calls are hoisted to top of file, so
+// factory variables must also be hoisted via vi.hoisted().
+// ---------------------------------------------------------------------------
+
+const {
+  mockExecuteTool,
+  mockListTools,
+  mockListServers,
+  mockUpsert,
+  mockResolve,
+} = vi.hoisted(() => {
+  const mockUpsert = vi.fn();
+  return {
+    mockExecuteTool: vi.fn(),
+    mockListTools: vi.fn(),
+    mockListServers: vi.fn(),
+    mockUpsert,
+    mockResolve: vi.fn().mockImplementation(<T>(name: string): T => {
+      if (name === "mcpConfigRepo") {
+        return {
+          ensureConfig: vi.fn(),
+          getConfig: vi.fn().mockResolvedValue({ mcpServers: {} }),
+          upsert: mockUpsert,
+          delete: vi.fn(),
+        } as unknown as T;
+      }
+      throw new Error(`Unknown container key: ${name}`);
+    }),
+  };
+});
+
+vi.mock("../../../mcp/mcp.js", () => ({
+  executeTool: mockExecuteTool,
+  listServers: mockListServers,
+  listTools: mockListTools,
+}));
+
+vi.mock("../../../di/container.js", () => ({
+  default: { resolve: mockResolve },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ToolFn = (input: Record<string, unknown>) => Promise<unknown>;
+
+function tool(name: keyof typeof mcpTools): ToolFn {
+  const entry = mcpTools[name];
+  if (!entry?.execute) {
+    throw new Error(`No execute function for builtin tool '${name}'`);
+  }
+  return (input: Record<string, unknown>) => (entry.execute as (input: Record<string, unknown>) => Promise<unknown>)(input);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ===========================================================================
+// executeMcpTool
+// ===========================================================================
+
+describe("executeMcpTool", () => {
+  it("executes a tool on an MCP server and returns the result", async () => {
+    mockExecuteTool.mockResolvedValue({ content: [{ type: "text", text: "Hello from MCP" }] });
+
+    const result = await tool("executeMcpTool")({
+      serverName: "my-server",
+      toolName: "greet",
+      arguments: { name: "World" },
+    });
+
+    expect(mockExecuteTool).toHaveBeenCalledWith("my-server", "greet", { name: "World" });
+    expect(result).toMatchObject({
+      success: true,
+      serverName: "my-server",
+      toolName: "greet",
+    });
+  });
+
+  it("works with no arguments provided", async () => {
+    mockExecuteTool.mockResolvedValue({ content: [] });
+
+    const result = await tool("executeMcpTool")({
+      serverName: "my-server",
+      toolName: "ping",
+    });
+
+    expect(mockExecuteTool).toHaveBeenCalledWith("my-server", "ping", {});
+    expect(result).toMatchObject({ success: true });
+  });
+
+  it("surfaces an error from the underlying MCP client", async () => {
+    mockExecuteTool.mockRejectedValue(new Error("Connection refused"));
+
+    const result = await tool("executeMcpTool")({
+      serverName: "offline-server",
+      toolName: "any",
+      arguments: {},
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Connection refused"),
+    });
+  });
+
+  it("provides a hint when execution fails", async () => {
+    mockExecuteTool.mockRejectedValue(new Error("not found"));
+
+    const result = await tool("executeMcpTool")({
+      serverName: "x",
+      toolName: "y",
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("not found"),
+      hint: expect.stringContaining("listMcpTools"),
+    });
+  });
+});
+
+// ===========================================================================
+// listMcpTools
+// ===========================================================================
+
+describe("listMcpTools", () => {
+  const sampleTools = [
+    {
+      name: "greet",
+      description: "Greet someone",
+      inputSchema: {
+        type: "object" as const,
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+    },
+    {
+      name: "ping",
+      description: "Ping the server",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+  ];
+
+  it("lists tools from a server", async () => {
+    mockListTools.mockResolvedValue({ tools: sampleTools });
+
+    const result = await tool("listMcpTools")({ serverName: "my-server" });
+
+    expect(mockListTools).toHaveBeenCalledWith("my-server", undefined);
+    expect(result).toMatchObject({
+      serverName: "my-server",
+      count: 2,
+      result: { tools: sampleTools },
+    });
+  });
+
+  it("forwards pagination cursor when provided", async () => {
+    mockListTools.mockResolvedValue({ tools: sampleTools.slice(0, 1), nextCursor: "cursor-abc" });
+
+    const result = await tool("listMcpTools")({
+      serverName: "my-server",
+      cursor: "cursor-abc",
+    });
+
+    expect(mockListTools).toHaveBeenCalledWith("my-server", "cursor-abc");
+    expect(result).toMatchObject({
+      result: { nextCursor: "cursor-abc" },
+    });
+  });
+
+  it("handles errors from the MCP client", async () => {
+    mockListTools.mockRejectedValue(new Error("Server unreachable"));
+
+    const result = await tool("listMcpTools")({ serverName: "dead" });
+
+    expect(result).toMatchObject({
+      error: expect.stringContaining("Server unreachable"),
+    });
+  });
+});
+
+// ===========================================================================
+// listMcpServers
+// ===========================================================================
+
+describe("listMcpServers", () => {
+  it("lists all registered MCP servers with their connection state", async () => {
+    mockListServers.mockResolvedValue({
+      mcpServers: {
+        "server-a": {
+          config: { command: "node", args: ["a.js"] },
+          state: "connected",
+          error: null,
+        },
+        "server-b": {
+          config: { url: "http://localhost:8080" },
+          state: "disconnected",
+          error: null,
+        },
+      },
+    });
+
+    const result = await tool("listMcpServers")({});
+
+    expect(result).toMatchObject({
+      count: 2,
+      result: {
+        mcpServers: {
+          "server-a": { state: "connected" },
+          "server-b": { state: "disconnected" },
+        },
+      },
+    });
+  });
+
+  it("returns count 0 when no servers are configured", async () => {
+    mockListServers.mockResolvedValue({ mcpServers: {} });
+
+    const result = await tool("listMcpServers")({});
+
+    expect(result).toMatchObject({ count: 0 });
+  });
+
+  it("handles errors", async () => {
+    mockListServers.mockRejectedValue(new Error("Config read failure"));
+
+    const result = await tool("listMcpServers")({});
+
+    expect(result).toMatchObject({
+      error: expect.stringContaining("Config read failure"),
+    });
+  });
+});
+
+// ===========================================================================
+// addMcpServer
+// ===========================================================================
+
+describe("addMcpServer", () => {
+  const stdioConfig = {
+    command: "node",
+    args: ["server.js"],
+    env: { KEY: "value" },
+  };
+
+  const httpConfig = {
+    url: "http://localhost:8080/mcp",
+    headers: { Authorization: "Bearer token" },
+  };
+
+  it("adds a valid stdio-based MCP server", async () => {
+    const result = await tool("addMcpServer")({
+      serverName: "my-server",
+      config: stdioConfig,
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith("my-server", stdioConfig);
+    expect(result).toMatchObject({ success: true, serverName: "my-server" });
+  });
+
+  it("adds a valid HTTP-based MCP server", async () => {
+    const result = await tool("addMcpServer")({
+      serverName: "http-server",
+      config: httpConfig,
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith("http-server", httpConfig);
+    expect(result).toMatchObject({ success: true });
+  });
+
+  it("rejects an invalid server config with validation errors", async () => {
+    const result = await tool("addMcpServer")({
+      serverName: "bad-server",
+      config: { command: 42 }, // command should be a string, not number
+    });
+
+    // The invalid config should fail McpServerDefinition.safeParse
+    expect(result).toMatchObject({
+      success: false,
+      message: expect.stringContaining("validation"),
+      validationErrors: expect.arrayContaining([expect.any(String)]),
+      providedDefinition: { command: 42 },
+    });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a config that matches neither stdio nor http schema", async () => {
+    const result = await tool("addMcpServer")({
+      serverName: "weird",
+      config: { something: "else" },
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      validationErrors: expect.any(Array),
+    });
+  });
+
+  it("surfaces repo errors gracefully", async () => {
+    mockUpsert.mockRejectedValue(new Error("Disk full"));
+
+    const result = await tool("addMcpServer")({
+      serverName: "failing",
+      config: httpConfig,
+    });
+
+    expect(result).toMatchObject({
+      error: expect.stringContaining("Disk full"),
+    });
+  });
+});

--- a/apps/x/packages/shared/src/frontmatter.test.ts
+++ b/apps/x/packages/shared/src/frontmatter.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "./frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  describe("no frontmatter", () => {
+    it("returns empty fields and the full body for plain markdown", () => {
+      const md = "# Hello\n\nThis is content.";
+      expect(parseFrontmatter(md)).toEqual({ fields: {}, body: md });
+    });
+
+    it("returns empty fields and the full body for an empty string", () => {
+      expect(parseFrontmatter("")).toEqual({ fields: {}, body: "" });
+    });
+
+    it("returns empty fields for content that starts with --- but has no closing delimiter", () => {
+      const md = "---\ntitle: Hello\nno closing delimiter here";
+      expect(parseFrontmatter(md)).toEqual({ fields: {}, body: md });
+    });
+
+    it("returns empty fields for a bare opening --- with trailing newline but no content", () => {
+      const md = "---\n";
+      expect(parseFrontmatter(md)).toEqual({ fields: {}, body: md });
+    });
+
+    it("returns empty fields for a lone --- without trailing newline", () => {
+      const md = "---";
+      expect(parseFrontmatter(md)).toEqual({ fields: {}, body: md });
+    });
+  });
+
+  describe("basic key-value frontmatter", () => {
+    it("parses a single key-value pair", () => {
+      const md = "---\ntitle: Hello\n---\nBody text";
+      expect(parseFrontmatter(md)).toEqual({
+        fields: { title: "Hello" },
+        body: "Body text",
+      });
+    });
+
+    it("parses multiple key-value pairs", () => {
+      const md = "---\ntitle: Hello World\ndate: 2024-01-15\n---\nContent";
+      expect(parseFrontmatter(md)).toEqual({
+        fields: { title: "Hello World", date: "2024-01-15" },
+        body: "Content",
+      });
+    });
+
+    it("strips whitespace around values", () => {
+      const md = "---\ntitle:   Hello   \n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ title: "Hello" });
+    });
+
+    it("handles values with colons", () => {
+      const md = "---\ntitle: Hello: World\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ title: "Hello: World" });
+    });
+
+    it("handles keys with spaces", () => {
+      const md = "---\nmy title: Hello\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ "my title": "Hello" });
+    });
+
+    it("handles single-word keys", () => {
+      const md = "---\na: b\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ a: "b" });
+    });
+  });
+
+  describe("empty values", () => {
+    it("treats an empty value as the start of a list", () => {
+      const md = "---\ntags:\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ tags: [] });
+    });
+
+    it("treats a key with trailing whitespace but no value as a list start", () => {
+      const md = "---\ntags: \n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ tags: [] });
+    });
+  });
+
+  describe("list values", () => {
+    it("parses a list of items", () => {
+      const md = "---\ntags:\n  - one\n  - two\n  - three\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({
+        tags: ["one", "two", "three"],
+      });
+    });
+
+    it("trims whitespace from list items", () => {
+      const md = "---\ntags:\n  -   spaced   \n  -   item  \n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({
+        tags: ["spaced", "item"],
+      });
+    });
+
+    it("handles mixed key-value and list frontmatter", () => {
+      const md =
+        "---\ntitle: Hello\ndate: 2024-01-15\ntags:\n  - a\n  - b\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({
+        title: "Hello",
+        date: "2024-01-15",
+        tags: ["a", "b"],
+      });
+    });
+
+    it("handles multiple list keys", () => {
+      const md = "---\ntags:\n  - one\n  - two\ncategories:\n  - x\n  - y\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({
+        tags: ["one", "two"],
+        categories: ["x", "y"],
+      });
+    });
+
+    it("does not confuse a non-list indented line with a list item", () => {
+      const md = "---\ntags:\n  not a list item\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ tags: [] });
+    });
+  });
+
+  describe("body extraction", () => {
+    it("returns the body after the closing ---", () => {
+      const md = "---\ntitle: Hello\n---\n# Section\n\nSome text";
+      expect(parseFrontmatter(md).body).toBe("# Section\n\nSome text");
+    });
+
+    it("returns empty body when frontmatter is immediately followed by end of string", () => {
+      const md = "---\ntitle: Hello\n---";
+      expect(parseFrontmatter(md).body).toBe("");
+    });
+
+    it("strips the first leading newline from the body but keeps the second", () => {
+      const md = "---\ntitle: Hello\n---\n\nBody with leading blank line";
+      // After closing --- there are two newlines (line end + blank line);
+      // the function strips only the first \n from the body.
+      expect(parseFrontmatter(md).body).toBe("\nBody with leading blank line");
+    });
+
+    it("strips the first leading newline and keeps multiple remaining", () => {
+      const md = "---\ntitle: Hello\n---\n\n\nBody with two leading blank lines";
+      // After closing --- there are three newlines (line end + two blank lines);
+      // the function strips only the first \n, leaving two.
+      expect(parseFrontmatter(md).body).toBe("\n\nBody with two leading blank lines");
+    });
+
+    it("handles body with no newline after closing ---", () => {
+      const md = "---\ntitle: Hello\n---Body without newline";
+      expect(parseFrontmatter(md).body).toBe("Body without newline");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty frontmatter block (---\\n---)", () => {
+      const md = "---\n---\nBody";
+      expect(parseFrontmatter(md)).toEqual({
+        fields: {},
+        body: "Body",
+      });
+    });
+
+    it("handles --- in the body content (only first closing matters)", () => {
+      const md = "---\ntitle: Hello\n---\nBody with --- in it";
+      expect(parseFrontmatter(md).fields).toEqual({ title: "Hello" });
+      expect(parseFrontmatter(md).body).toBe("Body with --- in it");
+    });
+
+    it("strips blank lines within the frontmatter block", () => {
+      const md = "---\ntitle: Hello\n\ndate: 2024-01-15\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({
+        title: "Hello",
+        date: "2024-01-15",
+      });
+    });
+
+    it("handles a single field with a numeric value as a string", () => {
+      const md = "---\nversion: 42\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({ version: "42" });
+    });
+
+    it("handles boolean-looking values as strings", () => {
+      const md = "---\npublished: true\nfeatured: false\n---\nBody";
+      expect(parseFrontmatter(md).fields).toEqual({
+        published: "true",
+        featured: "false",
+      });
+    });
+  });
+});

--- a/apps/x/packages/shared/src/prefix-logger.test.ts
+++ b/apps/x/packages/shared/src/prefix-logger.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PrefixLogger } from "./prefix-logger.js";
+
+describe("PrefixLogger", () => {
+  const FIXED_TIMESTAMP = "2026-01-01T00:00:00.000Z";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_TIMESTAMP));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("root logger (no parent)", () => {
+    it("logs with prefix, timestamp, and args", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = new PrefixLogger("app");
+
+      logger.log("Hello");
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[app]",
+        "Hello",
+      );
+    });
+
+    it("logs multiple arguments", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = new PrefixLogger("test");
+
+      logger.log("a", 42, { key: "value" });
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[test]",
+        "a",
+        42,
+        { key: "value" },
+      );
+    });
+
+    it("logs with no additional args", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = new PrefixLogger("alone");
+
+      logger.log();
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[alone]",
+      );
+    });
+  });
+
+  describe("child logger", () => {
+    it("creates a child logger that delegates to the parent", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const parent = new PrefixLogger("parent");
+      const child = parent.child("child");
+
+      child.log("message");
+
+      // Parent receives child's prefix first, then the args
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[parent]",
+        "[child]",
+        "message",
+      );
+    });
+
+    it("supports multiple levels of nesting", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const root = new PrefixLogger("root");
+      const mid = root.child("mid");
+      const leaf = mid.child("leaf");
+
+      leaf.log("deep");
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[root]",
+        "[mid]",
+        "[leaf]",
+        "deep",
+      );
+    });
+
+    it("child of root logs correctly with multiple args", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const root = new PrefixLogger("app");
+      const child = root.child("sub");
+
+      child.log("info", 123, true);
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[app]",
+        "[sub]",
+        "info",
+        123,
+        true,
+      );
+    });
+  });
+
+  describe("prefix formatting", () => {
+    it("wraps prefix in brackets", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = new PrefixLogger("my-component");
+
+      logger.log("test");
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[my-component]",
+        "test",
+      );
+    });
+
+    it("handles empty string prefix", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = new PrefixLogger("");
+
+      logger.log("test");
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[]",
+        "test",
+      );
+    });
+
+    it("handles prefix with special characters", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = new PrefixLogger("test@#$");
+
+      logger.log("test");
+
+      expect(spy).toHaveBeenCalledWith(
+        FIXED_TIMESTAMP,
+        "[test@#$]",
+        "test",
+      );
+    });
+  });
+
+  describe("independence", () => {
+    it("sibling loggers do not interfere with each other", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const root = new PrefixLogger("root");
+      const a = root.child("a");
+      const b = root.child("b");
+
+      a.log("from-a");
+      b.log("from-b");
+
+      expect(spy).toHaveBeenNthCalledWith(
+        1,
+        FIXED_TIMESTAMP,
+        "[root]",
+        "[a]",
+        "from-a",
+      );
+      expect(spy).toHaveBeenNthCalledWith(
+        2,
+        FIXED_TIMESTAMP,
+        "[root]",
+        "[b]",
+        "from-b",
+      );
+    });
+
+    it("logs from the root do not affect child recording", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const root = new PrefixLogger("root");
+      const child = root.child("child");
+
+      root.log("root-only");
+      child.log("child-only");
+
+      expect(spy).toHaveBeenNthCalledWith(
+        1,
+        FIXED_TIMESTAMP,
+        "[root]",
+        "root-only",
+      );
+      expect(spy).toHaveBeenNthCalledWith(
+        2,
+        FIXED_TIMESTAMP,
+        "[root]",
+        "[child]",
+        "child-only",
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR adds test coverage for three areas that were previously untested:
 
### `packages/shared` — Frontmatter parsing (28 tests)
- Edge cases: no frontmatter, empty string, bare `---`, missing closing delimiter
- Key-value pairs with whitespace, colons in values, spaces in keys
- List values and non-list indented lines
- Body extraction with leading newlines and empty body
- Frontmatter `---` delimiter appearing inside body content
 
### `packages/shared` — PrefixLogger (11 tests)
- Root logging with and without arguments
- Child logger delegation (1 and 3 levels deep)
- Empty prefix, special characters, sibling independence
- Root vs child isolation
 
### `packages/core` — MCP builtin tools (15 tests)
- `executeMcpTool`: success, empty args, error surfacing, error hints
- `listMcpTools`: tool listing, pagination cursor, error handling
- `listMcpServers`: server states, empty list, error handling
- `addMcpServer`: valid stdio/HTTP config, schema validation errors, repo error propagation
 
### Test results
- `packages/shared`: **146/146** tests passing
- `packages/core`: **548/548** tests passing
- Typecheck: clean in both packages
 
No source logic was modified — only test files were added.