### PR TITLE
fix(x): meeting popup Dock-icon loss + restore macOS signing

### DIFF
--- a/apps/x/apps/main/forge.config.cjs
+++ b/apps/x/apps/main/forge.config.cjs
@@ -236,18 +236,18 @@ module.exports = {
         // maker below separately signs the installer it produces.
         ...(WINDOWS_SIGN ? { windowsSign: WINDOWS_SIGN } : {}),
         ...(SKIP_CODE_SIGNING ? {} : {
-            // osxSign: {
-            //     batchCodesignCalls: true,
-            //     optionsForFile: () => ({
-            //         entitlements: path.join(__dirname, 'entitlements.plist'),
-            //         'entitlements-inherit': path.join(__dirname, 'entitlements.plist'),
-            //     }),
-            // },
-            // osxNotarize: {
-            //     appleId: process.env.APPLE_ID,
-            //     appleIdPassword: process.env.APPLE_PASSWORD,
-            //     teamId: process.env.APPLE_TEAM_ID
-            // },
+            osxSign: {
+                batchCodesignCalls: true,
+                optionsForFile: () => ({
+                    entitlements: path.join(__dirname, 'entitlements.plist'),
+                    'entitlements-inherit': path.join(__dirname, 'entitlements.plist'),
+                }),
+            },
+            osxNotarize: {
+                appleId: process.env.APPLE_ID,
+                appleIdPassword: process.env.APPLE_PASSWORD,
+                teamId: process.env.APPLE_TEAM_ID
+            },
         }),
         // Since we bundle the main process with esbuild, we don't need the workspace
         // node_modules. These settings prevent Forge's dependency walker (flora-colossus)

--- a/apps/x/apps/main/src/meeting-popup.ts
+++ b/apps/x/apps/main/src/meeting-popup.ts
@@ -127,17 +127,14 @@ export function showMeetingPopup(meeting: DetectedMeeting): void {
     // meeting apps on every workspace — the whole point of the popup is to be
     // seen while the user is IN the meeting, wherever that is.
     win.setAlwaysOnTop(true, "screen-saver");
-    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-    // visibleOnFullScreen flips the app's activation policy to "accessory":
-    // the Dock icon disappears and the app can no longer take foreground
-    // focus — clicking "Take Notes" then hands focus to whatever is next in
-    // the window stack instead of Rowboat. Restore the policy immediately:
-    // the popup keeps its fullscreen-auxiliary collection behavior (it's a
-    // non-activating panel, same trick as Zoom's floating controls), while
-    // Rowboat stays a regular app.
-    if (process.platform === "darwin") {
-        void app.dock?.show();
-    }
+    // `skipTransformProcessType` keeps the Dock icon (same as the video
+    // popout and quick-ask bar): without it, visibleOnFullScreen flips the
+    // app's activation policy to "accessory" — the Dock icon disappears and
+    // an app.dock.show() repair is unreliable (the policy comes back, so
+    // Cmd-Tab works, but the Dock tile often never re-registers until
+    // relaunch). The popup keeps its fullscreen-auxiliary behavior — it's a
+    // non-activating panel, same trick as Zoom's floating controls.
+    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
     win.webContents.once("did-finish-load", () => {
         if (win.isDestroyed()) return;
         win.webContents.send("meetingDetect:payload", payload);


### PR DESCRIPTION
## Summary

Two fixes from investigating "Rowboat vanished from the Dock (Cmd-Tab still works)":

- **Meeting popup no longer drops the Dock icon.** `showMeetingPopup` called `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })` without `skipTransformProcessType`, which flips the app's activation policy to "accessory". The immediate `app.dock.show()` repair is unreliable — the policy comes back (Cmd-Tab works) but the Dock tile often never re-registers until relaunch. Now passes `skipTransformProcessType: true`, matching the video popout (`ipc.ts`) and quick-ask bar, and drops the `dock.show()` band-aid.
- **Restore `osxSign`/`osxNotarize` in `forge.config.cjs`.** The block was accidentally commented out in db299f35 (an unrelated screen-share/PTT fix), so every packaged macOS build was unsigned and un-notarized regardless of `ROWBOAT_SKIP_CODE_SIGNING`. Unsigned builds get blocked by Gatekeeper, can't post notifications, and lose TCC permissions across builds. Local unsigned packaging remains available via `ROWBOAT_SKIP_CODE_SIGNING=1`.

## Test plan

- `npm run deps` + `tsc --noEmit` in `apps/main` passes; lint errors are pre-existing in untouched files
- Manual: trigger the meeting-detected popup (join a Zoom/Meet call) and confirm the Dock icon stays put while the popup floats over fullscreen Spaces
- Packaging: `npm run package` with Apple creds set signs + notarizes; with `ROWBOAT_SKIP_CODE_SIGNING=1` still skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)