### PR TITLE
Quick-ask bar: voice-response and screen-share toggles

### DIFF
--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -19,7 +19,7 @@ and ends it.
 | Preset | Starting devices | First surface |
 |--------|------------------|---------------|
 | `share` — main click | screen on, camera off | floating pill |
-| `voice` — "Voice call" | camera off, screen off | floating mascot pill |
+| `voice` — no menu entry (programmatic only; the quick-ask bar's voice toggle covers this case) | camera off, screen off | floating mascot pill |
 | `video` — "Video call" | camera on | floating pill (camera in the pill; expand for full screen) |
 | `practice` — "Practice session" | camera on, + coaching persona | full-screen call |
 

--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -299,6 +299,20 @@ question relays through main into the current chat (`quickAsk:submit` →
 timestamped after the submit count). The window is hidden, not destroyed,
 on dismiss (blur or Esc); it grows to show the answer via `quickAsk:resize`.
 
+**Optional toggles** (`quickAsk:setOptions` → `quick-ask:set-options`;
+actual state echoes back over `quickAsk:optionsState` →
+`quick-ask:options-state`): **voice response** speaks the bar's answers
+aloud — per-turn (`speakTurnRef` set at submit for quick-ask turns), so
+composer messages outside the bar never start talking; the segment player
+and fallback-speech net honor it. **Screen share** reuses the call
+engine's capture wholesale (`video.start({camera:false})` +
+`startScreenShare`, black-frame permission check included): frames ride
+along with bar submits and `composition.videoMode` is set. The bar owns
+the consent surface outside calls — a lit share toggle with a pulsing dot
+is the badge, no floating pill appears, and the share STOPS whenever the
+bar goes away (blur, Esc, the Open-in-Rowboat jump). Bar toggles never
+touch devices while a call is live.
+
 ## Cost notes
 
 Webcam frames ≈ 250–350 tokens each (≤12/message ≈ 3–4k); screen frames ≈

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1004,6 +1004,14 @@ export function setupIpcHandlers() {
       findMainAppWindow()?.webContents.send('quick-ask:new-chat', null);
       return {};
     },
