### PR TITLE
Quick-ask bar: Windows support

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -972,6 +972,23 @@ export function setupIpcHandlers() {
       return {};
     },
     'app:openPrivacySettings': async (_event, args) => {
+      if (process.platform === 'win32') {
+        // Windows Settings deep links (ms-settings). Sections without a
+        // Windows equivalent (screen recording, input monitoring are macOS
+        // TCC concepts) report failure, as before.
+        const winUris: Partial<Record<typeof args.section, string>> = {
+          microphone: 'ms-settings:privacy-microphone',
+          camera: 'ms-settings:privacy-webcam',
+        };
+        const uri = winUris[args.section];
+        if (!uri) return { success: false };
+        try {
+          await shell.openExternal(uri);
+          return { success: true };
+        } catch {
+          return { success: false };
+        }
+      }
       if (process.platform !== 'darwin') return { success: false };
       const anchors = {
         microphone: 'Privacy_Microphone',

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -62,9 +62,13 @@ function createWindow(): BrowserWindow {
     },
   });
   // Same all-workspaces setup as the call popout: float over fullscreen
-  // Spaces too, keeping the Dock icon (skipTransformProcessType).
+  // Spaces too, keeping the Dock icon (skipTransformProcessType). macOS
+  // concepts — on Windows `alwaysOnTop` alone is the whole story (no
+  // Spaces), and the options object is meaningless there.
   win.setAlwaysOnTop(true, 'floating');
-  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
+  if (process.platform === 'darwin') {
+    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
+  }
   // Spotlight behavior: clicking away dismisses the bar.
   win.on('blur', () => {
     if (!win.isDestroyed() && win.isVisible()) win.hide();

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1792,7 +1792,7 @@ function App() {
     const timer = setTimeout(() => {
       localStorage.setItem('quick-ask-tip-shown', '1')
       toast('Ask Rowboat from anywhere', {
-        description: 'Press ⌥⇧Space in any app for a quick question — the answer shows up right there and in your chat.',
+        description: `Press ${isMac ? '⌥⇧Space' : 'Alt+Shift+Space'} in any app for a quick question — the answer shows up right there and in your chat.`,
         duration: 12000,
         action: {
           label: 'Try it',

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -11,6 +11,12 @@ import { useVoiceMode } from '@/hooks/useVoiceMode'
 const BAR_HEIGHT = 88
 const ANSWER_HEIGHT = 380
 
+// Hold-to-speak key by platform. macOS: right ⌘, unchanged. Windows: the
+// same physical position is the right Win key, which the OS owns (a tap
+// opens the Start menu) — right Ctrl is the safe equivalent there.
+const IS_MAC = navigator.platform.startsWith('Mac')
+const PTT_CODE = IS_MAC ? 'MetaRight' : 'ControlRight'
+
 /**
  * Content of the quick-ask window (global ⌥⇧Space — see main's quick-ask.ts).
  * A Spotlight-style bar floating over whatever the user is doing: type a
@@ -27,7 +33,8 @@ export function QuickAskBar() {
   const awaitingRef = useRef(false)
   const inputRef = useRef<HTMLInputElement | null>(null)
 
-  // Voice input: hold Right ⌘ while the bar is focused. Local dictation via
+  // Voice input: hold the platform PTT key (right ⌘ on macOS, right Ctrl on
+  // Windows) while the bar is focused. Local dictation via
   // the same Deepgram flow as the composer mic — no global hook needed, the
   // bar has keyboard focus by construction.
   const [recording, setRecording] = useState(false)
@@ -127,10 +134,10 @@ export function QuickAskBar() {
     reset()
   }, [reset])
 
-  // Hold Right ⌘ to speak; release submits the transcript.
+  // Hold the platform PTT key to speak; release submits the transcript.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.code === 'MetaRight' && !e.repeat && !recordingRef.current) {
+      if (e.code === PTT_CODE && !e.repeat && !recordingRef.current) {
         recordingRef.current = true
         setRecording(true)
         void voice.start().then((result) => {
@@ -154,7 +161,7 @@ export function QuickAskBar() {
       }
     }
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code === 'MetaRight' && recordingRef.current) {
+      if (e.code === PTT_CODE && recordingRef.current) {
         recordingRef.current = false
         setRecording(false)
         void voice.submit().then((text) => {
@@ -293,8 +300,8 @@ export function QuickAskBar() {
                 inset hairline, radial top sheen. */}
             <span className="relative flex items-center gap-2 overflow-hidden rounded-full bg-gradient-to-b from-white/10 to-white/[0.03] px-3.5 py-2 text-sm text-neutral-200 ring-1 ring-inset ring-white/15">
               <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.12),transparent_55%)]" />
-              <span className="relative">Hold right</span>
-              <Command className="relative h-4 w-4 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
+              <span className="relative">{IS_MAC ? 'Hold right' : 'Hold right Ctrl'}</span>
+              {IS_MAC && <Command className="relative h-4 w-4 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />}
             </span>
             <span className="text-sm text-neutral-400">to speak</span>
           </span>


### PR DESCRIPTION
## What

Makes the quick-ask bar work on Windows. **Windows-only adjustments — every macOS path is untouched** (gated by platform checks; mac behavior is byte-identical).

- **Hold-to-speak → right Ctrl** on Windows. The physical right-⌘ position is the Win key, which the OS owns (a tap opens the Start menu). The chip reads "Hold right Ctrl" (no ⌘ glyph); macOS keeps right ⌘ exactly as before.
- **`setVisibleOnAllWorkspaces` darwin-gated** — Spaces are a macOS concept and the options we pass are macOS-only; on Windows `alwaysOnTop` alone is the whole story.
- **Mic/camera settings deep links** via `ms-settings:` URIs in `app:openPrivacySettings` (the bar's "Mic blocked" action now works on Windows). macOS branch unchanged.
- **Launch toast** prints `Alt+Shift+Space` instead of the mac symbols.

Already Windows-safe with no changes needed: ⌥⇧Space registers as Alt+Shift+Space, the panel window type and `invalidateShadow` were darwin-gated from the start, transparent+frameless works, and Liquid Glass lazy-loads with a solid-capsule fallback (the native module is macOS-only and staged only on macOS).

## Base

Stacked on #793 (`feat/quick-ask`) — retargets `main` automatically when that merges.

## Testing

Typechecked (main + renderer). Needs a hands-on pass on a real Windows machine: summon/dismiss, right-Ctrl dictation, streaming panel, ms-settings links, transparent capsule rendering.