### PR TITLE
fix(x): Windows login item via Squirrel stub, not the versioned exe

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -72,6 +72,7 @@ import { isOnboardingComplete, markOnboardingComplete } from '@x/core/dist/confi
 import { loadNotificationSettings, saveNotificationSettings } from '@x/core/dist/config/notification_config.js';
 import { loadTurnLimitsSettings, saveTurnLimitsSettings } from '@x/core/dist/config/turn_limits.js';
 import { saveAppSettings } from '@x/core/dist/config/app_settings.js';
+import { isLoginItemEnabled, setLoginItemEnabled } from './login_item.js';
 import { setSelfCaptureActive } from '@x/core/dist/meetings/detector.js';
 import { notifyIfEnabled } from '@x/core/dist/application/notification/notifier.js';
 import { consumePendingToggleMeetingNotes, setTrayRecordingState } from './tray.js';
@@ -926,14 +927,11 @@ export function setupIpcHandlers() {
       // Dev builds never register a login item (it would point at the dev
       // Electron binary), so report off.
       if (!app.isPackaged) return { openAtLogin: false };
-      return { openAtLogin: app.getLoginItemSettings().openAtLogin };
+      return { openAtLogin: isLoginItemEnabled() };
     },
     'app:setLoginItemSettings': async (_event, args) => {
       if (app.isPackaged) {
-        app.setLoginItemSettings({
-          openAtLogin: args.openAtLogin,
-          ...(process.platform === 'win32' ? { args: ['--hidden'] } : {}),
-        });
+        setLoginItemEnabled(args.openAtLogin);
         // The user has expressed an explicit choice — never re-apply the
         // first-run default over it.
         saveAppSettings({ loginItemRegistered: true });

--- a/apps/x/apps/main/src/login_item.ts
+++ b/apps/x/apps/main/src/login_item.ts
@@ -1,0 +1,121 @@
+import { app } from "electron";
+import fs from "node:fs";
+import path from "node:path";
+import { loadAppSettings, saveAppSettings } from "@x/core/dist/config/app_settings.js";
+
+/**
+ * OS login-item registration.
+ *
+ * On Squirrel.Windows, process.execPath is the VERSIONED exe
+ * (...\Rowboat-win32-x64\app-x.y.z\rowboat.exe), and Electron defaults the
+ * login item's `path` to process.execPath. Registering without an explicit
+ * path bakes the versioned folder into HKCU\...\CurrentVersion\Run, so after
+ * the next update Windows keeps auto-starting the OLD version (Squirrel
+ * leaves previous app-* folders on disk). Register Squirrel's stub launcher
+ * at the install root instead — it always starts the newest installed
+ * version and forwards its command line verbatim, so --hidden still reaches
+ * the app and wasLaunchedAtLogin() keeps working.
+ */
+
+// The stub shares our basename (rowboat.exe) and lives one level above the
+// versioned app-* folder.
+function windowsStub(): { path: string; args: string[] } {
+  const exeName = path.basename(process.execPath);
+  return {
+    path: path.resolve(path.dirname(process.execPath), "..", exeName),
+    args: ["--hidden"],
+  };
+}
+
+export function setLoginItemEnabled(openAtLogin: boolean): void {
+  if (process.platform === "win32") {
+    const stub = windowsStub();
+    app.setLoginItemSettings({ openAtLogin, path: stub.path, args: stub.args });
+  } else {
+    app.setLoginItemSettings({ openAtLogin });
+  }
+}
+
+export function isLoginItemEnabled(): boolean {
+  if (process.platform === "win32") {
+    // Windows compares the stored registry command against path+args as an
+    // exact string — the getter must mirror the setter or it always reads
+    // false (as the pre-stub getter did).
+    const stub = windowsStub();
+    return app.getLoginItemSettings({ path: stub.path, args: stub.args }).openAtLogin;
+  }
+  return app.getLoginItemSettings().openAtLogin;
+}
+
+/**
+ * Registry Run entries created by pre-V2 builds point at whatever versioned
+ * app-x.y.z\rowboat.exe was current at registration time — unknowable now,
+ * and getLoginItemSettings only reports entries whose program matches
+ * options.path exactly. So probe every app-* sibling still on disk; Squirrel
+ * keeps old versions around, which is exactly what makes the stale entry
+ * keep launching.
+ */
+function findStaleVersionedEntries(): Array<{ enabled: boolean }> {
+  const exeName = path.basename(process.execPath);
+  const installRoot = path.resolve(path.dirname(process.execPath), "..");
+  let siblings: fs.Dirent[] = [];
+  try {
+    siblings = fs.readdirSync(installRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return siblings
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("app-"))
+    .flatMap((entry) => {
+      const candidate = path.join(installRoot, entry.name, exeName);
+      return app.getLoginItemSettings({ path: candidate }).launchItems ?? [];
+    });
+}
+
+/**
+ * First-run registration plus the one-time Windows path migration.
+ *
+ * macOS (and anything non-Windows): register once on the first packaged run
+ * (default on). Afterwards the OS registry is the source of truth — the
+ * Settings toggle writes it directly, and disabling the login item in System
+ * Settings sticks because we never re-register on boot.
+ *
+ * Windows: builds before loginItemRegisteredV2 registered the versioned exe
+ * (see above), so every such install auto-starts the version that was
+ * current at registration time, forever. Rewrite that entry in place to the
+ * stub launcher (same registry value name — Electron keys it off the
+ * AppUserModelID, which is stable across versions), preserving a Task
+ * Manager "disabled" verdict via the `enabled` option. Users with no entry
+ * turned auto-launch off (the toggle deletes it) — they stay off.
+ */
+export function ensureLoginItemRegistration(): void {
+  if (!app.isPackaged) return;
+  const settings = loadAppSettings();
+  try {
+    if (process.platform !== "win32") {
+      if (settings.loginItemRegistered) return;
+      setLoginItemEnabled(true);
+      saveAppSettings({ loginItemRegistered: true });
+      return;
+    }
+    if (settings.loginItemRegisteredV2) return;
+    if (!settings.loginItemRegistered) {
+      // Fresh install: the usual first-run default, on the correct path.
+      setLoginItemEnabled(true);
+    } else {
+      const stale = findStaleVersionedEntries();
+      if (stale.length > 0) {
+        const stub = windowsStub();
+        app.setLoginItemSettings({
+          openAtLogin: true,
+          path: stub.path,
+          args: stub.args,
+          enabled: stale.some((item) => item.enabled),
+        });
+      }
+    }
+    saveAppSettings({ loginItemRegistered: true, loginItemRegisteredV2: true });
+  } catch (error) {
+    console.error("[LoginItem] Failed to register login item:", error);
+  }
+}

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -69,7 +69,7 @@ import {
 } from "./deeplink.js";
 import { disconnectGoogleIfScopesStale } from "./oauth-handler.js";
 import { startModelsDevRefresh } from "@x/core/dist/models/models-dev.js";
-import { loadAppSettings, saveAppSettings } from "@x/core/dist/config/app_settings.js";
+import { ensureLoginItemRegistration } from "./login_item.js";
 import { init as initMeetingDetection } from "@x/core/dist/meetings/detector.js";
 import { createAppTray, hasTray, isRecordingActive, markPendingToggleMeetingNotes } from "./tray.js";
 import { initMeetingPopup, showMeetingPopup } from "./meeting-popup.js";
@@ -555,20 +555,12 @@ app.whenReady().then(async () => {
   });
 
   // Resident app (Granola-style): register as an OS login item once, on the
-  // first packaged run. After that the OS registry is the source of truth —
-  // the Settings toggle writes it directly, and disabling the login item in
-  // System Settings sticks because we never re-register on boot.
-  if (app.isPackaged && !loadAppSettings().loginItemRegistered) {
-    try {
-      app.setLoginItemSettings({
-        openAtLogin: true,
-        ...(process.platform === "win32" ? { args: ["--hidden"] } : {}),
-      });
-      saveAppSettings({ loginItemRegistered: true });
-    } catch (error) {
-      console.error("[LoginItem] Failed to register login item:", error);
-    }
-  }
+  // first packaged run — and on Windows, migrate pre-existing registrations
+  // that point at a stale versioned exe (see login_item.ts). After that the
+  // OS registry is the source of truth — the Settings toggle writes it
+  // directly, and disabling the login item in System Settings sticks because
+  // we never re-register on boot.
+  ensureLoginItemRegistration();
 
   createWindow({ startHidden: wasLaunchedAtLogin() });
 

--- a/apps/x/packages/core/src/config/app_settings.ts
+++ b/apps/x/packages/core/src/config/app_settings.ts
@@ -12,6 +12,14 @@ export interface AppSettings {
      * re-registers on boot, so disabling it in System Settings sticks.
      */
     loginItemRegistered?: boolean;
+    /**
+     * Windows only: set once the login item has been (re-)registered via the
+     * version-agnostic Squirrel stub launcher. Builds before this flag
+     * registered the versioned app-x.y.z exe, which keeps auto-starting the
+     * OLD version after every update — the first run of a newer build
+     * rewrites that registry entry in place (see apps/main/src/login_item.ts).
+     */
+    loginItemRegisteredV2?: boolean;
 }
 
 export function loadAppSettings(): AppSettings {


### PR DESCRIPTION
## What

- Fixes the P0 where Windows users auto-start an **old version** after updating ([RCA gist](https://gist.github.com/ramnique/16c5fe4bd860b3243b067bfef7067213) — vetted independently, accurate). The login item was registered without a `path`, so Electron baked the versioned `app-x.y.z\rowboat.exe` into `HKCU\...\Run`; the first-run-only flag made the stale path permanent.
- Registers via Squirrel's version-agnostic stub (`<installRoot>\rowboat.exe`), which always launches the newest installed version — and migrates existing installs' stale entries in place on first run.
- Also fixes the Settings toggle, which has **always read OFF on Windows**: Electron matches the registry command against `path`+`args` exactly, and the getter never mirrored the setter's `--hidden`.

## How

- New `login_item.ts` owns all registration. Windows uses the stub + `--hidden` (the stub forwards args, so `wasLaunchedAtLogin()` still works); macOS unchanged.
- One-time migration gated on `loginItemRegisteredV2`: probes the on-disk `app-*` siblings via `getLoginItemSettings({path})` to locate the stale entry, then rewrites it under the same AUMID-keyed registry value — an in-place overwrite, no duplicate. Task Manager enabled/disabled state is preserved; users who toggled auto-launch off have no entry and stay off.

## Test plan

Reproduced the full lifecycle in a staged Squirrel install root (`stub + Update.exe + app-*` folders) on Windows 11:

- Packaged **v0.8.1 (buggy)**, staged as `app-0.7.7`, ran once → Run entry = `...\app-0.7.7\rowboat.exe --hidden` — bug reproduced
- Packaged **this branch**, staged as `app-0.8.2`, ran once → entry rewritten in place to `...\rowboat.exe --hidden` (stub), `loginItemRegisteredV2` set
- Ran the exact boot command (`rowboat.exe --hidden`) → process runs from `app-0.8.2`
- Staged a fake future update `app-0.9.0`, ran the boot command again → runs from `app-0.9.0` with **zero registry changes** — updates can never break startup again
- Electron's registry semantics (exact-match getter, `launchItems` path probing, AUMID-keyed overwrite) verified against the real registry with a throwaway Electron 39 script

Known limitation: if Squirrel cleanup already deleted the registered `app-*` folder, the probe can't find the entry (auto-launch is already silently dead for that user). In practice cleanup doesn't run (#792) — which is exactly why the old exe keeps launching.

Note: **v0.8.1 (tagged today) still ships the bug** — this should drive a v0.8.2 release.