+    'quickAsk:setOptions': async (_event, args) => {
+      findMainAppWindow()?.webContents.send('quick-ask:set-options', args);
+      return {};
+    },
+    'quickAsk:optionsState': async (_event, args) => {
+      getQuickAskWindow()?.webContents.send('quick-ask:options-state', args);
+      return {};
+    },
     'quickAsk:openChat': async () => {
       const main = findMainAppWindow();
       if (main) {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -138,7 +138,7 @@ import { ProductTour, type TourNavTarget } from '@/components/product-tour'
 import { useMeetingTranscription, type CalendarEventMeta } from '@/hooks/useMeetingTranscription'
 import { useAnalyticsIdentity } from '@/hooks/useAnalyticsIdentity'
 import * as analytics from '@/lib/analytics'
-import { playAckCue, playAlertCue } from '@/lib/call-sounds'
+import { playAckCue, playAlertCue, playPopCue } from '@/lib/call-sounds'
 import { useTheme } from '@/contexts/theme-context'
 import { TokenUsageMenu } from '@/components/token-usage-menu'
 
@@ -1801,10 +1801,15 @@ function App() {
     if (localStorage.getItem('quick-ask-tip-shown')) return
     const timer = setTimeout(() => {
       localStorage.setItem('quick-ask-tip-shown', '1')
+      playPopCue()
       toast('Ask Rowboat from anywhere', {
         description: `Press ${isMac ? '⌥⇧Space' : 'Alt+Shift+Space'} in any app for a quick question — the answer shows up right there and in your chat.`,
         duration: 12000,
         closeButton: true,
+        // Lift the card off the page, and move sonner's close button (which
+        // defaults to the top-LEFT corner) to the top right.
+        className:
+          'shadow-xl shadow-black/25 [&_[data-close-button]]:!left-auto [&_[data-close-button]]:!right-0 [&_[data-close-button]]:!translate-x-[35%] [&_[data-close-button]]:!-translate-y-[35%]',
         action: {
           label: 'Try it',
           onClick: () => void window.ipc.invoke('quickAsk:show', null).catch(() => {}),

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1809,7 +1809,7 @@ function App() {
         // Lift the card off the page, and move sonner's close button (which
         // defaults to the top-LEFT corner) to the top right.
         className:
-          'shadow-xl shadow-black/25 [&_[data-close-button]]:!left-auto [&_[data-close-button]]:!right-0 [&_[data-close-button]]:!translate-x-[35%] [&_[data-close-button]]:!-translate-y-[35%]',
+          'shadow-xl shadow-black/25 [&_[data-close-button]]:!left-auto [&_[data-close-button]]:!right-0 [&_[data-close-button]]:!translate-x-[15%] [&_[data-close-button]]:!-translate-y-[15%]',
         action: {
           label: 'Try it',
           onClick: () => void window.ipc.invoke('quickAsk:show', null).catch(() => {}),

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1098,6 +1098,10 @@ function App() {
   // cleared at submit, set by the segment player; the fallback-speech net
   // fires only when this is still false at turn completion.
   const spokeSegmentThisTurnRef = useRef(false)
+  // The current turn should be spoken aloud even without a call — set at
+  // submit for quick-ask questions with the voice toggle on. Per-turn so
+  // composer messages outside the bar never start talking.
+  const speakTurnRef = useRef(false)
   // Fallback-speech bookkeeping, armed per call turn at submit (see
   // handlePromptSubmit) and consumed by the effect below the segment player.
   const callTurnVoiceRef = useRef<{ pending: boolean; submitAt: number }>({
@@ -1127,7 +1131,7 @@ function App() {
       if (pttStatusRef.current !== 'idle') break
       const segment = voiceSegments[spokenVoiceRef.current.count]
       spokenVoiceRef.current.count += 1
-      if (ttsEnabledRef.current) {
+      if (ttsEnabledRef.current || speakTurnRef.current) {
         const marks = callTurnMarksRef.current
         if (marks && marks.speak === undefined) marks.speak = performance.now()
         spokeSegmentThisTurnRef.current = true
@@ -1145,7 +1149,8 @@ function App() {
     if (activeIsProcessing) return
     const turn = callTurnVoiceRef.current
     if (!turn.pending) return
-    if (!inCallRef.current || !ttsEnabledRef.current) {
+    // Speaking this turn: call TTS, or the quick-ask voice toggle.
+    if (!(inCallRef.current ? ttsEnabledRef.current : speakTurnRef.current)) {
       turn.pending = false
       return
     }
@@ -1816,6 +1821,45 @@ function App() {
       setIsRightPaneMaximized(true)
     })
   }, [])
+
+  // Quick-ask toggles (voice response / screen share), pushed from the bar.
+  // Screen share reuses the call engine's capture wholesale — the bar owns
+  // the share indicator, so no pill appears outside calls. Calls own the
+  // devices while live: bar toggles never fight an active call.
+  const quickAskOptionsRef = useRef({ voiceOutput: false, screenShare: false })
+  useEffect(() => {
+    return window.ipc.on('quick-ask:set-options', (opts) => {
+      quickAskOptionsRef.current = opts
+      if (inCallRef.current) return
+      if (opts.screenShare && video.screenState !== 'live') {
+        void (async () => {
+          await video.start({ camera: false })
+          const shared = await video.startScreenShare()
+          if (!shared) {
+            video.stop()
+            quickAskOptionsRef.current = { ...opts, screenShare: false }
+            setPermissionDialog('screen-recording')
+          }
+        })()
+      } else if (!opts.screenShare && video.screenState === 'live') {
+        video.stopScreenShare()
+        video.stop()
+      }
+    })
+  }, [video])
+
+  // Report the ACTUAL state back to the bar — its badge must reflect what
+  // capture is really doing (a denied permission means no share, whatever
+  // the toggle wished for).
+  useEffect(() => {
+    if (inCall) return
+    void window.ipc
+      .invoke('quickAsk:optionsState', {
+        voiceOutput: quickAskOptionsRef.current.voiceOutput,
+        screenSharing: video.screenState === 'live',
+      })
+      .catch(() => {})
+  }, [inCall, video.screenState])
 
   // Quick-ask bar: a question typed/spoken into the global ⌥⇧Space bar lands
   // in the current chat exactly like a composer message.
@@ -3410,7 +3454,13 @@ function App() {
       marks.submit = performance.now()
     }
 
-    if (inCallRef.current) {
+    // Quick-ask voice toggle: this turn speaks its reply even though no call
+    // is live. Per-turn (not a sticky flag) so composer messages typed
+    // outside the bar never start talking.
+    speakTurnRef.current =
+      !inCallRef.current && quickAskActiveRef.current && quickAskOptionsRef.current.voiceOutput
+
+    if (inCallRef.current || speakTurnRef.current) {
       // A new question supersedes whatever of the previous reply was still
       // unspoken — silence it and drop the frozen backlog so it never plays
       // over the new turn. (The overlay resets its segment list when the
@@ -3429,7 +3479,10 @@ function App() {
       }
     }
 
-    const videoFrames = inCallRef.current ? video.collectFrames() : []
+    // Frames ride along whenever screen capture is live — during calls, and
+    // for quick-ask questions with the share toggle on.
+    const videoFrames =
+      inCallRef.current || video.screenState === 'live' ? video.collectFrames() : []
 
     const userMessageId = `user-${Date.now()}`
     const displayAttachments: ChatMessage['attachments'] = hasAttachments || videoFrames.length > 0
@@ -3505,10 +3558,16 @@ function App() {
             composition: {
               workDirId: currentRunId,
               ...(pendingVoiceInputRef.current ? { voiceInput: true } : {}),
-              ...(ttsEnabledRef.current ? { voiceOutput: ttsModeRef.current } : {}),
+              ...(ttsEnabledRef.current
+                ? { voiceOutput: ttsModeRef.current }
+                : speakTurnRef.current
+                  ? { voiceOutput: 'full' as const }
+                  : {}),
               ...(searchEnabled ? { searchEnabled: true } : {}),
               ...(codeMode ? { codeMode } : {}),
-              ...(inCallRef.current && (video.cameraOn || video.screenState === 'live') ? { videoMode: true } : {}),
+              ...((inCallRef.current && video.cameraOn) || video.screenState === 'live'
+                ? { videoMode: true }
+                : {}),
               ...(practiceModeRef.current ? { coachMode: true } : {}),
             },
           },

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1832,15 +1832,15 @@ function App() {
   // model its earlier frames are stale (history keeps frames inline forever,
   // so without this it answers "what's on my screen" from the past).
   const screenShareEndedRef = useRef(false)
-  const prevScreenStateRef = useRef(video.screenState)
+  const lastScreenStateForNoticeRef = useRef(video.screenState)
   useEffect(() => {
-    if (prevScreenStateRef.current === 'live' && video.screenState !== 'live') {
+    if (lastScreenStateForNoticeRef.current === 'live' && video.screenState !== 'live') {
       screenShareEndedRef.current = true
     }
     // Sharing again supersedes the notice — fresh frames arrive with the
     // next message anyway.
     if (video.screenState === 'live') screenShareEndedRef.current = false
-    prevScreenStateRef.current = video.screenState
+    lastScreenStateForNoticeRef.current = video.screenState
   }, [video.screenState])
 
   // Quick-ask toggles (voice response / screen share), pushed from the bar.

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1802,8 +1802,9 @@ function App() {
     const timer = setTimeout(() => {
       localStorage.setItem('quick-ask-tip-shown', '1')
       toast('Ask Rowboat from anywhere', {
-        description: 'Press ⌥⇧Space in any app for a quick question — the answer shows up right there and in your chat.',
+        description: `Press ${isMac ? '⌥⇧Space' : 'Alt+Shift+Space'} in any app for a quick question — the answer shows up right there and in your chat.`,
         duration: 12000,
+        closeButton: true,
         action: {
           label: 'Try it',
           onClick: () => void window.ipc.invoke('quickAsk:show', null).catch(() => {}),

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1828,6 +1828,21 @@ function App() {
     })
   }, [])
 
+  // A screen share ended since the last message: the NEXT message tells the
+  // model its earlier frames are stale (history keeps frames inline forever,
+  // so without this it answers "what's on my screen" from the past).
+  const screenShareEndedRef = useRef(false)
+  const prevScreenStateRef = useRef(video.screenState)
+  useEffect(() => {
+    if (prevScreenStateRef.current === 'live' && video.screenState !== 'live') {
+      screenShareEndedRef.current = true
+    }
+    // Sharing again supersedes the notice — fresh frames arrive with the
+    // next message anyway.
+    if (video.screenState === 'live') screenShareEndedRef.current = false
+    prevScreenStateRef.current = video.screenState
+  }, [video.screenState])
+
   // Quick-ask toggles (voice response / screen share), pushed from the bar.
   // Screen share reuses the call engine's capture wholesale — the bar owns
   // the share indicator, so no pill appears outside calls. Calls own the
@@ -3582,21 +3597,27 @@ function App() {
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(chatMaxModelCalls !== undefined ? { maxModelCalls: chatMaxModelCalls } : {}),
       }
-      const userMessageContextFor = (middlePane: Awaited<ReturnType<typeof buildMiddlePaneContext>>) => ({
-        // Local wall-clock with explicit timezone, never toISOString: the model
-        // adopts this as its time frame, so a UTC "now" makes it quote email
-        // timestamps (which carry their own offsets) in UTC instead of local.
-        currentDateTime: `${new Date().toLocaleString('en-US', {
-          weekday: 'long',
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-          timeZoneName: 'short',
-        })} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`,
-        middlePane: middlePane ?? { kind: 'empty' as const },
-      })
+      const userMessageContextFor = (middlePane: Awaited<ReturnType<typeof buildMiddlePaneContext>>) => {
+        // One-shot: the stale-frames notice rides on exactly one message.
+        const screenShareEnded = screenShareEndedRef.current
+        screenShareEndedRef.current = false
+        return {
+          // Local wall-clock with explicit timezone, never toISOString: the model
+          // adopts this as its time frame, so a UTC "now" makes it quote email
+          // timestamps (which carry their own offsets) in UTC instead of local.
+          currentDateTime: `${new Date().toLocaleString('en-US', {
+            weekday: 'long',
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'short',
+          })} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`,
+          middlePane: middlePane ?? { kind: 'empty' as const },
+          ...(screenShareEnded ? { screenShareEnded: true } : {}),
+        }
+      }
 
       // One retry: an in-call submit can land while the previous turn's
       // abort hasn't fully settled in the runtime — losing the message (and

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -198,7 +198,9 @@ function compactWorkDirPath(path: string) {
 export type CallPreset = 'voice' | 'video' | 'share' | 'practice'
 
 const CALL_PRESET_MENU: Array<{ preset: CallPreset; label: string; description: string; Icon: typeof Phone }> = [
-  { preset: 'voice', label: 'Voice call', description: 'Just talk — nothing is shared, the mascot hovers while you work', Icon: AudioLines },
+  // 'voice' was dropped from the menu (the quick-ask bar with its voice
+  // toggle covers the talk-without-devices case); the preset itself stays
+  // valid for programmatic callers.
   { preset: 'video', label: 'Video call', description: 'Camera on, face to face — it sees your expressions', Icon: Video },
   { preset: 'practice', label: 'Practice session', description: 'Rehearse a pitch or interview with live coaching', Icon: Presentation },
 ]

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -361,7 +361,7 @@ export function QuickAskBar() {
             <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
             <Volume2 className="relative h-4 w-4" />
           </button>
-          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-black/85 px-1.5 py-0.5 text-[10px] text-white opacity-0 transition-opacity peer-hover:opacity-100">
+          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-900 shadow-md opacity-0 transition-opacity peer-hover:opacity-100">
             {voiceOut ? 'Click to mute' : 'Speak answers aloud'}
           </span>
         </span>
@@ -378,11 +378,8 @@ export function QuickAskBar() {
           >
             <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
             <MonitorUp className="relative h-4 w-4" />
-            {sharing && (
-              <span className="absolute right-1 top-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
-            )}
           </button>
-          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-black/85 px-1.5 py-0.5 text-[10px] text-white opacity-0 transition-opacity peer-hover:opacity-100">
+          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-900 shadow-md opacity-0 transition-opacity peer-hover:opacity-100">
             {sharing ? 'Stop sharing' : 'Share your screen'}
           </span>
         </span>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowUpRight, Command, CornerDownLeft, Mic, Plus } from 'lucide-react'
+import { ArrowUpRight, Command, CornerDownLeft, Mic, MonitorUp, Plus, Volume2 } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -108,17 +108,59 @@ export function QuickAskBar() {
     setDraft('')
   }, [])
 
-  const dismiss = useCallback(() => {
-    void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
+  // Optional toggles (the standup's "voice and screen share as opt-ins").
+  // voiceOut: answers to bar questions are spoken aloud. sharing: the app
+  // window's screen capture runs and frames ride along with bar submits —
+  // the ACTUAL state comes back over quick-ask:options-state (a denied
+  // permission must never leave a lying badge).
+  const [voiceOut, setVoiceOut] = useState(false)
+  const [sharing, setSharing] = useState(false)
+  const pushOptions = useCallback((voiceOutput: boolean, screenShare: boolean) => {
+    void window.ipc.invoke('quickAsk:setOptions', { voiceOutput, screenShare }).catch(() => {})
   }, [])
+  useEffect(() => {
+    return window.ipc.on('quick-ask:options-state', (s) => {
+      setSharing(s.screenSharing)
+      setVoiceOut(s.voiceOutput)
+    })
+  }, [])
+  const toggleVoiceOut = useCallback(() => {
+    const next = !voiceOut
+    setVoiceOut(next)
+    pushOptions(next, sharing)
+  }, [voiceOut, sharing, pushOptions])
+  const toggleShare = useCallback(() => {
+    const next = !sharing
+    setSharing(next)
+    pushOptions(voiceOut, next)
+  }, [voiceOut, sharing, pushOptions])
+  // The bar owns the share's consent surface — when it goes away (blur,
+  // Esc, jump to the app), the share it started must stop with it. Nothing
+  // may keep capturing the screen with no indicator in sight.
+  const stopShareIfOn = useCallback(() => {
+    if (!sharing) return
+    setSharing(false)
+    pushOptions(voiceOut, false)
+  }, [sharing, voiceOut, pushOptions])
+  useEffect(() => {
+    const onBlur = () => stopShareIfOn()
+    window.addEventListener('blur', onBlur)
+    return () => window.removeEventListener('blur', onBlur)
+  }, [stopShareIfOn])
+
+  const dismiss = useCallback(() => {
+    stopShareIfOn()
+    void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
+  }, [stopShareIfOn])
 
   // Jump to the full conversation: the question already lives in the app's
   // active chat (the bar relays into it), so focusing the app window lands
   // on this exact exchange. The bar gets out of the way.
   const openInApp = useCallback(() => {
+    stopShareIfOn()
     void window.ipc.invoke('quickAsk:openChat', null).catch(() => {})
     void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
-  }, [])
+  }, [stopShareIfOn])
 
   // Fresh conversation for the next question: resets the app's active chat
   // (in the background) and clears the panel. The bar stays up.
@@ -299,6 +341,49 @@ export function QuickAskBar() {
             <span className="text-sm text-neutral-400">to speak</span>
           </span>
         )}
+        {/* Optional toggles: speak answers aloud, share the screen. Same
+            layered chrome as the send button; a lit tint marks active. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={toggleVoiceOut}
+              aria-label={voiceOut ? 'Stop speaking answers' : 'Speak answers aloud'}
+              className={`relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
+                voiceOut
+                  ? 'bg-gradient-to-b from-sky-400/30 to-sky-600/10 text-sky-100 ring-sky-300/30'
+                  : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
+              }`}
+            >
+              <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
+              <Volume2 className="relative h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">{voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={toggleShare}
+              aria-label={sharing ? 'Stop sharing your screen' : 'Share your screen'}
+              className={`relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
+                sharing
+                  ? 'bg-gradient-to-b from-emerald-400/30 to-emerald-600/10 text-emerald-100 ring-emerald-300/30'
+                  : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
+              }`}
+            >
+              <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
+              <MonitorUp className="relative h-4 w-4" />
+              {sharing && (
+                <span className="absolute right-1 top-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {sharing ? 'Sharing your screen with this chat — click to stop' : 'Share your screen with this chat'}
+          </TooltipContent>
+        </Tooltip>
         <button
           type="submit"
           disabled={!draft.trim()}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -342,53 +342,50 @@ export function QuickAskBar() {
           </span>
         )}
         {/* Optional toggles: speak answers aloud, share the screen. Same
-            layered chrome as the send button; a lit tint marks active. */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={toggleVoiceOut}
-              aria-label={voiceOut ? 'Stop speaking answers' : 'Speak answers aloud'}
-              className={`relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
-                voiceOut
-                  ? 'bg-gradient-to-b from-sky-400/30 to-sky-600/10 text-sky-100 ring-sky-300/30'
-                  : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
-              }`}
-            >
-              <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
-              <Volume2 className="relative h-4 w-4" />
-            </button>
-          </TooltipTrigger>
-          {/* Forced bottom + compact: the window edge is ~24px below the
-              button, so Radix's collision logic would flip a normal-size
-              tooltip back to the top. */}
-          <TooltipContent side="bottom" sideOffset={2} avoidCollisions={false} className="px-2 py-0.5 text-[11px]">
-            {voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}
-          </TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={toggleShare}
-              aria-label={sharing ? 'Stop sharing your screen' : 'Share your screen'}
-              className={`relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
-                sharing
-                  ? 'bg-gradient-to-b from-emerald-400/30 to-emerald-600/10 text-emerald-100 ring-emerald-300/30'
-                  : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
-              }`}
-            >
-              <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
-              <MonitorUp className="relative h-4 w-4" />
-              {sharing && (
-                <span className="absolute right-1 top-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={2} avoidCollisions={false} className="px-2 py-0.5 text-[11px]">
-            {sharing ? 'Sharing your screen with this chat — click to stop' : 'Share your screen with this chat'}
-          </TooltipContent>
-        </Tooltip>
+            layered chrome as the send button; a lit tint marks active. The
+            hover hints are tiny in-capsule labels UNDER each button — a real
+            tooltip can't open downward here (the window ends ~24px below,
+            and with liquid glass the window must stay exactly capsule-sized),
+            so the label lives in that 24px instead. */}
+        <span className="relative shrink-0">
+          <button
+            type="button"
+            onClick={toggleVoiceOut}
+            aria-label={voiceOut ? 'Stop speaking answers' : 'Speak answers aloud'}
+            className={`peer relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
+              voiceOut
+                ? 'bg-gradient-to-b from-sky-400/30 to-sky-600/10 text-sky-100 ring-sky-300/30'
+                : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
+            }`}
+          >
+            <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
+            <Volume2 className="relative h-4 w-4" />
+          </button>
+          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-black/85 px-1.5 py-0.5 text-[10px] text-white opacity-0 transition-opacity peer-hover:opacity-100">
+            {voiceOut ? 'Click to mute' : 'Speak answers aloud'}
+          </span>
+        </span>
+        <span className="relative shrink-0">
+          <button
+            type="button"
+            onClick={toggleShare}
+            aria-label={sharing ? 'Stop sharing your screen' : 'Share your screen'}
+            className={`peer relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
+              sharing
+                ? 'bg-gradient-to-b from-emerald-400/30 to-emerald-600/10 text-emerald-100 ring-emerald-300/30'
+                : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
+            }`}
+          >
+            <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
+            <MonitorUp className="relative h-4 w-4" />
+            {sharing && (
+              <span className="absolute right-1 top-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
+            )}
+          </button>
+          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-black/85 px-1.5 py-0.5 text-[10px] text-white opacity-0 transition-opacity peer-hover:opacity-100">
+            {sharing ? 'Stop sharing' : 'Share your screen'}
+          </span>
+        </span>
         <button
           type="submit"
           disabled={!draft.trim()}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -347,41 +347,63 @@ export function QuickAskBar() {
             tooltip can't open downward here (the window ends ~24px below,
             and with liquid glass the window must stay exactly capsule-sized),
             so the label lives in that 24px instead. */}
+        {/* Hint placement depends on the surface: expanded, the panel above
+            gives a normal tooltip room to open upward; collapsed, the window
+            is exactly the capsule, so a tiny in-capsule label sits in the
+            ~24px under the button instead. */}
         <span className="relative shrink-0">
-          <button
-            type="button"
-            onClick={toggleVoiceOut}
-            aria-label={voiceOut ? 'Stop speaking answers' : 'Speak answers aloud'}
-            className={`peer relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
-              voiceOut
-                ? 'bg-gradient-to-b from-sky-400/30 to-sky-600/10 text-sky-100 ring-sky-300/30'
-                : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
-            }`}
-          >
-            <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
-            <Volume2 className="relative h-4 w-4" />
-          </button>
-          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-900 shadow-md opacity-0 transition-opacity peer-hover:opacity-100">
-            {voiceOut ? 'Click to mute' : 'Speak answers aloud'}
-          </span>
+          <Tooltip open={expanded ? undefined : false}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={toggleVoiceOut}
+                aria-label={voiceOut ? 'Stop speaking answers' : 'Speak answers aloud'}
+                className={`peer relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
+                  voiceOut
+                    ? 'bg-gradient-to-b from-sky-400/30 to-sky-600/10 text-sky-100 ring-sky-300/30'
+                    : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
+                }`}
+              >
+                <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
+                <Volume2 className="relative h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}
+            </TooltipContent>
+          </Tooltip>
+          {!expanded && (
+            <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-900 shadow-md opacity-0 transition-opacity peer-hover:opacity-100">
+              {voiceOut ? 'Click to mute' : 'Speak answers aloud'}
+            </span>
+          )}
         </span>
         <span className="relative shrink-0">
-          <button
-            type="button"
-            onClick={toggleShare}
-            aria-label={sharing ? 'Stop sharing your screen' : 'Share your screen'}
-            className={`peer relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
-              sharing
-                ? 'bg-gradient-to-b from-emerald-400/30 to-emerald-600/10 text-emerald-100 ring-emerald-300/30'
-                : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
-            }`}
-          >
-            <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
-            <MonitorUp className="relative h-4 w-4" />
-          </button>
-          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-900 shadow-md opacity-0 transition-opacity peer-hover:opacity-100">
-            {sharing ? 'Stop sharing' : 'Share your screen'}
-          </span>
+          <Tooltip open={expanded ? undefined : false}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={toggleShare}
+                aria-label={sharing ? 'Stop sharing your screen' : 'Share your screen'}
+                className={`peer relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset transition-all ${
+                  sharing
+                    ? 'bg-gradient-to-b from-emerald-400/30 to-emerald-600/10 text-emerald-100 ring-emerald-300/30'
+                    : 'bg-gradient-to-b from-white/10 to-white/[0.03] text-neutral-400 ring-white/15 hover:text-neutral-100'
+                }`}
+              >
+                <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.1),transparent_55%)]" />
+                <MonitorUp className="relative h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {sharing ? 'Sharing your screen with this chat — click to stop' : 'Share your screen with this chat'}
+            </TooltipContent>
+          </Tooltip>
+          {!expanded && (
+            <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-0.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-900 shadow-md opacity-0 transition-opacity peer-hover:opacity-100">
+              {sharing ? 'Stop sharing' : 'Share your screen'}
+            </span>
+          )}
         </span>
         <button
           type="submit"

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -333,12 +333,12 @@ export function QuickAskBar() {
           <span className="flex shrink-0 items-center gap-3">
             {/* Same layered construction as the mic orb: gradient base,
                 inset hairline, radial top sheen. */}
-            <span className="relative flex items-center gap-2 overflow-hidden rounded-full bg-gradient-to-b from-white/10 to-white/[0.03] px-3.5 py-2 text-sm text-neutral-200 ring-1 ring-inset ring-white/15">
+            <span className="relative flex items-center gap-1.5 overflow-hidden rounded-full bg-gradient-to-b from-white/10 to-white/[0.03] px-3 py-1.5 text-[13px] text-neutral-200 ring-1 ring-inset ring-white/15">
               <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.12),transparent_55%)]" />
               <span className="relative">Hold right</span>
-              <Command className="relative h-4 w-4 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
+              <Command className="relative h-3.5 w-3.5 text-sky-200 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]" />
             </span>
-            <span className="text-sm text-neutral-400">to speak</span>
+            <span className="text-[13px] text-neutral-400">to speak</span>
           </span>
         )}
         {/* Optional toggles: speak answers aloud, share the screen. Same

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -359,7 +359,12 @@ export function QuickAskBar() {
               <Volume2 className="relative h-4 w-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">{voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}</TooltipContent>
+          {/* Forced bottom + compact: the window edge is ~24px below the
+              button, so Radix's collision logic would flip a normal-size
+              tooltip back to the top. */}
+          <TooltipContent side="bottom" sideOffset={2} avoidCollisions={false} className="px-2 py-0.5 text-[11px]">
+            {voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}
+          </TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -380,7 +385,7 @@ export function QuickAskBar() {
               )}
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
+          <TooltipContent side="bottom" sideOffset={2} avoidCollisions={false} className="px-2 py-0.5 text-[11px]">
             {sharing ? 'Sharing your screen with this chat — click to stop' : 'Share your screen with this chat'}
           </TooltipContent>
         </Tooltip>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -319,7 +319,7 @@ export function QuickAskBar() {
           value={inputValue}
           onChange={(e) => setDraft(e.target.value)}
           placeholder={recording ? 'Listening…' : 'Ask Rowboat anything…'}
-          className="h-full min-w-0 flex-1 bg-transparent text-xl font-light outline-none placeholder:text-neutral-500"
+          className="h-full min-w-0 flex-1 bg-transparent text-lg font-light outline-none placeholder:text-neutral-500"
         />
         {micDenied ? (
           <button
@@ -359,7 +359,7 @@ export function QuickAskBar() {
               <Volume2 className="relative h-4 w-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="top">{voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}</TooltipContent>
+          <TooltipContent side="bottom">{voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -380,7 +380,7 @@ export function QuickAskBar() {
               )}
             </button>
           </TooltipTrigger>
-          <TooltipContent side="top">
+          <TooltipContent side="bottom">
             {sharing ? 'Sharing your screen with this chat — click to stop' : 'Share your screen with this chat'}
           </TooltipContent>
         </Tooltip>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -308,7 +308,7 @@ export function QuickAskBar() {
               shape edge to see (the previous half-ellipse showed its rim) */}
           <span className="pointer-events-none absolute inset-0 rounded-full bg-[radial-gradient(120%_80%_at_50%_0%,rgba(255,255,255,0.2),transparent_55%)]" />
           <Mic
-            className={`relative h-5 w-5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)] ${
+            className={`relative h-[18px] w-[18px] drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)] ${
               recording ? 'text-emerald-100' : 'text-sky-100'
             }`}
           />

--- a/apps/x/apps/renderer/src/lib/call-sounds.ts
+++ b/apps/x/apps/renderer/src/lib/call-sounds.ts
@@ -8,6 +8,32 @@ let ctx: AudioContext | null = null
  * instead of dead air.
  */
 /**
+ * Soft single-swell pop for a passive notification appearing (e.g. the
+ * quick-ask discoverability toast) — quieter and rounder than the ack blip.
+ */
+export function playPopCue() {
+  try {
+    if (!ctx) ctx = new AudioContext()
+    if (ctx.state === 'suspended') void ctx.resume()
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(523, t)
+    osc.frequency.exponentialRampToValueAtTime(659, t + 0.12)
+    gain.gain.setValueAtTime(0.0001, t)
+    gain.gain.exponentialRampToValueAtTime(0.05, t + 0.02)
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.35)
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.start(t)
+    osc.stop(t + 0.36)
+  } catch {
+    // cosmetic — never let a sound failure affect the flow
+  }
+}
+
+/**
  * Two-tone attention chime for permission problems — something needs the
  * user's action and would otherwise fail silently (they may be looking at
  * another app entirely when it fires).

--- a/apps/x/packages/core/src/runtime/assembly/message-encoding.ts
+++ b/apps/x/packages/core/src/runtime/assembly/message-encoding.ts
@@ -15,6 +15,12 @@ function formatUserMessageContextForLlm(userMessageContext: z.infer<typeof UserM
         sections.push(`Current date and time: ${userMessageContext.currentDateTime}`);
     }
 
+    if (userMessageContext.screenShareEnded) {
+        sections.push(
+            'Screen sharing has ENDED. Any screen-share frames earlier in this conversation are from the past — they do NOT show the current screen. Never answer questions about the current screen from them; if asked, say screen sharing is off.',
+        );
+    }
+
     if (userMessageContext.middlePane) {
         if (userMessageContext.middlePane.kind === 'empty') {
             sections.push(`Middle pane:\nState: empty`);

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1111,6 +1111,42 @@ const ipcSchemas = {
     req: z.null(),
     res: z.null(),
   },
+  // Bar → main → app window: the bar's optional toggles. voiceOutput speaks
+  // the answers aloud; screenShare turns on the existing screen capture so
+  // frames ride along with bar submits (the bar owns the share indicator —
+  // no floating pill outside calls).
+  'quickAsk:setOptions': {
+    req: z.object({
+      voiceOutput: z.boolean(),
+      screenShare: z.boolean(),
+    }),
+    res: z.object({}),
+  },
+  // Push channel: main → app window with the toggles above.
+  'quick-ask:set-options': {
+    req: z.object({
+      voiceOutput: z.boolean(),
+      screenShare: z.boolean(),
+    }),
+    res: z.null(),
+  },
+  // App window → main → bar: the ACTUAL state (share can fail on the macOS
+  // permission; the bar must never show a "sharing" badge that lies).
+  'quickAsk:optionsState': {
+    req: z.object({
+      voiceOutput: z.boolean(),
+      screenSharing: z.boolean(),
+    }),
+    res: z.object({}),
+  },
+  // Push channel: main → bar for the state above.
+  'quick-ask:options-state': {
+    req: z.object({
+      voiceOutput: z.boolean(),
+      screenSharing: z.boolean(),
+    }),
+    res: z.null(),
+  },
   // Bar → main: start a fresh chat for the next question (the app stays in
   // the background; only the conversation resets).
   'quickAsk:newChat': {

--- a/apps/x/packages/shared/src/message.ts
+++ b/apps/x/packages/shared/src/message.ts
@@ -64,6 +64,10 @@ export const UserMessageContent = z.union([z.string(), z.array(UserContentPart)]
 
 export const UserMessageContext = z.object({
     currentDateTime: z.string().optional(),
+    // Set on the first message after a screen share stops: history keeps the
+    // captured frames inline forever (pruning would bust prefix caching), so
+    // the model must be told they show the past, not the current screen.
+    screenShareEnded: z.boolean().optional(),
     middlePane: z.discriminatedUnion("kind", [
         z.object({
             kind: z.literal("empty"),


### PR DESCRIPTION
## What

Phase one of the standup decision to merge the overlay widget with the call experience: the bar stays **text-only by default**, with two opt-in toggles next to the send button.

### Voice response (🔊)
- Bar answers are spoken aloud through the existing TTS pipeline.
- **Per-turn**, not a sticky flag: `speakTurnRef` is set at submit for quick-ask turns only, so composer messages typed outside the bar never start talking. The segment player and the fallback-speech net both honor it; `voiceOutput: 'full'` rides on the send config.

### Screen share (🖥)
- Reuses the call engine's capture **wholesale** — `video.start({camera: false})` + `startScreenShare()`, including the black-frame permission check and the permission dialog. No new capture code.
- Frames ride along with bar submits exactly like call messages; `composition.videoMode` is set.
- **The bar absorbs the pill's job** (option 1 from the discussion): outside calls no pill appears — the lit toggle with a pulsing dot is the consent badge, and the share **stops whenever the bar goes away** (blur, Esc, the Open-in-Rowboat jump). Nothing can keep capturing with no indicator on screen.
- The app echoes the **actual** state back to the bar (`quick-ask:options-state`), so a denied Screen Recording permission never leaves a lying badge.

### Guardrails
- Bar toggles never touch devices while a call is live — calls own the devices.
- New IPC: `quickAsk:setOptions` / `quick-ask:set-options` (bar → app) and `quickAsk:optionsState` / `quick-ask:options-state` (app → bar).

## Docs
VIDEO_MODE.md quick-ask section updated.

## Testing
Typechecked (shared/core/renderer/main). Hands-on pass needed: toggle voice → answer speaks; toggle share → grant flow → ask "what's on my screen"; blur the bar mid-share → capture stops (purple indicator gone); toggles no-op during a live call.