### PR TITLE
fix(x): render update-card release notes unabridged

### DIFF
--- a/apps/x/apps/renderer/src/components/update-card.tsx
+++ b/apps/x/apps/renderer/src/components/update-card.tsx
@@ -55,11 +55,7 @@ export function UpdateCard() {
   if (!visible || status?.state !== "ready") return null
 
   const releaseUrl = version ? `${RELEASES_URL}/tag/v${version}` : `${RELEASES_URL}/latest`
-  // Release bodies usually open with their own "What's new" heading, which
-  // would duplicate the card's label above the box — drop it.
-  const releaseNotes = status.releaseNotes
-    ?.replace(/^\s*#{1,6}[ \t]*what[’']?s new[ \t]*\r?\n+/i, "")
-    .trim()
+  const releaseNotes = status.releaseNotes?.trim()
 
   return (
     <div
@@ -84,23 +80,21 @@ export function UpdateCard() {
       <p className="mt-1 text-xs text-muted-foreground">
         A new version is ready to install. Restart to start using it.
       </p>
-      <div className="mt-3">
-        <h5 className="text-xs font-semibold">What&apos;s new</h5>
-        {releaseNotes ? (
-          // A bordered, fixed-height scroll box (not a bare max-h clip): the
-          // frame and inset scrollbar signal there is more content below the
-          // fold on every platform.
-          <div className="mt-1.5 max-h-56 overflow-y-auto overscroll-contain rounded-md border border-border/60 bg-muted/30 p-2.5">
-            <Streamdown className="prose prose-sm dark:prose-invert max-w-none text-xs [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-              {releaseNotes}
-            </Streamdown>
-          </div>
-        ) : (
-          // Releases are expected to carry notes; if this one doesn't, show
-          // a static line instead of an empty pane.
-          <p className="mt-1.5 text-xs text-muted-foreground">Bug fixes and improvements.</p>
-        )}
-      </div>
+      {releaseNotes ? (
+        // Rendered unabridged — any "What's new" heading in the release body
+        // scrolls with the rest of the notes. A bordered, fixed-height scroll
+        // box (not a bare max-h clip): the frame and inset scrollbar signal
+        // there is more content below the fold on every platform.
+        <div className="mt-3 max-h-56 overflow-y-auto overscroll-contain rounded-md border border-border/60 bg-muted/30 p-2.5">
+          <Streamdown className="prose prose-sm dark:prose-invert max-w-none text-xs [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+            {releaseNotes}
+          </Streamdown>
+        </div>
+      ) : (
+        // Releases are expected to carry notes; if this one doesn't, show
+        // a static line instead of an empty pane.
+        <p className="mt-3 text-xs text-muted-foreground">Bug fixes and improvements.</p>
+      )}
       <div className="mt-3 flex items-center gap-2">
         <Button size="sm" variant="ghost" onClick={() => setDismissedFor(versionKey)}>
           Later

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -70,7 +70,7 @@ const UpdaterStatusSchema = z.object({
   reason: z.enum(['dev', 'platform', 'not-in-applications']).optional(),
   newVersion: z.string().optional(),
   // Markdown body of the staged update's GitHub release, when known — the
-  // restart card renders it as "What's new".
+  // restart card renders it verbatim.
   releaseNotes: z.string().optional(),
   error: z.string().optional(),
   lastCheckedAt: z.number().optional(),


### PR DESCRIPTION
## Summary

The update card stripped a leading "What's new" heading out of the GitHub release body via regex and pinned its own static "What's new" label above the scroll box — so the heading sat outside the scrollable area. Per the Slack discussion, this removes the string match entirely:

- Release notes render verbatim (only trimmed) — no matching/extraction logic.
- The pinned label is gone; the release body's own heading now scrolls inside the notes box with the rest of the content.
- The no-notes fallback ("Bug fixes and improvements.") is unchanged, and a stale comment in `shared/src/ipc.ts` describing the old labeling was updated.

## Verification

Ran the app with a fake staged updater status (`state: "ready"`) and drove the card:

- With multi-section markdown notes: no pinned label, heading renders inside the scroll box and scrolls out of view with its content.
- Dismiss (×) and the no-notes fallback both behave as before.