### PR TITLE
feat(x): folders as workspaces — linked folders, list view, live workspace chats

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -8,7 +8,7 @@ import {
   disconnectProvider,
   listProviders,
 } from './oauth-handler.js';
-import { watcher as watcherCore, workspace } from '@x/core';
+import { watcher as watcherCore, workspace, linkedFolders } from '@x/core';
 import { WorkDir } from '@x/core/dist/config/config.js';
 import { workspace as workspaceShared } from '@x/shared';
 import * as mcpCore from '@x/core/dist/mcp/mcp.js';
@@ -872,6 +872,10 @@ export function setupIpcHandlers() {
   // Forward knowledge commit events to renderer for panel refresh
   versionHistory.onCommit(() => emitKnowledgeCommitEvent());
 
+  // Deletions inside a linked folder go to the OS trash — core can't reach
+  // Electron's shell, so hand it the implementation.
+  workspace.registerTrashHandler((absPath) => shell.trashItem(absPath));
+
   // Relay backend-confirmed credit grants (first-time-action rewards) to all
   // windows so the UI can update balances and celebrate.
   subscribeCreditActivations((event) => broadcastToWindows('credits:didActivate', event));
@@ -1039,6 +1043,35 @@ export function setupIpcHandlers() {
     },
     'workspace:remove': async (_event, args) => {
       return workspace.remove(args.path, args.opts);
+    },
+    'workspace:toAbsolute': async (_event, args) => {
+      return { path: workspace.resolveWorkspacePath(args.path) };
+    },
+    'workspace:listFolders': async () => {
+      return { folders: linkedFolders.listLinkedFolders() };
+    },
+    'workspace:addFolder': async (event, args) => {
+      let chosen = args.path;
+      if (!chosen) {
+        const win = BrowserWindow.fromWebContents(event.sender);
+        const result = await dialog.showOpenDialog(win!, {
+          title: 'Choose a folder to add as a workspace',
+          defaultPath: os.homedir(),
+          buttonLabel: 'Add folder',
+          properties: ['openDirectory', 'createDirectory'],
+        });
+        if (result.canceled || result.filePaths.length === 0) {
+          return { folder: null };
+        }
+        chosen = result.filePaths[0];
+      }
+      return { folder: await linkedFolders.addLinkedFolder(chosen!, args.name) };
+    },
+    'workspace:renameFolder': async (_event, args) => {
+      return { folder: await linkedFolders.renameLinkedFolder(args.id, args.name) };
+    },
+    'workspace:removeFolder': async (_event, args) => {
+      return linkedFolders.removeLinkedFolder(args.id);
     },
     'gmail:getImportant': async (_event, args) => {
       return listImportantThreads({ cursor: args.cursor, limit: args.limit });

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -32,6 +32,7 @@ import { ServiceEvent } from '@x/shared/dist/service-events.js';
 import type { SessionBusEvent } from '@x/shared/dist/sessions.js';
 import { isDurableTurnEvent } from '@x/shared/dist/turns.js';
 import type { ISessions, EmitterSessionBus } from '@x/core/dist/runtime/sessions/index.js';
+import { listByWorkDir as listSessionsByWorkDir } from '@x/core/dist/runtime/sessions/by-workdir.js';
 import type { ITurnEventBus } from '@x/core/dist/runtime/turns/event-hub.js';
 import container from '@x/core/dist/di/container.js';
 import { testModelConnection, listModelsForProvider, generateOneShot } from '@x/core/dist/models/models.js';
@@ -1210,7 +1211,23 @@ export function setupIpcHandlers() {
       return runsCore.listRuns(args.cursor);
     },
     'runs:listByWorkDir': async (_event, args) => {
-      return runsCore.listRunsByWorkDir(args.dir);
+      // Chats are sessions now; the legacy runs/*.jsonl logs this used to scan
+      // are migrated away at boot, so the session index is the only source.
+      await sessionsIndexReady;
+      const sessions = container.resolve<ISessions>('sessions').listSessions();
+      return listSessionsByWorkDir(args.dir, sessions
+        // A session the index couldn't load carries empty timestamps, which
+        // the response schema rejects — one of those would otherwise fail the
+        // whole call and blank the panel. It has no title or date to show
+        // anyway, so leave it out.
+        .filter((s) => !s.error && s.createdAt)
+        .map((s) => ({
+          id: s.sessionId,
+          ...(s.title ? { title: s.title } : {}),
+          createdAt: s.createdAt,
+          modifiedAt: s.updatedAt || s.createdAt,
+          ...(s.lastAgentId ? { agentId: s.lastAgentId } : {}),
+        })));
     },
     'runs:delete': async (_event, args) => {
       await runsCore.deleteRun(args.runId);

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -31,7 +31,7 @@ import { LiveNotesView } from '@/components/live-notes-view';
 import { BgTasksView } from '@/components/bg-tasks-view';
 import { AppsView } from '@/components/apps/apps-view';
 import { EmailView } from '@/components/email-view';
-import { WorkspaceView } from '@/components/workspace-view';
+import { WorkspaceView, WORKSPACE_CHATS_CHANGED } from '@/components/workspace-view';
 import { CodingRunBlock } from '@/components/coding-run';
 import { SubAgentBlock } from '@/components/sub-agent-block';
 import { KnowledgeView, type KnowledgeViewMode } from '@/components/knowledge-view';
@@ -1886,6 +1886,9 @@ function App() {
         path: `config/workdir-${runId}.json`,
         data: JSON.stringify(value ? { path: value } : {}, null, 2),
       })
+      // Nothing watches config/, so tell an open workspace view itself — this
+      // chat just joined (or left) one of its folders.
+      window.dispatchEvent(new Event(WORKSPACE_CHATS_CHANGED))
     } catch (err) {
       console.error('Failed to persist work directory for run', runId, err)
     }

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -143,7 +143,10 @@ import { useTheme } from '@/contexts/theme-context'
 import { TokenUsageMenu } from '@/components/token-usage-menu'
 
 type DirEntry = z.infer<typeof workspace.DirEntry>
+type LinkedFolder = z.infer<typeof workspace.LinkedFolder>
 type RunEventType = z.infer<typeof RunEvent>
+
+const LINKED_FOLDER_PREFIX = workspace.LINKED_FOLDER_PREFIX
 
 interface TreeNode extends DirEntry {
   children?: TreeNode[]
@@ -628,6 +631,32 @@ function flattenMeetingsTree(nodes: TreeNode[]): TreeNode[] {
 
     return [{ ...node, children: flattenedSourceChildren }]
   })
+}
+
+/**
+ * Show linked folders (workspaces that live outside WorkDir) alongside the real
+ * subfolders of knowledge/Workspace. Their children are loaded on demand by the
+ * workspace view — a linked folder can be an entire repo, so the recursive walk
+ * that builds this tree deliberately stops at the root.
+ */
+function graftLinkedFolders(nodes: TreeNode[], folders: LinkedFolder[]): TreeNode[] {
+  if (folders.length === 0) return nodes
+  const linkedNodes: TreeNode[] = folders.map((folder) => ({
+    name: folder.name,
+    path: `${LINKED_FOLDER_PREFIX}/${folder.id}`,
+    kind: 'dir' as const,
+    children: [],
+    loaded: false,
+  }))
+  const workspaceNode = nodes.find((n) => n.path === WORKSPACE_ROOT)
+  if (!workspaceNode) {
+    // knowledge/Workspace doesn't exist on disk yet — the linked folders are
+    // still workspaces, so surface the parent for them to hang off.
+    return [...nodes, { name: 'Workspace', path: WORKSPACE_ROOT, kind: 'dir', children: linkedNodes, loaded: true }]
+  }
+  return nodes.map((n) =>
+    n === workspaceNode ? { ...n, children: [...(n.children ?? []), ...linkedNodes] } : n,
+  )
 }
 
 /** Extract YYYY-MM-DD from filenames like "meeting-2026-03-17T05-01-47.md" */
@@ -2282,10 +2311,10 @@ function App() {
     }
   }, [runId, processingRunIds])
 
