### PR TITLE
Reasoning effort everywhere: one ModelSelection from picker to runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,8 @@ Long-form docs for specific features. Read the relevant file before making chang
 
 ### LLM configuration
 - Config file: `~/.rowboat/config/models.json` (v2; v1 files are migrated on boot by `core/models/migrate.ts`)
-- Schema: `{ version: 2, providers: { <id>: { flavor, apiKey?, baseURL?, … } }, assistantModel?: { provider, model }, taskModels?: { knowledgeGraph?, meetingNotes?, liveNoteAgent?, autoPermissionDecision?, chatTitle? }, deferBackgroundTasks? }`
-- Providers carry credentials only (no model fields) — model lists are always fetched live via the unified catalog (`core/models/catalog.ts`, `models:list` IPC). Model choices live in `assistantModel` (the one primary) and `taskModels` (optional overrides that otherwise inherit the assistant).
+- Schema: `{ version: 2, providers: { <id>: { flavor, apiKey?, baseURL?, … } }, assistantModel?: { provider, model, effort? }, taskModels?: { knowledgeGraph?, meetingNotes?, liveNoteAgent?, autoPermissionDecision?, chatTitle?, backgroundTask?, subagent? }, deferBackgroundTasks? }`
+- Providers carry credentials only (no model fields) — model lists are always fetched live via the unified catalog (`core/models/catalog.ts`, `models:list` IPC). Model choices live in `assistantModel` (the one primary) and `taskModels` (optional overrides that otherwise inherit the assistant). Every choice is a `{ provider, model, effort? }` pair — `effort` is the reasoning effort picked with the model (`low`/`medium`/`high`; missing, `null`, or `"auto"` all mean Auto = provider default).
 - Models catalog cache: `~/.rowboat/config/models.dev.json` (OpenAI/Anthropic/Google only)
 
 ### Add a new shared type

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -3834,7 +3834,7 @@ function App() {
     // selection from the settings pair (the composer re-seeds when its
     // runId prop drops to null; clearing here keeps the map in lockstep).
     setWorkDirByTab(prev => ({ ...prev, [activeChatTabIdRef.current]: null }))
-    selectionByTabRef.current.delete(activeChatTabIdRef.current)
+    selectionByTabRef.current.delete(chatIdForTab(activeChatTabIdRef.current))
   }, [setChatViewportAnchor])
 
   // Chat tab operations
@@ -4434,8 +4434,14 @@ function App() {
   }, [dismissBrowserOverlay, handleNewChat, selectedPath, isGraphOpen, isSuggestedTopicsOpen, isMeetingsOpen, isLiveNotesOpen, isBgTasksOpen, isAppsOpen, isEmailOpen, isWorkspaceOpen, isKnowledgeViewOpen, isChatHistoryOpen, isHomeOpen])
 
   // Sidebar variant: reset the chat in place without leaving file/graph context.
-  const handleNewChatTabInSidebar = useCallback(() => {
-    setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId: crypto.randomUUID() }])
+  // A caller with a selection already chosen for the fresh chat (the Home
+  // composer handoff) passes it here so the map entry exists BEFORE the
+  // rebind commit — the remounted composer's initialSelection then shows the
+  // same pair the sends will use, instead of racing the settings seed.
+  const handleNewChatTabInSidebar = useCallback((initialSelection?: ModelSelection | null) => {
+    const chatId = crypto.randomUUID()
+    if (initialSelection) selectionByTabRef.current.set(chatId, initialSelection)
+    setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId }])
     handleNewChat()
   }, [handleNewChat])
 
@@ -4548,7 +4554,7 @@ function App() {
     // Chat mode has NO routing rules: mentions here just address the
     // assistant. Tasks are born via the chip, the list, or by asking.
     setIsChatSidebarOpen(true)
-    handleNewChatTabInSidebar()
+    handleNewChatTabInSidebar(homeSelectionRef.current)
     setPendingHomeSubmit({ message, mentions, attachments: stagedAttachments, searchEnabled, codeMode, permissionMode })
   }, [handleNewChatTabInSidebar])
   const homeComposeTargetRef = useRef(homeComposeTarget)
@@ -7482,7 +7488,9 @@ function App() {
                           // (loading) until activated. lastSelection is null
                           // for a session with no turns (settings seed).
                           restoredSelection={
-                            isActive && tab.runId && sessionChat.chatState
+                            isActive && tab.runId
+                              && sessionChat.sessionId === tab.runId
+                              && sessionChat.chatState
                               ? sessionChat.chatState.lastSelection
                               : undefined
                           }
@@ -7536,7 +7544,7 @@ function App() {
                 chatTabs={chatTabs}
                 activeChatTabId={activeChatTabId}
                 getChatTabTitle={getChatTabTitle}
-                onNewChatTab={handleNewChatTabInSidebar}
+                onNewChatTab={() => handleNewChatTabInSidebar()}
                 recentRuns={runs}
                 onSelectRun={(rid) => {
                   const existingTab = chatTabs.find((t) => t.runId === rid)
@@ -7575,7 +7583,9 @@ function App() {
                 }}
                 getInitialSelection={(tabId) => selectionByTabRef.current.get(chatIdForTab(tabId)) ?? null}
                 restoredSelectionForActive={
-                  runId && sessionChat.chatState ? sessionChat.chatState.lastSelection : undefined
+                  runId && sessionChat.sessionId === runId && sessionChat.chatState
+                    ? sessionChat.chatState.lastSelection
+                    : undefined
                 }
                 workDirByTab={workDirByTab}
                 onWorkDirChangeForTab={setTabWorkDir}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7476,6 +7476,16 @@ function App() {
                             }
                           }}
                           initialSelection={selectionByTabRef.current.get(tab.chatId) ?? null}
+                          // Last-turn restore: the single session store is
+                          // bound to the ACTIVE tab's run, so only that tab
+                          // gets a resolved value; others stay undefined
+                          // (loading) until activated. lastSelection is null
+                          // for a session with no turns (settings seed).
+                          restoredSelection={
+                            isActive && tab.runId && sessionChat.chatState
+                              ? sessionChat.chatState.lastSelection
+                              : undefined
+                          }
                           workDirByTab={workDirByTab}
                           onWorkDirChange={setTabWorkDir}
                           isRecording={isRecording}
@@ -7564,6 +7574,9 @@ function App() {
                   }
                 }}
                 getInitialSelection={(tabId) => selectionByTabRef.current.get(chatIdForTab(tabId)) ?? null}
+                restoredSelectionForActive={
+                  runId && sessionChat.chatState ? sessionChat.chatState.lastSelection : undefined
+                }
                 workDirByTab={workDirByTab}
                 onWorkDirChangeForTab={setTabWorkDir}
                 codeSessionLocks={codeSessionLocks}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -15,7 +15,7 @@ import { ChatHeader } from './components/chat-header';
 import { ChatSessionPane, ChatSessionComposer } from './components/chat-session';
 // Value import: the Home to-do surface mounts a standalone composer directly
 // (not tab-bound); chat tabs render theirs through ChatSessionComposer.
-import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment } from './components/chat-input-with-mentions';
+import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from './components/chat-input-with-mentions';
 import { GraphView, type GraphEdge, type GraphNode } from '@/components/graph-view';
 import { BasesView, type BaseConfig, DEFAULT_BASE_CONFIG } from '@/components/bases-view';
 import { ImageFileViewer } from '@/components/image-file-viewer';
@@ -1950,10 +1950,10 @@ function App() {
   })
   const chatViewStateByTabRef = useRef(chatViewStateByTab)
   const chatDraftsRef = useRef(new Map<string, string>())
-  const selectedModelByTabRef = useRef(new Map<string, { provider: string; model: string }>())
-  // Reasoning effort is per-tab, next-turn intent like the model selection —
-  // but unlike model it is never frozen on a run; it applies turn by turn.
-  const reasoningEffortByTabRef = useRef(new Map<string, 'low' | 'medium' | 'high'>())
+  // Per-tab selection (model + effort as ONE value) — the composer reports
+  // every change (settings seed included) and reads it back on remount, so
+  // a tab's selection survives tab switches for the life of the app.
+  const selectionByTabRef = useRef(new Map<string, { provider: string; model: string; effort?: 'low' | 'medium' | 'high' }>())
   // Work directory is per-chat. Keyed by tab id; null/absent means none set.
   const [workDirByTab, setWorkDirByTab] = useState<Record<string, string | null>>({})
   const workDirByTabRef = useRef(workDirByTab)
@@ -3514,7 +3514,7 @@ function App() {
       let currentRunId = runId
       let isNewRun = false
       let newRunCreatedAt: string | null = null
-      const selected = selectedModelByTabRef.current.get(chatIdForTab(submitTabId))
+      const selected = selectionByTabRef.current.get(chatIdForTab(submitTabId))
       if (!currentRunId) {
         const createdSession = await window.ipc.invoke('sessions:create', {})
         currentRunId = createdSession.sessionId
@@ -3540,7 +3540,7 @@ function App() {
       // Per-message turn config. Composition inputs land in the system prompt
       // via the agent resolver; keep them session-sticky where possible so the
       // provider prefix cache survives across turns.
-      const reasoningEffort = reasoningEffortByTabRef.current.get(chatIdForTab(submitTabId))
+      const reasoningEffort = selected?.effort
       // The runtime defaults omitted maxModelCalls to the global limit; the
       // chat-specific override is the UI's job to pass explicitly. A failed
       // settings read just falls back to the global limit.
@@ -3830,8 +3830,11 @@ function App() {
       ...prev,
       [activeChatTabIdRef.current]: createEmptyChatTabViewState(),
     }))
-    // A brand-new chat starts with no work directory.
+    // A brand-new chat starts with no work directory and restarts its
+    // selection from the settings pair (the composer re-seeds when its
+    // runId prop drops to null; clearing here keeps the map in lockstep).
     setWorkDirByTab(prev => ({ ...prev, [activeChatTabIdRef.current]: null }))
+    selectionByTabRef.current.delete(activeChatTabIdRef.current)
   }, [setChatViewportAnchor])
 
   // Chat tab operations
@@ -3954,8 +3957,7 @@ function App() {
       return next
     })
     chatDraftsRef.current.delete(closingChatId)
