### PR TITLE
Quick-ask bar: ask Rowboat from anywhere (⌥⇧Space)

### DIFF
--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -193,7 +193,7 @@ the key while muted does nothing; muting mid-capture discards it).
   "agent" app while the window exists — looks like Rowboat vanished). It is
   also `fullscreenable: false` — a window created while the active Space is
   fullscreen can otherwise open AS a fullscreen window (the pill swallowing
-  the whole screen).
+  the whole screen). The quick-ask bar uses the same setup.
 - Shown iff the derived `callSurface === 'popout'` (effect in `App.tsx`).
   Renderer asks `video:setPopout {show}`; main creates a frameless,
   `alwaysOnTop` ('floating'), all-workspaces BrowserWindow at the top-right
@@ -285,6 +285,19 @@ distribution (utterance → submit → first speak → audio playing):
   speech starts while the rest of the sentence generates.
 - **Acknowledgment cue** (`lib/call-sounds.ts`): a soft blip the instant an
   utterance is accepted — perceived latency matters as much as measured.
+
+## Quick-ask bar (related surface)
+
+Global ⌥⇧Space summons a Spotlight-style bar over any app
+(`apps/main/src/quick-ask.ts` window + `components/quick-ask-bar.tsx`
+renderer, hash `#quick-ask`). Type — or hold Right ⌘ for local dictation
+(DOM events; the bar has focus, no Input Monitoring needed) — and the
+question relays through main into the current chat (`quickAsk:submit` →
+`quick-ask:submit` → `handlePromptSubmit`); the answer mirrors back over
+`quickAsk:state` → `quick-ask:state` (streaming text from
+`currentAssistantMessage`, final text from the conversation — only messages
+timestamped after the submit count). The window is hidden, not destroyed,
+on dismiss (blur or Esc); it grows to show the answer via `quickAsk:resize`.
 
 ## Cost notes
 

