### PR TITLE
perf: stop copilot taking unnecessary time  to answer trivial messages

### DIFF
--- a/apps/x/packages/core/src/runtime/assembly/copilot/instructions.ts
+++ b/apps/x/packages/core/src/runtime/assembly/copilot/instructions.ts
@@ -260,7 +260,7 @@ Use the base file tools to search and read it:
 
 ## When to Access the Knowledge Graph
 
-**CRITICAL: When the user mentions ANY person, organization, project, or topic by name, you MUST look them up in the knowledge base FIRST before responding.** Do not provide generic responses. Do not guess. Look up the context first, then respond with that knowledge.
+**CRITICAL: When the user mentions ANY person, organization, project, or topic by name, you MUST look them up in the knowledge base FIRST before responding.** Do not provide generic responses. Do not guess. Look up the context first, then respond with that knowledge. This applies to recognizable entities only. If the message is a greeting, small talk, an obvious typo, gibberish, or contains no recognizable name or work context, do NOT call any tools — respond directly (asking what they meant is fine).
 
 - **Do access IMMEDIATELY** when the user mentions any person, organization, project, or topic by name (e.g., "draft an email to Monica" → first search for Monica in knowledge/, read her note, understand the relationship, THEN draft).
 - **Do access** when the task involves specific people, projects, organizations, or past context (e.g., "prep me for my call with Sarah," "what did we decide about the pricing change," "draft a follow-up to yesterday's meeting").
@@ -268,6 +268,7 @@ Use the base file tools to search and read it:
 - **Do access first** for anything related to meetings, emails, or calendar - your knowledge graph already has this context extracted and organized. Check memory before looking for MCP tools.
 - **Don't access** for general knowledge questions, brainstorming, writing help, or tasks that don't involve the user's specific work context (e.g., "explain how OAuth works," "help me write a job description," "what's a good framework for prioritization").
 - **Don't access** repeatedly within a single task - pull the relevant context once at the start, then work from it.
+- **Stop after one miss.** If a knowledge-base grep returns no matches, the entity is not in the knowledge base. Do not follow up with directory listings, recursive file-list calls, or reads of unrelated files to explore — answer from what you know or ask the user.
 
 ## Local-First and Private
 Everything runs locally. User data stays on their machine. Users can connect any LLM they want, or run fully local with Ollama.

--- a/apps/x/packages/core/src/runtime/assembly/workspace-context.ts
+++ b/apps/x/packages/core/src/runtime/assembly/workspace-context.ts
@@ -76,11 +76,11 @@ export function loadAgentNotesContext(): string | null {
     } catch { /* ignore */ }
 
     if (otherFiles.length > 0) {
-        sections.push(`## More Specific Preferences\nFor more specific preferences, you can read these files using file-readText. Only read them when relevant to the current task.\n\n${otherFiles.map(f => `- knowledge/Agent Notes/${f}`).join('\n')}`);
+        sections.push(`## More Specific Preferences\nFor more specific preferences, you can read these files using file-readText. Only read one of these when it is directly relevant to the current task; never read them for greetings or trivial messages.\n\n${otherFiles.map(f => `- knowledge/Agent Notes/${f}`).join('\n')}`);
     }
 
     if (sections.length === 0) return null;
-    return `# Agent Memory\n\n${sections.join('\n\n')}`;
+    return `# Agent Memory\nThe sections below are already fully loaded into this prompt. NEVER re-read knowledge/Agent Notes/user.md or knowledge/Agent Notes/preferences.md with file tools — their complete contents are here.\n\n${sections.join('\n\n')}`;
 }
 
 export interface WorkspaceContext {


### PR DESCRIPTION
## Problem

The copilot wastes tool calls on messages where the knowledge base cannot help. The system prompt says "if the user mentions ANY name, you MUST search the knowledge base first" — with no exception for messages that contain no real entity, and no rule for what to do when a search finds nothing.

Worst measured case: the gibberish message "hsbuu" took **30 seconds and 6 model calls**. The model treated it as a name and ran 5 tool calls: grep (0 matches) → full recursive listing of `knowledge/` → 3 file reads. Two of those reads (`user.md`, `preferences.md`) fetched content that is already pasted into the system prompt's `# Agent Memory` section on every turn.

Measured with the turn inspector (`npm run inspect -- <turnId> --full`):

| | Before | After |
|---|---:|---:|
| Model calls | 6 | 1 |
| Tool calls | 5 | 0 |
| Input tokens | 110,598 | ~12,000 |
| Time to reply | 30 s | instant |

The same fix also covers cases beyond gibberish:

- **Short messages generally** — greetings, acknowledgements, typos — now get an instant direct reply instead of a retrieval round-trip.
- **Questions about entities not (yet) in the knowledge base** — exploration is now bounded to a single grep instead of a grep → recursive-listing → unrelated-reads cascade.
- **Every turn** — the model no longer re-reads memory files whose contents are already in its prompt.

## What changed

**Only prompt text. 2 files, ~7 lines added, zero code-path changes.**

1. `runtime/assembly/copilot/instructions.ts` — the lookup mandate now applies to recognizable entities only: greetings, small talk, typos, and gibberish get a direct reply with no tool calls.
2. Same file — new rule: "Stop after one miss." If a knowledge-base grep finds nothing, the entity isn't there — don't follow up with directory listings or unrelated file reads.
3. `runtime/assembly/workspace-context.ts` — the `# Agent Memory` block now states its contents are already in the prompt and `user.md` / `preferences.md` must never be re-read via file tools.
4. Same file — the "More Specific Preferences" file list is tightened: read one only when directly relevant, never for trivial messages.

## Why this is safe

- These strings go only into the **copilot** system prompt. Background tasks, knowledge-graph agents, and live notes have their own instructions — untouched.
- Real-name lookups behave exactly as before ("draft an email to Monica" still greps `knowledge/` first) — verified manually, see below.
- Worst case if the model misjudges an unusual real name as gibberish: it simply asks "who do you mean?" and looks it up after the user clarifies. No wrong answers, no data loss.

## Testing

- Unit tests: 16/16 passing (`workspace-context.test.ts`, `compose-instructions.test.ts`). No snapshot or expectation updates needed — a repo-wide grep confirmed nothing else asserts on the modified phrases.
- Typecheck (`npm run typecheck` in `packages/core`) and lint on both files: clean.
- Manual, dev build: gibberish messages now get an instant single-call reply (screenshots below — two separate runs, ~12K input each vs 110K before).
- Regression: "prep me for a call with <name>" still triggers the `knowledge/` grep and answers from the retrieved note.


<img width="376" height="186" alt="Screenshot 2026-07-28 at 00 03 59" src="https://github.com/user-attachments/assets/b58973a8-148f-40b7-a33b-a707993a4bd4" />
<img width="877" height="279" alt="Screenshot 2026-07-28 at 00 03 54" src="https://github.com/user-attachments/assets/68e02492-cffc-4887-a0f0-fe049b3b0c3b" />