-  // Load directory tree (knowledge + bases)
+  // Load directory tree (knowledge + bases + linked folders)
   const loadDirectory = useCallback(async () => {
     try {
-      const [knowledgeResult, basesResult] = await Promise.all([
+      const [knowledgeResult, basesResult, foldersResult] = await Promise.all([
         window.ipc.invoke('workspace:readdir', {
           path: 'knowledge',
           opts: { recursive: true, includeHidden: false, includeStats: true }
@@ -2294,8 +2323,12 @@ function App() {
           path: 'bases',
           opts: { recursive: false, includeHidden: false, includeStats: true }
         }).catch(() => [] as DirEntry[]),
+        window.ipc.invoke('workspace:listFolders', null).catch(() => ({ folders: [] })),
       ])
-      const knowledgeTree = flattenMeetingsTree(buildTree(knowledgeResult))
+      const knowledgeTree = graftLinkedFolders(
+        flattenMeetingsTree(buildTree(knowledgeResult)),
+        foldersResult.folders,
+      )
       const basesChildren: TreeNode[] = (basesResult as DirEntry[])
         .filter((e) => e.name.endsWith('.base'))
         .map((e) => ({ ...e, kind: 'file' as const }))
@@ -5952,14 +5985,27 @@ function App() {
       }
     },
     copyPath: (path: string) => {
-      const fullPath = workspaceRoot ? `${workspaceRoot}/${path}` : path
-      navigator.clipboard.writeText(fullPath).catch(() => {
-        const textarea = document.createElement('textarea')
-        textarea.value = fullPath
-        document.body.appendChild(textarea)
-        textarea.select()
-        document.execCommand('copy')
-        document.body.removeChild(textarea)
+      // Linked folders live outside WorkDir, so ask the main process where the
+      // path actually points rather than assuming the workspace root.
+      const resolve = async (): Promise<string> => {
+        if (path.startsWith(`${LINKED_FOLDER_PREFIX}/`)) {
+          try {
+            return (await window.ipc.invoke('workspace:toAbsolute', { path })).path
+          } catch {
+            return path
+          }
+        }
+        return workspaceRoot ? `${workspaceRoot}/${path}` : path
+      }
+      void resolve().then((fullPath) => {
+        navigator.clipboard.writeText(fullPath).catch(() => {
+          const textarea = document.createElement('textarea')
+          textarea.value = fullPath
+          document.body.appendChild(textarea)
+          textarea.select()
+          document.execCommand('copy')
+          document.body.removeChild(textarea)
+        })
       })
     },
     revealInFileManager: (path: string, isDir: boolean) => {
@@ -6983,6 +7029,7 @@ function App() {
                     onNavigate={(path) => { void navigateToView({ type: 'workspace', path: path === WORKSPACE_ROOT ? undefined : path }) }}
                     onOpenNote={(path) => navigateToFile(path)}
                     onCreateWorkspace={async (name) => { await knowledgeActions.createWorkspace(name) }}
+                    onWorkspacesChanged={async () => { setTree(await loadDirectory()) }}
                     onOpenRun={(rid) => void navigateToView({ type: 'chat', runId: rid })}
                   />
                 </div>

--- a/apps/x/apps/renderer/src/components/workspace-view.tsx
+++ b/apps/x/apps/renderer/src/components/workspace-view.tsx
@@ -1,5 +1,8 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   ChevronRight,
   Copy,
   ExternalLink,
@@ -58,6 +61,45 @@ interface TreeNode {
   name: string
   kind: 'file' | 'dir'
   children?: TreeNode[]
+  stat?: { size: number; mtimeMs: number }
+}
+
+type SortKey = 'name' | 'modified'
+type SortState = { key: SortKey; dir: 'asc' | 'desc' }
+const SORT_STORAGE_KEY = 'workspace:sort'
+
+function readStoredSort(): SortState {
+  try {
+    const raw = localStorage.getItem(SORT_STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as SortState
+      if ((parsed.key === 'name' || parsed.key === 'modified') && (parsed.dir === 'asc' || parsed.dir === 'desc')) {
+        return parsed
+      }
+    }
+  } catch {
+    // ignore unreadable/legacy values
+  }
+  return { key: 'name', dir: 'asc' }
+}
+
+/** "just now" / "6h ago" / "Yesterday" / "3d ago" / "Mar 14" */
+function formatModified(mtimeMs: number | undefined): string {
+  if (!mtimeMs) return '—'
+  const diffMs = Math.max(0, Date.now() - mtimeMs)
+  const min = Math.floor(diffMs / 60000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.floor(hr / 24)
+  if (day === 1) return 'Yesterday'
+  if (day < 7) return `${day}d ago`
+  const d = new Date(mtimeMs)
+  const sameYear = d.getFullYear() === new Date().getFullYear()
+  return d.toLocaleDateString([], sameYear
+    ? { month: 'short', day: 'numeric' }
+    : { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 /** `@folder/<id>/sub/path` → the folder id and the folder-relative remainder. */
@@ -79,6 +121,11 @@ type WorkspaceActions = {
   addGoogleDoc: (parentPath?: string) => void
   createFolder: (parentPath?: string) => Promise<string>
   onOpenInNewTab?: (path: string) => void
+}
+
+function SortArrow({ active, dir }: { active: boolean; dir: 'asc' | 'desc' }) {
+  if (!active) return <ArrowUpDown className="size-3 opacity-40" />
+  return dir === 'asc' ? <ArrowUp className="size-3" /> : <ArrowDown className="size-3" />
 }
 
 function GoogleDriveIcon({ className }: { className?: string }) {
@@ -153,6 +200,20 @@ function findNode(nodes: TreeNode[] | undefined, path: string): TreeNode | null 
   return null
 }
 
+/**
+ * Newest mtime anywhere under a node. A folder's own mtime only moves when its
+ * direct children change, so for a workspace row — where "last updated" should
+ * mean "someone touched something in here" — walk what the tree already holds.
+ */
+function deepMtime(node: TreeNode): number {
+  let newest = node.stat?.mtimeMs ?? 0
+  for (const child of node.children ?? []) {
+    const childMtime = deepMtime(child)
+    if (childMtime > newest) newest = childMtime
+  }
+  return newest
+}
+
 function countChildren(node: TreeNode | null): number {
   if (!node || node.kind !== 'dir' || !node.children) return 0
   return node.children.length
@@ -193,6 +254,10 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
   const [linkedEntries, setLinkedEntries] = useState<TreeNode[]>([])
   const [linkedLoading, setLinkedLoading] = useState(false)
   const [linkedError, setLinkedError] = useState<string | null>(null)
+  // mtime of each linked folder's root, keyed by folder id — the registry
+  // itself has no timestamps, so these are stat'd separately.
+  const [linkedMtimes, setLinkedMtimes] = useState<Record<string, number>>({})
+  const [sort, setSort] = useState<SortState>(readStoredSort)
   const [chatsOpen, setChatsOpen] = useState(false)
   const [chats, setChats] = useState<WorkspaceChat[]>([])
   const [chatsLoading, setChatsLoading] = useState(false)
@@ -226,20 +291,49 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
     if (isRoot) {
       // Linked folders come from this view's own state, not the shared tree —
       // nothing watches the registry, so the tree can lag behind an add/remove.
+      // Their time is the folder's own mtime: their contents aren't walked
+      // (a linked folder can be an entire repo), so there's nothing deeper to read.
       filtered = [
-        ...filtered.filter((c) => !c.path.startsWith(`${LINKED_PREFIX}/`)),
+        ...filtered
+          .filter((c) => !c.path.startsWith(`${LINKED_PREFIX}/`))
+          .map((c) => ({ ...c, stat: { size: c.stat?.size ?? 0, mtimeMs: deepMtime(c) } })),
         ...linkedFolders.map((f) => ({
           name: f.name,
           path: `${LINKED_PREFIX}/${f.id}`,
           kind: 'dir' as const,
+          stat: linkedMtimes[f.id] ? { size: 0, mtimeMs: linkedMtimes[f.id]! } : undefined,
         })),
       ]
     }
+    const flip = sort.dir === 'asc' ? 1 : -1
     return [...filtered].sort((a, b) => {
-      if (a.kind !== b.kind) return a.kind === 'dir' ? -1 : 1
-      return a.name.localeCompare(b.name)
+      // Sorting by time means most-recent-first across the whole folder;
+      // grouping directories ahead of files only makes sense by name.
+      if (sort.key === 'name' && a.kind !== b.kind) return a.kind === 'dir' ? -1 : 1
+      if (sort.key === 'modified') {
+        const diff = (a.stat?.mtimeMs ?? 0) - (b.stat?.mtimeMs ?? 0)
+        if (diff !== 0) return diff * flip
+        return a.name.localeCompare(b.name)
+      }
+      return a.name.localeCompare(b.name) * flip
     })
-  }, [currentNode, isRoot, isLinked, linkedEntries, linkedFolders])
+  }, [currentNode, isRoot, isLinked, linkedEntries, linkedFolders, linkedMtimes, sort])
+
+  const toggleSort = useCallback((key: SortKey) => {
+    setSort((prev) => {
+      // First click on a column picks its natural direction: A→Z for names,
+      // newest first for times.
+      const next: SortState = prev.key === key
+        ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : { key, dir: key === 'modified' ? 'desc' : 'asc' }
+      try {
+        localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify(next))
+      } catch {
+        // non-fatal: the sort just won't persist
+      }
+      return next
+    })
+  }, [])
 
   const breadcrumbs = useMemo(() => {
     if (isRoot) return [] as { path: string; name: string }[]
@@ -267,6 +361,16 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
     try {
       const { folders } = await window.ipc.invoke('workspace:listFolders', null)
       setLinkedFolders(folders)
+      // A folder that has been moved or unmounted simply has no time to show.
+      const stats = await Promise.all(folders.map(async (f) => {
+        try {
+          const s = await window.ipc.invoke('workspace:stat', { path: `${LINKED_PREFIX}/${f.id}` })
+          return [f.id, s.mtimeMs] as const
+        } catch {
+          return null
+        }
+      }))
+      setLinkedMtimes(Object.fromEntries(stats.filter((s) => s !== null)))
     } catch (err) {
       console.error('Failed to load linked folders:', err)
     }
@@ -287,7 +391,7 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
         path: currentPath,
         opts: { includeHidden: false, includeStats: true },
       })
-      setLinkedEntries(entries.map((e) => ({ path: e.path, name: e.name, kind: e.kind })))
+      setLinkedEntries(entries.map((e) => ({ path: e.path, name: e.name, kind: e.kind, stat: e.stat })))
       setLinkedError(null)
     } catch (err) {
       setLinkedEntries([])
@@ -696,23 +800,54 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
             )}
           </div>
         ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-3">
+          <div className="overflow-hidden rounded-lg border border-border bg-card">
+            {/* Column headers double as the sort control. */}
+            <div className="flex items-center gap-3 border-b border-border px-3 py-2 text-xs text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => toggleSort('name')}
+                className="flex min-w-0 flex-1 items-center gap-1 rounded px-1 py-0.5 text-left transition-colors hover:text-foreground"
+              >
+                Name
+                <SortArrow active={sort.key === 'name'} dir={sort.dir} />
+              </button>
+              <span className="hidden w-[180px] shrink-0 px-1 sm:block">{isRoot ? 'Location' : 'Kind'}</span>
+              <button
+                type="button"
+                onClick={() => toggleSort('modified')}
+                className="flex w-[130px] shrink-0 items-center gap-1 rounded px-1 py-0.5 text-left transition-colors hover:text-foreground"
+              >
+                Last updated
+                <SortArrow active={sort.key === 'modified'} dir={sort.dir} />
+              </button>
+            </div>
             {items.map((item) => {
               const childCount = item.kind === 'dir' ? countChildren(item) : 0
-              // A card for a linked folder's root: it points somewhere outside
-              // WorkDir, and its item count is only known once you open it.
+              // A linked folder's root row: it points somewhere outside WorkDir,
+              // and its item count is only known once you open it.
               const linkedItem = parseLinkedPath(item.path)
               const linkedRoot = linkedItem && !linkedItem.sub ? linkedById.get(linkedItem.id) ?? null : null
               const Icon = linkedRoot ? FolderSymlink : item.kind === 'dir' ? FolderIcon : FileIcon
               const isRenaming = renameTarget === item.path
+              const detail = linkedRoot
+                ? linkedRoot.path
+                : item.kind === 'file'
+                  ? fileExtensionLabel(item.name)
+                  // Children of a linked folder are loaded one level at a time,
+                  // so a subfolder's own count isn't known yet.
+                  : isLinked
+                    ? 'Folder'
+                    : isRoot
+                      ? 'In Rowboat'
+                      : `${childCount} ${childCount === 1 ? 'item' : 'items'}`
               const card = (
                 <button
                   type="button"
                   onClick={() => handleItemClick(item)}
-                  className="group flex w-full flex-col items-start gap-2 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-foreground/20 hover:bg-accent"
+                  className="group flex w-full items-center gap-3 border-b border-border px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-accent"
                 >
-                  <Icon className="size-6 text-muted-foreground group-hover:text-foreground" />
-                  <div className="min-w-0 w-full">
+                  <Icon className="size-4 shrink-0 text-muted-foreground group-hover:text-foreground" />
+                  <div className="min-w-0 flex-1">
                     {isRenaming ? (
                       <Input
                         autoFocus
@@ -728,21 +863,17 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
                         className="h-6 text-sm"
                       />
                     ) : (
-                      <div className="truncate text-sm font-medium">{item.name}</div>
+                      <div className="truncate text-sm">{item.name}</div>
                     )}
-                    {!isRenaming && (
-                      <div className="truncate text-xs text-muted-foreground" title={linkedRoot?.path}>
-                        {linkedRoot
-                          ? linkedRoot.path
-                          : item.kind === 'file'
-                            ? fileExtensionLabel(item.name)
-                            // Children of a linked folder are loaded one level at
-                            // a time, so a subfolder's own count isn't known yet.
-                            : isLinked
-                              ? 'Folder'
-                              : `${childCount} ${childCount === 1 ? 'item' : 'items'}`}
-                      </div>
-                    )}
+                  </div>
+                  <div className="hidden w-[180px] shrink-0 truncate text-xs text-muted-foreground sm:block" title={detail}>
+                    {detail}
+                  </div>
+                  <div
+                    className="w-[130px] shrink-0 truncate text-xs text-muted-foreground"
+                    title={item.stat?.mtimeMs ? new Date(item.stat.mtimeMs).toLocaleString() : undefined}
+                  >
+                    {formatModified(item.stat?.mtimeMs)}
                   </div>
                 </button>
               )

--- a/apps/x/apps/renderer/src/components/workspace-view.tsx
+++ b/apps/x/apps/renderer/src/components/workspace-view.tsx
@@ -54,6 +54,14 @@ import { cn } from '@/lib/utils'
 const WORKSPACE_ROOT = 'knowledge/Workspace'
 const LINKED_PREFIX = workspace.LINKED_FOLDER_PREFIX
 
+/**
+ * Fired by the app after a chat's work-directory sidecar is written, so an open
+ * workspace can pick the chat up. That sidecar (`config/workdir-<id>.json`)
+ * lives outside the workspace watcher's roots and doesn't touch the session
+ * index, so this is the only signal for "an existing chat joined/left a folder".
+ */
+export const WORKSPACE_CHATS_CHANGED = 'workspace-chats:changed'
+
 type LinkedFolder = z.infer<typeof workspace.LinkedFolder>
 
 interface TreeNode {
@@ -438,6 +446,35 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
   useEffect(() => {
     void loadChats()
   }, [loadChats])
+
+  // Keep the list live. The session index changes whenever a chat is created,
+  // retitled or deleted; WORKSPACE_CHATS_CHANGED covers an existing chat having
+  // its work directory (re)pointed. Both can fire in bursts — a turn advancing
+  // republishes the index entry — so coalesce into one refetch.
+  useEffect(() => {
+    if (isRoot) return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const schedule = () => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        void loadChats()
+      }, 400)
+    }
+    const stopSessions = window.ipc.on('sessions:events', schedule)
+    window.addEventListener(WORKSPACE_CHATS_CHANGED, schedule)
+    return () => {
+      if (timer) clearTimeout(timer)
+      stopSessions()
+      window.removeEventListener(WORKSPACE_CHATS_CHANGED, schedule)
+    }
+  }, [isRoot, loadChats])
+
+  // Opening the panel always shows current data, even if every live signal was
+  // somehow missed while it sat closed.
+  useEffect(() => {
+    if (chatsOpen) void loadChats()
+  }, [chatsOpen, loadChats])
 
   const handleItemClick = useCallback(
     (item: TreeNode) => {

--- a/apps/x/apps/renderer/src/components/workspace-view.tsx
+++ b/apps/x/apps/renderer/src/components/workspace-view.tsx
@@ -8,13 +8,18 @@ import {
   Folder as FolderIcon,
   FolderOpen,
   FolderPlus,
+  FolderSymlink,
+  Link2Off,
   Loader2,
   MessageSquare,
   Pencil,
   Plus,
+  RefreshCw,
   Trash2,
   UploadCloud,
 } from 'lucide-react'
+import type { z } from 'zod'
+import { workspace } from '@x/shared'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -44,12 +49,26 @@ import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 
 const WORKSPACE_ROOT = 'knowledge/Workspace'
+const LINKED_PREFIX = workspace.LINKED_FOLDER_PREFIX
+
+type LinkedFolder = z.infer<typeof workspace.LinkedFolder>
 
 interface TreeNode {
   path: string
   name: string
   kind: 'file' | 'dir'
   children?: TreeNode[]
+}
+
+/** `@folder/<id>/sub/path` → the folder id and the folder-relative remainder. */
+function parseLinkedPath(path: string): { id: string; sub: string } | null {
+  if (!path.startsWith(`${LINKED_PREFIX}/`)) return null
+  const rest = path.slice(LINKED_PREFIX.length + 1)
+  if (!rest) return null
+  const slash = rest.indexOf('/')
+  return slash === -1
+    ? { id: rest, sub: '' }
+    : { id: rest.slice(0, slash), sub: rest.slice(slash + 1) }
 }
 
 type WorkspaceActions = {
@@ -86,6 +105,8 @@ type WorkspaceViewProps = {
   onNavigate: (path: string) => void
   onOpenNote: (path: string) => void
   onCreateWorkspace: (name: string) => Promise<void>
+  // A linked folder was added, renamed or unlinked — reload the shared tree.
+  onWorkspacesChanged: () => Promise<void> | void
   // Opens a previous chat (run) whose work directory is set to this workspace.
   onOpenRun: (runId: string) => void
 }
@@ -162,9 +183,16 @@ function readFileAsBase64(file: File): Promise<string> {
   })
 }
 
-export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNote, onCreateWorkspace, onOpenRun }: WorkspaceViewProps) {
+export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNote, onCreateWorkspace, onWorkspacesChanged, onOpenRun }: WorkspaceViewProps) {
   const currentPath = initialPath || WORKSPACE_ROOT
   const [addOpen, setAddOpen] = useState(false)
+  const [linkedFolders, setLinkedFolders] = useState<LinkedFolder[]>([])
+  // Contents of the linked folder currently being browsed. Linked folders sit
+  // outside the workspace watcher, so this is fetched (and refreshed) here
+  // rather than read off the shared tree.
+  const [linkedEntries, setLinkedEntries] = useState<TreeNode[]>([])
+  const [linkedLoading, setLinkedLoading] = useState(false)
+  const [linkedError, setLinkedError] = useState<string | null>(null)
   const [chatsOpen, setChatsOpen] = useState(false)
   const [chats, setChats] = useState<WorkspaceChat[]>([])
   const [chatsLoading, setChatsLoading] = useState(false)
@@ -182,19 +210,50 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
   const isRoot = currentPath === WORKSPACE_ROOT
   const fileManagerName = getFileManagerName()
 
+  const linkedRef = useMemo(() => parseLinkedPath(currentPath), [currentPath])
+  const isLinked = linkedRef !== null
+  const linkedById = useMemo(
+    () => new Map(linkedFolders.map((f) => [f.id, f])),
+    [linkedFolders],
+  )
+  const currentFolder = linkedRef ? linkedById.get(linkedRef.id) ?? null : null
+
   const currentNode = useMemo(() => findNode(tree, currentPath), [tree, currentPath])
 
   const items = useMemo<TreeNode[]>(() => {
-    const children = currentNode?.children ?? []
-    const filtered = isRoot ? children.filter((c) => c.kind === 'dir') : children
+    const children = isLinked ? linkedEntries : currentNode?.children ?? []
+    let filtered = isRoot ? children.filter((c) => c.kind === 'dir') : children
+    if (isRoot) {
+      // Linked folders come from this view's own state, not the shared tree —
+      // nothing watches the registry, so the tree can lag behind an add/remove.
+      filtered = [
+        ...filtered.filter((c) => !c.path.startsWith(`${LINKED_PREFIX}/`)),
+        ...linkedFolders.map((f) => ({
+          name: f.name,
+          path: `${LINKED_PREFIX}/${f.id}`,
+          kind: 'dir' as const,
+        })),
+      ]
+    }
     return [...filtered].sort((a, b) => {
       if (a.kind !== b.kind) return a.kind === 'dir' ? -1 : 1
       return a.name.localeCompare(b.name)
     })
-  }, [currentNode, isRoot])
+  }, [currentNode, isRoot, isLinked, linkedEntries, linkedFolders])
 
   const breadcrumbs = useMemo(() => {
     if (isRoot) return [] as { path: string; name: string }[]
+    if (linkedRef) {
+      const root = `${LINKED_PREFIX}/${linkedRef.id}`
+      let acc = root
+      return [
+        { path: root, name: currentFolder?.name ?? 'Folder' },
+        ...linkedRef.sub.split('/').filter(Boolean).map((seg) => {
+          acc = `${acc}/${seg}`
+          return { path: acc, name: seg }
+        }),
+      ]
+    }
     const rel = currentPath.slice(WORKSPACE_ROOT.length + 1)
     const parts = rel.split('/').filter(Boolean)
     let acc = WORKSPACE_ROOT
@@ -202,7 +261,54 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
       acc = `${acc}/${seg}`
       return { path: acc, name: seg }
     })
-  }, [currentPath, isRoot])
+  }, [currentPath, isRoot, linkedRef, currentFolder])
+
+  const loadLinkedFolders = useCallback(async () => {
+    try {
+      const { folders } = await window.ipc.invoke('workspace:listFolders', null)
+      setLinkedFolders(folders)
+    } catch (err) {
+      console.error('Failed to load linked folders:', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadLinkedFolders()
+  }, [loadLinkedFolders])
+
+  // Read the current linked directory. Nothing watches folders outside
+  // WorkDir (a linked repo's node_modules would blow the fd limit), so this
+  // re-runs on navigation, on window focus, and after our own mutations.
+  const refreshLinkedEntries = useCallback(async () => {
+    if (!isLinked) return
+    setLinkedLoading(true)
+    try {
+      const entries = await window.ipc.invoke('workspace:readdir', {
+        path: currentPath,
+        opts: { includeHidden: false, includeStats: true },
+      })
+      setLinkedEntries(entries.map((e) => ({ path: e.path, name: e.name, kind: e.kind })))
+      setLinkedError(null)
+    } catch (err) {
+      setLinkedEntries([])
+      setLinkedError(err instanceof Error ? err.message : 'Failed to read this folder')
+    } finally {
+      setLinkedLoading(false)
+    }
+  }, [currentPath, isLinked])
+
+  useEffect(() => {
+    setLinkedEntries([])
+    setLinkedError(null)
+    void refreshLinkedEntries()
+  }, [refreshLinkedEntries])
+
+  useEffect(() => {
+    if (!isLinked) return
+    const onFocus = () => void refreshLinkedEntries()
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [isLinked, refreshLinkedEntries])
 
   // Load the chats whose work directory is this workspace folder (or nested
   // inside it). The work directory is stored as an absolute path per run, so
@@ -214,8 +320,7 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
     }
     setChatsLoading(true)
     try {
-      const { root } = await window.ipc.invoke('workspace:getRoot', null)
-      const abs = `${root.replace(/\/$/, '')}/${currentPath}`
+      const { path: abs } = await window.ipc.invoke('workspace:toAbsolute', { path: currentPath })
       const { runs } = await window.ipc.invoke('runs:listByWorkDir', { dir: abs })
       setChats(runs.map((r) => ({ id: r.id, title: r.title, createdAt: r.createdAt, modifiedAt: r.modifiedAt })))
     } catch (err) {
@@ -253,23 +358,66 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
     const trimmed = renameValue.trim()
     setRenameTarget(null)
     if (!node || !trimmed || trimmed === node.name || trimmed.includes('/')) return
+    const linked = parseLinkedPath(renameTarget)
+    // Renaming a linked folder renames how Rowboat labels it — the folder on
+    // disk keeps its own name.
+    if (linked && !linked.sub) {
+      try {
+        await window.ipc.invoke('workspace:renameFolder', { id: linked.id, name: trimmed })
+        await loadLinkedFolders()
+        await onWorkspacesChanged()
+        toast('Renamed', 'success')
+      } catch (err) {
+        toast(err instanceof Error ? err.message : 'Failed to rename', 'error')
+      }
+      return
+    }
     const parent = renameTarget.slice(0, renameTarget.lastIndexOf('/'))
     try {
       await window.ipc.invoke('workspace:rename', { from: renameTarget, to: `${parent}/${trimmed}` })
+      await refreshLinkedEntries()
       toast('Renamed', 'success')
     } catch {
       toast('Failed to rename', 'error')
     }
-  }, [renameTarget, renameValue, items])
+  }, [renameTarget, renameValue, items, loadLinkedFolders, onWorkspacesChanged, refreshLinkedEntries])
 
   const handleDelete = useCallback(async (item: TreeNode) => {
     try {
       await actions.remove(item.path)
+      await refreshLinkedEntries()
       toast('Moved to trash', 'success')
-    } catch {
-      toast('Failed to delete', 'error')
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to delete', 'error')
     }
-  }, [actions])
+  }, [actions, refreshLinkedEntries])
+
+  // Unlinking never touches the folder itself — it only stops Rowboat
+  // showing it as a workspace.
+  const handleUnlink = useCallback(async (folderId: string) => {
+    try {
+      await window.ipc.invoke('workspace:removeFolder', { id: folderId })
+      await loadLinkedFolders()
+      await onWorkspacesChanged()
+      toast('Folder removed from Rowboat. Nothing on disk was deleted.', 'success')
+    } catch {
+      toast('Failed to remove folder', 'error')
+    }
+  }, [loadLinkedFolders, onWorkspacesChanged])
+
+  const handleAddFolder = useCallback(async () => {
+    try {
+      const { folder } = await window.ipc.invoke('workspace:addFolder', {})
+      if (!folder) return
+      setAddOpen(false)
+      await loadLinkedFolders()
+      await onWorkspacesChanged()
+      toast(`Added "${folder.name}"`, 'success')
+      onNavigate(`${LINKED_PREFIX}/${folder.id}`)
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to add folder', 'error')
+    }
+  }, [loadLinkedFolders, onWorkspacesChanged, onNavigate])
 
   const uploadFiles = useCallback(async (files: FileList | File[], preserveStructure = false) => {
     const list = Array.from(files)
@@ -289,13 +437,14 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
         })
       }
       toast(list.length === 1 ? 'Added' : `${list.length} items added`, 'success')