--- a/apps/x/apps/main/bundle.mjs
+++ b/apps/x/apps/main/bundle.mjs
@@ -33,7 +33,10 @@ await esbuild.build({
   // relative to their own package dirs), so they stay external and are copied
   // into .package/node_modules below, where require() from dist/main.cjs
   // finds them.
-  external: ['electron', 'node-pty', 'uiohook-napi'],
+  // electron-liquid-glass is external but NOT staged: the quick-ask glass
+  // experiment loads it lazily and degrades to the solid capsule when the
+  // require fails (as it will in packaged builds until it's staged).
+  external: ['electron', 'node-pty', 'uiohook-napi', 'electron-liquid-glass'],
   // Use CommonJS format - many dependencies use require() which doesn't work
   // well with esbuild's ESM shim. CJS handles dynamic requires natively.
   format: 'cjs',

--- a/apps/x/apps/main/bundle.mjs
+++ b/apps/x/apps/main/bundle.mjs
@@ -33,9 +33,9 @@ await esbuild.build({
   // relative to their own package dirs), so they stay external and are copied
   // into .package/node_modules below, where require() from dist/main.cjs
   // finds them.
-  // electron-liquid-glass is external but NOT staged: the quick-ask glass
-  // experiment loads it lazily and degrades to the solid capsule when the
-  // require fails (as it will in packaged builds until it's staged).
+  // electron-liquid-glass is staged below on macOS (its only platform);
+  // elsewhere the quick-ask bar's lazy import fails and it keeps the solid
+  // capsule.
   external: ['electron', 'node-pty', 'uiohook-napi', 'electron-liquid-glass'],
   // Use CommonJS format - many dependencies use require() which doesn't work
   // well with esbuild's ESM shim. CJS handles dynamic requires natively.
@@ -130,6 +130,28 @@ const nodeGypBuildDest = path.join(here, '.package', 'node_modules', 'node-gyp-b
 fs.rmSync(nodeGypBuildDest, { recursive: true, force: true });
 fs.cpSync(nodeGypBuildSrc, nodeGypBuildDest, { recursive: true, dereference: true });
 console.log('✅ uiohook-napi staged in .package/node_modules');
+
+// electron-liquid-glass (quick-ask bar's glass material): same node-gyp-build
+// loader + prebuilds layout as uiohook-napi. macOS-only prebuilds — on other
+// platforms nothing is staged and the lazy import in quick-ask.ts falls back
+// to the solid capsule.
+if (process.platform === 'darwin') {
+  const glassSrc = fs.realpathSync(path.join(here, 'node_modules', 'electron-liquid-glass'));
+  const glassDest = path.join(here, '.package', 'node_modules', 'electron-liquid-glass');
+  fs.rmSync(glassDest, { recursive: true, force: true });
+  fs.mkdirSync(glassDest, { recursive: true });
+  for (const item of ['package.json', 'dist']) {
+    fs.cpSync(path.join(glassSrc, item), path.join(glassDest, item), { recursive: true, dereference: true });
+  }
+  const glassPrebuildsSrc = path.join(glassSrc, 'prebuilds');
+  const glassPrebuildsDest = path.join(glassDest, 'prebuilds');
+  fs.mkdirSync(glassPrebuildsDest, { recursive: true });
+  for (const dir of fs.readdirSync(glassPrebuildsSrc)) {
+    if (!dir.startsWith(`${process.platform}-`)) continue;
+    fs.cpSync(path.join(glassPrebuildsSrc, dir), path.join(glassPrebuildsDest, dir), { recursive: true, dereference: true });
+  }
+  console.log('✅ electron-liquid-glass staged in .package/node_modules');
+}
 
 // electron-chrome-extensions injects a preload script into browser tabs to
 // implement the chrome.* extension APIs. It resolves that file at runtime:

--- a/apps/x/apps/main/package.json
+++ b/apps/x/apps/main/package.json
@@ -20,6 +20,7 @@
         "agent-slack": "0.9.3",
         "chokidar": "^4.0.3",
         "electron-chrome-extensions": "^4.9.0",
+        "electron-liquid-glass": "^1.1.1",
         "electron-squirrel-startup": "^1.0.1",
         "html-to-docx": "^1.8.0",
         "mammoth": "^1.11.0",

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1001,6 +1001,10 @@ export function setupIpcHandlers() {
       showQuickAsk();
       return {};
     },
+    'quickAsk:newChat': async () => {
+      findMainAppWindow()?.webContents.send('quick-ask:new-chat', null);
+      return {};
+    },
     'quickAsk:openChat': async () => {
       const main = findMainAppWindow();
       if (main) {

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -462,7 +462,12 @@ function findMainAppWindow(): BrowserWindow | undefined {
     if (w === videoPopoutWin || w.isDestroyed()) return false;
     const url = w.webContents.getURL();
     const isAppWindow = url.startsWith('app://') || url.startsWith('http://localhost');
-    return isAppWindow && !url.includes('#video-popout');
+    // Every utility window loads the same bundle with a hash route
+    // (#video-popout, #quick-ask, #meeting-detected) — only the hashless
+    // window is the real app. Matching just video-popout let the quick-ask
+    // relay pick the quick-ask window ITSELF as the "app window" and send
+    // the question right back to it (bar stuck on "Thinking…").
+    return isAppWindow && !url.includes('#');
   });
 }
 

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1001,6 +1001,17 @@ export function setupIpcHandlers() {
       showQuickAsk();
       return {};
     },
+    'quickAsk:openChat': async () => {
+      const main = findMainAppWindow();
+      if (main) {
+        if (main.isMinimized()) main.restore();
+        main.show();
+        main.focus();
+        app.focus({ steal: true });
+        main.webContents.send('quick-ask:open-chat', null);
+      }
+      return {};
+    },
     'quickAsk:resize': async (_event, args) => {
       resizeQuickAsk(args.height);
       return {};

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -27,6 +27,7 @@ const execFileAsync = promisify(execFile);
 let caffeinateBlockerId: number | null = null;
 
 import { initPtt, setPttActive, getPttStatus, retryPttHook, openInputMonitoringSettings } from './ptt.js';
+import { getQuickAskWindow, hideQuickAsk, showQuickAsk, resizeQuickAsk } from './quick-ask.js';
 import { RunEvent } from '@x/shared/dist/runs.js';
 import { ServiceEvent } from '@x/shared/dist/service-events.js';
 import type { SessionBusEvent } from '@x/shared/dist/sessions.js';
@@ -981,6 +982,27 @@ export function setupIpcHandlers() {
       } catch {
         return { success: false };
       }
+    },
+    // --- Quick-ask bar relays ---
+    'quickAsk:submit': async (_event, args) => {
+      findMainAppWindow()?.webContents.send('quick-ask:submit', args);
+      return {};
+    },
+    'quickAsk:hide': async () => {
+      hideQuickAsk();
+      return {};
+    },
+    'quickAsk:show': async () => {
+      showQuickAsk();
+      return {};
+    },
+    'quickAsk:resize': async (_event, args) => {
+      resizeQuickAsk(args.height);
+      return {};
+    },
+    'quickAsk:state': async (_event, args) => {
+      getQuickAskWindow()?.webContents.send('quick-ask:state', args);
+      return {};
     },
     'meeting:notifyNotesReady': async (_event, args) => {
       // Granola-style re-entry point: the note refreshed in place, but the

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -72,6 +72,7 @@ import { loadAppSettings, saveAppSettings } from "@x/core/dist/config/app_settin
 import { init as initMeetingDetection } from "@x/core/dist/meetings/detector.js";
 import { createAppTray, hasTray, isRecordingActive, markPendingToggleMeetingNotes } from "./tray.js";
 import { initMeetingPopup, showMeetingPopup } from "./meeting-popup.js";
+import { initQuickAsk } from "./quick-ask.js";
 
 // Captured as early as possible so it reflects actual process start. Used to
 // gate grace-eligible notifications (e.g. the burst of background-task
@@ -518,6 +519,10 @@ app.whenReady().then(async () => {
   setupIpcHandlers();
   setupBrowserEventForwarding();
   setupBrowserExtensions();
+
+  // Quick-ask bar: global ⌥⇧Space summons a Spotlight-style ask-anything
+  // window over whatever app the user is in.
+  initQuickAsk();
 
   // Start the Rowboat Apps server (per-app origins on 127.0.0.1:3210) BEFORE
   // the window and the long service-init chain below. The Apps view is

--- a/apps/x/apps/main/src/ptt.ts
+++ b/apps/x/apps/main/src/ptt.ts
@@ -1,8 +1,8 @@
 /**
  * Global push-to-talk key hook (uiohook-napi).
  *
- * Watches the Right ⌘ key system-wide while a call needs it and relays
- * down/up/chord transitions to the app window, which
+ * Watches the Right ⌘ key system-wide while a call (or the quick-ask bar)
+ * needs it and relays down/up/chord transitions to the app window, which
  * owns the PTT state machine. The hook only runs while a consumer is
  * registered — no input monitoring outside calls.
  *
@@ -124,7 +124,7 @@ function stopHook() {
 
 /**
  * Reference-counted activation: key events are forwarded while at least one
- * consumer (currently just 'call') is active. The hook itself starts lazily on
+ * consumer ('call', 'quick-ask') is active. The hook itself starts lazily on
  * the first consumer and then STAYS running for the app's lifetime —
  * libuiohook's stop/start cycle is unreliable on macOS (the recreated tap
  * intermittently delivers nothing, which surfaced as PTT "randomly" dying

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -108,6 +108,7 @@ export function toggleQuickAsk() {
   // to type. The renderer focuses its input on window focus.
   win.show();
   win.focus();
+  if (process.platform === 'darwin') win.invalidateShadow();
 }
 
 /** Show (never hide) — the discoverability toast's "Try it" action. */
@@ -128,6 +129,9 @@ export function resizeQuickAsk(height: number) {
   const [width, currentHeight] = win.getSize();
   const bottom = y + currentHeight;
   win.setBounds({ x, y: bottom - clamped, width, height: clamped });
+  // Transparent windows keep a stale native shadow for the PREVIOUS shape
+  // after a resize (ghost outline hugging the old edges) — recompute it.
+  if (process.platform === 'darwin') win.invalidateShadow();
 }
 
 export function initQuickAsk() {

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -45,7 +45,9 @@ function createWindow(): BrowserWindow {
     skipTaskbar: true,
     show: false,
     hasShadow: true,
-    backgroundColor: '#171717',
+    // Transparent window + CSS border-radius on the root gives the bar its
+    // large rounded corners (the frameless default radius is much tighter).
+    transparent: true,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -13,9 +13,9 @@ import { app, BrowserWindow, globalShortcut, screen } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const BAR_WIDTH = 640;
-const BAR_HEIGHT = 88;
-const MAX_HEIGHT = 480;
+const BAR_WIDTH = 580;
+const BAR_HEIGHT = 76;
+const MAX_HEIGHT = 460;
 
 let quickAskWin: BrowserWindow | null = null;
 

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -73,15 +73,19 @@ function createWindow(): BrowserWindow {
   return win;
 }
 
+// Gap between the bar's bottom edge and the bottom of the work area.
+const BOTTOM_MARGIN = 96;
+
 function positionOnActiveDisplay(win: BrowserWindow) {
   // The display the cursor is on — the user summons the bar where they're
-  // working, which may not be where the app window lives.
+  // working, which may not be where the app window lives. Bottom-centered,
+  // dock-style.
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
   const { workArea } = display;
-  const [width] = win.getSize();
+  const [width, height] = win.getSize();
   win.setPosition(
     Math.round(workArea.x + (workArea.width - width) / 2),
-    Math.round(workArea.y + workArea.height * 0.2),
+    Math.round(workArea.y + workArea.height - height - BOTTOM_MARGIN),
   );
 }
 
@@ -109,13 +113,19 @@ export function showQuickAsk() {
   if (!getQuickAskWindow()?.isVisible()) toggleQuickAsk();
 }
 
-/** Grow/shrink the bar as the response area appears (renderer-driven). */
+/**
+ * Grow/shrink the bar as the response area appears (renderer-driven).
+ * The bar is bottom-anchored, so growth extends UPWARD: the bottom edge
+ * stays put and the top rises.
+ */
 export function resizeQuickAsk(height: number) {
   const win = getQuickAskWindow();
   if (!win) return;
   const clamped = Math.max(BAR_HEIGHT, Math.min(MAX_HEIGHT, Math.round(height)));
-  const [width] = win.getSize();
-  win.setSize(width, clamped);
+  const [x, y] = win.getPosition();
+  const [width, currentHeight] = win.getSize();
+  const bottom = y + currentHeight;
+  win.setBounds({ x, y: bottom - clamped, width, height: clamped });
 }
 
 export function initQuickAsk() {

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -75,6 +75,7 @@ function createWindow(): BrowserWindow {
   // Zoom factor resets on navigation — apply it once the page is in.
   win.webContents.on('did-finish-load', () => {
     win.webContents.setZoomFactor(SCALE);
+    void applyLiquidGlass(win);
   });
   if (app.isPackaged) {
     void win.loadURL('app://-/index.html#quick-ask');
@@ -99,6 +100,30 @@ function positionOnActiveDisplay(win: BrowserWindow) {
     Math.round(workArea.x + (workArea.width - width) / 2),
     Math.round(workArea.y + workArea.height - height - BOTTOM_MARGIN),
   );
+}
+
+// --- Liquid Glass (experiment) ---
+// Real NSGlassEffectView behind the bar via electron-liquid-glass (macOS
+// 26+; safe no-op elsewhere). Loaded lazily: it's a native module, and its
+// absence (older macOS, packaged builds that don't stage it) must degrade
+// to the solid capsule — the renderer only swaps to a translucent
+// background when told the glass actually applied.
+async function applyLiquidGlass(win: BrowserWindow) {
+  if (process.platform !== 'darwin') return;
+  try {
+    const { default: liquidGlass } = await import('electron-liquid-glass');
+    liquidGlass.addView(win.getNativeWindowHandle(), {
+      // Matches the CSS capsule radius (44 design px × 0.9 zoom).
+      cornerRadius: 40,
+      tintColor: '#1a1b1e33',
+    });
+    await win.webContents.executeJavaScript(
+      "document.documentElement.dataset.liquidGlass = '1'",
+      true,
+    );
+  } catch (err) {
+    console.warn('[quick-ask] liquid glass unavailable, keeping solid capsule:', err);
+  }
 }
 
 export function hideQuickAsk() {

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -1,0 +1,134 @@
+/**
+ * Quick-ask bar: a Spotlight-style floating window summoned with a global
+ * shortcut (⌥⇧Space) from anywhere — type (or hold Right ⌘ to speak) and the
+ * question lands in the current chat; the answer streams back into the bar.
+ *
+ * The window is created once and shown/hidden on toggle so summoning is
+ * instant. It loads the renderer bundle with #quick-ask (see
+ * renderer/src/main.tsx) and talks over quickAsk:* channels: submits relay
+ * to the app window (which owns the chat), response state relays back here
+ * (see the quickAsk handlers in ipc.ts).
+ */
+import { app, BrowserWindow, globalShortcut, screen } from 'electron';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BAR_WIDTH = 640;
+const BAR_HEIGHT = 88;
+const MAX_HEIGHT = 480;
+
+let quickAskWin: BrowserWindow | null = null;
+
+export function getQuickAskWindow(): BrowserWindow | null {
+  return quickAskWin && !quickAskWin.isDestroyed() ? quickAskWin : null;
+}
+
+function createWindow(): BrowserWindow {
+  const hereDir = path.dirname(fileURLToPath(import.meta.url));
+  const preloadPath = app.isPackaged
+    ? path.join(hereDir, '../preload/dist/preload.js')
+    : path.join(hereDir, '../../../preload/dist/preload.js');
+  const win = new BrowserWindow({
+    width: BAR_WIDTH,
+    height: BAR_HEIGHT,
+    frame: false,
+    resizable: false,
+    // Never fullscreenable — see the popout in ipc.ts: windows created while
+    // a fullscreen Space is active can otherwise open fullscreen themselves.
+    fullscreenable: false,
+    minimizable: false,
+    maximizable: false,
+    // NSPanel: the bar must appear over other apps' fullscreen Spaces — the
+    // whole point is summoning it from wherever the user is.
+    ...(process.platform === 'darwin' ? { type: 'panel' as const } : {}),
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    show: false,
+    hasShadow: true,
+    backgroundColor: '#171717',
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      preload: preloadPath,
+    },
+  });
+  // Same all-workspaces setup as the call popout: float over fullscreen
+  // Spaces too, keeping the Dock icon (skipTransformProcessType).
+  win.setAlwaysOnTop(true, 'floating');
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
+  // Spotlight behavior: clicking away dismisses the bar.
+  win.on('blur', () => {
+    if (!win.isDestroyed() && win.isVisible()) win.hide();
+  });
+  win.on('closed', () => {
+    if (quickAskWin === win) quickAskWin = null;
+  });
+  if (app.isPackaged) {
+    void win.loadURL('app://-/index.html#quick-ask');
+  } else {
+    void win.loadURL('http://localhost:5173/#quick-ask');
+  }
+  quickAskWin = win;
+  return win;
+}
+
+function positionOnActiveDisplay(win: BrowserWindow) {
+  // The display the cursor is on — the user summons the bar where they're
+  // working, which may not be where the app window lives.
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const { workArea } = display;
+  const [width] = win.getSize();
+  win.setPosition(
+    Math.round(workArea.x + (workArea.width - width) / 2),
+    Math.round(workArea.y + workArea.height * 0.2),
+  );
+}
+
+export function hideQuickAsk() {
+  const win = getQuickAskWindow();
+  if (win?.isVisible()) win.hide();
+}
+
+export function toggleQuickAsk() {
+  let win = getQuickAskWindow();
+  if (win?.isVisible()) {
+    win.hide();
+    return;
+  }
+  if (!win) win = createWindow();
+  positionOnActiveDisplay(win);
+  // Unlike the call popout, taking focus is the point — the user is about
+  // to type. The renderer focuses its input on window focus.
+  win.show();
+  win.focus();
+}
+
+/** Show (never hide) — the discoverability toast's "Try it" action. */
+export function showQuickAsk() {
+  if (!getQuickAskWindow()?.isVisible()) toggleQuickAsk();
+}
+
+/** Grow/shrink the bar as the response area appears (renderer-driven). */
+export function resizeQuickAsk(height: number) {
+  const win = getQuickAskWindow();
+  if (!win) return;
+  const clamped = Math.max(BAR_HEIGHT, Math.min(MAX_HEIGHT, Math.round(height)));
+  const [width] = win.getSize();
+  win.setSize(width, clamped);
+}
+
+export function initQuickAsk() {
+  // ⌥⇧Space: plain ⌥Space is the most contested launcher chord on macOS
+  // (Raycast, ChatGPT desktop, …) — registering it would silently lose or,
+  // worse, double-fire alongside whatever owns it.
+  const ok = globalShortcut.register('Alt+Shift+Space', toggleQuickAsk);
+  if (!ok) {
+    // Another app owns the chord — quick-ask is simply unavailable rather
+    // than fighting over it.
+    console.warn('[quick-ask] failed to register Alt+Shift+Space (already taken?)');
+  }
+  app.on('will-quit', () => {
+    globalShortcut.unregisterAll();
+  });
+}

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -13,9 +13,9 @@ import { app, BrowserWindow, globalShortcut, screen } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const BAR_WIDTH = 580;
-const BAR_HEIGHT = 76;
-const MAX_HEIGHT = 460;
+const BAR_WIDTH = 640;
+const BAR_HEIGHT = 88;
+const MAX_HEIGHT = 480;
 
 let quickAskWin: BrowserWindow | null = null;
 

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -13,9 +13,15 @@ import { app, BrowserWindow, globalShortcut, screen } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// Design-space dimensions (what the renderer lays out against, in CSS px).
 const BAR_WIDTH = 640;
 const BAR_HEIGHT = 88;
 const MAX_HEIGHT = 480;
+// Uniform downscale: the window shrinks and the page zooms by the SAME
+// factor, so every proportion of the design survives exactly — unlike
+// hand-shrinking individual sizes, which broke the alignment.
+const SCALE = 0.9;
+const scaled = (v: number) => Math.round(v * SCALE);
 
 let quickAskWin: BrowserWindow | null = null;
 
@@ -29,8 +35,8 @@ function createWindow(): BrowserWindow {
     ? path.join(hereDir, '../preload/dist/preload.js')
     : path.join(hereDir, '../../../preload/dist/preload.js');
   const win = new BrowserWindow({
-    width: BAR_WIDTH,
-    height: BAR_HEIGHT,
+    width: scaled(BAR_WIDTH),
+    height: scaled(BAR_HEIGHT),
     frame: false,
     resizable: false,
     // Never fullscreenable — see the popout in ipc.ts: windows created while
@@ -65,6 +71,10 @@ function createWindow(): BrowserWindow {
   });
   win.on('closed', () => {
     if (quickAskWin === win) quickAskWin = null;
+  });
+  // Zoom factor resets on navigation — apply it once the page is in.
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.setZoomFactor(SCALE);
   });
   if (app.isPackaged) {
     void win.loadURL('app://-/index.html#quick-ask');
@@ -124,7 +134,9 @@ export function showQuickAsk() {
 export function resizeQuickAsk(height: number) {
   const win = getQuickAskWindow();
   if (!win) return;
-  const clamped = Math.max(BAR_HEIGHT, Math.min(MAX_HEIGHT, Math.round(height)));
+  // The renderer requests design-space heights; the window lives in scaled
+  // space.
+  const clamped = scaled(Math.max(BAR_HEIGHT, Math.min(MAX_HEIGHT, Math.round(height))));
   const [x, y] = win.getPosition();
   const [width, currentHeight] = win.getSize();
   const bottom = y + currentHeight;

--- a/apps/x/apps/main/src/tray.ts
+++ b/apps/x/apps/main/src/tray.ts
@@ -1,4 +1,5 @@
 import { app, Menu, Tray, nativeImage } from "electron";
+import { toggleQuickAsk } from "./quick-ask.js";
 
 /**
  * Menu bar / system tray presence (Granola-style resident app).
@@ -150,6 +151,15 @@ function rebuildMenu(): void {
   if (!tray) return;
   const menu = Menu.buildFromTemplate([
     { label: "Open Rowboat", click: () => actions?.openApp() },
+    // Permanent discoverability for the global quick-ask shortcut — the
+    // accelerator renders next to the label (display only; the real binding
+    // is the globalShortcut in quick-ask.ts).
+    {
+      label: "Quick Ask",
+      accelerator: "Alt+Shift+Space",
+      registerAccelerator: false,
+      click: () => toggleQuickAsk(),
+    },
     recording
       ? {
           label: "Stop recording and generate notes",

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1840,11 +1840,28 @@ function App() {
     // Nothing new yet (run not started / no fresh answer): pushing would
     // only flicker the bar's local "Thinking…" state away.
     if (!text && !activeIsProcessing) return
+    // What's happening right now, for the bar's blinking status line: the
+    // most recent activity wins — a running tool by name, else reasoning,
+    // else plain thinking.
+    let statusText: string | null = null
+    if (activeIsProcessing) {
+      statusText = activeIsReasoning ? 'Reasoning…' : 'Thinking…'
+      for (let i = liveConversation.length - 1; i >= 0; i--) {
+        const item = liveConversation[i]
+        if (isToolCall(item)) {
+          if (item.status === 'pending' || item.status === 'running') {
+            statusText = `${getToolDisplayName(item)}…`
+          }
+          break
+        }
+        if (isChatMessage(item)) break
+      }
+    }
     void window.ipc
-      .invoke('quickAsk:state', { processing: activeIsProcessing, responseText: text || null })
+      .invoke('quickAsk:state', { processing: activeIsProcessing, responseText: text || null, statusText })
       .catch(() => {})
     if (!activeIsProcessing && text) quickAskActiveRef.current = false
-  }, [activeIsProcessing, liveAssistantMessage, liveConversation])
+  }, [activeIsProcessing, activeIsReasoning, liveAssistantMessage, liveConversation])
 
   // Enter to submit voice input, Escape to cancel
   useEffect(() => {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1819,15 +1819,18 @@ function App() {
 
   // Mirror the in-flight answer back to the bar while a quick-ask turn is
   // live: streaming text while generating, the final assistant message when
-  // done (which also ends the mirror). Only messages from AFTER the submit
-  // count — the previous turn's answer is still the newest one in the
-  // conversation at submit time.
+  // done (which also ends the mirror). Reads the LIVE chat state — the
+  // standalone conversation/currentAssistantMessage states are legacy
+  // pre-load fallbacks the new runtime never feeds (the original quick-ask
+  // read those, which is why its mirror never showed anything). Only
+  // messages from AFTER the submit count — the previous turn's answer is
+  // still the newest one in the conversation at submit time.
   useEffect(() => {
     if (!quickAskActiveRef.current) return
-    let text = currentAssistantMessage
+    let text = liveAssistantMessage
     if (!text) {
-      for (let i = conversation.length - 1; i >= 0; i--) {
-        const item = conversation[i]
+      for (let i = liveConversation.length - 1; i >= 0; i--) {
+        const item = liveConversation[i]
         if (isChatMessage(item) && item.role === 'assistant') {
           if (item.timestamp >= quickAskStartedAtRef.current) text = item.content
           break
@@ -1841,7 +1844,7 @@ function App() {
       .invoke('quickAsk:state', { processing: activeIsProcessing, responseText: text || null })
       .catch(() => {})
     if (!activeIsProcessing && text) quickAskActiveRef.current = false
-  }, [activeIsProcessing, currentAssistantMessage, conversation])
+  }, [activeIsProcessing, liveAssistantMessage, liveConversation])
 
   // Enter to submit voice input, Escape to cancel
   useEffect(() => {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -4351,6 +4351,13 @@ function App() {
     handleNewChat()
   }, [handleNewChat])
 
+  // Quick-ask "+": the bar wants a fresh conversation for its next question.
+  useEffect(() => {
+    return window.ipc.on('quick-ask:new-chat', () => {
+      handleNewChatTabInSidebar()
+    })
+  }, [handleNewChatTabInSidebar])
+
   // Palette → sidebar submission. Opens the sidebar (if closed), forces a fresh chat tab,
   // queues the message; the pending-submit effect (below) flushes it once state has settled
   // so handlePromptSubmit sees the new tab's null runId.

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1785,6 +1785,64 @@ function App() {
     })
   }, [handleToggleMic, handleToggleCamera, handleToggleScreenShare, handleInterruptAssistant, handlePttDown, handlePttUp, endCall, video])
 
+  // Discoverability: nothing else in the UI reveals the global quick-ask
+  // shortcut. One toast, once per install, shortly after launch.
+  useEffect(() => {
+    if (localStorage.getItem('quick-ask-tip-shown')) return
+    const timer = setTimeout(() => {
+      localStorage.setItem('quick-ask-tip-shown', '1')
+      toast('Ask Rowboat from anywhere', {
+        description: 'Press ⌥⇧Space in any app for a quick question — the answer shows up right there and in your chat.',
+        duration: 12000,
+        action: {
+          label: 'Try it',
+          onClick: () => void window.ipc.invoke('quickAsk:show', null).catch(() => {}),
+        },
+      })
+    }, 3000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  // Quick-ask bar: a question typed/spoken into the global ⌥⇧Space bar lands
+  // in the current chat exactly like a composer message.
+  const quickAskActiveRef = useRef(false)
+  const quickAskStartedAtRef = useRef(0)
+  useEffect(() => {
+    return window.ipc.on('quick-ask:submit', ({ text }) => {
+      const trimmed = text.trim()
+      if (!trimmed) return
+      quickAskActiveRef.current = true
+      quickAskStartedAtRef.current = Date.now()
+      handlePromptSubmitRef.current?.({ text: trimmed, files: [] })
+    })
+  }, [])
+
+  // Mirror the in-flight answer back to the bar while a quick-ask turn is
+  // live: streaming text while generating, the final assistant message when
+  // done (which also ends the mirror). Only messages from AFTER the submit
+  // count — the previous turn's answer is still the newest one in the
+  // conversation at submit time.
+  useEffect(() => {
+    if (!quickAskActiveRef.current) return
+    let text = currentAssistantMessage
+    if (!text) {
+      for (let i = conversation.length - 1; i >= 0; i--) {
+        const item = conversation[i]
+        if (isChatMessage(item) && item.role === 'assistant') {
+          if (item.timestamp >= quickAskStartedAtRef.current) text = item.content
+          break
+        }
+      }
+    }
+    // Nothing new yet (run not started / no fresh answer): pushing would
+    // only flicker the bar's local "Thinking…" state away.
+    if (!text && !activeIsProcessing) return
+    void window.ipc
+      .invoke('quickAsk:state', { processing: activeIsProcessing, responseText: text || null })
+      .catch(() => {})
+    if (!activeIsProcessing && text) quickAskActiveRef.current = false
+  }, [activeIsProcessing, currentAssistantMessage, conversation])
+
   // Enter to submit voice input, Escape to cancel
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -3295,11 +3353,11 @@ function App() {
     permissionMode?: PermissionMode,
   ) => {
     if (activeIsProcessing) {
-      // In-call input arrives at arbitrary moments — a hard drop here
-      // silently ate utterances submitted while the previous turn was still
-      // stopping (the PTT interrupt is async). Finish the stop and proceed
-      // with this message instead.
-      if (!inCallRef.current) return
+      // In-call and quick-ask input arrives at arbitrary moments — a hard
+      // drop here silently ate utterances submitted while the previous turn
+      // was still stopping (the PTT interrupt is async). Finish the stop and
+      // proceed with this message instead.
+      if (!inCallRef.current && !quickAskActiveRef.current) return
       await stopRunRef.current?.()
     }
 

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1803,6 +1803,15 @@ function App() {
     return () => clearTimeout(timer)
   }, [])
 
+  // Quick-ask "Open in Rowboat": land on the conversation full-view — chat
+  // pane open and maximized, no middle pane.
+  useEffect(() => {
+    return window.ipc.on('quick-ask:open-chat', () => {
+      setIsChatSidebarOpen(true)
+      setIsRightPaneMaximized(true)
+    })
+  }, [])
+
   // Quick-ask bar: a question typed/spoken into the global ⌥⇧Space bar lands
   // in the current chat exactly like a composer message.
   const quickAskActiveRef = useRef(false)

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -239,8 +239,8 @@ export function QuickAskBar() {
                 inset hairline, radial top sheen. */}
             <span className="relative flex items-center gap-2 overflow-hidden rounded-full bg-gradient-to-b from-white/10 to-white/[0.03] px-3.5 py-2 text-sm text-neutral-200 ring-1 ring-inset ring-white/15">
               <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.12),transparent_55%)]" />
-              <Command className="relative h-4 w-4 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
               <span className="relative">Hold right</span>
+              <Command className="relative h-4 w-4 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
             </span>
             <span className="text-sm text-neutral-400">to speak</span>
           </span>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -7,8 +7,8 @@ import { useVoiceMode } from '@/hooks/useVoiceMode'
 // Window heights the bar asks main for: just the input row, or input +
 // answer area. Fixed steps (not content-measured) so the window never
 // feedback-loops with its own resize.
-const BAR_HEIGHT = 88
-const ANSWER_HEIGHT = 380
+const BAR_HEIGHT = 76
+const ANSWER_HEIGHT = 360
 
 /**
  * Content of the quick-ask window (global ⌥⇧Space — see main's quick-ask.ts).
@@ -140,11 +140,11 @@ export function QuickAskBar() {
       // zones (the only area it isn't clipped) as dark smudges — the native
       // window shadow already provides the depth.
       className={`flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white ${
-        expanded ? 'rounded-[28px]' : 'rounded-full'
+        expanded ? 'rounded-[24px]' : 'rounded-full'
       }`}
     >
       {asked && (
-        <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
+        <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-6 pb-3 pt-4">
           <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">{asked}</div>
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
             {answer?.text ? (
@@ -165,7 +165,7 @@ export function QuickAskBar() {
       )}
 
       <form
-        className="flex h-[88px] shrink-0 items-center gap-4 pl-4 pr-4"
+        className="flex h-[76px] shrink-0 items-center gap-3 pl-3.5 pr-3.5"
         onSubmit={(e) => {
           e.preventDefault()
           submit(draft)
@@ -173,13 +173,13 @@ export function QuickAskBar() {
       >
         {/* Mic orb: blue accent with a soft glow; green pulse while live. */}
         <span
-          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-colors ${
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors ${
             recording
               ? 'animate-pulse bg-green-500/20 shadow-[0_0_24px_rgba(34,197,94,0.35)] ring-1 ring-green-400/40'
               : 'bg-blue-500/15 shadow-[0_0_24px_rgba(59,130,246,0.3)] ring-1 ring-blue-400/30'
           }`}
         >
-          <Mic className={`h-5 w-5 ${recording ? 'text-green-400' : 'text-blue-400'}`} />
+          <Mic className={`h-4 w-4 ${recording ? 'text-green-400' : 'text-blue-400'}`} />
         </span>
         <input
           ref={inputRef}
@@ -187,7 +187,7 @@ export function QuickAskBar() {
           value={inputValue}
           onChange={(e) => setDraft(e.target.value)}
           placeholder={recording ? 'Listening…' : 'Ask Rowboat anything…'}
-          className="h-full min-w-0 flex-1 bg-transparent text-xl font-light outline-none placeholder:text-neutral-500"
+          className="h-full min-w-0 flex-1 bg-transparent text-lg font-light outline-none placeholder:text-neutral-500"
         />
         {micDenied ? (
           <button
@@ -199,20 +199,20 @@ export function QuickAskBar() {
           </button>
         ) : (
           <span className="flex shrink-0 items-center gap-3">
-            <span className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3.5 py-2 text-sm text-neutral-300">
-              <Command className="h-4 w-4 text-blue-400" />
+            <span className="flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[13px] text-neutral-300">
+              <Command className="h-3.5 w-3.5 text-blue-400" />
               Hold right
             </span>
-            <span className="text-sm text-neutral-400">to speak</span>
+            <span className="text-[13px] text-neutral-400">to speak</span>
           </span>
         )}
         <button
           type="submit"
           disabled={!draft.trim()}
           aria-label="Send"
-          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-200 transition-colors hover:bg-white/10 disabled:opacity-40"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-200 transition-colors hover:bg-white/10 disabled:opacity-40"
         >
-          <CornerDownLeft className="h-5 w-5" />
+          <CornerDownLeft className="h-4 w-4" />
         </button>
       </form>
     </div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -59,10 +59,24 @@ export function QuickAskBar() {
   }, [])
 
   // Ask main to grow/shrink the window when the answer area toggles.
+  // Content-driven: the panel takes only what the answer needs (short
+  // answers get a short panel), up to the unchanged ANSWER_HEIGHT cap.
+  // Measured off an inner wrapper so the scroll container's own size can
+  // never feed back into the measurement.
   const expanded = asked !== null
+  const panelContentRef = useRef<HTMLDivElement | null>(null)
+  // Panel chrome around the measured content: pt-5 + pb-3 + footer line +
+  // its mt-2 + the divider, in design px.
+  const PANEL_CHROME = 62
   useEffect(() => {
-    void window.ipc.invoke('quickAsk:resize', { height: expanded ? ANSWER_HEIGHT : BAR_HEIGHT }).catch(() => {})
-  }, [expanded])
+    if (!expanded) {
+      void window.ipc.invoke('quickAsk:resize', { height: BAR_HEIGHT }).catch(() => {})
+      return
+    }
+    const content = panelContentRef.current?.offsetHeight ?? 0
+    const needed = Math.min(ANSWER_HEIGHT, BAR_HEIGHT + PANEL_CHROME + content)
+    void window.ipc.invoke('quickAsk:resize', { height: needed }).catch(() => {})
+  }, [expanded, asked, answer?.text, answer?.statusText, answer?.processing])
 
   const submit = useCallback((raw: string) => {
     const text = raw.trim()
@@ -155,6 +169,7 @@ export function QuickAskBar() {
       {asked && (
         <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
+            <div ref={panelContentRef}>
             {/* Inside the scroll area — the question scrolls away with the
                 answer instead of persisting as a header. */}
             <div className="mb-2 text-sm font-medium text-neutral-400">{asked}</div>
@@ -168,6 +183,7 @@ export function QuickAskBar() {
               )
             )}
             {answer?.processing && answer.text && <span className="animate-pulse">▍</span>}
+            </div>
           </div>
           <div className="mt-2 shrink-0 text-[11px] text-neutral-600">
             Also in your Rowboat chat · Esc to {answer?.processing ? 'dismiss' : 'clear'}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { CornerDownLeft, Mic } from 'lucide-react'
+
+import { useVoiceMode } from '@/hooks/useVoiceMode'
+
+// Window heights the bar asks main for: just the input row, or input +
+// answer area. Fixed steps (not content-measured) so the window never
+// feedback-loops with its own resize.
+const BAR_HEIGHT = 88
+const ANSWER_HEIGHT = 380
+
+/**
+ * Content of the quick-ask window (global ⌥⇧Space — see main's quick-ask.ts).
+ * A Spotlight-style bar floating over whatever the user is doing: type a
+ * question (or hold Right ⌘ to speak it) and it lands in the current chat in
+ * the app window; the answer streams back here over `quick-ask:state`.
+ * The window is hidden, not destroyed, on dismiss — state survives toggles.
+ */
+export function QuickAskBar() {
+  const [draft, setDraft] = useState('')
+  const [asked, setAsked] = useState<string | null>(null)
+  const [answer, setAnswer] = useState<{ processing: boolean; text: string } | null>(null)
+  // Only answer pushes that follow OUR submit render — the app window's chat
+  // may show unrelated turns from before the bar was opened.
+  const awaitingRef = useRef(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // Voice input: hold Right ⌘ while the bar is focused. Local dictation via
+  // the same Deepgram flow as the composer mic — no global hook needed, the
+  // bar has keyboard focus by construction.
+  const [recording, setRecording] = useState(false)
+  const recordingRef = useRef(false)
+  const [micDenied, setMicDenied] = useState(false)
+  const voice = useVoiceMode()
+
+  useEffect(() => {
+    const focusInput = () => inputRef.current?.focus()
+    focusInput()
+    window.addEventListener('focus', focusInput)
+    return () => window.removeEventListener('focus', focusInput)
+  }, [])
+
+  useEffect(() => {
+    return window.ipc.on('quick-ask:state', (s) => {
+      if (!awaitingRef.current) return
+      setAnswer({ processing: s.processing, text: s.responseText ?? '' })
+    })
+  }, [])
+
+  // Ask main to grow/shrink the window when the answer area toggles.
+  const expanded = asked !== null
+  useEffect(() => {
+    void window.ipc.invoke('quickAsk:resize', { height: expanded ? ANSWER_HEIGHT : BAR_HEIGHT }).catch(() => {})
+  }, [expanded])
+
+  const submit = useCallback((raw: string) => {
+    const text = raw.trim()
+    if (!text) return
+    setAsked(text)
+    setDraft('')
+    awaitingRef.current = true
+    setAnswer({ processing: true, text: '' })
+    void window.ipc.invoke('quickAsk:submit', { text }).catch(() => {})
+  }, [])
+
+  const reset = useCallback(() => {
+    awaitingRef.current = false
+    setAsked(null)
+    setAnswer(null)
+    setDraft('')
+  }, [])
+
+  const dismiss = useCallback(() => {
+    void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
+  }, [])
+
+  // Hold Right ⌘ to speak; release submits the transcript.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code === 'MetaRight' && !e.repeat && !recordingRef.current) {
+        recordingRef.current = true
+        setRecording(true)
+        void voice.start().then((result) => {
+          if (result === 'mic-denied') {
+            recordingRef.current = false
+            setRecording(false)
+            setMicDenied(true)
+          }
+        })
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        if (recordingRef.current) {
+          voice.cancel()
+          recordingRef.current = false
+          setRecording(false)
+        } else if (asked) {
+          reset()
+        } else {
+          dismiss()
+        }
+      }
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code === 'MetaRight' && recordingRef.current) {
+        recordingRef.current = false
+        setRecording(false)
+        void voice.submit().then((text) => {
+          if (text) submit(text)
+        })
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('keyup', onKeyUp)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('keyup', onKeyUp)
+    }
+  }, [voice, asked, reset, dismiss, submit])
+
+  const inputValue = recording ? voice.interimText || draft : draft
+
+  return (
+    <div className="flex h-screen w-screen select-none flex-col overflow-hidden bg-neutral-900 text-white">
+      <form
+        className="flex h-[88px] shrink-0 items-center gap-3 px-5"
+        onSubmit={(e) => {
+          e.preventDefault()
+          submit(draft)
+        }}
+      >
+        <span
+          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
+            recording ? 'bg-green-600 animate-pulse' : 'bg-sky-600'
+          }`}
+        >
+          <Mic className="h-4 w-4" />
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={recording ? 'Listening…' : 'Ask Rowboat anything…'}
+          className="h-full min-w-0 flex-1 bg-transparent text-lg outline-none placeholder:text-neutral-500"
+        />
+        {micDenied ? (
+          <button
+            type="button"
+            onClick={() => void window.ipc.invoke('app:openPrivacySettings', { section: 'microphone' }).catch(() => {})}
+            className="shrink-0 text-[11px] text-red-400 underline-offset-2 hover:underline"
+          >
+            Mic blocked — open System Settings
+          </button>
+        ) : (
+          <span className="flex shrink-0 items-center gap-2 text-[11px] text-neutral-500">
+            <kbd className="rounded border border-neutral-700 px-1.5 py-0.5">hold right ⌘</kbd>
+            to speak
+            <kbd className="rounded border border-neutral-700 px-1.5 py-0.5">
+              <CornerDownLeft className="h-3 w-3" />
+            </kbd>
+          </span>
+        )}
+      </form>
+
+      {asked && (
+        <div className="flex min-h-0 flex-1 flex-col border-t border-neutral-800 px-5 py-3">
+          <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">You asked: {asked}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-neutral-100">
+            {answer?.text ? (
+              answer.text
+            ) : (
+              <span className="text-neutral-500">{answer?.processing ? 'Thinking…' : ''}</span>
+            )}
+            {answer?.processing && answer.text && <span className="animate-pulse">▍</span>}
+          </div>
+          <div className="mt-2 shrink-0 text-[11px] text-neutral-600">
+            Also in your Rowboat chat · Esc to {answer?.processing ? 'dismiss' : 'clear'}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowUpRight, Command, CornerDownLeft, Mic } from 'lucide-react'
+import { ArrowUpRight, Command, CornerDownLeft, Mic, Plus } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -120,6 +120,13 @@ export function QuickAskBar() {
     void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
   }, [])
 
+  // Fresh conversation for the next question: resets the app's active chat
+  // (in the background) and clears the panel. The bar stays up.
+  const newChat = useCallback(() => {
+    void window.ipc.invoke('quickAsk:newChat', null).catch(() => {})
+    reset()
+  }, [reset])
+
   // Hold Right ⌘ to speak; release submits the transcript.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -189,6 +196,19 @@ export function QuickAskBar() {
       `}</style>
       {asked && (
         <div className="relative flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={newChat}
+                aria-label="New chat"
+                className="absolute right-14 top-4 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/[0.04] text-neutral-400 ring-1 ring-inset ring-white/10 transition-colors hover:bg-white/10 hover:text-white"
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">New chat</TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <button

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -192,8 +192,9 @@ export function QuickAskBar() {
               : 'bg-gradient-to-b from-sky-400/25 via-blue-500/15 to-indigo-500/10 shadow-[0_0_16px_rgba(96,165,250,0.25)] ring-white/15'
           }`}
         >
-          {/* top sheen */}
-          <span className="pointer-events-none absolute inset-x-1 top-0.5 h-1/2 rounded-full bg-gradient-to-b from-white/20 to-transparent" />
+          {/* top sheen — a radial fade from the top center, so there is no
+              shape edge to see (the previous half-ellipse showed its rim) */}
+          <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.2),transparent_55%)]" />
           <Mic
             className={`relative h-5 w-5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)] ${
               recording ? 'text-emerald-100' : 'text-sky-100'

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -112,7 +112,7 @@ export function QuickAskBar() {
   // active chat (the bar relays into it), so focusing the app window lands
   // on this exact exchange. The bar gets out of the way.
   const openInApp = useCallback(() => {
-    void window.ipc.invoke('app:focusMainWindow', null).catch(() => {})
+    void window.ipc.invoke('quickAsk:openChat', null).catch(() => {})
     void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
   }, [])
 
@@ -191,9 +191,9 @@ export function QuickAskBar() {
                 type="button"
                 onClick={openInApp}
                 aria-label="Open in Rowboat"
-                className="absolute right-4 top-3 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/5 text-neutral-300 ring-1 ring-inset ring-white/15 transition-colors hover:bg-white/10 hover:text-white"
+                className="absolute right-4 top-3 z-10 text-neutral-400 transition-colors hover:text-white"
               >
-                <ArrowUpRight className="h-3.5 w-3.5" />
+                <ArrowUpRight className="h-4 w-4" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">Open in Rowboat</TooltipContent>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Command, CornerDownLeft, Mic } from 'lucide-react'
+import { ArrowUpRight, Command, CornerDownLeft, Mic } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useVoiceMode } from '@/hooks/useVoiceMode'
 
 // Window heights the bar asks main for: just the input row, or input +
@@ -107,6 +108,14 @@ export function QuickAskBar() {
     void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
   }, [])
 
+  // Jump to the full conversation: the question already lives in the app's
+  // active chat (the bar relays into it), so focusing the app window lands
+  // on this exact exchange. The bar gets out of the way.
+  const openInApp = useCallback(() => {
+    void window.ipc.invoke('app:focusMainWindow', null).catch(() => {})
+    void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
+  }, [])
+
   // Hold Right ⌘ to speak; release submits the transcript.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -175,7 +184,20 @@ export function QuickAskBar() {
         }
       `}</style>
       {asked && (
-        <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
+        <div className="relative flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={openInApp}
+                aria-label="Open in Rowboat"
+                className="absolute right-4 top-3 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/5 text-neutral-300 ring-1 ring-inset ring-white/15 transition-colors hover:bg-white/10 hover:text-white"
+              >
+                <ArrowUpRight className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in Rowboat</TooltipContent>
+          </Tooltip>
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
             <div ref={panelContentRef}>
             {/* Inside the scroll area — the question scrolls away with the

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -145,7 +145,7 @@ export function QuickAskBar() {
     >
       {asked && (
         <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
-          <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">{asked}</div>
+          <div className="mb-2 shrink-0 truncate text-sm font-medium text-neutral-400">{asked}</div>
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
             {answer?.text ? (
               <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { CornerDownLeft, Mic } from 'lucide-react'
+import { Streamdown } from 'streamdown'
 
 import { useVoiceMode } from '@/hooks/useVoiceMode'
 
@@ -165,9 +166,11 @@ export function QuickAskBar() {
       {asked && (
         <div className="flex min-h-0 flex-1 flex-col border-t border-neutral-800 px-5 py-3">
           <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">You asked: {asked}</div>
-          <div className="min-h-0 flex-1 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-neutral-100">
+          <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
             {answer?.text ? (
-              answer.text
+              <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">
+                {answer.text}
+              </Streamdown>
             ) : (
               <span className="text-neutral-500">{answer?.processing ? 'Thinking…' : ''}</span>
             )}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -182,15 +182,23 @@ export function QuickAskBar() {
           submit(draft)
         }}
       >
-        {/* Mic orb: blue accent with a soft glow; green pulse while live. */}
+        {/* Mic orb: layered like a physical button — a soft vertical
+            gradient base, an inset hairline, a top sheen, and a tight halo.
+            Green (and breathing) while live. */}
         <span
-          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-colors ${
+          className={`relative flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all duration-300 ${
             recording
-              ? 'animate-pulse bg-green-500/20 shadow-[0_0_24px_rgba(34,197,94,0.35)] ring-1 ring-green-400/40'
-              : 'bg-blue-500/15 shadow-[0_0_24px_rgba(59,130,246,0.3)] ring-1 ring-blue-400/30'
+              ? 'animate-pulse bg-gradient-to-b from-emerald-400/30 to-emerald-600/10 shadow-[0_0_18px_rgba(52,211,153,0.35)] ring-white/20'
+              : 'bg-gradient-to-b from-sky-400/25 via-blue-500/15 to-indigo-500/10 shadow-[0_0_16px_rgba(96,165,250,0.25)] ring-white/15'
           }`}
         >
-          <Mic className={`h-5 w-5 ${recording ? 'text-green-400' : 'text-blue-400'}`} />
+          {/* top sheen */}
+          <span className="pointer-events-none absolute inset-x-1 top-0.5 h-1/2 rounded-full bg-gradient-to-b from-white/20 to-transparent" />
+          <Mic
+            className={`relative h-5 w-5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)] ${
+              recording ? 'text-emerald-100' : 'text-sky-100'
+            }`}
+          />
         </span>
         <input
           ref={inputRef}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -123,7 +123,7 @@ export function QuickAskBar() {
   return (
     // Bottom-anchored window (grows upward): the answer stacks ABOVE the
     // input row, which stays pinned to the bottom edge.
-    <div className="flex h-screen w-screen select-none flex-col overflow-hidden bg-neutral-900 text-white">
+    <div className="flex h-screen w-screen select-none flex-col overflow-hidden rounded-2xl border border-neutral-700/60 bg-neutral-900 text-white">
       {asked && (
         <div className="flex min-h-0 flex-1 flex-col border-b border-neutral-800 px-5 py-3">
           <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">You asked: {asked}</div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -39,6 +39,10 @@ export function QuickAskBar() {
   // corner areas OUTSIDE the border-radius — white spurs at every corner.
   // Clear every layer so only the rounded capsule is visible.
   useEffect(() => {
+    // The bar window skips the app's ThemeProvider, so theme CSS variables
+    // default to LIGHT — inline code rendered as white pills with white
+    // text. The bar is permanently dark; claim the dark tokens.
+    document.documentElement.classList.add('dark')
     document.documentElement.style.background = 'transparent'
     document.body.style.background = 'transparent'
     // The document must never scroll: during window resize transitions the
@@ -191,9 +195,9 @@ export function QuickAskBar() {
                 type="button"
                 onClick={openInApp}
                 aria-label="Open in Rowboat"
-                className="absolute right-4 top-3 z-10 text-neutral-400 transition-colors hover:text-white"
+                className="absolute right-5 top-4 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/[0.04] text-neutral-400 ring-1 ring-inset ring-white/10 transition-colors hover:bg-white/10 hover:text-white"
               >
-                <ArrowUpRight className="h-4 w-4" />
+                <ArrowUpRight className="h-3.5 w-3.5" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">Open in Rowboat</TooltipContent>
@@ -204,7 +208,7 @@ export function QuickAskBar() {
                 answer instead of persisting as a header. */}
             <div className="mb-2 text-sm font-medium text-neutral-400">{asked}</div>
             {answer?.text ? (
-              <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">
+              <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-white/10 [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-100">
                 {answer.text}
               </Streamdown>
             ) : (

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -121,7 +121,28 @@ export function QuickAskBar() {
   const inputValue = recording ? voice.interimText || draft : draft
 
   return (
+    // Bottom-anchored window (grows upward): the answer stacks ABOVE the
+    // input row, which stays pinned to the bottom edge.
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden bg-neutral-900 text-white">
+      {asked && (
+        <div className="flex min-h-0 flex-1 flex-col border-b border-neutral-800 px-5 py-3">
+          <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">You asked: {asked}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
+            {answer?.text ? (
+              <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">
+                {answer.text}
+              </Streamdown>
+            ) : (
+              <span className="text-neutral-500">{answer?.processing ? 'Thinking…' : ''}</span>
+            )}
+            {answer?.processing && answer.text && <span className="animate-pulse">▍</span>}
+          </div>
+          <div className="mt-2 shrink-0 text-[11px] text-neutral-600">
+            Also in your Rowboat chat · Esc to {answer?.processing ? 'dismiss' : 'clear'}
+          </div>
+        </div>
+      )}
+
       <form
         className="flex h-[88px] shrink-0 items-center gap-3 px-5"
         onSubmit={(e) => {
@@ -162,25 +183,6 @@ export function QuickAskBar() {
           </span>
         )}
       </form>
-
-      {asked && (
-        <div className="flex min-h-0 flex-1 flex-col border-t border-neutral-800 px-5 py-3">
-          <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">You asked: {asked}</div>
-          <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
-            {answer?.text ? (
-              <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">
-                {answer.text}
-              </Streamdown>
-            ) : (
-              <span className="text-neutral-500">{answer?.processing ? 'Thinking…' : ''}</span>
-            )}
-            {answer?.processing && answer.text && <span className="animate-pulse">▍</span>}
-          </div>
-          <div className="mt-2 shrink-0 text-[11px] text-neutral-600">
-            Also in your Rowboat chat · Esc to {answer?.processing ? 'dismiss' : 'clear'}
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -40,6 +40,12 @@ export function QuickAskBar() {
   useEffect(() => {
     document.documentElement.style.background = 'transparent'
     document.body.style.background = 'transparent'
+    // The document must never scroll: during window resize transitions the
+    // layout can be a frame taller than the viewport, and a wheel event in
+    // that frame scrolls the whole capsule out of place (input row drifting
+    // up, content bleeding past it).
+    document.documentElement.style.overflow = 'hidden'
+    document.body.style.overflow = 'hidden'
     const root = document.getElementById('root')
     if (root) root.style.background = 'transparent'
   }, [])
@@ -76,6 +82,8 @@ export function QuickAskBar() {
     const content = panelContentRef.current?.offsetHeight ?? 0
     const needed = Math.min(ANSWER_HEIGHT, BAR_HEIGHT + PANEL_CHROME + content)
     void window.ipc.invoke('quickAsk:resize', { height: needed }).catch(() => {})
+    // Undo any scroll offset a resize frame let slip through.
+    window.scrollTo(0, 0)
   }, [expanded, asked, answer?.text, answer?.statusText, answer?.processing])
 
   const submit = useCallback((raw: string) => {

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -136,7 +136,10 @@ export function QuickAskBar() {
     // is a full capsule; expanded, the capsule softens so the answer panel
     // reads as one surface.
     <div
-      className={`flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white shadow-2xl ${
+      // No CSS shadow here: it would paint into the window's square corner
+      // zones (the only area it isn't clipped) as dark smudges — the native
+      // window shadow already provides the depth.
+      className={`flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white ${
         expanded ? 'rounded-[28px]' : 'rounded-full'
       }`}
     >

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -139,10 +139,19 @@ export function QuickAskBar() {
       // No CSS shadow here: it would paint into the window's square corner
       // zones (the only area it isn't clipped) as dark smudges — the native
       // window shadow already provides the depth.
-      className={`flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white ${
-        expanded ? 'rounded-[28px]' : 'rounded-full'
+      className={`qa-root flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white ${
+        expanded ? 'rounded-[44px]' : 'rounded-full'
       }`}
     >
+      {/* Liquid Glass experiment: when main confirms the native glass view
+          applied (html[data-liquid-glass]), the solid capsule becomes a
+          translucent skin over it. Plain CSS so no re-render is needed. */}
+      <style>{`
+        html[data-liquid-glass="1"] .qa-root {
+          background-color: rgba(12, 12, 16, 0.18) !important;
+          border-color: rgba(255, 255, 255, 0.18) !important;
+        }
+      `}</style>
       {asked && (
         <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { CornerDownLeft, Mic } from 'lucide-react'
+import { Command, CornerDownLeft, Mic } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
 import { useVoiceMode } from '@/hooks/useVoiceMode'
@@ -122,11 +122,17 @@ export function QuickAskBar() {
 
   return (
     // Bottom-anchored window (grows upward): the answer stacks ABOVE the
-    // input row, which stays pinned to the bottom edge.
-    <div className="flex h-screen w-screen select-none flex-col overflow-hidden rounded-2xl border border-neutral-700/60 bg-neutral-900 text-white">
+    // input row, which stays pinned to the bottom edge. Collapsed, the bar
+    // is a full capsule; expanded, the capsule softens so the answer panel
+    // reads as one surface.
+    <div
+      className={`flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white shadow-2xl ${
+        expanded ? 'rounded-[28px]' : 'rounded-full'
+      }`}
+    >
       {asked && (
-        <div className="flex min-h-0 flex-1 flex-col border-b border-neutral-800 px-5 py-3">
-          <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">You asked: {asked}</div>
+        <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
+          <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">{asked}</div>
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
             {answer?.text ? (
               <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">
@@ -146,18 +152,21 @@ export function QuickAskBar() {
       )}
 
       <form
-        className="flex h-[88px] shrink-0 items-center gap-3 px-5"
+        className="flex h-[88px] shrink-0 items-center gap-4 pl-4 pr-4"
         onSubmit={(e) => {
           e.preventDefault()
           submit(draft)
         }}
       >
+        {/* Mic orb: blue accent with a soft glow; green pulse while live. */}
         <span
-          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
-            recording ? 'bg-green-600 animate-pulse' : 'bg-sky-600'
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-colors ${
+            recording
+              ? 'animate-pulse bg-green-500/20 shadow-[0_0_24px_rgba(34,197,94,0.35)] ring-1 ring-green-400/40'
+              : 'bg-blue-500/15 shadow-[0_0_24px_rgba(59,130,246,0.3)] ring-1 ring-blue-400/30'
           }`}
         >
-          <Mic className="h-4 w-4" />
+          <Mic className={`h-5 w-5 ${recording ? 'text-green-400' : 'text-blue-400'}`} />
         </span>
         <input
           ref={inputRef}
@@ -165,7 +174,7 @@ export function QuickAskBar() {
           value={inputValue}
           onChange={(e) => setDraft(e.target.value)}
           placeholder={recording ? 'Listening…' : 'Ask Rowboat anything…'}
-          className="h-full min-w-0 flex-1 bg-transparent text-lg outline-none placeholder:text-neutral-500"
+          className="h-full min-w-0 flex-1 bg-transparent text-xl font-light outline-none placeholder:text-neutral-500"
         />
         {micDenied ? (
           <button
@@ -176,14 +185,22 @@ export function QuickAskBar() {
             Mic blocked — open System Settings
           </button>
         ) : (
-          <span className="flex shrink-0 items-center gap-2 text-[11px] text-neutral-500">
-            <kbd className="rounded border border-neutral-700 px-1.5 py-0.5">hold right ⌘</kbd>
-            to speak
-            <kbd className="rounded border border-neutral-700 px-1.5 py-0.5">
-              <CornerDownLeft className="h-3 w-3" />
-            </kbd>
+          <span className="flex shrink-0 items-center gap-3">
+            <span className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3.5 py-2 text-sm text-neutral-300">
+              <Command className="h-4 w-4 text-blue-400" />
+              Hold right
+            </span>
+            <span className="text-sm text-neutral-400">to speak</span>
           </span>
         )}
+        <button
+          type="submit"
+          disabled={!draft.trim()}
+          aria-label="Send"
+          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-200 transition-colors hover:bg-white/10 disabled:opacity-40"
+        >
+          <CornerDownLeft className="h-5 w-5" />
+        </button>
       </form>
     </div>
   )

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -235,9 +235,12 @@ export function QuickAskBar() {
           </button>
         ) : (
           <span className="flex shrink-0 items-center gap-3">
-            <span className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3.5 py-2 text-sm text-neutral-300">
-              <Command className="h-4 w-4 text-blue-400" />
-              Hold right
+            {/* Same layered construction as the mic orb: gradient base,
+                inset hairline, radial top sheen. */}
+            <span className="relative flex items-center gap-2 overflow-hidden rounded-full bg-gradient-to-b from-white/10 to-white/[0.03] px-3.5 py-2 text-sm text-neutral-200 ring-1 ring-inset ring-white/15">
+              <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.12),transparent_55%)]" />
+              <Command className="relative h-4 w-4 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
+              <span className="relative">Hold right</span>
             </span>
             <span className="text-sm text-neutral-400">to speak</span>
           </span>
@@ -246,9 +249,10 @@ export function QuickAskBar() {
           type="submit"
           disabled={!draft.trim()}
           aria-label="Send"
-          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-200 transition-colors hover:bg-white/10 disabled:opacity-40"
+          className="relative flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-100 ring-1 ring-inset ring-white/15 transition-all hover:from-white/[0.16] disabled:opacity-40"
         >
-          <CornerDownLeft className="h-5 w-5" />
+          <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.12),transparent_55%)]" />
+          <CornerDownLeft className="relative h-5 w-5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
         </button>
       </form>
     </div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -20,7 +20,7 @@ const ANSWER_HEIGHT = 380
 export function QuickAskBar() {
   const [draft, setDraft] = useState('')
   const [asked, setAsked] = useState<string | null>(null)
-  const [answer, setAnswer] = useState<{ processing: boolean; text: string } | null>(null)
+  const [answer, setAnswer] = useState<{ processing: boolean; text: string; statusText: string | null } | null>(null)
   // Only answer pushes that follow OUR submit render — the app window's chat
   // may show unrelated turns from before the bar was opened.
   const awaitingRef = useRef(false)
@@ -44,7 +44,7 @@ export function QuickAskBar() {
   useEffect(() => {
     return window.ipc.on('quick-ask:state', (s) => {
       if (!awaitingRef.current) return
-      setAnswer({ processing: s.processing, text: s.responseText ?? '' })
+      setAnswer({ processing: s.processing, text: s.responseText ?? '', statusText: s.statusText ?? null })
     })
   }, [])
 
@@ -60,7 +60,7 @@ export function QuickAskBar() {
     setAsked(text)
     setDraft('')
     awaitingRef.current = true
-    setAnswer({ processing: true, text: '' })
+    setAnswer({ processing: true, text: '', statusText: 'Thinking…' })
     void window.ipc.invoke('quickAsk:submit', { text }).catch(() => {})
   }, [])
 
@@ -133,7 +133,9 @@ export function QuickAskBar() {
                 {answer.text}
               </Streamdown>
             ) : (
-              <span className="text-neutral-500">{answer?.processing ? 'Thinking…' : ''}</span>
+              answer?.processing && (
+                <span className="animate-pulse text-neutral-500">{answer.statusText ?? 'Thinking…'}</span>
+              )
             )}
             {answer?.processing && answer.text && <span className="animate-pulse">▍</span>}
           </div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -7,8 +7,8 @@ import { useVoiceMode } from '@/hooks/useVoiceMode'
 // Window heights the bar asks main for: just the input row, or input +
 // answer area. Fixed steps (not content-measured) so the window never
 // feedback-loops with its own resize.
-const BAR_HEIGHT = 76
-const ANSWER_HEIGHT = 360
+const BAR_HEIGHT = 88
+const ANSWER_HEIGHT = 380
 
 /**
  * Content of the quick-ask window (global ⌥⇧Space — see main's quick-ask.ts).
@@ -140,11 +140,11 @@ export function QuickAskBar() {
       // zones (the only area it isn't clipped) as dark smudges — the native
       // window shadow already provides the depth.
       className={`flex h-screen w-screen select-none flex-col overflow-hidden border border-white/10 bg-[#1a1b1e]/95 text-white ${
-        expanded ? 'rounded-[24px]' : 'rounded-full'
+        expanded ? 'rounded-[28px]' : 'rounded-full'
       }`}
     >
       {asked && (
-        <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-6 pb-3 pt-4">
+        <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
           <div className="mb-2 shrink-0 truncate text-xs text-neutral-500">{asked}</div>
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
             {answer?.text ? (
@@ -165,7 +165,7 @@ export function QuickAskBar() {
       )}
 
       <form
-        className="flex h-[76px] shrink-0 items-center gap-3 pl-3.5 pr-3.5"
+        className="flex h-[88px] shrink-0 items-center gap-4 pl-4 pr-4"
         onSubmit={(e) => {
           e.preventDefault()
           submit(draft)
@@ -173,13 +173,13 @@ export function QuickAskBar() {
       >
         {/* Mic orb: blue accent with a soft glow; green pulse while live. */}
         <span
-          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors ${
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-colors ${
             recording
               ? 'animate-pulse bg-green-500/20 shadow-[0_0_24px_rgba(34,197,94,0.35)] ring-1 ring-green-400/40'
               : 'bg-blue-500/15 shadow-[0_0_24px_rgba(59,130,246,0.3)] ring-1 ring-blue-400/30'
           }`}
         >
-          <Mic className={`h-4 w-4 ${recording ? 'text-green-400' : 'text-blue-400'}`} />
+          <Mic className={`h-5 w-5 ${recording ? 'text-green-400' : 'text-blue-400'}`} />
         </span>
         <input
           ref={inputRef}
@@ -187,7 +187,7 @@ export function QuickAskBar() {
           value={inputValue}
           onChange={(e) => setDraft(e.target.value)}
           placeholder={recording ? 'Listening…' : 'Ask Rowboat anything…'}
-          className="h-full min-w-0 flex-1 bg-transparent text-lg font-light outline-none placeholder:text-neutral-500"
+          className="h-full min-w-0 flex-1 bg-transparent text-xl font-light outline-none placeholder:text-neutral-500"
         />
         {micDenied ? (
           <button
@@ -199,20 +199,20 @@ export function QuickAskBar() {
           </button>
         ) : (
           <span className="flex shrink-0 items-center gap-3">
-            <span className="flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[13px] text-neutral-300">
-              <Command className="h-3.5 w-3.5 text-blue-400" />
+            <span className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3.5 py-2 text-sm text-neutral-300">
+              <Command className="h-4 w-4 text-blue-400" />
               Hold right
             </span>
-            <span className="text-[13px] text-neutral-400">to speak</span>
+            <span className="text-sm text-neutral-400">to speak</span>
           </span>
         )}
         <button
           type="submit"
           disabled={!draft.trim()}
           aria-label="Send"
-          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-200 transition-colors hover:bg-white/10 disabled:opacity-40"
+          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-neutral-200 transition-colors hover:bg-white/10 disabled:opacity-40"
         >
-          <CornerDownLeft className="h-4 w-4" />
+          <CornerDownLeft className="h-5 w-5" />
         </button>
       </form>
     </div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -34,6 +34,16 @@ export function QuickAskBar() {
   const [micDenied, setMicDenied] = useState(false)
   const voice = useVoiceMode()
 
+  // Transparent window: the page's default (light) background paints the
+  // corner areas OUTSIDE the border-radius — white spurs at every corner.
+  // Clear every layer so only the rounded capsule is visible.
+  useEffect(() => {
+    document.documentElement.style.background = 'transparent'
+    document.body.style.background = 'transparent'
+    const root = document.getElementById('root')
+    if (root) root.style.background = 'transparent'
+  }, [])
+
   useEffect(() => {
     const focusInput = () => inputRef.current?.focus()
     focusInput()

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -145,8 +145,10 @@ export function QuickAskBar() {
     >
       {asked && (
         <div className="flex min-h-0 flex-1 flex-col border-b border-white/5 px-7 pb-3 pt-5">
-          <div className="mb-2 shrink-0 truncate text-sm font-medium text-neutral-400">{asked}</div>
           <div className="min-h-0 flex-1 overflow-y-auto text-sm leading-relaxed text-neutral-100">
+            {/* Inside the scroll area — the question scrolls away with the
+                answer instead of persisting as a header. */}
+            <div className="mb-2 text-sm font-medium text-neutral-400">{asked}</div>
             {answer?.text ? (
               <Streamdown className="prose prose-sm prose-invert max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]">
                 {answer.text}

--- a/apps/x/apps/renderer/src/components/video-popout.tsx
+++ b/apps/x/apps/renderer/src/components/video-popout.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ChevronDown, ChevronUp, Maximize2, Mic, MicOff, MonitorUp, PhoneOff, SendHorizontal, Square, User, Video, VideoOff } from 'lucide-react'
+import { Streamdown } from 'streamdown'
 
 import { TalkingHead } from '@/components/talking-head'
 
@@ -327,8 +328,12 @@ export function VideoPopout() {
                   {state.questionText}
                 </div>
               )}
-              <div className="whitespace-pre-wrap text-neutral-100">
-                {state.responseText}
+              <div className="text-neutral-100">
+                {state.responseText && (
+                  <Streamdown className="prose prose-sm prose-invert max-w-none text-[11px] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0 [&_pre]:my-1.5 [&_pre]:text-[10px] [&_code]:text-[10px]">
+                    {state.responseText}
+                  </Streamdown>
+                )}
                 {state.status === 'thinking' && <span className="animate-pulse">▍</span>}
               </div>
             </div>

--- a/apps/x/apps/renderer/src/main.tsx
+++ b/apps/x/apps/renderer/src/main.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@/contexts/theme-context'
 import { configureAnalyticsContext } from './lib/analytics'
 import { VideoPopout } from '@/components/video-popout'
 import { MeetingDetectedPopup } from '@/components/meeting-detected-popup'
+import { QuickAskBar } from '@/components/quick-ask-bar'
 
 // Fetch the stable installation ID from main so renderer + main share one
 // PostHog distinct_id. Falls back to PostHog's auto-generated anonymous ID
@@ -72,6 +73,13 @@ if (window.location.hash === '#video-popout') {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <MeetingDetectedPopup />
+    </StrictMode>,
+  )
+} else if (window.location.hash === '#quick-ask') {
+  // Global ⌥⇧Space quick-ask bar; same pattern.
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <QuickAskBar />
     </StrictMode>,
   )
 } else {

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1040,6 +1040,9 @@ const ipcSchemas = {
     req: z.object({
       processing: z.boolean(),
       responseText: z.string().nullable(),
+      // What the agent is doing right now ("Reasoning…", "Web search…") —
+      // shown blinking in the bar until the answer starts streaming.
+      statusText: z.string().nullable(),
     }),
     res: z.object({}),
   },
@@ -1048,6 +1051,9 @@ const ipcSchemas = {
     req: z.object({
       processing: z.boolean(),
       responseText: z.string().nullable(),
+      // What the agent is doing right now ("Reasoning…", "Web search…") —
+      // shown blinking in the bar until the answer starts streaming.
+      statusText: z.string().nullable(),
     }),
     res: z.null(),
   },

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1040,6 +1040,17 @@ const ipcSchemas = {
     req: z.null(),
     res: z.null(),
   },
+  // Bar → main: start a fresh chat for the next question (the app stays in
+  // the background; only the conversation resets).
+  'quickAsk:newChat': {
+    req: z.null(),
+    res: z.object({}),
+  },
+  // Push channel: main → app window for the reset above.
+  'quick-ask:new-chat': {
+    req: z.null(),
+    res: z.null(),
+  },
   // Bar → main: grow/shrink the window as the response area changes.
   'quickAsk:resize': {
     req: z.object({ height: z.number() }),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1029,6 +1029,17 @@ const ipcSchemas = {
     req: z.null(),
     res: z.object({}),
   },
+  // Bar → main: jump to the conversation in the app — focuses the app
+  // window and tells it to show the chat full-view (no middle pane).
+  'quickAsk:openChat': {
+    req: z.null(),
+    res: z.object({}),
+  },
+  // Push channel: main → app window for the jump above.
+  'quick-ask:open-chat': {
+    req: z.null(),
+    res: z.null(),
+  },
   // Bar → main: grow/shrink the window as the response area changes.
   'quickAsk:resize': {
     req: z.object({ height: z.number() }),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1008,6 +1008,49 @@ const ipcSchemas = {
     req: z.null(),
     res: z.object({}),
   },
+  // --- Quick-ask bar (global ⌥Space, own always-on-top window) ---
+  // Bar → main: relay a typed/spoken question into the app window's chat.
+  'quickAsk:submit': {
+    req: z.object({ text: z.string() }),
+    res: z.object({}),
+  },
+  // Push channel: main → app window with the relayed question.
+  'quick-ask:submit': {
+    req: z.object({ text: z.string() }),
+    res: z.null(),
+  },
+  // Bar → main: dismiss the bar (Esc).
+  'quickAsk:hide': {
+    req: z.null(),
+    res: z.object({}),
+  },
+  // App window → main: open the bar (the discoverability toast's "Try it").
+  'quickAsk:show': {
+    req: z.null(),
+    res: z.object({}),
+  },
+  // Bar → main: grow/shrink the window as the response area changes.
+  'quickAsk:resize': {
+    req: z.object({ height: z.number() }),
+    res: z.object({}),
+  },
+  // App window → main: mirror of the in-flight answer for the bar
+  // (streaming text while processing, final text when done).
+  'quickAsk:state': {
+    req: z.object({
+      processing: z.boolean(),
+      responseText: z.string().nullable(),
+    }),
+    res: z.object({}),
+  },
+  // Push channel: main → bar with the latest answer state.
+  'quick-ask:state': {
+    req: z.object({
+      processing: z.boolean(),
+      responseText: z.string().nullable(),
+    }),
+    res: z.null(),
+  },
   // --- Ambient meeting detection popup (own always-on-top window) ---
   // Main → popup: the detection to display.
   'meetingDetect:payload': {

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       electron-chrome-extensions:
         specifier: ^4.9.0
         version: 4.9.0
+      electron-liquid-glass:
+        specifier: ^1.1.1
+        version: 1.1.1
       electron-squirrel-startup:
         specifier: ^1.0.1
         version: 1.0.1
@@ -4723,6 +4726,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -5492,6 +5498,11 @@ packages:
     os: [darwin, linux]
     hasBin: true
 
+  electron-liquid-glass@1.1.1:
+    resolution: {integrity: sha512-AfPxcu6RJYxlsW2sjgjDEON0rVOjhh5QYM6ur5hsfILQmfY5ewHCWJZJZoDsQxhjeW1DAhbRbvB79IvgW4ansA==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   electron-squirrel-startup@1.0.1:
     resolution: {integrity: sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==}
 
@@ -5813,6 +5824,9 @@ packages:
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filename-reserved-regex@2.0.0:
     resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
@@ -7275,6 +7289,10 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-addon-api@8.9.0:
+    resolution: {integrity: sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
@@ -14355,6 +14373,10 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -15199,6 +15221,13 @@ snapshots:
       - supports-color
     optional: true
 
+  electron-liquid-glass@1.1.1:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 8.9.0
+    optionalDependencies:
+      node-gyp-build: 4.8.4
+
   electron-squirrel-startup@1.0.1:
     dependencies:
       debug: 2.6.9
@@ -15617,6 +15646,8 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
+
+  file-uri-to-path@1.0.0: {}
 
   filename-reserved-regex@2.0.0: {}
 
@@ -17498,6 +17529,8 @@ snapshots:
       semver: 7.7.3
 
   node-addon-api@7.1.1: {}
+
+  node-addon-api@8.9.0: {}
 
   node-api-version@0.2.1:
     dependencies:


### PR DESCRIPTION
## What

A Spotlight-style **quick-ask bar** summoned with **⌥⇧Space** from any app: type a question (or hold right ⌘ to speak it), it lands in the current Rowboat chat, and the answer streams back into the bar. Builds on the PTT/call work from #787.

### The bar
- Bottom-center docked capsule on the active display; grows **upward** as the answer streams, sized to content (capped). Bottom edge stays anchored.
- **Voice**: hold right ⌘ in the bar for local dictation (DOM events — no Input Monitoring needed); release auto-submits.
- **Live status line** while the agent works: the running tool by name / "Reasoning…" / "Thinking…", blinking until text arrives (`statusText` in `quickAsk:state`).
- Markdown answers via Streamdown (also applied to the call pill's response panel); the question shows above the answer and scrolls with it.
- **Open in Rowboat** jump (top-right of the panel): focuses the app with the chat sidebar maximized — no middle pane — on the exchange.
- Esc clears/dismisses; blur hides; window is hidden not destroyed (instant re-summon). Tray gains "Quick Ask ⌥⇧Space"; a one-time launch toast introduces the shortcut. ⌥⇧Space chosen over ⌥Space (Raycast/ChatGPT conflict).

### Design
- Capsule on a transparent panel window (floats over fullscreen Spaces, Dock intact), 10% uniform downscale via matched window-shrink + page-zoom.
- **Liquid Glass experiment**: real `NSGlassEffectView` via `electron-liquid-glass` on macOS 26+, lazy-loaded — older macOS and packaged builds (module not staged) keep the solid capsule.
- Layered controls (mic orb / ⌘ chip / send): gradient base, inset hairline, radial sheen.

### Fixes found along the way
- `findMainAppWindow` now excludes **every** hash-routed utility window — it could previously resolve the quick-ask window itself and relay the question back to it (bar stuck on "Thinking…").
- The response mirror reads the LIVE chat state (`sessionChat.chatState`), not the legacy pre-load fallbacks — the original bar's mirror was silently dead.
- Bar window claims dark-theme tokens (no ThemeProvider → light variables → white inline-code pills) and hard-locks document scroll (resize frames could let the page scroll the capsule out of place).

## Testing
Hand-tested in dev across the full flow: summon over other apps + fullscreen Spaces, typed + voice questions, streaming/status/markdown rendering, content-sized panel, Open-in-Rowboat jump, Esc/blur behavior, Raycast coexistence.

## Notes
- `electron-liquid-glass` is staged into packaged macOS builds (node-gyp-build prebuilds, same pattern as uiohook-napi) — glass ships to users on macOS 26+; older macOS and other platforms keep the solid capsule via the lazy-import fallback.
- No PostHog events for quick-ask yet — left as a product/CTO call.