-    selectedModelByTabRef.current.delete(closingChatId)
-    reasoningEffortByTabRef.current.delete(closingChatId)
+    selectionByTabRef.current.delete(closingChatId)
     chatScrollTopByTabRef.current.delete(tabId)
     setWorkDirByTab((prev) => {
       if (!(tabId in prev)) return prev
@@ -4481,8 +4483,9 @@ function App() {
   // palette: the fresh tab's null runId must be visible to handlePromptSubmit
   // before the message goes out. Model/effort picked on the Home composer are
   // copied onto the fresh tab at flush time.
-  const homeSelectedModelRef = useRef<{ provider: string; model: string } | null>(null)
-  const homeReasoningEffortRef = useRef<'low' | 'medium' | 'high' | null>(null)
+  // The Home composer's selection (model + effort as one value) — handed to
+  // todo:* calls and onto the chat tab a home submit turns into.
+  const homeSelectionRef = useRef<ModelSelection | null>(null)
   // Destination chip: when set, the Home composer writes to the to-do list
   // instead of the chat. Entered via the list's ＋ affordances, announced by
   // the chip + tint, cleared on send/Escape/✕.
@@ -4525,7 +4528,11 @@ function App() {
       const attachments = stagedAttachments.length > 0
         ? stagedAttachments.map((a) => ({ path: a.path, name: a.filename }))
         : undefined
-      const model = homeSelectedModelRef.current ?? undefined
+      // todo:* schemas carry a bare {provider, model} ref today; effort
+      // threading through the todo runner is a follow-up.
+      const model = homeSelectionRef.current
+        ? { provider: homeSelectionRef.current.provider, model: homeSelectionRef.current.model }
+        : undefined
       if (target.kind === 'comment') {
         void window.ipc.invoke('todo:comment', { key: target.key, message: text, attachments, model, permissionMode })
       } else if (target.kind === 'chatReply') {
@@ -4550,8 +4557,7 @@ function App() {
   useEffect(() => {
     if (!pendingHomeSubmit) return
     const tabId = activeChatTabIdRef.current
-    if (homeSelectedModelRef.current) selectedModelByTabRef.current.set(tabId, homeSelectedModelRef.current)
-    if (homeReasoningEffortRef.current) reasoningEffortByTabRef.current.set(tabId, homeReasoningEffortRef.current)
+    if (homeSelectionRef.current) selectionByTabRef.current.set(chatIdForTab(tabId), homeSelectionRef.current)
     void handlePromptSubmitRef.current?.(
       pendingHomeSubmit.message,
       pendingHomeSubmit.mentions,
@@ -6967,8 +6973,7 @@ function App() {
                           runId={null}
                           presetMessage={homeComposerPreset}
                           onPresetMessageConsumed={() => setHomeComposerPreset(undefined)}
-                          onSelectedModelChange={(m) => { homeSelectedModelRef.current = m ?? null }}
-                          onReasoningEffortChange={(effort) => { homeReasoningEffortRef.current = effort ?? null }}
+                          onSelectionChange={(selection) => { homeSelectionRef.current = selection }}
                           workDir={null}
                           focusSignal={homeComposerFocusSignal}
                           contextChip={homeComposeTarget ? {
@@ -7463,8 +7468,14 @@ function App() {
                           codeSessionLocks={codeSessionLocks}
                           initialDraft={chatDraftsRef.current.get(tab.chatId)}
                           onDraftChange={setChatDraftForTab}
-                          selectedModelByTabRef={selectedModelByTabRef}
-                          reasoningEffortByTabRef={reasoningEffortByTabRef}
+                          onSelectionChange={(t, selection) => {
+                            if (selection) {
+                              selectionByTabRef.current.set(t.chatId, selection)
+                            } else {
+                              selectionByTabRef.current.delete(t.chatId)
+                            }
+                          }}
+                          initialSelection={selectionByTabRef.current.get(tab.chatId) ?? null}
                           workDirByTab={workDirByTab}
                           onWorkDirChange={setTabWorkDir}
                           isRecording={isRecording}
@@ -7545,20 +7556,14 @@ function App() {
                 onPresetMessageConsumed={() => setPresetMessage(undefined)}
                 getInitialDraft={(tabId) => chatDraftsRef.current.get(chatIdForTab(tabId))}
                 onDraftChangeForTab={setChatDraftForTab}
-                onSelectedModelChangeForTab={(tabId, m) => {
-                  if (m) {
-                    selectedModelByTabRef.current.set(chatIdForTab(tabId), m)
+                onSelectionChangeForTab={(tabId, selection) => {
+                  if (selection) {
+                    selectionByTabRef.current.set(chatIdForTab(tabId), selection)
                   } else {
-                    selectedModelByTabRef.current.delete(chatIdForTab(tabId))
+                    selectionByTabRef.current.delete(chatIdForTab(tabId))
                   }
                 }}
-                onReasoningEffortChangeForTab={(tabId, effort) => {
-                  if (effort) {
-                    reasoningEffortByTabRef.current.set(chatIdForTab(tabId), effort)
-                  } else {
-                    reasoningEffortByTabRef.current.delete(chatIdForTab(tabId))
-                  }
-                }}
+                getInitialSelection={(tabId) => selectionByTabRef.current.get(chatIdForTab(tabId)) ?? null}
                 workDirByTab={workDirByTab}
                 onWorkDirChangeForTab={setTabWorkDir}
                 codeSessionLocks={codeSessionLocks}

--- a/apps/x/apps/renderer/src/components/bg-tasks-view.tsx
+++ b/apps/x/apps/renderer/src/components/bg-tasks-view.tsx
@@ -930,8 +930,9 @@ function SetupTab({
                                 variant="field"
                                 inheritDefault={{ label: '(global default)' }}
                                 allowCustom
-                                value={modelOverrideToRef(draft.model, draft.provider)}
-                                onChange={(ref) => setDraft({ ...draft, ...refToModelOverride(ref) })}
+                                effortSelectable
+                                value={modelOverrideToRef(draft.model, draft.provider, draft.effort)}
+                                onChange={(selection) => setDraft({ ...draft, ...refToModelOverride(selection) })}
                             />
                         </div>
                         <div className="mt-4">
@@ -1464,6 +1465,7 @@ function TaskDetail({
             if (JSON.stringify(draft.triggers) !== JSON.stringify(task.triggers)) partial.triggers = draft.triggers
             if (draft.model !== task.model) partial.model = draft.model
             if (draft.provider !== task.provider) partial.provider = draft.provider
+            if (draft.effort !== task.effort) partial.effort = draft.effort
             const result = await window.ipc.invoke('bg-task:patch', { slug, partial })
             if (result.success && result.task) {
                 analytics.bgAgentUpdated()

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -242,8 +242,15 @@ interface ChatInputInnerProps {
    * locked-chat effort pick. Never null after the seed resolves.
    */
   onSelectionChange?: (selection: ModelSelection | null) => void
-  /** The chat's prior selection (per-tab continuity / latest-turn restore); seeds the state before the settings default does. */
+  /** The chat's prior selection (per-tab continuity within the app run); seeds the state before anything else. */
   initialSelection?: ModelSelection | null
+  /**
+   * A reopened session's last-turn selection: undefined = session still
+   * loading (hold the settings seed), a value = adopt it, null = session
+   * has no turns (fall through to the settings seed). Ignored once the
+   * selection is set.
+   */
+  restoredSelection?: ModelSelection | null
   /** Work directory for this chat (per-chat). Null when none is set. */
   workDir?: string | null
   /** Fired when the user sets/changes/clears the work directory for this chat. */
@@ -284,6 +291,7 @@ function ChatInputInner({
   callAvailable,
   onSelectionChange,
   initialSelection = null,
+  restoredSelection,
   workDir = null,
   onWorkDirChange,
   codeSessionLock = null,
@@ -579,15 +587,26 @@ function ChatInputInner({
     onSelectionChange?.(next)
   }, [lockedModel, onSelectionChange])
 
-  // Settings seed: a new chat starts on the settings pair, adopted once as
-  // the explicit initial selection when the catalog loads (a snapshot — the
-  // state does not track later settings edits).
+  // Seed order for an unset selection: an existing session restores its
+  // last turn's selection (waiting for the session to load rather than
+  // flashing the settings pair); drafts and no-turn sessions adopt the
+  // settings pair once the catalog delivers it. Either way the result is
+  // ONE explicit snapshot — the state never tracks later settings edits.
   useEffect(() => {
-    if (selection !== null || !defaultModel) return
+    if (selection !== null) return
+    if (runId) {
+      if (restoredSelection === undefined) return
+      if (restoredSelection) {
+        setSelection(restoredSelection)
+        onSelectionChange?.(restoredSelection)
+        return
+      }
+    }
+    if (!defaultModel) return
     const seeded: ModelSelection = { ...defaultModel, ...(defaultEffort ? { effort: defaultEffort } : {}) }
     setSelection(seeded)
     onSelectionChange?.(seeded)
-  }, [selection, defaultModel, defaultEffort, onSelectionChange])
+  }, [selection, runId, restoredSelection, defaultModel, defaultEffort, onSelectionChange])
 
   // "New chat" reuses the tab (and this component instance) in place — the
   // runId dropping back to null is the reset signal: clear the selection so
@@ -1475,6 +1494,7 @@ export interface ChatInputWithMentionsProps {
   callAvailable?: boolean
   onSelectionChange?: (selection: ModelSelection | null) => void
   initialSelection?: ModelSelection | null
+  restoredSelection?: ModelSelection | null
   workDir?: string | null
   onWorkDirChange?: (value: string | null) => void
   /** Set when this chat is bound to a Code-section session — freezes workdir + agent. */
@@ -1517,6 +1537,7 @@ export function ChatInputWithMentions({
   callAvailable,
   onSelectionChange,
   initialSelection,
+  restoredSelection,
   workDir,
   onWorkDirChange,
   codeSessionLock,
@@ -1551,6 +1572,7 @@ export function ChatInputWithMentions({
         callAvailable={callAvailable}
         onSelectionChange={onSelectionChange}
         initialSelection={initialSelection}
+        restoredSelection={restoredSelection}
         workDir={workDir}
         onWorkDirChange={onWorkDirChange}
         codeSessionLock={codeSessionLock}

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -44,7 +44,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { ModelSelector, type ModelRef, type ReasoningEffortLevel } from '@/components/model-selector'
+import { ModelSelector, type ModelRef, type ModelSelection } from '@/components/model-selector'
 import { useModels } from '@/hooks/use-models'
 import {
   type AttachmentIconKind,
@@ -91,8 +91,10 @@ type RecentWorkDir = {
 
 // The picker itself lives in ModelSelector; these aliases keep the composer's
 // public prop surface stable for existing consumers (chat-sidebar, App).
+// SelectedModel is the frozen/locked ref shape; ModelSelection is THE
+// canonical value (ref + effort) the composer holds and reports.
 export type SelectedModel = ModelRef
-export type { ReasoningEffortLevel } from '@/components/model-selector'
+export type { ModelSelection, ReasoningEffortLevel } from '@/components/model-selector'
 
 export type PermissionMode = 'manual' | 'auto'
 
@@ -234,13 +236,14 @@ interface ChatInputInnerProps {
   onEndCall?: () => void
   /** Calls need both voice input (STT) and voice output (TTS) configured. */
   callAvailable?: boolean
-  /** Fired when the user picks a different model in the dropdown (only when no run exists yet). */
-  onSelectedModelChange?: (model: SelectedModel | null) => void
   /**
-   * Fired when the user picks a reasoning effort (null = auto). Unlike model,
-   * effort is never frozen on a run — it applies per turn.
+   * Fired whenever this chat's selection (model + effort, one value)
+   * changes: the settings seed on mount, a picker interaction, or a
+   * locked-chat effort pick. Never null after the seed resolves.
    */
-  onReasoningEffortChange?: (effort: ReasoningEffortLevel | null) => void
+  onSelectionChange?: (selection: ModelSelection | null) => void
+  /** The chat's prior selection (per-tab continuity / latest-turn restore); seeds the state before the settings default does. */
+  initialSelection?: ModelSelection | null
   /** Work directory for this chat (per-chat). Null when none is set. */
   workDir?: string | null
   /** Fired when the user sets/changes/clears the work directory for this chat. */
@@ -279,8 +282,8 @@ function ChatInputInner({
   onStartCall,
   onEndCall,
   callAvailable,
-  onSelectedModelChange,
-  onReasoningEffortChange,
+  onSelectionChange,
+  initialSelection = null,
   workDir = null,
   onWorkDirChange,
   codeSessionLock = null,
@@ -297,11 +300,13 @@ function ChatInputInner({
 
   // Shared model-catalog store (one fetch app-wide); sign-in state also
   // gates search availability below.
-  const { isRowboatConnected, refresh: refreshModels } = useModels()
-  const [selectedModel, setSelectedModel] = useState<SelectedModel | null>(null)
+  const { isRowboatConnected, defaultModel, defaultEffort, refresh: refreshModels } = useModels()
+  // THE chat's selection (model + effort, one value). Initialized from the
+  // tab's prior selection when the caller has one, else seeded once from the
+  // settings pair when the catalog loads; thereafter it changes only on
+  // picker interactions. null only before the seed resolves.
+  const [selection, setSelection] = useState<ModelSelection | null>(initialSelection)
   const [lockedModel, setLockedModel] = useState<SelectedModel | null>(null)
-  // '' = auto. Effort is per-turn config: reported up, never persisted.
-  const [reasoningEffort, setReasoningEffort] = useState<'' | ReasoningEffortLevel>('')
   const [searchEnabled, setSearchEnabled] = useState(false)
   const [searchAvailable, setSearchAvailable] = useState(false)
   const [codingAgent, setCodingAgent] = useState<'claude' | 'codex'>('claude')
@@ -343,7 +348,7 @@ function ChatInputInner({
   // no-dep effect below still re-collapses if any toggle happens to widen the row.
   useLayoutEffect(() => {
     setCollapseLevel(0)
-  }, [workDir, searchAvailable, codeModeFeatureEnabled, lockedModel, selectedModel])
+  }, [workDir, searchAvailable, codeModeFeatureEnabled, lockedModel, selection])
 
   // After each render, if the left group still overflows, collapse one more step.
   // Runs before paint, so the intermediate (overflowing) state is never visible.
@@ -559,26 +564,43 @@ function ChatInputInner({
     checkSearch()
   }, [isActive, isRowboatConnected])
 
-  // Selecting a model here is PER-CHAT: it affects the next run created
-  // from this tab (frozen once a run exists) and nothing else. The config's
-  // assistantModel is the durable default — new tabs and background work
-  // always start from it, and only the settings Assistant picker (or a
-  // provider connect's initial selection) writes it.
-  const handleModelChange = useCallback((model: SelectedModel | null) => {
-    if (lockedModel) return
+  // Selecting here is PER-CHAT: it affects the next run created from this
+  // tab and nothing else. The config's assistantModel is the durable
+  // default — new tabs and background work always start from it, and only
+  // the settings Assistant picker (or a provider connect's initial
+  // selection) writes it. On a locked chat the model is frozen but the
+  // picker still commits effort-only selections carrying the locked ref.
+  const handleSelectionChange = useCallback((next: ModelSelection | null) => {
     // null = the sentinel row, which the composer never renders (no
     // defaultOption) — guard for the widened onChange contract only.
-    if (!model) return
-    setSelectedModel(model)
-    onSelectedModelChange?.(model)
-  }, [lockedModel, onSelectedModelChange])
+    if (!next) return
+    if (lockedModel && next.model !== lockedModel.model) return
+    setSelection(next)
+    onSelectionChange?.(next)
+  }, [lockedModel, onSelectionChange])
 
-  // Effort is per-turn and unpersisted; ModelSelector reports '' when the
-  // effective model loses reasoning support so a stale effort never sticks.
-  const handleReasoningEffortChange = useCallback((effort: '' | ReasoningEffortLevel) => {
-    setReasoningEffort(effort)
-    onReasoningEffortChange?.(effort === '' ? null : effort)
-  }, [onReasoningEffortChange])
+  // Settings seed: a new chat starts on the settings pair, adopted once as
+  // the explicit initial selection when the catalog loads (a snapshot — the
+  // state does not track later settings edits).
+  useEffect(() => {
+    if (selection !== null || !defaultModel) return
+    const seeded: ModelSelection = { ...defaultModel, ...(defaultEffort ? { effort: defaultEffort } : {}) }
+    setSelection(seeded)
+    onSelectionChange?.(seeded)
+  }, [selection, defaultModel, defaultEffort, onSelectionChange])
+
+  // "New chat" reuses the tab (and this component instance) in place — the
+  // runId dropping back to null is the reset signal: clear the selection so
+  // the seed effect above restarts it from the CURRENT settings pair.
+  const prevRunIdRef = useRef(runId)
+  useEffect(() => {
+    const prev = prevRunIdRef.current
+    prevRunIdRef.current = runId
+    if (prev && !runId) {
+      setSelection(null)
+      onSelectionChange?.(null)
+    }
+  }, [runId, onSelectionChange])
 
   // Restore the tab draft when this input mounts.
   useEffect(() => {
@@ -1208,11 +1230,10 @@ function ChatInputInner({
         )}
         <div className="flex-1" />
         <ModelSelector
-          value={selectedModel}
-          onChange={handleModelChange}
+          value={selection}
+          onChange={handleSelectionChange}
           lockedModel={lockedModel}
-          effort={reasoningEffort}
-          onEffortChange={handleReasoningEffortChange}
+          effortSelectable
         />
         {onStartCall && (
           <div className="flex shrink-0 items-center">
@@ -1452,8 +1473,8 @@ export interface ChatInputWithMentionsProps {
   onStartCall?: (preset: CallPreset) => void
   onEndCall?: () => void
   callAvailable?: boolean
-  onSelectedModelChange?: (model: SelectedModel | null) => void
-  onReasoningEffortChange?: (effort: ReasoningEffortLevel | null) => void
+  onSelectionChange?: (selection: ModelSelection | null) => void
+  initialSelection?: ModelSelection | null
   workDir?: string | null
   onWorkDirChange?: (value: string | null) => void
   /** Set when this chat is bound to a Code-section session — freezes workdir + agent. */
@@ -1494,8 +1515,8 @@ export function ChatInputWithMentions({
   onStartCall,
   onEndCall,
   callAvailable,
-  onSelectedModelChange,
-  onReasoningEffortChange,
+  onSelectionChange,
+  initialSelection,
   workDir,
   onWorkDirChange,
   codeSessionLock,
@@ -1528,8 +1549,8 @@ export function ChatInputWithMentions({
         onStartCall={onStartCall}
         onEndCall={onEndCall}
         callAvailable={callAvailable}
-        onSelectedModelChange={onSelectedModelChange}
-        onReasoningEffortChange={onReasoningEffortChange}
+        onSelectionChange={onSelectionChange}
+        initialSelection={initialSelection}
         workDir={workDir}
         onWorkDirChange={onWorkDirChange}
         codeSessionLock={codeSessionLock}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -36,7 +36,7 @@ import { useSmoothedText } from '@/hooks/useSmoothedText'
 import type { useVoiceMode } from '@/hooks/useVoiceMode'
 import type { PermissionDecision } from '@x/shared/src/code-mode.js'
 import { ChatEmptyState } from './chat-empty-state'
-import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from './chat-input-with-mentions'
+import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from './chat-input-with-mentions'
 import { type ChatTab } from './tab-bar'
 import { useReportTabMeta } from '@/lib/tab-meta'
 import { useSessionTitle } from '@/lib/session-title'
@@ -516,14 +516,14 @@ export interface ChatSessionComposerProps {
   codeSessionLocks: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
   initialDraft: string | undefined
   onDraftChange: (tabId: string, text: string) => void
-  /** Ref-style model tracking keyed by chatId (App). Either this or onSelectedModelChange. */
-  selectedModelByTabRef?: React.RefObject<Map<string, { provider: string; model: string }>>
-  /** Ref-style effort tracking keyed by chatId (App). Either this or onReasoningEffortChange. */
-  reasoningEffortByTabRef?: React.RefObject<Map<string, 'low' | 'medium' | 'high'>>
-  /** Callback-style model reporting (side-pane chat); receives the tab so the caller picks its key. */
-  onSelectedModelChange?: (tab: ChatTab, model: SelectedModel | null) => void
-  /** Callback-style effort reporting (side-pane chat). */
-  onReasoningEffortChange?: (tab: ChatTab, effort: ReasoningEffortLevel | null) => void
+  /**
+   * The chat's selection (model + effort, ONE value — see the composer's
+   * ModelSelection contract) reported on every change, settings seed
+   * included; receives the tab so the caller picks its key (chatId).
+   */
+  onSelectionChange?: (tab: ChatTab, selection: ModelSelection | null) => void
+  /** The chat's prior selection (per-tab continuity / latest-turn restore). */
+  initialSelection?: ModelSelection | null
   workDirByTab: Record<string, string | null>
   onWorkDirChange: (tabId: string, value: string | null) => void
   isRecording?: boolean
@@ -568,10 +568,8 @@ export function ChatSessionComposer({
   codeSessionLocks,
   initialDraft,
   onDraftChange,
-  selectedModelByTabRef,
-  reasoningEffortByTabRef,
-  onSelectedModelChange,
-  onReasoningEffortChange,
+  onSelectionChange,
+  initialSelection = null,
   workDirByTab,
   onWorkDirChange,
   isRecording,
@@ -610,26 +608,8 @@ export function ChatSessionComposer({
         codeSessionLock={tabState.runId ? codeSessionLocks[tabState.runId] ?? null : null}
         initialDraft={initialDraft}
         onDraftChange={(text) => onDraftChange(tab.id, text)}
-        onSelectedModelChange={(m) => {
-          if (selectedModelByTabRef) {
-            if (m) {
-              selectedModelByTabRef.current.set(tab.chatId, m)
-            } else {
-              selectedModelByTabRef.current.delete(tab.chatId)
-            }
-          }
-          onSelectedModelChange?.(tab, m)
-        }}
-        onReasoningEffortChange={(effort) => {
-          if (reasoningEffortByTabRef) {
-            if (effort) {
-              reasoningEffortByTabRef.current.set(tab.chatId, effort)
-            } else {
-              reasoningEffortByTabRef.current.delete(tab.chatId)
-            }
-          }
-          onReasoningEffortChange?.(tab, effort)
-        }}
+        onSelectionChange={(selection) => onSelectionChange?.(tab, selection)}
+        initialSelection={initialSelection}
         workDir={workDirByTab[tab.id] ?? null}
         onWorkDirChange={(v) => onWorkDirChange(tab.id, v)}
         isRecording={recordingOverrides ? recordingOverrides.isRecording : (isRecording && ownsVoice)}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -522,8 +522,10 @@ export interface ChatSessionComposerProps {
    * included; receives the tab so the caller picks its key (chatId).
    */
   onSelectionChange?: (tab: ChatTab, selection: ModelSelection | null) => void
-  /** The chat's prior selection (per-tab continuity / latest-turn restore). */
+  /** The chat's prior selection (per-tab continuity within the app run). */
   initialSelection?: ModelSelection | null
+  /** A reopened session's last-turn selection (see the composer prop). */
+  restoredSelection?: ModelSelection | null
   workDirByTab: Record<string, string | null>
   onWorkDirChange: (tabId: string, value: string | null) => void
   isRecording?: boolean
@@ -570,6 +572,7 @@ export function ChatSessionComposer({
   onDraftChange,
   onSelectionChange,
   initialSelection = null,
+  restoredSelection,
   workDirByTab,
   onWorkDirChange,
   isRecording,
@@ -610,6 +613,7 @@ export function ChatSessionComposer({
         onDraftChange={(text) => onDraftChange(tab.id, text)}
         onSelectionChange={(selection) => onSelectionChange?.(tab, selection)}
         initialSelection={initialSelection}
+        restoredSelection={restoredSelection}
         workDir={workDirByTab[tab.id] ?? null}
         onWorkDirChange={(v) => onWorkDirChange(tab.id, v)}
         isRecording={recordingOverrides ? recordingOverrides.isRecording : (isRecording && ownsVoice)}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -8,7 +8,7 @@ import { ChatHeader } from '@/components/chat-header'
 import { type PromptInputMessage, type FileMention } from '@/components/ai-elements/prompt-input'
 import { FileCardProvider } from '@/contexts/file-card-context'
 import { type ChatTab } from '@/components/tab-bar'
-import { type CallPreset, type PermissionMode, type StagedAttachment, type SelectedModel, type ReasoningEffortLevel } from '@/components/chat-input-with-mentions'
+import { type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from '@/components/chat-input-with-mentions'
 import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
 import { useTabMeta } from '@/lib/tab-meta'
 import { useSidebar } from '@/components/ui/sidebar'
@@ -83,8 +83,8 @@ interface ChatSidebarProps {
   onPresetMessageConsumed?: () => void
   getInitialDraft?: (tabId: string) => string | undefined
   onDraftChangeForTab?: (tabId: string, text: string) => void
-  onSelectedModelChangeForTab?: (tabId: string, model: SelectedModel | null) => void
-  onReasoningEffortChangeForTab?: (tabId: string, effort: ReasoningEffortLevel | null) => void
+  onSelectionChangeForTab?: (tabId: string, selection: ModelSelection | null) => void
+  getInitialSelection?: (tabId: string) => ModelSelection | null
   workDirByTab?: Record<string, string | null>
   /** Composer locks for runs bound to Code-section sessions (cwd + agent frozen). */
   codeSessionLocks?: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
@@ -155,8 +155,8 @@ export function ChatSidebar({
   onPresetMessageConsumed,
   getInitialDraft,
   onDraftChangeForTab,
-  onSelectedModelChangeForTab,
-  onReasoningEffortChangeForTab,
+  onSelectionChangeForTab,
+  getInitialSelection,
   workDirByTab = {},
   codeSessionLocks = {},
   pinnedToCodeSession = null,
@@ -467,8 +467,8 @@ export function ChatSidebar({
                         codeSessionLocks={codeSessionLocks}
                         initialDraft={getInitialDraft?.(tab.id)}
                         onDraftChange={(tabId, text) => onDraftChangeForTab?.(tabId, text)}
-                        onSelectedModelChange={(t, m) => onSelectedModelChangeForTab?.(t.id, m)}
-                        onReasoningEffortChange={(t, effort) => onReasoningEffortChangeForTab?.(t.id, effort)}
+                        onSelectionChange={(t, selection) => onSelectionChangeForTab?.(t.id, selection)}
+                        initialSelection={getInitialSelection?.(tab.id) ?? null}
                         workDirByTab={workDirByTab}
                         onWorkDirChange={(tabId, v) => onWorkDirChangeForTab?.(tabId, v)}
                         recordingOverrides={{

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -85,6 +85,8 @@ interface ChatSidebarProps {
   onDraftChangeForTab?: (tabId: string, text: string) => void
   onSelectionChangeForTab?: (tabId: string, selection: ModelSelection | null) => void
   getInitialSelection?: (tabId: string) => ModelSelection | null
+  /** Last-turn selection for the ACTIVE tab's session (single store — see App). */
+  restoredSelectionForActive?: ModelSelection | null
   workDirByTab?: Record<string, string | null>
   /** Composer locks for runs bound to Code-section sessions (cwd + agent frozen). */
   codeSessionLocks?: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
@@ -157,6 +159,7 @@ export function ChatSidebar({
   onDraftChangeForTab,
   onSelectionChangeForTab,
   getInitialSelection,
+  restoredSelectionForActive,
   workDirByTab = {},
   codeSessionLocks = {},
   pinnedToCodeSession = null,
@@ -469,6 +472,7 @@ export function ChatSidebar({
                         onDraftChange={(tabId, text) => onDraftChangeForTab?.(tabId, text)}
                         onSelectionChange={(t, selection) => onSelectionChangeForTab?.(t.id, selection)}
                         initialSelection={getInitialSelection?.(tab.id) ?? null}
+                        restoredSelection={isActive ? restoredSelectionForActive : undefined}
                         workDirByTab={workDirByTab}
                         onWorkDirChange={(tabId, v) => onWorkDirChangeForTab?.(tabId, v)}
                         recordingOverrides={{

--- a/apps/x/apps/renderer/src/components/live-note-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/live-note-sidebar.tsx
@@ -611,8 +611,9 @@ function DetailsTab({
                 variant="field"
                 inheritDefault={{ label: '(global default)' }}
                 allowCustom
-                value={modelOverrideToRef(draft.model, draft.provider)}
-                onChange={(ref) => setDraft({ ...draft, ...refToModelOverride(ref) })}
+                effortSelectable
+                value={modelOverrideToRef(draft.model, draft.provider, draft.effort)}
+                onChange={(selection) => setDraft({ ...draft, ...refToModelOverride(selection) })}
               />
             </div>
             <div className="mt-4">

--- a/apps/x/apps/renderer/src/components/model-selector.tsx
+++ b/apps/x/apps/renderer/src/components/model-selector.tsx
@@ -1,14 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { createPortal } from 'react-dom'
 import { Brain, Check, ChevronDown } from 'lucide-react'
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
   Command,
@@ -17,10 +11,10 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command'
-import { useModels, type ModelPickerGroup, type ModelRef } from '@/hooks/use-models'
+import { useModels, type ModelPickerGroup, type ModelRef, type ModelSelection } from '@/hooks/use-models'
 import { cn } from '@/lib/utils'
 
-export type { ModelRef } from '@/hooks/use-models'
+export type { ModelRef, ModelSelection } from '@/hooks/use-models'
 
 export type ReasoningEffortLevel = 'low' | 'medium' | 'high'
 
@@ -41,12 +35,38 @@ export const providerDisplayNames: Record<string, string> = {
 }
 
 // '' = auto (provider default). Ordered as shown in the picker.
-const REASONING_EFFORT_OPTIONS: Array<{ value: '' | ReasoningEffortLevel; label: string; hint: string }> = [
-  { value: '', label: 'Auto', hint: 'Provider default' },
-  { value: 'low', label: 'Fast', hint: 'Minimal thinking' },
-  { value: 'medium', label: 'Balanced', hint: 'Moderate thinking' },
-  { value: 'high', label: 'Thorough', hint: 'Deep thinking, costs more' },
+// `short` is the compact form shown inline after the model name (trigger
+// pill and list rows), hermes-style ("Fable 5 Med"); Auto renders nothing.
+const REASONING_EFFORT_OPTIONS: Array<{ value: '' | ReasoningEffortLevel; label: string; short: string; hint: string }> = [
+  { value: '', label: 'Auto', short: '', hint: 'Provider default' },
+  { value: 'low', label: 'Fast', short: 'Fast', hint: 'Minimal thinking' },
+  { value: 'medium', label: 'Balanced', short: 'Bal', hint: 'Moderate thinking' },
+  { value: 'high', label: 'Thorough', short: 'Thoro', hint: 'Deep thinking, costs more' },
 ]
+
+// Effort submenu panel geometry (px). Width matches hermes' w-52 submenu;
+// the height estimate only feeds the viewport clamp, not layout.
+const SUB_PANEL_WIDTH = 208
+const SUB_PANEL_GAP = 4
+const SUB_PANEL_EST_HEIGHT = 180
+// How long the grace triangle stays armed after leaving the anchor row.
+// Radix menus keep theirs alive while the pointer stays inside the polygon;
+// a generous expiry approximates that without per-move re-arming.
+const SUB_GRACE_MS = 500
+
+interface Point { x: number; y: number }
+
+// Standard sign-based point-in-triangle test.
+function pointInTriangle(p: Point, a: Point, b: Point, c: Point): boolean {
+  const sign = (p1: Point, p2: Point, p3: Point) =>
+    (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y)
+  const d1 = sign(p, a, b)
+  const d2 = sign(p, b, c)
+  const d3 = sign(p, c, a)
+  const hasNeg = d1 < 0 || d2 < 0 || d3 < 0
+  const hasPos = d1 > 0 || d2 > 0 || d3 > 0
+  return !(hasNeg && hasPos)
+}
 
 function getModelDisplayName(model: string) {
   return model.split('/').pop() || model
@@ -65,10 +85,18 @@ function getModelDisplayName(model: string) {
 // collapses to one flat list filtered across ALL providers (model ids and
 // provider names both match). Scoped/static pickers stay flat.
 export interface ModelSelectorProps {
-  /** Current selection; null follows the app default / the sentinel. */
-  value: ModelRef | null
-  /** null only ever fires when defaultOption is set (sentinel picked). */
-  onChange: (value: ModelRef | null) => void
+  /**
+   * Current selection — model AND effort as one value (effort absent =
+   * Auto); null follows the app default / the sentinel.
+   */
+  value: ModelSelection | null
+  /**
+   * Fires with the complete selection on every commit: a plain row click
+   * carries no effort (Auto), an effort-submenu click carries its level,
+   * and on a locked chat an effort pick re-fires the locked ref with the
+   * new effort. null only ever fires when a sentinel row is picked.
+   */
+  onChange: (value: ModelSelection | null) => void
   /**
    * Pinned top entry ("Same as Assistant") that selects null. When set, a
    * null value renders this label instead of the app default model.
@@ -115,13 +143,14 @@ export interface ModelSelectorProps {
   /** Frozen selection: renders a static label + tooltip instead of the dropdown. */
   lockedModel?: ModelRef | null
   /**
-   * Reasoning effort ('' = auto). The control renders only for models the
-   * catalog flags as reasoning-capable. When the effective model loses
-   * reasoning support, '' is reported up so a stale effort never outlives
-   * its model. Omit onEffortChange to hide the effort control entirely.
+   * Enables the effort submenu: hovering a reasoning-capable model row
+   * opens a side panel (hermes-style) listing effort levels — clicking one
+   * commits that model AND effort in one shot; clicking the row itself
+   * commits the model with effort Auto. The committed pair arrives via
+   * onChange. Works in both pill and field variants; on locked chats the
+   * frozen model still allows effort-only picks.
    */
-  effort?: '' | ReasoningEffortLevel
-  onEffortChange?: (effort: '' | ReasoningEffortLevel) => void
+  effortSelectable?: boolean
 }
 
 // cmdk item value for the defaultOption sentinel row. Never a valid model
@@ -141,17 +170,28 @@ function parseCustomModel(text: string, providerFilter: string | undefined, defa
   return { provider: defaultModel?.provider ?? '', model: text }
 }
 
-// Adapters for surfaces that persist a per-item override as two optional
-// strings (BackgroundTask.model/provider, LiveNote.model/provider) where
-// unset = inherit the global default. A model without a provider is legal
-// (the runtime pairs it with the default provider), so '' round-trips to
-// undefined and a null ref clears both fields.
-export function modelOverrideToRef(model: string | undefined, provider: string | undefined): ModelRef | null {
-  return model ? { provider: provider ?? '', model } : null
+// Adapters for surfaces that persist a per-item override as optional
+// strings (BackgroundTask.model/provider/effort, LiveNote equivalents)
+// where unset = inherit the global default. A model without a provider is
+// legal (the runtime pairs it with the default provider), so '' round-trips
+// to undefined and a null ref clears every field — effort included, since
+// model and effort are one explicit pair.
+export function modelOverrideToRef(
+  model: string | undefined,
+  provider: string | undefined,
+  effort?: ReasoningEffortLevel,
+): ModelSelection | null {
+  return model ? { provider: provider ?? '', model, ...(effort ? { effort } : {}) } : null
 }
 
-export function refToModelOverride(ref: ModelRef | null): { model: string | undefined; provider: string | undefined } {
-  return { model: ref?.model || undefined, provider: ref?.provider || undefined }
+export function refToModelOverride(
+  selection: ModelSelection | null,
+): { model: string | undefined; provider: string | undefined; effort: ReasoningEffortLevel | undefined } {
+  return {
+    model: selection?.model || undefined,
+    provider: selection?.provider || undefined,
+    effort: selection?.model ? selection.effort : undefined,
+  }
 }
 
 export function ModelSelector({
@@ -165,8 +205,7 @@ export function ModelSelector({
   staticOptions,
   triggerTitle,
   lockedModel = null,
-  effort = '',
-  onEffortChange,
+  effortSelectable = false,
 }: ModelSelectorProps) {
   const { groups: allGroups, reasoningByKey, defaultModel, catalogByProvider, refresh } = useModels()
 
@@ -206,8 +245,70 @@ export function ModelSelector({
     ? (groups.find((g) => g.id === activeProviderId) ?? groups[0])
     : null
 
+  // Hover-opened effort submenu (hermes-style): one floating panel anchored
+  // to the hovered model row, portalled to <body> because PopoverContent is
+  // overflow-hidden. Position is captured from the row's rect at open time;
+  // list scroll and query changes close it rather than tracking movement.
+  const [sub, setSub] = useState<{ key: string; provider: string; model: string; top: number; left: number } | null>(null)
+  const subPanelRef = useRef<HTMLDivElement | null>(null)
+  const subCloseTimer = useRef<number | null>(null)
+  const cancelSubClose = useCallback(() => {
+    if (subCloseTimer.current !== null) {
+      window.clearTimeout(subCloseTimer.current)
+      subCloseTimer.current = null
+    }
+  }, [])
+  // Delayed close so the pointer can travel row → panel without flicker
+  // (generous enough to cover a slow diagonal through the grace triangle).
+  const scheduleSubClose = useCallback(() => {
+    cancelSubClose()
+    subCloseTimer.current = window.setTimeout(() => setSub(null), 300)
+  }, [cancelSubClose])
+  useEffect(() => cancelSubClose, [cancelSubClose])
+  // Grace-intent triangle (what Radix DropdownMenuSub does natively): when
+  // the pointer leaves the anchor row heading toward its open panel, the
+  // triangle between the exit point and the panel's near edge is a dead
+  // zone — rows crossed inside it neither re-anchor nor close the panel.
+  // Without this, a diagonal move toward the panel sweeps the submenu onto
+  // the row below (the bug hermes never sees because Radix handles it).
+  const graceRef = useRef<{ apex: Point; top: Point; bottom: Point; expires: number } | null>(null)
+  const inGraceArea = useCallback((x: number, y: number) => {
+    const g = graceRef.current
+    if (!g) return false
+    if (performance.now() > g.expires) {
+      graceRef.current = null
+      return false
+    }
+    return pointInTriangle({ x, y }, g.apex, g.top, g.bottom)
+  }, [])
+  const armGrace = useCallback((x: number, y: number) => {
+    const rect = subPanelRef.current?.getBoundingClientRect()
+    if (!rect) return
+    // The panel edge facing the rows, padded a little vertically so the
+    // triangle isn't razor-thin at the corners.
+    const nearX = x <= rect.left ? rect.left : rect.right
+    graceRef.current = {
+      apex: { x, y },
+      top: { x: nearX, y: rect.top - 8 },
+      bottom: { x: nearX, y: rect.bottom + 8 },
+      expires: performance.now() + SUB_GRACE_MS,
+    }
+  }, [])
+  const openSub = useCallback((row: HTMLElement, provider: string, model: string) => {
+    cancelSubClose()
+    const rect = row.getBoundingClientRect()
+    // Right of the row, flipped left when the viewport edge is close; top
+    // clamped so the panel never renders off-screen.
+    const left = rect.right + SUB_PANEL_GAP + SUB_PANEL_WIDTH > window.innerWidth
+      ? rect.left - SUB_PANEL_WIDTH - SUB_PANEL_GAP
+      : rect.right + SUB_PANEL_GAP
+    const top = Math.max(8, Math.min(rect.top, window.innerHeight - SUB_PANEL_EST_HEIGHT - 8))
+    setSub({ key: `${provider}/${model}`, provider, model, top, left })
+  }, [cancelSubClose])
+
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next)
+    setSub(null)
     if (next) {
       // Per-opening state: fresh search, provider column on the selection's
       // (else the assistant's) provider — groups[0] is already the
@@ -222,6 +323,7 @@ export function ModelSelector({
   // Switch the split view's provider column and re-anchor the keyboard
   // highlight on the new group's first row (see commandValue above).
   const switchProvider = useCallback((g: ModelPickerGroup) => {
+    setSub(null)
     setActiveProviderId(g.id)
     setCommandValue(
       g.models.length > 0
@@ -269,10 +371,14 @@ export function ModelSelector({
       ? DEFAULT_OPTION_KEY
       : (defaultModel ? `${defaultModel.provider}/${defaultModel.model}` : '')
 
-  const select = useCallback((ref: ModelRef | null) => {
+  // Model and effort commit together as ONE value: a plain row click means
+  // Auto (no effort key), an effort-submenu click carries its level — so
+  // switching models never drags a stale effort along.
+  const select = useCallback((ref: ModelRef | null, effortLevel: '' | ReasoningEffortLevel = '') => {
     if (lockedModel) return
+    setSub(null)
     setOpen(false)
-    onChange(ref)
+    onChange(ref ? { ...ref, ...(effortLevel ? { effort: effortLevel } : {}) } : null)
   }, [lockedModel, onChange])
 
   // Reasoning effort applies to the model the next message will actually use:
@@ -283,31 +389,145 @@ export function ModelSelector({
     : (value ? `${value.provider}/${value.model}` : '')
       || (defaultModel ? `${defaultModel.provider}/${defaultModel.model}` : '')
   const reasoningAvailable = reasoningByKey[effectiveModelKey] === true
+  const effortControl = reasoningAvailable && effortSelectable
+  // The effort shown on the trigger and ticked in panels — always the
+  // value's own effort. A stale effort on a non-reasoning model is not
+  // auto-cleared here: the pair semantics make it unreachable via the UI,
+  // and the runtime's capability mapping fails closed anyway.
+  const shownEffort: '' | ReasoningEffortLevel = value?.effort ?? ''
 
-  const handleEffortChange = useCallback((raw: string) => {
-    onEffortChange?.(raw === 'low' || raw === 'medium' || raw === 'high' ? raw : '')
-  }, [onEffortChange])
+  // Effort radio row for the locked-model popover only (model frozen, effort
+  // still adjustable): commits the locked ref with the new effort as one
+  // selection. The main picker uses the per-row hover submenu instead.
+  const renderEffortFooter = () => effortControl && lockedModel && (
+    <div className="flex items-center justify-between gap-2 border-t px-3 py-2">
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Brain className="h-3 w-3 shrink-0" />
+        Reasoning
+      </span>
+      <div className="flex items-center gap-0.5">
+        {REASONING_EFFORT_OPTIONS.map((option) => (
+          <button
+            key={option.value || 'auto'}
+            type="button"
+            title={option.hint}
+            onClick={() => onChange({
+              provider: lockedModel.provider,
+              model: lockedModel.model,
+              ...(option.value ? { effort: option.value } : {}),
+            })}
+            className={cn(
+              'rounded-full px-2 py-0.5 text-xs transition-colors',
+              shownEffort === option.value
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
 
-  // Switching to a model without reasoning support drops a stale selection —
-  // otherwise the next message would carry an effort the model rejects.
-  useEffect(() => {
-    if (!reasoningAvailable && effort !== '') {
-      onEffortChange?.('')
-    }
-  }, [reasoningAvailable, effort, onEffortChange])
+  // Non-auto effort surfaces on the trigger the same way the list rows show
+  // it: model name followed by the grayed short form ("claude-fable-5 Thoro").
+  const renderEffortBadge = () => effortControl && shownEffort !== '' && (
+    <span className="shrink-0 text-xs text-muted-foreground">
+      {REASONING_EFFORT_OPTIONS.find((o) => o.value === shownEffort)?.short}
+    </span>
+  )
 
   const renderModelItem = (providerId: string, model: string, secondary?: string) => {
     const key = `${providerId}/${model}`
+    // Hovering a reasoning-capable row opens the effort submenu (hermes
+    // pattern); hovering any other row schedules it closed so the panel
+    // always tracks the row under the pointer. Both re-check on every move
+    // (not just enter) so a pointer that parks on a row past the grace
+    // expiry still takes effect without needing to re-enter the row.
+    const canEffort = effortSelectable && reasoningByKey[key] === true
+    const isSelected = selectedKey === key
+    const onHover = canEffort
+      ? (e: ReactMouseEvent<HTMLDivElement>) => {
+          if (inGraceArea(e.clientX, e.clientY)) return
+          graceRef.current = null
+          if (sub?.key === key) {
+            cancelSubClose()
+            return
+          }
+          openSub(e.currentTarget, providerId, model)
+        }
+      : (e: ReactMouseEvent<HTMLDivElement>) => {
+          if (inGraceArea(e.clientX, e.clientY)) return
+          scheduleSubClose()
+        }
     return (
       <CommandItem
         key={key}
         value={key}
         onSelect={() => select({ provider: providerId, model })}
+        onMouseEnter={onHover}
+        onMouseMove={onHover}
+        onMouseLeave={canEffort
+          ? (e) => {
+              // Arm the dead zone toward the open panel, then let the close
+              // timer race the pointer's travel (panel entry cancels it).
+              if (sub?.key === key) armGrace(e.clientX, e.clientY)
+              scheduleSubClose()
+            }
+          : undefined}
       >
-        <Check className={cn('size-3.5 shrink-0', selectedKey === key ? 'opacity-100' : 'opacity-0')} />
+        <Check className={cn('size-3.5 shrink-0', isSelected ? 'opacity-100' : 'opacity-0')} />
         <span className="truncate">{model}</span>
+        {isSelected && canEffort && shownEffort !== '' && (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {REASONING_EFFORT_OPTIONS.find((o) => o.value === shownEffort)?.short}
+          </span>
+        )}
         {secondary && <span className="ml-auto shrink-0 text-xs text-muted-foreground">{secondary}</span>}
       </CommandItem>
+    )
+  }
+
+  // The floating effort panel. Portalled to <body> (PopoverContent clips);
+  // the popover is modal, so pointer-events must be re-enabled explicitly
+  // and PopoverContent's onInteractOutside must ignore clicks landing here.
+  const renderEffortSubPanel = () => {
+    if (!open || !sub) return null
+    // The panel's ticked level: the value's own effort for the currently
+    // selected model, and Auto — the level a plain row click commits — for
+    // any other row, mirroring hermes' per-model default pre-selection.
+    const subEffort = selectedKey === sub.key ? shownEffort : ''
+    return createPortal(
+      <div
+        ref={subPanelRef}
+        style={{ position: 'fixed', top: sub.top, left: sub.left, width: SUB_PANEL_WIDTH, pointerEvents: 'auto' }}
+        className="z-50 rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+        onMouseEnter={() => {
+          graceRef.current = null
+          cancelSubClose()
+        }}
+        onMouseLeave={scheduleSubClose}
+      >
+        <div className="px-2 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Effort
+        </div>
+        {REASONING_EFFORT_OPTIONS.map((option) => (
+          <button
+            key={option.value || 'auto'}
+            type="button"
+            title={option.hint}
+            onClick={() => select({ provider: sub.provider, model: sub.model }, option.value)}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+          >
+            <span className="min-w-0 flex-1 truncate">{option.label}</span>
+            {subEffort === option.value && (
+              <Check className="size-3.5 shrink-0" />
+            )}
+          </button>
+        ))}
+      </div>,
+      document.body,
     )
   }
 
@@ -332,57 +552,50 @@ export function ModelSelector({
     </CommandItem>
   )
 
+  if (lockedModel) {
+    // The model is frozen but effort (per-message) is still adjustable: the
+    // locked label becomes a popover holding just the effort row. Without an
+    // effort control it stays the old static label + tooltip.
+    return effortControl ? (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="flex h-7 min-w-0 items-center gap-1 rounded-full px-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <span className="min-w-0 truncate text-foreground/80">{getModelDisplayName(lockedModel.model)}</span>
+            {renderEffortBadge()}
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-72 p-0 overflow-hidden">
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            {providerDisplayNames[lockedModel.provider] || lockedModel.provider} — model is fixed for this chat
+          </div>
+          {renderEffortFooter()}
+        </PopoverContent>
+      </Popover>
+    ) : (
+      <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
+        <TooltipTrigger asChild>
+          <span className="flex h-7 min-w-0 items-center gap-1 rounded-full px-2 text-xs text-muted-foreground">
+            <span className="min-w-0 truncate">{getModelDisplayName(lockedModel.model)}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {providerDisplayNames[lockedModel.provider] || lockedModel.provider} — fixed for this chat
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  // modal: the settings Dialog's scroll-lock cancels wheel events over
+  // content portalled outside its subtree — a modal popover brings its
+  // own lock layer that permits scrolling within (Radix's supported
+  // fix for popover-inside-dialog; matches the old DropdownMenu's
+  // modality). Keyboard scrolling was never affected (cmdk uses
+  // programmatic scrollIntoView).
   return (
-    <>
-      {reasoningAvailable && onEffortChange && (
-        <DropdownMenu>
-          <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="flex h-7 shrink-0 items-center gap-1 rounded-full px-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  <Brain className="h-3 w-3 shrink-0" />
-                  {effort !== '' && (
-                    <span>{REASONING_EFFORT_OPTIONS.find((o) => o.value === effort)?.label}</span>
-                  )}
-                  <ChevronDown className="h-3 w-3 shrink-0" />
-                </button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="top">Reasoning effort — applies to your next message</TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="end">
-            <DropdownMenuRadioGroup value={effort} onValueChange={handleEffortChange}>
-              {REASONING_EFFORT_OPTIONS.map((option) => (
-                <DropdownMenuRadioItem key={option.value || 'auto'} value={option.value}>
-                  <span>{option.label}</span>
-                  <span className="ml-2 text-xs text-muted-foreground">{option.hint}</span>
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-      {lockedModel ? (
-        <Tooltip delayDuration={TOOLTIP_DELAY_MS}>
-          <TooltipTrigger asChild>
-            <span className="flex h-7 min-w-0 items-center gap-1 rounded-full px-2 text-xs text-muted-foreground">
-              <span className="min-w-0 truncate">{getModelDisplayName(lockedModel.model)}</span>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            {providerDisplayNames[lockedModel.provider] || lockedModel.provider} — fixed for this chat
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        // modal: the settings Dialog's scroll-lock cancels wheel events over
-        // content portalled outside its subtree — a modal popover brings its
-        // own lock layer that permits scrolling within (Radix's supported
-        // fix for popover-inside-dialog; matches the old DropdownMenu's
-        // modality). Keyboard scrolling was never affected (cmdk uses
-        // programmatic scrollIntoView).
         <Popover open={open} onOpenChange={handleOpenChange} modal>
           <PopoverTrigger asChild>
             {variant === 'field' ? (
@@ -399,6 +612,7 @@ export function ModelSelector({
                       ? (staticOptions ? staticLabelFor(value.model) : value.model)
                       : (sentinel?.label || defaultModel?.model || 'Select a model')}
                   </span>
+                  {renderEffortBadge()}
                   {value && !providerFilter && !staticOptions && (
                     <span className="shrink-0 text-xs text-muted-foreground">
                       {providerDisplayNames[value.provider] || value.provider}
@@ -413,17 +627,28 @@ export function ModelSelector({
                 title={triggerTitle}
                 className="flex h-7 min-w-0 items-center gap-1 rounded-full px-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
-                <span className="min-w-0 truncate">
+                {/* Name in foreground vs muted effort — same hierarchy as the
+                    list rows, else the two read as one undifferentiated label. */}
+                <span className="min-w-0 truncate text-foreground/80">
                   {staticOptions
                     ? (value ? staticLabelFor(value.model) : (sentinel?.label ?? 'Model'))
                     : getModelDisplayName(value?.model || defaultModel?.model || 'Model')}
                 </span>
+                {renderEffortBadge()}
                 <ChevronDown className="h-3 w-3 shrink-0" />
               </button>
             )}
           </PopoverTrigger>
           <PopoverContent
             align={variant === 'field' ? 'start' : 'end'}
+            // The effort panel lives outside the popover subtree (body
+            // portal), so Radix would treat clicks on it as outside
+            // interactions and dismiss the picker mid-click.
+            onInteractOutside={(e) => {
+              if (subPanelRef.current && e.target instanceof Node && subPanelRef.current.contains(e.target)) {
+                e.preventDefault()
+              }
+            }}
             className={cn(
               'p-0 overflow-hidden',
               splitMode
@@ -460,7 +685,11 @@ export function ModelSelector({
                 <CommandInput
                   autoFocus
                   value={query}
-                  onValueChange={setQuery}
+                  onValueChange={(v) => {
+                    setQuery(v)
+                    // Typing refilters the rows the panel was anchored to.
+                    setSub(null)
+                  }}
                   placeholder="Search models and providers…"
                 />
                 {splitMode && activeGroup ? (
@@ -489,7 +718,7 @@ export function ModelSelector({
                         </button>
                       ))}
                     </div>
-                    <CommandList className="max-h-80 flex-1">
+                    <CommandList className="max-h-80 flex-1" onScroll={() => setSub(null)}>
                       <CommandGroup>
                         {renderSentinelItem()}
                         {standaloneDefault && standaloneDefault.provider === activeGroup.id &&
@@ -503,7 +732,7 @@ export function ModelSelector({
                     </CommandList>
                   </div>
                 ) : (
-                  <CommandList className="max-h-80">
+                  <CommandList className="max-h-80" onScroll={() => setSub(null)}>
                     {sentinel && !queryValue && (
                       <CommandGroup>{renderSentinelItem()}</CommandGroup>
                     )}
@@ -568,8 +797,7 @@ export function ModelSelector({
               </Command>
             )}
           </PopoverContent>
+          {renderEffortSubPanel()}
         </Popover>
-      )}
-    </>
   )
 }

--- a/apps/x/apps/renderer/src/components/settings/model-selection-section.tsx
+++ b/apps/x/apps/renderer/src/components/settings/model-selection-section.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
-import { ModelSelector, providerDisplayNames, type ModelRef } from "@/components/model-selector"
+import { ModelSelector, providerDisplayNames, type ModelRef, type ModelSelection } from "@/components/model-selector"
 import { useModels } from "@/hooks/use-models"
 
 // The unified model-selection surface (signed-in and BYOK alike): ONE
@@ -34,8 +34,13 @@ function refLabel(ref: ModelRef): string {
 
 export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
   // The effective assistant model — the same value every picker shows.
-  const { defaultModel, groups } = useModels()
-  const [taskModels, setTaskModels] = useState<Partial<Record<TaskKey, ModelRef | null>>>({})
+  const { defaultModel, defaultEffort, groups } = useModels()
+  const [taskModels, setTaskModels] = useState<Partial<Record<TaskKey, ModelSelection | null>>>({})
+  // The assistant field's value: the stored pair, reassembled from the two
+  // snapshot fields the models store exposes.
+  const assistantSelection: ModelSelection | null = defaultModel
+    ? { ...defaultModel, ...(defaultEffort ? { effort: defaultEffort } : {}) }
+    : null
 
   // Retired-model detection: the saved assistant no longer appears in its
   // provider's live list. Only trusted lists count — a failed fetch or an
@@ -63,23 +68,24 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
     if (dialogOpen) void load()
   }, [dialogOpen, load])
 
-  const setAssistant = useCallback(async (ref: ModelRef | null) => {
-    // No sentinel row on the assistant picker, so ref is never null — the
-    // assistant is the one required selection.
-    if (!ref) return
+  const setAssistant = useCallback(async (selection: ModelSelection | null) => {
+    // No sentinel row on the assistant picker, so the selection is never
+    // null — the assistant is the one required choice. It persists whole
+    // (Auto = no effort key).
+    if (!selection) return
     try {
-      await window.ipc.invoke("models:updateConfig", { assistantModel: ref })
+      await window.ipc.invoke("models:updateConfig", { assistantModel: selection })
       window.dispatchEvent(new Event("models-config-changed"))
     } catch {
       toast.error("Failed to save the Assistant model")
     }
   }, [])
 
-  const setTask = useCallback(async (key: TaskKey, ref: ModelRef | null) => {
+  const setTask = useCallback(async (key: TaskKey, selection: ModelSelection | null) => {
     const previous = taskModels
-    setTaskModels((prev) => ({ ...prev, [key]: ref }))
+    setTaskModels((prev) => ({ ...prev, [key]: selection }))
     try {
-      await window.ipc.invoke("models:updateConfig", { taskModels: { [key]: ref } })
+      await window.ipc.invoke("models:updateConfig", { taskModels: { [key]: selection } })
       window.dispatchEvent(new Event("models-config-changed"))
     } catch {
       toast.error("Failed to save the model")
@@ -106,8 +112,9 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
         </div>
         <ModelSelector
           variant="field"
-          value={defaultModel}
-          onChange={setAssistant}
+          value={assistantSelection}
+          effortSelectable
+          onChange={(selection) => void setAssistant(selection)}
           triggerTitle="Assistant model"
         />
         {assistantUnavailable && defaultModel && (
@@ -152,7 +159,8 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
                   allowCustom
                   inheritDefault={{ label: "Same as Assistant" }}
                   value={override}
-                  onChange={(ref) => void setTask(key, ref)}
+                  effortSelectable
+                  onChange={(selection) => void setTask(key, selection)}
                   triggerTitle={label}
                 />
                 <p className="text-[11px] text-muted-foreground truncate" title={override ? refLabel(override) : inheritText}>

--- a/apps/x/apps/renderer/src/components/settings/providers-section.tsx
+++ b/apps/x/apps/renderer/src/components/settings/providers-section.tsx
@@ -370,7 +370,10 @@ function AddProviderDialog({ open, onOpenChange, connectedIds, isRowboatConnecte
       const listRes = await window.ipc.invoke("models:listForProvider", { provider: providerEntry })
       const list = listRes.success ? listRes.models ?? [] : []
       const typed = manualModel.trim()
-      const model = typed || (selectInitialModel(flavor, list, modelRecommendations) ?? "")
+      // A hand-typed id is a bare choice (effort Auto); the recommendation
+      // path may carry a recommended effort alongside the model.
+      const choice = typed ? { model: typed } : selectInitialModel(flavor, list, modelRecommendations)
+      const model = choice?.model ?? ""
       if (!listRes.success && !model) {
         setStep({ kind: "error", flavor, message: listRes.error || "Could not load the provider's model list." })
         return
@@ -394,15 +397,19 @@ function AddProviderDialog({ open, onOpenChange, connectedIds, isRowboatConnecte
       if (!hasAssistantNow) {
         // Task recommendations ride along the seeding moment as visible
         // overrides (validated against the live list; only differences).
-        const taskModels = selectInitialTaskModels(flavor, flavor, list, modelRecommendations, model)
+        const taskModels = selectInitialTaskModels(flavor, flavor, list, modelRecommendations, choice ?? { model })
         await window.ipc.invoke("models:updateConfig", {
-          assistantModel: { provider: flavor, model },
+          assistantModel: {
+            provider: flavor,
+            model,
+            ...(choice?.effort ? { effort: choice.effort } : {}),
+          },
           ...(Object.keys(taskModels).length > 0 ? { taskModels } : {}),
         })
         analytics.llmInitialModelSelected({
           flavor,
           model,
-          recommended: model === normalizeModelRecommendation(modelRecommendations, flavor)?.assistantModel,
+          recommended: model === normalizeModelRecommendation(modelRecommendations, flavor)?.assistantModel.model,
           taskOverridesSeeded: Object.keys(taskModels).length,
           source: analyticsSource,
         })

--- a/apps/x/apps/renderer/src/hooks/use-models.ts
+++ b/apps/x/apps/renderer/src/hooks/use-models.ts
@@ -5,6 +5,13 @@ export interface ModelRef {
   model: string
 }
 
+// THE canonical selection threaded UI → IPC → run creation: the ref plus
+// the reasoning effort picked with it (absent = Auto / provider default).
+// Mirrors shared/models.ts ModelSelection.
+export interface ModelSelection extends ModelRef {
+  effort?: 'low' | 'medium' | 'high'
+}
+
 // One picker group per connected provider, straight from the unified model
 // catalog (models:list → core/models/catalog.ts). Every provider — Rowboat
 // gateway, ChatGPT subscription (codex), BYOK keys, local endpoints — comes
@@ -30,6 +37,9 @@ export interface ModelsSnapshot {
   // hasn't picked a model) — shown in pickers instead of guessing from list
   // order, which can disagree with the real default.
   defaultModel: ModelRef | null
+  // The reasoning effort stored WITH the assistant model ('' = Auto). Seeds
+  // new chats' composer state and the settings field display.
+  defaultEffort: '' | 'low' | 'medium' | 'high'
   isRowboatConnected: boolean
   // Raw catalog model ids per provider id, unpinned — for provider-scoped
   // pickers that need a provider's list without group ordering applied.
@@ -50,6 +60,7 @@ const EMPTY_SNAPSHOT: ModelsSnapshot = {
   groups: [],
   reasoningByKey: {},
   defaultModel: null,
+  defaultEffort: '',
   isRowboatConnected: false,
   catalogByProvider: {},
 }
@@ -72,6 +83,9 @@ async function buildSnapshot(refreshProvider?: string): Promise<ModelsSnapshot> 
   )
 
   const defaultModel: ModelRef | null = catalog.defaultModel
+    ? { provider: catalog.defaultModel.provider, model: catalog.defaultModel.model }
+    : null
+  const defaultEffort = catalog.defaultModel?.effort ?? ''
   const reasoningByKey: Record<string, boolean> = {}
   const catalogByProvider: Record<string, string[]> = {}
   const groups: ModelPickerGroup[] = []
@@ -112,6 +126,7 @@ async function buildSnapshot(refreshProvider?: string): Promise<ModelsSnapshot> 
     groups,
     reasoningByKey,
     defaultModel,
+    defaultEffort,
     isRowboatConnected: catalog.providers.some((p) => p.id === 'rowboat'),
     catalogByProvider,
   }

--- a/apps/x/packages/core/src/apps/agents.ts
+++ b/apps/x/packages/core/src/apps/agents.ts
@@ -105,6 +105,9 @@ async function materializeAgent(folder: string, agentFile: string): Promise<stri
         const sel = await getDefaultModelAndProvider();
         task.model = sel.model;
         task.provider = sel.provider;
+        // Effort travels with the pinned model (the pairing rule suppresses
+        // the category selection's effort once task.model is set).
+        if (sel.effort) task.effort = sel.effort;
     } catch { /* no model config — leave the category default */ }
     await fs.mkdir(taskDir, { recursive: true });
     await fs.writeFile(taskYaml, stringifyYaml(task), 'utf-8');

--- a/apps/x/packages/core/src/background-tasks/event-consumer.ts
+++ b/apps/x/packages/core/src/background-tasks/event-consumer.ts
@@ -9,6 +9,8 @@ import { listTasks } from './fileops.js';
 import { runBackgroundTask } from './runner.js';
 
 async function resolveRoutingModel() {
+    // Deliberately effort-free: the routing pass is a cheap yes/no
+    // classifier; the backgroundTask effort applies to the agent RUNS it triggers.
     const { model: modelId, provider } = await getBackgroundTaskAgentModel();
     const config = await resolveProviderConfig(provider);
     return {

--- a/apps/x/packages/core/src/background-tasks/runner.ts
+++ b/apps/x/packages/core/src/background-tasks/runner.ts
@@ -150,6 +150,10 @@ export async function runBackgroundTask(
         const selection = await getBackgroundTaskAgentModel();
         const model = task.model || selection.model;
         const provider = task.provider ?? (task.model ? undefined : selection.provider);
+        // Effort pairs with whichever source supplied the model: an explicit
+        // task effort always wins; otherwise the category selection's effort
+        // applies only when the task didn't pin its own model.
+        const effort = task.effort ?? (task.model ? undefined : selection.effort);
         // Manual runs are user-requested (the Run button, or the copilot's
         // run-background-task-agent tool mid-chat) and must NOT wait for
         // chat-idle: the requesting chat turn holds the chat-activity lock,
@@ -167,6 +171,7 @@ export async function runBackgroundTask(
                 message: buildMessage(slug, task, trigger, context, codeProject),
                 model,
                 ...(provider ? { provider } : {}),
+                ...(effort ? { reasoningEffort: effort } : {}),
                 throwOnError: true,
             }),
         );

--- a/apps/x/packages/core/src/knowledge/agent_notes.ts
+++ b/apps/x/packages/core/src/knowledge/agent_notes.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { google } from 'googleapis';
 import { WorkDir } from '../config/config.js';
 import { runWhenPossible } from '../runtime/assembly/headless-app.js';
-import { getKgModel } from '../models/defaults.js';
+import { asRunModelOptions, getKgModel } from '../models/defaults.js';
 import { getErrorDetails } from '../application/lib/errors.js';
 import { serviceLogger } from '../services/service_logger.js';
 import { loadUserConfig, updateUserEmail } from '../config/user_config.js';
@@ -284,7 +284,7 @@ async function processAgentNotes(): Promise<void> {
         await runWhenPossible({
             agentId: AGENT_ID,
             message,
-            ...(await getKgModel()),
+            ...asRunModelOptions(await getKgModel()),
             throwOnError: true,
         });
 

--- a/apps/x/packages/core/src/knowledge/build_graph.ts
+++ b/apps/x/packages/core/src/knowledge/build_graph.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { WorkDir } from '../config/config.js';
-import { getKgModel } from '../models/defaults.js';
+import { asRunModelOptions, getKgModel } from '../models/defaults.js';
 import { runWhenPossible, toolInputPaths } from '../runtime/assembly/headless-app.js';
 import { getErrorDetails } from '../application/lib/errors.js';
 import { serviceLogger, type ServiceRunContext } from '../services/service_logger.js';
@@ -409,7 +409,7 @@ async function createNotesFromBatch(
     const { turnId, state } = await runWhenPossible({
         agentId: NOTE_CREATION_AGENT,
         message,
-        ...(await getKgModel()),
+        ...asRunModelOptions(await getKgModel()),
         throwOnError: true,
     });
 
@@ -967,7 +967,7 @@ export async function curateNotes(): Promise<void> {
             await runWhenPossible({
                 agentId: CURATION_AGENT,
                 message,
-                ...(await getKgModel()),
+                ...asRunModelOptions(await getKgModel()),
                 throwOnError: true,
             });
             curated++;

--- a/apps/x/packages/core/src/knowledge/classify_thread.ts
+++ b/apps/x/packages/core/src/knowledge/classify_thread.ts
@@ -6,6 +6,7 @@ import type { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
 import { createLanguageModel } from '../models/models.js';
 import { generateObjectSafe } from '../models/structured.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import {
     getKgModel,
     resolveProviderConfig,
@@ -299,9 +300,10 @@ export async function classifyThread(
         // (no-ops unless enough new corrections exist).
         await maybeDistillImportanceRules();
 
-        const { model: modelId, provider } = await getKgModel();
+        const { model: modelId, provider, effort } = await getKgModel();
         const config = await resolveProviderConfig(provider);
         const model = createLanguageModel(config, modelId);
+        const reasoning = await directCallReasoningOptions(config.flavor, modelId, effort);
 
         // Assembled fresh per call so labels the user just defined apply to
         // the very next classification (the registry read is mtime-cached).
@@ -335,6 +337,7 @@ export async function classifyThread(
             prompt: buildPrompt(snapshot, userEmail, styleGuide, calendar),
             schema: buildClassificationSchema(labels.map((l) => l.id)),
             retry: true,
+            generateOptions: reasoning,
         }));
 
         captureLlmUsage({

--- a/apps/x/packages/core/src/knowledge/email_importance_feedback.ts
+++ b/apps/x/packages/core/src/knowledge/email_importance_feedback.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { WorkDir } from '../config/config.js';
 import { createLanguageModel } from '../models/models.js';
 import { generateObjectSafe } from '../models/structured.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import { getKgModel, resolveProviderConfig } from '../models/defaults.js';
 import { captureLlmUsage } from '../analytics/usage.js';
 import { withUseCase } from '../analytics/use_case.js';
@@ -145,9 +146,10 @@ export async function maybeDistillImportanceRules(): Promise<void> {
     if (newSince <= 0) return;
 
     try {
-        const { model: modelId, provider } = await getKgModel();
+        const { model: modelId, provider, effort } = await getKgModel();
         const config = await resolveProviderConfig(provider);
         const model = createLanguageModel(config, modelId);
+        const reasoning = await directCallReasoningOptions(config.flavor, modelId, effort);
 
         const correctionLines = fb.corrections.map(c =>
             `- From: ${c.from} | Subject: "${c.subject}" | classifier said ${c.agentVerdict}, user corrected to ${c.userVerdict}`
@@ -160,6 +162,7 @@ export async function maybeDistillImportanceRules(): Promise<void> {
             prompt: `Corrections (oldest first):\n${correctionLines}${existingRules}`,
             schema: DistilledRules,
             retry: true,
+            generateOptions: reasoning,
         }));
 
         captureLlmUsage({

--- a/apps/x/packages/core/src/knowledge/email_labels.ts
+++ b/apps/x/packages/core/src/knowledge/email_labels.ts
@@ -5,6 +5,7 @@ import { WorkDir } from '../config/config.js';
 import { createLanguageModel } from '../models/models.js';
 import { generateObjectSafe } from '../models/structured.js';
 import { getKgModel, resolveProviderConfig } from '../models/defaults.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import { captureLlmUsage } from '../analytics/usage.js';
 import { withUseCase } from '../analytics/use_case.js';
 
@@ -134,9 +135,10 @@ export async function syncCustomLabelsFromInstructions(instructions: string): Pr
         return { labels: getEmailLabels() };
     }
 
-    const { model: modelId, provider } = await getKgModel();
+    const { model: modelId, provider, effort } = await getKgModel();
     const config = await resolveProviderConfig(provider);
     const model = createLanguageModel(config, modelId);
+    const reasoning = await directCallReasoningOptions(config.flavor, modelId, effort);
 
     const builtinList = BUILTIN_EMAIL_LABELS.map(l => `- ${l.id} ("${l.name}"): ${l.description}`).join('\n');
 
@@ -160,6 +162,7 @@ export async function syncCustomLabelsFromInstructions(instructions: string): Pr
         prompt: text,
         schema: ExtractedLabels,
         retry: true,
+        generateOptions: reasoning,
     }));
 
     captureLlmUsage({

--- a/apps/x/packages/core/src/knowledge/generate_title.ts
+++ b/apps/x/packages/core/src/knowledge/generate_title.ts
@@ -1,7 +1,7 @@
 import { generateText } from 'ai';
 import { createLanguageModel } from '../models/models.js';
 import { getChatTitleModel, resolveProviderConfig } from '../models/defaults.js';
-import { mapReasoningEffort } from '../models/reasoning.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import { captureLlmUsage } from '../analytics/usage.js';
 import { withUseCase } from '../analytics/use_case.js';
 
@@ -34,20 +34,22 @@ export async function generateChatTitle(firstMessage: string): Promise<string | 
     const text = firstMessage.trim().replace(/\s+/g, ' ');
     if (!text) return null;
 
-    const { model: modelId, provider: providerName } = await getChatTitleModel();
+    const { model: modelId, provider: providerName, effort } = await getChatTitleModel();
     const providerConfig = await resolveProviderConfig(providerName);
     const model = createLanguageModel(providerConfig, modelId);
 
     // Reasoning models (e.g. gateway gemini-3.5-flash) think by default and
     // can starve a tight output cap — dial thinking to low and leave the cap
-    // roomy; the title itself is a handful of tokens either way.
-    const reasoning = mapReasoningEffort(providerConfig.flavor, modelId, 'low', undefined);
+    // roomy; the title itself is a handful of tokens either way. An explicit
+    // effort on the chatTitle task slot overrides the low pin (spread last so
+    // its Anthropic budget floor can raise the cap).
+    const reasoning = await directCallReasoningOptions(providerConfig.flavor, modelId, effort ?? 'low');
     const result = await withUseCase({ useCase: 'copilot_chat', subUseCase: 'chat_title' }, () => generateText({
         model,
         system: SYSTEM_PROMPT,
         prompt: text.slice(0, MAX_INPUT_CHARS),
         maxOutputTokens: 1000,
-        ...(reasoning?.providerOptions ? { providerOptions: reasoning.providerOptions } : {}),
+        ...reasoning,
     }));
 
     captureLlmUsage({

--- a/apps/x/packages/core/src/knowledge/inline_tasks.ts
+++ b/apps/x/packages/core/src/knowledge/inline_tasks.ts
@@ -4,7 +4,8 @@ import { CronExpressionParser } from 'cron-parser';
 import { generateText } from 'ai';
 import { WorkDir } from '../config/config.js';
 import { runWhenPossible } from '../runtime/assembly/headless-app.js';
-import { getKgModel, resolveProviderConfig } from '../models/defaults.js';
+import { asRunModelOptions, getKgModel, resolveProviderConfig } from '../models/defaults.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import { createLanguageModel } from '../models/models.js';
 import { inlineTask } from '@x/shared';
 import { captureLlmUsage } from '../analytics/usage.js';
@@ -481,7 +482,7 @@ async function processInlineTasks(): Promise<void> {
                 const { summary: result } = await runWhenPossible({
                     agentId: INLINE_TASK_AGENT,
                     message,
-                    ...(await getKgModel()),
+                    ...asRunModelOptions(await getKgModel()),
                 });
                 if (result) {
                     if (task.targetId) {
@@ -560,7 +561,7 @@ export async function processRowboatInstruction(
     const { summary: rawResponse } = await runWhenPossible({
         agentId: INLINE_TASK_AGENT,
         message,
-        ...(await getKgModel()),
+        ...asRunModelOptions(await getKgModel()),
     });
     if (!rawResponse) {
         return { instruction, schedule: null, scheduleLabel: null, response: null };
@@ -612,6 +613,7 @@ export async function classifySchedule(instruction: string): Promise<InlineTaskS
     const selection = await getKgModel();
     const providerConfig = await resolveProviderConfig(selection.provider);
     const model = createLanguageModel(providerConfig, selection.model);
+    const reasoning = await directCallReasoningOptions(providerConfig.flavor, selection.model, selection.effort);
 
     const now = new Date();
     const defaultEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
@@ -653,6 +655,7 @@ Respond with ONLY valid JSON: either a schedule object or null. No other text.`;
             model,
             instructions: systemPrompt,
             prompt: instruction,
+            ...reasoning,
         }));
 
         captureLlmUsage({

--- a/apps/x/packages/core/src/knowledge/live-note/event-consumer.ts
+++ b/apps/x/packages/core/src/knowledge/live-note/event-consumer.ts
@@ -7,6 +7,8 @@ import { createLanguageModel } from '../../models/models.js';
 import { getLiveNoteAgentModel, resolveProviderConfig } from '../../models/defaults.js';
 
 async function resolveRoutingModel() {
+    // Deliberately effort-free: the routing pass is a cheap yes/no
+    // classifier; the liveNoteAgent effort applies to the agent RUNS it triggers.
     const { model: modelId, provider } = await getLiveNoteAgentModel();
     const config = await resolveProviderConfig(provider);
     return {

--- a/apps/x/packages/core/src/knowledge/live-note/runner.ts
+++ b/apps/x/packages/core/src/knowledge/live-note/runner.ts
@@ -114,6 +114,10 @@ export async function runLiveNoteAgent(
         const selection = await getLiveNoteAgentModel();
         const model = live.model ?? selection.model;
         const provider = live.provider ?? (live.model ? undefined : selection.provider);
+        // Effort pairs with whichever source supplied the model: an explicit
+        // note effort always wins; otherwise the category selection's effort
+        // applies only when the note didn't pin its own model.
+        const effort = live.effort ?? (live.model ? undefined : selection.effort);
         // Manual runs are user-requested (the Run button, or the copilot's
         // run-live-note-agent tool mid-chat) and must NOT wait for chat-idle:
         // the requesting chat turn holds the chat-activity lock, so deferring
@@ -130,6 +134,7 @@ export async function runLiveNoteAgent(
                 message: buildMessage(filePath, live, trigger, context),
                 model,
                 ...(provider ? { provider } : {}),
+                ...(effort ? { reasoningEffort: effort } : {}),
                 throwOnError: true,
             }),
         );

--- a/apps/x/packages/core/src/knowledge/meeting_prep_brief.ts
+++ b/apps/x/packages/core/src/knowledge/meeting_prep_brief.ts
@@ -4,6 +4,7 @@ import { generateText } from 'ai';
 import { WorkDir } from '../config/config.js';
 import { createLanguageModel } from '../models/models.js';
 import { getMeetingNotesModel, resolveProviderConfig } from '../models/defaults.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import { captureLlmUsage } from '../analytics/usage.js';
 import { withUseCase } from '../analytics/use_case.js';
 import { parseFrontmatter } from '../application/lib/parse-frontmatter.js';
@@ -175,14 +176,16 @@ async function generateBrief(event: CalendarEvent, ctx: Awaited<ReturnType<typeo
     });
     if (attendeeLines.length) parts.push(`Attendees:\n${attendeeLines.join('\n')}`);
 
-    const { model: modelId, provider: providerName } = await getMeetingNotesModel();
+    const { model: modelId, provider: providerName, effort } = await getMeetingNotesModel();
     const providerConfig = await resolveProviderConfig(providerName);
     const model = createLanguageModel(providerConfig, modelId);
+    const reasoning = await directCallReasoningOptions(providerConfig.flavor, modelId, effort);
 
     const result = await withUseCase({ useCase: 'meeting_prep' }, () => generateText({
         model,
         instructions: BRIEF_SYSTEM,
         prompt: parts.join('\n\n'),
+        ...reasoning,
     }));
     captureLlmUsage({ useCase: 'meeting_prep', model: modelId, provider: providerName, usage: result.usage });
     return result.text.trim();

--- a/apps/x/packages/core/src/knowledge/summarize_meeting.ts
+++ b/apps/x/packages/core/src/knowledge/summarize_meeting.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { generateText } from 'ai';
 import { createLanguageModel } from '../models/models.js';
 import { getMeetingNotesModel, resolveProviderConfig } from '../models/defaults.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
 import { WorkDir } from '../config/config.js';
 import { captureLlmUsage } from '../analytics/usage.js';
 import { withUseCase } from '../analytics/use_case.js';
@@ -137,9 +138,10 @@ function loadCalendarEventContext(calendarEventJson: string): string {
 }
 
 export async function summarizeMeeting(transcript: string, meetingStartTime?: string, calendarEventJson?: string): Promise<string> {
-    const { model: modelId, provider: providerName } = await getMeetingNotesModel();
+    const { model: modelId, provider: providerName, effort } = await getMeetingNotesModel();
     const providerConfig = await resolveProviderConfig(providerName);
     const model = createLanguageModel(providerConfig, modelId);
+    const reasoning = await directCallReasoningOptions(providerConfig.flavor, modelId, effort);
 
     // If a specific calendar event was linked, use it directly.
     // Otherwise fall back to scanning events within ±3 hours.
@@ -156,6 +158,7 @@ export async function summarizeMeeting(transcript: string, meetingStartTime?: st
         model,
         instructions: SYSTEM_PROMPT,
         prompt,
+        ...reasoning,
     }));
 
     captureLlmUsage({

--- a/apps/x/packages/core/src/knowledge/tag_notes.ts
+++ b/apps/x/packages/core/src/knowledge/tag_notes.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { WorkDir } from '../config/config.js';
 import { runWhenPossible, toolInputPaths } from '../runtime/assembly/headless-app.js';
-import { getKgModel } from '../models/defaults.js';
+import { asRunModelOptions, getKgModel } from '../models/defaults.js';
 import { getErrorDetails } from '../application/lib/errors.js';
 import { serviceLogger } from '../services/service_logger.js';
 import { limitEventItems } from './limit_event_items.js';
@@ -100,7 +100,7 @@ async function tagNoteBatch(
     const { turnId, state } = await runWhenPossible({
         agentId: NOTE_TAGGING_AGENT,
         message,
-        ...(await getKgModel()),
+        ...asRunModelOptions(await getKgModel()),
         throwOnError: true,
     });
 

--- a/apps/x/packages/core/src/models/catalog.ts
+++ b/apps/x/packages/core/src/models/catalog.ts
@@ -48,8 +48,9 @@ export interface CatalogProviderEntry {
 
 export interface ModelCatalogResult {
     providers: CatalogProviderEntry[];
-    /** The effective runtime default (what runs when nothing is picked). */
-    defaultModel: { provider: string; model: string } | null;
+    /** The effective runtime default (what runs when nothing is picked),
+     *  with the effort stored alongside it — seeds new chats' composers. */
+    defaultModel: { provider: string; model: string; effort?: "low" | "medium" | "high" } | null;
 }
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {

--- a/apps/x/packages/core/src/models/chatgpt-selection.ts
+++ b/apps/x/packages/core/src/models/chatgpt-selection.ts
@@ -26,19 +26,23 @@ export async function applyCodexInitialSelection(): Promise<void> {
         const catalog = await listCodexModels();
         const ids = catalog.providers[0]?.models.map((m) => m.id) ?? [];
         const recommendations = (await getRowboatConfig().catch(() => null))?.modelRecommendations;
-        const model = selectInitialModel("codex", ids, recommendations);
-        if (model) {
+        const choice = selectInitialModel("codex", ids, recommendations);
+        if (choice) {
             // Task recommendations ride along the seeding moment (codex has
             // none today; the path is uniform across providers).
-            const taskModels = selectInitialTaskModels("codex", "codex", ids, recommendations, model);
+            const taskModels = selectInitialTaskModels("codex", "codex", ids, recommendations, choice);
             await repo.updateConfig({
-                assistantModel: { provider: "codex", model },
+                assistantModel: {
+                    provider: "codex",
+                    model: choice.model,
+                    ...(choice.effort ? { effort: choice.effort } : {}),
+                },
                 ...(Object.keys(taskModels).length > 0 ? { taskModels } : {}),
             });
             capture("llm_initial_model_selected", {
                 flavor: "codex",
-                model,
-                recommended: model === normalizeModelRecommendation(recommendations, "codex")?.assistantModel,
+                model: choice.model,
+                recommended: choice.model === normalizeModelRecommendation(recommendations, "codex")?.assistantModel.model,
                 task_overrides_seeded: Object.keys(taskModels).length,
                 source: "sign_in",
             });

--- a/apps/x/packages/core/src/models/defaults.ts
+++ b/apps/x/packages/core/src/models/defaults.ts
@@ -1,9 +1,12 @@
 import z from "zod";
-import { LlmModelConfig, LlmProvider, ModelRef, type TaskModelKey } from "@x/shared/dist/models.js";
+import { LlmModelConfig, LlmProvider, ModelSelection as ModelSelectionSchema, type TaskModelKey } from "@x/shared/dist/models.js";
 import { IModelConfigRepo } from "./repo.js";
 import container from "../di/container.js";
 
-export type ModelSelection = z.infer<typeof ModelRef>;
+// THE canonical selection: provider + model + the effort picked with them,
+// one value threaded from UI through IPC to run creation. Callers forward
+// `effort` verbatim into run options; absent = Auto (send nothing).
+export type ModelSelection = z.infer<typeof ModelSelectionSchema>;
 
 async function readConfig(): Promise<z.infer<typeof LlmModelConfig> | null> {
     try {
@@ -22,13 +25,34 @@ async function readConfig(): Promise<z.infer<typeof LlmModelConfig> | null> {
  * (via initial selection) and by every model pick in the UI; hidden
  * fallback defaults were removed with the v2 config migration.
  */
-export async function getDefaultModelAndProvider(): Promise<{ model: string; provider: string }> {
+export async function getDefaultModelAndProvider(): Promise<ModelSelection> {
     const cfg = await readConfig();
     const assistant = cfg?.assistantModel;
     if (!assistant) {
         throw new Error("No assistant model configured (connect a provider or sign in)");
     }
-    return { model: assistant.model, provider: assistant.provider };
+    return {
+        model: assistant.model,
+        provider: assistant.provider,
+        ...(assistant.effort ? { effort: assistant.effort } : {}),
+    };
+}
+
+/**
+ * A resolved selection as headless-run options: the `effort` stored on the
+ * selection travels as the run option `reasoningEffort`. Spread this instead
+ * of the raw selection (whose `effort` key run options don't know).
+ */
+export function asRunModelOptions(selection: ModelSelection): {
+    model: string;
+    provider: string;
+    reasoningEffort?: "low" | "medium" | "high";
+} {
+    return {
+        model: selection.model,
+        provider: selection.provider,
+        ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
+    };
 }
 
 /**
@@ -66,15 +90,20 @@ export async function resolveProviderConfig(name: string): Promise<z.infer<typeo
 }
 
 /**
- * Per-task model resolution: the explicit taskModels override wins, else the
- * assistant model. No hidden per-task defaults — the v2 migration
- * materialized the historical curated models as visible overrides.
+ * Per-task model resolution: the explicit taskModels override wins (with the
+ * effort stored on it), else the assistant model+effort pair. No hidden
+ * per-task defaults — the v2 migration materialized the historical curated
+ * models as visible overrides.
  */
 async function getCategoryModel(category: TaskModelKey): Promise<ModelSelection> {
     const cfg = await readConfig();
     const override = cfg?.taskModels?.[category];
     if (override) {
-        return { model: override.model, provider: override.provider };
+        return {
+            model: override.model,
+            provider: override.provider,
+            ...(override.effort ? { effort: override.effort } : {}),
+        };
     }
     return getDefaultModelAndProvider();
 }

--- a/apps/x/packages/core/src/models/initial-selection.test.ts
+++ b/apps/x/packages/core/src/models/initial-selection.test.ts
@@ -9,21 +9,21 @@ describe('selectInitialModel', () => {
 
     it('picks the recommended model when the provider lists it', () => {
         expect(selectInitialModel('openai', ['gpt-4.1', 'gpt-5.4', 'gpt-5.4-mini'], recommendations))
-            .toBe('gpt-5.4');
+            .toEqual({ model: 'gpt-5.4' });
     });
 
     it('falls back to the first listed model when the recommendation is not in the list', () => {
         expect(selectInitialModel('openai', ['gpt-4.1', 'gpt-4o'], recommendations))
-            .toBe('gpt-4.1');
+            .toEqual({ model: 'gpt-4.1' });
     });
 
     it('falls back to the first listed model for flavors with no recommendation', () => {
         expect(selectInitialModel('ollama', ['llama3', 'qwen3'], recommendations))
-            .toBe('llama3');
+            .toEqual({ model: 'llama3' });
     });
 
     it('falls back to the first listed model when no recommendations map is available', () => {
-        expect(selectInitialModel('openai', ['gpt-4.1'], undefined)).toBe('gpt-4.1');
+        expect(selectInitialModel('openai', ['gpt-4.1'], undefined)).toEqual({ model: 'gpt-4.1' });
     });
 
     it('returns null when the provider listed nothing', () => {
@@ -33,7 +33,13 @@ describe('selectInitialModel', () => {
     it('accepts the nested { assistantModel, taskModels } wire shape', () => {
         const nested = { rowboat: { assistantModel: 'google/gemini-3.5-flash', taskModels: {} } };
         expect(selectInitialModel('rowboat', ['a', 'google/gemini-3.5-flash'], nested))
-            .toBe('google/gemini-3.5-flash');
+            .toEqual({ model: 'google/gemini-3.5-flash' });
+    });
+
+    it('carries effort from the { model, effort } wire shape', () => {
+        const nested = { rowboat: { assistantModel: { model: 'google/gemini-3.5-flash', effort: 'high' as const } } };
+        expect(selectInitialModel('rowboat', ['google/gemini-3.5-flash'], nested))
+            .toEqual({ model: 'google/gemini-3.5-flash', effort: 'high' });
     });
 });
 
@@ -60,7 +66,7 @@ describe('selectInitialTaskModels', () => {
     };
 
     it('writes overrides only for listed recs that differ from the assistant', () => {
-        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, nested, 'google/gemini-3.5-flash'))
+        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, nested, { model: 'google/gemini-3.5-flash' }))
             .toEqual({
                 knowledgeGraph: { provider: 'rowboat', model: 'google/gemini-3.1-flash-lite' },
                 chatTitle: { provider: 'rowboat', model: 'google/gemini-3.5-flash-lite' },
@@ -68,8 +74,26 @@ describe('selectInitialTaskModels', () => {
     });
 
     it('returns nothing for legacy flat recommendations or absent maps', () => {
-        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, { rowboat: 'google/gemini-3.5-flash' }, 'x'))
+        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, { rowboat: 'google/gemini-3.5-flash' }, { model: 'x' }))
             .toEqual({});
-        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, undefined, 'x')).toEqual({});
+        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, undefined, { model: 'x' })).toEqual({});
+    });
+
+    it('keeps a same-model rec whose effort differs from the assistant, and carries effort', () => {
+        const withEffort = {
+            rowboat: {
+                assistantModel: { model: 'google/gemini-3.5-flash', effort: 'high' as const },
+                taskModels: {
+                    // Same model, lower effort → meaningful override.
+                    chatTitle: { model: 'google/gemini-3.5-flash', effort: 'low' as const },
+                    // Same model AND effort → redundant, inherit produces it.
+                    meetingNotes: { model: 'google/gemini-3.5-flash', effort: 'high' as const },
+                },
+            },
+        };
+        expect(selectInitialTaskModels('rowboat', 'rowboat', gatewayList, withEffort, { model: 'google/gemini-3.5-flash', effort: 'high' }))
+            .toEqual({
+                chatTitle: { provider: 'rowboat', model: 'google/gemini-3.5-flash', effort: 'low' },
+            });
     });
 });

--- a/apps/x/packages/core/src/models/reasoning.ts
+++ b/apps/x/packages/core/src/models/reasoning.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type { ReasoningEffort } from "@x/shared/dist/models.js";
 import type { JsonValue } from "@x/shared/dist/turns.js";
+import { isReasoningModel } from "./models-dev.js";
 
 export type ReasoningEffortLevel = z.infer<typeof ReasoningEffort>;
 
@@ -41,6 +42,32 @@ export function parseReasoningEffort(value: unknown): ReasoningEffortLevel | und
  * provider-level fetch rewrite (models/local.ts), and openai-compatible
  * endpoints have no safe universal parameter.
  */
+/**
+ * Effort options for DIRECT AI SDK calls (generateText/generateObject in the
+ * task utilities — chat titles, classifiers, summarizers), mirroring what
+ * the turn bridge does centrally: cache-only capability lookup, canonical →
+ * provider mapping, and the Anthropic output floor. Returns {} when there is
+ * no effort or the model/flavor cannot express it — spread the result into
+ * the call's options as the LAST entry so maxOutputTokens can apply.
+ */
+export async function directCallReasoningOptions(
+    flavor: string,
+    modelId: string,
+    effort: ReasoningEffortLevel | undefined,
+): Promise<{
+    providerOptions?: Record<string, Record<string, JsonValue>>;
+    maxOutputTokens?: number;
+}> {
+    if (!effort) return {};
+    const supports = await isReasoningModel(flavor, modelId).catch(() => undefined);
+    const mapped = mapReasoningEffort(flavor, modelId, effort, supports);
+    if (!mapped) return {};
+    return {
+        providerOptions: mapped.providerOptions,
+        ...(mapped.minOutputTokens ? { maxOutputTokens: mapped.minOutputTokens } : {}),
+    };
+}
+
 export function mapReasoningEffort(
     flavor: string,
     modelId: string,

--- a/apps/x/packages/core/src/models/reasoning.ts
+++ b/apps/x/packages/core/src/models/reasoning.ts
@@ -27,22 +27,6 @@ export function parseReasoningEffort(value: unknown): ReasoningEffortLevel | und
 }
 
 /**
- * Map the canonical reasoning effort to provider-specific request options.
- * Transport-only, like prompt caching: persisted turn events carry only the
- * canonical value; this translation happens at invoke time.
- *
- * Returns undefined when nothing should be sent — unsupported flavor, model
- * not known to reason, or a level the model family cannot express. Unknown
- * capability fails closed for strict flavors (OpenAI/Anthropic/Google reject
- * reasoning parameters on non-reasoning models); OpenRouter-shaped flavors
- * (openrouter, rowboat) are forgiving — OpenRouter drops the field for
- * models that cannot reason — so they map unless the model is known-false.
- *
- * Ollama is deliberately absent: its `think` parameter is applied by the
- * provider-level fetch rewrite (models/local.ts), and openai-compatible
- * endpoints have no safe universal parameter.
- */
-/**
  * Effort options for DIRECT AI SDK calls (generateText/generateObject in the
  * task utilities — chat titles, classifiers, summarizers), mirroring what
  * the turn bridge does centrally: cache-only capability lookup, canonical →
@@ -68,6 +52,30 @@ export async function directCallReasoningOptions(
     };
 }
 
+/**
+ * Map the canonical reasoning effort to provider-specific request options.
+ * Transport-only, like prompt caching: persisted turn events carry only the
+ * canonical value; this translation happens at invoke time.
+ *
+ * Returns undefined when nothing should be sent — unsupported flavor, model
+ * not known to reason, or a level the model family cannot express. Unknown
+ * capability fails closed for strict flavors (OpenAI/Anthropic/Google reject
+ * reasoning parameters on non-reasoning models); OpenRouter-shaped flavors
+ * (openrouter, rowboat) are forgiving — OpenRouter drops the field for
+ * models that cannot reason — so they map unless the model is known-false.
+ *
+ * Ollama is deliberately absent: its `think` parameter is applied by the
+ * provider-level fetch rewrite (models/local.ts), and openai-compatible
+ * endpoints have no safe universal parameter.
+ */
+/**
+ * Effort options for DIRECT AI SDK calls (generateText/generateObject in the
+ * task utilities — chat titles, classifiers, summarizers), mirroring what
+ * the turn bridge does centrally: cache-only capability lookup, canonical →
+ * provider mapping, and the Anthropic output floor. Returns {} when there is
+ * no effort or the model/flavor cannot express it — spread the result into
+ * the call's options as the LAST entry so maxOutputTokens can apply.
+ */
 export function mapReasoningEffort(
     flavor: string,
     modelId: string,

--- a/apps/x/packages/core/src/models/repo.ts
+++ b/apps/x/packages/core/src/models/repo.ts
@@ -1,4 +1,4 @@
-import { LlmModelConfig, LlmProvider, ModelRef, TaskModels } from "@x/shared/dist/models.js";
+import { LlmModelConfig, LlmProvider, ModelSelection, TaskModels } from "@x/shared/dist/models.js";
 import { WorkDir } from "../config/config.js";
 import { isSignedIn } from "../account/account.js";
 import { capture } from "../analytics/posthog.js";
@@ -13,13 +13,14 @@ import path from "path";
 import z from "zod";
 
 type Config = z.infer<typeof LlmModelConfig>;
-type Ref = z.infer<typeof ModelRef>;
-type TaskModelPatch = { [K in keyof z.infer<typeof TaskModels>]?: Ref | null };
+// Selections are stored as ModelSelection (ref + the effort picked with it).
+type Choice = z.infer<typeof ModelSelection>;
+type TaskModelPatch = { [K in keyof z.infer<typeof TaskModels>]?: Choice | null };
 
 // Top-level merge patch: omitted keys are untouched; an explicit null clears
 // a key. taskModels merges per-key (null clears that task's override).
 export type ModelConfigPatch = {
-    assistantModel?: Ref | null;
+    assistantModel?: Choice | null;
     taskModels?: TaskModelPatch;
     deferBackgroundTasks?: boolean | null;
 };

--- a/apps/x/packages/core/src/models/rowboat-selection.ts
+++ b/apps/x/packages/core/src/models/rowboat-selection.ts
@@ -27,23 +27,27 @@ export async function applyRowboatInitialSelection(): Promise<void> {
         const catalog = await listGatewayModels();
         const ids = catalog.providers[0]?.models.map((m) => m.id) ?? [];
         const recommendations = (await getRowboatConfig().catch(() => null))?.modelRecommendations;
-        const model = selectInitialModel("rowboat", ids, recommendations);
-        if (model) {
+        const choice = selectInitialModel("rowboat", ids, recommendations);
+        if (choice) {
             // Task recommendations ride along the seeding moment: the
             // gateway's lite-tier task models become visible overrides so
             // always-on background work doesn't run on assistant-class
             // models (plan-credit economics).
-            const taskModels = selectInitialTaskModels("rowboat", "rowboat", ids, recommendations, model);
+            const taskModels = selectInitialTaskModels("rowboat", "rowboat", ids, recommendations, choice);
             await repo.updateConfig({
-                assistantModel: { provider: "rowboat", model },
+                assistantModel: {
+                    provider: "rowboat",
+                    model: choice.model,
+                    ...(choice.effort ? { effort: choice.effort } : {}),
+                },
                 ...(Object.keys(taskModels).length > 0 ? { taskModels } : {}),
             });
             // Measures recommendation quality: hit = the backend's pick was
             // in the gateway list; miss = first-listed fallback.
             capture("llm_initial_model_selected", {
                 flavor: "rowboat",
-                model,
-                recommended: model === normalizeModelRecommendation(recommendations, "rowboat")?.assistantModel,
+                model: choice.model,
+                recommended: choice.model === normalizeModelRecommendation(recommendations, "rowboat")?.assistantModel.model,
                 task_overrides_seeded: Object.keys(taskModels).length,
                 source: "sign_in",
             });

--- a/apps/x/packages/core/src/models/structured.ts
+++ b/apps/x/packages/core/src/models/structured.ts
@@ -1,6 +1,7 @@
 import {
     generateObject,
     NoObjectGeneratedError,
+    type JSONValue,
     type LanguageModel,
     type LanguageModelUsage,
 } from "ai";
@@ -23,6 +24,15 @@ export interface GenerateObjectSafeOptions<T> {
      * run on a local model should enable this.
      */
     retry?: boolean;
+    /**
+     * Extra generation options forwarded verbatim to generateObject on both
+     * attempts — the shape directCallReasoningOptions returns (providerOptions
+     * for the effort mapping, maxOutputTokens for the Anthropic budget floor).
+     */
+    generateOptions?: {
+        providerOptions?: Record<string, Record<string, JSONValue>>;
+        maxOutputTokens?: number;
+    };
 }
 
 export interface GenerateObjectSafeResult<T> {
@@ -47,6 +57,7 @@ export async function generateObjectSafe<T>(
             ...(options.system ? { instructions: options.system } : {}),
             prompt: options.prompt,
             schema: options.schema,
+            ...(options.generateOptions ?? {}),
         });
         return { object: result.object, usage: result.usage };
     } catch (error) {
@@ -71,6 +82,7 @@ export async function generateObjectSafe<T>(
                 instructions: system,
                 prompt: options.prompt,
                 schema: options.schema,
+                ...(options.generateOptions ?? {}),
             });
             return { object: result.object, usage: result.usage };
         } catch (retryError) {

--- a/apps/x/packages/core/src/pre_built/runner.ts
+++ b/apps/x/packages/core/src/pre_built/runner.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { WorkDir } from '../config/config.js';
 import { runWhenPossible } from '../runtime/assembly/headless-app.js';
-import { getKgModel } from '../models/defaults.js';
+import { asRunModelOptions, getKgModel } from '../models/defaults.js';
 import {
     loadConfig,
     loadState,
@@ -55,7 +55,7 @@ Process new items and use the user context above to identify yourself when draft
         await runWhenPossible({
             agentId: agentName,
             message,
-            ...(await getKgModel()),
+            ...asRunModelOptions(await getKgModel()),
         });
 
         // Update last run time

--- a/apps/x/packages/core/src/runtime/assembly/spawn-agent.ts
+++ b/apps/x/packages/core/src/runtime/assembly/spawn-agent.ts
@@ -143,7 +143,16 @@ export async function runSpawnedAgent(
               provider: input.provider ?? parentModel?.provider ?? "",
               model: input.model,
           }
-        : subagentOverride ?? parentModel;
+        : subagentOverride
+          ? { provider: subagentOverride.provider, model: subagentOverride.model }
+          : parentModel;
+    // Effort pairs with the model source: an explicit per-spawn effort always
+    // wins; else the subagent override's stored effort rides along when the
+    // override supplied the model. Parent-model fallback carries no effort
+    // (the parent's effort is per-message, not a model property).
+    const reasoningEffort = input.reasoning_effort !== undefined
+        ? input.reasoning_effort
+        : subagentOverride?.effort;
     if (model && !model.provider) {
         return spawnError(
             "`model` was set but no provider could be determined; pass `provider` too",
@@ -186,9 +195,7 @@ export async function runSpawnedAgent(
             agent,
             message: input.task,
             maxModelCalls,
-            ...(input.reasoning_effort === undefined
-                ? {}
-                : { reasoningEffort: input.reasoning_effort }),
+            ...(reasoningEffort === undefined ? {} : { reasoningEffort }),
             signal: opts.signal,
         });
     } catch (error) {
@@ -238,7 +245,7 @@ export async function runSpawnedAgent(
 // Lazy for the same import-cycle reason as resolveServices; best-effort —
 // an unreadable config means "no override", never a failed spawn.
 async function readSubagentOverride(): Promise<
-    z.infer<typeof ModelDescriptor> | null
+    (z.infer<typeof ModelDescriptor> & { effort?: "low" | "medium" | "high" }) | null
 > {
     try {
         const { getSubagentModelOverride } = await import(

--- a/apps/x/packages/core/src/runtime/tools/domains/background-tasks.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/background-tasks.ts
@@ -115,7 +115,10 @@ export const backgroundTaskTools: z.infer<typeof BuiltinToolsSchema> = {
                     (partial as { projectId?: string }).projectId = r.projectId;
                     warning = r.warning;
                 }
-                const result = await patchTask(slug, partial, clearModel ? ['model', 'provider'] : []);
+                // Effort pairs with the model override — clearing the model must clear
+                // it too, or an orphaned effort would override the category
+                // selection's own effort on the next run.
+                const result = await patchTask(slug, partial, clearModel ? ['model', 'provider', 'effort'] : []);
                 return { success: true, task: result, ...(warning ? { warning } : {}) };
             } catch (err) {
                 return { success: false, error: err instanceof Error ? err.message : String(err) };

--- a/apps/x/packages/core/src/security/auto-permission-classifier.ts
+++ b/apps/x/packages/core/src/security/auto-permission-classifier.ts
@@ -7,6 +7,7 @@ import { withUseCase, type UseCase } from "../analytics/use_case.js";
 import { getAutoPermissionDecisionModel, resolveProviderConfig } from "../models/defaults.js";
 import { createLanguageModel } from "../models/models.js";
 import { generateObjectSafe } from "../models/structured.js";
+import { directCallReasoningOptions } from "../models/reasoning.js";
 
 const DecisionSchema = z.object({
     decisions: z.array(z.object({
@@ -81,9 +82,10 @@ export async function classifyToolPermissions(input: {
 }): Promise<AutoPermissionDecision[]> {
     if (input.candidates.length === 0) return [];
 
-    const { model: modelId, provider: providerName } = await getAutoPermissionDecisionModel();
+    const { model: modelId, provider: providerName, effort } = await getAutoPermissionDecisionModel();
     const providerConfig = await resolveProviderConfig(providerName);
     const model = createLanguageModel(providerConfig, modelId);
+    const reasoning = await directCallReasoningOptions(providerConfig.flavor, modelId, effort);
 
     const result = await withUseCase(
         {
@@ -97,6 +99,7 @@ export async function classifyToolPermissions(input: {
             prompt: buildPrompt(input),
             schema: DecisionSchema,
             retry: true,
+            generateOptions: reasoning,
         }),
     );
 

--- a/apps/x/packages/core/src/todo/runner.ts
+++ b/apps/x/packages/core/src/todo/runner.ts
@@ -278,8 +278,13 @@ async function driveTurn(
     try {
         let sent: { turnId: string };
         try {
-            // Chat parity: the assistant model unless the composer overrode it.
-            const { model, provider } = modelOverride ?? await getDefaultModelAndProvider();
+            // Chat parity: the assistant selection (model + effort) unless the
+            // composer overrode the model — an override carries no effort of
+            // its own yet (todo:* sends a bare ref; effort rides only with
+            // the assistant pair, per the pairing rule).
+            const selection: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' } =
+                modelOverride ?? await getDefaultModelAndProvider();
+            const { model, provider } = selection;
             sent = await withUseCase(
                 { useCase: 'todo_item_agent', subUseCase },
                 () => sessions.sendMessage(
@@ -290,6 +295,7 @@ async function driveTurn(
                             agentId: 'todo-item-agent',
                             overrides: { model: { provider, model } },
                         },
+                        ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
                         autoPermission,
                     },
                 ),
@@ -412,7 +418,10 @@ async function driveChatTurn(
     try {
         let sent: { turnId: string };
         try {
-            const { model, provider } = modelOverride ?? await getDefaultModelAndProvider();
+            // Same selection semantics as runTodoItem above.
+            const selection: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' } =
+                modelOverride ?? await getDefaultModelAndProvider();
+            const { model, provider } = selection;
             sent = await withUseCase(
                 { useCase: 'copilot_chat', subUseCase: 'home_stream' },
                 () => sessions.sendMessage(
@@ -423,6 +432,7 @@ async function driveChatTurn(
                             agentId: 'copilot',
                             overrides: { model: { provider, model } },
                         },
+                        ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
                         autoPermission,
                     },
                 ),

--- a/apps/x/packages/shared/src/background-task.ts
+++ b/apps/x/packages/shared/src/background-task.ts
@@ -33,6 +33,7 @@ export type BackgroundTask = {
     projectId?: string;
     model?: string;
     provider?: string;
+    effort?: "low" | "medium" | "high";
     // Folder slug of the Rowboat App that installed this task (spec §8.2).
     // Runtime-managed; tasks with sourceApp are owned by the app lifecycle.
     sourceApp?: string;
@@ -75,6 +76,7 @@ export const BackgroundTaskSchema = z.object({
     projectId: z.string().optional().describe('When set, marks this as a coding task pinned to a registered code project (repo). The agent implements detected work via the launch-code-task tool, each launch in its own isolated worktree.'),
     model: z.string().optional().describe('ADVANCED — leave unset. Per-task model override.'),
     provider: z.string().optional().describe('ADVANCED — leave unset. Per-task provider name override.'),
+    effort: z.enum(['low', 'medium', 'high']).optional().describe('ADVANCED — leave unset. Reasoning effort paired with the per-task model override; unset means Auto (provider default). Only meaningful alongside `model`.'),
     sourceApp: z.string().optional().describe('Folder slug of the app that installed this task. Runtime-managed.'),
     createdAt: z.string().describe('ISO timestamp set once at create-time.'),
     lastAttemptAt: z.string().optional().describe('Runtime-managed — never write this yourself. Bumped at the start of every agent run; used by the scheduler for backoff so failures do not retry-storm.'),

--- a/apps/x/packages/shared/src/initial-selection.ts
+++ b/apps/x/packages/shared/src/initial-selection.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import { ModelRef, TaskModels } from "./models.js";
-import { normalizeModelRecommendation, type ModelRecommendations } from "./rowboat-account.js";
+import { ModelSelection, TaskModels } from "./models.js";
+import {
+    normalizeModelRecommendation,
+    type ModelRecommendations,
+    type RecommendedModelChoice,
+} from "./rowboat-account.js";
 
 /**
  * Initial model selection for a provider being connected for the first time.
@@ -38,12 +42,13 @@ export function selectInitialModel(
     flavor: string,
     availableModelIds: string[],
     recommendations: ModelRecommendations | undefined,
-): string | null {
+): RecommendedModelChoice | null {
     const recommended = normalizeModelRecommendation(recommendations, flavor)?.assistantModel;
-    if (recommended && availableModelIds.includes(recommended)) {
+    if (recommended && availableModelIds.includes(recommended.model)) {
         return recommended;
     }
-    return availableModelIds[0] ?? null;
+    const first = availableModelIds[0];
+    return first ? { model: first } : null;
 }
 
 export function selectInitialTaskModels(
@@ -51,17 +56,23 @@ export function selectInitialTaskModels(
     flavor: string,
     availableModelIds: string[],
     recommendations: ModelRecommendations | undefined,
-    assistantModel: string,
-): Partial<Record<keyof z.infer<typeof TaskModels>, z.infer<typeof ModelRef>>> {
+    assistantModel: RecommendedModelChoice,
+): Partial<Record<keyof z.infer<typeof TaskModels>, z.infer<typeof ModelSelection>>> {
     const taskRecommendations = normalizeModelRecommendation(recommendations, flavor)?.taskModels;
     if (!taskRecommendations) return {};
-    const overrides: Partial<Record<keyof z.infer<typeof TaskModels>, z.infer<typeof ModelRef>>> = {};
+    const overrides: Partial<Record<keyof z.infer<typeof TaskModels>, z.infer<typeof ModelSelection>>> = {};
     for (const key of TASK_MODEL_KEYS) {
-        const model = taskRecommendations[key];
-        // Unknown keys are ignored; a rec equal to the assistant is redundant
-        // (inherit produces it); an unlisted rec is a stale hint.
-        if (!model || model === assistantModel || !availableModelIds.includes(model)) continue;
-        overrides[key] = { provider: providerId, model };
+        const rec = taskRecommendations[key];
+        // Unknown keys are ignored; a rec equal to the assistant pair (model
+        // AND effort) is redundant (inherit produces it); an unlisted rec is
+        // a stale hint.
+        if (!rec || !availableModelIds.includes(rec.model)) continue;
+        if (rec.model === assistantModel.model && rec.effort === assistantModel.effort) continue;
+        overrides[key] = {
+            provider: providerId,
+            model: rec.model,
+            ...(rec.effort ? { effort: rec.effort } : {}),
+        };
     }
     return overrides;
 }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { RelPath, Encoding, Stat, DirEntry, ReaddirOptions, ReadFileResult, WorkspaceChangeEvent, WriteFileOptions, WriteFileResult, RemoveOptions } from './workspace.js';
 import { ListToolsResponse } from './mcp.js';
 import { AskHumanResponsePayload, CreateRunOptions, Run, ListRunsResponse, ToolPermissionAuthorizePayload } from './runs.js';
-import { LlmProvider, ModelRef, ReasoningEffort } from './models.js';
+import { LlmProvider, ModelSelection, ModelRef, ReasoningEffort } from './models.js';
 import { AgentScheduleConfig, AgentScheduleEntry } from './agent-schedule.js';
 import { AgentScheduleState } from './agent-schedule-state.js';
 import { ServiceEvent } from './service-events.js';
@@ -680,8 +680,9 @@ const ipcSchemas = {
           reasoning: z.boolean().optional(),
         })),
       })),
-      // The effective runtime default (what runs when nothing is picked).
-      defaultModel: ModelRef.nullable(),
+      // The effective runtime default (what runs when nothing is picked),
+      // effort included — it seeds new chats' composer state.
+      defaultModel: ModelSelection.nullable(),
     }),
   },
   'models:test': {
@@ -767,15 +768,15 @@ const ipcSchemas = {
         baseURL: z.string().optional(),
         hasApiKey: z.boolean(),
       })),
-      assistantModel: ModelRef.nullable(),
+      assistantModel: ModelSelection.nullable(),
       taskModels: z.object({
-        knowledgeGraph: ModelRef.nullable(),
-        meetingNotes: ModelRef.nullable(),
-        liveNoteAgent: ModelRef.nullable(),
-        autoPermissionDecision: ModelRef.nullable(),
-        chatTitle: ModelRef.nullable(),
-        backgroundTask: ModelRef.nullable(),
-        subagent: ModelRef.nullable(),
+        knowledgeGraph: ModelSelection.nullable(),
+        meetingNotes: ModelSelection.nullable(),
+        liveNoteAgent: ModelSelection.nullable(),
+        autoPermissionDecision: ModelSelection.nullable(),
+        chatTitle: ModelSelection.nullable(),
+        backgroundTask: ModelSelection.nullable(),
+        subagent: ModelSelection.nullable(),
       }),
       deferBackgroundTasks: z.boolean(),
     }),
@@ -785,15 +786,15 @@ const ipcSchemas = {
   // assistant model again). taskModels merges per-key.
   'models:updateConfig': {
     req: z.object({
-      assistantModel: ModelRef.nullable().optional(),
+      assistantModel: ModelSelection.nullable().optional(),
       taskModels: z.object({
-        knowledgeGraph: ModelRef.nullable().optional(),
-        meetingNotes: ModelRef.nullable().optional(),
-        liveNoteAgent: ModelRef.nullable().optional(),
-        autoPermissionDecision: ModelRef.nullable().optional(),
-        chatTitle: ModelRef.nullable().optional(),
-        backgroundTask: ModelRef.nullable().optional(),
-        subagent: ModelRef.nullable().optional(),
+        knowledgeGraph: ModelSelection.nullable().optional(),
+        meetingNotes: ModelSelection.nullable().optional(),
+        liveNoteAgent: ModelSelection.nullable().optional(),
+        autoPermissionDecision: ModelSelection.nullable().optional(),
+        chatTitle: ModelSelection.nullable().optional(),
+        backgroundTask: ModelSelection.nullable().optional(),
+        subagent: ModelSelection.nullable().optional(),
       }).optional(),
       deferBackgroundTasks: z.boolean().nullable().optional(),
     }),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { RelPath, Encoding, Stat, DirEntry, ReaddirOptions, ReadFileResult, WorkspaceChangeEvent, WriteFileOptions, WriteFileResult, RemoveOptions } from './workspace.js';
 import { ListToolsResponse } from './mcp.js';
 import { AskHumanResponsePayload, CreateRunOptions, Run, ListRunsResponse, ToolPermissionAuthorizePayload } from './runs.js';
-import { LlmProvider, ModelSelection, ModelRef, ReasoningEffort } from './models.js';
+import { LlmProvider, ModelSelection, ReasoningEffort } from './models.js';
 import { AgentScheduleConfig, AgentScheduleEntry } from './agent-schedule.js';
 import { AgentScheduleState } from './agent-schedule-state.js';
 import { ServiceEvent } from './service-events.js';

--- a/apps/x/packages/shared/src/live-note.ts
+++ b/apps/x/packages/shared/src/live-note.ts
@@ -50,6 +50,7 @@ export type LiveNote = {
     triggers?: Triggers;
     model?: string;
     provider?: string;
+    effort?: "low" | "medium" | "high";
     lastAttemptAt?: string;
     lastRunAt?: string;
     lastRunId?: string;
@@ -74,6 +75,7 @@ export const LiveNoteSchema = z.object({
     triggers: TriggersSchema.optional().describe('When the agent fires. Omit for manual-only.'),
     model: z.string().optional().describe('ADVANCED — leave unset. Per-note LLM model override (e.g. "anthropic/claude-sonnet-4.6"). Only set when the user explicitly asked for a specific model for THIS note. The global default already picks a tuned model for live-note runs; overriding usually makes things worse, not better.'),
     provider: z.string().optional().describe('ADVANCED — leave unset. Per-note provider name override (e.g. "openai", "anthropic"). Almost always omitted; the global default flows through correctly.'),
+    effort: z.enum(['low', 'medium', 'high']).optional().describe('ADVANCED — leave unset. Reasoning effort paired with the per-note model override; unset means Auto (provider default). Only meaningful alongside `model`.'),
     lastAttemptAt: z.string().optional().describe('Runtime-managed — never write this yourself. Bumped at the start of every agent run; used by the scheduler for backoff so failures do not retry-storm.'),
     lastRunAt: z.string().optional().describe('Runtime-managed — never write this yourself. Bumped only when an agent run *succeeds*; used as the cycle anchor for cron / window triggers and as the freshness timestamp shown in the UI.'),
     lastRunId: z.string().optional().describe('Runtime-managed — never write this yourself. The id of the most recent run (success or failure); used by the live-note:stop handler.'),

--- a/apps/x/packages/shared/src/models.ts
+++ b/apps/x/packages/shared/src/models.ts
@@ -41,17 +41,34 @@ export const ModelRef = z.object({
   model: z.string(),
 });
 
+// Stored effort is lenient on read: missing, null, and "auto" all mean Auto
+// (send nothing; provider default) and normalize to `undefined`. Writers
+// emit the canonical form — the key omitted when Auto.
+export const StoredReasoningEffort = z
+  .union([ReasoningEffort, z.literal("auto"), z.null(), z.undefined()])
+  .transform((v) => (v === "auto" || v === null ? undefined : v));
+
+// A model choice as stored in config: the ref plus the reasoning effort the
+// user picked with it. Model and effort are selected together in the picker
+// and treated as one explicit pair everywhere — Auto (absent effort) means
+// the user picked Auto. Runs seeded from a choice use its effort verbatim;
+// there is no cross-level effort inference.
+export const ModelSelection = ModelRef.extend({
+  effort: StoredReasoningEffort.optional(),
+});
+
 // The per-task model override slots. Absence = inherit the assistant model
 // (except `subagent`, whose default is the PARENT turn's model — which is
-// the assistant for a top-level chat).
+// the assistant for a top-level chat). An override carries its own effort;
+// inheriting the assistant model inherits the assistant's effort with it.
 export const TaskModels = z.object({
-  knowledgeGraph: ModelRef.optional(),
-  meetingNotes: ModelRef.optional(),
-  liveNoteAgent: ModelRef.optional(),
-  autoPermissionDecision: ModelRef.optional(),
-  chatTitle: ModelRef.optional(),
-  backgroundTask: ModelRef.optional(),
-  subagent: ModelRef.optional(),
+  knowledgeGraph: ModelSelection.optional(),
+  meetingNotes: ModelSelection.optional(),
+  liveNoteAgent: ModelSelection.optional(),
+  autoPermissionDecision: ModelSelection.optional(),
+  chatTitle: ModelSelection.optional(),
+  backgroundTask: ModelSelection.optional(),
+  subagent: ModelSelection.optional(),
 });
 export type TaskModelKey = keyof z.infer<typeof TaskModels>;
 
@@ -72,8 +89,10 @@ export const LlmModelConfig = z.object({
   version: z.literal(2),
   providers: z.record(z.string(), LlmProvider),
   // The one primary model choice: what runs when nothing more specific was
-  // picked. Absent only before onboarding / first provider connect.
-  assistantModel: ModelRef.optional(),
+  // picked, and what seeds a new chat's composer (model + effort shown as
+  // the explicit initial selection). Absent only before onboarding / first
+  // provider connect.
+  assistantModel: ModelSelection.optional(),
   taskModels: TaskModels.optional(),
   // When true, background agent runs (knowledge pipeline, live notes,
   // background tasks) wait until no chat turn is running before starting.

--- a/apps/x/packages/shared/src/rowboat-account.ts
+++ b/apps/x/packages/shared/src/rowboat-account.ts
@@ -1,16 +1,21 @@
 import { z } from 'zod';
 import { BillingCatalogSchema } from './billing.js';
 import { CreditActivationCatalogEntrySchema } from './credits.js';
-import { ReasoningEffort, StoredReasoningEffort } from './models.js';
+import { ReasoningEffort } from './models.js';
 
 // One recommended slot on the wire: a bare model id (legacy — effort Auto)
-// or { model, effort? }. Effort is lenient like stored config: missing,
-// null, and "auto" all normalize to undefined (= Auto).
+// or { model, effort? }. Effort is MORE lenient than stored config: any
+// unrecognized value (not just null/"auto") normalizes to undefined (= Auto)
+// — a backend experimenting with a new level (e.g. "minimal") must degrade
+// this hint, never fail the whole /v1/config parse that auth and billing
+// also ride on.
 const RecommendedChoice = z.union([
   z.string(),
   z.object({
     model: z.string(),
-    effort: StoredReasoningEffort.optional(),
+    effort: z.unknown().transform((v) =>
+      v === 'low' || v === 'medium' || v === 'high' ? v : undefined,
+    ).optional(),
   }),
 ]);
 

--- a/apps/x/packages/shared/src/rowboat-account.ts
+++ b/apps/x/packages/shared/src/rowboat-account.ts
@@ -1,6 +1,18 @@
 import { z } from 'zod';
 import { BillingCatalogSchema } from './billing.js';
 import { CreditActivationCatalogEntrySchema } from './credits.js';
+import { ReasoningEffort, StoredReasoningEffort } from './models.js';
+
+// One recommended slot on the wire: a bare model id (legacy — effort Auto)
+// or { model, effort? }. Effort is lenient like stored config: missing,
+// null, and "auto" all normalize to undefined (= Auto).
+const RecommendedChoice = z.union([
+  z.string(),
+  z.object({
+    model: z.string(),
+    effort: StoredReasoningEffort.optional(),
+  }),
+]);
 
 export const RowboatApiConfig = z.object({
   appUrl: z.string(),
@@ -28,17 +40,28 @@ export const RowboatApiConfig = z.object({
   modelRecommendations: z.record(z.string(), z.union([
     z.string(),
     z.object({
-      assistantModel: z.string(),
-      taskModels: z.record(z.string(), z.string()).optional(),
+      assistantModel: RecommendedChoice,
+      taskModels: z.record(z.string(), RecommendedChoice).optional(),
     }),
   ])).optional(),
 });
 
 export type ModelRecommendations = NonNullable<z.infer<typeof RowboatApiConfig>['modelRecommendations']>;
 
+/** A recommendation slot in canonical form: model id + normalized effort. */
+export interface RecommendedModelChoice {
+  model: string;
+  effort?: z.infer<typeof ReasoningEffort>;
+}
+
 export interface NormalizedModelRecommendation {
-  assistantModel: string;
-  taskModels: Record<string, string>;
+  assistantModel: RecommendedModelChoice;
+  taskModels: Record<string, RecommendedModelChoice>;
+}
+
+function normalizeChoice(raw: z.infer<typeof RecommendedChoice>): RecommendedModelChoice {
+  if (typeof raw === 'string') return { model: raw };
+  return { model: raw.model, ...(raw.effort ? { effort: raw.effort } : {}) };
 }
 
 /** One provider's recommendation in canonical form; null when absent. */
@@ -48,6 +71,11 @@ export function normalizeModelRecommendation(
 ): NormalizedModelRecommendation | null {
   const raw = recommendations?.[flavor];
   if (!raw) return null;
-  if (typeof raw === 'string') return { assistantModel: raw, taskModels: {} };
-  return { assistantModel: raw.assistantModel, taskModels: raw.taskModels ?? {} };
+  if (typeof raw === 'string') return { assistantModel: { model: raw }, taskModels: {} };
+  return {
+    assistantModel: normalizeChoice(raw.assistantModel),
+    taskModels: Object.fromEntries(
+      Object.entries(raw.taskModels ?? {}).map(([key, value]) => [key, normalizeChoice(value)]),
+    ),
+  };
 }


### PR DESCRIPTION
## Problem

Reasoning effort existed only as a per-message lever in the composer. The model picker and effort control were separate widgets with separate state; settings had no notion of effort; background work (task slots, live notes, bg tasks, subagents, one-shot utilities) ran effort-blind; and a chat's model/effort didn't survive reopening. Under the hood, model and effort travelled as disconnected values through different plumbing at every layer.

## Change

**One canonical value.** `ModelSelection { provider, model, effort? }` is THE selection type, threaded UI → IPC → config → run creation. Model and effort are picked together, stored together, and sent together; absent effort = Auto (provider default). Stored config is lenient on read (missing / `null` / `"auto"` all mean Auto) and canonical on write. The persisted turn-event store keeps its flat fields — the selection decomposes at turn creation; append-only history is untouched.

**Picker.** The composer's separate effort pill is gone. Hovering a reasoning-capable model row opens an effort panel (Auto / Fast / Balanced / Thorough) — clicking a level commits model AND effort in one gesture; clicking the row commits the model at Auto, so a stale effort can never ride a model switch. A grace-intent triangle (what Radix submenus do natively) keeps diagonal pointer travel from re-anchoring the panel. The pill and settings fields show the grayed short form ("claude-fable-5 Thoro").

**Selection lifecycle.** Settings is a seed, not a live binding: a new chat's composer starts on the settings pair as an explicit snapshot; picking anything in-chat owns it; every send carries the full explicit selection, so a session's turns record exactly what the pill showed. Reopened sessions restore the selection their last turn ran with (surfaced by the session store as `lastSelection`), holding the settings seed while the session loads — with an identity gate so a still-bound previous session can never leak its selection into the newly opened one. Built on the ChatSession architecture: one chatId-keyed selection map, `ChatSessionComposer` in both panes, Home v2's composer folded onto the same single value.

**Settings + background work.** The assistant model and all seven task slots store the pair; every consumer honors it: headless agent runs (knowledge graph, live notes, bg tasks), one-shot utilities (chat titles, meeting notes/prep, auto-permission, email classifiers, schedule classifier) via a shared `directCallReasoningOptions` helper with the same capability gating and Anthropic output floor the turn bridge uses, subagent spawns (explicit per-spawn effort > slot override > parent), todo-item runs (chat parity: assistant effort rides along), and per-item overrides on individual live notes (`live:` frontmatter) and bg tasks (`task.yaml`) — item effort pairs with the item's model, clearing the model clears it.

**Recommendations.** `/v1/config` slots accept `string | { model, effort? }` (legacy string form still supported); initial selection at provider connect / sign-in seeds effort. The effort field is fail-soft: an unknown level degrades to Auto rather than failing the config parse that auth and billing also ride on.

An adversarial two-lens self-review of the full diff ran before this PR; its confirmed findings (stale-restore race, Home handoff seed race, orphaned-effort clears, todo parity, fail-soft parsing) are fixed in-branch.

## Verification

Typecheck clean across the workspace; 133 renderer + 90 core + 107 shared tests (new coverage: picker contract, initial-selection effort seeding, stored-effort leniency); production build green; lint delta vs main zero.

## Known follow-ups

- `/v1/config` backend change to actually send `{ model, effort? }` slots (client accepts both forms today).
- `todo:*` IPC still carries a bare model ref — effort threading through an explicit todo model override.
- Effort selection is pointer-only in the picker (keyboard commits Auto) — a11y follow-up.
- QA watch: gemini-2.5 at low effort pairs a 2048 thinking budget with the 1000-token chat-title cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)