+      await refreshLinkedEntries()
     } catch (err) {
       console.error('Failed to add files:', err)
       toast('Failed to add', 'error')
     } finally {
       setUploading(false)
     }
-  }, [currentPath])
+  }, [currentPath, refreshLinkedEntries])
 
   // Drag-and-drop (only inside a workspace folder, not at the root grid).
   // stopPropagation keeps the drop from also reaching the copilot's
@@ -410,6 +559,17 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
               Chats{chats.length ? ` (${chats.length})` : ''}
             </Button>
           )}
+          {isLinked && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void refreshLinkedEntries()}
+              title="Reload this folder"
+            >
+              <RefreshCw className={cn('size-4', linkedLoading && 'animate-spin')} />
+              Refresh
+            </Button>
+          )}
           <Button
             size="sm"
             variant="outline"
@@ -419,10 +579,24 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
             Open in {fileManagerName}
           </Button>
           {isRoot ? (
-            <Button size="sm" onClick={() => setAddOpen(true)}>
-              <Plus className="size-4" />
-              Add workspace
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm">
+                  <Plus className="size-4" />
+                  Add workspace
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setAddOpen(true)}>
+                  <FolderPlus className="mr-2 size-4" />
+                  New workspace
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => void handleAddFolder()}>
+                  <FolderSymlink className="mr-2 size-4" />
+                  Add existing folder…
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -489,24 +663,47 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
         <div className="mx-auto h-full w-full max-w-[1120px] px-[30px] py-6">
         {items.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
-            <FolderIcon className="size-10 opacity-50" />
-            <div className="text-sm">
-              {isRoot
-                ? 'No workspaces yet. Create one to get started.'
-                : 'This folder is empty. Drag files in or use New note / New folder.'}
-            </div>
-            {isRoot && (
-              <Button size="sm" variant="outline" onClick={() => setAddOpen(true)}>
-                <Plus className="size-4" />
-                Add workspace
-              </Button>
+            {linkedLoading ? (
+              <Loader2 className="size-6 animate-spin opacity-60" />
+            ) : (
+              <>
+                <FolderIcon className="size-10 opacity-50" />
+                <div className="text-sm">
+                  {linkedError
+                    ? linkedError
+                    : isRoot
+                      ? 'No workspaces yet. Create one, or add a folder you already have.'
+                      : 'This folder is empty. Drag files in or use New note / New folder.'}
+                </div>
+                {isLinked && currentFolder && !linkedError && (
+                  <div className="max-w-[520px] truncate font-mono text-xs opacity-70" title={currentFolder.path}>
+                    {currentFolder.path}
+                  </div>
+                )}
+                {isRoot && (
+                  <div className="flex items-center gap-2">
+                    <Button size="sm" variant="outline" onClick={() => setAddOpen(true)}>
+                      <Plus className="size-4" />
+                      New workspace
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => void handleAddFolder()}>
+                      <FolderSymlink className="size-4" />
+                      Add existing folder…
+                    </Button>
+                  </div>
+                )}
+              </>
             )}
           </div>
         ) : (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-3">
             {items.map((item) => {
               const childCount = item.kind === 'dir' ? countChildren(item) : 0
-              const Icon = item.kind === 'dir' ? FolderIcon : FileIcon
+              // A card for a linked folder's root: it points somewhere outside
+              // WorkDir, and its item count is only known once you open it.
+              const linkedItem = parseLinkedPath(item.path)
+              const linkedRoot = linkedItem && !linkedItem.sub ? linkedById.get(linkedItem.id) ?? null : null
+              const Icon = linkedRoot ? FolderSymlink : item.kind === 'dir' ? FolderIcon : FileIcon
               const isRenaming = renameTarget === item.path
               const card = (
                 <button
@@ -534,10 +731,16 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
                       <div className="truncate text-sm font-medium">{item.name}</div>
                     )}
                     {!isRenaming && (
-                      <div className="truncate text-xs text-muted-foreground">
-                        {item.kind === 'dir'
-                          ? `${childCount} ${childCount === 1 ? 'item' : 'items'}`
-                          : fileExtensionLabel(item.name)}
+                      <div className="truncate text-xs text-muted-foreground" title={linkedRoot?.path}>
+                        {linkedRoot
+                          ? linkedRoot.path
+                          : item.kind === 'file'
+                            ? fileExtensionLabel(item.name)
+                            // Children of a linked folder are loaded one level at
+                            // a time, so a subfolder's own count isn't known yet.
+                            : isLinked
+                              ? 'Folder'
+                              : `${childCount} ${childCount === 1 ? 'item' : 'items'}`}
                       </div>
                     )}
                   </div>
@@ -583,10 +786,17 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
                       <Pencil className="mr-2 size-4" />
                       Rename
                     </ContextMenuItem>
-                    <ContextMenuItem variant="destructive" onClick={() => void handleDelete(item)}>
-                      <Trash2 className="mr-2 size-4" />
-                      Delete
-                    </ContextMenuItem>
+                    {linkedRoot ? (
+                      <ContextMenuItem onClick={() => void handleUnlink(linkedRoot.id)}>
+                        <Link2Off className="mr-2 size-4" />
+                        Remove from Rowboat
+                      </ContextMenuItem>
+                    ) : (
+                      <ContextMenuItem variant="destructive" onClick={() => void handleDelete(item)}>
+                        <Trash2 className="mr-2 size-4" />
+                        Delete
+                      </ContextMenuItem>
+                    )}
                   </ContextMenuContent>
                 </ContextMenu>
               )
@@ -658,7 +868,7 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
           <DialogHeader>
             <DialogTitle>New workspace</DialogTitle>
             <DialogDescription>
-              Workspaces are top-level folders inside knowledge/Workspace.
+              A new workspace is a folder inside knowledge/Workspace.
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-2">
@@ -678,6 +888,24 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
             />
             {error && <p className="text-xs text-destructive">{error}</p>}
           </div>
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs text-muted-foreground">or</span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleAddFolder()}
+            className="flex w-full items-center gap-3 rounded-lg border border-border p-3 text-left transition-colors hover:border-foreground/20 hover:bg-accent"
+          >
+            <FolderSymlink className="size-5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0">
+              <span className="block text-sm font-medium">Add a folder you already have</span>
+              <span className="block text-xs text-muted-foreground">
+                Browse it in Rowboat, wherever it lives. Files stay where they are.
+              </span>
+            </span>
+          </button>
           <DialogFooter>
             <Button
               variant="outline"

--- a/apps/x/packages/core/src/index.ts
+++ b/apps/x/packages/core/src/index.ts
@@ -1,6 +1,9 @@
 // Workspace filesystem operations
 export * as workspace from './workspace/workspace.js';
 
+// Workspaces that live outside WorkDir (folders the user pointed Rowboat at)
+export * as linkedFolders from './workspace/linked-folders.js';
+
 // Workspace watcher
 export * as watcher from './workspace/watcher.js';
 

--- a/apps/x/packages/core/src/runtime/legacy/repo.ts
+++ b/apps/x/packages/core/src/runtime/legacy/repo.ts
@@ -44,46 +44,14 @@ function runLogPath(runId: string): string {
     return path.join(WorkDir, 'runs', `${runId}.jsonl`);
 }
 
-// Per-run work directory sidecar, written by the renderer when a chat's work
-// directory is set (see `persistRunWorkDir` in the app). A run "belongs to" a
-// workspace folder when its work directory is that folder or nested inside it.
-function runWorkDirConfigPath(runId: string): string {
-    return path.join(WorkDir, 'config', `workdir-${runId}.json`);
-}
-
-function isPathInside(parent: string, child: string): boolean {
-    const relative = path.relative(parent, child);
-    return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
-}
-
-async function readRunWorkDir(runId: string): Promise<string | null> {
-    try {
-        const raw = await fsp.readFile(runWorkDirConfigPath(runId), 'utf8');
-        const parsed = JSON.parse(raw) as { path?: unknown };
-        return typeof parsed?.path === 'string' && parsed.path ? parsed.path : null;
-    } catch {
-        return null;
-    }
-}
-
-// Code-section sessions are runs (id == runId) but live in the Code view, not
-// the chat list. Their metadata sidecar identifies them so they can be kept out
-// of the workspace chats panel (opening one as a plain chat wouldn't resume code
-// mode). See FSCodeSessionsRepo — one JSON file per session id.
-async function isCodeSession(runId: string): Promise<boolean> {
-    try {
-        await fsp.access(path.join(WorkDir, 'code-mode', 'sessions-meta', `${runId}.json`));
-        return true;
-    } catch {
-        return false;
-    }
-}
+// Listing chats by work directory moved to runtime/sessions/by-workdir.ts when
+// chats became sessions — the runs/*.jsonl logs this repo serves are migrated
+// away at boot, so scanning them here found nothing.
 
 export interface IRunsRepo {
     create(options: CreateRunRepoOptions): Promise<z.infer<typeof Run>>;
     fetch(id: string): Promise<z.infer<typeof Run>>;
     list(cursor?: string): Promise<z.infer<typeof ListRunsResponse>>;
-    listByWorkDir(dir: string): Promise<z.infer<typeof ListRunsResponse>>;
     appendEvents(runId: string, events: z.infer<typeof RunEvent>[]): Promise<void>;
     delete(id: string): Promise<void>;
 }
@@ -359,63 +327,6 @@ export class FSRunsRepo implements IRunsRepo {
             runs,
             ...(nextCursor ? { nextCursor } : {}),
         };
-    }
-
-    /**
-     * List runs whose work directory is `dir` or nested inside it. Unlike
-     * `list`, this scans every run (no pagination) and reads each run's
-     * work-directory sidecar to decide membership, so the caller gets the
-     * complete set of chats scoped to a workspace folder. Newest first.
-     */
-    async listByWorkDir(dir: string): Promise<z.infer<typeof ListRunsResponse>> {
-        const target = path.resolve(dir);
-        const runsDir = path.join(WorkDir, 'runs');
-
-        let files: string[] = [];
-        try {
-            const entries = await fsp.readdir(runsDir, { withFileTypes: true });
-            files = entries
-                .filter(e => e.isFile() && e.name.endsWith('.jsonl'))
-                .map(e => e.name);
-        } catch (err: unknown) {
-            const e = err as { code?: string };
-            if (e.code === 'ENOENT') {
-                return { runs: [] };
-            }
-            throw err;
-        }
-
-        files.sort((a, b) => b.localeCompare(a));
-
-        const runs: z.infer<typeof ListRunsResponse>['runs'] = [];
-        for (const name of files) {
-            const runId = name.slice(0, -'.jsonl'.length);
-            const workDir = await readRunWorkDir(runId);
-            if (!workDir || !isPathInside(target, path.resolve(workDir))) {
-                continue;
-            }
-            // Code-section sessions share the run/workdir machinery but belong
-            // in the Code view, not the workspace chats list.
-            if (await isCodeSession(runId)) {
-                continue;
-            }
-            const filePath = path.join(runsDir, name);
-            const metadata = await this.readRunMetadata(filePath);
-            if (!metadata) {
-                continue;
-            }
-            const stat = await fsp.stat(filePath);
-            runs.push({
-                id: runId,
-                title: metadata.title,
-                createdAt: metadata.start.ts!,
-                modifiedAt: stat.mtime.toISOString(),
-                agentId: metadata.start.agentName,
-                ...(metadata.start.useCase ? { useCase: metadata.start.useCase } : {}),
-            });
-        }
-
-        return { runs };
     }
 
     async delete(id: string): Promise<void> {

--- a/apps/x/packages/core/src/runtime/legacy/runs.ts
+++ b/apps/x/packages/core/src/runtime/legacy/runs.ts
@@ -152,8 +152,3 @@ export async function listRuns(cursor?: string): Promise<z.infer<typeof ListRuns
     const repo = container.resolve<IRunsRepo>('runsRepo');
     return repo.list(cursor);
 }
-
-export async function listRunsByWorkDir(dir: string): Promise<z.infer<typeof ListRunsResponse>> {
-    const repo = container.resolve<IRunsRepo>('runsRepo');
-    return repo.listByWorkDir(dir);
-}

--- a/apps/x/packages/core/src/runtime/sessions/by-workdir.ts
+++ b/apps/x/packages/core/src/runtime/sessions/by-workdir.ts
@@ -1,0 +1,84 @@
+import fsp from "node:fs/promises";
+import path from "node:path";
+import type { z } from "zod";
+import type { ListRunsResponse } from "@x/shared/dist/runs.js";
+import { WorkDir } from "../../config/config.js";
+
+// Which chats belong to a workspace folder.
+//
+// A chat's work directory is stored in a sidecar (`config/workdir-<id>.json`,
+// written by the renderer when the user sets it and read on every turn by
+// loadUserWorkDir); sessions themselves store none. Membership is therefore a
+// filter over the session index rather than anything the index can answer.
+
+export interface WorkDirCandidate {
+    id: string;
+    title?: string;
+    createdAt: string;
+    modifiedAt: string;
+    // The session's last agent, where it has one — a session with no turns yet
+    // has none. Carried only because the shared response shape requires it.
+    agentId?: string;
+}
+
+function workDirConfigPath(sessionId: string): string {
+    return path.join(WorkDir, "config", `workdir-${sessionId}.json`);
+}
+
+function isPathInside(parent: string, child: string): boolean {
+    const relative = path.relative(parent, child);
+    return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function readWorkDir(sessionId: string): Promise<string | null> {
+    try {
+        const raw = await fsp.readFile(workDirConfigPath(sessionId), "utf8");
+        const parsed = JSON.parse(raw) as { path?: unknown };
+        return typeof parsed?.path === "string" && parsed.path ? parsed.path : null;
+    } catch {
+        return null;
+    }
+}
+
+// Code-section sessions share the session/workdir machinery but belong in the
+// Code view, not the workspace chats list — opening one as a plain chat
+// wouldn't resume code mode. See FSCodeSessionsRepo: one JSON file per id.
+async function isCodeSession(sessionId: string): Promise<boolean> {
+    try {
+        await fsp.access(path.join(WorkDir, "code-mode", "sessions-meta", `${sessionId}.json`));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Filter `candidates` (typically the whole session index) down to the chats
+ * whose work directory is `dir` or nested inside it. Newest first.
+ */
+export async function listByWorkDir(
+    dir: string,
+    candidates: WorkDirCandidate[],
+): Promise<z.infer<typeof ListRunsResponse>> {
+    const target = path.resolve(dir);
+
+    const matches = await Promise.all(candidates.map(async (candidate) => {
+        const workDir = await readWorkDir(candidate.id);
+        if (!workDir || !isPathInside(target, path.resolve(workDir))) return null;
+        if (await isCodeSession(candidate.id)) return null;
+        return candidate;
+    }));
+
+    const runs = matches
+        .filter((entry): entry is WorkDirCandidate => entry !== null)
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+        .map((entry) => ({
+            id: entry.id,
+            ...(entry.title ? { title: entry.title } : {}),
+            createdAt: entry.createdAt,
+            modifiedAt: entry.modifiedAt,
+            agentId: entry.agentId ?? '',
+        }));
+
+    return { runs };
+}

--- a/apps/x/packages/core/src/runtime/sessions/index.ts
+++ b/apps/x/packages/core/src/runtime/sessions/index.ts
@@ -1,5 +1,6 @@
 export * from "./api.js";
 export * from "./bus.js";
+export * from "./by-workdir.js";
 export * from "./fs-repo.js";
 export * from "./in-memory-session-repo.js";
 export * from "./repo.js";

--- a/apps/x/packages/core/src/workspace/linked-folders.ts
+++ b/apps/x/packages/core/src/workspace/linked-folders.ts
@@ -1,0 +1,226 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { z } from 'zod';
+import { workspace } from '@x/shared';
+import { WorkDir } from '../config/config.js';
+
+// ============================================================================
+// Linked Folder Registry
+// ============================================================================
+//
+// A workspace normally lives under `$WorkDir/knowledge/Workspace`. A *linked*
+// workspace is any folder elsewhere on disk that the user has pointed Rowboat
+// at. The folder is never copied or symlinked — the registry just records
+// where it is, and the workspace path space gains a second kind of root:
+//
+//     @folder/<id>/<sub/path>
+//
+// `resolveWorkspacePath` maps that to the real location and containment-checks
+// against the linked root (instead of WorkDir), so every existing workspace:*
+// operation — readdir, read, write, rename, delete, reveal-in-Finder — works
+// on a linked folder with no other changes.
+//
+// Deliberately NOT wired up: the knowledge index, the knowledge graph, wiki
+// links, and version history all scan `knowledge/` under WorkDir, so linked
+// folders stay out of them by construction. The workspace watcher does not
+// watch linked roots either (a folder with node_modules would exhaust the
+// process fd limit — see workspace/watcher.ts); the UI refreshes on navigation
+// and after its own mutations instead.
+
+export type LinkedFolder = z.infer<typeof workspace.LinkedFolder>;
+
+const PREFIX = workspace.LINKED_FOLDER_PREFIX;
+
+const RegistryFile = z.object({
+  version: z.literal(1),
+  folders: z.array(workspace.LinkedFolder),
+});
+
+function registryPath(): string {
+  return path.join(WorkDir, 'config', 'workspace-folders.json');
+}
+
+// The registry is read on every path resolution, so keep an in-memory copy and
+// only re-parse when the file's mtime/size changes (it is also hand-editable).
+let cache: { folders: LinkedFolder[]; mtimeMs: number; size: number } | null = null;
+
+function isValidId(id: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(id);
+}
+
+function readRegistrySync(): LinkedFolder[] {
+  const file = registryPath();
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(file);
+  } catch {
+    cache = null;
+    return [];
+  }
+  if (cache && cache.mtimeMs === stats.mtimeMs && cache.size === stats.size) {
+    return cache.folders;
+  }
+  let folders: LinkedFolder[] = [];
+  try {
+    const parsed = RegistryFile.safeParse(JSON.parse(fs.readFileSync(file, 'utf8')));
+    if (parsed.success) {
+      folders = parsed.data.folders.filter((f) => isValidId(f.id) && path.isAbsolute(f.path));
+    } else {
+      console.error('[workspace] Ignoring malformed workspace-folders.json');
+    }
+  } catch (error) {
+    console.error('[workspace] Failed to read workspace-folders.json:', error);
+  }
+  cache = { folders, mtimeMs: stats.mtimeMs, size: stats.size };
+  return folders;
+}
+
+async function writeRegistry(folders: LinkedFolder[]): Promise<void> {
+  const file = registryPath();
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+  const body: z.infer<typeof RegistryFile> = { version: 1, folders };
+  await fsp.writeFile(file, JSON.stringify(body, null, 2), 'utf8');
+  cache = null;
+}
+
+/** All registered linked folders, in the order they were added. */
+export function listLinkedFolders(): LinkedFolder[] {
+  return readRegistrySync();
+}
+
+export function getLinkedFolder(id: string): LinkedFolder | null {
+  return readRegistrySync().find((f) => f.id === id) ?? null;
+}
+
+/** True for any path addressed against a linked folder (`@folder/<id>/…`). */
+export function isLinkedPath(relPath: string): boolean {
+  return relPath === PREFIX || relPath.startsWith(`${PREFIX}/`);
+}
+
+/** The workspace path of a linked folder's root. */
+export function linkedRootPath(id: string): string {
+  return `${PREFIX}/${id}`;
+}
+
+/**
+ * Split a linked workspace path into its folder id and the remaining
+ * folder-relative POSIX path (empty string for the folder root).
+ */
+export function parseLinkedPath(relPath: string): { id: string; sub: string } | null {
+  if (!isLinkedPath(relPath)) return null;
+  const rest = relPath.slice(PREFIX.length).replace(/^\/+/, '');
+  if (!rest) return null;
+  const slash = rest.indexOf('/');
+  const id = slash === -1 ? rest : rest.slice(0, slash);
+  const sub = slash === -1 ? '' : rest.slice(slash + 1);
+  if (!isValidId(id)) return null;
+  return { id, sub };
+}
+
+/**
+ * Resolve a linked workspace path to an absolute path, kept inside the linked
+ * folder's own boundary. Returns null if the path isn't a linked path.
+ * Throws if it names an unknown folder or escapes that folder.
+ */
+export function resolveLinkedPath(relPath: string): string | null {
+  const parsed = parseLinkedPath(relPath);
+  if (!parsed) {
+    if (isLinkedPath(relPath)) throw new Error('Invalid linked folder path');
+    return null;
+  }
+  const folder = getLinkedFolder(parsed.id);
+  if (!folder) {
+    throw new Error('This folder is no longer linked to Rowboat');
+  }
+  const root = path.resolve(folder.path);
+  if (!parsed.sub) return root;
+  if (path.isAbsolute(parsed.sub) || parsed.sub.split('/').includes('..')) {
+    throw new Error('Path traversal (..) is not allowed');
+  }
+  const resolved = path.resolve(root, parsed.sub);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+    throw new Error('Path outside folder boundary');
+  }
+  return resolved;
+}
+
+/**
+ * Map an absolute path back into the linked path space, if it sits inside a
+ * linked folder. Longest root wins, so nested links resolve to the closest one.
+ */
+export function absToLinkedPath(absPath: string): string | null {
+  const normalized = path.resolve(absPath);
+  let best: { folder: LinkedFolder; root: string } | null = null;
+  for (const folder of readRegistrySync()) {
+    const root = path.resolve(folder.path);
+    if (normalized !== root && !normalized.startsWith(root + path.sep)) continue;
+    if (!best || root.length > best.root.length) best = { folder, root };
+  }
+  if (!best) return null;
+  const rel = path.relative(best.root, normalized).split(path.sep).join('/');
+  return rel ? `${linkedRootPath(best.folder.id)}/${rel}` : linkedRootPath(best.folder.id);
+}
+
+/**
+ * Register a folder as a workspace. The folder itself is untouched — nothing
+ * is copied, moved, or written inside it.
+ */
+export async function addLinkedFolder(absPath: string, name?: string): Promise<LinkedFolder> {
+  if (!absPath || !path.isAbsolute(absPath)) {
+    throw new Error('Choose a folder to add');
+  }
+  const resolved = path.resolve(absPath);
+
+  const stats = await fsp.stat(resolved).catch(() => null);
+  if (!stats?.isDirectory()) {
+    throw new Error('That path is not a folder');
+  }
+
+  // A folder inside WorkDir is already reachable as a normal workspace path;
+  // linking it too would give the same files two identities.
+  const workRoot = path.resolve(WorkDir);
+  if (resolved === workRoot || resolved.startsWith(workRoot + path.sep)) {
+    throw new Error('That folder is already inside your Rowboat workspace');
+  }
+
+  const folders = readRegistrySync();
+  const existing = folders.find((f) => path.resolve(f.path) === resolved);
+  if (existing) {
+    throw new Error(`"${existing.name}" already points at that folder`);
+  }
+
+  const trimmed = name?.trim();
+  const folder: LinkedFolder = {
+    id: crypto.randomBytes(6).toString('hex'),
+    name: trimmed || path.basename(resolved) || resolved,
+    path: resolved,
+    addedAt: new Date().toISOString(),
+  };
+  await writeRegistry([...folders, folder]);
+  return folder;
+}
+
+/** Unregister a folder. Never touches the files on disk. */
+export async function removeLinkedFolder(id: string): Promise<{ ok: true }> {
+  const folders = readRegistrySync();
+  const next = folders.filter((f) => f.id !== id);
+  if (next.length !== folders.length) {
+    await writeRegistry(next);
+  }
+  return { ok: true as const };
+}
+
+/** Rename the workspace label. The folder on disk keeps its own name. */
+export async function renameLinkedFolder(id: string, name: string): Promise<LinkedFolder> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error('Name is required');
+  if (trimmed.includes('/')) throw new Error('Name cannot contain "/"');
+  const folders = readRegistrySync();
+  const folder = folders.find((f) => f.id === id);
+  if (!folder) throw new Error('This folder is no longer linked to Rowboat');
+  const updated: LinkedFolder = { ...folder, name: trimmed };
+  await writeRegistry(folders.map((f) => (f.id === id ? updated : f)));
+  return updated;
+}

--- a/apps/x/packages/core/src/workspace/workspace.ts
+++ b/apps/x/packages/core/src/workspace/workspace.ts
@@ -8,6 +8,7 @@ import { WorkDir } from '../config/config.js';
 import { rewriteWikiLinksForRenamedKnowledgeFile } from './wiki-link-rewrite.js';
 import { commitAll } from '../knowledge/version_history.js';
 import { withFileLock } from '../knowledge/file-lock.js';
+import { absToLinkedPath, isLinkedPath, resolveLinkedPath } from './linked-folders.js';
 
 // ============================================================================
 // Path Utilities
@@ -34,11 +35,17 @@ export function assertSafeRelPath(relPath: string): void {
  * Resolve a workspace-relative path to an absolute path
  * Ensures the resolved path stays within the workspace boundary
  * Empty string represents the root directory
+ *
+ * `@folder/<id>/…` paths address a linked folder (a workspace living outside
+ * WorkDir) and are bounded by that folder's root instead — see linked-folders.ts.
  */
 export function resolveWorkspacePath(relPath: string): string {
   // Empty string means root directory
   if (relPath === '') {
     return WorkDir;
+  }
+  if (isLinkedPath(relPath)) {
+    return resolveLinkedPath(relPath)!;
   }
   assertSafeRelPath(relPath);
   const resolved = path.resolve(WorkDir, relPath);
@@ -50,12 +57,13 @@ export function resolveWorkspacePath(relPath: string): string {
 
 /**
  * Convert absolute path to workspace-relative POSIX path
- * Returns null if path is outside workspace boundary
+ * Paths inside a linked folder come back as `@folder/<id>/…`.
+ * Returns null if path is outside every workspace boundary
  */
 export function absToRelPosix(absPath: string): string | null {
   const normalized = path.normalize(absPath);
   if (!normalized.startsWith(WorkDir + path.sep) && normalized !== WorkDir) {
-    return null;
+    return absToLinkedPath(normalized);
   }
   const relPath = path.relative(WorkDir, normalized);
   return relPath.split(path.sep).join('/');
@@ -384,6 +392,15 @@ export async function copy(
   return { ok: true as const };
 }
 
+// Moving a file to the OS trash needs Electron's shell, which core does not
+// depend on — the main process registers the implementation at boot.
+type TrashItem = (absPath: string) => Promise<void>;
+let trashItem: TrashItem | null = null;
+
+export function registerTrashHandler(handler: TrashItem): void {
+  trashItem = handler;
+}
+
 export async function remove(
   relPath: string,
   opts?: z.infer<typeof RemoveOptions>
@@ -392,6 +409,17 @@ export async function remove(
   const trash = opts?.trash !== false; // default true
 
   const stats = await fs.lstat(filePath);
+
+  // Deletions inside a linked folder go to the OS trash: WorkDir/.trash is on
+  // a different volume as often as not (the rename would fail with EXDEV), and
+  // a user's own project folder shouldn't leak files into Rowboat's workdir.
+  if (trash && isLinkedPath(relPath)) {
+    if (!trashItem) {
+      throw new Error('Trash is unavailable — delete this file from your file manager instead');
+    }
+    await trashItem(filePath);
+    return { ok: true as const };
+  }
 
   if (trash) {
     // Move to trash: ~/.workspace/.trash/<timestamp>-<name>

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { RelPath, Encoding, Stat, DirEntry, ReaddirOptions, ReadFileResult, WorkspaceChangeEvent, WriteFileOptions, WriteFileResult, RemoveOptions } from './workspace.js';
+import { RelPath, Encoding, Stat, DirEntry, LinkedFolder, ReaddirOptions, ReadFileResult, WorkspaceChangeEvent, WriteFileOptions, WriteFileResult, RemoveOptions } from './workspace.js';
 import { ListToolsResponse } from './mcp.js';
 import { AskHumanResponsePayload, CreateRunOptions, Run, ListRunsResponse, ToolPermissionAuthorizePayload } from './runs.js';
 import { LlmProvider, ModelRef, ReasoningEffort } from './models.js';
@@ -168,6 +168,47 @@ const ipcSchemas = {
     req: z.object({
       path: RelPath,
       opts: RemoveOptions.optional(),
+    }),
+    res: z.object({
+      ok: z.literal(true),
+    }),
+  },
+  'workspace:toAbsolute': {
+    req: z.object({
+      path: RelPath,
+    }),
+    res: z.object({
+      path: z.string(),
+    }),
+  },
+  'workspace:listFolders': {
+    req: z.null(),
+    res: z.object({
+      folders: z.array(LinkedFolder),
+    }),
+  },
+  'workspace:addFolder': {
+    req: z.object({
+      // Absolute path on disk. Omit to open the folder picker.
+      path: z.string().optional(),
+      name: z.string().optional(),
+    }),
+    res: z.object({
+      folder: LinkedFolder.nullable(),
+    }),
+  },
+  'workspace:renameFolder': {
+    req: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+    res: z.object({
+      folder: LinkedFolder,
+    }),
+  },
+  'workspace:removeFolder': {
+    req: z.object({
+      id: z.string(),
     }),
     res: z.object({
       ok: z.literal(true),

--- a/apps/x/packages/shared/src/workspace.ts
+++ b/apps/x/packages/shared/src/workspace.ts
@@ -64,6 +64,23 @@ export const RemoveOptions = z.object({
   trash: z.boolean().optional(),
 });
 
+// ============================================================================
+// Linked Folders
+// ============================================================================
+
+// A workspace that lives outside WorkDir: any folder on disk the user has
+// pointed Rowboat at. Addressed through the normal workspace path space with
+// the `@folder/<id>` prefix, so every workspace:* IPC works on it unchanged.
+export const LINKED_FOLDER_PREFIX = '@folder';
+
+export const LinkedFolder = z.object({
+  id: z.string(),
+  name: z.string(),
+  // Absolute path on disk.
+  path: z.string(),
+  addedAt: z.string(),
+});
+
 export const WorkspaceChangeEvent = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('created'),


### PR DESCRIPTION
## What

Three changes to the Workspaces section, verified end-to-end by driving the app with Playwright:

### 1. Any folder can be added as a workspace (`4c461259`)
- **Linked folders**: "Add workspace" now offers *New workspace* (existing behavior) or *Add existing folder…* — pick any folder on disk and browse/edit it in Rowboat. Nothing is copied or symlinked; a registry at `config/workspace-folders.json` records `{id, name, path}`.
- New `@folder/<id>/…` path space in `resolveWorkspacePath`/`absToRelPosix`, containment-checked against the linked root — every existing `workspace:*` IPC (readdir/read/write/rename/remove/reveal) works on linked folders unchanged.
- Deletes inside a linked folder go to the **OS trash** (main registers `shell.trashItem` into core) — `WorkDir/.trash` would fail cross-volume and leak files into Rowboat's workdir.
- Deliberately **not** watched by chokidar (a linked repo's `node_modules` would EMFILE — see `watcher.ts`); the view refreshes on navigation/focus + manual Refresh. Linked folders also stay out of the knowledge index/graph, wiki links, and version history by construction.
- Rename edits the Rowboat label only; "Remove from Rowboat" unlinks without touching disk.

### 2. Workspace browsing is a list view (`408c084b`)
- Both the workspaces root and folder contents render as a list: Name · Location/Kind · **Last updated** (`6h ago`, `Yesterday`, `Jul 20`; exact timestamp on hover).
- Column headers sort (name A→Z, time newest-first on first click), choice persisted in `localStorage`. Folders group first only when sorting by name.
- A workspace's time is the newest mtime anywhere inside it (deep walk of the already-loaded tree); linked roots show their own mtime since their contents load lazily.

### 3. Workspace chats work again, and live (`ab78c975`)
- **Fix**: `runs:listByWorkDir` still scanned legacy `runs/*.jsonl`, which the boot migration moves to `runs-archive/` — so the Chats panel was always empty. It now filters the in-memory **session index** against the `config/workdir-<id>.json` sidecars (new `runtime/sessions/by-workdir.ts`); dead legacy implementation removed.
- Sessions the index failed to load (empty timestamps) are filtered out — one corrupt session would previously fail schema validation for the whole response and blank the panel.
- The panel updates live: debounced refetch on `sessions:events` (create/retitle/delete) and on a new `WORKSPACE_CHATS_CHANGED` renderer event fired when a chat's work directory is set — covering the no-navigation case where the workspace is open in the middle pane while the chat sits in the right pane.

## Verification

Driven in the real app (isolated `ROWBOAT_WORKDIR`, real session fixtures): add/browse/edit/rename/delete in linked folders incl. path-traversal + boundary rejections; sort flips and persistence; chats panel populated from a real migrated session, nested-dir matching, live appearance of new/retitled/moved-in chats. `npm run typecheck` clean; lint unchanged from `main` (same 11 pre-existing errors).

## Known follow-ups
- Chats panel could open by default when entering a workspace.
- Recent-work-dir picker shows only folder basenames — picking a same-named folder from another Rowboat workdir is indistinguishable (bit us once already).
- Pre-existing: rename input doesn't take keyboard focus from the context menu (present before this branch).
- The larger chat-first workspace redesign (default workspace, switcher, per-tab binding) is specced separately and builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)