### PR TITLE
Chat sessions become self-contained instances; tabs become containers

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -12,8 +12,8 @@ import { ChatSidebar } from './components/chat-sidebar';
 import { useSessionChat } from '@/hooks/useSessionChat';
 import { subscribeSessionFeed } from '@/lib/session-chat/feed';
 import { ChatHeader } from './components/chat-header';
-import { ChatEmptyState } from './components/chat-empty-state';
-import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment } from './components/chat-input-with-mentions';
+import { ChatSessionPane, ChatSessionComposer } from './components/chat-session';
+import { type CallPreset, type PermissionMode, type StagedAttachment } from './components/chat-input-with-mentions';
 import { ChatMessageAttachments } from '@/components/chat-message-attachments'
 import { GraphView, type GraphEdge, type GraphNode } from '@/components/graph-view';
 import { BasesView, type BaseConfig, DEFAULT_BASE_CONFIG } from '@/components/bases-view';
@@ -45,11 +45,6 @@ import { CodeChat } from '@/components/code/code-chat';
 import { ResizableRightPane } from '@/components/code/resizable-right-pane';
 import { SidebarSectionProvider } from '@/contexts/sidebar-context';
 import {
-  Conversation,
-  ConversationContent,
-  ConversationScrollButton,
-} from '@/components/ai-elements/conversation';
-import {
   Message,
   MessageContent,
   MessageCopyButton,
@@ -60,16 +55,11 @@ import {
   type FileMention,
 } from '@/components/ai-elements/prompt-input';
 
-import { TurnActivityIndicator } from '@/components/turn-activity-indicator';
-import { useSmoothedText } from './hooks/useSmoothedText';
-import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool';
+import { Tool, ToolContent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool';
 import { WebSearchResult } from '@/components/ai-elements/web-search-result';
 import { AppActionCard } from '@/components/ai-elements/app-action-card';
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card';
-import { PermissionRequest } from '@/components/ai-elements/permission-request';
-import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision';
 import { TerminalOutput } from '@/components/terminal-output';
-import { AskHumanRequest } from '@/components/ai-elements/ask-human-request';
 import { ToolPermissionAutoDecisionEvent, ToolPermissionRequestEvent, AskHumanRequestEvent } from '@x/shared/src/runs.js';
 import {
   SidebarInset,
@@ -113,12 +103,10 @@ import {
   getAppActionCardData,
   getComposioConnectCardData,
   getToolDisplayName,
-  groupConversationItems,
   inferRunTitleFromMessage,
   isChatMessage,
   isErrorMessage,
   isToolCall,
-  isToolGroup,
   isTurnUsageMessage,
   normalizeToolInput,
   normalizeToolOutput,
@@ -158,11 +146,6 @@ const streamdownComponents = { pre: MarkdownPreOverride }
 // round-trip from the input textarea. `remarkBreaks` turns single newlines
 // into <br> so typed line breaks are preserved without requiring blank lines.
 const userMessageRemarkPlugins = [...Object.values(defaultRemarkPlugins), remarkBreaks]
-
-function SmoothStreamingMessage({ text, components }: { text: string; components: typeof streamdownComponents }) {
-  const smoothText = useSmoothedText(text)
-  return <MessageResponse components={components}>{smoothText}</MessageResponse>
-}
 
 function AutoScrollPre({ className, children }: { className?: string; children: React.ReactNode }) {
   const ref = useRef<HTMLPreElement>(null)
@@ -7673,127 +7656,26 @@ function App() {
                 <div className="relative min-h-0 flex-1">
                   {chatTabs.map((tab) => {
                     const isActive = tab.id === activeChatTabId
-                    const tabState = getChatTabStateForRender(tab.id)
-                    const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
-                    const tabConversationContentClassName = tabHasConversation
-                      ? "mx-auto w-full max-w-4xl pb-28"
-                      : "mx-auto w-full max-w-4xl min-h-full items-center justify-center pb-0"
                     return (
-                      <div
+                      <ChatSessionPane
                         // Keyed by CHAT identity: rebinding this tab to a
                         // different session remounts the panel (fresh
                         // scroll/DOM state); first-send runId binding does not.
                         key={tab.chatId}
-                        className={cn(
-                          'min-h-0 h-full flex-col',
-                          isActive
-                            ? 'flex'
-                            : 'pointer-events-none invisible absolute inset-0 flex'
-                        )}
-                        data-chat-tab-panel={tab.id}
-                        aria-hidden={!isActive}
-                      >
-                        <Conversation
-                          anchorMessageId={chatViewportAnchorByTab[tab.id]?.messageId}
-                          anchorRequestKey={chatViewportAnchorByTab[tab.id]?.requestKey}
-                          className="relative flex-1"
-                        >
-                          <ConversationContent className={tabConversationContentClassName}>
-                            {!tabHasConversation ? (
-                              <ChatEmptyState
-                                wide
-                                onPickPrompt={setPresetMessage}
-                              />
-                            ) : (
-                              <>
-                                {groupConversationItems(
-                                  tabState.conversation,
-                                  (id) => !!tabState.allPermissionRequests.get(id) || !!tabState.autoPermissionDecisions.get(id)
-                                ).map(item => {
-                                  if (isToolGroup(item)) {
-                                    return (
-                                      <ToolGroupComponent
-                                        key={item.groupId}
-                                        group={item}
-                                        isToolOpen={(toolId) => isToolOpenForTab(tab.id, toolId)}
-                                        onToolOpenChange={(toolId, open) => setToolOpenForTab(tab.id, toolId, open)}
-                                      />
-                                    )
-                                  }
-                                  const autoDecision = isToolCall(item)
-                                    ? tabState.autoPermissionDecisions.get(item.id)
-                                    : undefined
-                                  const rendered = renderConversationItem(
-                                    item,
-                                    tab.id,
-                                    autoDecision?.decision === 'allow'
-                                      ? { autoPermissionDetail: { decision: 'allow', reason: autoDecision.reason } }
-                                      : undefined,
-                                  )
-                                  if (isToolCall(item)) {
-                                    const deniedAutoDecision = autoDecision?.decision === 'deny' ? autoDecision : null
-                                    const permRequest = tabState.allPermissionRequests.get(item.id)
-                                    if (deniedAutoDecision || permRequest) {
-                                      const response = tabState.permissionResponses.get(item.id) || null
-                                      return (
-                                        <React.Fragment key={item.id}>
-                                          {deniedAutoDecision && (
-                                            <AutoPermissionDecision
-                                              toolCall={deniedAutoDecision.toolCall}
-                                              permission={deniedAutoDecision.permission}
-                                              decision={deniedAutoDecision.decision}
-                                              reason={deniedAutoDecision.reason}
-                                            />
-                                          )}
-                                          {permRequest && (
-                                            <PermissionRequest
-                                              toolCall={permRequest.toolCall}
-                                              permission={permRequest.permission}
-                                              onApprove={() => handlePermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve')}
-                                              onDeny={() => handlePermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'deny')}
-                                              isProcessing={isActive && activeIsWorking}
-                                              response={response}
-                                            />
-                                          )}
-                                          {rendered}
-                                        </React.Fragment>
-                                      )
-                                    }
-                                  }
-                                  return rendered
-                                })}
-
-                                {Array.from(tabState.pendingAskHumanRequests.values()).map((request) => (
-                                  <AskHumanRequest
-                                    key={request.toolCallId}
-                                    query={request.query}
-                                    options={request.options}
-                                    onResponse={(response) => handleAskHumanResponse(request.toolCallId, request.subflow, response)}
-                                    isProcessing={isActive && activeIsWorking}
-                                  />
-                                ))}
-
-                                {tabState.currentAssistantMessage && (
-                                  <Message from="assistant">
-                                    <MessageContent>
-                                      <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />
-                                    </MessageContent>
-                                  </Message>
-                                )}
-
-                                {isActive && activeIsProcessing && (
-                                  <Message from="assistant">
-                                    <MessageContent>
-                                      <TurnActivityIndicator isReasoning={activeIsReasoning} />
-                                    </MessageContent>
-                                  </Message>
-                                )}
-                              </>
-                            )}
-                          </ConversationContent>
-                          <ConversationScrollButton />
-                        </Conversation>
-                      </div>
+                        tab={tab}
+                        isActive={isActive}
+                        tabState={getChatTabStateForRender(tab.id)}
+                        viewportAnchor={chatViewportAnchorByTab[tab.id]}
+                        onPickPrompt={setPresetMessage}
+                        isToolOpenForTab={isToolOpenForTab}
+                        setToolOpenForTab={setToolOpenForTab}
+                        renderItem={renderConversationItem}
+                        onPermissionResponse={handlePermissionResponse}
+                        onAskHumanResponse={handleAskHumanResponse}
+                        activeIsWorking={activeIsWorking}
+                        activeIsProcessing={activeIsProcessing}
+                        activeIsReasoning={activeIsReasoning}
+                      />
                     )
                   })}
                 </div>
@@ -7803,63 +7685,44 @@ function App() {
                   <div className="mx-auto w-full max-w-4xl px-4">
                     {chatTabs.map((tab) => {
                       const isActive = tab.id === activeChatTabId
-                      const tabState = getChatTabStateForRender(tab.id)
                       return (
-                        <div
+                        <ChatSessionComposer
                           // Composer instance per CHAT (see chat panel key
                           // above): a rebound tab gets a fresh composer, so
                           // attachments/toggles/selection can't leak across
                           // sessions; first-send binding keeps the instance.
                           key={tab.chatId}
-                          className={isActive ? 'block' : 'hidden'}
-                          data-chat-input-panel={tab.id}
-                          aria-hidden={!isActive}
-                        >
-                          <ChatInputWithMentions
-                            knowledgeFiles={knowledgeFiles}
-                            recentFiles={recentWikiFiles}
-                            visibleFiles={visibleKnowledgeFiles}
-                            onSubmit={handlePromptSubmit}
-                            onStop={handleStop}
-                            isProcessing={isActive && activeIsProcessing}
-                            isStopping={isActive && isStopping}
-                            isActive={isActive}
-                            presetMessage={isActive ? presetMessage : undefined}
-                            onPresetMessageConsumed={isActive ? () => setPresetMessage(undefined) : undefined}
-                            runId={tabState.runId}
-                            codeSessionLock={tabState.runId ? codeSessionLocks[tabState.runId] ?? null : null}
-                            initialDraft={chatDraftsRef.current.get(tab.chatId)}
-                            onDraftChange={(text) => setChatDraftForTab(tab.id, text)}
-                            onSelectedModelChange={(m) => {
-                              if (m) {
-                                selectedModelByTabRef.current.set(tab.chatId, m)
-                              } else {
-                                selectedModelByTabRef.current.delete(tab.chatId)
-                              }
-                            }}
-                            onReasoningEffortChange={(effort) => {
-                              if (effort) {
-                                reasoningEffortByTabRef.current.set(tab.chatId, effort)
-                              } else {
-                                reasoningEffortByTabRef.current.delete(tab.chatId)
-                              }
-                            }}
-                            workDir={workDirByTab[tab.id] ?? null}
-                            onWorkDirChange={(v) => setTabWorkDir(tab.id, v)}
-                            isRecording={isRecording && voiceOwner === tab.chatId}
-                            recordingText={voiceOwner === tab.chatId ? voice.interimText : undefined}
-                            recordingState={voiceOwner === tab.chatId ? (voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening') : undefined}
-                            audioLevelsRef={voice.audioLevelsRef}
-                            onStartRecording={isActive ? () => handleStartRecording(tab.chatId) : undefined}
-                            onSubmitRecording={isActive ? handleSubmitRecording : undefined}
-                            onCancelRecording={isActive ? handleCancelRecording : undefined}
-                            voiceAvailable={isActive && voiceAvailable}
-                            inCall={inCall}
-                            onStartCall={isActive ? startCall : undefined}
-                            onEndCall={isActive ? endCall : undefined}
-                            callAvailable={voiceAvailable && ttsAvailable}
-                          />
-                        </div>
+                          tab={tab}
+                          isActive={isActive}
+                          tabState={getChatTabStateForRender(tab.id)}
+                          knowledgeFiles={knowledgeFiles}
+                          recentFiles={recentWikiFiles}
+                          visibleFiles={visibleKnowledgeFiles}
+                          onSubmit={handlePromptSubmit}
+                          onStop={handleStop}
+                          activeIsProcessing={activeIsProcessing}
+                          isStopping={isStopping}
+                          presetMessage={presetMessage}
+                          onPresetMessageConsumed={() => setPresetMessage(undefined)}
+                          codeSessionLocks={codeSessionLocks}
+                          initialDraft={chatDraftsRef.current.get(tab.chatId)}
+                          onDraftChange={setChatDraftForTab}
+                          selectedModelByTabRef={selectedModelByTabRef}
+                          reasoningEffortByTabRef={reasoningEffortByTabRef}
+                          workDirByTab={workDirByTab}
+                          onWorkDirChange={setTabWorkDir}
+                          isRecording={isRecording}
+                          voiceOwner={voiceOwner}
+                          voice={voice}
+                          onStartRecording={handleStartRecording}
+                          onSubmitRecording={handleSubmitRecording}
+                          onCancelRecording={handleCancelRecording}
+                          voiceAvailable={voiceAvailable}
+                          inCall={inCall}
+                          onStartCall={startCall}
+                          onEndCall={endCall}
+                          ttsAvailable={ttsAvailable}
+                        />
                       )
                     })}
                   </div>

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -14,7 +14,6 @@ import { subscribeSessionFeed } from '@/lib/session-chat/feed';
 import { ChatHeader } from './components/chat-header';
 import { ChatSessionPane, ChatSessionComposer } from './components/chat-session';
 import { type CallPreset, type PermissionMode, type StagedAttachment } from './components/chat-input-with-mentions';
-import { ChatMessageAttachments } from '@/components/chat-message-attachments'
 import { GraphView, type GraphEdge, type GraphNode } from '@/components/graph-view';
 import { BasesView, type BaseConfig, DEFAULT_BASE_CONFIG } from '@/components/bases-view';
 import { ImageFileViewer } from '@/components/image-file-viewer';
@@ -32,8 +31,6 @@ import { BgTasksView } from '@/components/bg-tasks-view';
 import { AppsView } from '@/components/apps/apps-view';
 import { EmailView } from '@/components/email-view';
 import { WorkspaceView } from '@/components/workspace-view';
-import { CodingRunBlock } from '@/components/coding-run';
-import { SubAgentBlock } from '@/components/sub-agent-block';
 import { KnowledgeView, type KnowledgeViewMode } from '@/components/knowledge-view';
 import { GoogleDocPickerDialog } from '@/components/google-doc-picker-dialog';
 import { ChatHistoryView } from '@/components/chat-history-view';
@@ -45,21 +42,10 @@ import { CodeChat } from '@/components/code/code-chat';
 import { ResizableRightPane } from '@/components/code/resizable-right-pane';
 import { SidebarSectionProvider } from '@/contexts/sidebar-context';
 import {
-  Message,
-  MessageContent,
-  MessageCopyButton,
-  MessageResponse,
-} from '@/components/ai-elements/message';
-import {
   type PromptInputMessage,
   type FileMention,
 } from '@/components/ai-elements/prompt-input';
 
-import { Tool, ToolContent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool';
-import { WebSearchResult } from '@/components/ai-elements/web-search-result';
-import { AppActionCard } from '@/components/ai-elements/app-action-card';
-import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card';
-import { TerminalOutput } from '@/components/terminal-output';
 import { ToolPermissionAutoDecisionEvent, ToolPermissionRequestEvent, AskHumanRequestEvent } from '@x/shared/src/runs.js';
 import {
   SidebarInset,
@@ -72,7 +58,6 @@ import { Button } from "@/components/ui/button"
 import { Toaster } from "@/components/ui/sonner"
 import { UpdateCard } from "@/components/update-card"
 import { BillingErrorDialog } from "@/components/billing-error-dialog"
-import { BillingErrorNotice } from "@/components/billing-error-notice"
 import { CreditCelebration } from "@/components/credit-celebration"
 import { matchBillingError, type BillingErrorMatch } from "@/lib/billing-error"
 import { dispatchCreditExhausted, dispatchCreditReplenished } from "@/lib/credit-status"
@@ -87,9 +72,6 @@ import { BackgroundTaskDetail } from '@/components/background-task-detail'
 import { BrowserPane } from '@/components/browser-pane/BrowserPane'
 import { VersionHistoryPanel } from '@/components/version-history-panel'
 import { FileCardProvider } from '@/contexts/file-card-context'
-import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-override'
-import { defaultRemarkPlugins } from 'streamdown'
-import remarkBreaks from 'remark-breaks'
 import { TabBar, type ChatTab, type FileTab } from '@/components/tab-bar'
 import { CaffeinateIndicator } from '@/components/caffeinate-indicator'
 import {
@@ -99,20 +81,12 @@ import {
   type ConversationItem,
   type ToolCall,
   createEmptyChatTabViewState,
-  getWebSearchCardData,
-  getAppActionCardData,
-  getComposioConnectCardData,
   getToolDisplayName,
   inferRunTitleFromMessage,
   isChatMessage,
   isErrorMessage,
   isToolCall,
-  isTurnUsageMessage,
   normalizeToolInput,
-  normalizeToolOutput,
-  parseAttachedFiles,
-  REASONING_EFFORT_LABELS,
-  toToolState,
 } from '@/lib/chat-conversation'
 import { COMPOSIO_DISPLAY_NAMES as composioDisplayNames } from '@x/shared/src/composio.js'
 import { AgentScheduleConfig } from '@x/shared/dist/agent-schedule.js'
@@ -130,7 +104,6 @@ import { useAnalyticsIdentity } from '@/hooks/useAnalyticsIdentity'
 import * as analytics from '@/lib/analytics'
 import { playAckCue, playAlertCue, playPopCue } from '@/lib/call-sounds'
 import { useTheme } from '@/contexts/theme-context'
-import { TokenUsageMenu } from '@/components/token-usage-menu'
 
 type DirEntry = z.infer<typeof workspace.DirEntry>
 type RunEventType = z.infer<typeof RunEvent>
@@ -138,38 +111,6 @@ type RunEventType = z.infer<typeof RunEvent>
 interface TreeNode extends DirEntry {
   children?: TreeNode[]
   loaded?: boolean
-}
-
-const streamdownComponents = { pre: MarkdownPreOverride }
-
-// Render user messages with markdown so bullets, bold, links, etc. survive the
-// round-trip from the input textarea. `remarkBreaks` turns single newlines
-// into <br> so typed line breaks are preserved without requiring blank lines.
-const userMessageRemarkPlugins = [...Object.values(defaultRemarkPlugins), remarkBreaks]
-
-function AutoScrollPre({ className, children }: { className?: string; children: React.ReactNode }) {
-  const ref = useRef<HTMLPreElement>(null)
-  const stickToBottom = useRef(true)
-
-  useLayoutEffect(() => {
-    const el = ref.current
-    if (el && stickToBottom.current) {
-      el.scrollTop = el.scrollHeight
-    }
-  }, [children])
-
-  const handleScroll = useCallback(() => {
-    const el = ref.current
-    if (!el) return
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
-    stickToBottom.current = atBottom
-  }, [])
-
-  return (
-    <pre ref={ref} onScroll={handleScroll} className={className}>
-      {children}
-    </pre>
-  )
 }
 
 const DEFAULT_SIDEBAR_WIDTH = 256
@@ -6709,194 +6650,6 @@ function App() {
     }
   }, [isGraphOpen, isBrainGraphOpen, knowledgeFilePaths])
 
-  const renderConversationItem = (
-    item: ConversationItem,
-    tabId: string,
-    options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },
-  ) => {
-    if (isChatMessage(item)) {
-      if (item.role === 'user') {
-        if (item.attachments && item.attachments.length > 0) {
-          return (
-            <Message key={item.id} from={item.role} data-message-id={item.id}>
-              <MessageContent className="group-[.is-user]:bg-transparent group-[.is-user]:px-0 group-[.is-user]:py-0 group-[.is-user]:rounded-none">
-                <ChatMessageAttachments attachments={item.attachments} />
-              </MessageContent>
-              {item.content && (
-                <div className="flex flex-col items-end">
-                  <MessageContent>
-                    <MessageResponse
-                      components={streamdownComponents}
-                      remarkPlugins={userMessageRemarkPlugins}
-                    >
-                      {item.content}
-                    </MessageResponse>
-                  </MessageContent>
-                  <MessageCopyButton text={item.content} className="mt-0.5" />
-                </div>
-              )}
-            </Message>
-          )
-        }
-        const { message, files } = parseAttachedFiles(item.content)
-        return (
-          <Message key={item.id} from={item.role} data-message-id={item.id}>
-            <div className="flex flex-col items-end">
-              <MessageContent>
-                {files.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mb-2">
-                    {files.map((filePath, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center gap-1 text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full"
-                      >
-                        @{wikiLabel(filePath)}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <MessageResponse
-                  components={streamdownComponents}
-                  remarkPlugins={userMessageRemarkPlugins}
-                >
-                  {message}
-                </MessageResponse>
-              </MessageContent>
-              <MessageCopyButton text={message} className="mt-0.5" />
-            </div>
-          </Message>
-        )
-      }
-      return (
-        <Message key={item.id} from={item.role} data-message-id={item.id}>
-          <MessageContent>
-            <MessageResponse components={streamdownComponents}>{item.content}</MessageResponse>
-          </MessageContent>
-        </Message>
-      )
-    }
-
-    if (isToolCall(item)) {
-      if (item.name === 'code_agent_run') {
-        return (
-          <CodingRunBlock
-            key={item.id}
-            item={item}
-            open={isToolOpenForTab(tabId, item.id)}
-            onOpenChange={(open) => setToolOpenForTab(tabId, item.id, open)}
-            onPermissionDecision={(decision) => {
-              if (item.pendingCodePermission) {
-                handleCodePermissionResponse(item.id, item.pendingCodePermission.requestId, decision)
-              }
-            }}
-          />
-        )
-      }
-      if (item.name === 'spawn-agent') {
-        return (
-          <SubAgentBlock
-            key={item.id}
-            item={item}
-            open={isToolOpenForTab(tabId, item.id)}
-            onOpenChange={(open) => setToolOpenForTab(tabId, item.id, open)}
-          />
-        )
-      }
-      const appActionData = getAppActionCardData(item)
-      if (appActionData) {
-        return <AppActionCard key={item.id} data={appActionData} status={item.status} />
-      }
-      const webSearchData = getWebSearchCardData(item)
-      if (webSearchData) {
-        return (
-          <WebSearchResult
-            key={item.id}
-            query={webSearchData.query}
-            results={webSearchData.results}
-            status={item.status}
-            title={webSearchData.title}
-          />
-        )
-      }
-      const composioConnectData = getComposioConnectCardData(item)
-      if (composioConnectData) {
-        // Skip rendering if this is a duplicate "already connected" card
-        if (composioConnectData.hidden) return null
-        return (
-          <ComposioConnectCard
-            key={item.id}
-            toolkitSlug={composioConnectData.toolkitSlug}
-            toolkitDisplayName={composioConnectData.toolkitDisplayName}
-            status={item.status}
-            alreadyConnected={composioConnectData.alreadyConnected}
-            onConnected={handleComposioConnected}
-          />
-        )
-      }
-      const toolTitle = getToolDisplayName(item)
-      const errorText = item.status === 'error' ? 'Tool error' : ''
-      const output = normalizeToolOutput(item.result, item.status)
-      const input = normalizeToolInput(item.input)
-      return (
-        <Tool
-          key={item.id}
-          open={isToolOpenForTab(tabId, item.id)}
-          onOpenChange={(open) => setToolOpenForTab(tabId, item.id, open)}
-          autoPermissionDetail={options?.autoPermissionDetail}
-        >
-          <ToolHeader
-            title={toolTitle}
-            type={`tool-${item.name}`}
-            state={toToolState(item.status)}
-          />
-          <ToolContent>
-            {item.streamingOutput ? (
-              <AutoScrollPre className="max-h-80 overflow-auto px-4 py-3 font-mono text-xs whitespace-pre-wrap text-foreground/90">
-                <TerminalOutput raw={item.streamingOutput} />
-              </AutoScrollPre>
-            ) : (
-              <ToolTabbedContent input={input} output={output} errorText={errorText} />
-            )}
-          </ToolContent>
-        </Tool>
-      )
-    }
-
-    if (isTurnUsageMessage(item)) {
-      return (
-        <div key={item.id} className="-mt-6 -ml-1 flex items-center justify-start gap-1" data-message-id={item.id}>
-          <TokenUsageMenu
-            usage={item.usage}
-            scope="turn"
-            modelCallCount={item.modelCallCount}
-            align="start"
-          />
-          {item.reasoningEffort && (
-            <span className="text-xs text-muted-foreground/70">
-              {REASONING_EFFORT_LABELS[item.reasoningEffort]}
-            </span>
-          )}
-        </div>
-      )
-    }
-
-    if (isErrorMessage(item)) {
-      const billingMatch = matchBillingError(item.message)
-      if (billingMatch) {
-        return <BillingErrorNotice key={item.id} id={item.id} match={billingMatch} />
-      }
-      return (
-        <Message key={item.id} from="assistant" data-message-id={item.id}>
-          <MessageContent className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive">
-            <pre className="whitespace-pre-wrap font-mono text-xs">{item.message}</pre>
-          </MessageContent>
-        </Message>
-      )
-    }
-
-    return null
-  }
-
   // The active chat's view state, backed by the sessions hook (legacy
   // standalone states remain only as the pre-load fallback until stage 7).
   const activeChatTabState = React.useMemo<ChatTabViewState>(() => (
@@ -7669,9 +7422,10 @@ function App() {
                         onPickPrompt={setPresetMessage}
                         isToolOpenForTab={isToolOpenForTab}
                         setToolOpenForTab={setToolOpenForTab}
-                        renderItem={renderConversationItem}
                         onPermissionResponse={handlePermissionResponse}
                         onAskHumanResponse={handleAskHumanResponse}
+                        onCodePermissionResponse={handleCodePermissionResponse}
+                        onComposioConnected={handleComposioConnected}
                         activeIsWorking={activeIsWorking}
                         activeIsProcessing={activeIsProcessing}
                         activeIsReasoning={activeIsReasoning}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -131,6 +131,7 @@ import { AgentScheduleConfig } from '@x/shared/dist/agent-schedule.js'
 import { AgentScheduleState } from '@x/shared/dist/agent-schedule-state.js'
 import { toast } from "sonner"
 import { useVoiceMode } from '@/hooks/useVoiceMode'
+import { CALL_VOICE_HOLDER, acquireVoice, releaseVoice, useVoiceOwner, voiceOwnerId } from '@/lib/voice-ownership'
 import { useVideoMode } from '@/hooks/useVideoMode'
 import { useVoiceTTS } from '@/hooks/useVoiceTTS'
 import { VideoCallView } from '@/components/video-call-view'
@@ -1212,6 +1213,9 @@ function App() {
   const voice = useVoiceMode()
   const voiceRef = useRef(voice)
   voiceRef.current = voice
+  // Which chat (or the call engine) holds the mic — render gating for the
+  // per-chat recording UI reads this instead of "is this the active tab".
+  const voiceOwner = useVoiceOwner()
 
   // Calls: one engine (hands-free voice loop + forced read-aloud TTS + frame
   // capture), started via presets that only differ in device defaults. The
@@ -1329,19 +1333,29 @@ function App() {
     void window.ipc.invoke('app:focusMainWindow', null).catch(() => {})
   }, [permissionDialog])
 
-  const handleStartRecording = useCallback(() => {
+  // Steal handler for PTT: another holder is taking the mic — drop the
+  // in-flight recording without releasing ownership (the thief owns it now).
+  const cancelPttForSteal = useCallback(() => {
+    voice.cancel()
+    setIsRecording(false)
+    isRecordingRef.current = false
+  }, [voice])
+
+  const handleStartRecording = useCallback((holderId: string) => {
     // A live call owns the mic — ignore push-to-talk while one is running.
     if (inCallRef.current) return
+    acquireVoice(holderId, cancelPttForSteal)
     setIsRecording(true)
     isRecordingRef.current = true
     void voice.start().then((result) => {
       if (result === 'mic-denied') {
         setIsRecording(false)
         isRecordingRef.current = false
+        releaseVoice(holderId)
         setPermissionDialog('microphone')
       }
     })
-  }, [voice])
+  }, [voice, cancelPttForSteal])
 
   const handlePromptSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => Promise<void>) | null>(null)
   const pendingVoiceInputRef = useRef(false)
@@ -1356,6 +1370,8 @@ function App() {
     const text = await voice.submit()
     setIsRecording(false)
     isRecordingRef.current = false
+    const holder = voiceOwnerId()
+    if (holder && holder !== CALL_VOICE_HOLDER) releaseVoice(holder)
     if (text) {
       pendingVoiceInputRef.current = true
       handlePromptSubmitRef.current?.({ text, files: [] })
@@ -1366,6 +1382,8 @@ function App() {
     voice.cancel()
     setIsRecording(false)
     isRecordingRef.current = false
+    const holder = voiceOwnerId()
+    if (holder && holder !== CALL_VOICE_HOLDER) releaseVoice(holder)
   }, [voice])
 
   // Start a call. Presets only differ in device defaults — the engine
@@ -1381,10 +1399,16 @@ function App() {
 
   const startCall = useCallback(async (preset: CallPreset) => {
     if (inCallRef.current) return
+    // The call engine owns the mic for the call's whole duration; any live
+    // push-to-talk recording is stolen (cancelled cleanly) here. Nothing
+    // steals FROM a call — handleStartRecording defers while in-call — so
+    // the call's own onStolen is defensively a no-op.
+    acquireVoice(CALL_VOICE_HOLDER, () => {})
     const camera = preset === 'video' || preset === 'practice'
     const ok = await video.start({ camera })
     if (!ok) {
       // Camera denied/unavailable — stay out of the call, and say why.
+      releaseVoice(CALL_VOICE_HOLDER)
       if (camera) setPermissionDialog('camera')
       return
     }
@@ -1466,6 +1490,7 @@ function App() {
     setCallMinimized(false)
     inCallRef.current = false
     setInCall(false)
+    releaseVoice(CALL_VOICE_HOLDER)
   }, [video, setPttState])
 
   // The user-mute half that lives in the video pipeline: stop sampling
@@ -7821,11 +7846,11 @@ function App() {
                             }}
                             workDir={workDirByTab[tab.id] ?? null}
                             onWorkDirChange={(v) => setTabWorkDir(tab.id, v)}
-                            isRecording={isActive && isRecording}
-                            recordingText={isActive ? voice.interimText : undefined}
-                            recordingState={isActive ? (voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening') : undefined}
+                            isRecording={isRecording && voiceOwner === tab.chatId}
+                            recordingText={voiceOwner === tab.chatId ? voice.interimText : undefined}
+                            recordingState={voiceOwner === tab.chatId ? (voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening') : undefined}
                             audioLevelsRef={voice.audioLevelsRef}
-                            onStartRecording={isActive ? handleStartRecording : undefined}
+                            onStartRecording={isActive ? () => handleStartRecording(tab.chatId) : undefined}
                             onSubmitRecording={isActive ? handleSubmitRecording : undefined}
                             onCancelRecording={isActive ? handleCancelRecording : undefined}
                             voiceAvailable={isActive && voiceAvailable}
@@ -7944,7 +7969,7 @@ function App() {
                 recordingText={voice.interimText}
                 recordingState={voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening'}
                 audioLevelsRef={voice.audioLevelsRef}
-                onStartRecording={handleStartRecording}
+                onStartRecording={() => handleStartRecording(chatIdForTab(activeChatTabIdRef.current))}
                 onSubmitRecording={handleSubmitRecording}
                 onCancelRecording={handleCancelRecording}
                 voiceAvailable={voiceAvailable}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -13,7 +13,9 @@ import { useSessionChat } from '@/hooks/useSessionChat';
 import { subscribeSessionFeed } from '@/lib/session-chat/feed';
 import { ChatHeader } from './components/chat-header';
 import { ChatSessionPane, ChatSessionComposer } from './components/chat-session';
-import { type CallPreset, type PermissionMode, type StagedAttachment } from './components/chat-input-with-mentions';
+// Value import: the Home to-do surface mounts a standalone composer directly
+// (not tab-bound); chat tabs render theirs through ChatSessionComposer.
+import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment } from './components/chat-input-with-mentions';
 import { GraphView, type GraphEdge, type GraphNode } from '@/components/graph-view';
 import { BasesView, type BaseConfig, DEFAULT_BASE_CONFIG } from '@/components/bases-view';
 import { ImageFileViewer } from '@/components/image-file-viewer';

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1984,9 +1984,15 @@ function App() {
   const [runs, setRuns] = useState<RunListItem[]>([])
 
   // Chat tab state
-  const [chatTabs, setChatTabs] = useState<ChatTab[]>([{ id: 'default-chat-tab', runId: null }])
+  const [chatTabs, setChatTabs] = useState<ChatTab[]>(() => [{ id: 'default-chat-tab', runId: null, chatId: crypto.randomUUID() }])
   const chatTabsRef = useRef(chatTabs)
   chatTabsRef.current = chatTabs
+  // A tab's current chat identity (see ChatTab.chatId). Session-scoped maps
+  // below are keyed by chatId, not tab id, so rebinding a tab to another
+  // session can never leak the previous chat's draft/model/effort into it.
+  const chatIdForTab = useCallback((tabId: string) => (
+    chatTabsRef.current.find((t) => t.id === tabId)?.chatId ?? tabId
+  ), [])
   const [activeChatTabId, setActiveChatTabId] = useState('default-chat-tab')
   const [chatViewStateByTab, setChatViewStateByTab] = useState<Record<string, ChatTabViewState>>({
     'default-chat-tab': createEmptyChatTabViewState(),
@@ -2007,12 +2013,13 @@ function App() {
   const activeChatTabIdRef = useRef(activeChatTabId)
   activeChatTabIdRef.current = activeChatTabId
   const setChatDraftForTab = useCallback((tabId: string, text: string) => {
+    const chatId = chatIdForTab(tabId)
     if (text) {
-      chatDraftsRef.current.set(tabId, text)
+      chatDraftsRef.current.set(chatId, text)
     } else {
-      chatDraftsRef.current.delete(tabId)
+      chatDraftsRef.current.delete(chatId)
     }
-  }, [])
+  }, [chatIdForTab])
   // Persist a run's work directory to its per-run sidecar config file. The agent
   // runtime reads this same file (config/workdir-<runId>.json) on each turn.
   const persistRunWorkDir = useCallback(async (runId: string, value: string | null) => {
@@ -2166,7 +2173,10 @@ function App() {
       runId,
       conversation,
       currentAssistantMessage,
-      sessionUsage: {},
+      // The legacy mirrors this snapshot is built from never carried usage,
+      // so inactive tabs showed zero tokens; take it from the live session
+      // store instead.
+      sessionUsage: sessionChat.chatState?.sessionUsage ?? {},
       pendingAskHumanRequests: new Map(pendingAskHumanRequests),
       allPermissionRequests: new Map(allPermissionRequests),
       permissionResponses: new Map(permissionResponses),
@@ -2178,6 +2188,7 @@ function App() {
     runId,
     conversation,
     currentAssistantMessage,
+    sessionChat.chatState,
     pendingAskHumanRequests,
     allPermissionRequests,
     permissionResponses,
@@ -3004,8 +3015,11 @@ function App() {
     setPermissionResponses(new Map())
     setAutoPermissionDecisions(new Map())
     try {
-      // Restore the session's per-chat work directory into the active tab.
-      const tabId = activeChatTabIdRef.current
+      // Restore the session's per-chat work directory into the tab BOUND to
+      // this run when one exists — targeting the active tab is racy under
+      // fast switching (the guard below narrows but can't close the gap).
+      const tabId = chatTabsRef.current.find((t) => t.runId === id)?.id
+        ?? activeChatTabIdRef.current
       const wd = await loadRunWorkDir(id)
       if (loadRunRequestIdRef.current !== requestId) return
       setWorkDirByTab((prev) => ({ ...prev, [tabId]: wd }))
@@ -3549,7 +3563,7 @@ function App() {
       let currentRunId = runId
       let isNewRun = false
       let newRunCreatedAt: string | null = null
-      const selected = selectedModelByTabRef.current.get(submitTabId)
+      const selected = selectedModelByTabRef.current.get(chatIdForTab(submitTabId))
       if (!currentRunId) {
         const createdSession = await window.ipc.invoke('sessions:create', {})
         currentRunId = createdSession.sessionId
@@ -3575,7 +3589,7 @@ function App() {
       // Per-message turn config. Composition inputs land in the system prompt
       // via the agent resolver; keep them session-sticky where possible so the
       // provider prefix cache survives across turns.
-      const reasoningEffort = reasoningEffortByTabRef.current.get(submitTabId)
+      const reasoningEffort = reasoningEffortByTabRef.current.get(chatIdForTab(submitTabId))
       // The runtime defaults omitted maxModelCalls to the global limit; the
       // chat-specific override is the UI's job to pass explicitly. A failed
       // settings read just falls back to the global limit.
@@ -3967,7 +3981,8 @@ function App() {
       return
     }
     setChatTabs((prev) => prev.map((t) => (
-      t.id === activeChatTabIdRef.current ? { ...t, runId: rowboatSessionId } : t
+      // Rebinding to a different session = a different chat identity.
+      t.id === activeChatTabIdRef.current ? { ...t, runId: rowboatSessionId, chatId: crypto.randomUUID() } : t
     )))
     loadRun(rowboatSessionId)
   }, [switchChatTab, loadRun])
@@ -3977,6 +3992,8 @@ function App() {
     const idx = chatTabs.findIndex(t => t.id === tabId)
     if (idx === -1) return
     saveChatScrollForTab(tabId)
+    // Resolve before the tab list changes — chat-keyed maps below.
+    const closingChatId = chatIdForTab(tabId)
     const nextTabs = chatTabs.filter(t => t.id !== tabId)
     setChatTabs(nextTabs)
     setChatViewStateByTab(prev => {
@@ -3985,9 +4002,9 @@ function App() {
       delete next[tabId]
       return next
     })
-    chatDraftsRef.current.delete(tabId)
-    selectedModelByTabRef.current.delete(tabId)
-    reasoningEffortByTabRef.current.delete(tabId)
+    chatDraftsRef.current.delete(closingChatId)
+    selectedModelByTabRef.current.delete(closingChatId)
+    reasoningEffortByTabRef.current.delete(closingChatId)
     chatScrollTopByTabRef.current.delete(tabId)
     setWorkDirByTab((prev) => {
       if (!(tabId in prev)) return prev
@@ -4438,8 +4455,8 @@ function App() {
 
   const handleNewChatTab = useCallback(() => {
     // Single-chat model: reset the one conversation in place instead of
-    // opening a new tab.
-    setChatTabs([{ id: activeChatTabIdRef.current, runId: null }])
+    // opening a new tab. Fresh chatId = fresh chat-session instance.
+    setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId: crypto.randomUUID() }])
     dismissBrowserOverlay()
     handleNewChat()
     // Left-pane "new chat" should always open full chat view.
@@ -4465,7 +4482,7 @@ function App() {
 
   // Sidebar variant: reset the chat in place without leaving file/graph context.
   const handleNewChatTabInSidebar = useCallback(() => {
-    setChatTabs([{ id: activeChatTabIdRef.current, runId: null }])
+    setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId: crypto.randomUUID() }])
     handleNewChat()
   }, [handleNewChat])
 
@@ -5290,7 +5307,8 @@ function App() {
             setActiveChatTabId(existingTab.id)
           } else {
             setChatTabs((prev) => prev.map((tab) => (
-              tab.id === activeChatTabIdRef.current ? { ...tab, runId: targetRunId } : tab
+              // Rebinding to a different session = a different chat identity.
+              tab.id === activeChatTabIdRef.current ? { ...tab, runId: targetRunId, chatId: crypto.randomUUID() } : tab
             )))
           }
           await loadRun(targetRunId)
@@ -7637,7 +7655,10 @@ function App() {
                       : "mx-auto w-full max-w-4xl min-h-full items-center justify-center pb-0"
                     return (
                       <div
-                        key={tab.id}
+                        // Keyed by CHAT identity: rebinding this tab to a
+                        // different session remounts the panel (fresh
+                        // scroll/DOM state); first-send runId binding does not.
+                        key={tab.chatId}
                         className={cn(
                           'min-h-0 h-full flex-col',
                           isActive
@@ -7760,7 +7781,11 @@ function App() {
                       const tabState = getChatTabStateForRender(tab.id)
                       return (
                         <div
-                          key={tab.id}
+                          // Composer instance per CHAT (see chat panel key
+                          // above): a rebound tab gets a fresh composer, so
+                          // attachments/toggles/selection can't leak across
+                          // sessions; first-send binding keeps the instance.
+                          key={tab.chatId}
                           className={isActive ? 'block' : 'hidden'}
                           data-chat-input-panel={tab.id}
                           aria-hidden={!isActive}
@@ -7778,20 +7803,20 @@ function App() {
                             onPresetMessageConsumed={isActive ? () => setPresetMessage(undefined) : undefined}
                             runId={tabState.runId}
                             codeSessionLock={tabState.runId ? codeSessionLocks[tabState.runId] ?? null : null}
-                            initialDraft={chatDraftsRef.current.get(tab.id)}
+                            initialDraft={chatDraftsRef.current.get(tab.chatId)}
                             onDraftChange={(text) => setChatDraftForTab(tab.id, text)}
                             onSelectedModelChange={(m) => {
                               if (m) {
-                                selectedModelByTabRef.current.set(tab.id, m)
+                                selectedModelByTabRef.current.set(tab.chatId, m)
                               } else {
-                                selectedModelByTabRef.current.delete(tab.id)
+                                selectedModelByTabRef.current.delete(tab.chatId)
                               }
                             }}
                             onReasoningEffortChange={(effort) => {
                               if (effort) {
-                                reasoningEffortByTabRef.current.set(tab.id, effort)
+                                reasoningEffortByTabRef.current.set(tab.chatId, effort)
                               } else {
-                                reasoningEffortByTabRef.current.delete(tab.id)
+                                reasoningEffortByTabRef.current.delete(tab.chatId)
                               }
                             }}
                             workDir={workDirByTab[tab.id] ?? null}
@@ -7854,7 +7879,7 @@ function App() {
                     switchChatTab(existingTab.id)
                     return
                   }
-                  setChatTabs((prev) => prev.map((t) => (t.id === activeChatTabId ? { ...t, runId: rid } : t)))
+                  setChatTabs((prev) => prev.map((t) => (t.id === activeChatTabId ? { ...t, runId: rid, chatId: crypto.randomUUID() } : t)))
                   loadRun(rid)
                 }}
                 onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
@@ -7874,20 +7899,20 @@ function App() {
                 runId={runId}
                 presetMessage={presetMessage}
                 onPresetMessageConsumed={() => setPresetMessage(undefined)}
-                getInitialDraft={(tabId) => chatDraftsRef.current.get(tabId)}
+                getInitialDraft={(tabId) => chatDraftsRef.current.get(chatIdForTab(tabId))}
                 onDraftChangeForTab={setChatDraftForTab}
                 onSelectedModelChangeForTab={(tabId, m) => {
                   if (m) {
-                    selectedModelByTabRef.current.set(tabId, m)
+                    selectedModelByTabRef.current.set(chatIdForTab(tabId), m)
                   } else {
-                    selectedModelByTabRef.current.delete(tabId)
+                    selectedModelByTabRef.current.delete(chatIdForTab(tabId))
                   }
                 }}
                 onReasoningEffortChangeForTab={(tabId, effort) => {
                   if (effort) {
-                    reasoningEffortByTabRef.current.set(tabId, effort)
+                    reasoningEffortByTabRef.current.set(chatIdForTab(tabId), effort)
                   } else {
-                    reasoningEffortByTabRef.current.delete(tabId)
+                    reasoningEffortByTabRef.current.delete(chatIdForTab(tabId))
                   }
                 }}
                 workDirByTab={workDirByTab}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -38,6 +38,8 @@ import type { PermissionDecision } from '@x/shared/src/code-mode.js'
 import { ChatEmptyState } from './chat-empty-state'
 import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from './chat-input-with-mentions'
 import { type ChatTab } from './tab-bar'
+import { useReportTabMeta } from '@/lib/tab-meta'
+import { useSessionTitle } from '@/lib/session-title'
 import {
   type ChatTabViewState,
   type ChatViewportAnchorState,
@@ -161,6 +163,24 @@ export function ChatSessionPane({
   onCodePermissionResponse,
   onComposioConnected,
 }: ChatSessionPaneProps) {
+  // Content-owned tab meta (see lib/tab-meta.ts). Both live instances of a
+  // chat (full-screen App pane + side-pane chat) report the same values, so
+  // the store's dedupe keeps this quiet; the refcount inside useReportTabMeta
+  // keeps one instance's unmount from wiping the other's report.
+  // - title: only claimed once the shared session-title store knows this
+  //   session's title; `undefined` hands the field back to the strip's
+  //   fallback (App's `runs`-derived title, including the optimistic
+  //   first-send title and the 'New chat' / '(Untitled chat)' placeholders).
+  // - busy: claimed only while this pane has a truthy signal. The only signal
+  //   it receives (`activeIsProcessing`) is active-tab-gated, so background
+  //   tabs report `undefined` and App's `isChatTabProcessing` fallback keeps
+  //   driving their busy state.
+  const sessionTitle = useSessionTitle(tab.runId)
+  useReportTabMeta(tab.id, {
+    title: sessionTitle,
+    busy: isActive && activeIsProcessing ? true : undefined,
+  })
+
   const renderConversationItem = (
     item: ConversationItem,
     options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -1,0 +1,322 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ai-elements/conversation'
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from '@/components/ai-elements/message'
+import {
+  type PromptInputMessage,
+  type FileMention,
+} from '@/components/ai-elements/prompt-input'
+import { ToolGroupComponent } from '@/components/ai-elements/tool'
+import { PermissionRequest } from '@/components/ai-elements/permission-request'
+import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
+import { AskHumanRequest } from '@/components/ai-elements/ask-human-request'
+import { TurnActivityIndicator } from '@/components/turn-activity-indicator'
+import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-override'
+import { useSmoothedText } from '@/hooks/useSmoothedText'
+import type { useVoiceMode } from '@/hooks/useVoiceMode'
+import { ChatEmptyState } from './chat-empty-state'
+import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment } from './chat-input-with-mentions'
+import { type ChatTab } from './tab-bar'
+import {
+  type ChatTabViewState,
+  type ChatViewportAnchorState,
+  type ConversationItem,
+  groupConversationItems,
+  isToolCall,
+  isToolGroup,
+} from '@/lib/chat-conversation'
+
+const streamdownComponents = { pre: MarkdownPreOverride }
+
+function SmoothStreamingMessage({ text, components }: { text: string; components: typeof streamdownComponents }) {
+  const smoothText = useSmoothedText(text)
+  return <MessageResponse components={components}>{smoothText}</MessageResponse>
+}
+
+export interface ChatSessionPaneProps {
+  tab: ChatTab
+  isActive: boolean
+  tabState: ChatTabViewState
+  viewportAnchor: ChatViewportAnchorState | undefined
+  onPickPrompt: (prompt: string) => void
+  isToolOpenForTab: (tabId: string, toolId: string) => boolean
+  setToolOpenForTab: (tabId: string, toolId: string, open: boolean) => void
+  renderItem: (
+    item: ConversationItem,
+    tabId: string,
+    options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },
+  ) => React.ReactNode
+  onPermissionResponse: (toolCallId: string, subflow: string[], response: 'approve' | 'deny') => void | Promise<void>
+  onAskHumanResponse: (toolCallId: string, subflow: string[], response: string) => void | Promise<void>
+  activeIsWorking: boolean
+  activeIsProcessing: boolean
+  activeIsReasoning: boolean
+}
+
+export function ChatSessionPane({
+  tab,
+  isActive,
+  tabState,
+  viewportAnchor,
+  onPickPrompt,
+  isToolOpenForTab,
+  setToolOpenForTab,
+  renderItem,
+  onPermissionResponse,
+  onAskHumanResponse,
+  activeIsWorking,
+  activeIsProcessing,
+  activeIsReasoning,
+}: ChatSessionPaneProps) {
+  const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
+  const tabConversationContentClassName = tabHasConversation
+    ? "mx-auto w-full max-w-4xl pb-28"
+    : "mx-auto w-full max-w-4xl min-h-full items-center justify-center pb-0"
+  return (
+    <div
+      className={cn(
+        'min-h-0 h-full flex-col',
+        isActive
+          ? 'flex'
+          : 'pointer-events-none invisible absolute inset-0 flex'
+      )}
+      data-chat-tab-panel={tab.id}
+      aria-hidden={!isActive}
+    >
+      <Conversation
+        anchorMessageId={viewportAnchor?.messageId}
+        anchorRequestKey={viewportAnchor?.requestKey}
+        className="relative flex-1"
+      >
+        <ConversationContent className={tabConversationContentClassName}>
+          {!tabHasConversation ? (
+            <ChatEmptyState
+              wide
+              onPickPrompt={onPickPrompt}
+            />
+          ) : (
+            <>
+              {groupConversationItems(
+                tabState.conversation,
+                (id) => !!tabState.allPermissionRequests.get(id) || !!tabState.autoPermissionDecisions.get(id)
+              ).map(item => {
+                if (isToolGroup(item)) {
+                  return (
+                    <ToolGroupComponent
+                      key={item.groupId}
+                      group={item}
+                      isToolOpen={(toolId) => isToolOpenForTab(tab.id, toolId)}
+                      onToolOpenChange={(toolId, open) => setToolOpenForTab(tab.id, toolId, open)}
+                    />
+                  )
+                }
+                const autoDecision = isToolCall(item)
+                  ? tabState.autoPermissionDecisions.get(item.id)
+                  : undefined
+                const rendered = renderItem(
+                  item,
+                  tab.id,
+                  autoDecision?.decision === 'allow'
+                    ? { autoPermissionDetail: { decision: 'allow', reason: autoDecision.reason } }
+                    : undefined,
+                )
+                if (isToolCall(item)) {
+                  const deniedAutoDecision = autoDecision?.decision === 'deny' ? autoDecision : null
+                  const permRequest = tabState.allPermissionRequests.get(item.id)
+                  if (deniedAutoDecision || permRequest) {
+                    const response = tabState.permissionResponses.get(item.id) || null
+                    return (
+                      <React.Fragment key={item.id}>
+                        {deniedAutoDecision && (
+                          <AutoPermissionDecision
+                            toolCall={deniedAutoDecision.toolCall}
+                            permission={deniedAutoDecision.permission}
+                            decision={deniedAutoDecision.decision}
+                            reason={deniedAutoDecision.reason}
+                          />
+                        )}
+                        {permRequest && (
+                          <PermissionRequest
+                            toolCall={permRequest.toolCall}
+                            permission={permRequest.permission}
+                            onApprove={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve')}
+                            onDeny={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'deny')}
+                            isProcessing={isActive && activeIsWorking}
+                            response={response}
+                          />
+                        )}
+                        {rendered}
+                      </React.Fragment>
+                    )
+                  }
+                }
+                return rendered
+              })}
+
+              {Array.from(tabState.pendingAskHumanRequests.values()).map((request) => (
+                <AskHumanRequest
+                  key={request.toolCallId}
+                  query={request.query}
+                  options={request.options}
+                  onResponse={(response) => onAskHumanResponse(request.toolCallId, request.subflow, response)}
+                  isProcessing={isActive && activeIsWorking}
+                />
+              ))}
+
+              {tabState.currentAssistantMessage && (
+                <Message from="assistant">
+                  <MessageContent>
+                    <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />
+                  </MessageContent>
+                </Message>
+              )}
+
+              {isActive && activeIsProcessing && (
+                <Message from="assistant">
+                  <MessageContent>
+                    <TurnActivityIndicator isReasoning={activeIsReasoning} />
+                  </MessageContent>
+                </Message>
+              )}
+            </>
+          )}
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
+    </div>
+  )
+}
+
+export interface ChatSessionComposerProps {
+  tab: ChatTab
+  isActive: boolean
+  tabState: ChatTabViewState
+  knowledgeFiles: string[]
+  recentFiles: string[]
+  visibleFiles: string[]
+  onSubmit: (
+    message: PromptInputMessage,
+    mentions?: FileMention[],
+    stagedAttachments?: StagedAttachment[],
+    searchEnabled?: boolean,
+    codeMode?: 'claude' | 'codex',
+    permissionMode?: PermissionMode,
+  ) => void | Promise<void>
+  onStop: () => void | Promise<void>
+  activeIsProcessing: boolean
+  isStopping: boolean
+  presetMessage: string | undefined
+  onPresetMessageConsumed: () => void
+  codeSessionLocks: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
+  initialDraft: string | undefined
+  onDraftChange: (tabId: string, text: string) => void
+  selectedModelByTabRef: React.RefObject<Map<string, { provider: string; model: string }>>
+  reasoningEffortByTabRef: React.RefObject<Map<string, 'low' | 'medium' | 'high'>>
+  workDirByTab: Record<string, string | null>
+  onWorkDirChange: (tabId: string, value: string | null) => void
+  isRecording: boolean
+  voiceOwner: string | null
+  voice: Pick<ReturnType<typeof useVoiceMode>, 'state' | 'interimText' | 'audioLevelsRef'>
+  onStartRecording: (holderId: string) => void
+  onSubmitRecording: () => void | Promise<void>
+  onCancelRecording: () => void
+  voiceAvailable: boolean
+  inCall: boolean
+  onStartCall: (preset: CallPreset) => void
+  onEndCall: () => void
+  ttsAvailable: boolean
+}
+
+export function ChatSessionComposer({
+  tab,
+  isActive,
+  tabState,
+  knowledgeFiles,
+  recentFiles,
+  visibleFiles,
+  onSubmit,
+  onStop,
+  activeIsProcessing,
+  isStopping,
+  presetMessage,
+  onPresetMessageConsumed,
+  codeSessionLocks,
+  initialDraft,
+  onDraftChange,
+  selectedModelByTabRef,
+  reasoningEffortByTabRef,
+  workDirByTab,
+  onWorkDirChange,
+  isRecording,
+  voiceOwner,
+  voice,
+  onStartRecording,
+  onSubmitRecording,
+  onCancelRecording,
+  voiceAvailable,
+  inCall,
+  onStartCall,
+  onEndCall,
+  ttsAvailable,
+}: ChatSessionComposerProps) {
+  return (
+    <div
+      className={isActive ? 'block' : 'hidden'}
+      data-chat-input-panel={tab.id}
+      aria-hidden={!isActive}
+    >
+      <ChatInputWithMentions
+        knowledgeFiles={knowledgeFiles}
+        recentFiles={recentFiles}
+        visibleFiles={visibleFiles}
+        onSubmit={onSubmit}
+        onStop={onStop}
+        isProcessing={isActive && activeIsProcessing}
+        isStopping={isActive && isStopping}
+        isActive={isActive}
+        presetMessage={isActive ? presetMessage : undefined}
+        onPresetMessageConsumed={isActive ? onPresetMessageConsumed : undefined}
+        runId={tabState.runId}
+        codeSessionLock={tabState.runId ? codeSessionLocks[tabState.runId] ?? null : null}
+        initialDraft={initialDraft}
+        onDraftChange={(text) => onDraftChange(tab.id, text)}
+        onSelectedModelChange={(m) => {
+          if (m) {
+            selectedModelByTabRef.current.set(tab.chatId, m)
+          } else {
+            selectedModelByTabRef.current.delete(tab.chatId)
+          }
+        }}
+        onReasoningEffortChange={(effort) => {
+          if (effort) {
+            reasoningEffortByTabRef.current.set(tab.chatId, effort)
+          } else {
+            reasoningEffortByTabRef.current.delete(tab.chatId)
+          }
+        }}
+        workDir={workDirByTab[tab.id] ?? null}
+        onWorkDirChange={(v) => onWorkDirChange(tab.id, v)}
+        isRecording={isRecording && voiceOwner === tab.chatId}
+        recordingText={voiceOwner === tab.chatId ? voice.interimText : undefined}
+        recordingState={voiceOwner === tab.chatId ? (voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening') : undefined}
+        audioLevelsRef={voice.audioLevelsRef}
+        onStartRecording={isActive ? () => onStartRecording(tab.chatId) : undefined}
+        onSubmitRecording={isActive ? onSubmitRecording : undefined}
+        onCancelRecording={isActive ? onCancelRecording : undefined}
+        voiceAvailable={isActive && voiceAvailable}
+        inCall={inCall}
+        onStartCall={isActive ? onStartCall : undefined}
+        onEndCall={isActive ? onEndCall : undefined}
+        callAvailable={voiceAvailable && ttsAvailable}
+      />
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -23,7 +23,7 @@ import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-over
 import { useSmoothedText } from '@/hooks/useSmoothedText'
 import type { useVoiceMode } from '@/hooks/useVoiceMode'
 import { ChatEmptyState } from './chat-empty-state'
-import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment } from './chat-input-with-mentions'
+import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from './chat-input-with-mentions'
 import { type ChatTab } from './tab-bar'
 import {
   type ChatTabViewState,
@@ -54,11 +54,27 @@ export interface ChatSessionPaneProps {
     tabId: string,
     options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },
   ) => React.ReactNode
-  onPermissionResponse: (toolCallId: string, subflow: string[], response: 'approve' | 'deny') => void | Promise<void>
-  onAskHumanResponse: (toolCallId: string, subflow: string[], response: string) => void | Promise<void>
+  /** Optional: without it, pending permission requests render no approve/deny card (side-pane chat may omit the handler). */
+  onPermissionResponse?: (toolCallId: string, subflow: string[], response: 'approve' | 'deny') => void | Promise<void>
+  /** Optional: without it, pending ask-human requests are not rendered (side-pane chat may omit the handler). */
+  onAskHumanResponse?: (toolCallId: string, subflow: string[], response: string) => void | Promise<void>
   activeIsWorking: boolean
   activeIsProcessing: boolean
   activeIsReasoning: boolean
+  /** Extra classes appended to ConversationContent (the side-pane chat adds `px-3`). */
+  contentClassName?: string
+  /** Vertically center the empty state (default true). The side-pane chat only centers when maximized. */
+  centerEmptyState?: boolean
+  /** `wide` flag for ChatEmptyState (default true). The side-pane chat is wide only when maximized. */
+  emptyStateWide?: boolean
+  /**
+   * How the in-flight assistant message is rendered. 'smooth' (default, App)
+   * animates via useSmoothedText and strips <voice> tags; 'plain' (side-pane
+   * chat) renders the raw text directly.
+   */
+  streamingRenderer?: 'smooth' | 'plain'
+  /** Render quick-reply option buttons on ask-human requests (default true). The side-pane chat renders free-text only. */
+  askHumanShowOptions?: boolean
 }
 
 export function ChatSessionPane({
@@ -75,11 +91,19 @@ export function ChatSessionPane({
   activeIsWorking,
   activeIsProcessing,
   activeIsReasoning,
+  contentClassName,
+  centerEmptyState = true,
+  emptyStateWide = true,
+  streamingRenderer = 'smooth',
+  askHumanShowOptions = true,
 }: ChatSessionPaneProps) {
   const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
-  const tabConversationContentClassName = tabHasConversation
-    ? "mx-auto w-full max-w-4xl pb-28"
-    : "mx-auto w-full max-w-4xl min-h-full items-center justify-center pb-0"
+  const tabConversationContentClassName = cn(
+    'mx-auto w-full max-w-4xl',
+    contentClassName,
+    tabHasConversation ? 'pb-28' : 'pb-0',
+    !tabHasConversation && centerEmptyState && 'min-h-full items-center justify-center',
+  )
   return (
     <div
       className={cn(
@@ -99,7 +123,7 @@ export function ChatSessionPane({
         <ConversationContent className={tabConversationContentClassName}>
           {!tabHasConversation ? (
             <ChatEmptyState
-              wide
+              wide={emptyStateWide}
               onPickPrompt={onPickPrompt}
             />
           ) : (
@@ -131,7 +155,7 @@ export function ChatSessionPane({
                 if (isToolCall(item)) {
                   const deniedAutoDecision = autoDecision?.decision === 'deny' ? autoDecision : null
                   const permRequest = tabState.allPermissionRequests.get(item.id)
-                  if (deniedAutoDecision || permRequest) {
+                  if (deniedAutoDecision || (permRequest && onPermissionResponse)) {
                     const response = tabState.permissionResponses.get(item.id) || null
                     return (
                       <React.Fragment key={item.id}>
@@ -143,7 +167,7 @@ export function ChatSessionPane({
                             reason={deniedAutoDecision.reason}
                           />
                         )}
-                        {permRequest && (
+                        {permRequest && onPermissionResponse && (
                           <PermissionRequest
                             toolCall={permRequest.toolCall}
                             permission={permRequest.permission}
@@ -161,11 +185,11 @@ export function ChatSessionPane({
                 return rendered
               })}
 
-              {Array.from(tabState.pendingAskHumanRequests.values()).map((request) => (
+              {onAskHumanResponse && Array.from(tabState.pendingAskHumanRequests.values()).map((request) => (
                 <AskHumanRequest
                   key={request.toolCallId}
                   query={request.query}
-                  options={request.options}
+                  options={askHumanShowOptions ? request.options : undefined}
                   onResponse={(response) => onAskHumanResponse(request.toolCallId, request.subflow, response)}
                   isProcessing={isActive && activeIsWorking}
                 />
@@ -174,7 +198,11 @@ export function ChatSessionPane({
               {tabState.currentAssistantMessage && (
                 <Message from="assistant">
                   <MessageContent>
-                    <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />
+                    {streamingRenderer === 'plain' ? (
+                      <MessageResponse components={streamdownComponents}>{tabState.currentAssistantMessage}</MessageResponse>
+                    ) : (
+                      <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />
+                    )}
                   </MessageContent>
                 </Message>
               )}
@@ -210,29 +238,48 @@ export interface ChatSessionComposerProps {
     codeMode?: 'claude' | 'codex',
     permissionMode?: PermissionMode,
   ) => void | Promise<void>
-  onStop: () => void | Promise<void>
+  onStop?: () => void | Promise<void>
   activeIsProcessing: boolean
-  isStopping: boolean
+  isStopping?: boolean
   presetMessage: string | undefined
   onPresetMessageConsumed: () => void
   codeSessionLocks: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
   initialDraft: string | undefined
   onDraftChange: (tabId: string, text: string) => void
-  selectedModelByTabRef: React.RefObject<Map<string, { provider: string; model: string }>>
-  reasoningEffortByTabRef: React.RefObject<Map<string, 'low' | 'medium' | 'high'>>
+  /** Ref-style model tracking keyed by chatId (App). Either this or onSelectedModelChange. */
+  selectedModelByTabRef?: React.RefObject<Map<string, { provider: string; model: string }>>
+  /** Ref-style effort tracking keyed by chatId (App). Either this or onReasoningEffortChange. */
+  reasoningEffortByTabRef?: React.RefObject<Map<string, 'low' | 'medium' | 'high'>>
+  /** Callback-style model reporting (side-pane chat); receives the tab so the caller picks its key. */
+  onSelectedModelChange?: (tab: ChatTab, model: SelectedModel | null) => void
+  /** Callback-style effort reporting (side-pane chat). */
+  onReasoningEffortChange?: (tab: ChatTab, effort: ReasoningEffortLevel | null) => void
   workDirByTab: Record<string, string | null>
   onWorkDirChange: (tabId: string, value: string | null) => void
-  isRecording: boolean
-  voiceOwner: string | null
-  voice: Pick<ReturnType<typeof useVoiceMode>, 'state' | 'interimText' | 'audioLevelsRef'>
-  onStartRecording: (holderId: string) => void
-  onSubmitRecording: () => void | Promise<void>
-  onCancelRecording: () => void
-  voiceAvailable: boolean
-  inCall: boolean
-  onStartCall: (preset: CallPreset) => void
-  onEndCall: () => void
-  ttsAvailable: boolean
+  isRecording?: boolean
+  voiceOwner?: string | null
+  voice?: Pick<ReturnType<typeof useVoiceMode>, 'state' | 'interimText' | 'audioLevelsRef'>
+  onStartRecording?: (holderId: string) => void
+  /**
+   * Pre-resolved per-tab recording props (side-pane chat): passed straight
+   * through to the input instead of deriving them from voiceOwner/voice.
+   */
+  recordingOverrides?: {
+    isRecording?: boolean
+    recordingText?: string
+    recordingState?: 'connecting' | 'listening' | 'stopping'
+    audioLevelsRef?: React.MutableRefObject<number[]>
+    onStartRecording?: () => void
+  }
+  onSubmitRecording?: () => void | Promise<void>
+  onCancelRecording?: () => void
+  voiceAvailable?: boolean
+  inCall?: boolean
+  onStartCall?: (preset: CallPreset) => void
+  onEndCall?: () => void
+  ttsAvailable?: boolean
+  /** Pre-resolved call availability (side-pane chat); defaults to voiceAvailable && ttsAvailable. */
+  callAvailable?: boolean
 }
 
 export function ChatSessionComposer({
@@ -253,12 +300,15 @@ export function ChatSessionComposer({
   onDraftChange,
   selectedModelByTabRef,
   reasoningEffortByTabRef,
+  onSelectedModelChange,
+  onReasoningEffortChange,
   workDirByTab,
   onWorkDirChange,
   isRecording,
   voiceOwner,
   voice,
   onStartRecording,
+  recordingOverrides,
   onSubmitRecording,
   onCancelRecording,
   voiceAvailable,
@@ -266,7 +316,9 @@ export function ChatSessionComposer({
   onStartCall,
   onEndCall,
   ttsAvailable,
+  callAvailable,
 }: ChatSessionComposerProps) {
+  const ownsVoice = voiceOwner != null && voiceOwner === tab.chatId
   return (
     <div
       className={isActive ? 'block' : 'hidden'}
@@ -289,33 +341,45 @@ export function ChatSessionComposer({
         initialDraft={initialDraft}
         onDraftChange={(text) => onDraftChange(tab.id, text)}
         onSelectedModelChange={(m) => {
-          if (m) {
-            selectedModelByTabRef.current.set(tab.chatId, m)
-          } else {
-            selectedModelByTabRef.current.delete(tab.chatId)
+          if (selectedModelByTabRef) {
+            if (m) {
+              selectedModelByTabRef.current.set(tab.chatId, m)
+            } else {
+              selectedModelByTabRef.current.delete(tab.chatId)
+            }
           }
+          onSelectedModelChange?.(tab, m)
         }}
         onReasoningEffortChange={(effort) => {
-          if (effort) {
-            reasoningEffortByTabRef.current.set(tab.chatId, effort)
-          } else {
-            reasoningEffortByTabRef.current.delete(tab.chatId)
+          if (reasoningEffortByTabRef) {
+            if (effort) {
+              reasoningEffortByTabRef.current.set(tab.chatId, effort)
+            } else {
+              reasoningEffortByTabRef.current.delete(tab.chatId)
+            }
           }
+          onReasoningEffortChange?.(tab, effort)
         }}
         workDir={workDirByTab[tab.id] ?? null}
         onWorkDirChange={(v) => onWorkDirChange(tab.id, v)}
-        isRecording={isRecording && voiceOwner === tab.chatId}
-        recordingText={voiceOwner === tab.chatId ? voice.interimText : undefined}
-        recordingState={voiceOwner === tab.chatId ? (voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening') : undefined}
-        audioLevelsRef={voice.audioLevelsRef}
-        onStartRecording={isActive ? () => onStartRecording(tab.chatId) : undefined}
+        isRecording={recordingOverrides ? recordingOverrides.isRecording : (isRecording && ownsVoice)}
+        recordingText={recordingOverrides ? recordingOverrides.recordingText : (ownsVoice ? voice?.interimText : undefined)}
+        recordingState={recordingOverrides ? recordingOverrides.recordingState : (ownsVoice && voice ? (voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening') : undefined)}
+        audioLevelsRef={recordingOverrides ? recordingOverrides.audioLevelsRef : voice?.audioLevelsRef}
+        onStartRecording={
+          recordingOverrides
+            ? recordingOverrides.onStartRecording
+            : isActive && onStartRecording
+              ? () => onStartRecording(tab.chatId)
+              : undefined
+        }
         onSubmitRecording={isActive ? onSubmitRecording : undefined}
         onCancelRecording={isActive ? onCancelRecording : undefined}
         voiceAvailable={isActive && voiceAvailable}
         inCall={inCall}
         onStartCall={isActive ? onStartCall : undefined}
         onEndCall={isActive ? onEndCall : undefined}
-        callAvailable={voiceAvailable && ttsAvailable}
+        callAvailable={callAvailable ?? (voiceAvailable && ttsAvailable)}
       />
     </div>
   )

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -8,20 +8,33 @@ import {
 import {
   Message,
   MessageContent,
+  MessageCopyButton,
   MessageResponse,
 } from '@/components/ai-elements/message'
 import {
   type PromptInputMessage,
   type FileMention,
 } from '@/components/ai-elements/prompt-input'
-import { ToolGroupComponent } from '@/components/ai-elements/tool'
+import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
 import { PermissionRequest } from '@/components/ai-elements/permission-request'
 import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
 import { AskHumanRequest } from '@/components/ai-elements/ask-human-request'
 import { TurnActivityIndicator } from '@/components/turn-activity-indicator'
-import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-override'
+import { WebSearchResult } from '@/components/ai-elements/web-search-result'
+import { AppActionCard } from '@/components/ai-elements/app-action-card'
+import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card'
+import { CodingRunBlock } from '@/components/coding-run'
+import { SubAgentBlock } from '@/components/sub-agent-block'
+import { TerminalOutput } from '@/components/terminal-output'
+import { ChatMessageAttachments } from '@/components/chat-message-attachments'
+import { BillingErrorNotice } from '@/components/billing-error-notice'
+import { TokenUsageMenu } from '@/components/token-usage-menu'
+import { matchBillingError } from '@/lib/billing-error'
+import { wikiLabel } from '@/lib/wiki-links'
+import { streamdownComponents, userMessageRemarkPlugins } from '@/lib/markdown-render'
 import { useSmoothedText } from '@/hooks/useSmoothedText'
 import type { useVoiceMode } from '@/hooks/useVoiceMode'
+import type { PermissionDecision } from '@x/shared/src/code-mode.js'
 import { ChatEmptyState } from './chat-empty-state'
 import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from './chat-input-with-mentions'
 import { type ChatTab } from './tab-bar'
@@ -29,16 +42,52 @@ import {
   type ChatTabViewState,
   type ChatViewportAnchorState,
   type ConversationItem,
+  getAppActionCardData,
+  getComposioConnectCardData,
+  getToolDisplayName,
+  getToolErrorText,
+  getWebSearchCardData,
   groupConversationItems,
+  isChatMessage,
+  isErrorMessage,
   isToolCall,
   isToolGroup,
+  isTurnUsageMessage,
+  normalizeToolInput,
+  normalizeToolOutput,
+  parseAttachedFiles,
+  REASONING_EFFORT_LABELS,
+  toToolState,
 } from '@/lib/chat-conversation'
-
-const streamdownComponents = { pre: MarkdownPreOverride }
 
 function SmoothStreamingMessage({ text, components }: { text: string; components: typeof streamdownComponents }) {
   const smoothText = useSmoothedText(text)
   return <MessageResponse components={components}>{smoothText}</MessageResponse>
+}
+
+function AutoScrollPre({ className, children }: { className?: string; children: React.ReactNode }) {
+  const ref = React.useRef<HTMLPreElement>(null)
+  const stickToBottom = React.useRef(true)
+
+  React.useLayoutEffect(() => {
+    const el = ref.current
+    if (el && stickToBottom.current) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [children])
+
+  const handleScroll = React.useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
+    stickToBottom.current = atBottom
+  }, [])
+
+  return (
+    <pre ref={ref} onScroll={handleScroll} className={className}>
+      {children}
+    </pre>
+  )
 }
 
 export interface ChatSessionPaneProps {
@@ -49,11 +98,6 @@ export interface ChatSessionPaneProps {
   onPickPrompt: (prompt: string) => void
   isToolOpenForTab: (tabId: string, toolId: string) => boolean
   setToolOpenForTab: (tabId: string, toolId: string, open: boolean) => void
-  renderItem: (
-    item: ConversationItem,
-    tabId: string,
-    options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },
-  ) => React.ReactNode
   /** Optional: without it, pending permission requests render no approve/deny card (side-pane chat may omit the handler). */
   onPermissionResponse?: (toolCallId: string, subflow: string[], response: 'approve' | 'deny') => void | Promise<void>
   /** Optional: without it, pending ask-human requests are not rendered (side-pane chat may omit the handler). */
@@ -75,6 +119,23 @@ export interface ChatSessionPaneProps {
   streamingRenderer?: 'smooth' | 'plain'
   /** Render quick-reply option buttons on ask-human requests (default true). The side-pane chat renders free-text only. */
   askHumanShowOptions?: boolean
+  /**
+   * Render the rich tool cards — CodingRunBlock for `code_agent_run`,
+   * SubAgentBlock for `spawn-agent`, and AppActionCard for app actions
+   * (default true, App). The side-pane chat sets this to false and shows those
+   * tool calls as generic collapsible Tool rows instead.
+   */
+  richToolCards?: boolean
+  /**
+   * Surface the tool's actual error output (via getToolErrorText) on generic
+   * tool rows (side-pane chat). Default false (App): a plain 'Tool error'
+   * label when the call errored.
+   */
+  detailedToolErrors?: boolean
+  /** Answer a mid-run permission ask from a `code_agent_run` coding turn (App; used by CodingRunBlock). */
+  onCodePermissionResponse?: (toolCallId: string, requestId: string, decision: PermissionDecision) => void | Promise<void>
+  /** Notified when a ComposioConnectCard finishes connecting a toolkit. */
+  onComposioConnected?: (toolkitSlug: string) => void
 }
 
 export function ChatSessionPane({
@@ -85,7 +146,6 @@ export function ChatSessionPane({
   onPickPrompt,
   isToolOpenForTab,
   setToolOpenForTab,
-  renderItem,
   onPermissionResponse,
   onAskHumanResponse,
   activeIsWorking,
@@ -96,7 +156,198 @@ export function ChatSessionPane({
   emptyStateWide = true,
   streamingRenderer = 'smooth',
   askHumanShowOptions = true,
+  richToolCards = true,
+  detailedToolErrors = false,
+  onCodePermissionResponse,
+  onComposioConnected,
 }: ChatSessionPaneProps) {
+  const renderConversationItem = (
+    item: ConversationItem,
+    options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },
+  ): React.ReactNode => {
+    if (isChatMessage(item)) {
+      if (item.role === 'user') {
+        if (item.attachments && item.attachments.length > 0) {
+          return (
+            <Message key={item.id} from={item.role} data-message-id={item.id}>
+              <MessageContent className="group-[.is-user]:bg-transparent group-[.is-user]:px-0 group-[.is-user]:py-0 group-[.is-user]:rounded-none">
+                <ChatMessageAttachments attachments={item.attachments} />
+              </MessageContent>
+              {item.content && (
+                <div className="flex flex-col items-end">
+                  <MessageContent>
+                    <MessageResponse
+                      components={streamdownComponents}
+                      remarkPlugins={userMessageRemarkPlugins}
+                    >
+                      {item.content}
+                    </MessageResponse>
+                  </MessageContent>
+                  <MessageCopyButton text={item.content} className="mt-0.5" />
+                </div>
+              )}
+            </Message>
+          )
+        }
+        const { message, files } = parseAttachedFiles(item.content)
+        return (
+          <Message key={item.id} from={item.role} data-message-id={item.id}>
+            <div className="flex flex-col items-end">
+              <MessageContent>
+                {files.length > 0 && (
+                  <div className="mb-2 flex flex-wrap gap-1.5">
+                    {files.map((filePath, index) => (
+                      <span
+                        key={index}
+                        className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
+                      >
+                        @{wikiLabel(filePath)}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <MessageResponse
+                  components={streamdownComponents}
+                  remarkPlugins={userMessageRemarkPlugins}
+                >
+                  {message}
+                </MessageResponse>
+              </MessageContent>
+              <MessageCopyButton text={message} className="mt-0.5" />
+            </div>
+          </Message>
+        )
+      }
+      return (
+        <Message key={item.id} from={item.role} data-message-id={item.id}>
+          <MessageContent>
+            <MessageResponse components={streamdownComponents}>{item.content}</MessageResponse>
+          </MessageContent>
+        </Message>
+      )
+    }
+
+    if (isToolCall(item)) {
+      if (richToolCards) {
+        if (item.name === 'code_agent_run') {
+          return (
+            <CodingRunBlock
+              key={item.id}
+              item={item}
+              open={isToolOpenForTab(tab.id, item.id)}
+              onOpenChange={(open) => setToolOpenForTab(tab.id, item.id, open)}
+              onPermissionDecision={(decision) => {
+                if (item.pendingCodePermission) {
+                  onCodePermissionResponse?.(item.id, item.pendingCodePermission.requestId, decision)
+                }
+              }}
+            />
+          )
+        }
+        if (item.name === 'spawn-agent') {
+          return (
+            <SubAgentBlock
+              key={item.id}
+              item={item}
+              open={isToolOpenForTab(tab.id, item.id)}
+              onOpenChange={(open) => setToolOpenForTab(tab.id, item.id, open)}
+            />
+          )
+        }
+        const appActionData = getAppActionCardData(item)
+        if (appActionData) {
+          return <AppActionCard key={item.id} data={appActionData} status={item.status} />
+        }
+      }
+      const webSearchData = getWebSearchCardData(item)
+      if (webSearchData) {
+        return (
+          <WebSearchResult
+            key={item.id}
+            query={webSearchData.query}
+            results={webSearchData.results}
+            status={item.status}
+            title={webSearchData.title}
+          />
+        )
+      }
+      const composioConnectData = getComposioConnectCardData(item)
+      if (composioConnectData) {
+        // Skip rendering if this is a duplicate "already connected" card
+        if (composioConnectData.hidden) return null
+        return (
+          <ComposioConnectCard
+            key={item.id}
+            toolkitSlug={composioConnectData.toolkitSlug}
+            toolkitDisplayName={composioConnectData.toolkitDisplayName}
+            status={item.status}
+            alreadyConnected={composioConnectData.alreadyConnected}
+            onConnected={onComposioConnected}
+          />
+        )
+      }
+      const toolTitle = getToolDisplayName(item)
+      const errorText = detailedToolErrors
+        ? getToolErrorText(item)
+        : (item.status === 'error' ? 'Tool error' : '')
+      const output = normalizeToolOutput(item.result, item.status)
+      const input = normalizeToolInput(item.input)
+      return (
+        <Tool
+          key={item.id}
+          open={isToolOpenForTab(tab.id, item.id)}
+          onOpenChange={(open) => setToolOpenForTab(tab.id, item.id, open)}
+          autoPermissionDetail={options?.autoPermissionDetail}
+        >
+          <ToolHeader title={toolTitle} type={`tool-${item.name}`} state={toToolState(item.status)} />
+          <ToolContent>
+            {item.streamingOutput ? (
+              <AutoScrollPre className="max-h-80 overflow-auto px-4 py-3 font-mono text-xs whitespace-pre-wrap text-foreground/90">
+                <TerminalOutput raw={item.streamingOutput} />
+              </AutoScrollPre>
+            ) : (
+              <ToolTabbedContent input={input} output={output} errorText={errorText} />
+            )}
+          </ToolContent>
+        </Tool>
+      )
+    }
+
+    if (isTurnUsageMessage(item)) {
+      return (
+        <div key={item.id} className="-mt-6 -ml-1 flex items-center justify-start gap-1" data-message-id={item.id}>
+          <TokenUsageMenu
+            usage={item.usage}
+            scope="turn"
+            modelCallCount={item.modelCallCount}
+            align="start"
+          />
+          {item.reasoningEffort && (
+            <span className="text-xs text-muted-foreground/70">
+              {REASONING_EFFORT_LABELS[item.reasoningEffort]}
+            </span>
+          )}
+        </div>
+      )
+    }
+
+    if (isErrorMessage(item)) {
+      const billingMatch = matchBillingError(item.message)
+      if (billingMatch) {
+        return <BillingErrorNotice key={item.id} id={item.id} match={billingMatch} />
+      }
+      return (
+        <Message key={item.id} from="assistant" data-message-id={item.id}>
+          <MessageContent className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive">
+            <pre className="whitespace-pre-wrap font-mono text-xs">{item.message}</pre>
+          </MessageContent>
+        </Message>
+      )
+    }
+
+    return null
+  }
+
   const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
   const tabConversationContentClassName = cn(
     'mx-auto w-full max-w-4xl',
@@ -145,9 +396,8 @@ export function ChatSessionPane({
                 const autoDecision = isToolCall(item)
                   ? tabState.autoPermissionDecisions.get(item.id)
                   : undefined
-                const rendered = renderItem(
+                const rendered = renderConversationItem(
                   item,
-                  tab.id,
                   autoDecision?.decision === 'allow'
                     ? { autoPermissionDetail: { decision: 'allow', reason: autoDecision.reason } }
                     : undefined,

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -5,27 +5,12 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ChatHeader } from '@/components/chat-header'
-import {
-  Message,
-  MessageContent,
-  MessageCopyButton,
-  MessageResponse,
-} from '@/components/ai-elements/message'
-import { Tool, ToolContent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
-import { WebSearchResult } from '@/components/ai-elements/web-search-result'
-import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card'
-import { TerminalOutput } from '@/components/terminal-output'
 import { type PromptInputMessage, type FileMention } from '@/components/ai-elements/prompt-input'
 import { FileCardProvider } from '@/contexts/file-card-context'
-import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-override'
-import { defaultRemarkPlugins } from 'streamdown'
-import remarkBreaks from 'remark-breaks'
 import { type ChatTab } from '@/components/tab-bar'
 import { type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from '@/components/chat-input-with-mentions'
-import { ChatMessageAttachments } from '@/components/chat-message-attachments'
 import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
 import { useSidebar } from '@/components/ui/sidebar'
-import { wikiLabel } from '@/lib/wiki-links'
 import type { ChatPaneSize } from '@/contexts/theme-context'
 import {
   type ChatViewportAnchorState,
@@ -34,55 +19,7 @@ import {
   type PermissionResponse,
   type TokenUsage,
   createEmptyChatTabViewState,
-  getWebSearchCardData,
-  getComposioConnectCardData,
-  getToolDisplayName,
-  getToolErrorText,
-  isChatMessage,
-  isErrorMessage,
-  isToolCall,
-  isTurnUsageMessage,
-  normalizeToolInput,
-  normalizeToolOutput,
-  parseAttachedFiles,
-  REASONING_EFFORT_LABELS,
-  toToolState,
 } from '@/lib/chat-conversation'
-import { matchBillingError } from '@/lib/billing-error'
-import { BillingErrorNotice } from '@/components/billing-error-notice'
-import { TokenUsageMenu } from '@/components/token-usage-menu'
-
-const streamdownComponents = { pre: MarkdownPreOverride }
-
-// Render user messages with markdown so bullets, bold, links, etc. survive the
-// round-trip from the input textarea. `remarkBreaks` turns single newlines
-// into <br> so typed line breaks are preserved without requiring blank lines.
-const userMessageRemarkPlugins = [...Object.values(defaultRemarkPlugins), remarkBreaks]
-
-function AutoScrollPre({ className, children }: { className?: string; children: React.ReactNode }) {
-  const ref = useRef<HTMLPreElement>(null)
-  const stickToBottom = useRef(true)
-
-  useEffect(() => {
-    const el = ref.current
-    if (el && stickToBottom.current) {
-      el.scrollTop = el.scrollHeight
-    }
-  }, [children])
-
-  const handleScroll = useCallback(() => {
-    const el = ref.current
-    if (!el) return
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
-    stickToBottom.current = atBottom
-  }, [])
-
-  return (
-    <pre ref={ref} onScroll={handleScroll} className={className}>
-      {children}
-    </pre>
-  )
-}
 
 const MIN_WIDTH = 360
 const MAX_WIDTH = 1600
@@ -362,160 +299,6 @@ export function ChatSidebar({
     if (tabId === activeChatTabId) return activeTabState
     return chatTabStates[tabId] ?? emptyTabState
   }, [activeChatTabId, activeTabState, chatTabStates, emptyTabState])
-  const renderConversationItem = (
-    item: ConversationItem,
-    tabId: string,
-    options?: { autoPermissionDetail?: { decision: 'allow'; reason: string } },
-  ) => {
-    if (isChatMessage(item)) {
-      if (item.role === 'user') {
-        if (item.attachments && item.attachments.length > 0) {
-          return (
-            <Message key={item.id} from={item.role} data-message-id={item.id}>
-              <MessageContent className="group-[.is-user]:bg-transparent group-[.is-user]:px-0 group-[.is-user]:py-0 group-[.is-user]:rounded-none">
-                <ChatMessageAttachments attachments={item.attachments} />
-              </MessageContent>
-              {item.content && (
-                <div className="flex flex-col items-end">
-                  <MessageContent>
-                    <MessageResponse
-                      components={streamdownComponents}
-                      remarkPlugins={userMessageRemarkPlugins}
-                    >
-                      {item.content}
-                    </MessageResponse>
-                  </MessageContent>
-                  <MessageCopyButton text={item.content} className="mt-0.5" />
-                </div>
-              )}
-            </Message>
-          )
-        }
-        const { message, files } = parseAttachedFiles(item.content)
-        return (
-          <Message key={item.id} from={item.role} data-message-id={item.id}>
-            <div className="flex flex-col items-end">
-              <MessageContent>
-                {files.length > 0 && (
-                  <div className="mb-2 flex flex-wrap gap-1.5">
-                    {files.map((filePath, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
-                      >
-                        @{wikiLabel(filePath)}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <MessageResponse
-                  components={streamdownComponents}
-                  remarkPlugins={userMessageRemarkPlugins}
-                >
-                  {message}
-                </MessageResponse>
-              </MessageContent>
-              <MessageCopyButton text={message} className="mt-0.5" />
-            </div>
-          </Message>
-        )
-      }
-      return (
-        <Message key={item.id} from={item.role} data-message-id={item.id}>
-          <MessageContent>
-            <MessageResponse components={streamdownComponents}>{item.content}</MessageResponse>
-          </MessageContent>
-        </Message>
-      )
-    }
-
-    if (isToolCall(item)) {
-      const webSearchData = getWebSearchCardData(item)
-      if (webSearchData) {
-        return (
-          <WebSearchResult
-            key={item.id}
-            query={webSearchData.query}
-            results={webSearchData.results}
-            status={item.status}
-            title={webSearchData.title}
-          />
-        )
-      }
-      const composioConnectData = getComposioConnectCardData(item)
-      if (composioConnectData) {
-        if (composioConnectData.hidden) return null
-        return (
-          <ComposioConnectCard
-            key={item.id}
-            toolkitSlug={composioConnectData.toolkitSlug}
-            toolkitDisplayName={composioConnectData.toolkitDisplayName}
-            status={item.status}
-            alreadyConnected={composioConnectData.alreadyConnected}
-            onConnected={onComposioConnected}
-          />
-        )
-      }
-      const toolTitle = getToolDisplayName(item)
-      const errorText = getToolErrorText(item)
-      const output = normalizeToolOutput(item.result, item.status)
-      const input = normalizeToolInput(item.input)
-      return (
-        <Tool
-          key={item.id}
-          open={isToolOpenForTab?.(tabId, item.id) ?? false}
-          onOpenChange={(open) => onToolOpenChangeForTab?.(tabId, item.id, open)}
-          autoPermissionDetail={options?.autoPermissionDetail}
-        >
-          <ToolHeader title={toolTitle} type={`tool-${item.name}`} state={toToolState(item.status)} />
-          <ToolContent>
-            {item.streamingOutput ? (
-              <AutoScrollPre className="max-h-80 overflow-auto px-4 py-3 font-mono text-xs whitespace-pre-wrap text-foreground/90">
-                <TerminalOutput raw={item.streamingOutput} />
-              </AutoScrollPre>
-            ) : (
-              <ToolTabbedContent input={input} output={output} errorText={errorText} />
-            )}
-          </ToolContent>
-        </Tool>
-      )
-    }
-
-    if (isTurnUsageMessage(item)) {
-      return (
-        <div key={item.id} className="-mt-6 -ml-1 flex items-center justify-start gap-1" data-message-id={item.id}>
-          <TokenUsageMenu
-            usage={item.usage}
-            scope="turn"
-            modelCallCount={item.modelCallCount}
-            align="start"
-          />
-          {item.reasoningEffort && (
-            <span className="text-xs text-muted-foreground/70">
-              {REASONING_EFFORT_LABELS[item.reasoningEffort]}
-            </span>
-          )}
-        </div>
-      )
-    }
-
-    if (isErrorMessage(item)) {
-      const billingMatch = matchBillingError(item.message)
-      if (billingMatch) {
-        return <BillingErrorNotice key={item.id} id={item.id} match={billingMatch} />
-      }
-      return (
-        <Message key={item.id} from="assistant" data-message-id={item.id}>
-          <MessageContent className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive">
-            <pre className="whitespace-pre-wrap font-mono text-xs">{item.message}</pre>
-          </MessageContent>
-        </Message>
-      )
-    }
-
-    return null
-  }
-
   const paneStyle = useMemo<React.CSSProperties>(() => {
     if (!isOpen) {
       return { width: 0, flex: '0 0 auto' }
@@ -633,7 +416,6 @@ export function ChatSidebar({
                       onPickPrompt={setLocalPresetMessage}
                       isToolOpenForTab={(tabId, toolId) => isToolOpenForTab?.(tabId, toolId) ?? false}
                       setToolOpenForTab={(tabId, toolId, open) => onToolOpenChangeForTab?.(tabId, toolId, open)}
-                      renderItem={renderConversationItem}
                       onPermissionResponse={onPermissionResponse}
                       onAskHumanResponse={onAskHumanResponse}
                       activeIsWorking={isProcessing && !isWaitingOnHuman}
@@ -644,6 +426,9 @@ export function ChatSidebar({
                       emptyStateWide={isMaximized}
                       streamingRenderer="plain"
                       askHumanShowOptions={false}
+                      richToolCards={false}
+                      detailedToolErrors
+                      onComposioConnected={onComposioConnected}
                     />
                   )
                 })}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -5,34 +5,25 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ChatHeader } from '@/components/chat-header'
-import { ChatEmptyState } from '@/components/chat-empty-state'
-import {
-  Conversation,
-  ConversationContent,
-  ConversationScrollButton,
-} from '@/components/ai-elements/conversation'
 import {
   Message,
   MessageContent,
   MessageCopyButton,
   MessageResponse,
 } from '@/components/ai-elements/message'
-import { TurnActivityIndicator } from '@/components/turn-activity-indicator'
-import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
+import { Tool, ToolContent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
 import { WebSearchResult } from '@/components/ai-elements/web-search-result'
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card'
-import { PermissionRequest } from '@/components/ai-elements/permission-request'
-import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
 import { TerminalOutput } from '@/components/terminal-output'
-import { AskHumanRequest } from '@/components/ai-elements/ask-human-request'
 import { type PromptInputMessage, type FileMention } from '@/components/ai-elements/prompt-input'
 import { FileCardProvider } from '@/contexts/file-card-context'
 import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-override'
 import { defaultRemarkPlugins } from 'streamdown'
 import remarkBreaks from 'remark-breaks'
 import { type ChatTab } from '@/components/tab-bar'
-import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from '@/components/chat-input-with-mentions'
+import { type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from '@/components/chat-input-with-mentions'
 import { ChatMessageAttachments } from '@/components/chat-message-attachments'
+import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
 import { useSidebar } from '@/components/ui/sidebar'
 import { wikiLabel } from '@/lib/wiki-links'
 import type { ChatPaneSize } from '@/contexts/theme-context'
@@ -47,11 +38,9 @@ import {
   getComposioConnectCardData,
   getToolDisplayName,
   getToolErrorText,
-  groupConversationItems,
   isChatMessage,
   isErrorMessage,
   isToolCall,
-  isToolGroup,
   isTurnUsageMessage,
   normalizeToolInput,
   normalizeToolOutput,
@@ -633,125 +622,29 @@ export function ChatSidebar({
               <div className="relative min-h-0 flex-1">
                 {chatTabs.map((tab) => {
                   const isActive = tab.id === activeChatTabId
-                  const tabState = getTabState(tab.id)
-                  const tabHasConversation = tabState.conversation.length > 0 || Boolean(tabState.currentAssistantMessage)
                   return (
-                    <div
+                    <ChatSessionPane
                       // Keyed by chat identity — see App's chat panel key.
                       key={tab.chatId}
-                      className={cn(
-                        'min-h-0 h-full flex-col',
-                        isActive
-                          ? 'flex'
-                          : 'pointer-events-none invisible absolute inset-0 flex'
-                      )}
-                      data-chat-tab-panel={tab.id}
-                      aria-hidden={!isActive}
-                      >
-                        <Conversation
-                          anchorMessageId={viewportAnchors[tab.id]?.messageId}
-                          anchorRequestKey={viewportAnchors[tab.id]?.requestKey}
-                          className="relative flex-1"
-                      >
-                        <ConversationContent className={cn(
-                          'mx-auto w-full max-w-4xl px-3',
-                          tabHasConversation ? 'pb-28' : 'pb-0',
-                          !tabHasConversation && isMaximized && 'min-h-full items-center justify-center',
-                        )}>
-                          {!tabHasConversation ? (
-                            <ChatEmptyState
-                              wide={isMaximized}
-                              onPickPrompt={setLocalPresetMessage}
-                            />
-                          ) : (
-                            <>
-                              {groupConversationItems(
-                                tabState.conversation,
-                                (id) => !!tabState.allPermissionRequests.get(id) || !!tabState.autoPermissionDecisions.get(id)
-                              ).map((item) => {
-                                if (isToolGroup(item)) {
-                                  return (
-                                    <ToolGroupComponent
-                                      key={item.groupId}
-                                      group={item}
-                                      isToolOpen={(toolId) => isToolOpenForTab?.(tab.id, toolId) ?? false}
-                                      onToolOpenChange={(toolId, open) => onToolOpenChangeForTab?.(tab.id, toolId, open)}
-                                    />
-                                  )
-                                }
-                                const autoDecision = isToolCall(item)
-                                  ? tabState.autoPermissionDecisions.get(item.id)
-                                  : undefined
-                                const rendered = renderConversationItem(
-                                  item,
-                                  tab.id,
-                                  autoDecision?.decision === 'allow'
-                                    ? { autoPermissionDetail: { decision: 'allow', reason: autoDecision.reason } }
-                                    : undefined,
-                                )
-                                if (isToolCall(item)) {
-                                  const deniedAutoDecision = autoDecision?.decision === 'deny' ? autoDecision : null
-                                  const permRequest = tabState.allPermissionRequests.get(item.id)
-                                  if (deniedAutoDecision || (permRequest && onPermissionResponse)) {
-                                    const response = tabState.permissionResponses.get(item.id) || null
-                                    return (
-                                      <React.Fragment key={item.id}>
-                                        {deniedAutoDecision && (
-                                          <AutoPermissionDecision
-                                            toolCall={deniedAutoDecision.toolCall}
-                                            permission={deniedAutoDecision.permission}
-                                            decision={deniedAutoDecision.decision}
-                                            reason={deniedAutoDecision.reason}
-                                          />
-                                        )}
-                                        {permRequest && onPermissionResponse && (
-                                          <PermissionRequest
-                                            toolCall={permRequest.toolCall}
-                                            permission={permRequest.permission}
-                                            onApprove={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'approve')}
-                                            onDeny={() => onPermissionResponse(permRequest.toolCall.toolCallId, permRequest.subflow, 'deny')}
-                                            isProcessing={isActive && isProcessing && !isWaitingOnHuman}
-                                            response={response}
-                                          />
-                                        )}
-                                        {rendered}
-                                      </React.Fragment>
-                                    )
-                                  }
-                                }
-                                return rendered
-                              })}
-
-                              {onAskHumanResponse && Array.from(tabState.pendingAskHumanRequests.values()).map((request) => (
-                                <AskHumanRequest
-                                  key={request.toolCallId}
-                                  query={request.query}
-                                  onResponse={(response) => onAskHumanResponse(request.toolCallId, request.subflow, response)}
-                                  isProcessing={isActive && isProcessing && !isWaitingOnHuman}
-                                />
-                              ))}
-
-                              {tabState.currentAssistantMessage && (
-                                <Message from="assistant">
-                                  <MessageContent>
-                                    <MessageResponse components={streamdownComponents}>{tabState.currentAssistantMessage}</MessageResponse>
-                                  </MessageContent>
-                                </Message>
-                              )}
-
-                              {isActive && isProcessing && (
-                                <Message from="assistant">
-                                  <MessageContent>
-                                    <TurnActivityIndicator isReasoning={isReasoning} />
-                                  </MessageContent>
-                                </Message>
-                              )}
-                            </>
-                            )}
-                          </ConversationContent>
-                          <ConversationScrollButton />
-                        </Conversation>
-                      </div>
+                      tab={tab}
+                      isActive={isActive}
+                      tabState={getTabState(tab.id)}
+                      viewportAnchor={viewportAnchors[tab.id]}
+                      onPickPrompt={setLocalPresetMessage}
+                      isToolOpenForTab={(tabId, toolId) => isToolOpenForTab?.(tabId, toolId) ?? false}
+                      setToolOpenForTab={(tabId, toolId, open) => onToolOpenChangeForTab?.(tabId, toolId, open)}
+                      renderItem={renderConversationItem}
+                      onPermissionResponse={onPermissionResponse}
+                      onAskHumanResponse={onAskHumanResponse}
+                      activeIsWorking={isProcessing && !isWaitingOnHuman}
+                      activeIsProcessing={isProcessing}
+                      activeIsReasoning={isReasoning}
+                      contentClassName="px-3"
+                      centerEmptyState={isMaximized}
+                      emptyStateWide={isMaximized}
+                      streamingRenderer="plain"
+                      askHumanShowOptions={false}
+                    />
                   )
                 })}
               </div>
@@ -761,51 +654,47 @@ export function ChatSidebar({
                 <div className="mx-auto w-full max-w-4xl px-3">
                   {chatTabs.map((tab) => {
                     const isActive = tab.id === activeChatTabId
-                    const tabState = getTabState(tab.id)
                     return (
-                      <div
+                      <ChatSessionComposer
                         // Composer instance per chat — see App's composer key.
                         key={tab.chatId}
-                        className={isActive ? 'block' : 'hidden'}
-                        data-chat-input-panel={tab.id}
-                        aria-hidden={!isActive}
-                      >
-                        <ChatInputWithMentions
-                          knowledgeFiles={knowledgeFiles}
-                          recentFiles={recentFiles}
-                          visibleFiles={visibleFiles}
-                          onSubmit={onSubmit}
-                          onStop={onStop}
-                          isProcessing={isActive && isProcessing}
-                          isStopping={isActive && isStopping}
-                          isActive={isActive}
-                          presetMessage={isActive ? (localPresetMessage ?? presetMessage) : undefined}
-                          onPresetMessageConsumed={isActive ? () => {
-                            setLocalPresetMessage(undefined)
-                            onPresetMessageConsumed?.()
-                          } : undefined}
-                          runId={tabState.runId}
-                          initialDraft={getInitialDraft?.(tab.id)}
-                          onDraftChange={onDraftChangeForTab ? (text) => onDraftChangeForTab(tab.id, text) : undefined}
-                          onSelectedModelChange={onSelectedModelChangeForTab ? (m) => onSelectedModelChangeForTab(tab.id, m) : undefined}
-                          onReasoningEffortChange={onReasoningEffortChangeForTab ? (effort) => onReasoningEffortChangeForTab(tab.id, effort) : undefined}
-                          workDir={workDirByTab[tab.id] ?? null}
-                          onWorkDirChange={onWorkDirChangeForTab ? (v) => onWorkDirChangeForTab(tab.id, v) : undefined}
-                          codeSessionLock={tabState.runId ? codeSessionLocks[tabState.runId] ?? null : null}
-                          isRecording={isActive && isRecording}
-                          recordingText={isActive ? recordingText : undefined}
-                          recordingState={isActive ? recordingState : undefined}
-                          audioLevelsRef={audioLevelsRef}
-                          onStartRecording={isActive ? onStartRecording : undefined}
-                          onSubmitRecording={isActive ? onSubmitRecording : undefined}
-                          onCancelRecording={isActive ? onCancelRecording : undefined}
-                          voiceAvailable={isActive && voiceAvailable}
-                          inCall={inCall}
-                          onStartCall={isActive ? onStartCall : undefined}
-                          onEndCall={isActive ? onEndCall : undefined}
-                          callAvailable={callAvailable}
-                        />
-                      </div>
+                        tab={tab}
+                        isActive={isActive}
+                        tabState={getTabState(tab.id)}
+                        knowledgeFiles={knowledgeFiles}
+                        recentFiles={recentFiles}
+                        visibleFiles={visibleFiles}
+                        onSubmit={onSubmit}
+                        onStop={onStop}
+                        activeIsProcessing={isProcessing}
+                        isStopping={isStopping}
+                        presetMessage={localPresetMessage ?? presetMessage}
+                        onPresetMessageConsumed={() => {
+                          setLocalPresetMessage(undefined)
+                          onPresetMessageConsumed?.()
+                        }}
+                        codeSessionLocks={codeSessionLocks}
+                        initialDraft={getInitialDraft?.(tab.id)}
+                        onDraftChange={(tabId, text) => onDraftChangeForTab?.(tabId, text)}
+                        onSelectedModelChange={(t, m) => onSelectedModelChangeForTab?.(t.id, m)}
+                        onReasoningEffortChange={(t, effort) => onReasoningEffortChangeForTab?.(t.id, effort)}
+                        workDirByTab={workDirByTab}
+                        onWorkDirChange={(tabId, v) => onWorkDirChangeForTab?.(tabId, v)}
+                        recordingOverrides={{
+                          isRecording: isActive && isRecording,
+                          recordingText: isActive ? recordingText : undefined,
+                          recordingState: isActive ? recordingState : undefined,
+                          audioLevelsRef,
+                          onStartRecording: isActive ? onStartRecording : undefined,
+                        }}
+                        onSubmitRecording={onSubmitRecording}
+                        onCancelRecording={onCancelRecording}
+                        voiceAvailable={voiceAvailable}
+                        inCall={inCall}
+                        onStartCall={onStartCall}
+                        onEndCall={onEndCall}
+                        callAvailable={callAvailable}
+                      />
                     )
                   })}
                 </div>

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -10,6 +10,7 @@ import { FileCardProvider } from '@/contexts/file-card-context'
 import { type ChatTab } from '@/components/tab-bar'
 import { type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from '@/components/chat-input-with-mentions'
 import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
+import { useTabMeta } from '@/lib/tab-meta'
 import { useSidebar } from '@/components/ui/sidebar'
 import type { ChatPaneSize } from '@/contexts/theme-context'
 import {
@@ -186,6 +187,10 @@ export function ChatSidebar({
   onComposioConnected,
 }: ChatSidebarProps) {
   const { state: sidebarState } = useSidebar()
+  // Content-reported tab meta (see lib/tab-meta.ts): the header title prefers
+  // what the chat content reports for the active tab, with the App-derived
+  // getChatTabTitle prop as the fallback for unclaimed titles.
+  const activeTabMeta = useTabMeta(activeChatTabId)
   const [width, setWidth] = useState(() => getInitialPaneWidth(defaultWidth))
   const [isResizing, setIsResizing] = useState(false)
   const [showContent, setShowContent] = useState(isOpen)
@@ -370,7 +375,8 @@ export function ChatSidebar({
               <ChatHeader
                 activeTitle={(() => {
                   const activeTab = chatTabs.find((tab) => tab.id === activeChatTabId)
-                  return activeTab ? getChatTabTitle(activeTab) : 'New chat'
+                  if (!activeTab) return 'New chat'
+                  return activeTabMeta.title ?? getChatTabTitle(activeTab)
                 })()}
                 onNewChatTab={onNewChatTab}
                 recentRuns={recentRuns}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -637,7 +637,8 @@ export function ChatSidebar({
                   const tabHasConversation = tabState.conversation.length > 0 || Boolean(tabState.currentAssistantMessage)
                   return (
                     <div
-                      key={tab.id}
+                      // Keyed by chat identity — see App's chat panel key.
+                      key={tab.chatId}
                       className={cn(
                         'min-h-0 h-full flex-col',
                         isActive
@@ -763,7 +764,8 @@ export function ChatSidebar({
                     const tabState = getTabState(tab.id)
                     return (
                       <div
-                        key={tab.id}
+                        // Composer instance per chat — see App's composer key.
+                        key={tab.chatId}
                         className={isActive ? 'block' : 'hidden'}
                         data-chat-input-panel={tab.id}
                         aria-hidden={!isActive}

--- a/apps/x/apps/renderer/src/components/tab-bar.tsx
+++ b/apps/x/apps/renderer/src/components/tab-bar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { useAllTabMeta } from "@/lib/tab-meta"
 
 export type ChatTab = {
   id: string
@@ -36,11 +37,16 @@ export function TabBar<T>({
   activeTabId,
   getTabTitle,
   getTabId,
+  isProcessing,
   onSwitchTab,
   onCloseTab,
   layout = 'fill',
   allowSingleTabClose = false,
 }: TabBarProps<T>) {
+  // Content-reported meta (see lib/tab-meta.ts): a tab whose content reports
+  // its own title/busy wins over the strip's derivation props; the props stay
+  // as the fallback for unmigrated content (file tabs, draft chats).
+  const tabMeta = useAllTabMeta()
   return (
     <div
       className={cn(
@@ -53,7 +59,12 @@ export function TabBar<T>({
       {tabs.map((tab, index) => {
         const tabId = getTabId(tab)
         const isActive = tabId === activeTabId
-        const title = getTabTitle(tab)
+        const meta = tabMeta.get(tabId)
+        const title = meta?.title ?? getTabTitle(tab)
+        // The strip currently renders no busy indicator (the green dot was
+        // removed deliberately); the effective value is still resolved
+        // content-first and exposed as data-busy for styling/tests.
+        const busy = meta?.busy ?? isProcessing?.(tab) ?? false
 
         return (
           <React.Fragment key={tabId}>
@@ -63,6 +74,7 @@ export function TabBar<T>({
             <button
               type="button"
               onClick={() => onSwitchTab(tabId)}
+              data-busy={busy || undefined}
               className={cn(
                 'rowboat-tab titlebar-no-drag group/tab relative flex items-center gap-1.5 px-3 self-stretch text-xs transition-colors',
                 layout === 'scroll' ? 'min-w-[140px] max-w-[240px]' : 'min-w-0 max-w-[220px]',

--- a/apps/x/apps/renderer/src/components/tab-bar.tsx
+++ b/apps/x/apps/renderer/src/components/tab-bar.tsx
@@ -5,6 +5,13 @@ import { cn } from "@/lib/utils"
 export type ChatTab = {
   id: string
   runId: string | null
+  // Identity of the CHAT this tab currently shows. Minted fresh on every
+  // rebinding (new chat, opening a history item into this tab) and kept
+  // stable when a draft chat's first send binds its runId — so components
+  // keyed by it remount exactly when the tab starts showing a different
+  // chat, never mid-send. Chat sessions behave like self-sufficient
+  // component instances; tabs stay dumb containers.
+  chatId: string
 }
 
 export type FileTab = {

--- a/apps/x/apps/renderer/src/lib/markdown-render.ts
+++ b/apps/x/apps/renderer/src/lib/markdown-render.ts
@@ -1,0 +1,11 @@
+import { MarkdownPreOverride } from '@/components/ai-elements/markdown-code-override'
+import { defaultRemarkPlugins } from 'streamdown'
+import remarkBreaks from 'remark-breaks'
+
+/** Shared streamdown component overrides for chat markdown rendering. */
+export const streamdownComponents = { pre: MarkdownPreOverride }
+
+// Render user messages with markdown so bullets, bold, links, etc. survive the
+// round-trip from the input textarea. `remarkBreaks` turns single newlines
+// into <br> so typed line breaks are preserved without requiring blank lines.
+export const userMessageRemarkPlugins = [...Object.values(defaultRemarkPlugins), remarkBreaks]

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
@@ -627,3 +627,34 @@ describe('buildSessionChatState', () => {
     expect(state.isReasoning).toBe(false)
   })
 })
+
+describe('lastSelection', () => {
+  it('surfaces the LATEST turn\'s resolved model and reasoning effort', () => {
+    const first = reduceTurn([created(T1, S1)])
+    const laterCreated = created('turn-2', S1)
+    laterCreated.config = { ...laterCreated.config, reasoningEffort: 'high' }
+    laterCreated.agent = {
+      ...laterCreated.agent,
+      resolved: {
+        ...laterCreated.agent.resolved,
+        model: { provider: 'anthropic', model: 'claude-fixture' },
+      },
+    }
+    const second = reduceTurn([laterCreated])
+    const state = buildSessionChatState([first, second], emptyOverlay())
+    expect(state.lastSelection).toEqual({
+      provider: 'anthropic',
+      model: 'claude-fixture',
+      effort: 'high',
+    })
+  })
+
+  it('omits effort when the turn ran on auto', () => {
+    const state = buildSessionChatState([reduceTurn([created(T1, S1)])], emptyOverlay())
+    expect(state.lastSelection).toEqual({ provider: 'openai', model: 'gpt-fixture' })
+  })
+
+  it('is null for a session with no turns', () => {
+    expect(buildSessionChatState([], emptyOverlay()).lastSelection).toBeNull()
+  })
+})

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
@@ -387,6 +387,10 @@ export type SessionChatState = {
   // Kept separate from processing so permission/ask-human controls remain
   // interactive while the turn is suspended for user input.
   isWaitingOnHuman: boolean
+  // The latest turn's model selection — resolved model + the reasoning
+  // effort it ran with. A reopened session's composer restores its
+  // selection from this (settings only seed brand-new chats).
+  lastSelection: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' } | null
 }
 
 function toolCallPartOf(tc: ToolCallState) {
@@ -504,7 +508,16 @@ export function buildSessionChatState(
 
   const settled = status === 'completed' || status === 'failed' || status === 'cancelled'
   const waitingOnHuman = allPermissionRequests.size > 0 || pendingAskHumanRequests.size > 0
+  const lastModel = latest?.definition.agent.resolved.model
+  const lastEffort = latest?.definition.config.reasoningEffort
   return {
+    lastSelection: lastModel
+      ? {
+          provider: lastModel.provider,
+          model: lastModel.model,
+          ...(lastEffort ? { effort: lastEffort } : {}),
+        }
+      : null,
     conversation,
     currentAssistantMessage: stripVoiceTags(overlay.text),
     sessionUsage,

--- a/apps/x/apps/renderer/src/lib/session-title.ts
+++ b/apps/x/apps/renderer/src/lib/session-title.ts
@@ -1,0 +1,95 @@
+import { useSyncExternalStore } from 'react'
+import { subscribeSessionFeed } from '@/lib/session-chat/feed'
+
+// Reactive session-title lookup for content components (ChatSessionPane
+// reports its tab title from here — see lib/tab-meta.ts).
+//
+// One module-level cache of sessionId -> title:
+// - Seeded lazily ONCE (first subscriber) from `sessions:list` — shared across
+//   every consumer, so N chat panes cost one IPC call total.
+// - Kept live from the session feed's `index-changed` events (published on
+//   every index write: create, turn settled, title change, delete).
+// - The feed subscription starts BEFORE the seed fetch resolves; sessions
+//   touched by a feed event in that window are skipped when the (older) seed
+//   lands, so the seed can never roll a title back.
+//
+// Only sessions with a real title are stored: an untitled session resolves to
+// `undefined`, which callers treat as "no claim" (App's fallback derivation —
+// including the optimistic first-send title in its `runs` state — shows
+// through).
+
+let titles = new Map<string, string>()
+const touchedBeforeSeed = new Set<string>()
+let started = false
+let seeded = false
+let stopFeed: (() => void) | null = null
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+/** Returns true when the cache changed. */
+function applyTitle(sessionId: string, title: string | undefined): boolean {
+  if (title === undefined) return titles.delete(sessionId)
+  if (titles.get(sessionId) === title) return false
+  titles.set(sessionId, title)
+  return true
+}
+
+function ensureStarted(): void {
+  if (started) return
+  started = true
+  stopFeed = subscribeSessionFeed((event) => {
+    if (event.kind !== 'index-changed') return
+    if (!seeded) touchedBeforeSeed.add(event.sessionId)
+    if (applyTitle(event.sessionId, event.entry?.title)) emit()
+  })
+  window.ipc
+    .invoke('sessions:list', {})
+    .then(({ sessions }) => {
+      let changed = false
+      for (const entry of sessions) {
+        if (touchedBeforeSeed.has(entry.sessionId)) continue
+        if (applyTitle(entry.sessionId, entry.title)) changed = true
+      }
+      if (changed) emit()
+    })
+    .catch((err: unknown) => {
+      console.error('session-title: failed to seed from sessions:list', err)
+    })
+    .finally(() => {
+      seeded = true
+      touchedBeforeSeed.clear()
+    })
+}
+
+export function sessionTitleFor(sessionId: string | null | undefined): string | undefined {
+  return sessionId ? titles.get(sessionId) : undefined
+}
+
+export function subscribeSessionTitles(listener: () => void): () => void {
+  ensureStarted()
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/**
+ * Reactive title for a session; `undefined` while unknown/untitled (or when
+ * `sessionId` is null). Snapshot is a primitive string, so it is referentially
+ * stable between changes.
+ */
+export function useSessionTitle(sessionId: string | null | undefined): string | undefined {
+  return useSyncExternalStore(subscribeSessionTitles, () => sessionTitleFor(sessionId))
+}
+
+// Test-only.
+export function __resetSessionTitlesForTests(): void {
+  stopFeed?.()
+  stopFeed = null
+  titles = new Map()
+  touchedBeforeSeed.clear()
+  started = false
+  seeded = false
+  listeners.clear()
+}

--- a/apps/x/apps/renderer/src/lib/tab-meta.test.ts
+++ b/apps/x/apps/renderer/src/lib/tab-meta.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetTabMetaForTests,
+  clearTabMeta,
+  getAllTabMeta,
+  getTabMeta,
+  reportTabMeta,
+  retainTabMeta,
+  subscribeTabMeta,
+} from './tab-meta'
+
+describe('tab-meta store', () => {
+  beforeEach(() => {
+    __resetTabMetaForTests()
+  })
+
+  describe('reportTabMeta (merge)', () => {
+    it('merges fields across separate reports', () => {
+      reportTabMeta('t1', { title: 'Hello' })
+      reportTabMeta('t1', { busy: true })
+      expect(getTabMeta('t1')).toEqual({ title: 'Hello', busy: true })
+    })
+
+    it('overwrites only the keys present in the patch', () => {
+      reportTabMeta('t1', { title: 'Hello', busy: true })
+      reportTabMeta('t1', { title: 'World' })
+      expect(getTabMeta('t1')).toEqual({ title: 'World', busy: true })
+    })
+
+    it('an explicitly-undefined key withdraws that field', () => {
+      const listener = vi.fn()
+      reportTabMeta('t1', { title: 'Hello', busy: true })
+      subscribeTabMeta(listener)
+      reportTabMeta('t1', { title: undefined })
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(getTabMeta('t1').title).toBeUndefined()
+      expect(getTabMeta('t1').busy).toBe(true)
+    })
+
+    it('keeps tabs independent', () => {
+      reportTabMeta('t1', { title: 'One' })
+      reportTabMeta('t2', { title: 'Two' })
+      expect(getTabMeta('t1').title).toBe('One')
+      expect(getTabMeta('t2').title).toBe('Two')
+    })
+  })
+
+  describe('dedupe', () => {
+    it('does not emit when reported meta is identical', () => {
+      const listener = vi.fn()
+      reportTabMeta('t1', { title: 'Hello', busy: true })
+      subscribeTabMeta(listener)
+      // A second instance of the same chat reports the same values.
+      reportTabMeta('t1', { title: 'Hello', busy: true })
+      reportTabMeta('t1', { title: 'Hello' })
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('does not create an entry for an all-undefined report', () => {
+      const listener = vi.fn()
+      subscribeTabMeta(listener)
+      reportTabMeta('t1', { title: undefined, busy: undefined })
+      reportTabMeta('t2', {})
+      expect(listener).not.toHaveBeenCalled()
+      expect(getAllTabMeta().size).toBe(0)
+    })
+
+    it('keeps snapshot references stable across no-op reports', () => {
+      reportTabMeta('t1', { title: 'Hello' })
+      const all = getAllTabMeta()
+      const entry = getTabMeta('t1')
+      reportTabMeta('t1', { title: 'Hello' })
+      expect(getAllTabMeta()).toBe(all)
+      expect(getTabMeta('t1')).toBe(entry)
+    })
+
+    it('reuses untouched entries when another tab changes', () => {
+      reportTabMeta('t1', { title: 'One' })
+      const entry = getTabMeta('t1')
+      const all = getAllTabMeta()
+      reportTabMeta('t2', { title: 'Two' })
+      // The map snapshot is rebuilt (change happened) …
+      expect(getAllTabMeta()).not.toBe(all)
+      // … but t1's entry object is reused, so its consumers see no change.
+      expect(getTabMeta('t1')).toBe(entry)
+    })
+
+    it('returns a stable empty meta for unknown tabs', () => {
+      expect(getTabMeta('nope')).toBe(getTabMeta('nope'))
+    })
+  })
+
+  describe('clearTabMeta', () => {
+    it('drops the entry and emits', () => {
+      const listener = vi.fn()
+      reportTabMeta('t1', { title: 'Hello' })
+      subscribeTabMeta(listener)
+      clearTabMeta('t1')
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(getTabMeta('t1')).toEqual({})
+      expect(getAllTabMeta().has('t1')).toBe(false)
+    })
+
+    it('is a silent no-op for unknown tabs', () => {
+      const listener = vi.fn()
+      subscribeTabMeta(listener)
+      clearTabMeta('nope')
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('subscription', () => {
+    it('notifies on change and stops after unsubscribe', () => {
+      const listener = vi.fn()
+      const unsubscribe = subscribeTabMeta(listener)
+      reportTabMeta('t1', { title: 'Hello' })
+      expect(listener).toHaveBeenCalledTimes(1)
+      unsubscribe()
+      reportTabMeta('t1', { title: 'World' })
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('retainTabMeta (refcounted lifecycle)', () => {
+    it('keeps meta while another holder is live, clears on last release', () => {
+      const releaseA = retainTabMeta('t1')
+      const releaseB = retainTabMeta('t1')
+      reportTabMeta('t1', { title: 'Hello' })
+
+      releaseA()
+      expect(getTabMeta('t1').title).toBe('Hello')
+
+      releaseB()
+      expect(getAllTabMeta().has('t1')).toBe(false)
+    })
+
+    it('release is idempotent', () => {
+      const releaseA = retainTabMeta('t1')
+      const releaseB = retainTabMeta('t1')
+      reportTabMeta('t1', { title: 'Hello' })
+
+      releaseA()
+      releaseA() // double-release must not steal B's hold
+      expect(getTabMeta('t1').title).toBe('Hello')
+
+      releaseB()
+      expect(getAllTabMeta().has('t1')).toBe(false)
+    })
+
+    it('emits when the last release clears reported meta', () => {
+      const release = retainTabMeta('t1')
+      reportTabMeta('t1', { title: 'Hello' })
+      const listener = vi.fn()
+      subscribeTabMeta(listener)
+      release()
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/x/apps/renderer/src/lib/tab-meta.ts
+++ b/apps/x/apps/renderer/src/lib/tab-meta.ts
@@ -1,0 +1,136 @@
+import { useEffect, useSyncExternalStore } from 'react'
+
+// Tab metadata reported by CONTENT, read by the tab strip.
+//
+// Ownership inversion: instead of the tab strip deriving a tab's title/busy
+// state from app-level lists (App's `runs`, `processingRunIds`), the content
+// component that lives inside the tab reports its own meta here, keyed by tab
+// id. The strip prefers reported meta and falls back to its legacy
+// `getTabTitle` / `isProcessing` props for content that has not migrated
+// (notes/code/bases file tabs, draft chats with no resolved title).
+//
+// Design notes:
+// - Fields are individually optional; `undefined` means "no claim" and hands
+//   that field back to the strip's fallback derivation. `reportTabMeta` is a
+//   MERGE: only keys present in the patch are written (an explicitly-undefined
+//   key withdraws that field's claim).
+// - Dedupe: reporting values identical to what is stored emits nothing and
+//   allocates nothing. This matters because one chat renders as TWO live
+//   ChatSession instances (full-screen App pane + side-pane chat) that report
+//   the same values.
+// - Snapshot stability: the store keeps one immutable Map snapshot, rebuilt
+//   only on an actual change; per-tab entry objects are reused untouched when
+//   another tab changes. `useTabMeta` / `useAllTabMeta` are therefore safe
+//   with useSyncExternalStore (no fresh-object-per-read render loops).
+// - Lifecycle: with two instances per chat, "clear on unmount" must not let
+//   the last unmount wipe a still-live instance's report. Instances hold a
+//   refcount via `retainTabMeta`; the entry is deleted only when the LAST
+//   holder releases. `useReportTabMeta` bundles retain/release + merge
+//   reporting for component use. `clearTabMeta` is the unconditional wipe
+//   (owner/tests); live instances re-assert on their next report.
+
+export interface TabMeta {
+  title?: string
+  busy?: boolean
+}
+
+const EMPTY_META: TabMeta = Object.freeze({})
+
+let snapshot: ReadonlyMap<string, TabMeta> = new Map()
+const refCounts = new Map<string, number>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+function commit(mutate: (next: Map<string, TabMeta>) => void): void {
+  const next = new Map(snapshot)
+  mutate(next)
+  snapshot = next
+  emit()
+}
+
+/**
+ * Merge `patch` into the tab's reported meta. Keys absent from the patch are
+ * left as-is; keys present overwrite (explicit `undefined` withdraws the
+ * claim). No-ops (identical resulting meta) do not emit.
+ */
+export function reportTabMeta(tabId: string, patch: TabMeta): void {
+  const prev = snapshot.get(tabId)
+  const next: TabMeta = {
+    title: 'title' in patch ? patch.title : prev?.title,
+    busy: 'busy' in patch ? patch.busy : prev?.busy,
+  }
+  if (prev && prev.title === next.title && prev.busy === next.busy) return
+  if (!prev && next.title === undefined && next.busy === undefined) return
+  commit((map) => map.set(tabId, next))
+}
+
+/** Unconditionally drop a tab's reported meta (falls back to strip props). */
+export function clearTabMeta(tabId: string): void {
+  if (!snapshot.has(tabId)) return
+  commit((map) => map.delete(tabId))
+}
+
+export function getTabMeta(tabId: string): TabMeta {
+  return snapshot.get(tabId) ?? EMPTY_META
+}
+
+export function getAllTabMeta(): ReadonlyMap<string, TabMeta> {
+  return snapshot
+}
+
+export function subscribeTabMeta(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/**
+ * Register a live reporting instance for this tab. Returns a release function
+ * (idempotent). The tab's meta is deleted only when the last holder releases,
+ * so one of two co-mounted instances unmounting never wipes the other's
+ * report.
+ */
+export function retainTabMeta(tabId: string): () => void {
+  refCounts.set(tabId, (refCounts.get(tabId) ?? 0) + 1)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    const remaining = (refCounts.get(tabId) ?? 1) - 1
+    if (remaining > 0) {
+      refCounts.set(tabId, remaining)
+      return
+    }
+    refCounts.delete(tabId)
+    clearTabMeta(tabId)
+  }
+}
+
+export function useTabMeta(tabId: string): TabMeta {
+  return useSyncExternalStore(subscribeTabMeta, () => getTabMeta(tabId))
+}
+
+export function useAllTabMeta(): ReadonlyMap<string, TabMeta> {
+  return useSyncExternalStore(subscribeTabMeta, getAllTabMeta)
+}
+
+/**
+ * Component-side reporter: holds a refcount for the component's lifetime and
+ * merge-reports both fields whenever they change. Passing `undefined` for a
+ * field withdraws the claim so the strip's fallback derivation shows through.
+ */
+export function useReportTabMeta(tabId: string, meta: TabMeta): void {
+  useEffect(() => retainTabMeta(tabId), [tabId])
+  useEffect(() => {
+    reportTabMeta(tabId, { title: meta.title, busy: meta.busy })
+  }, [tabId, meta.title, meta.busy])
+}
+
+// Test-only.
+export function __resetTabMetaForTests(): void {
+  snapshot = new Map()
+  refCounts.clear()
+  listeners.clear()
+}

--- a/apps/x/apps/renderer/src/lib/voice-ownership.test.ts
+++ b/apps/x/apps/renderer/src/lib/voice-ownership.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetVoiceOwnershipForTests,
+  acquireVoice,
+  releaseVoice,
+  subscribeVoiceOwner,
+  voiceOwnerId,
+} from './voice-ownership'
+
+beforeEach(__resetVoiceOwnershipForTests)
+
+describe('voice ownership', () => {
+  it('acquire takes the mic and release frees it', () => {
+    acquireVoice('chat-a', () => {})
+    expect(voiceOwnerId()).toBe('chat-a')
+    releaseVoice('chat-a')
+    expect(voiceOwnerId()).toBeNull()
+  })
+
+  it('acquiring over another holder runs its onStolen before ownership moves', () => {
+    const stolen = vi.fn(() => {
+      // The previous holder still observes itself as owner while cleaning up.
+      expect(voiceOwnerId()).toBe('chat-a')
+    })
+    acquireVoice('chat-a', stolen)
+    acquireVoice('chat-b', () => {})
+    expect(stolen).toHaveBeenCalledOnce()
+    expect(voiceOwnerId()).toBe('chat-b')
+  })
+
+  it('re-acquiring as the current owner does not self-steal', () => {
+    const stolen = vi.fn()
+    acquireVoice('chat-a', stolen)
+    acquireVoice('chat-a', stolen)
+    expect(stolen).not.toHaveBeenCalled()
+    expect(voiceOwnerId()).toBe('chat-a')
+  })
+
+  it('a stale release cannot revoke a newer holder', () => {
+    acquireVoice('chat-a', () => {})
+    acquireVoice('chat-b', () => {})
+    releaseVoice('chat-a')
+    expect(voiceOwnerId()).toBe('chat-b')
+  })
+
+  it('notifies subscribers on every ownership change', () => {
+    const seen: Array<string | null> = []
+    const unsubscribe = subscribeVoiceOwner(() => seen.push(voiceOwnerId()))
+    acquireVoice('chat-a', () => {})
+    acquireVoice('chat-b', () => {})
+    releaseVoice('chat-b')
+    unsubscribe()
+    acquireVoice('chat-c', () => {})
+    expect(seen).toEqual(['chat-a', 'chat-b', null])
+  })
+})

--- a/apps/x/apps/renderer/src/lib/voice-ownership.ts
+++ b/apps/x/apps/renderer/src/lib/voice-ownership.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from 'react'
+
+// Which chat currently owns the microphone.
+//
+// The mic is one physical resource: useVoiceMode (PTT/STT) and the call
+// engine are instantiated once at App level. Historically "only one chat
+// records at a time" was enforced implicitly — recording props were wired
+// only to the ACTIVE tab's composer — which breaks down the moment chat
+// sessions are self-sufficient components that can each try to start
+// voice. This store makes ownership an explicit token:
+//
+// - `acquireVoice(holderId, onStolen)` — take the mic. If another holder
+//   owns it, its `onStolen` runs first (cancel recording, tear down UI),
+//   so acquisition is always a clean hand-off, never a shared mic.
+// - `releaseVoice(holderId)` — free it; ignored unless you are the owner,
+//   so a stale release can never revoke a newer holder.
+// - `useVoiceOwner()` — reactive owner id for render gating
+//   (`owner === myChatId`), via useSyncExternalStore.
+//
+// Holder ids are chat ids for composer push-to-talk; calls use the
+// reserved CALL_VOICE_HOLDER (a call owns the mic for its whole duration
+// and outranks PTT — see the acquire call sites in App).
+
+export const CALL_VOICE_HOLDER = '__call__'
+
+interface VoiceOwner {
+  holderId: string
+  onStolen: () => void
+}
+
+let owner: VoiceOwner | null = null
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+export function acquireVoice(holderId: string, onStolen: () => void): void {
+  if (owner && owner.holderId !== holderId) {
+    // Hand-off: the previous holder cleans up before ownership moves.
+    owner.onStolen()
+  }
+  owner = { holderId, onStolen }
+  emit()
+}
+
+export function releaseVoice(holderId: string): void {
+  if (owner?.holderId !== holderId) return
+  owner = null
+  emit()
+}
+
+export function voiceOwnerId(): string | null {
+  return owner?.holderId ?? null
+}
+
+export function subscribeVoiceOwner(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function useVoiceOwner(): string | null {
+  return useSyncExternalStore(subscribeVoiceOwner, voiceOwnerId)
+}
+
+// Test-only.
+export function __resetVoiceOwnershipForTests(): void {
+  owner = null
+  listeners.clear()
+}


### PR DESCRIPTION
## Problem

Chat tabs were rebound in place everywhere — \"new chat\" resets the active tab, opening a history item / recent run / code session swaps the active tab's runId — while the conversation panel and composer stayed mounted, keyed by tab id. Every piece of session state (draft, picked model, reasoning effort, attachments, toggles, scroll, workdir) needed hand-written reset/restore logic on every rebinding path, and each one missed was a bug: one chat's model silently applied to the next chat opened in the same tab, a run's workdir landed on whatever tab happened to be active, inactive tabs showed zero token usage. Mic exclusivity was equally implicit (recording props only wired to the active tab), and the chat rendering existed as two drifting copies (main pane + side pane) with ~350 lines of duplicated JSX and two diverging item renderers.

## Change

**Chat identity.** Every tab carries a `chatId` — minted fresh on each rebinding, stable when a draft chat's first send binds its runId. Conversation panels and composer instances are React-keyed by it, so rebinding a tab = clean remount of the chat instance (never mid-send), and session-scoped state maps are keyed by it, so cross-chat leakage is structurally impossible. Tabs are now dumb containers.

**ChatSession components.** The per-chat rendering moves out of App.tsx and chat-sidebar.tsx into `components/chat-session.tsx` (`ChatSessionPane` + `ChatSessionComposer`) with typed props contracts. Both panes render the same components; the two conversation-item renderers are merged into one, with genuine surface differences expressed as explicit flags rather than parallel copies (`richToolCards`, `detailedToolErrors`, `streamingRenderer`). One real drift surfaced during the merge and is preserved behind a flag rather than silently changed: the side pane's ask-human card never offered option buttons (`askHumanShowOptions`) — unifying it is now a one-line decision.

**Voice ownership.** Mic exclusivity becomes an invariant instead of a coupling: `lib/voice-ownership.ts` tracks one holder (`acquireVoice`/`releaseVoice`/`useVoiceOwner`), hand-offs run the previous holder's cleanup before ownership moves, stale releases are ignored. Push-to-talk acquires with the chat's `chatId`; calls hold a reserved token for their duration and outrank PTT. A chat's recording UI renders because it owns the mic, not because its tab is active.

**Tab meta contract.** Content reports its own `{title, busy}` into `lib/tab-meta.ts`; `TabBar` prefers reported meta and falls back to the existing derivation for unmigrated content. Chat sessions report their title via a shared reactive session-title cache (one lazy `sessions:list` seed + live session-feed updates), with deduped reports and refcounted clearing so the two live instances per chat coexist. File tabs (notes/code/bases) are untouched and can migrate with a 3-line `useReportTabMeta` call each.

**Also fixed along the way:** `loadRun` restoring a workdir onto the active tab instead of the tab bound to the run; the per-tab snapshot hardcoding `sessionUsage: {}` (inactive tabs showed zero tokens); `buildSessionChatState` now surfaces the latest turn's resolved model + effort as `lastSelection` — groundwork for restoring a reopened chat's model selection (used by the effort branch that follows this PR).

## Numbers & verification

Net ~-450 lines across App.tsx/chat-sidebar.tsx into shared, contract-typed modules. 23 new unit tests (tab-meta store, voice ownership, lastSelection). Every step verified: workspace typecheck clean, 133/133 renderer tests, production build green, eslint byte-identical to baseline.

## Follow-ups (not in this PR)

- Manual smoke areas reviewers should click through: tab switching, new chat, history reopen, PTT in two different chats, call start/end, live tab-title updates.
- Migrate note/code tab titles onto the meta contract opportunistically.
- Decide the ask-human options unification (`askHumanShowOptions`).
- Rebase `effort-ui` on this to complete the model-selection restore story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)