### PR TITLE
feat(x): in-house PPTX editor — view, edit, and present decks in the workspace

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1105,6 +1105,38 @@ export function setupIpcHandlers() {
     'workspace:remove': async (_event, args) => {
       return workspace.remove(args.path, args.opts);
     },
+    'workspace:pickImage': async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      const options = {
+        properties: ['openFile' as const],
+        filters: [
+          { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'tiff'] },
+        ],
+      };
+      const result = win
+        ? await dialog.showOpenDialog(win, options)
+        : await dialog.showOpenDialog(options);
+      const filePath = result.filePaths[0];
+      if (result.canceled || !filePath) {
+        return { picked: false };
+      }
+      try {
+        const bytes = await fs.readFile(filePath);
+        const ext = path.extname(filePath).slice(1).toLowerCase();
+        if (!ext) {
+          return { picked: false, error: 'That file has no extension' };
+        }
+        return {
+          picked: true,
+          name: path.basename(filePath),
+          ext,
+          dataBase64: bytes.toString('base64'),
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to read the image';
+        return { picked: false, error: message };
+      }
+    },
     'workspace:exportCopy': async (event, args) => {
       // Same path scoping as every other workspace handler: the source must
       // resolve inside the workspace boundary, and this throws if it does not.

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1105,6 +1105,29 @@ export function setupIpcHandlers() {
     'workspace:remove': async (_event, args) => {
       return workspace.remove(args.path, args.opts);
     },
+    'workspace:exportCopy': async (event, args) => {
+      // Same path scoping as every other workspace handler: the source must
+      // resolve inside the workspace boundary, and this throws if it does not.
+      const sourcePath = workspace.resolveWorkspacePath(args.path);
+      const win = BrowserWindow.fromWebContents(event.sender);
+      const options = { defaultPath: path.basename(sourcePath) };
+      // Electron rejects an explicit null window, so use the modeless overload
+      // when the sender has none rather than passing one through.
+      const result = win
+        ? await dialog.showSaveDialog(win, options)
+        : await dialog.showSaveDialog(options);
+      if (result.canceled || !result.filePath) {
+        return { saved: false };
+      }
+      try {
+        // The dialog already confirmed any overwrite with the user.
+        await fs.copyFile(sourcePath, result.filePath);
+        return { saved: true, dest: result.filePath };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to export a copy';
+        return { saved: false, error: message };
+      }
+    },
     'gmail:getImportant': async (_event, args) => {
       return listImportantThreads({ cursor: args.cursor, limit: args.limit });
     },

--- a/apps/x/apps/renderer/NOTICE.md
+++ b/apps/x/apps/renderer/NOTICE.md
@@ -1,0 +1,32 @@
+# Third-party attributions
+
+This application contains code adapted from the following open-source
+projects. Each source file containing adapted code carries a header noting
+its origin.
+
+## pptx-viewer (Apache License 2.0)
+
+<https://github.com/ChristopherVR/pptx-viewer>
+
+Portions adapted in:
+
+- `src/lib/pptx/theme.ts` — OOXML drawing color transform application order
+  and math (structural → shade/tint → batched HSL → RGB channels), RGB/HSL
+  conversion behavior, scRGB gamma companding, and the lazy `p:clrMap` alias
+  routing model (the theme scheme as source of truth, `tx1`/`bg1`/`tx2`/`bg2`
+  resolved through the active master's color map at lookup time). Reference
+  files: `packages/core/src/core/color/color-transforms.ts`,
+  `packages/core/src/core/color/color-primitives.ts`,
+  `packages/core/src/core/core/runtime/PptxHandlerRuntimeThemeLoading.ts`.
+- `src/lib/pptx/geometry.ts` — the `phClr` substitution model for resolving
+  `p:style` fill/line references through the theme format scheme.
+
+The XML traversal in both files is our own (this codebase uses
+fast-xml-parser's preserveOrder document shape); the adapted portions are the
+resolution semantics and math noted above.
+
+## PPTXjs (MIT License)
+
+<https://github.com/meshesha/PPTXjs>
+
+License reviewed; no code from this project is currently included.

--- a/apps/x/apps/renderer/package.json
+++ b/apps/x/apps/renderer/package.json
@@ -54,6 +54,8 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "codemirror": "^6.0.2",
+    "fast-xml-parser": "^5.10.1",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.562.0",
     "mermaid": "^11.14.0",
     "motion": "^12.23.26",

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import { ImageFileViewer } from '@/components/image-file-viewer';
 import { VideoFileViewer } from '@/components/video-file-viewer';
 import { AudioFileViewer } from '@/components/audio-file-viewer';
 import { DocxFileViewer } from '@/components/docx-file-viewer';
+import { PptxEditor } from '@/components/pptx-editor';
 import { PersistentViewerCache } from '@/components/persistent-viewer-cache';
 import { UnsupportedFileViewer } from '@/components/unsupported-file-viewer';
 import { getViewerType, isCacheableViewerPath } from '@/lib/file-types';
@@ -7428,6 +7429,10 @@ function App() {
                 ) : selectedPath && getViewerType(selectedPath) === 'docx' ? (
                   <div className="flex-1 min-h-0 overflow-hidden">
                     <DocxFileViewer path={selectedPath} />
+                  </div>
+                ) : selectedPath && getViewerType(selectedPath) === 'pptx' ? (
+                  <div className="flex-1 min-h-0 overflow-hidden">
+                    <PptxEditor key={selectedPath} path={selectedPath} />
                   </div>
                 ) : (
                   <div className="flex-1 min-h-0 overflow-hidden">

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -2,52 +2,59 @@ import {
   Component,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
-  type MouseEvent as ReactMouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
-import {
-  BarChart3Icon,
-  ExternalLinkIcon,
-  FilmIcon,
-  GroupIcon,
-  Loader2Icon,
-  PresentationIcon,
-  ShapesIcon,
-  TableIcon,
-} from 'lucide-react'
+import { ExternalLinkIcon, Loader2Icon, PresentationIcon } from 'lucide-react'
+import { toast } from 'sonner'
 import { disposeDeck, parsePptx } from '@/lib/pptx/parse'
+import { writeDeck, type EditedParagraph, type RunFormatOverrides } from '@/lib/pptx/serialize'
+import type { NodePath, Paragraph, Shape, Slide, SlideDeck, TextAlign, TextShape } from '@/lib/pptx/types'
 import {
-  normalizeParagraphs,
-  writeDeck,
-  type EditedParagraph,
-  type EditedTextRun,
-  type ShapeTextEdit,
-} from '@/lib/pptx/serialize'
-import type {
-  PlaceholderKind,
-  Shape,
-  Slide,
-  SlideDeck,
-  TextRun,
-  TextShape,
-} from '@/lib/pptx/types'
+  EMPTY_EDIT_SET,
+  EMU_PER_PX,
+  acceptsFormatting,
+  applyEditSet,
+  hasEdits,
+  runKeyOf,
+  shapeKeyOf,
+  structureMatches,
+  toSlideEdits,
+  withShapeEdit,
+  type EditSet,
+  type RectEmuBox,
+  type ShapeKey,
+} from '@/components/pptx/edit-model'
+import { SlideCanvas } from '@/components/pptx/canvas'
+import {
+  EditorToolbar,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  ZOOM_STEPS,
+  type SaveStatus,
+} from '@/components/pptx/toolbar'
+import {
+  DEFAULT_TEXT_PT,
+  aggregateFormat,
+  aggregateFormatOfParagraphs,
+  applyAlignToBlocks,
+  applyFormatToSpans,
+  selectedParagraphBlocks,
+  selectedRunSpans,
+  type TextOverlayHandle,
+} from '@/components/pptx/text-dom'
 
 interface PptxEditorProps {
   path: string
 }
 
 type LoadState = 'loading' | 'ready' | 'error'
-type SaveStatus = 'clean' | 'saving' | 'saved' | 'error'
 
 const SAVE_DEBOUNCE_MS = 800
-/** 914400 EMU per inch / 72 pt per inch. */
-const EMU_PER_PT = 12700
-const DEFAULT_TEXT_PT = 18
+const MAX_HISTORY = 100
 
 function base64ToUint8Array(base64: string): Uint8Array {
   const binary = atob(base64)
@@ -71,25 +78,6 @@ function baseName(path: string): string {
   return segs[segs.length - 1] || path
 }
 
-function alignToCss(align: string | undefined): 'left' | 'center' | 'right' | 'justify' {
-  return align === 'ctr' ? 'center' : align === 'r' ? 'right' : align === 'just' ? 'justify' : 'left'
-}
-
-function rectStyle(shape: Shape, scale: number): CSSProperties {
-  return {
-    position: 'absolute',
-    left: shape.xfrmEmu.x * scale,
-    top: shape.xfrmEmu.y * scale,
-    width: shape.xfrmEmu.w * scale,
-    height: shape.xfrmEmu.h * scale,
-  }
-}
-
-/** Stable identity for a shape across state updates: slide + node path. */
-function editKeyOf(slide: Slide, shape: Shape): string {
-  return `${slide.xmlPath}#${shape.nodePath.join('.')}`
-}
-
 /** First non-empty line of text on a slide, used to label its rail card. */
 function slideTitle(slide: Slide): string | null {
   for (const shape of slide.shapes) {
@@ -102,55 +90,76 @@ function slideTitle(slide: Slide): string | null {
   return null
 }
 
-const PLACEHOLDER_META: Record<PlaceholderKind, { label: string; Icon: typeof ShapesIcon }> = {
-  chart: { label: 'Chart', Icon: BarChart3Icon },
-  smartart: { label: 'Diagram', Icon: ShapesIcon },
-  table: { label: 'Table', Icon: TableIcon },
-  group: { label: 'Group', Icon: GroupIcon },
-  video: { label: 'Video', Icon: FilmIcon },
-  unknown: { label: 'Shape', Icon: ShapesIcon },
+function findShape(slide: Slide | null, key: ShapeKey | null): Shape | undefined {
+  if (!slide || !key) return undefined
+  return slide.shapes.find((s) => shapeKeyOf(slide.xmlPath, s.nodePath) === key)
+}
+
+function baseParagraphsOf(
+  base: SlideDeck | null,
+  slidePath: string,
+  nodePath: NodePath,
+): Paragraph[] | undefined {
+  const slide = base?.slides.find((s) => s.xmlPath === slidePath)
+  const shape = slide?.shapes.find((s) => s.nodePath.join('.') === nodePath.join('.'))
+  return shape?.type === 'text' ? shape.paragraphs : undefined
+}
+
+/** Structure + text only; formatting is compared separately. */
+function textSignature(paras: readonly { runs: readonly { text: string }[] }[]): string {
+  return JSON.stringify(paras.map((p) => p.runs.map((r) => r.text)))
 }
 
 export function PptxEditor({ path }: PptxEditorProps) {
   const [loadState, setLoadState] = useState<LoadState>('loading')
-  const [deck, setDeck] = useState<SlideDeck | null>(null)
+  const [baseDeck, setBaseDeck] = useState<SlideDeck | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
-  const [selectedShapeId, setSelectedShapeId] = useState<string | null>(null)
+  const [selectedKey, setSelectedKey] = useState<ShapeKey | null>(null)
+  const [editingKey, setEditingKey] = useState<ShapeKey | null>(null)
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('clean')
-  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [zoomMode, setZoomMode] = useState<'fit' | number>('fit')
+  const [zoomPercent, setZoomPercent] = useState(100)
+  const [selectionTick, setSelectionTick] = useState(0)
 
-  // Held separately from state so save/cleanup closures always see the live
-  // deck. Not cleared on unmount: an in-flight save may still be serializing.
-  const deckRef = useRef<SlideDeck | null>(null)
-  /** slideXmlPath → (nodePath key → edit). `original` is always the as-parsed model. */
-  const editsRef = useRef<Map<string, Map<string, ShapeTextEdit>>>(new Map())
+  const [history, setHistory] = useState<EditSet[]>([EMPTY_EDIT_SET])
+  const [histIndex, setHistIndex] = useState(0)
+  const editSet = history[histIndex] ?? EMPTY_EDIT_SET
+
+  const rootRef = useRef<HTMLDivElement>(null)
+  const baseDeckRef = useRef<SlideDeck | null>(null)
+  const editSetRef = useRef<EditSet>(EMPTY_EDIT_SET)
+  const histIndexRef = useRef(0)
+  const overlayRef = useRef<TextOverlayHandle | null>(null)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const savingRef = useRef(false)
   const pendingRef = useRef(false)
   const dirtyRef = useRef(false)
   const lastWrittenRef = useRef<string | null>(null)
 
-  // Serialize the deck (original bytes + accumulated edits) and write it back.
-  // `path` is constant for this mount (App keys the component by path), so a
-  // late-firing save can only ever write its own document.
+  useEffect(() => {
+    editSetRef.current = editSet
+  }, [editSet])
+  useEffect(() => {
+    histIndexRef.current = histIndex
+  }, [histIndex])
+
+  // ------------------------------------------------------------- persistence
+
   const persist = useCallback(async () => {
-    const deckNow = deckRef.current
-    if (!deckNow) return
+    const base = baseDeckRef.current
+    if (!base) return
     if (savingRef.current) {
       pendingRef.current = true
       return
     }
     savingRef.current = true
     try {
-      const editsBySlide = new Map<string, ShapeTextEdit[]>()
-      for (const [slidePath, shapeEdits] of editsRef.current) {
-        if (shapeEdits.size > 0) editsBySlide.set(slidePath, [...shapeEdits.values()])
-      }
-      if (editsBySlide.size === 0) {
+      const edits = editSetRef.current
+      if (!hasEdits(edits) && lastWrittenRef.current === null) {
         setSaveStatus('clean')
         return
       }
-      const bytes = await writeDeck(deckNow, editsBySlide)
+      const bytes = await writeDeck(base, toSlideEdits(edits))
       const b64 = uint8ArrayToBase64(bytes)
       if (b64 !== lastWrittenRef.current) {
         await window.ipc.invoke('workspace:writeFile', {
@@ -167,7 +176,6 @@ export function PptxEditor({ path }: PptxEditorProps) {
       setSaveStatus('error')
     } finally {
       savingRef.current = false
-      // A commit landed while we were saving — flush it.
       if (pendingRef.current) {
         pendingRef.current = false
         scheduleSave()
@@ -177,16 +185,29 @@ export function PptxEditor({ path }: PptxEditorProps) {
   }, [path])
 
   const scheduleSave = useCallback(() => {
+    dirtyRef.current = true
+    setSaveStatus('saving')
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     saveTimerRef.current = setTimeout(() => {
       void persist()
     }, SAVE_DEBOUNCE_MS)
   }, [persist])
 
-  // Flush pending edits when navigating away or unmounting. Declared BEFORE
-  // the load effect so this cleanup runs before the deck's blob URLs are
-  // revoked (writeDeck reads the zip, not the blob URLs, so even an async
-  // in-flight serialization stays valid).
+  /** Commits a new edit set: pushes onto the undo stack and schedules a save. */
+  const pushEdits = useCallback(
+    (next: EditSet) => {
+      setHistory((h) => {
+        const trimmed = [...h.slice(0, histIndexRef.current + 1), next]
+        return trimmed.length > MAX_HISTORY ? trimmed.slice(trimmed.length - MAX_HISTORY) : trimmed
+      })
+      setHistIndex((i) => Math.min(i + 1, MAX_HISTORY - 1))
+      editSetRef.current = next
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
+
+  // Flush pending edits on unmount / path change, before blob URLs are revoked.
   useEffect(() => {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
@@ -195,80 +216,368 @@ export function PptxEditor({ path }: PptxEditorProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path])
 
-  // App.tsx keys this component by path, so a different file arrives as a fresh
-  // mount with fresh state — no synchronous resets needed here.
+  // App.tsx keys this component by path, so a different file is a fresh mount.
   useEffect(() => {
     let cancelled = false
-
     ;(async () => {
       try {
         const result = await window.ipc.invoke('workspace:readFile', { path, encoding: 'base64' })
         const parsed = await parsePptx(base64ToUint8Array(result.data))
         if (cancelled) {
-          // Nobody will render these; release them now.
           disposeDeck(parsed)
           return
         }
-        deckRef.current = parsed
-        setDeck(parsed)
+        baseDeckRef.current = parsed
+        setBaseDeck(parsed)
         setLoadState('ready')
       } catch (err) {
         console.error('Failed to open pptx:', err)
         if (!cancelled) setLoadState('error')
       }
     })()
-
     return () => {
       cancelled = true
-      if (deckRef.current) disposeDeck(deckRef.current)
+      if (baseDeckRef.current) disposeDeck(baseDeckRef.current)
     }
   }, [path])
 
-  const commitEdit = useCallback(
-    (slide: Slide, shape: TextShape, next: EditedParagraph[] | null) => {
-      setEditingKey(null)
-      if (!next) return
-      if (normalizeParagraphs(next) === normalizeParagraphs(shape.paragraphs)) return
+  // ------------------------------------------------------------ derived deck
 
-      const slideEdits = editsRef.current.get(slide.xmlPath) ?? new Map<string, ShapeTextEdit>()
-      editsRef.current.set(slide.xmlPath, slideEdits)
-      const key = shape.nodePath.join('.')
-      const existing = slideEdits.get(key)
-      slideEdits.set(key, {
-        nodePath: shape.nodePath,
-        // First edit of this shape: its current paragraphs ARE the as-parsed
-        // original. Later edits keep the first capture.
-        original: existing?.original ?? shape.paragraphs,
-        next,
-      })
+  const deck = useMemo(
+    () => (baseDeck ? applyEditSet(baseDeck, editSet) : null),
+    [baseDeck, editSet],
+  )
+  const slide = deck?.slides[activeIndex] ?? null
+  const selectedShape = findShape(slide, selectedKey)
+  const shapeEdit = selectedKey ? editSet[selectedKey] : undefined
 
-      setDeck(
-        (d) =>
-          d && {
-            ...d,
-            slides: d.slides.map((s) =>
-              s !== slide
-                ? s
-                : { ...s, shapes: s.shapes.map((sh) => (sh !== shape ? sh : { ...sh, paragraphs: next })) },
-            ),
-          },
-      )
-      dirtyRef.current = true
-      setSaveStatus('saving')
-      scheduleSave()
-    },
-    [scheduleSave],
+  // ------------------------------------------------------------ undo / redo
+
+  const canUndo = histIndex > 0
+  const canRedo = histIndex < history.length - 1
+
+  const undo = useCallback(() => {
+    if (histIndexRef.current <= 0) return
+    const next = histIndexRef.current - 1
+    histIndexRef.current = next
+    editSetRef.current = history[next] ?? EMPTY_EDIT_SET
+    setHistIndex(next)
+    setEditingKey(null)
+    scheduleSave()
+  }, [history, scheduleSave])
+
+  const redo = useCallback(() => {
+    if (histIndexRef.current >= history.length - 1) return
+    const next = histIndexRef.current + 1
+    histIndexRef.current = next
+    editSetRef.current = history[next] ?? EMPTY_EDIT_SET
+    setHistIndex(next)
+    setEditingKey(null)
+    scheduleSave()
+  }, [history, scheduleSave])
+
+  // ----------------------------------------------------------- edit commits
+
+  const seedFor = useCallback(
+    (slidePath: string, shape: Shape) => ({
+      slidePath,
+      nodePath: shape.nodePath,
+      original:
+        shape.type === 'text'
+          ? baseParagraphsOf(baseDeckRef.current, slidePath, shape.nodePath)
+          : undefined,
+    }),
+    [],
   )
 
-  const slide = deck?.slides[activeIndex] ?? null
+  const handleGeometryCommit = useCallback(
+    (shape: Shape, rect: RectEmuBox) => {
+      if (!slide) return
+      const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
+      pushEdits(
+        withShapeEdit(editSetRef.current, key, seedFor(slide.xmlPath, shape), (draft) => {
+          draft.geometry = rect
+        }),
+      )
+    },
+    [slide, pushEdits, seedFor],
+  )
+
+  const handleTextCommit = useCallback(
+    (shape: TextShape, next: EditedParagraph[] | null) => {
+      setEditingKey(null)
+      if (!next || !slide) return
+      const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
+      const original = baseParagraphsOf(baseDeckRef.current, slide.xmlPath, shape.nodePath)
+      if (!original) return
+
+      // The text edit carries ORIGINAL formatting so it stays on the
+      // in-place splice path; formatting travels as formatRuns / aligns.
+      const textNext: EditedParagraph[] = next.map((p) => ({
+        align: p.srcPara !== undefined ? original[p.srcPara]?.align : p.align,
+        srcPara: p.srcPara,
+        runs: p.runs.map((r) => {
+          const src =
+            r.srcPara !== undefined && r.srcRun !== undefined
+              ? original[r.srcPara]?.runs[r.srcRun]
+              : undefined
+          return {
+            text: r.text,
+            srcPara: r.srcPara,
+            srcRun: r.srcRun,
+            bold: src?.bold,
+            italic: src?.italic,
+            underline: src?.underline,
+            sizePt: src?.sizePt,
+            colorHex: src?.colorHex,
+          }
+        }),
+      }))
+
+      const structural = !structureMatches(original, textNext)
+      const textChanged = textSignature(textNext) !== textSignature(original)
+
+      // Formatting is only addressable while the structure still lines up.
+      const formats: Record<string, RunFormatOverrides> = {}
+      const aligns: Record<string, TextAlign> = {}
+      if (!structural) {
+        next.forEach((p, pi) => {
+          const srcPara = original[pi]
+          if (!srcPara) return
+          if (p.align && p.align !== srcPara.align) aligns[String(pi)] = p.align
+          p.runs.forEach((r, ri) => {
+            if (r.text === '\n') return
+            const src = srcPara.runs[ri]
+            if (!src) return
+            const delta: RunFormatOverrides = {}
+            if (Boolean(r.bold) !== Boolean(src.bold)) delta.bold = Boolean(r.bold)
+            if (Boolean(r.italic) !== Boolean(src.italic)) delta.italic = Boolean(r.italic)
+            if (Boolean(r.underline) !== Boolean(src.underline)) delta.underline = Boolean(r.underline)
+            if ((r.sizePt ?? null) !== (src.sizePt ?? null) && r.sizePt !== undefined) {
+              delta.sizePt = r.sizePt
+            }
+            if ((r.colorHex ?? null) !== (src.colorHex ?? null) && r.colorHex !== undefined) {
+              delta.colorHex = r.colorHex
+            }
+            if (Object.keys(delta).length > 0) formats[runKeyOf(pi, ri)] = delta
+          })
+        })
+      }
+
+      const previous = editSetRef.current[key]
+      const hadFormatting =
+        Boolean(previous?.formats && Object.keys(previous.formats).length) ||
+        Boolean(previous?.aligns && Object.keys(previous.aligns).length)
+      const nothingChanged =
+        !textChanged &&
+        Object.keys(formats).length === 0 &&
+        Object.keys(aligns).length === 0 &&
+        !hadFormatting
+      if (nothingChanged) return
+
+      if (structural && hadFormatting) {
+        toast.info('Formatting was reset on this text box because its structure changed.')
+      }
+
+      pushEdits(
+        withShapeEdit(editSetRef.current, key, seedFor(slide.xmlPath, shape), (draft) => {
+          draft.original = original
+          draft.text = textChanged || structural ? textNext : undefined
+          if (structural) {
+            // A rebuilt <a:p> range would overlap formatting splices.
+            draft.formats = undefined
+            draft.aligns = undefined
+          } else {
+            draft.formats = Object.keys(formats).length > 0 ? formats : undefined
+            draft.aligns = Object.keys(aligns).length > 0 ? aligns : undefined
+          }
+        }),
+      )
+    },
+    [slide, pushEdits, seedFor],
+  )
+
+  // ------------------------------------------------------------ formatting
+
+  const canFormat =
+    selectedShape?.type === 'text' && acceptsFormatting(shapeEdit) && slide !== null
+
+  const formatDisabledReason = !selectedShape
+    ? 'Select a text box first'
+    : selectedShape.type !== 'text'
+      ? 'This shape has no text'
+      : !acceptsFormatting(shapeEdit)
+        ? 'Formatting is unavailable after changing this text box’s structure'
+        : null
+
+  // Reads live DOM while editing so the toolbar mirrors the caret's run.
+  // `selectionTick` is what forces the recompute.
+  void selectionTick
+  const activeFormat: RunFormatOverrides | null = !canFormat
+    ? null
+    : overlayRef.current
+      ? aggregateFormat(selectedRunSpans(overlayRef.current.root), overlayRef.current.scale)
+      : aggregateFormatOfParagraphs((selectedShape as TextShape).paragraphs)
+
+  const activeAlign: TextAlign | null = !canFormat
+    ? null
+    : overlayRef.current
+      ? ((selectedParagraphBlocks(overlayRef.current.root)[0]?.getAttribute('data-algn') ||
+          'l') as TextAlign)
+      : ((selectedShape as TextShape).paragraphs[0]?.align ?? 'l')
+
+  const applyFormat = useCallback(
+    (set: RunFormatOverrides) => {
+      if (!slide || !selectedKey) return
+      const shape = findShape(slide, selectedKey)
+      if (shape?.type !== 'text') return
+
+      const overlay = overlayRef.current
+      if (overlay) {
+        // Editing: mutate the spans; the commit on blur turns this into edits.
+        applyFormatToSpans(selectedRunSpans(overlay.root), set, overlay.scale)
+        setSelectionTick((t) => t + 1)
+        dirtyRef.current = true
+        return
+      }
+
+      const original = baseParagraphsOf(baseDeckRef.current, slide.xmlPath, shape.nodePath)
+      if (!original) return
+      pushEdits(
+        withShapeEdit(editSetRef.current, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
+          draft.original = original
+          const formats = { ...(draft.formats ?? {}) }
+          original.forEach((p, pi) =>
+            p.runs.forEach((r, ri) => {
+              if (r.text === '\n') return
+              const key = runKeyOf(pi, ri)
+              formats[key] = { ...formats[key], ...set }
+            }),
+          )
+          draft.formats = formats
+        }),
+      )
+    },
+    [slide, selectedKey, pushEdits, seedFor],
+  )
+
+  const applyAlign = useCallback(
+    (align: TextAlign) => {
+      if (!slide || !selectedKey) return
+      const shape = findShape(slide, selectedKey)
+      if (shape?.type !== 'text') return
+
+      const overlay = overlayRef.current
+      if (overlay) {
+        applyAlignToBlocks(selectedParagraphBlocks(overlay.root), align)
+        setSelectionTick((t) => t + 1)
+        dirtyRef.current = true
+        return
+      }
+
+      const original = baseParagraphsOf(baseDeckRef.current, slide.xmlPath, shape.nodePath)
+      if (!original) return
+      pushEdits(
+        withShapeEdit(editSetRef.current, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
+          draft.original = original
+          const aligns = { ...(draft.aligns ?? {}) }
+          original.forEach((_, pi) => {
+            aligns[String(pi)] = align
+          })
+          draft.aligns = aligns
+        }),
+      )
+    },
+    [slide, selectedKey, pushEdits, seedFor],
+  )
+
+  const stepFontSize = useCallback(
+    (delta: number) => {
+      const current = activeFormat?.sizePt ?? DEFAULT_TEXT_PT
+      const next = Math.min(400, Math.max(1, Math.round(current + delta)))
+      applyFormat({ sizePt: next })
+    },
+    [activeFormat, applyFormat],
+  )
+
+  // Keep the toolbar in step with the caret while editing.
+  useEffect(() => {
+    if (!editingKey) return
+    const onSelectionChange = () => setSelectionTick((t) => t + 1)
+    document.addEventListener('selectionchange', onSelectionChange)
+    return () => document.removeEventListener('selectionchange', onSelectionChange)
+  }, [editingKey])
+
+  // ------------------------------------------------------------------ zoom
+
+  const zoomTo = useCallback(
+    (direction: 1 | -1) => {
+      const current = Math.round(zoomPercent)
+      const next =
+        direction > 0
+          ? (ZOOM_STEPS.find((z) => z > current + 0.5) ?? MAX_ZOOM)
+          : ([...ZOOM_STEPS].reverse().find((z) => z < current - 0.5) ?? MIN_ZOOM)
+      setZoomMode(next)
+    },
+    [zoomPercent],
+  )
+
+  const handleScaleChange = useCallback((_scale: number, percent: number) => {
+    setZoomPercent(percent)
+  }, [])
+
+  // -------------------------------------------------------------- keyboard
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      const mod = e.metaKey || e.ctrlKey
+      if (mod && e.key.toLowerCase() === 'z') {
+        // Inside the text overlay the browser owns undo.
+        if (editingKey) return
+        e.preventDefault()
+        if (e.shiftKey) redo()
+        else undo()
+        return
+      }
+      if (e.key === 'Escape') {
+        if (editingKey) return // the overlay commits and clears it
+        if (selectedKey) {
+          e.preventDefault()
+          setSelectedKey(null)
+        }
+        return
+      }
+      if (editingKey || !selectedKey || !slide) return
+
+      const nudge: Record<string, [number, number]> = {
+        ArrowLeft: [-1, 0],
+        ArrowRight: [1, 0],
+        ArrowUp: [0, -1],
+        ArrowDown: [0, 1],
+      }
+      const dir = nudge[e.key]
+      if (!dir) return
+      const shape = findShape(slide, selectedKey)
+      if (!shape) return
+      e.preventDefault()
+      const step = EMU_PER_PX * (e.shiftKey ? 10 : 1)
+      handleGeometryCommit(shape, {
+        x: Math.round(shape.xfrmEmu.x + dir[0] * step),
+        y: Math.round(shape.xfrmEmu.y + dir[1] * step),
+        w: shape.xfrmEmu.w,
+        h: shape.xfrmEmu.h,
+      })
+    },
+    [editingKey, selectedKey, slide, undo, redo, handleGeometryCommit],
+  )
+
+  // ---------------------------------------------------------------- render
 
   const openExternally = useCallback(() => {
     void window.ipc.invoke('shell:openPath', { path })
   }, [path])
 
-  if (loadState === 'error') {
-    return <FailurePanel path={path} onOpen={openExternally} />
-  }
+  if (loadState === 'error') return <FailurePanel path={path} onOpen={openExternally} />
 
   if (loadState === 'loading' || !deck) {
     return (
@@ -291,58 +600,87 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
   return (
     <EditorErrorBoundary path={path} onOpen={openExternally}>
-      <div className="flex h-full w-full min-h-0 bg-background">
-        <nav
-          aria-label="Slides"
-          className="flex w-56 shrink-0 flex-col gap-2 overflow-y-auto border-r border-border bg-card/40 p-3"
-        >
-          {deck.slides.map((s, i) => (
-            <SlideCard
-              key={s.xmlPath}
-              index={i}
-              title={slideTitle(s)}
-              active={i === activeIndex}
-              aspect={deck.slideSizeEmu.w / deck.slideSizeEmu.h}
-              onSelect={() => {
-                setActiveIndex(i)
-                setSelectedShapeId(null)
-              }}
-            />
-          ))}
-        </nav>
+      <div
+        ref={rootRef}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        // The text overlay stops pointer events, so this only fires for the
+        // chrome and the canvas — where shortcuts need to reach us.
+        onPointerDown={() => rootRef.current?.focus({ preventScroll: true })}
+        className="flex h-full w-full min-h-0 flex-col bg-background outline-none"
+      >
+        <EditorToolbar
+          canUndo={canUndo}
+          canRedo={canRedo}
+          onUndo={undo}
+          onRedo={redo}
+          zoomPercent={zoomPercent}
+          isFitZoom={zoomMode === 'fit'}
+          onZoomIn={() => zoomTo(1)}
+          onZoomOut={() => zoomTo(-1)}
+          onZoomFit={() => setZoomMode('fit')}
+          format={activeFormat}
+          formatDisabledReason={formatDisabledReason}
+          onToggleBold={() => applyFormat({ bold: !activeFormat?.bold })}
+          onToggleItalic={() => applyFormat({ italic: !activeFormat?.italic })}
+          onToggleUnderline={() => applyFormat({ underline: !activeFormat?.underline })}
+          onFontSizeStep={stepFontSize}
+          onColorChange={(hex) => applyFormat({ colorHex: hex })}
+          align={activeAlign}
+          onAlign={applyAlign}
+          slideNumber={activeIndex + 1}
+          slideCount={deck.slides.length}
+          saveStatus={saveStatus}
+        />
 
-        <div className="flex min-w-0 flex-1 flex-col">
-          <header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
-            <PresentationIcon className="size-4 shrink-0 text-muted-foreground" />
-            <span className="truncate text-sm font-medium text-foreground" title={path}>
-              {baseName(path)}
-            </span>
-            <span className="ml-auto flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
-              {saveStatus !== 'clean' && (
-                <span className={saveStatus === 'error' ? 'text-destructive' : undefined}>
-                  {saveStatus === 'saving' ? 'Saving…' : saveStatus === 'saved' ? 'Saved' : 'Save failed'}
-                </span>
-              )}
-              <span>
-                Slide {activeIndex + 1} of {deck.slides.length}
+        <div className="flex min-h-0 flex-1">
+          <nav
+            aria-label="Slides"
+            className="flex w-56 shrink-0 flex-col gap-2 overflow-y-auto border-r border-border bg-card/40 p-3"
+          >
+            {deck.slides.map((s, i) => (
+              <SlideCard
+                key={s.xmlPath}
+                index={i}
+                title={slideTitle(s)}
+                active={i === activeIndex}
+                aspect={deck.slideSizeEmu.w / deck.slideSizeEmu.h}
+                onSelect={() => {
+                  setActiveIndex(i)
+                  setSelectedKey(null)
+                  setEditingKey(null)
+                }}
+              />
+            ))}
+          </nav>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-1.5">
+              <PresentationIcon className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate text-sm font-medium text-foreground" title={path}>
+                {baseName(path)}
               </span>
-            </span>
-          </header>
+            </header>
 
-          {slide && (
-            <SlideCanvas
-              slide={slide}
-              sizeEmu={deck.slideSizeEmu}
-              selectedShapeId={selectedShapeId}
-              onSelectShape={setSelectedShapeId}
-              editingKey={editingKey}
-              onStartEdit={(shape) => {
-                setSelectedShapeId(shape.id)
-                setEditingKey(editKeyOf(slide, shape))
-              }}
-              onCommitEdit={(shape, next) => commitEdit(slide, shape, next)}
-            />
-          )}
+            {slide && (
+              <SlideCanvas
+                slide={slide}
+                sizeEmu={deck.slideSizeEmu}
+                zoomMode={zoomMode}
+                onScaleChange={handleScaleChange}
+                selectedKey={selectedKey}
+                editingKey={editingKey}
+                onSelect={setSelectedKey}
+                onStartEdit={setEditingKey}
+                onGeometryCommit={handleGeometryCommit}
+                onOverlayAttach={(h) => {
+                  overlayRef.current = h
+                  setSelectionTick((t) => t + 1)
+                }}
+                onTextCommit={handleTextCommit}
+              />
+            )}
+          </div>
         </div>
       </div>
     </EditorErrorBoundary>
@@ -365,17 +703,23 @@ function SlideCard({ index, title, active, aspect, onSelect }: SlideCardProps) {
       type="button"
       onClick={onSelect}
       aria-current={active ? 'true' : undefined}
-      className={`flex items-start gap-2 rounded-md border p-2 text-left transition-colors ${
+      className={`group flex items-start gap-2 rounded-md border p-2 text-left transition-colors ${
         active
           ? 'border-ring bg-accent text-accent-foreground'
-          : 'border-border bg-background hover:bg-accent/50'
+          : 'border-border bg-background hover:border-ring/40 hover:bg-accent/50'
       }`}
     >
-      <span className="mt-0.5 w-4 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+      <span
+        className={`mt-0.5 w-4 shrink-0 text-right text-[11px] tabular-nums ${
+          active ? 'text-foreground' : 'text-muted-foreground'
+        }`}
+      >
         {index + 1}
       </span>
       <span
-        className="flex min-w-0 flex-1 items-center rounded-sm border border-border/60 bg-muted/40 px-1.5 py-1"
+        className={`flex min-w-0 flex-1 items-center rounded-sm border bg-muted/40 px-1.5 py-1 transition-colors ${
+          active ? 'border-ring/50' : 'border-border/60 group-hover:border-border'
+        }`}
         style={{ aspectRatio: String(aspect) }}
       >
         <span className="line-clamp-3 text-[11px] leading-tight text-foreground/80">
@@ -383,392 +727,6 @@ function SlideCard({ index, title, active, aspect, onSelect }: SlideCardProps) {
         </span>
       </span>
     </button>
-  )
-}
-
-// ------------------------------------------------------------------ canvas
-
-interface SlideCanvasProps {
-  slide: Slide
-  sizeEmu: { w: number; h: number }
-  selectedShapeId: string | null
-  onSelectShape: (id: string | null) => void
-  editingKey: string | null
-  onStartEdit: (shape: TextShape) => void
-  onCommitEdit: (shape: TextShape, next: EditedParagraph[] | null) => void
-}
-
-function SlideCanvas({
-  slide,
-  sizeEmu,
-  selectedShapeId,
-  onSelectShape,
-  editingKey,
-  onStartEdit,
-  onCommitEdit,
-}: SlideCanvasProps) {
-  const frameRef = useRef<HTMLDivElement>(null)
-  const [scale, setScale] = useState(0)
-
-  // Fit the deck's EMU page into whatever space the pane has, preserving aspect.
-  useLayoutEffect(() => {
-    const el = frameRef.current
-    if (!el) return
-    const fit = () => {
-      const { width, height } = el.getBoundingClientRect()
-      if (width <= 0 || height <= 0) return
-      setScale(Math.min(width / sizeEmu.w, height / sizeEmu.h))
-    }
-    fit()
-    const observer = new ResizeObserver(fit)
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [sizeEmu.w, sizeEmu.h])
-
-  return (
-    <div
-      ref={frameRef}
-      className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden p-6"
-      onClick={() => onSelectShape(null)}
-    >
-      {scale > 0 && (
-        <div
-          className="relative overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-border"
-          style={{ width: sizeEmu.w * scale, height: sizeEmu.h * scale }}
-        >
-          {slide.shapes.map((shape, i) => {
-            // Ids repeat across some decks; pair with position for uniqueness.
-            const reactKey = `${shape.id}:${i}`
-            if (shape.type === 'text' && editingKey === editKeyOf(slide, shape)) {
-              return (
-                <TextEditOverlay
-                  key={reactKey}
-                  shape={shape}
-                  scale={scale}
-                  style={rectStyle(shape, scale)}
-                  onCommit={(next) => onCommitEdit(shape, next)}
-                />
-              )
-            }
-            return (
-              <ShapeView
-                key={reactKey}
-                shape={shape}
-                scale={scale}
-                selected={shape.id === selectedShapeId}
-                onSelect={(e) => {
-                  e.stopPropagation()
-                  onSelectShape(shape.id)
-                  if (shape.type === 'text') onStartEdit(shape)
-                }}
-              />
-            )
-          })}
-        </div>
-      )}
-    </div>
-  )
-}
-
-interface ShapeViewProps {
-  shape: Shape
-  scale: number
-  selected: boolean
-  onSelect: (e: ReactMouseEvent) => void
-}
-
-function ShapeView({ shape, scale, selected, onSelect }: ShapeViewProps) {
-  const style = rectStyle(shape, scale)
-  const ring = selected ? 'outline outline-2 outline-offset-1 outline-[var(--ring)]' : ''
-
-  if (shape.type === 'image') {
-    return (
-      <img
-        src={shape.blobUrl}
-        alt=""
-        draggable={false}
-        onClick={onSelect}
-        style={style}
-        className={`object-contain ${ring}`}
-      />
-    )
-  }
-
-  if (shape.type === 'placeholder') {
-    const { label, Icon } = PLACEHOLDER_META[shape.kind]
-    return (
-      <div
-        onClick={onSelect}
-        style={style}
-        className={`flex items-center justify-center gap-1.5 rounded-sm border border-dashed border-neutral-400/70 bg-neutral-500/5 ${ring}`}
-      >
-        <Icon className="size-3.5 shrink-0 text-neutral-500" />
-        <span className="truncate text-[11px] text-neutral-500">{label}</span>
-      </div>
-    )
-  }
-
-  return <TextShapeView shape={shape} scale={scale} style={style} ring={ring} onSelect={onSelect} />
-}
-
-interface TextShapeViewProps {
-  shape: TextShape
-  scale: number
-  style: CSSProperties
-  ring: string
-  onSelect: (e: ReactMouseEvent) => void
-}
-
-function TextShapeView({ shape, scale, style, ring, onSelect }: TextShapeViewProps) {
-  // Point sizes are relative to the deck page, so they scale with it.
-  const ptToPx = (pt: number) => pt * EMU_PER_PT * scale
-
-  return (
-    <div
-      onClick={onSelect}
-      style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
-      className={`cursor-text overflow-hidden ${ring}`}
-    >
-      {shape.paragraphs.map((para, pi) => (
-        <p
-          key={pi}
-          style={{
-            textAlign: alignToCss(para.align),
-            margin: 0,
-            whiteSpace: 'pre-wrap',
-          }}
-        >
-          {para.runs.map((run, ri) => (
-            <span
-              key={ri}
-              style={{
-                fontWeight: run.bold ? 700 : undefined,
-                fontStyle: run.italic ? 'italic' : undefined,
-                textDecoration: run.underline ? 'underline' : undefined,
-                fontSize: ptToPx(run.sizePt ?? DEFAULT_TEXT_PT),
-                color: run.colorHex ? `#${run.colorHex}` : '#000',
-                lineHeight: 1.2,
-              }}
-            >
-              {run.text}
-            </span>
-          ))}
-        </p>
-      ))}
-    </div>
-  )
-}
-
-// ----------------------------------------------------------- editing overlay
-
-/**
- * Rendered HTML for the contentEditable overlay. Every run carries its CURRENT
- * coordinates (data-cp/data-cr — for style lookup at extraction time) and,
- * when known, its ORIGINAL provenance (data-op/data-or — indexes into the
- * shape's as-parsed paragraphs, which the serializer uses to reuse rPr/pPr
- * bytes). When a browser splits a block or span on Enter, it clones these
- * attributes onto both halves — exactly the inheritance we want.
- */
-function buildEditableHtml(shape: TextShape, scale: number): string {
-  const escapeHtml = (s: string) =>
-    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-
-  return shape.paragraphs
-    .map((para, pi) => {
-      const ep = para as EditedParagraph
-      const paraSrc = 'srcPara' in ep ? ep.srcPara : pi
-      const paraProv = paraSrc !== undefined ? ` data-op="${paraSrc}"` : ''
-      const inner = para.runs
-        .map((run, ri) => {
-          const er = run as EditedTextRun
-          const runSrcPara = 'srcPara' in er ? er.srcPara : pi
-          const runSrcRun = 'srcRun' in er ? er.srcRun : ri
-          const prov =
-            runSrcPara !== undefined && runSrcRun !== undefined
-              ? ` data-op="${runSrcPara}" data-or="${runSrcRun}"`
-              : ''
-          if (run.text === '\n') return `<br data-cp="${pi}" data-cr="${ri}"${prov}>`
-          const px = (run.sizePt ?? DEFAULT_TEXT_PT) * EMU_PER_PT * scale
-          const style =
-            `font-weight:${run.bold ? 700 : 400};font-style:${run.italic ? 'italic' : 'normal'};` +
-            `text-decoration:${run.underline ? 'underline' : 'none'};font-size:${px}px;` +
-            `color:#${run.colorHex ?? '000000'};line-height:1.2`
-          return `<span data-cp="${pi}" data-cr="${ri}"${prov} style="${style}">${escapeHtml(run.text)}</span>`
-        })
-        .join('')
-      return `<div data-cp="${pi}"${paraProv} style="margin:0;text-align:${alignToCss(para.align)}">${inner || '<br>'}</div>`
-    })
-    .join('')
-}
-
-function numAttr(el: Element, name: string): number | undefined {
-  const v = el.getAttribute(name)
-  if (v === null) return undefined
-  const n = Number(v)
-  return Number.isInteger(n) && n >= 0 ? n : undefined
-}
-
-/** contentEditable output → model text. NBSP and CRLF normalized, zero-widths dropped. */
-function normText(s: string): string {
-  return s.replace(/\u00A0/g, ' ').replace(/\r\n?/g, '\n').replace(/[\u200B\uFEFF]/g, '')
-}
-
-/** Reads the committed paragraphs back out of the overlay's DOM. */
-function extractParagraphs(root: HTMLElement, shape: TextShape): EditedParagraph[] {
-  const paras: EditedParagraph[] = []
-  let loose: EditedTextRun[] = []
-
-  const flushLoose = () => {
-    if (loose.length) paras.push({ align: undefined, runs: loose, srcPara: undefined })
-    loose = []
-  }
-
-  const runFromStyledNode = (el: Element): EditedTextRun | null => {
-    const text = normText(el.textContent ?? '')
-    if (!text) return null
-    const cp = numAttr(el, 'data-cp')
-    const cr = numAttr(el, 'data-cr')
-    const base: TextRun | undefined =
-      cp !== undefined && cr !== undefined ? shape.paragraphs[cp]?.runs[cr] : undefined
-    return {
-      text,
-      bold: base?.bold,
-      italic: base?.italic,
-      underline: base?.underline,
-      sizePt: base?.sizePt,
-      colorHex: base?.colorHex,
-      srcPara: numAttr(el, 'data-op'),
-      srcRun: numAttr(el, 'data-or'),
-    }
-  }
-
-  const collectInline = (container: Node, into: EditedTextRun[]) => {
-    container.childNodes.forEach((n) => {
-      if (n.nodeType === Node.TEXT_NODE) {
-        const t = normText(n.nodeValue ?? '')
-        if (t) into.push({ text: t })
-      } else if (n instanceof Element) {
-        if (n.tagName === 'BR') {
-          into.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
-        } else if (n.tagName === 'SPAN' && n.getAttribute('data-cr') !== null) {
-          const r = runFromStyledNode(n)
-          if (r) into.push(r)
-        } else {
-          // Pasted markup or browser-inserted wrappers: keep the text, styled
-          // by whatever rPr the serializer's fallback picks.
-          collectInline(n, into)
-        }
-      }
-    })
-  }
-
-  root.childNodes.forEach((n) => {
-    if (n instanceof Element && (n.tagName === 'DIV' || n.tagName === 'P')) {
-      flushLoose()
-      const runs: EditedTextRun[] = []
-      collectInline(n, runs)
-
-      // `<div><br></div>` is contentEditable's empty paragraph.
-      const onlyBr =
-        n.childNodes.length === 1 && n.firstChild instanceof Element && n.firstChild.tagName === 'BR'
-      let finalRuns = onlyBr ? [] : runs
-      // Browsers keep a placeholder <br> at the end of non-empty blocks.
-      if (!onlyBr && finalRuns.length > 1) {
-        const lastRun = finalRuns[finalRuns.length - 1]
-        const lastChild = n.lastChild
-        if (
-          lastRun.text === '\n' &&
-          lastRun.srcRun === undefined &&
-          lastChild instanceof Element &&
-          lastChild.tagName === 'BR' &&
-          lastChild.getAttribute('data-cr') === null
-        ) {
-          finalRuns = finalRuns.slice(0, -1)
-        }
-      }
-
-      const cp = numAttr(n, 'data-cp')
-      paras.push({
-        align: cp !== undefined ? shape.paragraphs[cp]?.align : undefined,
-        runs: finalRuns,
-        srcPara: numAttr(n, 'data-op'),
-      })
-    } else if (n.nodeType === Node.TEXT_NODE) {
-      const t = normText(n.nodeValue ?? '')
-      if (t) loose.push({ text: t })
-    } else if (n instanceof Element) {
-      if (n.tagName === 'BR') {
-        loose.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
-      } else if (n.tagName === 'SPAN' && n.getAttribute('data-cr') !== null) {
-        const r = runFromStyledNode(n)
-        if (r) loose.push(r)
-      } else {
-        collectInline(n, loose)
-      }
-    }
-  })
-  flushLoose()
-
-  // Everything replaced by unanchored content (e.g. select-all + type): keep
-  // the first original paragraph's formatting rather than none at all.
-  if (paras.length > 0 && paras.every((p) => p.srcPara === undefined) && shape.paragraphs.length > 0) {
-    paras[0] = { ...paras[0], srcPara: 0, align: paras[0].align ?? shape.paragraphs[0].align }
-  }
-  if (paras.length === 0) {
-    paras.push({ align: shape.paragraphs[0]?.align, runs: [], srcPara: 0 })
-  }
-  return paras
-}
-
-interface TextEditOverlayProps {
-  shape: TextShape
-  scale: number
-  style: CSSProperties
-  onCommit: (next: EditedParagraph[] | null) => void
-}
-
-function TextEditOverlay({ shape, scale, style, onCommit }: TextEditOverlayProps) {
-  const ref = useRef<HTMLDivElement>(null)
-  const committedRef = useRef(false)
-  const html = useMemo(() => buildEditableHtml(shape, scale), [shape, scale])
-
-  const commit = useCallback(() => {
-    if (committedRef.current) return
-    committedRef.current = true
-    onCommit(ref.current ? extractParagraphs(ref.current, shape) : null)
-  }, [onCommit, shape])
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    el.focus()
-    const sel = window.getSelection()
-    if (sel) {
-      sel.selectAllChildren(el)
-      sel.collapseToEnd()
-    }
-  }, [])
-
-  return (
-    <div
-      ref={ref}
-      contentEditable
-      suppressContentEditableWarning
-      spellCheck={false}
-      dangerouslySetInnerHTML={{ __html: html }}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          commit()
-        }
-        // Keep app-level shortcuts away from typing.
-        e.stopPropagation()
-      }}
-      onClick={(e) => e.stopPropagation()}
-      style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
-      className="cursor-text overflow-hidden whitespace-pre-wrap outline-2 outline-offset-1 outline-[var(--ring)]"
-    />
   )
 }
 

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -42,6 +42,7 @@ import {
   type ShapeKey,
 } from '@/components/pptx/edit-model'
 import { SlideCanvas, SlideThumbnail } from '@/components/pptx/canvas'
+import { createSavePipeline, type SavePipeline } from '@/components/pptx/save-pipeline'
 import { PresentationOverlay } from '@/components/pptx/presentation'
 import {
   EditorHeader,
@@ -154,11 +155,6 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const editSetRef = useRef<DeckEdits>(EMPTY_DECK_EDITS)
   const histIndexRef = useRef(0)
   const overlayRef = useRef<TextOverlayHandle | null>(null)
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const savingRef = useRef(false)
-  const pendingRef = useRef(false)
-  const dirtyRef = useRef(false)
-  const lastWrittenRef = useRef<string | null>(null)
 
   useEffect(() => {
     editSetRef.current = editSet
@@ -169,55 +165,36 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
   // ------------------------------------------------------------- persistence
 
-  const persist = useCallback(async () => {
-    const base = baseDeckRef.current
-    if (!base) return
-    if (savingRef.current) {
-      pendingRef.current = true
-      return
-    }
-    savingRef.current = true
-    try {
-      const edits = editSetRef.current
-      if (!hasEdits(edits) && lastWrittenRef.current === null) {
-        setSaveStatus('clean')
-        return
-      }
-      const bytes = await writeDeck(base, toSlideEdits(edits.shapes), {
-        deleteSlides: edits.deletedSlides,
-      })
-      const b64 = uint8ArrayToBase64(bytes)
-      if (b64 !== lastWrittenRef.current) {
+  // One pipeline per mount (App.tsx keys this component by path). It owns the
+  // debounce timer and the dirty generations; the callbacks read refs so it
+  // never captures stale edit state. Lazy ref, not useMemo — React may drop
+  // a memo, and with it the generation counters an unmount flush relies on.
+  const savePipelineRef = useRef<SavePipeline | null>(null)
+  if (savePipelineRef.current === null) {
+    savePipelineRef.current = createSavePipeline({
+      debounceMs: SAVE_DEBOUNCE_MS,
+      hasEdits: () => hasEdits(editSetRef.current),
+      serialize: async () => {
+        const base = baseDeckRef.current
+        if (!base) throw new Error('presentation is not loaded')
+        const edits = editSetRef.current
+        const bytes = await writeDeck(base, toSlideEdits(edits.shapes), {
+          deleteSlides: edits.deletedSlides,
+        })
+        return uint8ArrayToBase64(bytes)
+      },
+      write: async (data) => {
         await window.ipc.invoke('workspace:writeFile', {
           path,
-          data: b64,
+          data,
           opts: { encoding: 'base64' },
         })
-        lastWrittenRef.current = b64
-      }
-      dirtyRef.current = false
-      setSaveStatus('saved')
-    } catch (err) {
-      console.error('Failed to save pptx:', err)
-      setSaveStatus('error')
-    } finally {
-      savingRef.current = false
-      if (pendingRef.current) {
-        pendingRef.current = false
-        scheduleSave()
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [path])
-
-  const scheduleSave = useCallback(() => {
-    dirtyRef.current = true
-    setSaveStatus('saving')
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-    saveTimerRef.current = setTimeout(() => {
-      void persist()
-    }, SAVE_DEBOUNCE_MS)
-  }, [persist])
+      },
+      onStatus: setSaveStatus,
+      onError: (err) => console.error('Failed to save pptx:', err),
+    })
+  }
+  const savePipeline = savePipelineRef.current
 
   /** Commits a new edit set: pushes onto the undo stack and schedules a save. */
   const pushEdits = useCallback(
@@ -228,9 +205,9 @@ export function PptxEditor({ path }: PptxEditorProps) {
       })
       setHistIndex((i) => Math.min(i + 1, MAX_HISTORY - 1))
       editSetRef.current = next
-      scheduleSave()
+      savePipeline.scheduleSave()
     },
-    [scheduleSave],
+    [savePipeline],
   )
 
   /** Commits a shape-level change, carrying the slide deletions forward. */
@@ -242,10 +219,10 @@ export function PptxEditor({ path }: PptxEditorProps) {
   )
 
   // Flush pending edits on unmount / path change, before blob URLs are revoked.
+  // The pipeline awaits any in-flight save and persists anything it missed.
   useEffect(() => {
     return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-      if (dirtyRef.current) void persist()
+      void savePipeline.flush()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path])
@@ -301,8 +278,8 @@ export function PptxEditor({ path }: PptxEditorProps) {
     editSetRef.current = history[next] ?? EMPTY_DECK_EDITS
     setHistIndex(next)
     setEditingKey(null)
-    scheduleSave()
-  }, [history, scheduleSave])
+    savePipeline.scheduleSave()
+  }, [history, savePipeline])
 
   const redo = useCallback(() => {
     if (histIndexRef.current >= history.length - 1) return
@@ -311,8 +288,8 @@ export function PptxEditor({ path }: PptxEditorProps) {
     editSetRef.current = history[next] ?? EMPTY_DECK_EDITS
     setHistIndex(next)
     setEditingKey(null)
-    scheduleSave()
-  }, [history, scheduleSave])
+    savePipeline.scheduleSave()
+  }, [history, savePipeline])
 
   // ----------------------------------------------------------- edit commits
 
@@ -481,7 +458,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         // Editing: mutate the spans; the commit on blur turns this into edits.
         applyFormatToSpans(selectedRunSpans(overlay.root), set, overlay.scale, fontScaleOf(overlay.shape))
         setSelectionTick((t) => t + 1)
-        dirtyRef.current = true
+        savePipeline.markEdited()
         return
       }
 
@@ -502,7 +479,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         }),
       )
     },
-    [slide, selectedKey, pushShapeEdits, seedFor],
+    [slide, selectedKey, pushShapeEdits, seedFor, savePipeline],
   )
 
   const applyAlign = useCallback(
@@ -515,7 +492,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
       if (overlay) {
         applyAlignToBlocks(selectedParagraphBlocks(overlay.root), align)
         setSelectionTick((t) => t + 1)
-        dirtyRef.current = true
+        savePipeline.markEdited()
         return
       }
 
@@ -532,7 +509,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         }),
       )
     },
-    [slide, selectedKey, pushShapeEdits, seedFor],
+    [slide, selectedKey, pushShapeEdits, seedFor, savePipeline],
   )
 
   const stepFontSize = useCallback(

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -301,9 +301,11 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const handleGeometryCommit = useCallback(
     (shape: Shape, rect: RectEmuBox) => {
       if (!slide) return
-      // The serializer writes geometry only for sp/pic/cxnSp. graphicFrame and
-      // group placeholders would fail the whole save closed, so their drags
-      // snap back instead of committing.
+      // The serializer writes geometry only for sp/pic/cxnSp. graphicFrame
+      // placeholders would fail the whole save closed, so their drags snap
+      // back instead of committing. Groups (and everything inside them) are
+      // read-only — their nodePaths must never reach the serializer.
+      if (shape.type === 'group') return
       if (shape.type === 'placeholder' && shape.kind !== 'video') return
       const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
       pushEdits(

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -1,0 +1,440 @@
+import {
+  Component,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from 'react'
+import {
+  BarChart3Icon,
+  ExternalLinkIcon,
+  FilmIcon,
+  GroupIcon,
+  Loader2Icon,
+  PresentationIcon,
+  ShapesIcon,
+  TableIcon,
+} from 'lucide-react'
+import { disposeDeck, parsePptx } from '@/lib/pptx/parse'
+import type {
+  PlaceholderKind,
+  Shape,
+  Slide,
+  SlideDeck,
+  TextShape,
+} from '@/lib/pptx/types'
+
+interface PptxEditorProps {
+  path: string
+}
+
+type LoadState = 'loading' | 'ready' | 'error'
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64)
+  const len = binary.length
+  const bytes = new Uint8Array(len)
+  for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+function baseName(path: string): string {
+  const segs = path.split('/')
+  return segs[segs.length - 1] || path
+}
+
+/** First non-empty line of text on a slide, used to label its rail card. */
+function slideTitle(slide: Slide): string | null {
+  for (const shape of slide.shapes) {
+    if (shape.type !== 'text') continue
+    for (const para of shape.paragraphs) {
+      const line = para.runs.map((r) => r.text).join('').trim()
+      if (line) return line
+    }
+  }
+  return null
+}
+
+const PLACEHOLDER_META: Record<PlaceholderKind, { label: string; Icon: typeof ShapesIcon }> = {
+  chart: { label: 'Chart', Icon: BarChart3Icon },
+  smartart: { label: 'Diagram', Icon: ShapesIcon },
+  table: { label: 'Table', Icon: TableIcon },
+  group: { label: 'Group', Icon: GroupIcon },
+  video: { label: 'Video', Icon: FilmIcon },
+  unknown: { label: 'Shape', Icon: ShapesIcon },
+}
+
+export function PptxEditor({ path }: PptxEditorProps) {
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [deck, setDeck] = useState<SlideDeck | null>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [selectedShapeId, setSelectedShapeId] = useState<string | null>(null)
+
+  // Held separately from state so the cleanup always sees the live deck, even
+  // if it is replaced mid-flight by a fast path change.
+  const deckRef = useRef<SlideDeck | null>(null)
+
+  // App.tsx keys this component by path, so a different file arrives as a fresh
+  // mount with fresh state — no synchronous resets needed here.
+  useEffect(() => {
+    let cancelled = false
+
+    ;(async () => {
+      try {
+        const result = await window.ipc.invoke('workspace:readFile', { path, encoding: 'base64' })
+        const parsed = await parsePptx(base64ToUint8Array(result.data))
+        if (cancelled) {
+          // Nobody will render these; release them now.
+          disposeDeck(parsed)
+          return
+        }
+        deckRef.current = parsed
+        setDeck(parsed)
+        setLoadState('ready')
+      } catch (err) {
+        console.error('Failed to open pptx:', err)
+        if (!cancelled) setLoadState('error')
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      if (deckRef.current) {
+        disposeDeck(deckRef.current)
+        deckRef.current = null
+      }
+    }
+  }, [path])
+
+  const slide = deck?.slides[activeIndex] ?? null
+
+  const openExternally = useCallback(() => {
+    void window.ipc.invoke('shell:openPath', { path })
+  }, [path])
+
+  if (loadState === 'error') {
+    return <FailurePanel path={path} onOpen={openExternally} />
+  }
+
+  if (loadState === 'loading' || !deck) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 text-muted-foreground">
+        <Loader2Icon className="size-6 animate-spin" />
+        <p className="text-sm">Opening presentation…</p>
+      </div>
+    )
+  }
+
+  if (deck.slides.length === 0) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center text-muted-foreground">
+        <PresentationIcon className="size-6" />
+        <p className="text-sm font-medium text-foreground">{baseName(path)}</p>
+        <p className="max-w-md text-xs">This presentation has no slides.</p>
+      </div>
+    )
+  }
+
+  return (
+    <EditorErrorBoundary path={path} onOpen={openExternally}>
+      <div className="flex h-full w-full min-h-0 bg-background">
+        <nav
+          aria-label="Slides"
+          className="flex w-56 shrink-0 flex-col gap-2 overflow-y-auto border-r border-border bg-card/40 p-3"
+        >
+          {deck.slides.map((s, i) => (
+            <SlideCard
+              key={s.xmlPath}
+              index={i}
+              title={slideTitle(s)}
+              active={i === activeIndex}
+              aspect={deck.slideSizeEmu.w / deck.slideSizeEmu.h}
+              onSelect={() => {
+                setActiveIndex(i)
+                setSelectedShapeId(null)
+              }}
+            />
+          ))}
+        </nav>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2">
+            <PresentationIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="truncate text-sm font-medium text-foreground" title={path}>
+              {baseName(path)}
+            </span>
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+              Slide {activeIndex + 1} of {deck.slides.length} · read-only
+            </span>
+          </header>
+
+          {slide && (
+            <SlideCanvas
+              slide={slide}
+              sizeEmu={deck.slideSizeEmu}
+              selectedShapeId={selectedShapeId}
+              onSelectShape={setSelectedShapeId}
+            />
+          )}
+        </div>
+      </div>
+    </EditorErrorBoundary>
+  )
+}
+
+// --------------------------------------------------------------- slide rail
+
+interface SlideCardProps {
+  index: number
+  title: string | null
+  active: boolean
+  aspect: number
+  onSelect: () => void
+}
+
+function SlideCard({ index, title, active, aspect, onSelect }: SlideCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={active ? 'true' : undefined}
+      className={`flex items-start gap-2 rounded-md border p-2 text-left transition-colors ${
+        active
+          ? 'border-ring bg-accent text-accent-foreground'
+          : 'border-border bg-background hover:bg-accent/50'
+      }`}
+    >
+      <span className="mt-0.5 w-4 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+        {index + 1}
+      </span>
+      <span
+        className="flex min-w-0 flex-1 items-center rounded-sm border border-border/60 bg-muted/40 px-1.5 py-1"
+        style={{ aspectRatio: String(aspect) }}
+      >
+        <span className="line-clamp-3 text-[11px] leading-tight text-foreground/80">
+          {title ?? <span className="text-muted-foreground">Untitled slide</span>}
+        </span>
+      </span>
+    </button>
+  )
+}
+
+// ------------------------------------------------------------------ canvas
+
+interface SlideCanvasProps {
+  slide: Slide
+  sizeEmu: { w: number; h: number }
+  selectedShapeId: string | null
+  onSelectShape: (id: string | null) => void
+}
+
+function SlideCanvas({ slide, sizeEmu, selectedShapeId, onSelectShape }: SlideCanvasProps) {
+  const frameRef = useRef<HTMLDivElement>(null)
+  const [scale, setScale] = useState(0)
+
+  // Fit the deck's EMU page into whatever space the pane has, preserving aspect.
+  useLayoutEffect(() => {
+    const el = frameRef.current
+    if (!el) return
+    const fit = () => {
+      const { width, height } = el.getBoundingClientRect()
+      if (width <= 0 || height <= 0) return
+      setScale(Math.min(width / sizeEmu.w, height / sizeEmu.h))
+    }
+    fit()
+    const observer = new ResizeObserver(fit)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [sizeEmu.w, sizeEmu.h])
+
+  return (
+    <div
+      ref={frameRef}
+      className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden p-6"
+      onClick={() => onSelectShape(null)}
+    >
+      {scale > 0 && (
+        <div
+          className="relative overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-border"
+          style={{ width: sizeEmu.w * scale, height: sizeEmu.h * scale }}
+        >
+          {slide.shapes.map((shape, i) => (
+            <ShapeView
+              // Ids repeat across some decks; pair with position for uniqueness.
+              key={`${shape.id}:${i}`}
+              shape={shape}
+              scale={scale}
+              selected={shape.id === selectedShapeId}
+              onSelect={(e) => {
+                e.stopPropagation()
+                onSelectShape(shape.id)
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface ShapeViewProps {
+  shape: Shape
+  scale: number
+  selected: boolean
+  onSelect: (e: ReactMouseEvent) => void
+}
+
+function ShapeView({ shape, scale, selected, onSelect }: ShapeViewProps) {
+  const style: CSSProperties = {
+    position: 'absolute',
+    left: shape.xfrmEmu.x * scale,
+    top: shape.xfrmEmu.y * scale,
+    width: shape.xfrmEmu.w * scale,
+    height: shape.xfrmEmu.h * scale,
+  }
+
+  const ring = selected ? 'outline outline-2 outline-offset-1 outline-[var(--ring)]' : ''
+
+  if (shape.type === 'image') {
+    return (
+      <img
+        src={shape.blobUrl}
+        alt=""
+        draggable={false}
+        onClick={onSelect}
+        style={style}
+        className={`object-contain ${ring}`}
+      />
+    )
+  }
+
+  if (shape.type === 'placeholder') {
+    const { label, Icon } = PLACEHOLDER_META[shape.kind]
+    return (
+      <div
+        onClick={onSelect}
+        style={style}
+        className={`flex items-center justify-center gap-1.5 rounded-sm border border-dashed border-neutral-400/70 bg-neutral-500/5 ${ring}`}
+      >
+        <Icon className="size-3.5 shrink-0 text-neutral-500" />
+        <span className="truncate text-[11px] text-neutral-500">{label}</span>
+      </div>
+    )
+  }
+
+  return <TextShapeView shape={shape} scale={scale} style={style} ring={ring} onSelect={onSelect} />
+}
+
+interface TextShapeViewProps {
+  shape: TextShape
+  scale: number
+  style: CSSProperties
+  ring: string
+  onSelect: (e: ReactMouseEvent) => void
+}
+
+function TextShapeView({ shape, scale, style, ring, onSelect }: TextShapeViewProps) {
+  // Point sizes are relative to the deck page, so they scale with it. 914400 EMU
+  // per inch / 72 pt per inch = 12700 EMU per point.
+  const ptToPx = (pt: number) => pt * 12700 * scale
+
+  return (
+    <div
+      onClick={onSelect}
+      style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
+      className={`overflow-hidden ${ring}`}
+    >
+      {shape.paragraphs.map((para, pi) => (
+        <p
+          key={pi}
+          style={{
+            textAlign:
+              para.align === 'ctr'
+                ? 'center'
+                : para.align === 'r'
+                  ? 'right'
+                  : para.align === 'just'
+                    ? 'justify'
+                    : 'left',
+            margin: 0,
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {para.runs.map((run, ri) => (
+            <span
+              key={ri}
+              style={{
+                fontWeight: run.bold ? 700 : undefined,
+                fontStyle: run.italic ? 'italic' : undefined,
+                textDecoration: run.underline ? 'underline' : undefined,
+                fontSize: run.sizePt ? ptToPx(run.sizePt) : ptToPx(18),
+                color: run.colorHex ? `#${run.colorHex}` : '#000',
+                lineHeight: 1.2,
+              }}
+            >
+              {run.text}
+            </span>
+          ))}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------- failures
+
+function FailurePanel({ path, onOpen }: { path: string; onOpen: () => void }) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center text-muted-foreground">
+      <PresentationIcon className="size-6" />
+      <p className="max-w-md truncate text-sm font-medium text-foreground" title={path}>
+        {baseName(path)}
+      </p>
+      <p className="max-w-md text-xs">
+        Cannot open this presentation. The file may be corrupted or not a valid PowerPoint
+        document.
+      </p>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+      >
+        <ExternalLinkIcon className="size-3.5" />
+        Open in system
+      </button>
+    </div>
+  )
+}
+
+interface EditorErrorBoundaryProps {
+  path: string
+  onOpen: () => void
+  children: ReactNode
+}
+
+/**
+ * A deck that parses but hits something unexpected while rendering falls back to
+ * "open externally" instead of taking the whole pane down.
+ */
+class EditorErrorBoundary extends Component<EditorErrorBoundaryProps, { failed: boolean }> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('pptx editor render error:', error)
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <FailurePanel path={this.props.path} onOpen={this.props.onOpen} />
+    }
+    return this.props.children
+  }
+}

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -31,6 +31,7 @@ import {
 import { SlideCanvas, SlideThumbnail } from '@/components/pptx/canvas'
 import { PresentationOverlay } from '@/components/pptx/presentation'
 import {
+  EditorHeader,
   EditorToolbar,
   MAX_ZOOM,
   MIN_ZOOM,
@@ -77,6 +78,11 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
 function baseName(path: string): string {
   const segs = path.split('/')
   return segs[segs.length - 1] || path
+}
+
+/** The header carries a PPTX badge, so the extension would just be noise. */
+function displayName(path: string): string {
+  return baseName(path).replace(/\.pptx$/i, '')
 }
 
 /** First non-empty line of text on a slide, used to label its rail card. */
@@ -622,6 +628,13 @@ export function PptxEditor({ path }: PptxEditorProps) {
         onPointerDown={() => rootRef.current?.focus({ preventScroll: true })}
         className="flex h-full w-full min-h-0 flex-col bg-background outline-none"
       >
+        <EditorHeader
+          fileName={displayName(path)}
+          filePath={path}
+          saveStatus={saveStatus}
+          onPlay={startPresenting}
+        />
+
         <EditorToolbar
           canUndo={canUndo}
           canRedo={canRedo}
@@ -641,42 +654,40 @@ export function PptxEditor({ path }: PptxEditorProps) {
           onColorChange={(hex) => applyFormat({ colorHex: hex })}
           align={activeAlign}
           onAlign={applyAlign}
-          onPlay={startPresenting}
           slideNumber={activeIndex + 1}
           slideCount={deck.slides.length}
-          saveStatus={saveStatus}
         />
 
         <div className="flex min-h-0 flex-1">
           <nav
             aria-label="Slides"
-            className="flex w-56 shrink-0 flex-col gap-2 overflow-y-auto border-r border-border bg-card/40 p-3"
+            className="flex w-56 shrink-0 flex-col border-r border-border bg-card/40"
           >
-            {deck.slides.map((s, i) => (
-              <SlideCard
-                key={s.xmlPath}
-                index={i}
-                slide={s}
-                sizeEmu={deck.slideSizeEmu}
-                title={slideTitle(s)}
-                active={i === activeIndex}
-                onSelect={() => {
-                  setActiveIndex(i)
-                  setSelectedKey(null)
-                  setEditingKey(null)
-                }}
-              />
-            ))}
+            <div className="flex shrink-0 items-center border-b border-border px-3 py-2">
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Slides · {deck.slides.length}
+              </span>
+            </div>
+            <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-2">
+              {deck.slides.map((s, i) => (
+                <SlideCard
+                  key={s.xmlPath}
+                  index={i}
+                  slide={s}
+                  sizeEmu={deck.slideSizeEmu}
+                  title={slideTitle(s)}
+                  active={i === activeIndex}
+                  onSelect={() => {
+                    setActiveIndex(i)
+                    setSelectedKey(null)
+                    setEditingKey(null)
+                  }}
+                />
+              ))}
+            </div>
           </nav>
 
           <div className="flex min-w-0 flex-1 flex-col">
-            <header className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-1.5">
-              <PresentationIcon className="size-4 shrink-0 text-muted-foreground" />
-              <span className="truncate text-sm font-medium text-foreground" title={path}>
-                {baseName(path)}
-              </span>
-            </header>
-
             {slide && (
               <SlideCanvas
                 slide={slide}
@@ -713,7 +724,10 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
 // --------------------------------------------------------------- slide rail
 
-/** Rail width (w-56 = 224) minus nav padding, button padding, badge + gap. */
+/**
+ * Rail width (w-56 = 224) minus its border, the list padding, the card padding,
+ * the number badge + gap, and the scrollbar gutter.
+ */
 const THUMB_WIDTH_PX = 160
 
 interface SlideCardProps {
@@ -732,24 +746,21 @@ function SlideCard({ index, slide, sizeEmu, title, active, onSelect }: SlideCard
       onClick={onSelect}
       aria-current={active ? 'true' : undefined}
       aria-label={`Slide ${index + 1}${title ? `: ${title}` : ''}`}
-      className={`group flex items-start gap-2 rounded-md border p-2 text-left transition-colors ${
+      className={`flex shrink-0 items-center gap-1.5 rounded-md p-1.5 transition-all ${
         active
-          ? 'border-ring bg-accent text-accent-foreground'
-          : 'border-border bg-background hover:border-ring/40 hover:bg-accent/50'
+          ? 'bg-accent/60 shadow-sm ring-2 ring-ring'
+          : 'ring-1 ring-border/60 hover:bg-accent/40 hover:ring-border'
       }`}
     >
+      {/* Outside the thumbnail on purpose — overlaid, it sat on the slide's own title. */}
       <span
-        className={`mt-0.5 w-4 shrink-0 text-right text-[11px] tabular-nums ${
-          active ? 'text-foreground' : 'text-muted-foreground'
+        className={`w-5 shrink-0 rounded py-px text-center text-[10px] font-medium leading-none tabular-nums ${
+          active ? 'bg-background text-foreground' : 'text-muted-foreground'
         }`}
       >
         {index + 1}
       </span>
-      <span
-        className={`min-w-0 flex-1 overflow-hidden rounded-sm ring-1 transition-shadow ${
-          active ? 'ring-[var(--ring)]' : 'ring-border/60 group-hover:ring-border'
-        }`}
-      >
+      <span className="mx-auto block shrink-0 overflow-hidden rounded-sm">
         <SlideThumbnail slide={slide} sizeEmu={sizeEmu} widthPx={THUMB_WIDTH_PX} />
       </span>
     </button>

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -8,7 +8,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
-import { ExternalLinkIcon, Loader2Icon, PresentationIcon, Trash2Icon } from 'lucide-react'
+import { ExternalLinkIcon, Loader2Icon, PlusIcon, PresentationIcon, Trash2Icon } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   AlertDialog,
@@ -20,7 +20,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { disposeDeck, parsePptx } from '@/lib/pptx/parse'
+import { disposeDeck, parseAddedSlide, parsePptx } from '@/lib/pptx/parse'
+import { planNewSlide } from '@/lib/pptx/add-slide'
 import { writeDeck, type EditedParagraph, type RunFormatOverrides } from '@/lib/pptx/serialize'
 import type { NodePath, Paragraph, Shape, Slide, SlideDeck, TextAlign, TextShape } from '@/lib/pptx/types'
 import {
@@ -36,6 +37,7 @@ import {
   structureMatches,
   toSlideEdits,
   withShapeEdit,
+  withSlideRemoved,
   type DeckEdits,
   type EditSet,
   type RectEmuBox,
@@ -180,6 +182,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         const edits = editSetRef.current
         const bytes = await writeDeck(base, toSlideEdits(edits.shapes), {
           deleteSlides: edits.deletedSlides,
+          addSlides: edits.addedSlides,
         })
         return uint8ArrayToBase64(bytes)
       },
@@ -586,21 +589,49 @@ export function PptxEditor({ path }: PptxEditorProps) {
     [deck],
   )
 
+  // Keynote-style Add Slide: a new slide on the SAME layout as the active one,
+  // inserted right after it, seeded with the layout's placeholder boxes. Both
+  // the part strings and the pre-parsed render live in the edit set, so the
+  // add is undoable and only reaches the file through the normal save.
+  const addingSlideRef = useRef(false)
+  const addSlide = useCallback(async () => {
+    const base = baseDeckRef.current
+    if (!base || !slide || addingSlideRef.current) return
+    addingSlideRef.current = true
+    try {
+      const cur = editSetRef.current
+      const anchorAdded = cur.addedSlides.find((a) => a.path === slide.xmlPath)
+      const plan = await planNewSlide(
+        base,
+        slide.xmlPath,
+        anchorAdded?.relsXml,
+        cur.addedSlides.map((a) => a.path),
+      )
+      const parsed = await parseAddedSlide(base, plan.path, plan.xml, plan.relsXml)
+      pushEdits({ ...cur, addedSlides: [...cur.addedSlides, { ...plan, slide: parsed }] })
+      setSelectedKey(null)
+      setEditingKey(null)
+      setActiveIndex(currentIndex + 1)
+    } catch (err) {
+      console.error('Failed to add slide:', err)
+      toast.error('Could not add a slide to this presentation.')
+    } finally {
+      addingSlideRef.current = false
+    }
+  }, [slide, currentIndex, pushEdits])
+
   const confirmDeleteSlide = useCallback(() => {
     const index = confirmDeleteIndex
     setConfirmDeleteIndex(null)
     if (index === null || !deck) return
     const target = deck.slides[index]
     if (!target || deck.slides.length <= 1) return
-    const cur = editSetRef.current
-    // Prune the deleted slide's shape edits: their splices are moot, and the
-    // serializer refuses a slide that is both edited and deleted. The prior
-    // history entry still holds them, so undo restores slide and edits alike.
-    const shapes: Record<ShapeKey, (typeof cur.shapes)[ShapeKey]> = {}
-    for (const [k, v] of Object.entries(cur.shapes)) {
-      if (v.slidePath !== target.xmlPath) shapes[k] = v
-    }
-    pushEdits({ shapes, deletedSlides: [...cur.deletedSlides, target.xmlPath] })
+    // withSlideRemoved prunes the slide's shape edits (their splices are moot,
+    // and the serializer refuses a slide both edited and deleted), drops an
+    // ADDED slide outright, and re-anchors any additions that followed it. The
+    // prior history entry still holds everything, so undo restores it all.
+    const reanchorTo = deck.slides[index - 1]?.xmlPath ?? ''
+    pushEdits(withSlideRemoved(editSetRef.current, target.xmlPath, reanchorTo))
     setSelectedKey(null)
     setEditingKey(null)
     setActiveIndex((i) => {
@@ -753,10 +784,19 @@ export function PptxEditor({ path }: PptxEditorProps) {
             aria-label="Slides"
             className="flex w-56 shrink-0 flex-col border-r border-border bg-card/40"
           >
-            <div className="flex shrink-0 items-center border-b border-border px-3 py-2">
+            <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
               <span className="text-[11px] font-medium text-muted-foreground">
                 Slides · {deck.slides.length}
               </span>
+              <button
+                type="button"
+                aria-label="Add slide"
+                title="Add slide"
+                onClick={() => void addSlide()}
+                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                <PlusIcon className="size-3.5" />
+              </button>
             </div>
             <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-2">
               {deck.slides.map((s, i) => (

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -20,11 +21,19 @@ import {
   TableIcon,
 } from 'lucide-react'
 import { disposeDeck, parsePptx } from '@/lib/pptx/parse'
+import {
+  normalizeParagraphs,
+  writeDeck,
+  type EditedParagraph,
+  type EditedTextRun,
+  type ShapeTextEdit,
+} from '@/lib/pptx/serialize'
 import type {
   PlaceholderKind,
   Shape,
   Slide,
   SlideDeck,
+  TextRun,
   TextShape,
 } from '@/lib/pptx/types'
 
@@ -33,6 +42,12 @@ interface PptxEditorProps {
 }
 
 type LoadState = 'loading' | 'ready' | 'error'
+type SaveStatus = 'clean' | 'saving' | 'saved' | 'error'
+
+const SAVE_DEBOUNCE_MS = 800
+/** 914400 EMU per inch / 72 pt per inch. */
+const EMU_PER_PT = 12700
+const DEFAULT_TEXT_PT = 18
 
 function base64ToUint8Array(base64: string): Uint8Array {
   const binary = atob(base64)
@@ -42,9 +57,37 @@ function base64ToUint8Array(base64: string): Uint8Array {
   return bytes
 }
 
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
 function baseName(path: string): string {
   const segs = path.split('/')
   return segs[segs.length - 1] || path
+}
+
+function alignToCss(align: string | undefined): 'left' | 'center' | 'right' | 'justify' {
+  return align === 'ctr' ? 'center' : align === 'r' ? 'right' : align === 'just' ? 'justify' : 'left'
+}
+
+function rectStyle(shape: Shape, scale: number): CSSProperties {
+  return {
+    position: 'absolute',
+    left: shape.xfrmEmu.x * scale,
+    top: shape.xfrmEmu.y * scale,
+    width: shape.xfrmEmu.w * scale,
+    height: shape.xfrmEmu.h * scale,
+  }
+}
+
+/** Stable identity for a shape across state updates: slide + node path. */
+function editKeyOf(slide: Slide, shape: Shape): string {
+  return `${slide.xmlPath}#${shape.nodePath.join('.')}`
 }
 
 /** First non-empty line of text on a slide, used to label its rail card. */
@@ -73,10 +116,84 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const [deck, setDeck] = useState<SlideDeck | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
   const [selectedShapeId, setSelectedShapeId] = useState<string | null>(null)
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('clean')
+  const [editingKey, setEditingKey] = useState<string | null>(null)
 
-  // Held separately from state so the cleanup always sees the live deck, even
-  // if it is replaced mid-flight by a fast path change.
+  // Held separately from state so save/cleanup closures always see the live
+  // deck. Not cleared on unmount: an in-flight save may still be serializing.
   const deckRef = useRef<SlideDeck | null>(null)
+  /** slideXmlPath → (nodePath key → edit). `original` is always the as-parsed model. */
+  const editsRef = useRef<Map<string, Map<string, ShapeTextEdit>>>(new Map())
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const savingRef = useRef(false)
+  const pendingRef = useRef(false)
+  const dirtyRef = useRef(false)
+  const lastWrittenRef = useRef<string | null>(null)
+
+  // Serialize the deck (original bytes + accumulated edits) and write it back.
+  // `path` is constant for this mount (App keys the component by path), so a
+  // late-firing save can only ever write its own document.
+  const persist = useCallback(async () => {
+    const deckNow = deckRef.current
+    if (!deckNow) return
+    if (savingRef.current) {
+      pendingRef.current = true
+      return
+    }
+    savingRef.current = true
+    try {
+      const editsBySlide = new Map<string, ShapeTextEdit[]>()
+      for (const [slidePath, shapeEdits] of editsRef.current) {
+        if (shapeEdits.size > 0) editsBySlide.set(slidePath, [...shapeEdits.values()])
+      }
+      if (editsBySlide.size === 0) {
+        setSaveStatus('clean')
+        return
+      }
+      const bytes = await writeDeck(deckNow, editsBySlide)
+      const b64 = uint8ArrayToBase64(bytes)
+      if (b64 !== lastWrittenRef.current) {
+        await window.ipc.invoke('workspace:writeFile', {
+          path,
+          data: b64,
+          opts: { encoding: 'base64' },
+        })
+        lastWrittenRef.current = b64
+      }
+      dirtyRef.current = false
+      setSaveStatus('saved')
+    } catch (err) {
+      console.error('Failed to save pptx:', err)
+      setSaveStatus('error')
+    } finally {
+      savingRef.current = false
+      // A commit landed while we were saving — flush it.
+      if (pendingRef.current) {
+        pendingRef.current = false
+        scheduleSave()
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path])
+
+  const scheduleSave = useCallback(() => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    saveTimerRef.current = setTimeout(() => {
+      void persist()
+    }, SAVE_DEBOUNCE_MS)
+  }, [persist])
+
+  // Flush pending edits when navigating away or unmounting. Declared BEFORE
+  // the load effect so this cleanup runs before the deck's blob URLs are
+  // revoked (writeDeck reads the zip, not the blob URLs, so even an async
+  // in-flight serialization stays valid).
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      if (dirtyRef.current) void persist()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path])
 
   // App.tsx keys this component by path, so a different file arrives as a fresh
   // mount with fresh state — no synchronous resets needed here.
@@ -103,12 +220,45 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
     return () => {
       cancelled = true
-      if (deckRef.current) {
-        disposeDeck(deckRef.current)
-        deckRef.current = null
-      }
+      if (deckRef.current) disposeDeck(deckRef.current)
     }
   }, [path])
+
+  const commitEdit = useCallback(
+    (slide: Slide, shape: TextShape, next: EditedParagraph[] | null) => {
+      setEditingKey(null)
+      if (!next) return
+      if (normalizeParagraphs(next) === normalizeParagraphs(shape.paragraphs)) return
+
+      const slideEdits = editsRef.current.get(slide.xmlPath) ?? new Map<string, ShapeTextEdit>()
+      editsRef.current.set(slide.xmlPath, slideEdits)
+      const key = shape.nodePath.join('.')
+      const existing = slideEdits.get(key)
+      slideEdits.set(key, {
+        nodePath: shape.nodePath,
+        // First edit of this shape: its current paragraphs ARE the as-parsed
+        // original. Later edits keep the first capture.
+        original: existing?.original ?? shape.paragraphs,
+        next,
+      })
+
+      setDeck(
+        (d) =>
+          d && {
+            ...d,
+            slides: d.slides.map((s) =>
+              s !== slide
+                ? s
+                : { ...s, shapes: s.shapes.map((sh) => (sh !== shape ? sh : { ...sh, paragraphs: next })) },
+            ),
+          },
+      )
+      dirtyRef.current = true
+      setSaveStatus('saving')
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
 
   const slide = deck?.slides[activeIndex] ?? null
 
@@ -167,8 +317,15 @@ export function PptxEditor({ path }: PptxEditorProps) {
             <span className="truncate text-sm font-medium text-foreground" title={path}>
               {baseName(path)}
             </span>
-            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-              Slide {activeIndex + 1} of {deck.slides.length} · read-only
+            <span className="ml-auto flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+              {saveStatus !== 'clean' && (
+                <span className={saveStatus === 'error' ? 'text-destructive' : undefined}>
+                  {saveStatus === 'saving' ? 'Saving…' : saveStatus === 'saved' ? 'Saved' : 'Save failed'}
+                </span>
+              )}
+              <span>
+                Slide {activeIndex + 1} of {deck.slides.length}
+              </span>
             </span>
           </header>
 
@@ -178,6 +335,12 @@ export function PptxEditor({ path }: PptxEditorProps) {
               sizeEmu={deck.slideSizeEmu}
               selectedShapeId={selectedShapeId}
               onSelectShape={setSelectedShapeId}
+              editingKey={editingKey}
+              onStartEdit={(shape) => {
+                setSelectedShapeId(shape.id)
+                setEditingKey(editKeyOf(slide, shape))
+              }}
+              onCommitEdit={(shape, next) => commitEdit(slide, shape, next)}
             />
           )}
         </div>
@@ -230,9 +393,20 @@ interface SlideCanvasProps {
   sizeEmu: { w: number; h: number }
   selectedShapeId: string | null
   onSelectShape: (id: string | null) => void
+  editingKey: string | null
+  onStartEdit: (shape: TextShape) => void
+  onCommitEdit: (shape: TextShape, next: EditedParagraph[] | null) => void
 }
 
-function SlideCanvas({ slide, sizeEmu, selectedShapeId, onSelectShape }: SlideCanvasProps) {
+function SlideCanvas({
+  slide,
+  sizeEmu,
+  selectedShapeId,
+  onSelectShape,
+  editingKey,
+  onStartEdit,
+  onCommitEdit,
+}: SlideCanvasProps) {
   const frameRef = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(0)
 
@@ -262,19 +436,34 @@ function SlideCanvas({ slide, sizeEmu, selectedShapeId, onSelectShape }: SlideCa
           className="relative overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-border"
           style={{ width: sizeEmu.w * scale, height: sizeEmu.h * scale }}
         >
-          {slide.shapes.map((shape, i) => (
-            <ShapeView
-              // Ids repeat across some decks; pair with position for uniqueness.
-              key={`${shape.id}:${i}`}
-              shape={shape}
-              scale={scale}
-              selected={shape.id === selectedShapeId}
-              onSelect={(e) => {
-                e.stopPropagation()
-                onSelectShape(shape.id)
-              }}
-            />
-          ))}
+          {slide.shapes.map((shape, i) => {
+            // Ids repeat across some decks; pair with position for uniqueness.
+            const reactKey = `${shape.id}:${i}`
+            if (shape.type === 'text' && editingKey === editKeyOf(slide, shape)) {
+              return (
+                <TextEditOverlay
+                  key={reactKey}
+                  shape={shape}
+                  scale={scale}
+                  style={rectStyle(shape, scale)}
+                  onCommit={(next) => onCommitEdit(shape, next)}
+                />
+              )
+            }
+            return (
+              <ShapeView
+                key={reactKey}
+                shape={shape}
+                scale={scale}
+                selected={shape.id === selectedShapeId}
+                onSelect={(e) => {
+                  e.stopPropagation()
+                  onSelectShape(shape.id)
+                  if (shape.type === 'text') onStartEdit(shape)
+                }}
+              />
+            )
+          })}
         </div>
       )}
     </div>
@@ -289,14 +478,7 @@ interface ShapeViewProps {
 }
 
 function ShapeView({ shape, scale, selected, onSelect }: ShapeViewProps) {
-  const style: CSSProperties = {
-    position: 'absolute',
-    left: shape.xfrmEmu.x * scale,
-    top: shape.xfrmEmu.y * scale,
-    width: shape.xfrmEmu.w * scale,
-    height: shape.xfrmEmu.h * scale,
-  }
-
+  const style = rectStyle(shape, scale)
   const ring = selected ? 'outline outline-2 outline-offset-1 outline-[var(--ring)]' : ''
 
   if (shape.type === 'image') {
@@ -338,28 +520,20 @@ interface TextShapeViewProps {
 }
 
 function TextShapeView({ shape, scale, style, ring, onSelect }: TextShapeViewProps) {
-  // Point sizes are relative to the deck page, so they scale with it. 914400 EMU
-  // per inch / 72 pt per inch = 12700 EMU per point.
-  const ptToPx = (pt: number) => pt * 12700 * scale
+  // Point sizes are relative to the deck page, so they scale with it.
+  const ptToPx = (pt: number) => pt * EMU_PER_PT * scale
 
   return (
     <div
       onClick={onSelect}
       style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
-      className={`overflow-hidden ${ring}`}
+      className={`cursor-text overflow-hidden ${ring}`}
     >
       {shape.paragraphs.map((para, pi) => (
         <p
           key={pi}
           style={{
-            textAlign:
-              para.align === 'ctr'
-                ? 'center'
-                : para.align === 'r'
-                  ? 'right'
-                  : para.align === 'just'
-                    ? 'justify'
-                    : 'left',
+            textAlign: alignToCss(para.align),
             margin: 0,
             whiteSpace: 'pre-wrap',
           }}
@@ -371,7 +545,7 @@ function TextShapeView({ shape, scale, style, ring, onSelect }: TextShapeViewPro
                 fontWeight: run.bold ? 700 : undefined,
                 fontStyle: run.italic ? 'italic' : undefined,
                 textDecoration: run.underline ? 'underline' : undefined,
-                fontSize: run.sizePt ? ptToPx(run.sizePt) : ptToPx(18),
+                fontSize: ptToPx(run.sizePt ?? DEFAULT_TEXT_PT),
                 color: run.colorHex ? `#${run.colorHex}` : '#000',
                 lineHeight: 1.2,
               }}
@@ -382,6 +556,219 @@ function TextShapeView({ shape, scale, style, ring, onSelect }: TextShapeViewPro
         </p>
       ))}
     </div>
+  )
+}
+
+// ----------------------------------------------------------- editing overlay
+
+/**
+ * Rendered HTML for the contentEditable overlay. Every run carries its CURRENT
+ * coordinates (data-cp/data-cr — for style lookup at extraction time) and,
+ * when known, its ORIGINAL provenance (data-op/data-or — indexes into the
+ * shape's as-parsed paragraphs, which the serializer uses to reuse rPr/pPr
+ * bytes). When a browser splits a block or span on Enter, it clones these
+ * attributes onto both halves — exactly the inheritance we want.
+ */
+function buildEditableHtml(shape: TextShape, scale: number): string {
+  const escapeHtml = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+  return shape.paragraphs
+    .map((para, pi) => {
+      const ep = para as EditedParagraph
+      const paraSrc = 'srcPara' in ep ? ep.srcPara : pi
+      const paraProv = paraSrc !== undefined ? ` data-op="${paraSrc}"` : ''
+      const inner = para.runs
+        .map((run, ri) => {
+          const er = run as EditedTextRun
+          const runSrcPara = 'srcPara' in er ? er.srcPara : pi
+          const runSrcRun = 'srcRun' in er ? er.srcRun : ri
+          const prov =
+            runSrcPara !== undefined && runSrcRun !== undefined
+              ? ` data-op="${runSrcPara}" data-or="${runSrcRun}"`
+              : ''
+          if (run.text === '\n') return `<br data-cp="${pi}" data-cr="${ri}"${prov}>`
+          const px = (run.sizePt ?? DEFAULT_TEXT_PT) * EMU_PER_PT * scale
+          const style =
+            `font-weight:${run.bold ? 700 : 400};font-style:${run.italic ? 'italic' : 'normal'};` +
+            `text-decoration:${run.underline ? 'underline' : 'none'};font-size:${px}px;` +
+            `color:#${run.colorHex ?? '000000'};line-height:1.2`
+          return `<span data-cp="${pi}" data-cr="${ri}"${prov} style="${style}">${escapeHtml(run.text)}</span>`
+        })
+        .join('')
+      return `<div data-cp="${pi}"${paraProv} style="margin:0;text-align:${alignToCss(para.align)}">${inner || '<br>'}</div>`
+    })
+    .join('')
+}
+
+function numAttr(el: Element, name: string): number | undefined {
+  const v = el.getAttribute(name)
+  if (v === null) return undefined
+  const n = Number(v)
+  return Number.isInteger(n) && n >= 0 ? n : undefined
+}
+
+/** contentEditable output → model text. NBSP and CRLF normalized, zero-widths dropped. */
+function normText(s: string): string {
+  return s.replace(/\u00A0/g, ' ').replace(/\r\n?/g, '\n').replace(/[\u200B\uFEFF]/g, '')
+}
+
+/** Reads the committed paragraphs back out of the overlay's DOM. */
+function extractParagraphs(root: HTMLElement, shape: TextShape): EditedParagraph[] {
+  const paras: EditedParagraph[] = []
+  let loose: EditedTextRun[] = []
+
+  const flushLoose = () => {
+    if (loose.length) paras.push({ align: undefined, runs: loose, srcPara: undefined })
+    loose = []
+  }
+
+  const runFromStyledNode = (el: Element): EditedTextRun | null => {
+    const text = normText(el.textContent ?? '')
+    if (!text) return null
+    const cp = numAttr(el, 'data-cp')
+    const cr = numAttr(el, 'data-cr')
+    const base: TextRun | undefined =
+      cp !== undefined && cr !== undefined ? shape.paragraphs[cp]?.runs[cr] : undefined
+    return {
+      text,
+      bold: base?.bold,
+      italic: base?.italic,
+      underline: base?.underline,
+      sizePt: base?.sizePt,
+      colorHex: base?.colorHex,
+      srcPara: numAttr(el, 'data-op'),
+      srcRun: numAttr(el, 'data-or'),
+    }
+  }
+
+  const collectInline = (container: Node, into: EditedTextRun[]) => {
+    container.childNodes.forEach((n) => {
+      if (n.nodeType === Node.TEXT_NODE) {
+        const t = normText(n.nodeValue ?? '')
+        if (t) into.push({ text: t })
+      } else if (n instanceof Element) {
+        if (n.tagName === 'BR') {
+          into.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
+        } else if (n.tagName === 'SPAN' && n.getAttribute('data-cr') !== null) {
+          const r = runFromStyledNode(n)
+          if (r) into.push(r)
+        } else {
+          // Pasted markup or browser-inserted wrappers: keep the text, styled
+          // by whatever rPr the serializer's fallback picks.
+          collectInline(n, into)
+        }
+      }
+    })
+  }
+
+  root.childNodes.forEach((n) => {
+    if (n instanceof Element && (n.tagName === 'DIV' || n.tagName === 'P')) {
+      flushLoose()
+      const runs: EditedTextRun[] = []
+      collectInline(n, runs)
+
+      // `<div><br></div>` is contentEditable's empty paragraph.
+      const onlyBr =
+        n.childNodes.length === 1 && n.firstChild instanceof Element && n.firstChild.tagName === 'BR'
+      let finalRuns = onlyBr ? [] : runs
+      // Browsers keep a placeholder <br> at the end of non-empty blocks.
+      if (!onlyBr && finalRuns.length > 1) {
+        const lastRun = finalRuns[finalRuns.length - 1]
+        const lastChild = n.lastChild
+        if (
+          lastRun.text === '\n' &&
+          lastRun.srcRun === undefined &&
+          lastChild instanceof Element &&
+          lastChild.tagName === 'BR' &&
+          lastChild.getAttribute('data-cr') === null
+        ) {
+          finalRuns = finalRuns.slice(0, -1)
+        }
+      }
+
+      const cp = numAttr(n, 'data-cp')
+      paras.push({
+        align: cp !== undefined ? shape.paragraphs[cp]?.align : undefined,
+        runs: finalRuns,
+        srcPara: numAttr(n, 'data-op'),
+      })
+    } else if (n.nodeType === Node.TEXT_NODE) {
+      const t = normText(n.nodeValue ?? '')
+      if (t) loose.push({ text: t })
+    } else if (n instanceof Element) {
+      if (n.tagName === 'BR') {
+        loose.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
+      } else if (n.tagName === 'SPAN' && n.getAttribute('data-cr') !== null) {
+        const r = runFromStyledNode(n)
+        if (r) loose.push(r)
+      } else {
+        collectInline(n, loose)
+      }
+    }
+  })
+  flushLoose()
+
+  // Everything replaced by unanchored content (e.g. select-all + type): keep
+  // the first original paragraph's formatting rather than none at all.
+  if (paras.length > 0 && paras.every((p) => p.srcPara === undefined) && shape.paragraphs.length > 0) {
+    paras[0] = { ...paras[0], srcPara: 0, align: paras[0].align ?? shape.paragraphs[0].align }
+  }
+  if (paras.length === 0) {
+    paras.push({ align: shape.paragraphs[0]?.align, runs: [], srcPara: 0 })
+  }
+  return paras
+}
+
+interface TextEditOverlayProps {
+  shape: TextShape
+  scale: number
+  style: CSSProperties
+  onCommit: (next: EditedParagraph[] | null) => void
+}
+
+function TextEditOverlay({ shape, scale, style, onCommit }: TextEditOverlayProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const committedRef = useRef(false)
+  const html = useMemo(() => buildEditableHtml(shape, scale), [shape, scale])
+
+  const commit = useCallback(() => {
+    if (committedRef.current) return
+    committedRef.current = true
+    onCommit(ref.current ? extractParagraphs(ref.current, shape) : null)
+  }, [onCommit, shape])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.focus()
+    const sel = window.getSelection()
+    if (sel) {
+      sel.selectAllChildren(el)
+      sel.collapseToEnd()
+    }
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      contentEditable
+      suppressContentEditableWarning
+      spellCheck={false}
+      dangerouslySetInnerHTML={{ __html: html }}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          commit()
+        }
+        // Keep app-level shortcuts away from typing.
+        e.stopPropagation()
+      }}
+      onClick={(e) => e.stopPropagation()}
+      style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
+      className="cursor-text overflow-hidden whitespace-pre-wrap outline-2 outline-offset-1 outline-[var(--ring)]"
+    />
   )
 }
 

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -293,6 +293,10 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const handleGeometryCommit = useCallback(
     (shape: Shape, rect: RectEmuBox) => {
       if (!slide) return
+      // The serializer writes geometry only for sp/pic/cxnSp. graphicFrame and
+      // group placeholders would fail the whole save closed, so their drags
+      // snap back instead of committing.
+      if (shape.type === 'placeholder' && shape.kind !== 'video') return
       const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
       pushEdits(
         withShapeEdit(editSetRef.current, key, seedFor(slide.xmlPath, shape), (draft) => {

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -65,6 +65,8 @@ import {
 } from '@/components/pptx/toolbar'
 import {
   DEFAULT_TEXT_PT,
+  aggregateFontOfShape,
+  aggregateFontOfSpans,
   aggregateFormat,
   aggregateFormatOfParagraphs,
   applyAlignToBlocks,
@@ -72,6 +74,7 @@ import {
   fontScaleOf,
   selectedParagraphBlocks,
   selectedRunSpans,
+  typefacesInShapes,
   type TextOverlayHandle,
 } from '@/components/pptx/text-dom'
 
@@ -368,6 +371,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
             underline: src?.underline,
             sizePt: src?.sizePt,
             colorHex: src?.colorHex,
+            latinFont: src?.latinFont,
           }
         }),
       }))
@@ -396,6 +400,9 @@ export function PptxEditor({ path }: PptxEditorProps) {
             }
             if ((r.colorHex ?? null) !== (src.colorHex ?? null) && r.colorHex !== undefined) {
               delta.colorHex = r.colorHex
+            }
+            if ((r.latinFont ?? null) !== (src.latinFont ?? null) && r.latinFont !== undefined) {
+              delta.latinFont = r.latinFont
             }
             if (Object.keys(delta).length > 0) formats[runKeyOf(pi, ri)] = delta
           })
@@ -463,6 +470,25 @@ export function PptxEditor({ path }: PptxEditorProps) {
       ? ((selectedParagraphBlocks(overlayRef.current.root)[0]?.getAttribute('data-algn') ||
           'l') as TextAlign)
       : ((selectedShape as TextShape).paragraphs[0]?.align ?? 'l')
+
+  // The RESOLVED typeface of the selection (inheritance included), so the
+  // picker shows what is on screen rather than only explicit run overrides.
+  const activeFont: string | undefined = !canFormat
+    ? undefined
+    : overlayRef.current
+      ? aggregateFontOfSpans(selectedRunSpans(overlayRef.current.root))
+      : aggregateFontOfShape(selectedShape as TextShape)
+
+  // Every typeface the deck renders with, for the picker's first group.
+  const deckFonts = useMemo(
+    () =>
+      deck
+        ? typefacesInShapes(
+            deck.slides.flatMap((s) => s.shapes.filter((sh): sh is TextShape => sh.type === 'text')),
+          )
+        : [],
+    [deck],
+  )
 
   const applyFormat = useCallback(
     (set: RunFormatOverrides) => {
@@ -865,6 +891,9 @@ export function PptxEditor({ path }: PptxEditorProps) {
           onZoomFit={() => setZoomMode('fit')}
           format={activeFormat}
           formatDisabledReason={formatDisabledReason}
+          font={activeFont}
+          deckFonts={deckFonts}
+          onFontChange={(family) => applyFormat({ latinFont: family })}
           onToggleBold={() => applyFormat({ bold: !activeFormat?.bold })}
           onToggleItalic={() => applyFormat({ italic: !activeFormat?.italic })}
           onToggleUnderline={() => applyFormat({ underline: !activeFormat?.underline })}

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -8,13 +8,23 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
-import { ExternalLinkIcon, Loader2Icon, PresentationIcon } from 'lucide-react'
+import { ExternalLinkIcon, Loader2Icon, PresentationIcon, Trash2Icon } from 'lucide-react'
 import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { disposeDeck, parsePptx } from '@/lib/pptx/parse'
 import { writeDeck, type EditedParagraph, type RunFormatOverrides } from '@/lib/pptx/serialize'
 import type { NodePath, Paragraph, Shape, Slide, SlideDeck, TextAlign, TextShape } from '@/lib/pptx/types'
 import {
-  EMPTY_EDIT_SET,
+  EMPTY_DECK_EDITS,
   EMU_PER_PX,
   acceptsFormatting,
   applyEditSet,
@@ -26,6 +36,7 @@ import {
   structureMatches,
   toSlideEdits,
   withShapeEdit,
+  type DeckEdits,
   type EditSet,
   type RectEmuBox,
   type ShapeKey,
@@ -132,13 +143,15 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const [selectionTick, setSelectionTick] = useState(0)
   const [presenting, setPresenting] = useState(false)
 
-  const [history, setHistory] = useState<EditSet[]>([EMPTY_EDIT_SET])
+  const [history, setHistory] = useState<DeckEdits[]>([EMPTY_DECK_EDITS])
   const [histIndex, setHistIndex] = useState(0)
-  const editSet = history[histIndex] ?? EMPTY_EDIT_SET
+  const editSet = history[histIndex] ?? EMPTY_DECK_EDITS
+  // Slide pending deletion, as an index into the RENDERED deck; null = closed.
+  const [confirmDeleteIndex, setConfirmDeleteIndex] = useState<number | null>(null)
 
   const rootRef = useRef<HTMLDivElement>(null)
   const baseDeckRef = useRef<SlideDeck | null>(null)
-  const editSetRef = useRef<EditSet>(EMPTY_EDIT_SET)
+  const editSetRef = useRef<DeckEdits>(EMPTY_DECK_EDITS)
   const histIndexRef = useRef(0)
   const overlayRef = useRef<TextOverlayHandle | null>(null)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -170,7 +183,9 @@ export function PptxEditor({ path }: PptxEditorProps) {
         setSaveStatus('clean')
         return
       }
-      const bytes = await writeDeck(base, toSlideEdits(edits))
+      const bytes = await writeDeck(base, toSlideEdits(edits.shapes), {
+        deleteSlides: edits.deletedSlides,
+      })
       const b64 = uint8ArrayToBase64(bytes)
       if (b64 !== lastWrittenRef.current) {
         await window.ipc.invoke('workspace:writeFile', {
@@ -206,7 +221,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
   /** Commits a new edit set: pushes onto the undo stack and schedules a save. */
   const pushEdits = useCallback(
-    (next: EditSet) => {
+    (next: DeckEdits) => {
       setHistory((h) => {
         const trimmed = [...h.slice(0, histIndexRef.current + 1), next]
         return trimmed.length > MAX_HISTORY ? trimmed.slice(trimmed.length - MAX_HISTORY) : trimmed
@@ -216,6 +231,14 @@ export function PptxEditor({ path }: PptxEditorProps) {
       scheduleSave()
     },
     [scheduleSave],
+  )
+
+  /** Commits a shape-level change, carrying the slide deletions forward. */
+  const pushShapeEdits = useCallback(
+    (shapes: EditSet) => {
+      pushEdits({ ...editSetRef.current, shapes })
+    },
+    [pushEdits],
   )
 
   // Flush pending edits on unmount / path change, before blob URLs are revoked.
@@ -258,9 +281,13 @@ export function PptxEditor({ path }: PptxEditorProps) {
     () => (baseDeck ? applyEditSet(baseDeck, editSet) : null),
     [baseDeck, editSet],
   )
-  const slide = deck?.slides[activeIndex] ?? null
+  // Deleting slides shrinks the rendered deck, and undo/redo can grow it back;
+  // clamp rather than track so a stale index can never render a blank pane.
+  const slideCount = deck?.slides.length ?? 0
+  const currentIndex = Math.max(0, Math.min(activeIndex, slideCount - 1))
+  const slide = deck?.slides[currentIndex] ?? null
   const selectedShape = findShape(slide, selectedKey)
-  const shapeEdit = selectedKey ? editSet[selectedKey] : undefined
+  const shapeEdit = selectedKey ? editSet.shapes[selectedKey] : undefined
 
   // ------------------------------------------------------------ undo / redo
 
@@ -271,7 +298,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
     if (histIndexRef.current <= 0) return
     const next = histIndexRef.current - 1
     histIndexRef.current = next
-    editSetRef.current = history[next] ?? EMPTY_EDIT_SET
+    editSetRef.current = history[next] ?? EMPTY_DECK_EDITS
     setHistIndex(next)
     setEditingKey(null)
     scheduleSave()
@@ -281,7 +308,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
     if (histIndexRef.current >= history.length - 1) return
     const next = histIndexRef.current + 1
     histIndexRef.current = next
-    editSetRef.current = history[next] ?? EMPTY_EDIT_SET
+    editSetRef.current = history[next] ?? EMPTY_DECK_EDITS
     setHistIndex(next)
     setEditingKey(null)
     scheduleSave()
@@ -311,13 +338,13 @@ export function PptxEditor({ path }: PptxEditorProps) {
       if (shape.type === 'group') return
       if (shape.type === 'placeholder' && shape.kind !== 'video') return
       const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
-      pushEdits(
-        withShapeEdit(editSetRef.current, key, seedFor(slide.xmlPath, shape), (draft) => {
+      pushShapeEdits(
+        withShapeEdit(editSetRef.current.shapes, key, seedFor(slide.xmlPath, shape), (draft) => {
           draft.geometry = rect
         }),
       )
     },
-    [slide, pushEdits, seedFor],
+    [slide, pushShapeEdits, seedFor],
   )
 
   const handleTextCommit = useCallback(
@@ -381,7 +408,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         })
       }
 
-      const previous = editSetRef.current[key]
+      const previous = editSetRef.current.shapes[key]
       const hadFormatting = editHoldsFormatting(previous)
       // Retyping the original text is a revert, not a no-op: it must fall
       // through so the accumulated text edit below is cleared.
@@ -396,8 +423,8 @@ export function PptxEditor({ path }: PptxEditorProps) {
         toast.info('Formatting was reset on this text box because its structure changed.')
       }
 
-      pushEdits(
-        withShapeEdit(editSetRef.current, key, seedFor(slide.xmlPath, shape), (draft) => {
+      pushShapeEdits(
+        withShapeEdit(editSetRef.current.shapes, key, seedFor(slide.xmlPath, shape), (draft) => {
           draft.original = original
           draft.text = textChanged || structural ? textNext : undefined
           if (structural) {
@@ -411,7 +438,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         }),
       )
     },
-    [slide, pushEdits, seedFor],
+    [slide, pushShapeEdits, seedFor],
   )
 
   // ------------------------------------------------------------ formatting
@@ -460,8 +487,8 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
       const original = baseParagraphsOf(baseDeckRef.current, slide.xmlPath, shape.nodePath)
       if (!original) return
-      pushEdits(
-        withShapeEdit(editSetRef.current, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
+      pushShapeEdits(
+        withShapeEdit(editSetRef.current.shapes, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
           draft.original = original
           const formats = { ...(draft.formats ?? {}) }
           original.forEach((p, pi) =>
@@ -475,7 +502,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         }),
       )
     },
-    [slide, selectedKey, pushEdits, seedFor],
+    [slide, selectedKey, pushShapeEdits, seedFor],
   )
 
   const applyAlign = useCallback(
@@ -494,8 +521,8 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
       const original = baseParagraphsOf(baseDeckRef.current, slide.xmlPath, shape.nodePath)
       if (!original) return
-      pushEdits(
-        withShapeEdit(editSetRef.current, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
+      pushShapeEdits(
+        withShapeEdit(editSetRef.current.shapes, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
           draft.original = original
           const aligns = { ...(draft.aligns ?? {}) }
           original.forEach((_, pi) => {
@@ -505,7 +532,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         }),
       )
     },
-    [slide, selectedKey, pushEdits, seedFor],
+    [slide, selectedKey, pushShapeEdits, seedFor],
   )
 
   const stepFontSize = useCallback(
@@ -550,6 +577,63 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const startPresenting = useCallback(() => setPresenting(true), [])
   const stopPresenting = useCallback(() => setPresenting(false), [])
 
+  // -------------------------------------------------------------- deletion
+
+  const deleteSelectedShape = useCallback(() => {
+    if (!slide || !selectedKey) return
+    const shape = findShape(slide, selectedKey)
+    if (!shape) return
+    pushShapeEdits(
+      withShapeEdit(editSetRef.current.shapes, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
+        // Deletion supersedes the other fields — their splices would land
+        // inside the removed range and fail the whole save closed.
+        draft.text = undefined
+        draft.formats = undefined
+        draft.aligns = undefined
+        draft.geometry = undefined
+        draft.deleted = { shapeType: shape.type, shapeId: shape.id }
+      }),
+    )
+    setSelectedKey(null)
+  }, [slide, selectedKey, pushShapeEdits, seedFor])
+
+  const requestDeleteSlide = useCallback(
+    (index: number) => {
+      if (!deck) return
+      if (deck.slides.length <= 1) {
+        toast.info('A presentation needs at least one slide.')
+        return
+      }
+      setConfirmDeleteIndex(index)
+    },
+    [deck],
+  )
+
+  const confirmDeleteSlide = useCallback(() => {
+    const index = confirmDeleteIndex
+    setConfirmDeleteIndex(null)
+    if (index === null || !deck) return
+    const target = deck.slides[index]
+    if (!target || deck.slides.length <= 1) return
+    const cur = editSetRef.current
+    // Prune the deleted slide's shape edits: their splices are moot, and the
+    // serializer refuses a slide that is both edited and deleted. The prior
+    // history entry still holds them, so undo restores slide and edits alike.
+    const shapes: Record<ShapeKey, (typeof cur.shapes)[ShapeKey]> = {}
+    for (const [k, v] of Object.entries(cur.shapes)) {
+      if (v.slidePath !== target.xmlPath) shapes[k] = v
+    }
+    pushEdits({ shapes, deletedSlides: [...cur.deletedSlides, target.xmlPath] })
+    setSelectedKey(null)
+    setEditingKey(null)
+    setActiveIndex((i) => {
+      // Stay on the same slide when one before it goes; the clamp handles
+      // deleting the last card.
+      const next = i > index ? i - 1 : i
+      return Math.max(0, Math.min(next, deck.slides.length - 2))
+    })
+  }, [confirmDeleteIndex, deck, pushEdits])
+
   // -------------------------------------------------------------- keyboard
 
   const handleKeyDown = useCallback(
@@ -569,6 +653,20 @@ export function PptxEditor({ path }: PptxEditorProps) {
           e.preventDefault()
           setSelectedKey(null)
         }
+        return
+      }
+      if (mod && e.key === 'Backspace') {
+        if (editingKey) return
+        e.preventDefault()
+        requestDeleteSlide(currentIndex)
+        return
+      }
+      if ((e.key === 'Backspace' || e.key === 'Delete') && !mod) {
+        if (editingKey || !selectedKey) return
+        // A press inside a toolbar input must never nuke the selected shape.
+        if (e.target instanceof HTMLElement && e.target.tagName === 'INPUT') return
+        e.preventDefault()
+        deleteSelectedShape()
         return
       }
       if (editingKey || !selectedKey || !slide) return
@@ -592,7 +690,17 @@ export function PptxEditor({ path }: PptxEditorProps) {
         h: shape.xfrmEmu.h,
       })
     },
-    [editingKey, selectedKey, slide, undo, redo, handleGeometryCommit],
+    [
+      editingKey,
+      selectedKey,
+      slide,
+      currentIndex,
+      undo,
+      redo,
+      handleGeometryCommit,
+      deleteSelectedShape,
+      requestDeleteSlide,
+    ],
   )
 
   // ---------------------------------------------------------------- render
@@ -659,7 +767,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
           onColorChange={(hex) => applyFormat({ colorHex: hex })}
           align={activeAlign}
           onAlign={applyAlign}
-          slideNumber={activeIndex + 1}
+          slideNumber={currentIndex + 1}
           slideCount={deck.slides.length}
         />
 
@@ -681,12 +789,13 @@ export function PptxEditor({ path }: PptxEditorProps) {
                   slide={s}
                   sizeEmu={deck.slideSizeEmu}
                   title={slideTitle(s)}
-                  active={i === activeIndex}
+                  active={i === currentIndex}
                   onSelect={() => {
                     setActiveIndex(i)
                     setSelectedKey(null)
                     setEditingKey(null)
                   }}
+                  onDelete={() => requestDeleteSlide(i)}
                 />
               ))}
             </div>
@@ -718,10 +827,32 @@ export function PptxEditor({ path }: PptxEditorProps) {
           <PresentationOverlay
             slides={deck.slides}
             sizeEmu={deck.slideSizeEmu}
-            startIndex={activeIndex}
+            startIndex={currentIndex}
             onExit={stopPresenting}
           />
         )}
+
+        <AlertDialog
+          open={confirmDeleteIndex !== null}
+          onOpenChange={(open) => {
+            if (!open) setConfirmDeleteIndex(null)
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                Delete slide {confirmDeleteIndex !== null ? confirmDeleteIndex + 1 : ''}?
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                The slide is removed from the presentation. You can undo this with ⌘Z.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={confirmDeleteSlide}>Delete slide</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </EditorErrorBoundary>
   )
@@ -742,33 +873,52 @@ interface SlideCardProps {
   title: string | null
   active: boolean
   onSelect: () => void
+  onDelete: () => void
 }
 
-function SlideCard({ index, slide, sizeEmu, title, active, onSelect }: SlideCardProps) {
+function SlideCard({ index, slide, sizeEmu, title, active, onSelect, onDelete }: SlideCardProps) {
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-current={active ? 'true' : undefined}
-      aria-label={`Slide ${index + 1}${title ? `: ${title}` : ''}`}
-      className={`flex shrink-0 items-center gap-1.5 rounded-md p-1.5 transition-all ${
-        active
-          ? 'bg-accent/60 shadow-sm ring-2 ring-ring'
-          : 'ring-1 ring-border/60 hover:bg-accent/40 hover:ring-border'
-      }`}
-    >
-      {/* Outside the thumbnail on purpose — overlaid, it sat on the slide's own title. */}
-      <span
-        className={`w-5 shrink-0 rounded py-px text-center text-[10px] font-medium leading-none tabular-nums ${
-          active ? 'bg-background text-foreground' : 'text-muted-foreground'
+    // The trash affordance is a SIBLING of the card button (buttons must not
+    // nest), floated over its corner; only the active card shows it.
+    <div className="relative shrink-0">
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-current={active ? 'true' : undefined}
+        aria-label={`Slide ${index + 1}${title ? `: ${title}` : ''}`}
+        className={`flex w-full shrink-0 items-center gap-1.5 rounded-md p-1.5 transition-all ${
+          active
+            ? 'bg-accent/60 shadow-sm ring-2 ring-ring'
+            : 'ring-1 ring-border/60 hover:bg-accent/40 hover:ring-border'
         }`}
       >
-        {index + 1}
-      </span>
-      <span className="mx-auto block shrink-0 overflow-hidden rounded-sm">
-        <SlideThumbnail slide={slide} sizeEmu={sizeEmu} widthPx={THUMB_WIDTH_PX} />
-      </span>
-    </button>
+        {/* Outside the thumbnail on purpose — overlaid, it sat on the slide's own title. */}
+        <span
+          className={`w-5 shrink-0 rounded py-px text-center text-[10px] font-medium leading-none tabular-nums ${
+            active ? 'bg-background text-foreground' : 'text-muted-foreground'
+          }`}
+        >
+          {index + 1}
+        </span>
+        <span className="mx-auto block shrink-0 overflow-hidden rounded-sm">
+          <SlideThumbnail slide={slide} sizeEmu={sizeEmu} widthPx={THUMB_WIDTH_PX} />
+        </span>
+      </button>
+      {active && (
+        <button
+          type="button"
+          aria-label={`Delete slide ${index + 1}`}
+          title="Delete slide (⌘⌫)"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+          className="absolute right-1.5 top-1.5 z-10 inline-flex size-5 items-center justify-center rounded bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border transition-colors hover:text-destructive"
+        >
+          <Trash2Icon className="size-3" />
+        </button>
+      )}
+    </div>
   )
 }
 

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -44,6 +44,7 @@ import {
   aggregateFormatOfParagraphs,
   applyAlignToBlocks,
   applyFormatToSpans,
+  fontScaleOf,
   selectedParagraphBlocks,
   selectedRunSpans,
   type TextOverlayHandle,
@@ -449,7 +450,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
       const overlay = overlayRef.current
       if (overlay) {
         // Editing: mutate the spans; the commit on blur turns this into edits.
-        applyFormatToSpans(selectedRunSpans(overlay.root), set, overlay.scale)
+        applyFormatToSpans(selectedRunSpans(overlay.root), set, overlay.scale, fontScaleOf(overlay.shape))
         setSelectionTick((t) => t + 1)
         dirtyRef.current = true
         return

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -29,21 +29,39 @@ import {
 } from '@/components/ui/alert-dialog'
 import { disposeDeck, parseAddedSlide, parsePptx } from '@/lib/pptx/parse'
 import { planDuplicateSlide, planNewSlide, readSlideRels } from '@/lib/pptx/add-slide'
+import { isLinePreset } from '@/lib/pptx/geometry'
+import type { NewShapeSpec } from '@/lib/pptx/shape-xml'
 import { writeDeck, type EditedParagraph, type RunFormatOverrides } from '@/lib/pptx/serialize'
-import type { NodePath, Paragraph, Shape, Slide, SlideDeck, TextAlign, TextShape } from '@/lib/pptx/types'
+import type {
+  Fill,
+  NodePath,
+  Paragraph,
+  Shape,
+  Slide,
+  SlideDeck,
+  TextAlign,
+  TextShape,
+} from '@/lib/pptx/types'
 import {
   EMPTY_DECK_EDITS,
+  EMU_PER_INCH,
   EMU_PER_PX,
   acceptsFormatting,
   applyEditSet,
   editHoldsFormatting,
   hasEdits,
+  isInsertedShape,
   isNoopCommit,
   runKeyOf,
   shapeKeyOf,
+  spTreeSlotOf,
   structureMatches,
+  insertsToSlideEdits,
+  mergeSlideEdits,
   toSlideEdits,
   withShapeEdit,
+  withShapeInserted,
+  withShapeUninserted,
   withSlideAdded,
   withSlideOrder,
   withSlideRemoved,
@@ -58,6 +76,7 @@ import { PresentationOverlay } from '@/components/pptx/presentation'
 import {
   EditorHeader,
   EditorToolbar,
+  type InsertChoice,
   MAX_ZOOM,
   MIN_ZOOM,
   ZOOM_STEPS,
@@ -83,6 +102,16 @@ interface PptxEditorProps {
 }
 
 type LoadState = 'loading' | 'ready' | 'error'
+
+/** Default sizes for inserted shapes, centred on the slide. */
+const INSERT_SIZES: Record<string, { w: number; h: number }> = {
+  textbox: { w: 4 * EMU_PER_INCH, h: 0.6 * EMU_PER_INCH },
+  rect: { w: 3 * EMU_PER_INCH, h: 2 * EMU_PER_INCH },
+  roundRect: { w: 3 * EMU_PER_INCH, h: 2 * EMU_PER_INCH },
+  ellipse: { w: 2.5 * EMU_PER_INCH, h: 2.5 * EMU_PER_INCH },
+  line: { w: 3 * EMU_PER_INCH, h: 0 },
+  image: { w: 4 * EMU_PER_INCH, h: 3 * EMU_PER_INCH },
+}
 
 const SAVE_DEBOUNCE_MS = 800
 const MAX_HISTORY = 100
@@ -141,6 +170,11 @@ function baseParagraphsOf(
   return shape?.type === 'text' ? shape.paragraphs : undefined
 }
 
+/** The displayed solid colour of a fill, if it has one. */
+function hexOfFill(fill: Fill | undefined): string | undefined {
+  return fill?.kind === 'solid' ? fill.hex : undefined
+}
+
 /** Structure + text only; formatting is compared separately. */
 function textSignature(paras: readonly { runs: readonly { text: string }[] }[]): string {
   return JSON.stringify(paras.map((p) => p.runs.map((r) => r.text)))
@@ -173,6 +207,8 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const editSetRef = useRef<DeckEdits>(EMPTY_DECK_EDITS)
   const histIndexRef = useRef(0)
   const overlayRef = useRef<TextOverlayHandle | null>(null)
+  /** Last reported save failure, so the same one is not announced repeatedly. */
+  const lastSaveErrorRef = useRef<string | null>(null)
 
   useEffect(() => {
     editSetRef.current = editSet
@@ -196,11 +232,15 @@ export function PptxEditor({ path }: PptxEditorProps) {
         const base = baseDeckRef.current
         if (!base) throw new Error('presentation is not loaded')
         const edits = editSetRef.current
-        const bytes = await writeDeck(base, toSlideEdits(edits.shapes), {
-          deleteSlides: edits.deletedSlides,
-          addSlides: edits.addedSlides,
-          slideOrder: edits.slideOrder,
-        })
+        const bytes = await writeDeck(
+          base,
+          mergeSlideEdits(toSlideEdits(edits.shapes), insertsToSlideEdits(edits.insertedShapes)),
+          {
+            deleteSlides: edits.deletedSlides,
+            addSlides: edits.addedSlides,
+            slideOrder: edits.slideOrder,
+          },
+        )
         return uint8ArrayToBase64(bytes)
       },
       write: async (data) => {
@@ -210,8 +250,25 @@ export function PptxEditor({ path }: PptxEditorProps) {
           opts: { encoding: 'base64' },
         })
       },
-      onStatus: setSaveStatus,
-      onError: (err) => console.error('Failed to save pptx:', err),
+      onStatus: (status) => {
+        if (status === 'saved') lastSaveErrorRef.current = null
+        setSaveStatus(status)
+      },
+      onError: (err) => {
+        console.error('Failed to save pptx:', err)
+        // The edit set is cumulative, so ONE rejected edit makes every later
+        // save fail too — silently, until now. Without the reason on screen
+        // this reads as "editing randomly stopped working", which is exactly
+        // how it was reported. Only announce a CHANGED reason, since the
+        // debounce would otherwise re-toast the same failure on every keystroke.
+        const message = err instanceof Error ? err.message : String(err)
+        if (message === lastSaveErrorRef.current) return
+        lastSaveErrorRef.current = message
+        toast.error('This presentation could not be saved.', {
+          description: message,
+          duration: 10000,
+        })
+      },
     })
   }
   const savePipeline = savePipelineRef.current
@@ -444,15 +501,23 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
   // ------------------------------------------------------------ formatting
 
+  // While a box is OPEN for editing, formatting goes onto DOM spans and is
+  // committed as run properties, which the serializer now emits even for runs
+  // with no provenance — so structure is irrelevant on that path. Only the
+  // closed-box path writes the `formats` map, whose keys are ORIGINAL run
+  // indices and therefore meaningless once the structure has diverged.
+  const editingThisShape = editingKey !== null && editingKey === selectedKey
   const canFormat =
-    selectedShape?.type === 'text' && acceptsFormatting(shapeEdit) && slide !== null
+    selectedShape?.type === 'text' &&
+    (editingThisShape || acceptsFormatting(shapeEdit)) &&
+    slide !== null
 
   const formatDisabledReason = !selectedShape
     ? 'Select a text box first'
     : selectedShape.type !== 'text'
       ? 'This shape has no text'
-      : !acceptsFormatting(shapeEdit)
-        ? 'Formatting is unavailable after changing this text box’s structure'
+      : !editingThisShape && !acceptsFormatting(shapeEdit)
+        ? 'Double-click the text to format it — this box’s structure has changed'
         : null
 
   // Reads live DOM while editing so the toolbar mirrors the caret's run.
@@ -478,6 +543,52 @@ export function PptxEditor({ path }: PptxEditorProps) {
     : overlayRef.current
       ? aggregateFontOfSpans(selectedRunSpans(overlayRef.current.root))
       : aggregateFontOfShape(selectedShape as TextShape)
+
+  // Fill / outline are offered only for the shape kinds the serializer can
+  // restyle — never images, groups or unrendered placeholders — and never
+  // while text is being edited, where the toolbar is about the text.
+  const styleTarget =
+    selectedShape &&
+    !editingKey &&
+    selectedShape.style &&
+    (selectedShape.type === 'text' || selectedShape.type === 'drawing')
+      ? selectedShape
+      : null
+  const styleEdit = styleTarget ? editSet.shapes[selectedKey as ShapeKey] : undefined
+  const shapeFill: string | null = !styleTarget
+    ? null
+    : // Anything drawn as a stroke has no fillable region: connectors, and
+      // inserted `line` shapes alike.
+      isLinePreset(styleTarget.visual?.geom?.preset ?? '')
+      ? null
+      : `#${styleEdit?.fillHex ?? hexOfFill(styleTarget.visual?.fill) ?? 'FFFFFF'}`
+  const shapeLine: string | null = !styleTarget
+    ? null
+    : `#${styleEdit?.lineHex ?? styleTarget.visual?.line?.hex ?? '000000'}`
+
+  /** Commits a fill/outline change through the normal edit-set pipeline. */
+  const applyShapeStyle = useCallback(
+    (set: { fillHex?: string; lineHex?: string }) => {
+      if (!selectedKey || !selectedShape || !selectedShape.style) return
+      pushShapeEdits(
+        withShapeEdit(
+          editSetRef.current.shapes,
+          selectedKey,
+          { slidePath: selectedShape.slideXmlPath, nodePath: selectedShape.nodePath },
+          (draft) => {
+            draft.shapeType = selectedShape.type
+            draft.shapeId = selectedShape.id
+            // The anchor is the file's style, not the current override, so a
+            // second recolour still validates against the original bytes.
+            draft.styleOriginal = selectedShape.style
+            if (set.fillHex !== undefined) draft.fillHex = set.fillHex
+            if (set.lineHex !== undefined) draft.lineHex = set.lineHex
+          },
+        ),
+      )
+    },
+    [selectedKey, selectedShape, pushShapeEdits],
+  )
 
   // Every typeface the deck renders with, for the picker's first group.
   const deckFonts = useMemo(
@@ -603,6 +714,15 @@ export function PptxEditor({ path }: PptxEditorProps) {
     if (!slide || !selectedKey) return
     const shape = findShape(slide, selectedKey)
     if (!shape) return
+    // A shape this session inserted is removed by dropping the insert; it has
+    // no element in the file to splice out, and its id is an editor key rather
+    // than a cNvPr id, so a deleteShape edit would fail the save closed.
+    if (isInsertedShape(editSetRef.current, selectedKey)) {
+      pushEdits(withShapeUninserted(editSetRef.current, selectedKey))
+      setSelectedKey(null)
+      setEditingKey(null)
+      return
+    }
     pushShapeEdits(
       withShapeEdit(editSetRef.current.shapes, selectedKey, seedFor(slide.xmlPath, shape), (draft) => {
         // Deletion supersedes the other fields — their splices would land
@@ -615,7 +735,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
       }),
     )
     setSelectedKey(null)
-  }, [slide, selectedKey, pushShapeEdits, seedFor])
+  }, [slide, selectedKey, pushShapeEdits, pushEdits, seedFor])
 
   const requestDeleteSlide = useCallback(
     (index: number) => {
@@ -713,6 +833,79 @@ export function PptxEditor({ path }: PptxEditorProps) {
       setActiveIndex(paths.indexOf(moved))
     },
     [deck, pushEdits],
+  )
+
+
+  // ------------------------------------------------------------------ insert
+
+  const insertShape = useCallback(
+    async (choice: InsertChoice) => {
+      if (!deck || !slide) return
+      const size = INSERT_SIZES[choice] ?? INSERT_SIZES.rect
+      const xfrmEmu = {
+        x: Math.round((deck.slideSizeEmu.w - size.w) / 2),
+        y: Math.round((deck.slideSizeEmu.h - size.h) / 2),
+        w: size.w,
+        h: Math.max(size.h, 1),
+      }
+
+      let spec: NewShapeSpec
+      let previewUrl: string | undefined
+      if (choice === 'image') {
+        // Opens the OS file picker in the main process. A throw here means the
+        // handler is missing — the main process does not hot-reload, so a
+        // stale app shows that as nothing happening at all unless it is said
+        // out loud.
+        let picked: Awaited<ReturnType<typeof window.ipc.invoke<'workspace:pickImage'>>>
+        try {
+          picked = await window.ipc.invoke('workspace:pickImage', {})
+        } catch (err) {
+          console.error('Image picker failed:', err)
+          toast.error('Could not open the image picker.', {
+            description:
+              (err instanceof Error ? err.message : String(err)) +
+              ' — fully quit and relaunch the app, then try again.',
+            duration: 10000,
+          })
+          return
+        }
+        if (picked.error) {
+          toast.error('Could not read that image.', { description: picked.error })
+          return
+        }
+        // Cancelled the dialog: nothing to say.
+        if (!picked.picked || !picked.dataBase64 || !picked.ext) return
+        const bytes = base64ToUint8Array(picked.dataBase64)
+        previewUrl = URL.createObjectURL(new Blob([bytes as unknown as BlobPart]))
+        spec = {
+          kind: 'image',
+          xfrmEmu,
+          ext: picked.ext,
+          dataBase64: picked.dataBase64,
+          name: picked.name,
+        }
+      } else if (choice === 'textbox') {
+        spec = { kind: 'textbox', xfrmEmu }
+      } else {
+        spec = { kind: 'shape', preset: choice, xfrmEmu }
+      }
+
+      // The key must be the one the RENDERED shape will carry, i.e. derived
+      // from the node path it will occupy — otherwise selection cannot find
+      // it and the whole toolbar stays disabled.
+      const slot = spTreeSlotOf(slide)
+      const pending = editSetRef.current.insertedShapes.filter(
+        (i) => i.slidePath === slide.xmlPath,
+      ).length
+      const key = shapeKeyOf(slide.xmlPath, [...slot.path, slot.nextChild + pending])
+      pushEdits(
+        withShapeInserted(editSetRef.current, { key, slidePath: slide.xmlPath, spec, previewUrl }),
+      )
+      setSelectedKey(key)
+      // A new text box opens for typing straight away; a shape is just selected.
+      setEditingKey(choice === 'textbox' ? key : null)
+    },
+    [deck, slide, pushEdits],
   )
 
   const confirmDeleteSlide = useCallback(() => {
@@ -891,6 +1084,11 @@ export function PptxEditor({ path }: PptxEditorProps) {
           onZoomFit={() => setZoomMode('fit')}
           format={activeFormat}
           formatDisabledReason={formatDisabledReason}
+          onInsert={(choice) => void insertShape(choice)}
+          shapeFill={shapeFill}
+          shapeLine={shapeLine}
+          onShapeFillChange={(hex) => applyShapeStyle({ fillHex: hex })}
+          onShapeLineChange={(hex) => applyShapeStyle({ lineHex: hex })}
           font={activeFont}
           deckFonts={deckFonts}
           onFontChange={(family) => applyFormat({ latinFont: family })}

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -8,7 +8,14 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
-import { ExternalLinkIcon, Loader2Icon, PlusIcon, PresentationIcon, Trash2Icon } from 'lucide-react'
+import {
+  CopyIcon,
+  ExternalLinkIcon,
+  Loader2Icon,
+  PlusIcon,
+  PresentationIcon,
+  Trash2Icon,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import {
   AlertDialog,
@@ -21,7 +28,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { disposeDeck, parseAddedSlide, parsePptx } from '@/lib/pptx/parse'
-import { planNewSlide } from '@/lib/pptx/add-slide'
+import { planDuplicateSlide, planNewSlide, readSlideRels } from '@/lib/pptx/add-slide'
 import { writeDeck, type EditedParagraph, type RunFormatOverrides } from '@/lib/pptx/serialize'
 import type { NodePath, Paragraph, Shape, Slide, SlideDeck, TextAlign, TextShape } from '@/lib/pptx/types'
 import {
@@ -37,6 +44,8 @@ import {
   structureMatches,
   toSlideEdits,
   withShapeEdit,
+  withSlideAdded,
+  withSlideOrder,
   withSlideRemoved,
   type DeckEdits,
   type EditSet,
@@ -151,6 +160,10 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const editSet = history[histIndex] ?? EMPTY_DECK_EDITS
   // Slide pending deletion, as an index into the RENDERED deck; null = closed.
   const [confirmDeleteIndex, setConfirmDeleteIndex] = useState<number | null>(null)
+  // Rail drag: the card being dragged, and the GAP the drop indicator sits in
+  // (gap g is above card g, so g === slides.length means "after the last").
+  const [dragFrom, setDragFrom] = useState<number | null>(null)
+  const [dragOver, setDragOver] = useState<number | null>(null)
 
   const rootRef = useRef<HTMLDivElement>(null)
   const baseDeckRef = useRef<SlideDeck | null>(null)
@@ -183,6 +196,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         const bytes = await writeDeck(base, toSlideEdits(edits.shapes), {
           deleteSlides: edits.deletedSlides,
           addSlides: edits.addedSlides,
+          slideOrder: edits.slideOrder,
         })
         return uint8ArrayToBase64(bytes)
       },
@@ -608,7 +622,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
         cur.addedSlides.map((a) => a.path),
       )
       const parsed = await parseAddedSlide(base, plan.path, plan.xml, plan.relsXml)
-      pushEdits({ ...cur, addedSlides: [...cur.addedSlides, { ...plan, slide: parsed }] })
+      pushEdits(withSlideAdded(cur, { ...plan, slide: parsed }))
       setSelectedKey(null)
       setEditingKey(null)
       setActiveIndex(currentIndex + 1)
@@ -619,6 +633,61 @@ export function PptxEditor({ path }: PptxEditorProps) {
       addingSlideRef.current = false
     }
   }, [slide, currentIndex, pushEdits])
+
+  /**
+   * Duplicate: copies the slide AS CURRENTLY SHOWN. The anchor's pending edits
+   * are baked into the copy's bytes here, once, so the two slides are fully
+   * independent from that point on — later edits address different parts.
+   */
+  const duplicateSlide = useCallback(
+    async (index: number) => {
+      const base = baseDeckRef.current
+      const target = deck?.slides[index]
+      if (!base || !target || addingSlideRef.current) return
+      addingSlideRef.current = true
+      try {
+        const cur = editSetRef.current
+        const anchorAdded = cur.addedSlides.find((a) => a.path === target.xmlPath)
+        const xml = anchorAdded?.xml ?? base.source.slideXml[target.xmlPath]
+        if (xml === undefined) throw new Error(`no retained XML for ${target.xmlPath}`)
+        const relsXml = anchorAdded?.relsXml ?? (await readSlideRels(base, target.xmlPath))
+        const plan = planDuplicateSlide(
+          base,
+          target.xmlPath,
+          { xml, relsXml, edits: toSlideEdits(cur.shapes).get(target.xmlPath) },
+          cur.addedSlides.map((a) => a.path),
+        )
+        const parsed = await parseAddedSlide(base, plan.path, plan.xml, plan.relsXml)
+        pushEdits(withSlideAdded(cur, { ...plan, slide: parsed }))
+        setSelectedKey(null)
+        setEditingKey(null)
+        setActiveIndex(index + 1)
+      } catch (err) {
+        console.error('Failed to duplicate slide:', err)
+        toast.error('Could not duplicate this slide.')
+      } finally {
+        addingSlideRef.current = false
+      }
+    },
+    [deck, pushEdits],
+  )
+
+  /** Commits one explicit order after a rail drag. */
+  const reorderSlides = useCallback(
+    (from: number, to: number) => {
+      if (!deck || from === to) return
+      const paths = deck.slides.map((s) => s.xmlPath)
+      const moved = paths.splice(from, 1)[0]
+      if (moved === undefined) return
+      // `to` is the index the card should occupy once it has been lifted out.
+      paths.splice(Math.max(0, Math.min(to, paths.length)), 0, moved)
+      pushEdits(withSlideOrder(editSetRef.current, paths))
+      setSelectedKey(null)
+      setEditingKey(null)
+      setActiveIndex(paths.indexOf(moved))
+    },
+    [deck, pushEdits],
+  )
 
   const confirmDeleteSlide = useCallback(() => {
     const index = confirmDeleteIndex
@@ -669,6 +738,12 @@ export function PptxEditor({ path }: PptxEditorProps) {
         requestDeleteSlide(currentIndex)
         return
       }
+      if (mod && e.key.toLowerCase() === 'd') {
+        if (editingKey) return
+        e.preventDefault()
+        void duplicateSlide(currentIndex)
+        return
+      }
       if ((e.key === 'Backspace' || e.key === 'Delete') && !mod) {
         if (editingKey || !selectedKey) return
         // A press inside a toolbar input must never nuke the selected shape.
@@ -708,6 +783,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
       handleGeometryCommit,
       deleteSelectedShape,
       requestDeleteSlide,
+      duplicateSlide,
     ],
   )
 
@@ -798,7 +874,21 @@ export function PptxEditor({ path }: PptxEditorProps) {
                 <PlusIcon className="size-3.5" />
               </button>
             </div>
-            <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-2">
+            <div
+              className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-2"
+              onDragOver={(e) => {
+                // The list itself accepts the drop, so a release in the gap
+                // between cards still lands on the last computed position.
+                if (dragFrom !== null) e.preventDefault()
+              }}
+              onDrop={(e) => {
+                if (dragFrom === null || dragOver === null) return
+                e.preventDefault()
+                reorderSlides(dragFrom, dragOver > dragFrom ? dragOver - 1 : dragOver)
+                setDragFrom(null)
+                setDragOver(null)
+              }}
+            >
               {deck.slides.map((s, i) => (
                 <SlideCard
                   key={s.xmlPath}
@@ -807,12 +897,22 @@ export function PptxEditor({ path }: PptxEditorProps) {
                   sizeEmu={deck.slideSizeEmu}
                   title={slideTitle(s)}
                   active={i === currentIndex}
+                  dragging={dragFrom === i}
+                  dropBefore={dragFrom !== null && dragOver === i}
+                  dropAfter={dragFrom !== null && dragOver === i + 1 && i === deck.slides.length - 1}
                   onSelect={() => {
                     setActiveIndex(i)
                     setSelectedKey(null)
                     setEditingKey(null)
                   }}
                   onDelete={() => requestDeleteSlide(i)}
+                  onDuplicate={() => void duplicateSlide(i)}
+                  onDragStart={() => setDragFrom(i)}
+                  onDragEnd={() => {
+                    setDragFrom(null)
+                    setDragOver(null)
+                  }}
+                  onDragOverCard={(before) => setDragOver(before ? i : i + 1)}
                 />
               ))}
             </div>
@@ -889,15 +989,64 @@ interface SlideCardProps {
   sizeEmu: { w: number; h: number }
   title: string | null
   active: boolean
+  /** This card is the one being dragged. */
+  dragging: boolean
+  /** Show the drop indicator above / below this card. */
+  dropBefore: boolean
+  dropAfter: boolean
   onSelect: () => void
   onDelete: () => void
+  onDuplicate: () => void
+  onDragStart: () => void
+  onDragEnd: () => void
+  /** `true` when the pointer is in the card's top half. */
+  onDragOverCard: (before: boolean) => void
 }
 
-function SlideCard({ index, slide, sizeEmu, title, active, onSelect, onDelete }: SlideCardProps) {
+function SlideCard({
+  index,
+  slide,
+  sizeEmu,
+  title,
+  active,
+  dragging,
+  dropBefore,
+  dropAfter,
+  onSelect,
+  onDelete,
+  onDuplicate,
+  onDragStart,
+  onDragEnd,
+  onDragOverCard,
+}: SlideCardProps) {
   return (
-    // The trash affordance is a SIBLING of the card button (buttons must not
-    // nest), floated over its corner; only the active card shows it.
-    <div className="relative shrink-0">
+    // The action affordances are SIBLINGS of the card button (buttons must not
+    // nest), floated over its corner; only the active card shows them.
+    <div
+      draggable
+      onDragStart={(e) => {
+        // Firefox requires data for a drag to start at all.
+        e.dataTransfer.setData('text/plain', String(index))
+        e.dataTransfer.effectAllowed = 'move'
+        onDragStart()
+      }}
+      onDragEnd={onDragEnd}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        const box = e.currentTarget.getBoundingClientRect()
+        onDragOverCard(e.clientY < box.top + box.height / 2)
+      }}
+      className={`relative shrink-0 transition-opacity ${dragging ? 'opacity-40' : ''}`}
+    >
+      {(dropBefore || dropAfter) && (
+        <span
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-x-1 z-20 h-0.5 rounded-full bg-[var(--ring)] ${
+            dropBefore ? '-top-1' : '-bottom-1'
+          }`}
+        />
+      )}
       <button
         type="button"
         onClick={onSelect}
@@ -922,18 +1071,32 @@ function SlideCard({ index, slide, sizeEmu, title, active, onSelect, onDelete }:
         </span>
       </button>
       {active && (
-        <button
-          type="button"
-          aria-label={`Delete slide ${index + 1}`}
-          title="Delete slide (⌘⌫)"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete()
-          }}
-          className="absolute right-1.5 top-1.5 z-10 inline-flex size-5 items-center justify-center rounded bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border transition-colors hover:text-destructive"
-        >
-          <Trash2Icon className="size-3" />
-        </button>
+        <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-1">
+          <button
+            type="button"
+            aria-label={`Duplicate slide ${index + 1}`}
+            title="Duplicate slide (⌘D)"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDuplicate()
+            }}
+            className="inline-flex size-5 items-center justify-center rounded bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border transition-colors hover:text-foreground"
+          >
+            <CopyIcon className="size-3" />
+          </button>
+          <button
+            type="button"
+            aria-label={`Delete slide ${index + 1}`}
+            title="Delete slide (⌘⌫)"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete()
+            }}
+            className="inline-flex size-5 items-center justify-center rounded bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border transition-colors hover:text-destructive"
+          >
+            <Trash2Icon className="size-3" />
+          </button>
+        </div>
       )}
     </div>
   )

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -793,6 +793,26 @@ export function PptxEditor({ path }: PptxEditorProps) {
     void window.ipc.invoke('shell:openPath', { path })
   }, [path])
 
+  /** Saves a copy elsewhere. Flushes first so the copy has the latest edits. */
+  const exportCopy = useCallback(async () => {
+    try {
+      await savePipeline.flush()
+      const result = await window.ipc.invoke('workspace:exportCopy', { path })
+      if (result.error) {
+        toast.error(`Could not export a copy: ${result.error}`)
+        return
+      }
+      // Cancelling the dialog is not a failure — say nothing.
+      if (result.saved && result.dest) toast.success(`Exported to ${baseName(result.dest)}`)
+    } catch (err) {
+      // Surface the reason: a generic message here hid a stale main process
+      // ("no handler registered") behind an unactionable toast.
+      console.error('Failed to export a copy:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error('Could not export a copy.', { description: message })
+    }
+  }, [path, savePipeline])
+
   if (loadState === 'error') return <FailurePanel path={path} onOpen={openExternally} />
 
   if (loadState === 'loading' || !deck) {
@@ -830,6 +850,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
           filePath={path}
           saveStatus={saveStatus}
           onPlay={startPresenting}
+          onExport={() => void exportCopy()}
         />
 
         <EditorToolbar

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -18,7 +18,9 @@ import {
   EMU_PER_PX,
   acceptsFormatting,
   applyEditSet,
+  editHoldsFormatting,
   hasEdits,
+  isNoopCommit,
   runKeyOf,
   shapeKeyOf,
   structureMatches,
@@ -380,15 +382,15 @@ export function PptxEditor({ path }: PptxEditorProps) {
       }
 
       const previous = editSetRef.current[key]
-      const hadFormatting =
-        Boolean(previous?.formats && Object.keys(previous.formats).length) ||
-        Boolean(previous?.aligns && Object.keys(previous.aligns).length)
-      const nothingChanged =
-        !textChanged &&
-        Object.keys(formats).length === 0 &&
-        Object.keys(aligns).length === 0 &&
-        !hadFormatting
-      if (nothingChanged) return
+      const hadFormatting = editHoldsFormatting(previous)
+      // Retyping the original text is a revert, not a no-op: it must fall
+      // through so the accumulated text edit below is cleared.
+      const noop = isNoopCommit(previous, {
+        textChanged,
+        formatCount: Object.keys(formats).length,
+        alignCount: Object.keys(aligns).length,
+      })
+      if (noop) return
 
       if (structural && hadFormatting) {
         toast.info('Formatting was reset on this text box because its structure changed.')

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -28,7 +28,7 @@ import {
   type RectEmuBox,
   type ShapeKey,
 } from '@/components/pptx/edit-model'
-import { SlideCanvas } from '@/components/pptx/canvas'
+import { SlideCanvas, SlideThumbnail } from '@/components/pptx/canvas'
 import {
   EditorToolbar,
   MAX_ZOOM,
@@ -646,9 +646,10 @@ export function PptxEditor({ path }: PptxEditorProps) {
               <SlideCard
                 key={s.xmlPath}
                 index={i}
+                slide={s}
+                sizeEmu={deck.slideSizeEmu}
                 title={slideTitle(s)}
                 active={i === activeIndex}
-                aspect={deck.slideSizeEmu.w / deck.slideSizeEmu.h}
                 onSelect={() => {
                   setActiveIndex(i)
                   setSelectedKey(null)
@@ -693,20 +694,25 @@ export function PptxEditor({ path }: PptxEditorProps) {
 
 // --------------------------------------------------------------- slide rail
 
+/** Rail width (w-56 = 224) minus nav padding, button padding, badge + gap. */
+const THUMB_WIDTH_PX = 160
+
 interface SlideCardProps {
   index: number
+  slide: Slide
+  sizeEmu: { w: number; h: number }
   title: string | null
   active: boolean
-  aspect: number
   onSelect: () => void
 }
 
-function SlideCard({ index, title, active, aspect, onSelect }: SlideCardProps) {
+function SlideCard({ index, slide, sizeEmu, title, active, onSelect }: SlideCardProps) {
   return (
     <button
       type="button"
       onClick={onSelect}
       aria-current={active ? 'true' : undefined}
+      aria-label={`Slide ${index + 1}${title ? `: ${title}` : ''}`}
       className={`group flex items-start gap-2 rounded-md border p-2 text-left transition-colors ${
         active
           ? 'border-ring bg-accent text-accent-foreground'
@@ -721,14 +727,11 @@ function SlideCard({ index, title, active, aspect, onSelect }: SlideCardProps) {
         {index + 1}
       </span>
       <span
-        className={`flex min-w-0 flex-1 items-center rounded-sm border bg-muted/40 px-1.5 py-1 transition-colors ${
-          active ? 'border-ring/50' : 'border-border/60 group-hover:border-border'
+        className={`min-w-0 flex-1 overflow-hidden rounded-sm ring-1 transition-shadow ${
+          active ? 'ring-[var(--ring)]' : 'ring-border/60 group-hover:ring-border'
         }`}
-        style={{ aspectRatio: String(aspect) }}
       >
-        <span className="line-clamp-3 text-[11px] leading-tight text-foreground/80">
-          {title ?? <span className="text-muted-foreground">Untitled slide</span>}
-        </span>
+        <SlideThumbnail slide={slide} sizeEmu={sizeEmu} widthPx={THUMB_WIDTH_PX} />
       </span>
     </button>
   )

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -29,6 +29,7 @@ import {
   type ShapeKey,
 } from '@/components/pptx/edit-model'
 import { SlideCanvas, SlideThumbnail } from '@/components/pptx/canvas'
+import { PresentationOverlay } from '@/components/pptx/presentation'
 import {
   EditorToolbar,
   MAX_ZOOM,
@@ -120,6 +121,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
   const [zoomMode, setZoomMode] = useState<'fit' | number>('fit')
   const [zoomPercent, setZoomPercent] = useState(100)
   const [selectionTick, setSelectionTick] = useState(0)
+  const [presenting, setPresenting] = useState(false)
 
   const [history, setHistory] = useState<EditSet[]>([EMPTY_EDIT_SET])
   const [histIndex, setHistIndex] = useState(0)
@@ -530,6 +532,13 @@ export function PptxEditor({ path }: PptxEditorProps) {
     setZoomPercent(percent)
   }, [])
 
+  // ------------------------------------------------------------ presentation
+
+  // `activeIndex` is untouched while presenting, so leaving lands back on the
+  // slide the editor was on; the overlay hands focus back as it unmounts.
+  const startPresenting = useCallback(() => setPresenting(true), [])
+  const stopPresenting = useCallback(() => setPresenting(false), [])
+
   // -------------------------------------------------------------- keyboard
 
   const handleKeyDown = useCallback(
@@ -632,6 +641,7 @@ export function PptxEditor({ path }: PptxEditorProps) {
           onColorChange={(hex) => applyFormat({ colorHex: hex })}
           align={activeAlign}
           onAlign={applyAlign}
+          onPlay={startPresenting}
           slideNumber={activeIndex + 1}
           slideCount={deck.slides.length}
           saveStatus={saveStatus}
@@ -687,6 +697,15 @@ export function PptxEditor({ path }: PptxEditorProps) {
             )}
           </div>
         </div>
+
+        {presenting && (
+          <PresentationOverlay
+            slides={deck.slides}
+            sizeEmu={deck.slideSizeEmu}
+            startIndex={activeIndex}
+            onExit={stopPresenting}
+          />
+        )}
       </div>
     </EditorErrorBoundary>
   )

--- a/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
@@ -99,6 +99,27 @@ describe('SlideThumbnail', () => {
     expect(p?.style.lineHeight).toBe(String(1.2 * (1 - 0.2)))
   })
 
+  it('renders authored character tracking, unscaled by normAutofit', () => {
+    const tracked: ResolvedRunStyle = { ...bodyRun, letterSpacingPt: -3.15 }
+    const shape: TextShape = {
+      ...textShape,
+      display: {
+        anchor: 't',
+        defaultRun: tracked,
+        autofit: { fontScale: 0.5, lnSpcReduction: 0 },
+        paragraphs: [displayParagraph({ runs: [tracked], defaultRun: tracked })],
+      },
+    }
+    const { container } = render(
+      <SlideThumbnail slide={slideWith(shape)} sizeEmu={SIZE_EMU} widthPx={160} />,
+    )
+    const run = container.querySelector<HTMLElement>('p > span')
+    // -3.15pt = -4.2px at the 96dpi reference layout. Tracking is an absolute
+    // typographic measure, so normAutofit's fontScale must NOT scale it.
+    expect(parseFloat(run?.style.letterSpacing ?? '')).toBeCloseTo((-3.15 * 96) / 72, 6)
+    expect(run?.style.fontSize).toBe(`${(BODY_PT * 0.5 * 96) / 72}px`)
+  })
+
   it('renders fixed line spacing and paragraph spacing as px on the block', () => {
     const shape: TextShape = {
       ...textShape,

--- a/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
@@ -26,7 +26,7 @@ const textShape: TextShape = {
   paragraphs: [{ runs: [{ text: 'Settings dialog · sign-in status', sizePt: BODY_PT }] }],
 }
 
-const slide: Slide = { id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [textShape] }
+const slide: Slide = { spTreePath: [0, 0, 0], id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [textShape] }
 
 const bodyRun: ResolvedRunStyle = {
   sizePt: BODY_PT,
@@ -53,7 +53,7 @@ function displayParagraph(overrides: Partial<ParagraphDisplay>): ParagraphDispla
 }
 
 function slideWith(shape: TextShape): Slide {
-  return { id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [shape] }
+  return { spTreePath: [0, 0, 0], id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [shape] }
 }
 
 describe('SlideThumbnail', () => {

--- a/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { EMU_PER_INCH, type Slide, type TextShape } from '@/lib/pptx/types'
+import { SlideThumbnail } from './canvas'
+
+afterEach(cleanup)
+
+/** 16:9 at 13.333in × 7.5in — the size PowerPoint gives a widescreen deck. */
+const SIZE_EMU = { w: 12192000, h: 6858000 }
+const REFERENCE_W = SIZE_EMU.w * (96 / EMU_PER_INCH)
+
+const BODY_PT = 12
+
+const textShape: TextShape = {
+  type: 'text',
+  id: '1',
+  slideXmlPath: 'ppt/slides/slide1.xml',
+  nodePath: [0],
+  xfrmEmu: { x: 0, y: 0, w: 6000000, h: 400000 },
+  paragraphs: [{ runs: [{ text: 'Settings dialog · sign-in status', sizePt: BODY_PT }] }],
+}
+
+const slide: Slide = { id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [textShape] }
+
+describe('SlideThumbnail', () => {
+  it('keeps the caller-requested box, whatever the reference layout is', () => {
+    const { container } = render(
+      <SlideThumbnail slide={slide} sizeEmu={SIZE_EMU} widthPx={160} />,
+    )
+    const outer = container.firstElementChild as HTMLElement
+    expect(outer.style.width).toBe('160px')
+    expect(outer.style.height).toBe('90px')
+  })
+
+  it('lays the slide out at 100% and scales the finished render down', () => {
+    const { container } = render(
+      <SlideThumbnail slide={slide} sizeEmu={SIZE_EMU} widthPx={160} />,
+    )
+    const layer = container.querySelector<HTMLElement>('[style*="scale"]')
+    expect(layer).not.toBeNull()
+    expect(layer?.style.width).toBe(`${REFERENCE_W}px`)
+    expect(layer?.style.transform).toBe(`scale(${160 / REFERENCE_W})`)
+    expect(layer?.style.transformOrigin).toBe('top left')
+  })
+
+  it('never lays text out at a sub-pixel font size', () => {
+    // Scaling each length straight into the target box put 12pt body text at
+    // ~2px, which Chromium renders as an invisible smear: the rail showed
+    // empty boxes where the slide was full of words. The run must be laid out
+    // at its real size and only then scaled.
+    for (const widthPx of [80, 160, 320]) {
+      const { container } = render(
+        <SlideThumbnail slide={slide} sizeEmu={SIZE_EMU} widthPx={widthPx} />,
+      )
+      const run = container.querySelector<HTMLElement>('p > span')
+      expect(run?.style.fontSize).toBe(`${(BODY_PT * 96) / 72}px`)
+      cleanup()
+    }
+  })
+})

--- a/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.test.tsx
@@ -1,6 +1,12 @@
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
-import { EMU_PER_INCH, type Slide, type TextShape } from '@/lib/pptx/types'
+import {
+  EMU_PER_INCH,
+  type ParagraphDisplay,
+  type ResolvedRunStyle,
+  type Slide,
+  type TextShape,
+} from '@/lib/pptx/types'
 import { SlideThumbnail } from './canvas'
 
 afterEach(cleanup)
@@ -22,6 +28,34 @@ const textShape: TextShape = {
 
 const slide: Slide = { id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [textShape] }
 
+const bodyRun: ResolvedRunStyle = {
+  sizePt: BODY_PT,
+  bold: false,
+  italic: false,
+  underline: false,
+  colorHex: '000000',
+  fontFamily: "'BodyFace', sans-serif",
+}
+
+function displayParagraph(overrides: Partial<ParagraphDisplay>): ParagraphDisplay {
+  return {
+    level: 0,
+    marLEmu: 0,
+    indentEmu: 0,
+    bullet: { kind: 'none' },
+    lineHeight: { kind: 'mult', value: 1.2 },
+    spaceBeforePt: 0,
+    spaceAfterPt: 0,
+    runs: [bodyRun],
+    defaultRun: bodyRun,
+    ...overrides,
+  }
+}
+
+function slideWith(shape: TextShape): Slide {
+  return { id: 's1', xmlPath: 'ppt/slides/slide1.xml', shapes: [shape] }
+}
+
 describe('SlideThumbnail', () => {
   it('keeps the caller-requested box, whatever the reference layout is', () => {
     const { container } = render(
@@ -41,6 +75,53 @@ describe('SlideThumbnail', () => {
     expect(layer?.style.width).toBe(`${REFERENCE_W}px`)
     expect(layer?.style.transform).toBe(`scale(${160 / REFERENCE_W})`)
     expect(layer?.style.transformOrigin).toBe('top left')
+  })
+
+  it('applies the authored typeface, line height and normAutofit scaling', () => {
+    const shape: TextShape = {
+      ...textShape,
+      display: {
+        anchor: 't',
+        defaultRun: bodyRun,
+        autofit: { fontScale: 0.625, lnSpcReduction: 0.2 },
+        paragraphs: [displayParagraph({})],
+      },
+    }
+    const { container } = render(
+      <SlideThumbnail slide={slideWith(shape)} sizeEmu={SIZE_EMU} widthPx={160} />,
+    )
+    const p = container.querySelector<HTMLElement>('p')
+    const run = container.querySelector<HTMLElement>('p > span')
+    // 12pt × 0.625 font scale = 7.5pt = 10px at the 96dpi reference layout.
+    expect(run?.style.fontSize).toBe('10px')
+    expect(run?.style.fontFamily).toContain('BodyFace')
+    // 1.2 default × (1 − 0.2) line-spacing reduction, unitless on the block.
+    expect(p?.style.lineHeight).toBe(String(1.2 * (1 - 0.2)))
+  })
+
+  it('renders fixed line spacing and paragraph spacing as px on the block', () => {
+    const shape: TextShape = {
+      ...textShape,
+      display: {
+        anchor: 't',
+        defaultRun: bodyRun,
+        paragraphs: [
+          displayParagraph({
+            lineHeight: { kind: 'pt', pt: 18 },
+            spaceBeforePt: 6,
+            spaceAfterPt: 3,
+          }),
+        ],
+      },
+    }
+    const { container } = render(
+      <SlideThumbnail slide={slideWith(shape)} sizeEmu={SIZE_EMU} widthPx={160} />,
+    )
+    const p = container.querySelector<HTMLElement>('p')
+    // 18pt fixed = 24px; spcBef 6pt = 8px; spcAft 3pt = 4px (96dpi reference).
+    expect(p?.style.lineHeight).toBe('24px')
+    expect(p?.style.paddingTop).toBe('8px')
+    expect(p?.style.paddingBottom).toBe('4px')
   })
 
   it('never lays text out at a sub-pixel font size', () => {

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -41,6 +41,8 @@ import {
   anchorJustify,
   displayAlign,
   displayRunStyle,
+  fontScaleOf,
+  paragraphMetrics,
   type CaretTarget,
   type TextOverlayHandle,
 } from './text-dom'
@@ -392,7 +394,9 @@ function TextShapeView({
   onPointerDown: (e: ReactPointerEvent) => void
   onDoubleClick?: (e: ReactMouseEvent) => void
 }) {
-  const ptToPx = (pt: number) => pt * EMU_PER_PT * scale
+  // normAutofit scales every rendered size; the model's pt values stay raw.
+  const fontScale = fontScaleOf(shape)
+  const ptToPx = (pt: number) => pt * fontScale * EMU_PER_PT * scale
   // Auto-number counters accumulate down the shape; deeper levels reset when
   // a shallower numbered paragraph appears.
   const counters: Record<number, number> = {}
@@ -442,6 +446,7 @@ function TextShapeView({
           const marLPx = (dp?.marLEmu ?? 0) * scale
           const indentPx = (dp?.indentEmu ?? 0) * scale
           const bulletStyle = dp?.defaultRun ?? shape.display?.defaultRun
+          const metrics = paragraphMetrics(dp, shape.display?.autofit, scale)
 
           return (
             <p
@@ -450,6 +455,9 @@ function TextShapeView({
                 textAlign: alignToCss(displayAlign(shape, pi, para)),
                 margin: 0,
                 whiteSpace: 'pre-wrap',
+                lineHeight: metrics.lineHeight,
+                paddingTop: metrics.padTopPx > 0 ? metrics.padTopPx : undefined,
+                paddingBottom: metrics.padBottomPx > 0 ? metrics.padBottomPx : undefined,
                 paddingLeft: marLPx > 0 ? marLPx : undefined,
                 textIndent: indentPx !== 0 ? indentPx : undefined,
               }}
@@ -463,7 +471,7 @@ function TextShapeView({
                     marginRight: indentPx < 0 ? undefined : '0.35em',
                     fontSize: ptToPx(bulletStyle?.sizePt ?? DEFAULT_TEXT_PT),
                     color: `#${bulletStyle?.colorHex ?? '000000'}`,
-                    lineHeight: 1.2,
+                    fontFamily: bulletStyle?.fontFamily,
                   }}
                 >
                   {bulletText}
@@ -480,7 +488,7 @@ function TextShapeView({
                       textDecoration: rs.underline ? 'underline' : 'none',
                       fontSize: ptToPx(rs.sizePt),
                       color: `#${rs.colorHex}`,
-                      lineHeight: 1.2,
+                      fontFamily: rs.fontFamily,
                     }}
                   >
                     {run.text}

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -11,7 +11,6 @@ import {
 import {
   BarChart3Icon,
   FilmIcon,
-  GroupIcon,
   ShapesIcon,
   TableIcon,
 } from 'lucide-react'
@@ -39,6 +38,7 @@ import {
 import {
   DEFAULT_TEXT_PT,
   alignToCss,
+  anchorJustify,
   displayAlign,
   displayRunStyle,
   type CaretTarget,
@@ -50,7 +50,6 @@ const PLACEHOLDER_META: Record<PlaceholderKind, { label: string; Icon: typeof Sh
   chart: { label: 'Chart', Icon: BarChart3Icon },
   smartart: { label: 'Diagram', Icon: ShapesIcon },
   table: { label: 'Table', Icon: TableIcon },
-  group: { label: 'Group', Icon: GroupIcon },
   video: { label: 'Video', Icon: FilmIcon },
   unknown: { label: 'Shape', Icon: ShapesIcon },
 }
@@ -254,6 +253,8 @@ function LineShapeView({
   )
 }
 
+const groupChildNoop = () => {}
+
 interface ShapeViewProps {
   shape: Shape
   rect: RectEmuBox
@@ -287,6 +288,34 @@ function ShapeView({
         style={{ ...style, cursor, ...lineCss(shape.visual?.line, scale) }}
         className="object-contain select-none"
       />
+    )
+  }
+
+  if (shape.type === 'group') {
+    // Children carry final slide-space rects, so they render as ordinary
+    // ShapeViews inside a layer that cancels the group box's own offset.
+    // The layer is inert: clicks land on the group box, which selects the
+    // group as one read-only unit — children are never individually
+    // interactive and never enter text editing.
+    return (
+      <div onPointerDown={onPointerDown} style={{ ...style, cursor: 'default' }}>
+        <div
+          className="pointer-events-none absolute"
+          style={{ left: -rect.x * scale, top: -rect.y * scale }}
+        >
+          {shape.children.map((child, i) => (
+            <ShapeView
+              key={`${child.id}:${i}`}
+              shape={child}
+              rect={child.xfrmEmu}
+              scale={scale}
+              selected={false}
+              transform={composeTransform(visualTransform(child))}
+              onPointerDown={groupChildNoop}
+            />
+          ))}
+        </div>
+      </div>
     )
   }
 
@@ -377,12 +406,12 @@ function TextShapeView({
         cursor: selected ? 'move' : 'text',
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'center',
+        justifyContent: anchorJustify(shape.display?.anchor),
         ...fillCss(shape.visual?.fill),
         ...lineCss(shape.visual?.line, scale),
         ...radiusCss(shape.visual?.geom, rect, scale),
       }}
-      className="group/pptx-shape overflow-hidden"
+      className="group/pptx-shape"
     >
       {isEmptyText(shape) ? (
         <span
@@ -470,11 +499,14 @@ function SelectionFrame({
   rect,
   scale,
   transform,
+  resizable,
   onHandleDown,
 }: {
   rect: RectEmuBox
   scale: number
   transform?: string
+  /** False for read-only selections (groups): outline only, no handles. */
+  resizable: boolean
   onHandleDown: (handle: HandleId, e: ReactPointerEvent) => void
 }) {
   return (
@@ -482,7 +514,8 @@ function SelectionFrame({
       style={{ ...rectStyle(rect, scale), transform }}
       className="pointer-events-none z-10 outline-2 outline-offset-1 outline-[var(--ring)]"
     >
-      {HANDLES.map((h) => (
+      {resizable &&
+        HANDLES.map((h) => (
         <span
           key={h.id}
           onPointerDown={(e) => onHandleDown(h.id, e)}
@@ -493,6 +526,29 @@ function SelectionFrame({
             cursor: h.cursor,
           }}
           className="pointer-events-auto size-2 rounded-[2px] border border-white bg-[var(--ring)] shadow-sm"
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Decoration inherited from the layout/master, painted beneath the slide's
+ * own shapes. Inert by construction: no selection, no editing, no pointer
+ * events — these shapes live in other parts and must never produce edits.
+ */
+function UnderlayView({ shapes, scale }: { shapes: Shape[]; scale: number }) {
+  return (
+    <div className="pointer-events-none" aria-hidden="true">
+      {shapes.map((shape, i) => (
+        <ShapeView
+          key={`u:${shape.id}:${i}`}
+          shape={shape}
+          rect={shape.xfrmEmu}
+          scale={scale}
+          selected={false}
+          transform={composeTransform(visualTransform(shape))}
+          onPointerDown={groupChildNoop}
         />
       ))}
     </div>
@@ -543,8 +599,11 @@ export const SlideThumbnail = memo(function SlideThumbnail({
           height: refH,
           transform: `scale(${zoom})`,
           transformOrigin: 'top left',
+          // Resolved page background paints over the white base.
+          ...fillCss(slide.background),
         }}
       >
+        {slide.underlay && <UnderlayView shapes={slide.underlay} scale={CSS_PX_PER_EMU} />}
         {slide.shapes.map((shape, i) => (
           <ShapeView
             key={`${shape.id}:${i}`}
@@ -649,6 +708,9 @@ export function SlideCanvas({
       onSelect(key)
       // Editing already: let the overlay keep the pointer.
       if (editingKey === key) return
+      // Groups select as one read-only unit — no move/resize gesture, so no
+      // geometry ever reaches the serializer for them.
+      if (shape.type === 'group') return
 
       if (mode === 'move' && shape.type === 'text') {
         const last = lastPressRef.current
@@ -760,8 +822,14 @@ export function SlideCanvas({
       {scale > 0 && (
         <div
           className="relative overflow-hidden rounded-md bg-white shadow-2xl ring-1 ring-black/20"
-          style={{ width: sizeEmu.w * scale, height: sizeEmu.h * scale }}
+          style={{
+            width: sizeEmu.w * scale,
+            height: sizeEmu.h * scale,
+            // Resolved page background paints over the white base.
+            ...fillCss(slide.background),
+          }}
         >
+          {slide.underlay && <UnderlayView shapes={slide.underlay} scale={scale} />}
           {slide.shapes.map((shape, i) => {
             const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
             const reactKey = `${shape.id}:${i}`
@@ -805,6 +873,7 @@ export function SlideCanvas({
                 liveTransform(selectedKey as ShapeKey),
                 visualTransform(selectedShape),
               )}
+              resizable={selectedShape.type !== 'group'}
               onHandleDown={(handle, e) => beginGesture(selectedShape, 'resize', handle, e)}
             />
           )}

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useLayoutEffect,
   useRef,
@@ -474,6 +475,48 @@ function SelectionFrame({
     </div>
   )
 }
+
+// --------------------------------------------------------------- thumbnail
+
+const thumbNoop = () => {}
+
+/**
+ * A miniature of one slide, rendered through the same ShapeView pipeline as
+ * the canvas so the rail shows the real slide and tracks live edits. Fully
+ * inert: pointer-events none, no selection chrome, no text overlay. Memoized —
+ * applyEditSet keeps untouched slides referentially stable, so only an edited
+ * slide's thumbnail re-renders.
+ */
+export const SlideThumbnail = memo(function SlideThumbnail({
+  slide,
+  sizeEmu,
+  widthPx,
+}: {
+  slide: Slide
+  sizeEmu: { w: number; h: number }
+  widthPx: number
+}) {
+  const scale = widthPx / sizeEmu.w
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none relative select-none overflow-hidden bg-white"
+      style={{ width: widthPx, height: sizeEmu.h * scale }}
+    >
+      {slide.shapes.map((shape, i) => (
+        <ShapeView
+          key={`${shape.id}:${i}`}
+          shape={shape}
+          rect={shape.xfrmEmu}
+          scale={scale}
+          selected={false}
+          transform={composeTransform(visualTransform(shape))}
+          onPointerDown={thumbNoop}
+        />
+      ))}
+    </div>
+  )
+})
 
 // ------------------------------------------------------------------ canvas
 

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react'
 import {
@@ -40,6 +41,7 @@ import {
   alignToCss,
   displayAlign,
   displayRunStyle,
+  type CaretTarget,
   type TextOverlayHandle,
 } from './text-dom'
 import { TextEditOverlay } from './text-overlay'
@@ -78,6 +80,11 @@ interface Gesture {
   /** Set when the pointer went down on an already-selected text box. */
   wantsEdit: boolean
 }
+
+/** Pointer travel a press may drift and still count as a click, not a drag. */
+const CLICK_SLOP_PX = 4
+/** Window in which a second press is part of a double-click. */
+const DOUBLE_CLICK_MS = 400
 
 const snapToGrid = (emu: number): number => Math.round(emu / GRID_EMU) * GRID_EMU
 
@@ -252,9 +259,19 @@ interface ShapeViewProps {
   selected: boolean
   transform?: string
   onPointerDown: (e: ReactPointerEvent) => void
+  /** Text shapes only: opens the editor with the caret at the click point. */
+  onDoubleClick?: (e: ReactMouseEvent) => void
 }
 
-function ShapeView({ shape, rect, scale, selected, transform, onPointerDown }: ShapeViewProps) {
+function ShapeView({
+  shape,
+  rect,
+  scale,
+  selected,
+  transform,
+  onPointerDown,
+  onDoubleClick,
+}: ShapeViewProps) {
   const style: CSSProperties = { ...rectStyle(rect, scale), transform }
   const cursor = selected ? 'move' : 'default'
 
@@ -322,6 +339,7 @@ function ShapeView({ shape, rect, scale, selected, transform, onPointerDown }: S
       style={style}
       selected={selected}
       onPointerDown={onPointerDown}
+      onDoubleClick={onDoubleClick}
     />
   )
 }
@@ -333,6 +351,7 @@ function TextShapeView({
   style,
   selected,
   onPointerDown,
+  onDoubleClick,
 }: {
   shape: TextShape
   rect: RectEmuBox
@@ -340,6 +359,7 @@ function TextShapeView({
   style: CSSProperties
   selected: boolean
   onPointerDown: (e: ReactPointerEvent) => void
+  onDoubleClick?: (e: ReactMouseEvent) => void
 }) {
   const ptToPx = (pt: number) => pt * EMU_PER_PT * scale
   // Auto-number counters accumulate down the shape; deeper levels reset when
@@ -349,6 +369,7 @@ function TextShapeView({
   return (
     <div
       onPointerDown={onPointerDown}
+      onDoubleClick={onDoubleClick}
       style={{
         ...style,
         cursor: selected ? 'move' : 'text',
@@ -558,6 +579,10 @@ export function SlideCanvas({
   const [gesture, setGestureState] = useState<Gesture | null>(null)
   const scaleRef = useRef(0)
   scaleRef.current = scale
+  // Where the caret should land when the next editing session opens.
+  const [caretPoint, setCaretPoint] = useState<CaretTarget | null>(null)
+  // Last press, for spotting the second half of a double-click.
+  const lastPressRef = useRef<{ t: number; x: number; y: number } | null>(null)
 
   const setGesture = useCallback((next: Gesture | null) => {
     gestureRef.current = next
@@ -586,6 +611,15 @@ export function SlideCanvas({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sizeEmu.w, sizeEmu.h, zoomMode])
 
+  /** Opens the text editor with the caret where the click landed. */
+  const enterEdit = useCallback(
+    (key: ShapeKey, clientX: number, clientY: number, selectWord: boolean) => {
+      setCaretPoint({ x: clientX, y: clientY, selectWord })
+      onStartEdit(key)
+    },
+    [onStartEdit],
+  )
+
   const beginGesture = useCallback(
     (shape: Shape, mode: 'move' | 'resize', handle: HandleId, e: ReactPointerEvent) => {
       e.stopPropagation()
@@ -595,6 +629,21 @@ export function SlideCanvas({
       onSelect(key)
       // Editing already: let the overlay keep the pointer.
       if (editingKey === key) return
+
+      if (mode === 'move' && shape.type === 'text') {
+        const last = lastPressRef.current
+        const isSecondPress =
+          last !== null &&
+          e.timeStamp - last.t >= 0 &&
+          e.timeStamp - last.t < DOUBLE_CLICK_MS &&
+          Math.abs(e.clientX - last.x) <= CLICK_SLOP_PX &&
+          Math.abs(e.clientY - last.y) <= CLICK_SLOP_PX
+        lastPressRef.current = { t: e.timeStamp, x: e.clientX, y: e.clientY }
+        // The second press of a double-click belongs to onDoubleClick: starting
+        // a gesture here would swallow it, because the pointerup swaps this
+        // shape for the overlay before the dblclick is ever dispatched.
+        if (isSecondPress) return
+      }
       ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
       setGesture({
         key,
@@ -611,6 +660,21 @@ export function SlideCanvas({
     [slide.xmlPath, selectedKey, editingKey, onSelect, setGesture],
   )
 
+  const handleDoubleClick = useCallback(
+    (shape: TextShape, e: ReactMouseEvent) => {
+      e.stopPropagation()
+      const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
+      if (editingKey === key) return
+      // Any gesture the presses left behind would fight the overlay.
+      setGesture(null)
+      lastPressRef.current = null
+      onSelect(key)
+      // Double-click takes the word, the way it does in any other editor.
+      enterEdit(key, e.clientX, e.clientY, true)
+    },
+    [slide.xmlPath, editingKey, onSelect, enterEdit, setGesture],
+  )
+
   const onPointerMove = useCallback(
     (e: ReactPointerEvent) => {
       const g = gestureRef.current
@@ -619,7 +683,9 @@ export function SlideCanvas({
       const dx = snapToGrid((e.clientX - g.startX) / s)
       const dy = snapToGrid((e.clientY - g.startY) / s)
       const moved =
-        g.moved || Math.abs(e.clientX - g.startX) > 3 || Math.abs(e.clientY - g.startY) > 3
+        g.moved ||
+        Math.abs(e.clientX - g.startX) > CLICK_SLOP_PX ||
+        Math.abs(e.clientY - g.startY) > CLICK_SLOP_PX
       const rect =
         g.mode === 'move'
           ? { ...g.startRect, x: g.startRect.x + dx, y: g.startRect.y + dy }
@@ -643,9 +709,9 @@ export function SlideCanvas({
       if (shape && changed) onGeometryCommit(shape, g.rect)
     } else if (g.wantsEdit) {
       // A click that didn't drag, on a box that was already selected.
-      onStartEdit(g.key)
+      enterEdit(g.key, g.startX, g.startY, false)
     }
-  }, [slide, onGeometryCommit, onStartEdit, setGesture])
+  }, [slide, onGeometryCommit, enterEdit, setGesture])
 
   const selectedShape = slide.shapes.find(
     (s) => shapeKeyOf(slide.xmlPath, s.nodePath) === selectedKey,
@@ -689,6 +755,7 @@ export function SlideCanvas({
                     ...rectStyle(shape.xfrmEmu, scale),
                     transform: composeTransform(visualTransform(shape)),
                   }}
+                  caretAt={caretPoint}
                   onAttach={onOverlayAttach}
                   onCommit={(next) => onTextCommit(shape, next)}
                 />
@@ -703,6 +770,9 @@ export function SlideCanvas({
                 selected={selectedKey === key}
                 transform={composeTransform(liveTransform(key), visualTransform(shape))}
                 onPointerDown={(e) => beginGesture(shape, 'move', 'se', e)}
+                onDoubleClick={
+                  shape.type === 'text' ? (e) => handleDoubleClick(shape, e) : undefined
+                }
               />
             )
           })}

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -489,6 +489,11 @@ function TextShapeView({
                       fontSize: ptToPx(rs.sizePt),
                       color: `#${rs.colorHex}`,
                       fontFamily: rs.fontFamily,
+                      // Absolute, so it is not scaled by normAutofit.
+                      letterSpacing:
+                        rs.letterSpacingPt !== undefined
+                          ? rs.letterSpacingPt * EMU_PER_PT * scale
+                          : undefined,
                     }}
                   >
                     {run.text}

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -1,0 +1,455 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import {
+  BarChart3Icon,
+  FilmIcon,
+  GroupIcon,
+  ShapesIcon,
+  TableIcon,
+} from 'lucide-react'
+import type { PlaceholderKind, Shape, Slide, TextShape } from '@/lib/pptx/types'
+import type { EditedParagraph } from '@/lib/pptx/serialize'
+import {
+  EMU_PER_INCH,
+  EMU_PER_PT,
+  GRID_EMU,
+  MIN_EXTENT_EMU,
+  shapeKeyOf,
+  type RectEmuBox,
+  type ShapeKey,
+} from './edit-model'
+import { DEFAULT_TEXT_PT, alignToCss, type TextOverlayHandle } from './text-dom'
+import { TextEditOverlay } from './text-overlay'
+
+const PLACEHOLDER_META: Record<PlaceholderKind, { label: string; Icon: typeof ShapesIcon }> = {
+  chart: { label: 'Chart', Icon: BarChart3Icon },
+  smartart: { label: 'Diagram', Icon: ShapesIcon },
+  table: { label: 'Table', Icon: TableIcon },
+  group: { label: 'Group', Icon: GroupIcon },
+  video: { label: 'Video', Icon: FilmIcon },
+  unknown: { label: 'Shape', Icon: ShapesIcon },
+}
+
+export type HandleId = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w'
+
+const HANDLES: Array<{ id: HandleId; cursor: string; x: number; y: number }> = [
+  { id: 'nw', cursor: 'nwse-resize', x: 0, y: 0 },
+  { id: 'n', cursor: 'ns-resize', x: 0.5, y: 0 },
+  { id: 'ne', cursor: 'nesw-resize', x: 1, y: 0 },
+  { id: 'e', cursor: 'ew-resize', x: 1, y: 0.5 },
+  { id: 'se', cursor: 'nwse-resize', x: 1, y: 1 },
+  { id: 's', cursor: 'ns-resize', x: 0.5, y: 1 },
+  { id: 'sw', cursor: 'nesw-resize', x: 0, y: 1 },
+  { id: 'w', cursor: 'ew-resize', x: 0, y: 0.5 },
+]
+
+interface Gesture {
+  key: ShapeKey
+  mode: 'move' | 'resize'
+  handle: HandleId
+  startRect: RectEmuBox
+  startX: number
+  startY: number
+  rect: RectEmuBox
+  moved: boolean
+  /** Set when the pointer went down on an already-selected text box. */
+  wantsEdit: boolean
+}
+
+const snapToGrid = (emu: number): number => Math.round(emu / GRID_EMU) * GRID_EMU
+
+function computeResize(
+  start: RectEmuBox,
+  handle: HandleId,
+  dx: number,
+  dy: number,
+  shift: boolean,
+): RectEmuBox {
+  const hasE = handle.includes('e')
+  const hasW = handle.includes('w')
+  const hasS = handle.includes('s')
+  const hasN = handle.includes('n')
+  let { x, y, w, h } = start
+
+  if (hasE) w = start.w + dx
+  if (hasW) {
+    x = start.x + dx
+    w = start.w - dx
+  }
+  if (hasS) h = start.h + dy
+  if (hasN) {
+    y = start.y + dy
+    h = start.h - dy
+  }
+
+  // Shift preserves the starting aspect ratio on corner handles.
+  if (shift && (hasE || hasW) && (hasN || hasS) && start.w > 0 && start.h > 0) {
+    const aspect = start.w / start.h
+    if (Math.abs(w - start.w) >= Math.abs(h - start.h)) h = w / aspect
+    else w = h * aspect
+    if (hasW) x = start.x + start.w - w
+    if (hasN) y = start.y + start.h - h
+  }
+
+  if (w < MIN_EXTENT_EMU) {
+    if (hasW) x = start.x + start.w - MIN_EXTENT_EMU
+    w = MIN_EXTENT_EMU
+  }
+  if (h < MIN_EXTENT_EMU) {
+    if (hasN) y = start.y + start.h - MIN_EXTENT_EMU
+    h = MIN_EXTENT_EMU
+  }
+  return { x: Math.round(x), y: Math.round(y), w: Math.round(w), h: Math.round(h) }
+}
+
+const inches = (emu: number): string => (emu / EMU_PER_INCH).toFixed(2)
+
+// ------------------------------------------------------------------ shapes
+
+function rectStyle(rect: RectEmuBox, scale: number): CSSProperties {
+  return {
+    position: 'absolute',
+    left: rect.x * scale,
+    top: rect.y * scale,
+    width: rect.w * scale,
+    height: rect.h * scale,
+  }
+}
+
+const isEmptyText = (shape: TextShape): boolean =>
+  shape.paragraphs.every((p) => p.runs.every((r) => r.text.trim() === ''))
+
+interface ShapeViewProps {
+  shape: Shape
+  rect: RectEmuBox
+  scale: number
+  selected: boolean
+  transform?: string
+  onPointerDown: (e: ReactPointerEvent) => void
+}
+
+function ShapeView({ shape, rect, scale, selected, transform, onPointerDown }: ShapeViewProps) {
+  const style: CSSProperties = { ...rectStyle(rect, scale), transform }
+  const cursor = selected ? 'move' : 'default'
+
+  if (shape.type === 'image') {
+    return (
+      <img
+        src={shape.blobUrl}
+        alt=""
+        draggable={false}
+        onPointerDown={onPointerDown}
+        style={{ ...style, cursor }}
+        className="object-contain select-none"
+      />
+    )
+  }
+
+  if (shape.type === 'placeholder') {
+    const { label, Icon } = PLACEHOLDER_META[shape.kind]
+    return (
+      <div
+        onPointerDown={onPointerDown}
+        style={{ ...style, cursor }}
+        className="flex select-none items-center justify-center gap-1.5 rounded-sm border border-dashed border-neutral-400/70 bg-neutral-500/5"
+      >
+        <Icon className="size-3.5 shrink-0 text-neutral-500" />
+        <span className="truncate text-[11px] text-neutral-500">{label}</span>
+      </div>
+    )
+  }
+
+  const ptToPx = (pt: number) => pt * EMU_PER_PT * scale
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      style={{
+        ...style,
+        cursor: selected ? 'move' : 'text',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+      className="overflow-hidden"
+    >
+      {isEmptyText(shape) ? (
+        <span className="select-none text-neutral-400" style={{ fontSize: ptToPx(DEFAULT_TEXT_PT) }}>
+          Add text
+        </span>
+      ) : (
+        shape.paragraphs.map((para, pi) => (
+          <p
+            key={pi}
+            style={{
+              textAlign: alignToCss(para.align),
+              margin: 0,
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {para.runs.map((run, ri) => (
+              <span
+                key={ri}
+                style={{
+                  fontWeight: run.bold ? 700 : undefined,
+                  fontStyle: run.italic ? 'italic' : undefined,
+                  textDecoration: run.underline ? 'underline' : undefined,
+                  fontSize: ptToPx(run.sizePt ?? DEFAULT_TEXT_PT),
+                  color: run.colorHex ? `#${run.colorHex}` : '#000',
+                  lineHeight: 1.2,
+                }}
+              >
+                {run.text}
+              </span>
+            ))}
+          </p>
+        ))
+      )}
+    </div>
+  )
+}
+
+function SelectionFrame({
+  rect,
+  scale,
+  transform,
+  onHandleDown,
+}: {
+  rect: RectEmuBox
+  scale: number
+  transform?: string
+  onHandleDown: (handle: HandleId, e: ReactPointerEvent) => void
+}) {
+  return (
+    <div
+      style={{ ...rectStyle(rect, scale), transform }}
+      className="pointer-events-none z-10 outline-2 outline-offset-1 outline-[var(--ring)]"
+    >
+      {HANDLES.map((h) => (
+        <span
+          key={h.id}
+          onPointerDown={(e) => onHandleDown(h.id, e)}
+          style={{
+            position: 'absolute',
+            left: `calc(${h.x * 100}% - 4px)`,
+            top: `calc(${h.y * 100}% - 4px)`,
+            cursor: h.cursor,
+          }}
+          className="pointer-events-auto size-2 rounded-[2px] border border-white bg-[var(--ring)] shadow-sm"
+        />
+      ))}
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------ canvas
+
+interface SlideCanvasProps {
+  slide: Slide
+  sizeEmu: { w: number; h: number }
+  /** 'fit' or a zoom percentage. */
+  zoomMode: 'fit' | number
+  onScaleChange: (scale: number, percent: number) => void
+  selectedKey: ShapeKey | null
+  editingKey: ShapeKey | null
+  onSelect: (key: ShapeKey | null) => void
+  onStartEdit: (key: ShapeKey) => void
+  onGeometryCommit: (shape: Shape, rect: RectEmuBox) => void
+  onOverlayAttach: (handle: TextOverlayHandle | null) => void
+  onTextCommit: (shape: TextShape, next: EditedParagraph[] | null) => void
+}
+
+const CSS_PX_PER_EMU = 96 / EMU_PER_INCH
+
+export function SlideCanvas({
+  slide,
+  sizeEmu,
+  zoomMode,
+  onScaleChange,
+  selectedKey,
+  editingKey,
+  onSelect,
+  onStartEdit,
+  onGeometryCommit,
+  onOverlayAttach,
+  onTextCommit,
+}: SlideCanvasProps) {
+  const frameRef = useRef<HTMLDivElement>(null)
+  const [scale, setScale] = useState(0)
+  // The gesture lives in a ref and is mirrored into state for rendering, so
+  // pointer handlers never have to run side effects inside a state updater.
+  const gestureRef = useRef<Gesture | null>(null)
+  const [gesture, setGestureState] = useState<Gesture | null>(null)
+  const scaleRef = useRef(0)
+  scaleRef.current = scale
+
+  const setGesture = useCallback((next: Gesture | null) => {
+    gestureRef.current = next
+    setGestureState(next)
+  }, [])
+
+  // Fit the deck's EMU page into the pane, or honour an explicit zoom.
+  useLayoutEffect(() => {
+    const el = frameRef.current
+    if (!el) return
+    const fit = () => {
+      const { width, height } = el.getBoundingClientRect()
+      if (width <= 0 || height <= 0) return
+      const padding = 48
+      const next =
+        zoomMode === 'fit'
+          ? Math.min((width - padding) / sizeEmu.w, (height - padding) / sizeEmu.h)
+          : (zoomMode / 100) * CSS_PX_PER_EMU
+      setScale(next)
+      onScaleChange(next, (next / CSS_PX_PER_EMU) * 100)
+    }
+    fit()
+    const observer = new ResizeObserver(fit)
+    observer.observe(el)
+    return () => observer.disconnect()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sizeEmu.w, sizeEmu.h, zoomMode])
+
+  const beginGesture = useCallback(
+    (shape: Shape, mode: 'move' | 'resize', handle: HandleId, e: ReactPointerEvent) => {
+      e.stopPropagation()
+      if (e.button !== 0) return
+      const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
+      const wasSelected = selectedKey === key
+      onSelect(key)
+      // Editing already: let the overlay keep the pointer.
+      if (editingKey === key) return
+      ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+      setGesture({
+        key,
+        mode,
+        handle,
+        startRect: { ...shape.xfrmEmu },
+        startX: e.clientX,
+        startY: e.clientY,
+        rect: { ...shape.xfrmEmu },
+        moved: false,
+        wantsEdit: mode === 'move' && wasSelected && shape.type === 'text',
+      })
+    },
+    [slide.xmlPath, selectedKey, editingKey, onSelect, setGesture],
+  )
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent) => {
+      const g = gestureRef.current
+      const s = scaleRef.current
+      if (!g || s <= 0) return
+      const dx = snapToGrid((e.clientX - g.startX) / s)
+      const dy = snapToGrid((e.clientY - g.startY) / s)
+      const moved =
+        g.moved || Math.abs(e.clientX - g.startX) > 3 || Math.abs(e.clientY - g.startY) > 3
+      const rect =
+        g.mode === 'move'
+          ? { ...g.startRect, x: g.startRect.x + dx, y: g.startRect.y + dy }
+          : computeResize(g.startRect, g.handle, dx, dy, e.shiftKey)
+      setGesture({ ...g, rect, moved })
+    },
+    [setGesture],
+  )
+
+  const endGesture = useCallback(() => {
+    const g = gestureRef.current
+    setGesture(null)
+    if (!g) return
+    if (g.moved) {
+      const shape = slide.shapes.find((s) => shapeKeyOf(slide.xmlPath, s.nodePath) === g.key)
+      const changed =
+        g.rect.x !== g.startRect.x ||
+        g.rect.y !== g.startRect.y ||
+        g.rect.w !== g.startRect.w ||
+        g.rect.h !== g.startRect.h
+      if (shape && changed) onGeometryCommit(shape, g.rect)
+    } else if (g.wantsEdit) {
+      // A click that didn't drag, on a box that was already selected.
+      onStartEdit(g.key)
+    }
+  }, [slide, onGeometryCommit, onStartEdit, setGesture])
+
+  const selectedShape = slide.shapes.find(
+    (s) => shapeKeyOf(slide.xmlPath, s.nodePath) === selectedKey,
+  )
+  const gestureRect = gesture?.rect
+  const liveRect = (key: ShapeKey, shape: Shape): RectEmuBox =>
+    gesture && gesture.key === key && gesture.mode === 'resize' && gestureRect
+      ? gestureRect
+      : shape.xfrmEmu
+  const liveTransform = (key: ShapeKey): string | undefined => {
+    if (!gesture || gesture.key !== key || gesture.mode !== 'move') return undefined
+    const dx = (gesture.rect.x - gesture.startRect.x) * scale
+    const dy = (gesture.rect.y - gesture.startRect.y) * scale
+    return `translate3d(${dx}px, ${dy}px, 0)`
+  }
+
+  return (
+    <div
+      ref={frameRef}
+      className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-neutral-900/40 p-6"
+      onPointerDown={() => onSelect(null)}
+      onPointerMove={gesture ? onPointerMove : undefined}
+      onPointerUp={gesture ? endGesture : undefined}
+      onPointerCancel={gesture ? endGesture : undefined}
+    >
+      {scale > 0 && (
+        <div
+          className="relative overflow-hidden rounded-md bg-white shadow-2xl ring-1 ring-black/20"
+          style={{ width: sizeEmu.w * scale, height: sizeEmu.h * scale }}
+        >
+          {slide.shapes.map((shape, i) => {
+            const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
+            const reactKey = `${shape.id}:${i}`
+            if (shape.type === 'text' && editingKey === key) {
+              return (
+                <TextEditOverlay
+                  key={reactKey}
+                  shape={shape}
+                  scale={scale}
+                  style={rectStyle(shape.xfrmEmu, scale)}
+                  onAttach={onOverlayAttach}
+                  onCommit={(next) => onTextCommit(shape, next)}
+                />
+              )
+            }
+            return (
+              <ShapeView
+                key={reactKey}
+                shape={shape}
+                rect={liveRect(key, shape)}
+                scale={scale}
+                selected={selectedKey === key}
+                transform={liveTransform(key)}
+                onPointerDown={(e) => beginGesture(shape, 'move', 'se', e)}
+              />
+            )
+          })}
+
+          {selectedShape && editingKey === null && (
+            <SelectionFrame
+              rect={liveRect(selectedKey as ShapeKey, selectedShape)}
+              scale={scale}
+              transform={liveTransform(selectedKey as ShapeKey)}
+              onHandleDown={(handle, e) => beginGesture(selectedShape, 'resize', handle, e)}
+            />
+          )}
+        </div>
+      )}
+
+      {gesture?.moved && (
+        <div className="pointer-events-none absolute bottom-3 left-1/2 z-30 -translate-x-1/2 rounded-md border border-border bg-background/90 px-2 py-1 text-[11px] tabular-nums text-muted-foreground shadow-sm backdrop-blur">
+          x {inches(gesture.rect.x)}″ · y {inches(gesture.rect.y)}″ · w {inches(gesture.rect.w)}″ · h{' '}
+          {inches(gesture.rect.h)}″
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -81,6 +81,8 @@ interface Gesture {
   wantsEdit: boolean
 }
 
+/** Scale at which one EMU maps to one CSS pixel — i.e. 100% zoom at 96 dpi. */
+const CSS_PX_PER_EMU = 96 / EMU_PER_INCH
 /** Pointer travel a press may drift and still count as a click, not a drag. */
 const CLICK_SLOP_PX = 4
 /** Window in which a second press is part of a double-click. */
@@ -507,6 +509,14 @@ const thumbNoop = () => {}
  * inert: pointer-events none, no selection chrome, no text overlay. Memoized —
  * applyEditSet keeps untouched slides referentially stable, so only an edited
  * slide's thumbnail re-renders.
+ *
+ * The slide is laid out at 100% (96 dpi) and the finished render is scaled to
+ * `widthPx`, rather than shrinking every length into the target box directly.
+ * Direct scaling puts body text at ~2px in a 160px-wide rail thumbnail, which
+ * Chromium renders as an invisible smear — most of the slide's content simply
+ * vanishes from the preview. Laying out full size and letting the compositor
+ * shrink the result keeps every run legible, and the outer box is unchanged
+ * because the transform is exactly `widthPx / referenceWidth`.
  */
 export const SlideThumbnail = memo(function SlideThumbnail({
   slide,
@@ -517,24 +527,36 @@ export const SlideThumbnail = memo(function SlideThumbnail({
   sizeEmu: { w: number; h: number }
   widthPx: number
 }) {
-  const scale = widthPx / sizeEmu.w
+  const refW = sizeEmu.w * CSS_PX_PER_EMU
+  const refH = sizeEmu.h * CSS_PX_PER_EMU
+  const zoom = widthPx / refW
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none relative select-none overflow-hidden bg-white"
-      style={{ width: widthPx, height: sizeEmu.h * scale }}
+      className="pointer-events-none select-none overflow-hidden bg-white"
+      style={{ width: widthPx, height: refH * zoom }}
     >
-      {slide.shapes.map((shape, i) => (
-        <ShapeView
-          key={`${shape.id}:${i}`}
-          shape={shape}
-          rect={shape.xfrmEmu}
-          scale={scale}
-          selected={false}
-          transform={composeTransform(visualTransform(shape))}
-          onPointerDown={thumbNoop}
-        />
-      ))}
+      <div
+        className="relative bg-white"
+        style={{
+          width: refW,
+          height: refH,
+          transform: `scale(${zoom})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        {slide.shapes.map((shape, i) => (
+          <ShapeView
+            key={`${shape.id}:${i}`}
+            shape={shape}
+            rect={shape.xfrmEmu}
+            scale={CSS_PX_PER_EMU}
+            selected={false}
+            transform={composeTransform(visualTransform(shape))}
+            onPointerDown={thumbNoop}
+          />
+        ))}
+      </div>
     </div>
   )
 })
@@ -555,8 +577,6 @@ interface SlideCanvasProps {
   onOverlayAttach: (handle: TextOverlayHandle | null) => void
   onTextCommit: (shape: TextShape, next: EditedParagraph[] | null) => void
 }
-
-const CSS_PX_PER_EMU = 96 / EMU_PER_INCH
 
 export function SlideCanvas({
   slide,

--- a/apps/x/apps/renderer/src/components/pptx/canvas.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/canvas.tsx
@@ -13,8 +13,18 @@ import {
   ShapesIcon,
   TableIcon,
 } from 'lucide-react'
-import type { PlaceholderKind, Shape, Slide, TextShape } from '@/lib/pptx/types'
+import type {
+  Fill,
+  LineStyle,
+  PlaceholderKind,
+  PresetGeometry,
+  Shape,
+  Slide,
+  TextShape,
+} from '@/lib/pptx/types'
 import type { EditedParagraph } from '@/lib/pptx/serialize'
+import { isLinePreset } from '@/lib/pptx/geometry'
+import { autoNumText } from '@/lib/pptx/textstyle'
 import {
   EMU_PER_INCH,
   EMU_PER_PT,
@@ -24,7 +34,13 @@ import {
   type RectEmuBox,
   type ShapeKey,
 } from './edit-model'
-import { DEFAULT_TEXT_PT, alignToCss, type TextOverlayHandle } from './text-dom'
+import {
+  DEFAULT_TEXT_PT,
+  alignToCss,
+  displayAlign,
+  displayRunStyle,
+  type TextOverlayHandle,
+} from './text-dom'
 import { TextEditOverlay } from './text-overlay'
 
 const PLACEHOLDER_META: Record<PlaceholderKind, { label: string; Icon: typeof ShapesIcon }> = {
@@ -125,6 +141,109 @@ function rectStyle(rect: RectEmuBox, scale: number): CSSProperties {
 const isEmptyText = (shape: TextShape): boolean =>
   shape.paragraphs.every((p) => p.runs.every((r) => r.text.trim() === ''))
 
+// ------------------------------------------------------------ shape visuals
+
+function cssColor(hex: string, alpha?: number): string {
+  if (alpha === undefined) return `#${hex}`
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function fillCss(fill: Fill | undefined): CSSProperties {
+  if (!fill || fill.kind === 'none') return {}
+  if (fill.kind === 'solid') return { backgroundColor: cssColor(fill.hex, fill.alpha) }
+  // OOXML angles: 0° points right, clockwise. CSS: 0° points up, clockwise.
+  const stops = fill.stops
+    .map((s) => `${cssColor(s.hex, s.alpha)} ${Math.round(s.pos * 100)}%`)
+    .join(', ')
+  return { backgroundImage: `linear-gradient(${fill.angleDeg + 90}deg, ${stops})` }
+}
+
+const DASH_CSS: Record<LineStyle['dash'], string> = {
+  solid: 'solid',
+  dash: 'dashed',
+  dot: 'dotted',
+}
+
+function lineCss(line: LineStyle | undefined, scale: number): CSSProperties {
+  if (!line) return {}
+  const w = Math.max(1, line.widthEmu * scale)
+  return { border: `${w}px ${DASH_CSS[line.dash]} ${cssColor(line.hex, line.alpha)}` }
+}
+
+function radiusCss(
+  geom: PresetGeometry | undefined,
+  rect: RectEmuBox,
+  scale: number,
+): CSSProperties {
+  if (!geom) return {}
+  if (geom.preset === 'ellipse') return { borderRadius: '50%' }
+  if (geom.preset === 'roundRect') {
+    const adj = geom.adj.adj ?? 16667
+    const r = Math.min(rect.w, rect.h) * (adj / 100000) * scale
+    return { borderRadius: `${Math.max(0, r)}px` }
+  }
+  return {}
+}
+
+/** Rotation and flips as a CSS transform fragment, applied about the center. */
+function visualTransform(shape: Shape): string {
+  const v = shape.visual
+  if (!v) return ''
+  const parts: string[] = []
+  if (v.rotDeg) parts.push(`rotate(${v.rotDeg}deg)`)
+  if (v.flipH) parts.push('scaleX(-1)')
+  if (v.flipV) parts.push('scaleY(-1)')
+  return parts.join(' ')
+}
+
+function composeTransform(...parts: Array<string | undefined>): string | undefined {
+  const s = parts.filter(Boolean).join(' ')
+  return s === '' ? undefined : s
+}
+
+/** A preset drawn as one stroked segment (`line`, connectors). */
+function LineShapeView({
+  rect,
+  scale,
+  line,
+  style,
+  onPointerDown,
+}: {
+  rect: RectEmuBox
+  scale: number
+  line: LineStyle | undefined
+  style: CSSProperties
+  onPointerDown: (e: ReactPointerEvent) => void
+}) {
+  const w = Math.max(rect.w * scale, 1)
+  const h = Math.max(rect.h * scale, 1)
+  const strokeW = Math.max(1, (line?.widthEmu ?? 9525) * scale)
+  const dashArray =
+    line?.dash === 'dash' ? `${strokeW * 3} ${strokeW * 2}` : line?.dash === 'dot' ? `${strokeW} ${strokeW * 1.5}` : undefined
+  return (
+    <svg
+      onPointerDown={onPointerDown}
+      style={{ ...style, overflow: 'visible' }}
+      width={w}
+      height={h}
+      className="select-none"
+    >
+      <line
+        x1={0}
+        y1={0}
+        x2={rect.w * scale}
+        y2={rect.h * scale}
+        stroke={line ? cssColor(line.hex, line.alpha) : '#666666'}
+        strokeWidth={strokeW}
+        strokeDasharray={dashArray}
+      />
+    </svg>
+  )
+}
+
 interface ShapeViewProps {
   shape: Shape
   rect: RectEmuBox
@@ -145,13 +264,14 @@ function ShapeView({ shape, rect, scale, selected, transform, onPointerDown }: S
         alt=""
         draggable={false}
         onPointerDown={onPointerDown}
-        style={{ ...style, cursor }}
+        style={{ ...style, cursor, ...lineCss(shape.visual?.line, scale) }}
         className="object-contain select-none"
       />
     )
   }
 
   if (shape.type === 'placeholder') {
+    // Only content we genuinely can't draw keeps the dashed treatment.
     const { label, Icon } = PLACEHOLDER_META[shape.kind]
     return (
       <div
@@ -165,7 +285,66 @@ function ShapeView({ shape, rect, scale, selected, transform, onPointerDown }: S
     )
   }
 
+  const geom = shape.visual?.geom
+  if (shape.type === 'drawing') {
+    if (geom && isLinePreset(geom.preset)) {
+      return (
+        <LineShapeView
+          rect={rect}
+          scale={scale}
+          line={shape.visual?.line}
+          style={{ ...style, cursor }}
+          onPointerDown={onPointerDown}
+        />
+      )
+    }
+    return (
+      <div
+        onPointerDown={onPointerDown}
+        style={{
+          ...style,
+          cursor,
+          ...fillCss(shape.visual?.fill),
+          ...lineCss(shape.visual?.line, scale),
+          ...radiusCss(geom, rect, scale),
+        }}
+        className="select-none"
+      />
+    )
+  }
+
+  return (
+    <TextShapeView
+      shape={shape}
+      rect={rect}
+      scale={scale}
+      style={style}
+      selected={selected}
+      onPointerDown={onPointerDown}
+    />
+  )
+}
+
+function TextShapeView({
+  shape,
+  rect,
+  scale,
+  style,
+  selected,
+  onPointerDown,
+}: {
+  shape: TextShape
+  rect: RectEmuBox
+  scale: number
+  style: CSSProperties
+  selected: boolean
+  onPointerDown: (e: ReactPointerEvent) => void
+}) {
   const ptToPx = (pt: number) => pt * EMU_PER_PT * scale
+  // Auto-number counters accumulate down the shape; deeper levels reset when
+  // a shallower numbered paragraph appears.
+  const counters: Record<number, number> = {}
+
   return (
     <div
       onPointerDown={onPointerDown}
@@ -175,40 +354,89 @@ function ShapeView({ shape, rect, scale, selected, transform, onPointerDown }: S
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
+        ...fillCss(shape.visual?.fill),
+        ...lineCss(shape.visual?.line, scale),
+        ...radiusCss(shape.visual?.geom, rect, scale),
       }}
-      className="overflow-hidden"
+      className="group/pptx-shape overflow-hidden"
     >
       {isEmptyText(shape) ? (
-        <span className="select-none text-neutral-400" style={{ fontSize: ptToPx(DEFAULT_TEXT_PT) }}>
+        <span
+          className={`select-none text-neutral-400 transition-opacity ${
+            selected ? 'opacity-70' : 'opacity-0 group-hover/pptx-shape:opacity-50'
+          }`}
+          style={{ fontSize: ptToPx(shape.display?.defaultRun.sizePt ?? DEFAULT_TEXT_PT) }}
+        >
           Add text
         </span>
       ) : (
-        shape.paragraphs.map((para, pi) => (
-          <p
-            key={pi}
-            style={{
-              textAlign: alignToCss(para.align),
-              margin: 0,
-              whiteSpace: 'pre-wrap',
-            }}
-          >
-            {para.runs.map((run, ri) => (
-              <span
-                key={ri}
-                style={{
-                  fontWeight: run.bold ? 700 : undefined,
-                  fontStyle: run.italic ? 'italic' : undefined,
-                  textDecoration: run.underline ? 'underline' : undefined,
-                  fontSize: ptToPx(run.sizePt ?? DEFAULT_TEXT_PT),
-                  color: run.colorHex ? `#${run.colorHex}` : '#000',
-                  lineHeight: 1.2,
-                }}
-              >
-                {run.text}
-              </span>
-            ))}
-          </p>
-        ))
+        shape.paragraphs.map((para, pi) => {
+          const dp = shape.display?.paragraphs[(para as EditedParagraph).srcPara ?? pi]
+          const hasText = para.runs.some((r) => r.text.trim() !== '')
+
+          let bulletText: string | null = null
+          if (dp && hasText) {
+            if (dp.bullet.kind === 'char') bulletText = dp.bullet.char
+            else if (dp.bullet.kind === 'auto') {
+              for (const k of Object.keys(counters)) {
+                if (Number(k) > dp.level) delete counters[Number(k)]
+              }
+              counters[dp.level] = (counters[dp.level] ?? dp.bullet.startAt - 1) + 1
+              bulletText = autoNumText(dp.bullet.scheme, counters[dp.level])
+            }
+          }
+
+          const marLPx = (dp?.marLEmu ?? 0) * scale
+          const indentPx = (dp?.indentEmu ?? 0) * scale
+          const bulletStyle = dp?.defaultRun ?? shape.display?.defaultRun
+
+          return (
+            <p
+              key={pi}
+              style={{
+                textAlign: alignToCss(displayAlign(shape, pi, para)),
+                margin: 0,
+                whiteSpace: 'pre-wrap',
+                paddingLeft: marLPx > 0 ? marLPx : undefined,
+                textIndent: indentPx !== 0 ? indentPx : undefined,
+              }}
+            >
+              {bulletText !== null && (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    textIndent: 0,
+                    minWidth: indentPx < 0 ? -indentPx : undefined,
+                    marginRight: indentPx < 0 ? undefined : '0.35em',
+                    fontSize: ptToPx(bulletStyle?.sizePt ?? DEFAULT_TEXT_PT),
+                    color: `#${bulletStyle?.colorHex ?? '000000'}`,
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {bulletText}
+                </span>
+              )}
+              {para.runs.map((run, ri) => {
+                const rs = displayRunStyle(shape, pi, ri, run)
+                return (
+                  <span
+                    key={ri}
+                    style={{
+                      fontWeight: rs.bold ? 700 : 400,
+                      fontStyle: rs.italic ? 'italic' : 'normal',
+                      textDecoration: rs.underline ? 'underline' : 'none',
+                      fontSize: ptToPx(rs.sizePt),
+                      color: `#${rs.colorHex}`,
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {run.text}
+                  </span>
+                )
+              })}
+            </p>
+          )
+        })
       )}
     </div>
   )
@@ -414,7 +642,10 @@ export function SlideCanvas({
                   key={reactKey}
                   shape={shape}
                   scale={scale}
-                  style={rectStyle(shape.xfrmEmu, scale)}
+                  style={{
+                    ...rectStyle(shape.xfrmEmu, scale),
+                    transform: composeTransform(visualTransform(shape)),
+                  }}
                   onAttach={onOverlayAttach}
                   onCommit={(next) => onTextCommit(shape, next)}
                 />
@@ -427,7 +658,7 @@ export function SlideCanvas({
                 rect={liveRect(key, shape)}
                 scale={scale}
                 selected={selectedKey === key}
-                transform={liveTransform(key)}
+                transform={composeTransform(liveTransform(key), visualTransform(shape))}
                 onPointerDown={(e) => beginGesture(shape, 'move', 'se', e)}
               />
             )
@@ -437,7 +668,10 @@ export function SlideCanvas({
             <SelectionFrame
               rect={liveRect(selectedKey as ShapeKey, selectedShape)}
               scale={scale}
-              transform={liveTransform(selectedKey as ShapeKey)}
+              transform={composeTransform(
+                liveTransform(selectedKey as ShapeKey),
+                visualTransform(selectedShape),
+              )}
               onHandleDown={(handle, e) => beginGesture(selectedShape, 'resize', handle, e)}
             />
           )}

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
@@ -8,6 +8,9 @@ import {
   EMPTY_DECK_EDITS,
   acceptsFormatting,
   applyEditSet,
+  renderedSlidePaths,
+  withSlideAdded,
+  withSlideOrder,
   withSlideRemoved,
   effectiveParagraphs,
   isNoopCommit,
@@ -247,6 +250,85 @@ describe('added slides in the edit set', () => {
     expect(afterBase.deletedSlides).toEqual(['ppt/slides/slide1.xml'])
     expect(applyEditSet(deck, afterBase).slides.map((s) => s.xmlPath)).toEqual([
       'ppt/slides/slide4.xml',
+      'ppt/slides/slide2.xml',
+    ])
+  })
+})
+
+describe('explicit slide order', () => {
+  const fakeAdd = (path: string, afterPath: string): AddedSlide => ({
+    path,
+    afterPath,
+    xml: '<p:sld/>',
+    relsXml: '<Relationships/>',
+    slide: { id: path, xmlPath: path, shapes: [] },
+  })
+
+  it('governs the render, keeps slide identity, and undo returns the prior rendering', async () => {
+    const deck = await loadTwoSlides()
+    const reordered = withSlideOrder(EMPTY_DECK_EDITS, [
+      'ppt/slides/slide2.xml',
+      'ppt/slides/slide1.xml',
+    ])
+    const rendered = applyEditSet(deck, reordered)
+    expect(rendered.slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide2.xml',
+      'ppt/slides/slide1.xml',
+    ])
+    // Reordering moves slides, it does not rebuild them.
+    expect(rendered.slides[0]).toBe(deck.slides[1])
+    expect(rendered.slides[1]).toBe(deck.slides[0])
+    // Undo: the prior snapshot is the base deck, by identity.
+    expect(applyEditSet(deck, EMPTY_DECK_EDITS)).toBe(deck)
+  })
+
+  it('renderedSlidePaths matches what applyEditSet renders', async () => {
+    const deck = await loadTwoSlides()
+    const a = fakeAdd('ppt/slides/slide3.xml', 'ppt/slides/slide1.xml')
+    const edits = withSlideOrder({ ...EMPTY_DECK_EDITS, addedSlides: [a] }, [
+      a.path,
+      'ppt/slides/slide2.xml',
+      'ppt/slides/slide1.xml',
+    ])
+    expect(renderedSlidePaths(deck, edits)).toEqual(
+      applyEditSet(deck, edits).slides.map((s) => s.xmlPath),
+    )
+    expect(renderedSlidePaths(deck, edits)).toEqual([
+      a.path,
+      'ppt/slides/slide2.xml',
+      'ppt/slides/slide1.xml',
+    ])
+  })
+
+  it('an add lands after its anchor inside an existing order; a removal prunes it', async () => {
+    const deck = await loadTwoSlides()
+    const ordered = withSlideOrder(EMPTY_DECK_EDITS, [
+      'ppt/slides/slide2.xml',
+      'ppt/slides/slide1.xml',
+    ])
+    const a = fakeAdd('ppt/slides/slide3.xml', 'ppt/slides/slide2.xml')
+    const added = withSlideAdded(ordered, a)
+    expect(added.slideOrder).toEqual([
+      'ppt/slides/slide2.xml',
+      a.path,
+      'ppt/slides/slide1.xml',
+    ])
+
+    // Removing a slide keeps the order an exact permutation of what survives.
+    const removed = withSlideRemoved(added, 'ppt/slides/slide2.xml', '')
+    expect(removed.slideOrder).toEqual([a.path, 'ppt/slides/slide1.xml'])
+    expect(applyEditSet(deck, removed).slides.map((s) => s.xmlPath)).toEqual([
+      a.path,
+      'ppt/slides/slide1.xml',
+    ])
+  })
+
+  it('a stale order never drops a slide from the editor', async () => {
+    const deck = await loadTwoSlides()
+    // An order that forgot slide2 and names a slide that no longer exists.
+    const edits = withSlideOrder(EMPTY_DECK_EDITS, ['ppt/slides/slide9.xml', 'ppt/slides/slide1.xml'])
+    expect(applyEditSet(deck, edits).slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide1.xml',
       'ppt/slides/slide2.xml',
     ])
   })

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx } from '@/lib/pptx/parse'
+import { updateSlideXml, type EditedParagraph } from '@/lib/pptx/serialize'
+import type { Paragraph, TextShape } from '@/lib/pptx/types'
+import { buildEditableHtml, extractParagraphs } from './text-dom'
+import {
+  acceptsFormatting,
+  applyEditSet,
+  effectiveParagraphs,
+  shapeKeyOf,
+  structureMatches,
+  type EditSet,
+} from './edit-model'
+
+const PRES =
+  '<p:presentation xmlns:p="p" xmlns:r="r"><p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>' +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+const RELS =
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>'
+
+/** Two paragraphs with DIFFERENT pPr bytes, so reusing the wrong one shows. */
+const TWO_PARA_SLIDE =
+  '<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100" cy="100"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/>' +
+  '<a:p><a:pPr algn="ctr"><a:buChar char="H"/></a:pPr><a:r><a:t>heading</a:t></a:r></a:p>' +
+  '<a:p><a:pPr algn="r"><a:buChar char="B"/></a:pPr><a:r><a:t>body</a:t></a:r></a:p>' +
+  '</p:txBody></p:sp></p:spTree></p:cSld></p:sld>'
+
+/** One run carrying an explicit rPr — the near-universal real-deck shape. */
+const STYLED_SLIDE =
+  '<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100" cy="100"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/>' +
+  '<a:p><a:r><a:rPr sz="2800" b="1"/><a:t>Hello</a:t></a:r></a:p>' +
+  '</p:txBody></p:sp></p:spTree></p:cSld></p:sld>'
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+async function loadSlide(xml: string) {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', PRES)
+  zip.file('ppt/_rels/presentation.xml.rels', RELS)
+  zip.file('ppt/slides/slide1.xml', xml)
+  const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+  return { deck, slide: deck.slides[0], shape: deck.slides[0].shapes[0] as TextShape }
+}
+
+describe('paragraph provenance survives rendering', () => {
+  it('effectiveParagraphs keeps srcPara, not just run-level provenance', () => {
+    const base: Paragraph[] = [{ align: 'ctr', runs: [{ text: 'a' }] }, { runs: [{ text: 'b' }] }]
+    const text: EditedParagraph[] = [{ srcPara: 1, runs: [{ text: 'b', srcPara: 1, srcRun: 0 }] }]
+    const out = effectiveParagraphs({ slidePath: 's', nodePath: [0], text }, base)
+    expect((out[0] as EditedParagraph).srcPara).toBe(1)
+    expect((out[0].runs[0] as { srcPara?: number }).srcPara).toBe(1)
+  })
+
+  it('a SECOND edit after a structural one still reuses the surviving pPr bytes', async () => {
+    const { deck, slide, shape } = await loadSlide(TWO_PARA_SLIDE)
+    const original = shape.paragraphs
+
+    // Edit 1 (structural): delete paragraph 0, keeping paragraph 1.
+    const first: EditedParagraph[] = [
+      { align: original[1].align, srcPara: 1, runs: [{ text: 'body', srcPara: 1, srcRun: 0 }] },
+    ]
+    expect(updateSlideXml(TWO_PARA_SLIDE, [
+      { kind: 'text', nodePath: shape.nodePath, original, next: first },
+    ])).toContain('<a:buChar char="B"/>')
+
+    // Render the edited deck, then re-open the box exactly as the editor does.
+    const edits: EditSet = {
+      [shapeKeyOf(slide.xmlPath, shape.nodePath)]: {
+        slidePath: slide.xmlPath,
+        nodePath: shape.nodePath,
+        original,
+        text: first,
+      },
+    }
+    const rendered = applyEditSet(deck, edits).slides[0].shapes[0] as TextShape
+    const host = document.createElement('div')
+    host.innerHTML = buildEditableHtml(rendered, 1)
+    const reopened = extractParagraphs(host, rendered, 1)
+
+    // The overlay must stamp the ORIGINAL paragraph index, not the position.
+    expect(reopened.map((p) => p.srcPara)).toEqual([1])
+
+    // Edit 2: retype the text; the write must still land on paragraph 1's pPr.
+    const second: EditedParagraph[] = reopened.map((p) => ({
+      align: p.srcPara !== undefined ? original[p.srcPara]?.align : p.align,
+      srcPara: p.srcPara,
+      runs: p.runs.map((r) => ({ text: 'body edited', srcPara: r.srcPara, srcRun: r.srcRun })),
+    }))
+    const out = updateSlideXml(TWO_PARA_SLIDE, [
+      { kind: 'text', nodePath: shape.nodePath, original, next: second },
+    ])
+    expect(out).toContain('<a:buChar char="B"/>')
+    expect(out).toContain('algn="r"')
+    expect(out).not.toContain('<a:buChar char="H"/>')
+  })
+})
+
+describe('structureMatches agrees with the serializer', () => {
+  it('stays true for an in-place text edit, so formatting remains addressable', async () => {
+    const { shape } = await loadSlide(STYLED_SLIDE)
+    const original = shape.paragraphs
+    // What handleTextCommit builds: provenance intact, ORIGINAL props copied.
+    const next: EditedParagraph[] = [
+      {
+        align: original[0].align,
+        srcPara: 0,
+        runs: [{ ...original[0].runs[0], text: 'Goodbye', srcPara: 0, srcRun: 0 }],
+      },
+    ]
+    expect(structureMatches(original, next)).toBe(true)
+    expect(acceptsFormatting({ slidePath: 's', nodePath: shape.nodePath, original, text: next })).toBe(true)
+    // Both edits together must still write cleanly.
+    expect(() =>
+      updateSlideXml(STYLED_SLIDE, [
+        { kind: 'text', nodePath: shape.nodePath, original, next },
+        { kind: 'formatRuns', nodePath: shape.nodePath, original, targets: [{ para: 0, run: 0 }], set: { bold: false } },
+      ]),
+    ).not.toThrow()
+  })
+
+  it('goes false when a run loses provenance, so formats are never co-emitted', async () => {
+    const { shape } = await loadSlide(STYLED_SLIDE)
+    const original = shape.paragraphs
+    // Paste destroys the styled span: same run count, but no provenance, so
+    // handleTextCommit stamps every property undefined.
+    const next: EditedParagraph[] = [
+      { align: original[0].align, srcPara: 0, runs: [{ text: 'Pasted' }] },
+    ]
+    // Structure is superficially intact, but the serializer must rebuild —
+    // so the editor has to agree and drop formatting for this shape.
+    expect(structureMatches(original, next)).toBe(false)
+    expect(acceptsFormatting({ slidePath: 's', nodePath: shape.nodePath, original, text: next })).toBe(false)
+
+    // The rebuild alone writes cleanly and preserves the original rPr bytes.
+    const out = updateSlideXml(STYLED_SLIDE, [
+      { kind: 'text', nodePath: shape.nodePath, original, next },
+    ])
+    expect(out).toContain('<a:rPr sz="2800" b="1"/>')
+    expect(out).toContain('<a:t>Pasted</a:t>')
+  })
+})

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
@@ -8,12 +8,14 @@ import {
   EMPTY_DECK_EDITS,
   acceptsFormatting,
   applyEditSet,
+  withSlideRemoved,
   effectiveParagraphs,
   isNoopCommit,
   shapeKeyOf,
   structureMatches,
   toSlideEdits,
   withShapeEdit,
+  type AddedSlide,
   type DeckEdits,
   type EditSet,
   type ShapeEdit,
@@ -116,7 +118,7 @@ describe('paragraph provenance survives rendering', () => {
         text: first,
       },
     }
-    const rendered = applyEditSet(deck, { shapes: edits, deletedSlides: [] }).slides[0]
+    const rendered = applyEditSet(deck, { shapes: edits, deletedSlides: [], addedSlides: [] }).slides[0]
       .shapes[0] as TextShape
     const host = document.createElement('div')
     host.innerHTML = buildEditableHtml(rendered, 1)
@@ -155,7 +157,7 @@ describe('deletion in the edit set', () => {
         draft.deleted = { shapeType: shape.type, shapeId: shape.id }
       },
     )
-    const edits: DeckEdits = { shapes, deletedSlides: [] }
+    const edits: DeckEdits = { shapes, deletedSlides: [], addedSlides: [] }
 
     const rendered = applyEditSet(deck, edits)
     expect(rendered.slides[0].shapes).toHaveLength(0)
@@ -179,7 +181,7 @@ describe('deletion in the edit set', () => {
 
   it('a deleted slide leaves the render, and undo restores shape and slide alike', async () => {
     const deck = await loadTwoSlides()
-    const edits: DeckEdits = { shapes: {}, deletedSlides: ['ppt/slides/slide2.xml'] }
+    const edits: DeckEdits = { shapes: {}, deletedSlides: ['ppt/slides/slide2.xml'], addedSlides: [] }
 
     const rendered = applyEditSet(deck, edits)
     expect(rendered.slides.map((s) => s.xmlPath)).toEqual(['ppt/slides/slide1.xml'])
@@ -188,6 +190,65 @@ describe('deletion in the edit set', () => {
     // Undo re-renders from the prior snapshot; the empty set IS the base deck,
     // so both the slide and any deleted shapes are back, identity intact.
     expect(applyEditSet(deck, EMPTY_DECK_EDITS)).toBe(deck)
+  })
+})
+
+describe('added slides in the edit set', () => {
+  const fakeAdded = (path: string, afterPath: string): AddedSlide => ({
+    path,
+    afterPath,
+    xml: '<p:sld/>',
+    relsXml: '<Relationships/>',
+    slide: { id: path, xmlPath: path, shapes: [] },
+  })
+
+  it('renders added slides after their anchors, chains included, undo restores', async () => {
+    const deck = await loadTwoSlides()
+    const a = fakeAdded('ppt/slides/slide3.xml', 'ppt/slides/slide1.xml')
+    const b = fakeAdded('ppt/slides/slide4.xml', a.path)
+    const edits: DeckEdits = { shapes: {}, deletedSlides: [], addedSlides: [a, b] }
+
+    const rendered = applyEditSet(deck, edits)
+    expect(rendered.slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide1.xml',
+      'ppt/slides/slide3.xml',
+      'ppt/slides/slide4.xml',
+      'ppt/slides/slide2.xml',
+    ])
+    // Base slides keep identity; the added slide IS the pre-parsed object.
+    expect(rendered.slides[0]).toBe(deck.slides[0])
+    expect(rendered.slides[1]).toBe(a.slide)
+
+    // Undo: the prior snapshot renders the base deck by identity.
+    expect(applyEditSet(deck, EMPTY_DECK_EDITS)).toBe(deck)
+  })
+
+  it("withSlideRemoved drops an added slide and re-anchors what followed it", async () => {
+    const deck = await loadTwoSlides()
+    const a = fakeAdded('ppt/slides/slide3.xml', 'ppt/slides/slide1.xml')
+    const b = fakeAdded('ppt/slides/slide4.xml', a.path)
+    const edits: DeckEdits = { shapes: {}, deletedSlides: [], addedSlides: [a, b] }
+
+    // Removing the ADDED slide A: no deletedSlides entry (it never existed in
+    // the file); B re-anchors to A's own anchor and keeps its place.
+    const next = withSlideRemoved(edits, a.path, 'ppt/slides/slide1.xml')
+    expect(next.deletedSlides).toEqual([])
+    expect(next.addedSlides.map((x) => [x.path, x.afterPath])).toEqual([
+      ['ppt/slides/slide4.xml', 'ppt/slides/slide1.xml'],
+    ])
+    expect(applyEditSet(deck, next).slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide1.xml',
+      'ppt/slides/slide4.xml',
+      'ppt/slides/slide2.xml',
+    ])
+
+    // Removing a BASE slide records the deletion and re-anchors its additions.
+    const afterBase = withSlideRemoved(next, 'ppt/slides/slide1.xml', '')
+    expect(afterBase.deletedSlides).toEqual(['ppt/slides/slide1.xml'])
+    expect(applyEditSet(deck, afterBase).slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide4.xml',
+      'ppt/slides/slide2.xml',
+    ])
   })
 })
 

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
@@ -5,6 +5,7 @@ import { updateSlideXml, writeDeck, type EditedParagraph } from '@/lib/pptx/seri
 import type { Paragraph, TextShape } from '@/lib/pptx/types'
 import { buildEditableHtml, extractParagraphs } from './text-dom'
 import {
+  EMPTY_DECK_EDITS,
   acceptsFormatting,
   applyEditSet,
   effectiveParagraphs,
@@ -13,6 +14,7 @@ import {
   structureMatches,
   toSlideEdits,
   withShapeEdit,
+  type DeckEdits,
   type EditSet,
   type ShapeEdit,
 } from './edit-model'
@@ -65,6 +67,25 @@ async function loadSlide(xml: string) {
   return { deck, slide: deck.slides[0], shape: deck.slides[0].shapes[0] as TextShape }
 }
 
+const TWO_SLIDE_PRES =
+  '<p:presentation xmlns:p="p" xmlns:r="r"><p:sldIdLst>' +
+  '<p:sldId id="256" r:id="rId2"/><p:sldId id="257" r:id="rId3"/></p:sldIdLst>' +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+const TWO_SLIDE_RELS =
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>' +
+  '<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>' +
+  '</Relationships>'
+
+async function loadTwoSlides() {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', TWO_SLIDE_PRES)
+  zip.file('ppt/_rels/presentation.xml.rels', TWO_SLIDE_RELS)
+  zip.file('ppt/slides/slide1.xml', STYLED_SLIDE)
+  zip.file('ppt/slides/slide2.xml', TWO_PARA_SLIDE)
+  return parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+}
+
 describe('paragraph provenance survives rendering', () => {
   it('effectiveParagraphs keeps srcPara, not just run-level provenance', () => {
     const base: Paragraph[] = [{ align: 'ctr', runs: [{ text: 'a' }] }, { runs: [{ text: 'b' }] }]
@@ -95,7 +116,8 @@ describe('paragraph provenance survives rendering', () => {
         text: first,
       },
     }
-    const rendered = applyEditSet(deck, edits).slides[0].shapes[0] as TextShape
+    const rendered = applyEditSet(deck, { shapes: edits, deletedSlides: [] }).slides[0]
+      .shapes[0] as TextShape
     const host = document.createElement('div')
     host.innerHTML = buildEditableHtml(rendered, 1)
     const reopened = extractParagraphs(host, rendered, 1)
@@ -115,6 +137,57 @@ describe('paragraph provenance survives rendering', () => {
     expect(out).toContain('<a:buChar char="B"/>')
     expect(out).toContain('algn="r"')
     expect(out).not.toContain('<a:buChar char="H"/>')
+  })
+})
+
+describe('deletion in the edit set', () => {
+  it('a deleted shape leaves the render and toSlideEdits emits its validation payload', async () => {
+    const deck = await loadTwoSlides()
+    const slide1 = deck.slides[0]
+    const shape = slide1.shapes[0] as TextShape
+    const key = shapeKeyOf(slide1.xmlPath, shape.nodePath)
+
+    const shapes = withShapeEdit(
+      {},
+      key,
+      { slidePath: slide1.xmlPath, nodePath: shape.nodePath, original: shape.paragraphs },
+      (draft) => {
+        draft.deleted = { shapeType: shape.type, shapeId: shape.id }
+      },
+    )
+    const edits: DeckEdits = { shapes, deletedSlides: [] }
+
+    const rendered = applyEditSet(deck, edits)
+    expect(rendered.slides[0].shapes).toHaveLength(0)
+    // The untouched slide keeps its identity, so its thumbnail never re-renders.
+    expect(rendered.slides[1]).toBe(deck.slides[1])
+
+    const emitted = toSlideEdits(shapes).get(slide1.xmlPath)
+    expect(emitted).toEqual([
+      {
+        kind: 'deleteShape',
+        nodePath: shape.nodePath,
+        shapeType: 'text',
+        shapeId: shape.id,
+        original: shape.paragraphs,
+      },
+    ])
+
+    // The whole pipeline holds: the emitted edit deletes cleanly.
+    expect(updateSlideXml(STYLED_SLIDE, emitted!)).not.toContain('<a:t>Hello</a:t>')
+  })
+
+  it('a deleted slide leaves the render, and undo restores shape and slide alike', async () => {
+    const deck = await loadTwoSlides()
+    const edits: DeckEdits = { shapes: {}, deletedSlides: ['ppt/slides/slide2.xml'] }
+
+    const rendered = applyEditSet(deck, edits)
+    expect(rendered.slides.map((s) => s.xmlPath)).toEqual(['ppt/slides/slide1.xml'])
+    expect(rendered.slides[0]).toBe(deck.slides[0])
+
+    // Undo re-renders from the prior snapshot; the empty set IS the base deck,
+    // so both the slide and any deleted shapes are back, identity intact.
+    expect(applyEditSet(deck, EMPTY_DECK_EDITS)).toBe(deck)
   })
 })
 

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
@@ -13,11 +13,17 @@ import {
   withSlideOrder,
   withSlideRemoved,
   effectiveParagraphs,
+  hasEdits,
+  insertsToSlideEdits,
+  isInsertedShape,
   isNoopCommit,
   shapeKeyOf,
+  spTreeSlotOf,
   structureMatches,
   toSlideEdits,
   withShapeEdit,
+  withShapeInserted,
+  withShapeUninserted,
   type AddedSlide,
   type DeckEdits,
   type EditSet,
@@ -121,7 +127,7 @@ describe('paragraph provenance survives rendering', () => {
         text: first,
       },
     }
-    const rendered = applyEditSet(deck, { shapes: edits, deletedSlides: [], addedSlides: [] }).slides[0]
+    const rendered = applyEditSet(deck, { shapes: edits, deletedSlides: [], insertedShapes: [], addedSlides: [] }).slides[0]
       .shapes[0] as TextShape
     const host = document.createElement('div')
     host.innerHTML = buildEditableHtml(rendered, 1)
@@ -160,7 +166,7 @@ describe('deletion in the edit set', () => {
         draft.deleted = { shapeType: shape.type, shapeId: shape.id }
       },
     )
-    const edits: DeckEdits = { shapes, deletedSlides: [], addedSlides: [] }
+    const edits: DeckEdits = { shapes, deletedSlides: [], insertedShapes: [], addedSlides: [] }
 
     const rendered = applyEditSet(deck, edits)
     expect(rendered.slides[0].shapes).toHaveLength(0)
@@ -184,7 +190,7 @@ describe('deletion in the edit set', () => {
 
   it('a deleted slide leaves the render, and undo restores shape and slide alike', async () => {
     const deck = await loadTwoSlides()
-    const edits: DeckEdits = { shapes: {}, deletedSlides: ['ppt/slides/slide2.xml'], addedSlides: [] }
+    const edits: DeckEdits = { shapes: {}, deletedSlides: ['ppt/slides/slide2.xml'], insertedShapes: [], addedSlides: [] }
 
     const rendered = applyEditSet(deck, edits)
     expect(rendered.slides.map((s) => s.xmlPath)).toEqual(['ppt/slides/slide1.xml'])
@@ -202,14 +208,14 @@ describe('added slides in the edit set', () => {
     afterPath,
     xml: '<p:sld/>',
     relsXml: '<Relationships/>',
-    slide: { id: path, xmlPath: path, shapes: [] },
+    slide: { spTreePath: [0, 0, 0], id: path, xmlPath: path, shapes: [] },
   })
 
   it('renders added slides after their anchors, chains included, undo restores', async () => {
     const deck = await loadTwoSlides()
     const a = fakeAdded('ppt/slides/slide3.xml', 'ppt/slides/slide1.xml')
     const b = fakeAdded('ppt/slides/slide4.xml', a.path)
-    const edits: DeckEdits = { shapes: {}, deletedSlides: [], addedSlides: [a, b] }
+    const edits: DeckEdits = { shapes: {}, deletedSlides: [], insertedShapes: [], addedSlides: [a, b] }
 
     const rendered = applyEditSet(deck, edits)
     expect(rendered.slides.map((s) => s.xmlPath)).toEqual([
@@ -230,7 +236,7 @@ describe('added slides in the edit set', () => {
     const deck = await loadTwoSlides()
     const a = fakeAdded('ppt/slides/slide3.xml', 'ppt/slides/slide1.xml')
     const b = fakeAdded('ppt/slides/slide4.xml', a.path)
-    const edits: DeckEdits = { shapes: {}, deletedSlides: [], addedSlides: [a, b] }
+    const edits: DeckEdits = { shapes: {}, deletedSlides: [], insertedShapes: [], addedSlides: [a, b] }
 
     // Removing the ADDED slide A: no deletedSlides entry (it never existed in
     // the file); B re-anchors to A's own anchor and keeps its place.
@@ -261,7 +267,7 @@ describe('explicit slide order', () => {
     afterPath,
     xml: '<p:sld/>',
     relsXml: '<Relationships/>',
-    slide: { id: path, xmlPath: path, shapes: [] },
+    slide: { spTreePath: [0, 0, 0], id: path, xmlPath: path, shapes: [] },
   })
 
   it('governs the render, keeps slide identity, and undo returns the prior rendering', async () => {
@@ -433,5 +439,173 @@ describe('structureMatches agrees with the serializer', () => {
     ])
     expect(out).toContain('<a:rPr sz="2800" b="1"/>')
     expect(out).toContain('<a:t>Pasted</a:t>')
+  })
+})
+
+describe('inserted shapes survive a Slide that predates spTreePath', () => {
+  it('derives the spTree slot from the shapes instead of crashing', async () => {
+    const deck = await loadTwoSlides()
+    const slide = deck.slides[0]
+    expect(slide.shapes[0].nodePath.length).toBeGreaterThan(1)
+
+    // A deck held across a hot reload was parsed by older code and has no
+    // spTreePath. Spreading it threw "undefined is not iterable", which took
+    // out insert and every render that built a preview.
+    const stale = { ...slide, spTreePath: undefined as unknown as number[] }
+    const slot = spTreeSlotOf(stale)
+    expect(slot.path).toEqual(slide.shapes[0].nodePath.slice(0, -1))
+    expect(slot.nextChild).toBe(
+      slide.shapes[slide.shapes.length - 1].nodePath.slice(-1)[0] + 1,
+    )
+
+    // And the render path itself no longer throws.
+    const staleDeck = { ...deck, slides: [stale, deck.slides[1]] }
+    const edits = withShapeInserted(EMPTY_DECK_EDITS, {
+      key: 'k',
+      slidePath: slide.xmlPath,
+      spec: { kind: 'textbox', xfrmEmu: { x: 0, y: 0, w: 10, h: 10 } },
+    })
+    const rendered = applyEditSet(staleDeck, edits)
+    const added = rendered.slides[0].shapes[rendered.slides[0].shapes.length - 1]
+    expect(added.nodePath).toEqual([...slot.path, slot.nextChild])
+    // The key it renders under is the one selection looks it up by.
+    expect(shapeKeyOf(slide.xmlPath, added.nodePath)).toBe(added.id)
+  })
+
+  it('an empty slide still falls back to the first shape slot', () => {
+    const empty = {
+      id: 's',
+      xmlPath: 'ppt/slides/slide1.xml',
+      shapes: [],
+      spTreePath: [1, 0, 0],
+    }
+    expect(spTreeSlotOf(empty)).toEqual({ path: [1, 0, 0], nextChild: 2 })
+  })
+})
+
+describe('removing a shape this session inserted', () => {
+  const box = (key: string, slidePath: string) => ({
+    key,
+    slidePath,
+    spec: { kind: 'textbox' as const, xfrmEmu: { x: 0, y: 0, w: 10, h: 10 } },
+  })
+
+  it('drops the insert instead of emitting an unsatisfiable deleteShape', async () => {
+    const deck = await loadTwoSlides()
+    const slide = deck.slides[0]
+    const slot = spTreeSlotOf(slide)
+    const key = shapeKeyOf(slide.xmlPath, [...slot.path, slot.nextChild])
+
+    const inserted = withShapeInserted(EMPTY_DECK_EDITS, box(key, slide.xmlPath))
+    expect(isInsertedShape(inserted, key)).toBe(true)
+    expect(applyEditSet(deck, inserted).slides[0].shapes).toHaveLength(
+      slide.shapes.length + 1,
+    )
+
+    const removed = withShapeUninserted(inserted, key)
+    expect(removed.insertedShapes).toHaveLength(0)
+    // Nothing is emitted for it: a preview shape's id is an editor key, not a
+    // cNvPr id, so a deleteShape edit would fail the whole save closed.
+    expect(insertsToSlideEdits(removed.insertedShapes).size).toBe(0)
+    expect(toSlideEdits(removed.shapes).size).toBe(0)
+    // And the deck renders exactly as before the insert.
+    expect(applyEditSet(deck, removed).slides[0].shapes).toHaveLength(slide.shapes.length)
+    expect(hasEdits(removed)).toBe(false)
+  })
+
+  it('leaves a NON-inserted shape alone, and clears the insert own edits', async () => {
+    const deck = await loadTwoSlides()
+    const slide = deck.slides[0]
+    const slot = spTreeSlotOf(slide)
+    const key = shapeKeyOf(slide.xmlPath, [...slot.path, slot.nextChild])
+    const other = shapeKeyOf(slide.xmlPath, slide.shapes[0].nodePath)
+
+    let edits = withShapeInserted(EMPTY_DECK_EDITS, box(key, slide.xmlPath))
+    // Give the inserted box a geometry edit, as dragging it would.
+    edits = {
+      ...edits,
+      shapes: withShapeEdit(
+        edits.shapes,
+        key,
+        { slidePath: slide.xmlPath, nodePath: [...slot.path, slot.nextChild] },
+        (draft) => {
+          draft.geometry = { x: 5, y: 5, w: 5, h: 5 }
+        },
+      ),
+    }
+    const removed = withShapeUninserted(edits, key)
+    // Its own edits go with it — they would address an element that is no
+    // longer being written.
+    expect(Object.keys(removed.shapes)).not.toContain(key)
+
+    // An untouched key is a no-op, returning the same object.
+    expect(withShapeUninserted(removed, other)).toBe(removed)
+    expect(isInsertedShape(removed, other)).toBe(false)
+  })
+})
+
+describe('an inserted shape accepts every edit kind', () => {
+  it('moves, retypes, recolours and restyles like a shape already in the file', async () => {
+    const deck = await loadTwoSlides()
+    const slide = deck.slides[0]
+    const slot = spTreeSlotOf(slide)
+    const nodePath = [...slot.path, slot.nextChild]
+    const key = shapeKeyOf(slide.xmlPath, nodePath)
+
+    let edits = withShapeInserted(EMPTY_DECK_EDITS, {
+      key,
+      slidePath: slide.xmlPath,
+      spec: { kind: 'textbox', xfrmEmu: { x: 100, y: 200, w: 300, h: 400 } },
+    })
+
+    // Dragging it: previously the preview kept rendering at spec.xfrmEmu, so
+    // the box snapped straight back and looked immovable.
+    edits = {
+      ...edits,
+      shapes: withShapeEdit(edits.shapes, key, { slidePath: slide.xmlPath, nodePath }, (draft) => {
+        draft.geometry = { x: 999, y: 888, w: 777, h: 666 }
+        draft.text = [{ runs: [{ text: 'typed into the new box' }] }]
+        draft.fillHex = 'ABCDEF'
+      }),
+    }
+
+    const rendered = applyEditSet(deck, edits)
+    const box = rendered.slides[0].shapes[rendered.slides[0].shapes.length - 1] as TextShape
+    expect(box.xfrmEmu).toEqual({ x: 999, y: 888, w: 777, h: 666 })
+    expect(box.paragraphs[0].runs[0].text).toBe('typed into the new box')
+    expect(box.visual?.fill).toEqual({ kind: 'solid', hex: 'ABCDEF' })
+    // Still last, i.e. still on top of the z-order.
+    expect(box.nodePath).toEqual(nodePath)
+    // And the shapes already on the slide are untouched.
+    expect(rendered.slides[0].shapes[0]).toBe(deck.slides[0].shapes[0])
+  })
+})
+
+describe('inserted-shape previews are truthful', () => {
+  it('a shape previews with the deck accent fill; a line previews with a stroke', async () => {
+    const deck = await loadTwoSlides()
+    deck.themeColors = { accent1: '4F81BD', tx1: '000000' }
+    const slide = deck.slides[0]
+    const at = (spec: Parameters<typeof withShapeInserted>[1]['spec']) =>
+      applyEditSet(
+        deck,
+        withShapeInserted(EMPTY_DECK_EDITS, { key: 'k', slidePath: slide.xmlPath, spec }),
+      ).slides[0].shapes.at(-1)!
+
+    // With no fill at all the canvas drew nothing — an inserted rectangle
+    // read as an invisible white box, and a line was invisible entirely.
+    const rect = at({ kind: 'shape', preset: 'rect', xfrmEmu: { x: 0, y: 0, w: 10, h: 10 } })
+    expect(rect.visual?.fill).toEqual({ kind: 'solid', hex: '4F81BD' })
+    // The snapshot matches what the synthesized XML parses to, so the
+    // Fill/Outline swatches target it and setShapeStyle validates.
+    expect(rect.style).toEqual({ fill: 'solidFill', hasLine: false, lineFill: null })
+
+    const line = at({ kind: 'shape', preset: 'line', xfrmEmu: { x: 0, y: 0, w: 10, h: 0 } })
+    expect(line.visual?.line?.hex).toBe('4F81BD')
+    expect(line.style).toEqual({ fill: 'noFill', hasLine: true, lineFill: 'solidFill' })
+
+    const box = at({ kind: 'textbox', xfrmEmu: { x: 0, y: 0, w: 10, h: 10 } })
+    expect(box.style).toEqual({ fill: 'noFill', hasLine: false, lineFill: null })
+    expect(box.visual?.fill).toBeUndefined()
   })
 })

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
 import JSZip from 'jszip'
 import { parsePptx } from '@/lib/pptx/parse'
-import { updateSlideXml, type EditedParagraph } from '@/lib/pptx/serialize'
+import { updateSlideXml, writeDeck, type EditedParagraph } from '@/lib/pptx/serialize'
 import type { Paragraph, TextShape } from '@/lib/pptx/types'
 import { buildEditableHtml, extractParagraphs } from './text-dom'
 import {
   acceptsFormatting,
   applyEditSet,
   effectiveParagraphs,
+  isNoopCommit,
   shapeKeyOf,
   structureMatches,
+  toSlideEdits,
+  withShapeEdit,
   type EditSet,
+  type ShapeEdit,
 } from './edit-model'
 
 const PRES =
@@ -49,6 +53,8 @@ afterAll(() => {
   URL.createObjectURL = originalCreate
   URL.revokeObjectURL = originalRevoke
 })
+
+type CommitDeltaCase = { textChanged: boolean; formatCount: number; alignCount: number }
 
 async function loadSlide(xml: string) {
   const zip = new JSZip()
@@ -109,6 +115,63 @@ describe('paragraph provenance survives rendering', () => {
     expect(out).toContain('<a:buChar char="B"/>')
     expect(out).toContain('algn="r"')
     expect(out).not.toContain('<a:buChar char="H"/>')
+  })
+})
+
+describe('retyping the original text reverts the edit', () => {
+  it('isNoopCommit only skips when there is no accumulated edit to clear', () => {
+    const clean: CommitDeltaCase = { textChanged: false, formatCount: 0, alignCount: 0 }
+    const withText: ShapeEdit = {
+      slidePath: 's',
+      nodePath: [0],
+      text: [{ srcPara: 0, runs: [{ text: 'edited' }] }],
+    }
+    // Nothing accumulated and nothing changed -> genuinely a no-op.
+    expect(isNoopCommit(undefined, clean)).toBe(true)
+    // A prior text edit is still recorded -> this commit is a REVERT.
+    expect(isNoopCommit(withText, clean)).toBe(false)
+    // Prior formatting likewise must be cleared.
+    expect(isNoopCommit({ slidePath: 's', nodePath: [0], formats: { '0:0': { bold: true } } }, clean)).toBe(false)
+    // Any real change always commits.
+    expect(isNoopCommit(undefined, { ...clean, textChanged: true })).toBe(false)
+  })
+
+  it('edit -> save -> retype original -> save writes byte-identical slide XML', async () => {
+    const { deck, slide, shape } = await loadSlide(STYLED_SLIDE)
+    const key = shapeKeyOf(slide.xmlPath, shape.nodePath)
+    const original = shape.paragraphs
+    const seed = { slidePath: slide.xmlPath, nodePath: shape.nodePath, original }
+
+    // 1. Edit the text and save — the slide really is rewritten.
+    const edited: EditedParagraph[] = [
+      { align: original[0].align, srcPara: 0, runs: [{ ...original[0].runs[0], text: 'Changed', srcPara: 0, srcRun: 0 }] },
+    ]
+    let edits = withShapeEdit({}, key, seed, (d) => {
+      d.original = original
+      d.text = edited
+    })
+    const afterEdit = await writeDeck(deck, toSlideEdits(edits))
+    const editedXml = await (await JSZip.loadAsync(afterEdit)).files[slide.xmlPath].async('string')
+    expect(editedXml).not.toBe(STYLED_SLIDE)
+    expect(editedXml).toContain('<a:t>Changed</a:t>')
+
+    // 2. Retype the original wording. Nothing differs from the original file,
+    //    but the accumulated text edit still has to be cleared.
+    const previous = edits[key]
+    expect(isNoopCommit(previous, { textChanged: false, formatCount: 0, alignCount: 0 })).toBe(false)
+    edits = withShapeEdit(edits, key, seed, (d) => {
+      d.original = original
+      d.text = undefined // what handleTextCommit assigns when nothing changed
+    })
+
+    // The shape's entry is gone entirely, so the slide is not touched at all.
+    expect(edits[key]).toBeUndefined()
+    expect(toSlideEdits(edits).size).toBe(0)
+
+    // 3. Save again — byte-identical to the original slide XML.
+    const afterRevert = await writeDeck(deck, toSlideEdits(edits))
+    const revertedXml = await (await JSZip.loadAsync(afterRevert)).files[slide.xmlPath].async('string')
+    expect(revertedXml).toBe(STYLED_SLIDE)
   })
 })
 

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -111,6 +111,36 @@ export function structureMatches(
   return isTextOnlyEdit(original, next)
 }
 
+/** True when the accumulated edit records run formatting or paragraph alignment. */
+export function editHoldsFormatting(edit: ShapeEdit | undefined): boolean {
+  return (
+    Boolean(edit?.formats && Object.keys(edit.formats).length > 0) ||
+    Boolean(edit?.aligns && Object.keys(edit.aligns).length > 0)
+  )
+}
+
+/** What a text commit found to differ from the ORIGINAL file. */
+export interface CommitDelta {
+  textChanged: boolean
+  formatCount: number
+  alignCount: number
+}
+
+/**
+ * True when a commit can be dropped entirely: nothing differs from the
+ * original AND no earlier edit for this shape is left to clear.
+ *
+ * That second half is the easy one to miss. Typing a box's text back to its
+ * original value is a REVERT, not a no-op: the commit has to go through so the
+ * stale `text` edit is dropped. Skipping it left the old edit in the set, so
+ * the canvas snapped back to the superseded text and every save kept writing
+ * it — with no way out but undo.
+ */
+export function isNoopCommit(previous: ShapeEdit | undefined, delta: CommitDelta): boolean {
+  if (delta.textChanged || delta.formatCount > 0 || delta.alignCount > 0) return false
+  return !previous?.text && !editHoldsFormatting(previous)
+}
+
 /** True when this shape can still take formatting/alignment edits. */
 export function acceptsFormatting(edit: ShapeEdit | undefined): boolean {
   if (!edit?.original) return true

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -23,6 +23,7 @@ import {
   isTextOnlyEdit,
   type DeleteShapeEdit,
   type EditedParagraph,
+  type NewSlidePart,
   type RunFormatOverrides,
   type RunRef,
   type SlideEdit,
@@ -31,6 +32,7 @@ import type {
   NodePath,
   Paragraph,
   Shape,
+  Slide,
   SlideDeck,
   TextAlign,
   TextShape,
@@ -101,19 +103,38 @@ export type EditSet = Readonly<Record<ShapeKey, ShapeEdit>>
 export const EMPTY_EDIT_SET: EditSet = {}
 
 /**
+ * A slide that exists only in the edit set: its synthesized part strings (what
+ * the serializer writes and applies this slide's shape edits against) plus the
+ * pre-parsed Slide the canvas renders. Parsed once at add time, so its object
+ * identity — and every nodePath in it — is stable across history snapshots.
+ */
+export interface AddedSlide extends NewSlidePart {
+  slide: Slide
+}
+
+/**
  * Everything the editor has changed, and the unit the history stack snapshots:
- * per-shape edits plus slides removed from the deck (by xml path — positions
- * shift as slides are deleted, paths never do).
+ * per-shape edits plus slides removed from / added to the deck (by xml path —
+ * positions shift as slides come and go, paths never do).
  */
 export interface DeckEdits {
   shapes: EditSet
   deletedSlides: readonly string[]
+  addedSlides: readonly AddedSlide[]
 }
 
-export const EMPTY_DECK_EDITS: DeckEdits = { shapes: EMPTY_EDIT_SET, deletedSlides: [] }
+export const EMPTY_DECK_EDITS: DeckEdits = {
+  shapes: EMPTY_EDIT_SET,
+  deletedSlides: [],
+  addedSlides: [],
+}
 
 export function hasEdits(edits: DeckEdits): boolean {
-  return Object.keys(edits.shapes).length > 0 || edits.deletedSlides.length > 0
+  return (
+    Object.keys(edits.shapes).length > 0 ||
+    edits.deletedSlides.length > 0 ||
+    edits.addedSlides.length > 0
+  )
 }
 
 /**
@@ -211,37 +232,100 @@ export function effectiveParagraphs(edit: ShapeEdit, base: readonly Paragraph[])
   return paras
 }
 
+/**
+ * The rendered slide order: base slides minus deletions, with added slides
+ * inserted after their anchors ('' anchors at the front; an added slide can
+ * itself anchor later additions).
+ */
+function composeSlideOrder(deck: SlideDeck, edits: DeckEdits): Slide[] {
+  const removed = new Set(edits.deletedSlides)
+  if (edits.addedSlides.length === 0) {
+    return removed.size === 0 ? [...deck.slides] : deck.slides.filter((s) => !removed.has(s.xmlPath))
+  }
+  const byAnchor = new Map<string, AddedSlide[]>()
+  for (const a of edits.addedSlides) {
+    const list = byAnchor.get(a.afterPath) ?? []
+    list.push(a)
+    byAnchor.set(a.afterPath, list)
+  }
+  const ordered: Slide[] = []
+  const visited = new Set<string>()
+  const emitAdds = (anchorPath: string): void => {
+    for (const a of byAnchor.get(anchorPath) ?? []) {
+      if (visited.has(a.path)) continue // defensive: an anchor cycle can't hang the render
+      visited.add(a.path)
+      ordered.push(a.slide)
+      emitAdds(a.path)
+    }
+  }
+  emitAdds('')
+  for (const slide of deck.slides) {
+    if (removed.has(slide.xmlPath)) continue
+    ordered.push(slide)
+    emitAdds(slide.xmlPath)
+  }
+  // An add whose anchor vanished (never reachable from the UI) still renders,
+  // at the end, rather than silently disappearing from the editor.
+  for (const a of edits.addedSlides) {
+    if (!visited.has(a.path)) ordered.push(a.slide)
+  }
+  return ordered
+}
+
 /** The deck as the user currently sees it. `deck` itself is never mutated. */
 export function applyEditSet(deck: SlideDeck, edits: DeckEdits): SlideDeck {
   if (!hasEdits(edits)) return deck
-  const removedSlides = new Set(edits.deletedSlides)
   return {
     ...deck,
-    slides: deck.slides
-      .filter((slide) => !removedSlides.has(slide.xmlPath))
-      .map((slide) => {
-        let touched = false
-        const shapes: Shape[] = []
-        for (const shape of slide.shapes) {
-          const edit = edits.shapes[shapeKeyOf(slide.xmlPath, shape.nodePath)]
-          if (!edit) {
-            shapes.push(shape)
-            continue
-          }
-          touched = true
-          if (edit.deleted) continue
-          let next: Shape = shape
-          if (edit.geometry) next = { ...next, xfrmEmu: { ...edit.geometry } }
-          if (next.type === 'text' && (edit.text || edit.formats || edit.aligns)) {
-            next = {
-              ...next,
-              paragraphs: effectiveParagraphs(edit, (next as TextShape).paragraphs),
-            }
-          }
-          shapes.push(next)
+    slides: composeSlideOrder(deck, edits).map((slide) => {
+      let touched = false
+      const shapes: Shape[] = []
+      for (const shape of slide.shapes) {
+        const edit = edits.shapes[shapeKeyOf(slide.xmlPath, shape.nodePath)]
+        if (!edit) {
+          shapes.push(shape)
+          continue
         }
-        return touched ? { ...slide, shapes } : slide
-      }),
+        touched = true
+        if (edit.deleted) continue
+        let next: Shape = shape
+        if (edit.geometry) next = { ...next, xfrmEmu: { ...edit.geometry } }
+        if (next.type === 'text' && (edit.text || edit.formats || edit.aligns)) {
+          next = {
+            ...next,
+            paragraphs: effectiveParagraphs(edit, (next as TextShape).paragraphs),
+          }
+        }
+        shapes.push(next)
+      }
+      return touched ? { ...slide, shapes } : slide
+    }),
+  }
+}
+
+/**
+ * The edit set after removing one rendered slide. An ADDED slide is removed by
+ * dropping its entry (it never existed in the file); a base slide joins
+ * `deletedSlides`. Either way its shape edits go, and any additions anchored
+ * to it re-anchor to `reanchorTo` (its rendered predecessor; '' for the front)
+ * so they keep their place in the deck.
+ */
+export function withSlideRemoved(
+  edits: DeckEdits,
+  targetPath: string,
+  reanchorTo: string,
+): DeckEdits {
+  const shapes = Object.fromEntries(
+    Object.entries(edits.shapes).filter(([, v]) => v.slidePath !== targetPath),
+  )
+  const wasAdded = edits.addedSlides.some((a) => a.path === targetPath)
+  const addedSlides = edits.addedSlides
+    .filter((a) => a.path !== targetPath)
+    .map((a) => (a.afterPath === targetPath ? { ...a, afterPath: reanchorTo } : a))
+  return {
+    shapes,
+    addedSlides,
+    deletedSlides: wasAdded ? edits.deletedSlides : [...edits.deletedSlides, targetPath],
   }
 }
 

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -19,6 +19,8 @@
  *    have no meaning, so formatting is dropped and disabled for that shape.
  */
 
+import { DEFAULT_LINE_EMU, type ShapeStyleSnapshot } from '@/lib/pptx/geometry'
+import type { NewShapeSpec } from '@/lib/pptx/shape-xml'
 import {
   isTextOnlyEdit,
   type DeleteShapeEdit,
@@ -90,6 +92,14 @@ export interface ShapeEdit {
   /** Original paragraph index (as a string key) -> alignment. */
   aligns?: Record<string, TextAlign>
   geometry?: RectEmuBox
+  /** Shape fill / outline, six-digit RRGGBB. */
+  fillHex?: string
+  lineHex?: string
+  /** The shape's as-parsed spPr style, the serializer's fail-closed anchor. */
+  styleOriginal?: ShapeStyleSnapshot
+  /** Shape identity, carried so the serializer can revalidate it. */
+  shapeType?: Shape['type']
+  shapeId?: string
   /**
    * Set when the shape is deleted. Supersedes every other field: their splices
    * would land inside the removed range, and the serializer fails closed on
@@ -117,8 +127,23 @@ export interface AddedSlide extends NewSlidePart {
  * per-shape edits plus slides removed from / added to the deck (by xml path —
  * positions shift as slides come and go, paths never do).
  */
+/**
+ * A shape inserted into an existing slide. The spec is what the serializer
+ * writes; `slide` records which slide it belongs to and `key` gives it a
+ * stable identity for selection and undo BEFORE it exists in any XML.
+ */
+export interface InsertedShape {
+  key: ShapeKey
+  slidePath: string
+  spec: NewShapeSpec
+  /** Object URL for an image's bytes, so the canvas can draw it pre-save. */
+  previewUrl?: string
+}
+
 export interface DeckEdits {
   shapes: EditSet
+  /** Shapes added to existing slides, in insertion (z-) order. */
+  insertedShapes: readonly InsertedShape[]
   deletedSlides: readonly string[]
   addedSlides: readonly AddedSlide[]
   /**
@@ -132,6 +157,7 @@ export interface DeckEdits {
 
 export const EMPTY_DECK_EDITS: DeckEdits = {
   shapes: EMPTY_EDIT_SET,
+  insertedShapes: [],
   deletedSlides: [],
   addedSlides: [],
 }
@@ -139,6 +165,7 @@ export const EMPTY_DECK_EDITS: DeckEdits = {
 export function hasEdits(edits: DeckEdits): boolean {
   return (
     Object.keys(edits.shapes).length > 0 ||
+    edits.insertedShapes.length > 0 ||
     edits.deletedSlides.length > 0 ||
     edits.addedSlides.length > 0 ||
     edits.slideOrder !== undefined
@@ -338,15 +365,117 @@ export function withSlideAdded(edits: DeckEdits, added: AddedSlide): DeckEdits {
   return { ...edits, addedSlides, slideOrder: order }
 }
 
+/**
+ * A preview of an inserted shape, so the canvas can draw it before it exists
+ * in any XML. Its nodePath is the position it WILL occupy — last in spTree —
+ * which is also what makes it addressable by move/style/delete edits.
+ */
+/**
+ * Where the next inserted shape lands: the spTree node path, and the child
+ * index it will occupy.
+ *
+ * Derived from the existing shapes wherever possible rather than read straight
+ * off `slide.spTreePath`. A Slide object can predate that field — a deck held
+ * in React state across a hot reload is exactly that — and spreading a missing
+ * one is a hard TypeError, which crashed insert instead of degrading. Any
+ * shape's node path already ends in its spTree child index, so the parent path
+ * is simply its prefix.
+ */
+export function spTreeSlotOf(slide: Slide): { path: NodePath; nextChild: number } {
+  const last = slide.shapes[slide.shapes.length - 1]
+  if (last && last.nodePath.length > 1) {
+    return {
+      path: last.nodePath.slice(0, -1),
+      nextChild: last.nodePath[last.nodePath.length - 1] + 1,
+    }
+  }
+  // No shapes to derive from. spTree always opens with nvGrpSpPr and grpSpPr,
+  // so the first shape slot is index 2.
+  return { path: slide.spTreePath ?? [], nextChild: 2 }
+}
+
+/** PowerPoint's stock accent1, for a deck whose theme could not be read. */
+const FALLBACK_ACCENT = '4472C4'
+
+function previewShapeOf(
+  ins: InsertedShape,
+  slide: Slide,
+  offset: number,
+  accentHex: string | undefined,
+): Shape {
+  // The node path the shape WILL have once written: inserts append to spTree,
+  // so it is the next spTree CHILD index — not the next model-shape index.
+  // spTree also holds nvGrpSpPr/grpSpPr, which are not shapes, so counting
+  // model shapes pointed at the wrong element and nothing addressed at it
+  // resolved.
+  const slot = spTreeSlotOf(slide)
+  const nodePath = [...slot.path, slot.nextChild + offset]
+  const base = {
+    id: shapeKeyOf(slide.xmlPath, nodePath),
+    slideXmlPath: slide.xmlPath,
+    nodePath,
+    xfrmEmu: { ...ins.spec.xfrmEmu },
+  }
+  if (ins.spec.kind === 'image') {
+    return { ...base, type: 'image', blobUrl: ins.previewUrl ?? '', mediaPath: '' }
+  }
+  // Every preview carries the `style` snapshot its synthesized XML will parse
+  // to. That is what lets the Fill/Outline swatches target it, and what the
+  // serializer's fail-closed check re-derives and compares.
+  if (ins.spec.kind === 'textbox') {
+    return {
+      ...base,
+      type: 'text',
+      paragraphs: [{ runs: [] }],
+      style: { fill: 'noFill', hasLine: false, lineFill: null },
+    }
+  }
+  // The preview must show what the file will contain: `schemeClr accent1`,
+  // resolved through the deck's own theme. With no fill at all here, an
+  // inserted rectangle rendered as an invisible "white" box.
+  const accent = accentHex ?? FALLBACK_ACCENT
+  if (ins.spec.preset === 'line') {
+    return {
+      ...base,
+      type: 'drawing',
+      visual: {
+        geom: { preset: 'line', adj: {} },
+        line: { hex: accent, widthEmu: DEFAULT_LINE_EMU, dash: 'solid' },
+      },
+      style: { fill: 'noFill', hasLine: true, lineFill: 'solidFill' },
+    }
+  }
+  return {
+    ...base,
+    type: 'drawing',
+    visual: {
+      geom: { preset: ins.spec.preset, adj: {} },
+      fill: { kind: 'solid', hex: accent },
+    },
+    style: { fill: 'solidFill', hasLine: false, lineFill: null },
+  }
+}
+
 /** The deck as the user currently sees it. `deck` itself is never mutated. */
 export function applyEditSet(deck: SlideDeck, edits: DeckEdits): SlideDeck {
   if (!hasEdits(edits)) return deck
   return {
     ...deck,
     slides: composeSlideOrder(deck, edits).map((slide) => {
-      let touched = false
+      // Inserted shapes join the list BEFORE edits are applied, so every edit
+      // kind reaches them exactly as it reaches a shape already in the file.
+      // Appending them afterwards meant nothing applied: a dragged box snapped
+      // straight back, and typing, recolouring and restyling were all inert.
+      const inserts = edits.insertedShapes.filter((i) => i.slidePath === slide.xmlPath)
+      // They append to spTree, so they paint on top of everything else.
+      const source =
+        inserts.length > 0
+          ? [...slide.shapes, ...inserts.map((ins, i) => previewShapeOf(ins, slide, i, deck.themeColors?.accent1))]
+          : slide.shapes
+
+      let touched = inserts.length > 0
       const shapes: Shape[] = []
-      for (const shape of slide.shapes) {
+      for (const shape of source) {
         const edit = edits.shapes[shapeKeyOf(slide.xmlPath, shape.nodePath)]
         if (!edit) {
           shapes.push(shape)
@@ -356,6 +485,23 @@ export function applyEditSet(deck: SlideDeck, edits: DeckEdits): SlideDeck {
         if (edit.deleted) continue
         let next: Shape = shape
         if (edit.geometry) next = { ...next, xfrmEmu: { ...edit.geometry } }
+        // Fill / outline overrides ride on the DISPLAY visual, so the canvas
+        // and the thumbnails pick them up through the one render path.
+        if (edit.fillHex !== undefined || edit.lineHex !== undefined) {
+          const visual = { ...next.visual }
+          if (edit.fillHex !== undefined) visual.fill = { kind: 'solid', hex: edit.fillHex }
+          if (edit.lineHex !== undefined) {
+            visual.line = {
+              // A shape with no authored outline gains a hairline, matching
+              // the minimal a:ln the serializer writes.
+              widthEmu: visual.line?.widthEmu ?? EMU_PER_PT,
+              dash: visual.line?.dash ?? 'solid',
+              ...visual.line,
+              hex: edit.lineHex,
+            }
+          }
+          next = { ...next, visual }
+        }
         if (next.type === 'text' && (edit.text || edit.formats || edit.aligns)) {
           next = {
             ...next,
@@ -367,6 +513,29 @@ export function applyEditSet(deck: SlideDeck, edits: DeckEdits): SlideDeck {
       return touched ? { ...slide, shapes } : slide
     }),
   }
+}
+
+/**
+ * Removes a shape that this edit set INSERTED. It never existed in the file,
+ * so there is nothing to splice out — the insert is simply dropped. Emitting a
+ * deleteShape for it instead would fail closed: a preview shape's `id` is its
+ * composite editor key, not the numeric cNvPr id the serializer re-derives.
+ */
+export function withShapeUninserted(edits: DeckEdits, key: ShapeKey): DeckEdits {
+  const insertedShapes = edits.insertedShapes.filter((i) => i.key !== key)
+  if (insertedShapes.length === edits.insertedShapes.length) return edits
+  const shapes = Object.fromEntries(Object.entries(edits.shapes).filter(([k]) => k !== key))
+  return { ...edits, shapes, insertedShapes }
+}
+
+/** True when `key` names a shape this edit set inserted. */
+export function isInsertedShape(edits: DeckEdits, key: ShapeKey): boolean {
+  return edits.insertedShapes.some((i) => i.key === key)
+}
+
+/** Adds an inserted shape to the edit set. */
+export function withShapeInserted(edits: DeckEdits, inserted: InsertedShape): DeckEdits {
+  return { ...edits, insertedShapes: [...edits.insertedShapes, inserted] }
 }
 
 /**
@@ -390,6 +559,8 @@ export function withSlideRemoved(
     .map((a) => (a.afterPath === targetPath ? { ...a, afterPath: reanchorTo } : a))
   const next: DeckEdits = {
     shapes,
+    // An inserted shape on a removed slide goes with it.
+    insertedShapes: edits.insertedShapes.filter((i) => i.slidePath !== targetPath),
     addedSlides,
     deletedSlides: wasAdded ? edits.deletedSlides : [...edits.deletedSlides, targetPath],
   }
@@ -405,6 +576,29 @@ function formatSignature(set: RunFormatOverrides): string {
 }
 
 /** Groups the edit set into the per-slide arrays `writeDeck` consumes. */
+/** Insert edits, grouped by slide, in insertion (z-) order. */
+export function insertsToSlideEdits(
+  inserted: readonly InsertedShape[],
+): Map<string, SlideEdit[]> {
+  const out = new Map<string, SlideEdit[]>()
+  for (const ins of inserted) {
+    const list = out.get(ins.slidePath) ?? []
+    list.push({ kind: 'insertShape', spec: ins.spec })
+    out.set(ins.slidePath, list)
+  }
+  return out
+}
+
+/** Merges two per-slide edit maps, keeping each slide's ordering. */
+export function mergeSlideEdits(
+  a: Map<string, SlideEdit[]>,
+  b: Map<string, SlideEdit[]>,
+): Map<string, SlideEdit[]> {
+  const out = new Map(a)
+  for (const [slide, edits] of b) out.set(slide, [...(out.get(slide) ?? []), ...edits])
+  return out
+}
+
 export function toSlideEdits(edits: EditSet): Map<string, SlideEdit[]> {
   const out = new Map<string, SlideEdit[]>()
   for (const edit of Object.values(edits)) {
@@ -431,6 +625,22 @@ export function toSlideEdits(edits: EditSet): Map<string, SlideEdit[]> {
         nodePath: edit.nodePath,
         offEmu: { x: edit.geometry.x, y: edit.geometry.y },
         extEmu: { w: edit.geometry.w, h: edit.geometry.h },
+      })
+    }
+    if (
+      (edit.fillHex !== undefined || edit.lineHex !== undefined) &&
+      edit.styleOriginal &&
+      edit.shapeType &&
+      edit.shapeId !== undefined
+    ) {
+      list.push({
+        kind: 'setShapeStyle',
+        nodePath: edit.nodePath,
+        shapeType: edit.shapeType,
+        shapeId: edit.shapeId,
+        original: edit.styleOriginal,
+        fillHex: edit.fillHex,
+        lineHex: edit.lineHex,
       })
     }
     if (edit.text && edit.original) {

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -121,6 +121,13 @@ export interface DeckEdits {
   shapes: EditSet
   deletedSlides: readonly string[]
   addedSlides: readonly AddedSlide[]
+  /**
+   * Explicit final slide order, as xml paths. Absent until the user reorders;
+   * when present it must be an exact permutation of the surviving base paths
+   * plus the added paths, and it fully governs both the render and the written
+   * `sldIdLst` (see `composeSlideOrder` for the composition rule).
+   */
+  slideOrder?: readonly string[]
 }
 
 export const EMPTY_DECK_EDITS: DeckEdits = {
@@ -133,7 +140,8 @@ export function hasEdits(edits: DeckEdits): boolean {
   return (
     Object.keys(edits.shapes).length > 0 ||
     edits.deletedSlides.length > 0 ||
-    edits.addedSlides.length > 0
+    edits.addedSlides.length > 0 ||
+    edits.slideOrder !== undefined
   )
 }
 
@@ -233,43 +241,100 @@ export function effectiveParagraphs(edit: ShapeEdit, base: readonly Paragraph[])
 }
 
 /**
- * The rendered slide order: base slides minus deletions, with added slides
- * inserted after their anchors ('' anchors at the front; an added slide can
- * itself anchor later additions).
+ * The rendered slide sequence. THE COMPOSITION RULE, in order:
+ *
+ *  1. base document order, minus `deletedSlides`;
+ *  2. each added slide inserted immediately after its `afterPath` anchor
+ *     ('' anchors at the front; an added slide may itself anchor later adds,
+ *     so chains resolve recursively);
+ *  3. if `slideOrder` is present it REPLACES 1–2 as the sequence — anchors
+ *     then only identify where a *new* add lands when the order is next
+ *     recomputed. Paths in the order that no longer exist are skipped, and
+ *     anything the order forgot is appended in 1–2 order, so a stale order can
+ *     never drop a slide from the editor.
+ *
+ * `writeDeck` applies the same rule to `sldIdLst`, so what you see is what is
+ * written.
  */
 function composeSlideOrder(deck: SlideDeck, edits: DeckEdits): Slide[] {
   const removed = new Set(edits.deletedSlides)
-  if (edits.addedSlides.length === 0) {
-    return removed.size === 0 ? [...deck.slides] : deck.slides.filter((s) => !removed.has(s.xmlPath))
-  }
-  const byAnchor = new Map<string, AddedSlide[]>()
-  for (const a of edits.addedSlides) {
-    const list = byAnchor.get(a.afterPath) ?? []
-    list.push(a)
-    byAnchor.set(a.afterPath, list)
-  }
-  const ordered: Slide[] = []
-  const visited = new Set<string>()
-  const emitAdds = (anchorPath: string): void => {
-    for (const a of byAnchor.get(anchorPath) ?? []) {
-      if (visited.has(a.path)) continue // defensive: an anchor cycle can't hang the render
-      visited.add(a.path)
-      ordered.push(a.slide)
-      emitAdds(a.path)
+  const anchored = (): Slide[] => {
+    if (edits.addedSlides.length === 0) {
+      return removed.size === 0
+        ? [...deck.slides]
+        : deck.slides.filter((s) => !removed.has(s.xmlPath))
     }
+    const byAnchor = new Map<string, AddedSlide[]>()
+    for (const a of edits.addedSlides) {
+      const list = byAnchor.get(a.afterPath) ?? []
+      list.push(a)
+      byAnchor.set(a.afterPath, list)
+    }
+    const ordered: Slide[] = []
+    const visited = new Set<string>()
+    const emitAdds = (anchorPath: string): void => {
+      for (const a of byAnchor.get(anchorPath) ?? []) {
+        if (visited.has(a.path)) continue // defensive: an anchor cycle can't hang the render
+        visited.add(a.path)
+        ordered.push(a.slide)
+        emitAdds(a.path)
+      }
+    }
+    emitAdds('')
+    for (const slide of deck.slides) {
+      if (removed.has(slide.xmlPath)) continue
+      ordered.push(slide)
+      emitAdds(slide.xmlPath)
+    }
+    // An add whose anchor vanished (never reachable from the UI) still renders,
+    // at the end, rather than silently disappearing from the editor.
+    for (const a of edits.addedSlides) {
+      if (!visited.has(a.path)) ordered.push(a.slide)
+    }
+    return ordered
   }
-  emitAdds('')
-  for (const slide of deck.slides) {
-    if (removed.has(slide.xmlPath)) continue
+
+  const natural = anchored()
+  if (!edits.slideOrder) return natural
+
+  const byPath = new Map(natural.map((s) => [s.xmlPath, s]))
+  const ordered: Slide[] = []
+  const placed = new Set<string>()
+  for (const p of edits.slideOrder) {
+    const slide = byPath.get(p)
+    if (!slide || placed.has(p)) continue
+    placed.add(p)
     ordered.push(slide)
-    emitAdds(slide.xmlPath)
   }
-  // An add whose anchor vanished (never reachable from the UI) still renders,
-  // at the end, rather than silently disappearing from the editor.
-  for (const a of edits.addedSlides) {
-    if (!visited.has(a.path)) ordered.push(a.slide)
+  for (const slide of natural) {
+    if (!placed.has(slide.xmlPath)) ordered.push(slide)
   }
   return ordered
+}
+
+/** The rendered slide paths, in the order `applyEditSet` will render them. */
+export function renderedSlidePaths(deck: SlideDeck, edits: DeckEdits): string[] {
+  return composeSlideOrder(deck, edits).map((s) => s.xmlPath)
+}
+
+/** Records an explicit final slide order (what a rail drag commits). */
+export function withSlideOrder(edits: DeckEdits, order: readonly string[]): DeckEdits {
+  return { ...edits, slideOrder: [...order] }
+}
+
+/**
+ * Adds a slide to the edit set. When an explicit order already exists the new
+ * path is spliced into it right after its anchor, so a reorder followed by an
+ * add keeps both intents.
+ */
+export function withSlideAdded(edits: DeckEdits, added: AddedSlide): DeckEdits {
+  const addedSlides = [...edits.addedSlides, added]
+  if (!edits.slideOrder) return { ...edits, addedSlides }
+  const order = [...edits.slideOrder]
+  const at = order.indexOf(added.afterPath)
+  if (at >= 0) order.splice(at + 1, 0, added.path)
+  else order.unshift(added.path)
+  return { ...edits, addedSlides, slideOrder: order }
 }
 
 /** The deck as the user currently sees it. `deck` itself is never mutated. */
@@ -322,11 +387,14 @@ export function withSlideRemoved(
   const addedSlides = edits.addedSlides
     .filter((a) => a.path !== targetPath)
     .map((a) => (a.afterPath === targetPath ? { ...a, afterPath: reanchorTo } : a))
-  return {
+  const next: DeckEdits = {
     shapes,
     addedSlides,
     deletedSlides: wasAdded ? edits.deletedSlides : [...edits.deletedSlides, targetPath],
   }
+  // An explicit order must stay an exact permutation of what survives.
+  if (edits.slideOrder) next.slideOrder = edits.slideOrder.filter((p) => p !== targetPath)
+  return next
 }
 
 // ------------------------------------------------------------- serialization

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -19,11 +19,12 @@
  *    have no meaning, so formatting is dropped and disabled for that shape.
  */
 
-import type {
-  EditedParagraph,
-  RunFormatOverrides,
-  RunRef,
-  SlideEdit,
+import {
+  isTextOnlyEdit,
+  type EditedParagraph,
+  type RunFormatOverrides,
+  type RunRef,
+  type SlideEdit,
 } from '@/lib/pptx/serialize'
 import type {
   NodePath,
@@ -90,28 +91,24 @@ export function hasEdits(edits: EditSet): boolean {
   return Object.keys(edits).length > 0
 }
 
-const isBrRun = (text: string): boolean => text === '\n'
-
 /**
  * True when `next` keeps the paragraph/run structure of `original`, so the
  * serializer can splice text in place and formatting edits stay addressable.
+ *
+ * This delegates to the serializer's own predicate rather than re-deriving it.
+ * A second implementation drifted from it: this one compared run counts and
+ * break positions only, while the serializer also compares alignment and run
+ * properties. A commit whose runs lost their provenance (paste, type-over)
+ * carries undefined props, so the serializer rebuilt the whole `<a:p>` range
+ * while the editor still recorded `formats` against original indices. The two
+ * splices overlap, `applySplices` fails closed — and because saves recompute
+ * from the same edit set, that file could never be saved again.
  */
 export function structureMatches(
   original: readonly Paragraph[],
-  next: readonly { runs: readonly { text: string }[] }[],
+  next: readonly EditedParagraph[],
 ): boolean {
-  if (original.length !== next.length) return false
-  for (let i = 0; i < original.length; i++) {
-    const o = original[i].runs
-    const n = next[i].runs
-    if (o.length !== n.length) return false
-    for (let j = 0; j < o.length; j++) {
-      if (isBrRun(o[j].text) !== isBrRun(n[j].text)) return false
-      // An embedded newline becomes new <a:br/> structure on write.
-      if (!isBrRun(n[j].text) && n[j].text.includes('\n')) return false
-    }
-  }
-  return true
+  return isTextOnlyEdit(original, next)
 }
 
 /** True when this shape can still take formatting/alignment edits. */
@@ -136,10 +133,13 @@ function applyOverrides(run: Record<string, unknown>, set: RunFormatOverrides): 
 /** The paragraphs to render: text replacement, then formatting on top. */
 export function effectiveParagraphs(edit: ShapeEdit, base: readonly Paragraph[]): Paragraph[] {
   const source = edit.text ?? base
-  const paras: Paragraph[] = source.map((p) => ({
-    align: p.align,
-    runs: p.runs.map((r) => ({ ...r })),
-  }))
+  // Spread the whole paragraph, the way the runs below already do: `srcPara`
+  // is what maps a rendered paragraph back to the original it came from.
+  // Rebuilding it as {align, runs} dropped that, so re-opening an edited box
+  // stamped positional provenance into the overlay and the NEXT commit reused
+  // a different paragraph's pPr/endParaRPr bytes — silently moving authored
+  // alignment, bullets and indent onto the wrong paragraph on save.
+  const paras: Paragraph[] = source.map((p) => ({ ...p, runs: p.runs.map((r) => ({ ...r })) }))
   if (edit.formats) {
     for (const [key, set] of Object.entries(edit.formats)) {
       const { para, run } = parseRunKey(key)

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -1,0 +1,285 @@
+/**
+ * The editor's in-memory edit set, and how it maps onto the C1 serializer.
+ *
+ * Saves are idempotent recomputations — original bytes + the whole accumulated
+ * edit set — so undo/redo is just a stack of these immutable snapshots and the
+ * rendered deck is always `applyEditSet(baseDeck, current)`.
+ *
+ * One structural constraint drives the shape of this module. The serializer
+ * writes a text change either as in-place `<a:t>` splices (when paragraph/run
+ * structure is unchanged) or by rebuilding the whole `<a:p>` range. A rebuild
+ * overlaps the regions that `formatRuns` and `paragraphAlign` splice, and the
+ * serializer fails closed on overlapping splices. So:
+ *
+ *  - text edits carry ORIGINAL run props and alignment, never the current
+ *    formatted ones, which keeps them on the in-place path;
+ *  - formatting lives only in `formats` / `aligns`, addressed by ORIGINAL
+ *    (paragraph, run) indices;
+ *  - once a shape's text structure diverges from the original those indices
+ *    have no meaning, so formatting is dropped and disabled for that shape.
+ */
+
+import type {
+  EditedParagraph,
+  RunFormatOverrides,
+  RunRef,
+  SlideEdit,
+} from '@/lib/pptx/serialize'
+import type {
+  NodePath,
+  Paragraph,
+  Shape,
+  SlideDeck,
+  TextAlign,
+  TextShape,
+} from '@/lib/pptx/types'
+
+export const EMU_PER_INCH = 914400
+export const CSS_PX_PER_INCH = 96
+/** One CSS pixel at 100% zoom. */
+export const EMU_PER_PX = EMU_PER_INCH / CSS_PX_PER_INCH
+export const EMU_PER_PT = 12700
+/** Grid step: 8 CSS px at 100% zoom. */
+export const GRID_EMU = 8 * EMU_PER_PX
+/** Smallest shape we will resize to (1/8 inch). */
+export const MIN_EXTENT_EMU = EMU_PER_INCH / 8
+
+export type ShapeKey = string
+
+export function shapeKeyOf(slidePath: string, nodePath: NodePath): ShapeKey {
+  return `${slidePath}#${nodePath.join('.')}`
+}
+
+export interface RectEmuBox {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/** `${originalParagraph}:${originalRun}` */
+export type RunKey = string
+
+export function runKeyOf(para: number, run: number): RunKey {
+  return `${para}:${run}`
+}
+
+function parseRunKey(key: RunKey): RunRef {
+  const [para, run] = key.split(':')
+  return { para: Number(para), run: Number(run) }
+}
+
+export interface ShapeEdit {
+  slidePath: string
+  nodePath: NodePath
+  /** As-parsed paragraphs. Present for text shapes; the serializer's anchor. */
+  original?: Paragraph[]
+  /** Replacement text. Run props/alignment mirror `original` by construction. */
+  text?: EditedParagraph[]
+  formats?: Record<RunKey, RunFormatOverrides>
+  /** Original paragraph index (as a string key) -> alignment. */
+  aligns?: Record<string, TextAlign>
+  geometry?: RectEmuBox
+}
+
+export type EditSet = Readonly<Record<ShapeKey, ShapeEdit>>
+
+export const EMPTY_EDIT_SET: EditSet = {}
+
+export function hasEdits(edits: EditSet): boolean {
+  return Object.keys(edits).length > 0
+}
+
+const isBrRun = (text: string): boolean => text === '\n'
+
+/**
+ * True when `next` keeps the paragraph/run structure of `original`, so the
+ * serializer can splice text in place and formatting edits stay addressable.
+ */
+export function structureMatches(
+  original: readonly Paragraph[],
+  next: readonly { runs: readonly { text: string }[] }[],
+): boolean {
+  if (original.length !== next.length) return false
+  for (let i = 0; i < original.length; i++) {
+    const o = original[i].runs
+    const n = next[i].runs
+    if (o.length !== n.length) return false
+    for (let j = 0; j < o.length; j++) {
+      if (isBrRun(o[j].text) !== isBrRun(n[j].text)) return false
+      // An embedded newline becomes new <a:br/> structure on write.
+      if (!isBrRun(n[j].text) && n[j].text.includes('\n')) return false
+    }
+  }
+  return true
+}
+
+/** True when this shape can still take formatting/alignment edits. */
+export function acceptsFormatting(edit: ShapeEdit | undefined): boolean {
+  if (!edit?.original) return true
+  if (!edit.text) return true
+  return structureMatches(edit.original, edit.text)
+}
+
+// ------------------------------------------------------------------ deriving
+
+function applyOverrides(run: Record<string, unknown>, set: RunFormatOverrides): void {
+  if (set.bold !== undefined) run.bold = set.bold || undefined
+  if (set.italic !== undefined) run.italic = set.italic || undefined
+  if (set.underline !== undefined) run.underline = set.underline || undefined
+  if (set.sizePt !== undefined) run.sizePt = set.sizePt
+  if (set.colorHex !== undefined) run.colorHex = set.colorHex
+}
+
+/** The paragraphs to render: text replacement, then formatting on top. */
+export function effectiveParagraphs(edit: ShapeEdit, base: readonly Paragraph[]): Paragraph[] {
+  const source = edit.text ?? base
+  const paras: Paragraph[] = source.map((p) => ({
+    align: p.align,
+    runs: p.runs.map((r) => ({ ...r })),
+  }))
+  if (edit.formats) {
+    for (const [key, set] of Object.entries(edit.formats)) {
+      const { para, run } = parseRunKey(key)
+      const target = paras[para]?.runs[run]
+      if (target) applyOverrides(target as unknown as Record<string, unknown>, set)
+    }
+  }
+  if (edit.aligns) {
+    for (const [key, align] of Object.entries(edit.aligns)) {
+      const target = paras[Number(key)]
+      if (target) target.align = align
+    }
+  }
+  return paras
+}
+
+/** The deck as the user currently sees it. `deck` itself is never mutated. */
+export function applyEditSet(deck: SlideDeck, edits: EditSet): SlideDeck {
+  if (!hasEdits(edits)) return deck
+  return {
+    ...deck,
+    slides: deck.slides.map((slide) => {
+      let touched = false
+      const shapes = slide.shapes.map((shape) => {
+        const edit = edits[shapeKeyOf(slide.xmlPath, shape.nodePath)]
+        if (!edit) return shape
+        touched = true
+        let next: Shape = shape
+        if (edit.geometry) next = { ...next, xfrmEmu: { ...edit.geometry } }
+        if (next.type === 'text' && (edit.text || edit.formats || edit.aligns)) {
+          next = {
+            ...next,
+            paragraphs: effectiveParagraphs(edit, (next as TextShape).paragraphs),
+          }
+        }
+        return next
+      })
+      return touched ? { ...slide, shapes } : slide
+    }),
+  }
+}
+
+// ------------------------------------------------------------- serialization
+
+function formatSignature(set: RunFormatOverrides): string {
+  return JSON.stringify([set.bold, set.italic, set.underline, set.sizePt, set.colorHex])
+}
+
+/** Groups the edit set into the per-slide arrays `writeDeck` consumes. */
+export function toSlideEdits(edits: EditSet): Map<string, SlideEdit[]> {
+  const out = new Map<string, SlideEdit[]>()
+  for (const edit of Object.values(edits)) {
+    let list = out.get(edit.slidePath)
+    if (!list) {
+      list = []
+      out.set(edit.slidePath, list)
+    }
+
+    if (edit.geometry) {
+      list.push({
+        kind: 'shapeGeometry',
+        nodePath: edit.nodePath,
+        offEmu: { x: edit.geometry.x, y: edit.geometry.y },
+        extEmu: { w: edit.geometry.w, h: edit.geometry.h },
+      })
+    }
+    if (edit.text && edit.original) {
+      list.push({
+        kind: 'text',
+        nodePath: edit.nodePath,
+        original: edit.original,
+        next: edit.text,
+      })
+    }
+    if (edit.formats && edit.original) {
+      // One formatRuns edit per distinct override set.
+      const grouped = new Map<string, { set: RunFormatOverrides; targets: RunRef[] }>()
+      for (const [key, set] of Object.entries(edit.formats)) {
+        const sig = formatSignature(set)
+        const group = grouped.get(sig) ?? { set, targets: [] }
+        group.targets.push(parseRunKey(key))
+        grouped.set(sig, group)
+      }
+      for (const group of grouped.values()) {
+        list.push({
+          kind: 'formatRuns',
+          nodePath: edit.nodePath,
+          original: edit.original,
+          targets: group.targets,
+          set: group.set,
+        })
+      }
+    }
+    if (edit.aligns && edit.original) {
+      for (const [key, align] of Object.entries(edit.aligns)) {
+        list.push({
+          kind: 'paragraphAlign',
+          nodePath: edit.nodePath,
+          original: edit.original,
+          paraIndex: Number(key),
+          align,
+        })
+      }
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------- mutation
+
+function isEmptyEdit(edit: ShapeEdit): boolean {
+  return (
+    !edit.text &&
+    !edit.geometry &&
+    (!edit.formats || Object.keys(edit.formats).length === 0) &&
+    (!edit.aligns || Object.keys(edit.aligns).length === 0)
+  )
+}
+
+/**
+ * Returns a new edit set with `mutate` applied to one shape's entry. Returning
+ * an entry that holds nothing removes it, so undoing back to a clean document
+ * yields a genuinely empty set.
+ */
+export function withShapeEdit(
+  edits: EditSet,
+  key: ShapeKey,
+  seed: Pick<ShapeEdit, 'slidePath' | 'nodePath' | 'original'>,
+  mutate: (draft: ShapeEdit) => void,
+): EditSet {
+  const existing = edits[key]
+  const draft: ShapeEdit = existing
+    ? {
+        ...existing,
+        formats: existing.formats ? { ...existing.formats } : undefined,
+        aligns: existing.aligns ? { ...existing.aligns } : undefined,
+      }
+    : { ...seed }
+  mutate(draft)
+
+  const next = { ...edits }
+  if (isEmptyEdit(draft)) delete next[key]
+  else next[key] = draft
+  return next
+}

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -124,9 +124,11 @@ export function acceptsFormatting(edit: ShapeEdit | undefined): boolean {
 // ------------------------------------------------------------------ deriving
 
 function applyOverrides(run: Record<string, unknown>, set: RunFormatOverrides): void {
-  if (set.bold !== undefined) run.bold = set.bold || undefined
-  if (set.italic !== undefined) run.italic = set.italic || undefined
-  if (set.underline !== undefined) run.underline = set.underline || undefined
+  // Explicit false is preserved: display resolution treats undefined as
+  // "inherit", so clearing bold on an inherited-bold run must stay `false`.
+  if (set.bold !== undefined) run.bold = set.bold
+  if (set.italic !== undefined) run.italic = set.italic
+  if (set.underline !== undefined) run.underline = set.underline
   if (set.sizePt !== undefined) run.sizePt = set.sizePt
   if (set.colorHex !== undefined) run.colorHex = set.colorHex
 }

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -21,6 +21,7 @@
 
 import {
   isTextOnlyEdit,
+  type DeleteShapeEdit,
   type EditedParagraph,
   type RunFormatOverrides,
   type RunRef,
@@ -70,6 +71,12 @@ function parseRunKey(key: RunKey): RunRef {
   return { para: Number(para), run: Number(run) }
 }
 
+/** Marks a shape deleted; carries what the serializer revalidates first. */
+export interface ShapeDeletion {
+  shapeType: DeleteShapeEdit['shapeType']
+  shapeId: string
+}
+
 export interface ShapeEdit {
   slidePath: string
   nodePath: NodePath
@@ -81,14 +88,32 @@ export interface ShapeEdit {
   /** Original paragraph index (as a string key) -> alignment. */
   aligns?: Record<string, TextAlign>
   geometry?: RectEmuBox
+  /**
+   * Set when the shape is deleted. Supersedes every other field: their splices
+   * would land inside the removed range, and the serializer fails closed on
+   * overlap — so marking deleted must also clear them.
+   */
+  deleted?: ShapeDeletion
 }
 
 export type EditSet = Readonly<Record<ShapeKey, ShapeEdit>>
 
 export const EMPTY_EDIT_SET: EditSet = {}
 
-export function hasEdits(edits: EditSet): boolean {
-  return Object.keys(edits).length > 0
+/**
+ * Everything the editor has changed, and the unit the history stack snapshots:
+ * per-shape edits plus slides removed from the deck (by xml path — positions
+ * shift as slides are deleted, paths never do).
+ */
+export interface DeckEdits {
+  shapes: EditSet
+  deletedSlides: readonly string[]
+}
+
+export const EMPTY_DECK_EDITS: DeckEdits = { shapes: EMPTY_EDIT_SET, deletedSlides: [] }
+
+export function hasEdits(edits: DeckEdits): boolean {
+  return Object.keys(edits.shapes).length > 0 || edits.deletedSlides.length > 0
 }
 
 /**
@@ -187,28 +212,36 @@ export function effectiveParagraphs(edit: ShapeEdit, base: readonly Paragraph[])
 }
 
 /** The deck as the user currently sees it. `deck` itself is never mutated. */
-export function applyEditSet(deck: SlideDeck, edits: EditSet): SlideDeck {
+export function applyEditSet(deck: SlideDeck, edits: DeckEdits): SlideDeck {
   if (!hasEdits(edits)) return deck
+  const removedSlides = new Set(edits.deletedSlides)
   return {
     ...deck,
-    slides: deck.slides.map((slide) => {
-      let touched = false
-      const shapes = slide.shapes.map((shape) => {
-        const edit = edits[shapeKeyOf(slide.xmlPath, shape.nodePath)]
-        if (!edit) return shape
-        touched = true
-        let next: Shape = shape
-        if (edit.geometry) next = { ...next, xfrmEmu: { ...edit.geometry } }
-        if (next.type === 'text' && (edit.text || edit.formats || edit.aligns)) {
-          next = {
-            ...next,
-            paragraphs: effectiveParagraphs(edit, (next as TextShape).paragraphs),
+    slides: deck.slides
+      .filter((slide) => !removedSlides.has(slide.xmlPath))
+      .map((slide) => {
+        let touched = false
+        const shapes: Shape[] = []
+        for (const shape of slide.shapes) {
+          const edit = edits.shapes[shapeKeyOf(slide.xmlPath, shape.nodePath)]
+          if (!edit) {
+            shapes.push(shape)
+            continue
           }
+          touched = true
+          if (edit.deleted) continue
+          let next: Shape = shape
+          if (edit.geometry) next = { ...next, xfrmEmu: { ...edit.geometry } }
+          if (next.type === 'text' && (edit.text || edit.formats || edit.aligns)) {
+            next = {
+              ...next,
+              paragraphs: effectiveParagraphs(edit, (next as TextShape).paragraphs),
+            }
+          }
+          shapes.push(next)
         }
-        return next
-      })
-      return touched ? { ...slide, shapes } : slide
-    }),
+        return touched ? { ...slide, shapes } : slide
+      }),
   }
 }
 
@@ -228,6 +261,17 @@ export function toSlideEdits(edits: EditSet): Map<string, SlideEdit[]> {
       out.set(edit.slidePath, list)
     }
 
+    if (edit.deleted) {
+      // Deletion supersedes every other field (withShapeEdit cleared them).
+      list.push({
+        kind: 'deleteShape',
+        nodePath: edit.nodePath,
+        shapeType: edit.deleted.shapeType,
+        shapeId: edit.deleted.shapeId,
+        original: edit.original,
+      })
+      continue
+    }
     if (edit.geometry) {
       list.push({
         kind: 'shapeGeometry',
@@ -284,6 +328,7 @@ function isEmptyEdit(edit: ShapeEdit): boolean {
   return (
     !edit.text &&
     !edit.geometry &&
+    !edit.deleted &&
     (!edit.formats || Object.keys(edit.formats).length === 0) &&
     (!edit.aligns || Object.keys(edit.aligns).length === 0)
   )

--- a/apps/x/apps/renderer/src/components/pptx/edit-model.ts
+++ b/apps/x/apps/renderer/src/components/pptx/edit-model.ts
@@ -212,6 +212,7 @@ function applyOverrides(run: Record<string, unknown>, set: RunFormatOverrides): 
   if (set.underline !== undefined) run.underline = set.underline
   if (set.sizePt !== undefined) run.sizePt = set.sizePt
   if (set.colorHex !== undefined) run.colorHex = set.colorHex
+  if (set.latinFont !== undefined) run.latinFont = set.latinFont
 }
 
 /** The paragraphs to render: text replacement, then formatting on top. */

--- a/apps/x/apps/renderer/src/components/pptx/presentation.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/presentation.tsx
@@ -1,0 +1,199 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronLeftIcon, ChevronRightIcon, XIcon } from 'lucide-react'
+import type { Slide } from '@/lib/pptx/types'
+import { SlideThumbnail } from './canvas'
+
+/** How long the control bar lingers after the pointer stops moving. */
+const CONTROLS_HIDE_MS = 2000
+
+function ControlButton({
+  label,
+  onClick,
+  disabled,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      // Keep focus on the overlay so the arrow keys keep working.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="inline-flex size-7 items-center justify-center rounded-full text-neutral-200 transition-colors hover:bg-white/15 disabled:pointer-events-none disabled:opacity-30"
+    >
+      {children}
+    </button>
+  )
+}
+
+interface PresentationOverlayProps {
+  slides: Slide[]
+  sizeEmu: { w: number; h: number }
+  /** Slide to open on — whichever one the editor had selected. */
+  startIndex: number
+  onExit: () => void
+}
+
+/**
+ * Full-screen slideshow. Renders through the same inert `SlideThumbnail`
+ * pipeline the canvas and the rail use, so what you present is exactly what the
+ * editor draws — just scaled to the viewport, with no editing chrome.
+ *
+ * Portaled to `document.body` so it escapes the editor's stacking context, and
+ * it stops its own pointer/key events from reaching the editor underneath.
+ */
+export function PresentationOverlay({
+  slides,
+  sizeEmu,
+  startIndex,
+  onExit,
+}: PresentationOverlayProps) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const last = slides.length - 1
+  const [index, setIndex] = useState(() => Math.min(Math.max(startIndex, 0), Math.max(last, 0)))
+  const [box, setBox] = useState({ w: 0, h: 0 })
+  const [controlsOn, setControlsOn] = useState(true)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Held in a ref so the fullscreen effect can stay mount-only.
+  const onExitRef = useRef(onExit)
+  useEffect(() => {
+    onExitRef.current = onExit
+  }, [onExit])
+
+  const go = useCallback((to: number) => setIndex(Math.min(last, Math.max(0, to))), [last])
+  // Clamped, not wrapped: the deck stops at both ends.
+  const step = useCallback(
+    (delta: number) => setIndex((i) => Math.min(last, Math.max(0, i + delta))),
+    [last],
+  )
+
+  // Focus for keyboard control, measure for fit, and hand focus back on exit.
+  useLayoutEffect(() => {
+    const el = rootRef.current
+    if (!el) return
+    const previous = document.activeElement as HTMLElement | null
+    el.focus({ preventScroll: true })
+    const measure = () => setBox({ w: el.clientWidth, h: el.clientHeight })
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => {
+      observer.disconnect()
+      previous?.focus?.({ preventScroll: true })
+    }
+  }, [])
+
+  // Real fullscreen when the platform allows it; the fixed overlay is already a
+  // complete fallback, so a rejection is not an error.
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el) return
+    let entered = false
+    void Promise.resolve(el.requestFullscreen?.())
+      .then(() => {
+        entered = document.fullscreenElement === el
+      })
+      .catch(() => {})
+    // Esc inside real fullscreen is eaten by the browser, so leaving fullscreen
+    // is what ends the presentation.
+    const onFullscreenChange = () => {
+      if (entered && document.fullscreenElement === null) onExitRef.current()
+    }
+    document.addEventListener('fullscreenchange', onFullscreenChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', onFullscreenChange)
+      if (entered && document.fullscreenElement !== null) {
+        void document.exitFullscreen().catch(() => {})
+      }
+    }
+  }, [])
+
+  const bumpControls = useCallback(() => {
+    setControlsOn(true)
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    hideTimerRef.current = setTimeout(() => setControlsOn(false), CONTROLS_HIDE_MS)
+  }, [])
+
+  // The bar starts visible and fades on its own; a mouse move brings it back.
+  useEffect(() => {
+    hideTimerRef.current = setTimeout(() => setControlsOn(false), CONTROLS_HIDE_MS)
+    return () => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    }
+  }, [])
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    // Nothing reaches the editor's shortcuts while presenting.
+    e.stopPropagation()
+    let handled = true
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === ' ') step(1)
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') step(-1)
+    else if (e.key === 'Home') go(0)
+    else if (e.key === 'End') go(last)
+    else if (e.key === 'Escape') onExit()
+    else handled = false
+    if (handled) e.preventDefault()
+  }
+
+  // Fit the deck's page into the viewport, preserving its aspect ratio.
+  const scale =
+    box.w > 0 && box.h > 0 ? Math.min(box.w / sizeEmu.w, box.h / sizeEmu.h) : 0
+  const current = slides[index]
+
+  return createPortal(
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Presentation, slide ${index + 1} of ${slides.length}`}
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      onMouseMove={bumpControls}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={() => step(1)}
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black outline-none"
+    >
+      {current && scale > 0 && (
+        <SlideThumbnail slide={current} sizeEmu={sizeEmu} widthPx={sizeEmu.w * scale} />
+      )}
+
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className={`absolute bottom-6 left-1/2 flex -translate-x-1/2 items-center gap-0.5 rounded-full border border-white/10 bg-neutral-900/80 px-1.5 py-1 shadow-lg backdrop-blur transition-opacity duration-300 ${
+          controlsOn ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+      >
+        <ControlButton label="Previous slide" onClick={() => step(-1)} disabled={index === 0}>
+          <ChevronLeftIcon className="size-4" />
+        </ControlButton>
+        <span className="px-1.5 text-xs tabular-nums text-neutral-300">
+          {index + 1} of {slides.length}
+        </span>
+        <ControlButton label="Next slide" onClick={() => step(1)} disabled={index === last}>
+          <ChevronRightIcon className="size-4" />
+        </ControlButton>
+        <span className="mx-1 h-4 w-px bg-white/15" aria-hidden="true" />
+        <ControlButton label="Exit presentation" onClick={onExit}>
+          <XIcon className="size-4" />
+        </ControlButton>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/apps/x/apps/renderer/src/components/pptx/save-pipeline.test.ts
+++ b/apps/x/apps/renderer/src/components/pptx/save-pipeline.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSavePipeline } from './save-pipeline'
+
+const DEBOUNCE = 100
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => (resolve = r))
+  return { promise, resolve }
+}
+
+/**
+ * A pipeline over a mutable "document": `edit()` changes the state and
+ * schedules, `gate` (when set) blocks the disk write mid-flight, `started` and
+ * `writes` record what reached the writer and what completed.
+ */
+function harness() {
+  let state = ''
+  const started: string[] = []
+  const writes: string[] = []
+  const statuses: string[] = []
+  const errors: unknown[] = []
+  const gate: { current: Promise<void> | null } = { current: null }
+  const failNext: { current: boolean } = { current: false }
+  const pipeline = createSavePipeline({
+    debounceMs: DEBOUNCE,
+    hasEdits: () => state !== '',
+    serialize: async () => state,
+    write: async (data) => {
+      started.push(data)
+      if (gate.current) await gate.current
+      if (failNext.current) {
+        failNext.current = false
+        throw new Error('disk unavailable')
+      }
+      writes.push(data)
+    },
+    onStatus: (s) => statuses.push(s),
+    onError: (err) => errors.push(err),
+  })
+  const edit = (next: string): void => {
+    state = next
+    pipeline.scheduleSave()
+  }
+  return { pipeline, edit, started, writes, statuses, errors, gate, failNext }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('save pipeline generations', () => {
+  it('AUDIT RACE: an edit during an in-flight save survives closing inside the debounce window', async () => {
+    const h = harness()
+    const block = deferred()
+    h.gate.current = block.promise
+
+    // Edit A; the debounce fires and save A starts, its write held in flight.
+    h.edit('A')
+    await vi.advanceTimersByTimeAsync(DEBOUNCE)
+    expect(h.started).toEqual(['A'])
+    expect(h.writes).toEqual([])
+
+    // Edit B lands while A's write is still on the wire.
+    h.edit('B')
+
+    // Save A completes. With a boolean dirty flag this is where B's dirtiness
+    // was wiped: A's completion cleared the flag B had set.
+    h.gate.current = null
+    block.resolve()
+
+    // The file is closed BEFORE B's debounce fires. The flush must still
+    // resolve only after B is on disk.
+    await h.pipeline.flush()
+    expect(h.writes).toEqual(['A', 'B'])
+    expect(h.statuses[h.statuses.length - 1]).toBe('saved')
+  })
+
+  it('an edit after a fully completed save is flushed when closed inside the debounce window', async () => {
+    const h = harness()
+    h.edit('A')
+    await vi.advanceTimersByTimeAsync(DEBOUNCE)
+    expect(h.writes).toEqual(['A'])
+
+    h.edit('B') // debounce armed, never fires
+    await h.pipeline.flush()
+    expect(h.writes).toEqual(['A', 'B'])
+  })
+
+  it('rapid edit/save/edit/close interleavings never lose the last edit', async () => {
+    // Vary how much of the second debounce elapses before the close, with a
+    // save of an older generation in flight the whole time.
+    for (const elapsed of [0, DEBOUNCE / 2, DEBOUNCE, DEBOUNCE * 1.5]) {
+      const h = harness()
+      const block = deferred()
+      h.gate.current = block.promise
+
+      h.edit('1')
+      await vi.advanceTimersByTimeAsync(DEBOUNCE) // save '1' starts, blocked
+      h.edit('2')
+      await vi.advanceTimersByTimeAsync(elapsed)
+      h.edit('3')
+      h.gate.current = null
+      block.resolve()
+
+      await h.pipeline.flush()
+      expect(h.writes[h.writes.length - 1], `elapsed=${elapsed}`).toBe('3')
+      expect(h.statuses[h.statuses.length - 1]).toBe('saved')
+    }
+  })
+
+  it('skips the disk write when the serialized state is unchanged', async () => {
+    const h = harness()
+    h.edit('A')
+    await vi.advanceTimersByTimeAsync(DEBOUNCE)
+    expect(h.writes).toEqual(['A'])
+
+    // An overlay-only change that serializes identically: dirty, but deduped.
+    h.pipeline.markEdited()
+    await h.pipeline.flush()
+    expect(h.writes).toEqual(['A'])
+    expect(h.statuses[h.statuses.length - 1]).toBe('saved')
+  })
+
+  it('a pristine document flushes to nothing and reports clean', async () => {
+    const h = harness()
+    await h.pipeline.persist()
+    await h.pipeline.flush()
+    expect(h.started).toEqual([])
+    expect(h.statuses).toEqual(['clean'])
+  })
+
+  it('a failed write stays dirty and the flush retries it', async () => {
+    const h = harness()
+    h.failNext.current = true
+    h.edit('A')
+    await vi.advanceTimersByTimeAsync(DEBOUNCE)
+    expect(h.writes).toEqual([])
+    expect(h.errors).toHaveLength(1)
+    expect(h.statuses[h.statuses.length - 1]).toBe('error')
+
+    await h.pipeline.flush()
+    expect(h.writes).toEqual(['A'])
+    expect(h.statuses[h.statuses.length - 1]).toBe('saved')
+  })
+})

--- a/apps/x/apps/renderer/src/components/pptx/save-pipeline.ts
+++ b/apps/x/apps/renderer/src/components/pptx/save-pipeline.ts
@@ -1,0 +1,111 @@
+/**
+ * The editor's debounced autosave, extracted from the component so the
+ * edit → save → edit → close interleavings are testable.
+ *
+ * Dirty tracking is GENERATION-based. Every edit bumps `editGen`; a save
+ * records the generation it serialized and marks it covered on completion.
+ * "Dirty" is derived (`editGen !== savedGen`), so a completing save can never
+ * clear dirtiness for an edit that arrived after it began — the race a boolean
+ * flag had: save A completes, clears the flag B had set, the file is closed
+ * inside the debounce window, and the unmount flush skips. B was never
+ * written anywhere while the UI said "Saved".
+ */
+
+import type { SaveStatus } from './toolbar'
+
+export interface SavePipelineOptions {
+  debounceMs: number
+  /** True when the current edit state differs from the original document. */
+  hasEdits: () => boolean
+  /** Serializes the CURRENT edit state to its canonical written form. */
+  serialize: () => Promise<string>
+  /** Writes one serialized state to disk. */
+  write: (data: string) => Promise<void>
+  onStatus: (status: SaveStatus) => void
+  onError: (err: unknown) => void
+}
+
+export interface SavePipeline {
+  /** Records an edit that must eventually reach disk, without scheduling. */
+  markEdited(): void
+  /** Records an edit and (re)arms the debounced save. */
+  scheduleSave(): void
+  /** Saves now. Deduped: during a save this returns the in-flight promise. */
+  persist(): Promise<void>
+  /**
+   * Unmount / path change: cancels the debounce and resolves only once every
+   * edit made before this call is covered — awaiting an in-flight save first.
+   */
+  flush(): Promise<void>
+}
+
+export function createSavePipeline(opts: SavePipelineOptions): SavePipeline {
+  let editGen = 0
+  let savedGen = 0
+  let lastWritten: string | null = null
+  let inFlight: Promise<void> | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const clearTimer = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  async function run(): Promise<void> {
+    try {
+      // Loop until the newest generation is covered: an edit landing while a
+      // write is in flight is picked up immediately, never left to a debounce
+      // timer that an unmount would clear. This is also what lets flush()
+      // simply await the in-flight save — it cannot resolve while behind.
+      for (;;) {
+        const gen = editGen
+        if (gen === savedGen) break
+        // Nothing to write only while nothing was ever written: undoing back
+        // to a clean document after a save must restore the original bytes.
+        if (opts.hasEdits() || lastWritten !== null) {
+          const data = await opts.serialize()
+          if (data !== lastWritten) {
+            await opts.write(data)
+            lastWritten = data
+          }
+        }
+        savedGen = gen
+      }
+      opts.onStatus(lastWritten === null ? 'clean' : 'saved')
+    } catch (err) {
+      // savedGen stays behind, so the next edit, persist() or flush() retries.
+      opts.onError(err)
+      opts.onStatus('error')
+    }
+  }
+
+  const persist = (): Promise<void> => {
+    if (inFlight === null) {
+      inFlight = run().finally(() => {
+        inFlight = null
+      })
+    }
+    return inFlight
+  }
+
+  return {
+    markEdited() {
+      editGen += 1
+    },
+    scheduleSave() {
+      editGen += 1
+      opts.onStatus('saving')
+      clearTimer()
+      timer = setTimeout(() => {
+        void persist()
+      }, opts.debounceMs)
+    },
+    persist,
+    async flush() {
+      clearTimer()
+      if (inFlight !== null || editGen !== savedGen) await persist()
+    },
+  }
+}

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -24,7 +24,7 @@ import {
   type TextRun,
   type TextShape,
 } from '@/lib/pptx/types'
-import { autoNumText } from '@/lib/pptx/textstyle'
+import { autoNumText, cssFontFamily } from '@/lib/pptx/textstyle'
 import { EMU_PER_PT } from './edit-model'
 
 export const DEFAULT_TEXT_PT = 18
@@ -50,9 +50,15 @@ export function displayRunStyle(
     underline: run.underline ?? dr?.underline ?? false,
     colorHex: run.colorHex ?? dr?.colorHex ?? '000000',
   }
-  // The model carries neither typeface nor tracking; the resolved cascade is
-  // the only source for both.
-  if (dr?.fontFamily) style.fontFamily = dr.fontFamily
+  // A run's own typeface wins over the cascade — that is how a font edit shows
+  // up on canvas, in thumbnails and in the overlay. Theme tokens (`+mn-lt`)
+  // are NOT literal families, so those keep the cascade's already-resolved
+  // value rather than being handed to CSS verbatim.
+  const own = run.latinFont && !run.latinFont.startsWith('+') ? run.latinFont : undefined
+  const family = own ? cssFontFamily(own, undefined, undefined) : dr?.fontFamily
+  if (family) style.fontFamily = family
+  if (own) style.latinFont = own
+  else if (dr?.latinFont) style.latinFont = dr.latinFont
   if (dr?.letterSpacingPt !== undefined) style.letterSpacingPt = dr.letterSpacingPt
   return style
 }
@@ -149,7 +155,8 @@ function runCss(style: ResolvedRunStyle, scale: number, fontScale: number): stri
 function runDataAttrs(run: TextRun): string {
   return (
     ` data-b="${run.bold ? 1 : 0}" data-i="${run.italic ? 1 : 0}" data-u="${run.underline ? 1 : 0}"` +
-    ` data-pt="${run.sizePt ?? ''}" data-c="${run.colorHex ?? ''}"`
+    ` data-pt="${run.sizePt ?? ''}" data-c="${run.colorHex ?? ''}"` +
+    ` data-ff="${escapeHtml(run.latinFont ?? '')}"`
   )
 }
 
@@ -311,6 +318,11 @@ function propsOfSpan(el: HTMLElement, scale: number): Omit<TextRun, 'text'> {
     // Plain black is the render default, not an authored color.
     if (hex && hex !== '000000') out.colorHex = hex
   }
+
+  // Only our own attribute is authoritative: a pasted span's inline
+  // font-family is a resolved CSS stack, not an authored OOXML typeface.
+  const dataFf = el.getAttribute('data-ff')
+  if (dataFf) out.latinFont = dataFf
 
   return out
 }
@@ -661,6 +673,10 @@ export function applyFormatToSpans(
       el.setAttribute('data-c', set.colorHex)
       el.style.color = `#${set.colorHex}`
     }
+    if (set.latinFont !== undefined) {
+      el.setAttribute('data-ff', set.latinFont)
+      el.style.fontFamily = cssFontFamily(set.latinFont, undefined, undefined) ?? ''
+    }
   }
 }
 
@@ -680,14 +696,17 @@ function aggregate(
   let underline = Boolean(items[0].underline)
   let sizePt: number | undefined = items[0].sizePt ?? DEFAULT_TEXT_PT
   let colorHex: string | undefined = items[0].colorHex ?? '000000'
+  // '' stands for "inherits", so runs that all inherit still agree.
+  let latinFont: string | undefined = items[0].latinFont ?? ''
   for (const p of items.slice(1)) {
     bold = bold && Boolean(p.bold)
     italic = italic && Boolean(p.italic)
     underline = underline && Boolean(p.underline)
     if ((p.sizePt ?? DEFAULT_TEXT_PT) !== sizePt) sizePt = undefined
     if ((p.colorHex ?? '000000') !== colorHex) colorHex = undefined
+    if ((p.latinFont ?? '') !== latinFont) latinFont = undefined
   }
-  return { bold, italic, underline, sizePt, colorHex }
+  return { bold, italic, underline, sizePt, colorHex, latinFont }
 }
 
 /** Aggregate formatting of a set of spans, for reflecting toolbar state. */
@@ -701,4 +720,88 @@ export function aggregateFormat(
 /** Aggregate formatting of model runs, for when nothing is being edited. */
 export function aggregateFormatOfParagraphs(paras: readonly Paragraph[]): RunFormatOverrides {
   return aggregate(paras.flatMap((p) => p.runs).filter((r) => r.text !== '\n'))
+}
+
+// ------------------------------------------------------------------- fonts
+
+/** First family out of a CSS font-family stack — one we generated ourselves. */
+function primaryFamily(css: string): string | undefined {
+  const quoted = css.match(/^\s*'([^']+)'/) ?? css.match(/^\s*"([^"]+)"/)
+  if (quoted) return quoted[1]
+  const first = css.split(',')[0]?.trim()
+  return first || undefined
+}
+
+/** The typeface a span renders with: its own when authored, else inherited. */
+function fontOfSpan(el: HTMLElement): string | undefined {
+  const own = el.getAttribute('data-ff')
+  if (own) return own
+  return primaryFamily(el.style.fontFamily)
+}
+
+/** The selection's typeface, or undefined when the spans disagree ("Mixed"). */
+export function aggregateFontOfSpans(spans: readonly HTMLElement[]): string | undefined {
+  if (spans.length === 0) return undefined
+  const first = fontOfSpan(spans[0])
+  return spans.every((s) => fontOfSpan(s) === first) ? first : undefined
+}
+
+/** The shape's typeface as RENDERED (cascade included), or undefined if mixed. */
+export function aggregateFontOfShape(shape: TextShape): string | undefined {
+  const fonts: Array<string | undefined> = []
+  shape.paragraphs.forEach((para, pi) =>
+    para.runs.forEach((run, ri) => {
+      if (run.text === '\n') return
+      fonts.push(displayRunStyle(shape, pi, ri, run).latinFont)
+    }),
+  )
+  if (fonts.length === 0) return shape.display?.defaultRun.latinFont
+  const first = fonts[0]
+  return fonts.every((f) => f === first) ? first : undefined
+}
+
+/**
+ * Whether a family actually resolves on this machine.
+ *
+ * `document.fonts.check()` is not usable here: Chromium answers true for
+ * families it has never heard of, because it reports on the fallback it would
+ * use. So measure instead — a probe string laid out in `family, <generic>` has
+ * a different width from the generic alone exactly when the family resolved.
+ */
+const fontAvailability = new Map<string, boolean>()
+
+export function isFontAvailable(family: string): boolean {
+  const cached = fontAvailability.get(family)
+  if (cached !== undefined) return cached
+
+  const ctx = document.createElement('canvas').getContext('2d')
+  // No measuring surface (jsdom): claim availability rather than warn wrongly.
+  if (!ctx) return true
+
+  const probe = 'mmmmmmmmmmlliWWWWWW@'
+  const available = (['monospace', 'serif', 'sans-serif'] as const).some((generic) => {
+    ctx.font = `72px ${generic}`
+    const base = ctx.measureText(probe).width
+    ctx.font = `72px '${family.replace(/'/g, '')}', ${generic}`
+    return ctx.measureText(probe).width !== base
+  })
+  fontAvailability.set(family, available)
+  return available
+}
+
+/** Every typeface the deck actually renders with, for the picker's first group. */
+export function typefacesInShapes(shapes: readonly TextShape[]): string[] {
+  const seen = new Set<string>()
+  for (const shape of shapes) {
+    const fallback = shape.display?.defaultRun.latinFont
+    if (fallback) seen.add(fallback)
+    shape.paragraphs.forEach((para, pi) =>
+      para.runs.forEach((run, ri) => {
+        if (run.text === '\n') return
+        const font = displayRunStyle(shape, pi, ri, run).latinFont
+        if (font) seen.add(font)
+      }),
+    )
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b))
 }

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -13,10 +13,50 @@
  */
 
 import type { EditedParagraph, EditedTextRun, RunFormatOverrides } from '@/lib/pptx/serialize'
-import type { Paragraph, TextAlign, TextRun, TextShape } from '@/lib/pptx/types'
+import type {
+  Paragraph,
+  ResolvedRunStyle,
+  TextAlign,
+  TextRun,
+  TextShape,
+} from '@/lib/pptx/types'
 import { EMU_PER_PT } from './edit-model'
 
 export const DEFAULT_TEXT_PT = 18
+
+/**
+ * The style a run renders with: explicit rPr props first, then the resolved
+ * inheritance cascade (looked up by ORIGINAL indices via the run's provenance,
+ * so styling survives text edits), then hard defaults.
+ */
+export function displayRunStyle(
+  shape: TextShape,
+  paraIndex: number,
+  runIndex: number,
+  run: TextRun,
+): ResolvedRunStyle {
+  const er = run as EditedTextRun
+  const dp = shape.display?.paragraphs[er.srcPara ?? paraIndex]
+  const dr = dp?.runs[er.srcRun ?? runIndex] ?? dp?.defaultRun ?? shape.display?.defaultRun
+  return {
+    sizePt: run.sizePt ?? dr?.sizePt ?? DEFAULT_TEXT_PT,
+    bold: run.bold ?? dr?.bold ?? false,
+    italic: run.italic ?? dr?.italic ?? false,
+    underline: run.underline ?? dr?.underline ?? false,
+    colorHex: run.colorHex ?? dr?.colorHex ?? '000000',
+  }
+}
+
+/** Resolved paragraph alignment: the paragraph's own, else the cascade's. */
+export function displayAlign(
+  shape: TextShape,
+  paraIndex: number,
+  para: Paragraph,
+): TextAlign | undefined {
+  if (para.align) return para.align
+  const ep = para as EditedParagraph
+  return shape.display?.paragraphs[ep.srcPara ?? paraIndex]?.align
+}
 
 export interface TextOverlayHandle {
   root: HTMLDivElement
@@ -36,17 +76,13 @@ function escapeHtml(s: string): string {
     .replace(/"/g, '&quot;')
 }
 
-function runFontPx(run: Pick<TextRun, 'sizePt'>, scale: number): number {
-  return (run.sizePt ?? DEFAULT_TEXT_PT) * EMU_PER_PT * scale
-}
-
-function runCss(run: TextRun, scale: number): string {
+function runCss(style: ResolvedRunStyle, scale: number): string {
   return (
-    `font-weight:${run.bold ? 700 : 400};` +
-    `font-style:${run.italic ? 'italic' : 'normal'};` +
-    `text-decoration:${run.underline ? 'underline' : 'none'};` +
-    `font-size:${runFontPx(run, scale)}px;` +
-    `color:#${run.colorHex ?? '000000'};` +
+    `font-weight:${style.bold ? 700 : 400};` +
+    `font-style:${style.italic ? 'italic' : 'normal'};` +
+    `text-decoration:${style.underline ? 'underline' : 'none'};` +
+    `font-size:${style.sizePt * EMU_PER_PT * scale}px;` +
+    `color:#${style.colorHex};` +
     `line-height:1.2`
   )
 }
@@ -74,15 +110,18 @@ export function buildEditableHtml(shape: TextShape, scale: number): string {
           const srcRun = er.srcRun ?? ri
           const prov = ` data-op="${srcPara}" data-or="${srcRun}"`
           if (run.text === '\n') return `<br data-cp="${pi}" data-cr="${ri}"${prov}>`
+          // Visual CSS is the RESOLVED style; the data attributes stay raw so
+          // extraction never bakes inherited values into write-back edits.
           return (
             `<span data-cp="${pi}" data-cr="${ri}"${prov}${runDataAttrs(run)}` +
-            ` style="${runCss(run, scale)}">${escapeHtml(run.text)}</span>`
+            ` style="${runCss(displayRunStyle(shape, pi, ri, run), scale)}">${escapeHtml(run.text)}</span>`
           )
         })
         .join('')
+      const align = displayAlign(shape, pi, para)
       return (
         `<div data-cp="${pi}" data-op="${paraSrc}" data-algn="${para.align ?? ''}"` +
-        ` style="margin:0;text-align:${alignToCss(para.align)}">${inner || '<br>'}</div>`
+        ` style="margin:0;text-align:${alignToCss(align)}">${inner || '<br>'}</div>`
       )
     })
     .join('')

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -18,6 +18,7 @@ import type {
   ParagraphDisplay,
   ResolvedRunStyle,
   TextAlign,
+  TextAnchor,
   TextRun,
   TextShape,
 } from '@/lib/pptx/types'
@@ -68,6 +69,19 @@ export interface TextOverlayHandle {
 
 export function alignToCss(align: string | undefined): 'left' | 'center' | 'right' | 'justify' {
   return align === 'ctr' ? 'center' : align === 'r' ? 'right' : align === 'just' ? 'justify' : 'left'
+}
+
+/**
+ * `a:bodyPr@anchor` → flex packing. Defaults to top, the OOXML default.
+ * Shared by the shape renderer and the edit overlay so the text does not jump
+ * when the editor opens.
+ */
+export function anchorJustify(
+  anchor: TextAnchor | undefined,
+): 'flex-start' | 'center' | 'flex-end' {
+  if (anchor === 'ctr') return 'center'
+  if (anchor === 'b') return 'flex-end'
+  return 'flex-start'
 }
 
 function escapeHtml(s: string): string {

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -13,14 +13,16 @@
  */
 
 import type { EditedParagraph, EditedTextRun, RunFormatOverrides } from '@/lib/pptx/serialize'
-import type {
-  Paragraph,
-  ParagraphDisplay,
-  ResolvedRunStyle,
-  TextAlign,
-  TextAnchor,
-  TextRun,
-  TextShape,
+import {
+  DEFAULT_LINE_HEIGHT,
+  type Paragraph,
+  type ParagraphDisplay,
+  type ResolvedRunStyle,
+  type TextAlign,
+  type TextAnchor,
+  type TextAutofit,
+  type TextRun,
+  type TextShape,
 } from '@/lib/pptx/types'
 import { autoNumText } from '@/lib/pptx/textstyle'
 import { EMU_PER_PT } from './edit-model'
@@ -41,12 +43,45 @@ export function displayRunStyle(
   const er = run as EditedTextRun
   const dp = shape.display?.paragraphs[er.srcPara ?? paraIndex]
   const dr = dp?.runs[er.srcRun ?? runIndex] ?? dp?.defaultRun ?? shape.display?.defaultRun
-  return {
+  const style: ResolvedRunStyle = {
     sizePt: run.sizePt ?? dr?.sizePt ?? DEFAULT_TEXT_PT,
     bold: run.bold ?? dr?.bold ?? false,
     italic: run.italic ?? dr?.italic ?? false,
     underline: run.underline ?? dr?.underline ?? false,
     colorHex: run.colorHex ?? dr?.colorHex ?? '000000',
+  }
+  // The model never carries a typeface; the resolved cascade is the only source.
+  if (dr?.fontFamily) style.fontFamily = dr.fontFamily
+  return style
+}
+
+/** normAutofit's multiplier on every rendered font size in a shape. */
+export function fontScaleOf(shape: TextShape): number {
+  return shape.display?.autofit?.fontScale ?? 1
+}
+
+/**
+ * Paragraph typography, resolved identically for the canvas renderer and the
+ * edit overlay so opening the editor never reflows. Line height is a unitless
+ * CSS multiplier (normAutofit's lnSpcReduction applied — it only ever reduces
+ * percentage spacing) or a fixed px value for a:spcPts. Paragraph spacing maps
+ * to paddings, not margins: sibling margins would collapse in the overlay's
+ * block layout but not between the canvas's flex children.
+ */
+export function paragraphMetrics(
+  dp: ParagraphDisplay | undefined,
+  autofit: TextAutofit | undefined,
+  scale: number,
+): { lineHeight: string; padTopPx: number; padBottomPx: number } {
+  const ls = dp?.lineHeight
+  const lineHeight =
+    ls?.kind === 'pt'
+      ? `${ls.pt * EMU_PER_PT * scale}px`
+      : String((ls?.value ?? DEFAULT_LINE_HEIGHT) * (1 - (autofit?.lnSpcReduction ?? 0)))
+  return {
+    lineHeight,
+    padTopPx: (dp?.spaceBeforePt ?? 0) * EMU_PER_PT * scale,
+    padBottomPx: (dp?.spaceAfterPt ?? 0) * EMU_PER_PT * scale,
   }
 }
 
@@ -92,14 +127,17 @@ function escapeHtml(s: string): string {
     .replace(/"/g, '&quot;')
 }
 
-function runCss(style: ResolvedRunStyle, scale: number): string {
+// Line-height is set on the paragraph block, not per run: the unitless form
+// inherits and recomputes against each span's own font size (matching the old
+// per-span 1.2), and the fixed-px form must be uniform across the paragraph.
+function runCss(style: ResolvedRunStyle, scale: number, fontScale: number): string {
   return (
     `font-weight:${style.bold ? 700 : 400};` +
     `font-style:${style.italic ? 'italic' : 'normal'};` +
     `text-decoration:${style.underline ? 'underline' : 'none'};` +
-    `font-size:${style.sizePt * EMU_PER_PT * scale}px;` +
-    `color:#${style.colorHex};` +
-    `line-height:1.2`
+    `font-size:${style.sizePt * fontScale * EMU_PER_PT * scale}px;` +
+    `color:#${style.colorHex}` +
+    (style.fontFamily ? `;font-family:${style.fontFamily}` : '')
   )
 }
 
@@ -140,8 +178,9 @@ function bulletHtml(
   const css =
     'display:inline-block;text-indent:0;' +
     (indentPx < 0 ? `min-width:${-indentPx}px;` : 'margin-right:0.35em;') +
-    `font-size:${(style?.sizePt ?? DEFAULT_TEXT_PT) * EMU_PER_PT * scale}px;` +
-    `color:#${style?.colorHex ?? '000000'};line-height:1.2`
+    `font-size:${(style?.sizePt ?? DEFAULT_TEXT_PT) * fontScaleOf(shape) * EMU_PER_PT * scale}px;` +
+    `color:#${style?.colorHex ?? '000000'}` +
+    (style?.fontFamily ? `;font-family:${style.fontFamily}` : '')
   return `<span data-bullet="1" contenteditable="false" style="${css}">${escapeHtml(text)}</span>`
 }
 
@@ -153,6 +192,7 @@ export function buildEditableHtml(shape: TextShape, scale: number): string {
   // Auto-number counters accumulate down the shape, exactly as the rendered
   // view does, so the editable shows the same numbers.
   const counters: Record<number, number> = {}
+  const fontScale = fontScaleOf(shape)
   return shape.paragraphs
     .map((para, pi) => {
       const ep = para as EditedParagraph
@@ -168,24 +208,27 @@ export function buildEditableHtml(shape: TextShape, scale: number): string {
           // extraction never bakes inherited values into write-back edits.
           return (
             `<span data-cp="${pi}" data-cr="${ri}"${prov}${runDataAttrs(run)}` +
-            ` style="${runCss(displayRunStyle(shape, pi, ri, run), scale)}">${escapeHtml(run.text)}</span>`
+            ` style="${runCss(displayRunStyle(shape, pi, ri, run), scale, fontScale)}">${escapeHtml(run.text)}</span>`
           )
         })
         .join('')
       const align = displayAlign(shape, pi, para)
-      // Mirror the rendered paragraph box exactly — padding, indent and the
-      // bullet. The bullet is an inline box that takes real horizontal space,
-      // so leaving it out reflows every line and the point the user clicked
-      // stops mapping to the word they clicked.
+      // Mirror the rendered paragraph box exactly — padding, indent, line
+      // height, paragraph spacing and the bullet. The bullet is an inline box
+      // that takes real horizontal space, so leaving it out reflows every line
+      // and the point the user clicked stops mapping to the word they clicked.
       const dp = shape.display?.paragraphs[paraSrc]
       const marLPx = (dp?.marLEmu ?? 0) * scale
       const indentPx = (dp?.indentEmu ?? 0) * scale
+      const metrics = paragraphMetrics(dp, shape.display?.autofit, scale)
       const boxCss =
         (marLPx > 0 ? `padding-left:${marLPx}px;` : '') +
-        (indentPx !== 0 ? `text-indent:${indentPx}px;` : '')
+        (indentPx !== 0 ? `text-indent:${indentPx}px;` : '') +
+        (metrics.padTopPx > 0 ? `padding-top:${metrics.padTopPx}px;` : '') +
+        (metrics.padBottomPx > 0 ? `padding-bottom:${metrics.padBottomPx}px;` : '')
       return (
         `<div data-cp="${pi}" data-op="${paraSrc}" data-algn="${para.align ?? ''}"` +
-        ` style="margin:0;${boxCss}text-align:${alignToCss(align)}">` +
+        ` style="margin:0;line-height:${metrics.lineHeight};${boxCss}text-align:${alignToCss(align)}">` +
         bulletHtml(shape, para, dp, indentPx, scale, counters) +
         `${inner || '<br>'}</div>`
       )
@@ -589,6 +632,8 @@ export function applyFormatToSpans(
   spans: readonly HTMLElement[],
   set: RunFormatOverrides,
   scale: number,
+  /** The shape's normAutofit font scale; data-pt stays the raw authored pt. */
+  fontScale = 1,
 ): void {
   for (const el of spans) {
     if (set.bold !== undefined) {
@@ -605,7 +650,7 @@ export function applyFormatToSpans(
     }
     if (set.sizePt !== undefined) {
       el.setAttribute('data-pt', String(set.sizePt))
-      el.style.fontSize = `${set.sizePt * EMU_PER_PT * scale}px`
+      el.style.fontSize = `${set.sizePt * fontScale * EMU_PER_PT * scale}px`
     }
     if (set.colorHex !== undefined) {
       el.setAttribute('data-c', set.colorHex)

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -1,0 +1,385 @@
+/**
+ * The DOM <-> model bridge for the contentEditable text overlay.
+ *
+ * Every run is rendered as a span carrying:
+ *  - `data-cp` / `data-cr`: where the run sits in the CURRENT model.
+ *  - `data-op` / `data-or`: where it came from in the ORIGINAL parse. The
+ *    serializer needs these to reuse rPr bytes and to address formatting.
+ *  - `data-b/-i/-u/-pt/-c`: the authoritative run properties. Inline style is
+ *    presentation only; reading these back avoids a px->pt float round-trip.
+ *
+ * When a browser splits a span or block on Enter it clones the attributes onto
+ * both halves, which is exactly the inheritance we want.
+ */
+
+import type { EditedParagraph, EditedTextRun, RunFormatOverrides } from '@/lib/pptx/serialize'
+import type { Paragraph, TextAlign, TextRun, TextShape } from '@/lib/pptx/types'
+import { EMU_PER_PT } from './edit-model'
+
+export const DEFAULT_TEXT_PT = 18
+
+export interface TextOverlayHandle {
+  root: HTMLDivElement
+  scale: number
+  shape: TextShape
+}
+
+export function alignToCss(align: string | undefined): 'left' | 'center' | 'right' | 'justify' {
+  return align === 'ctr' ? 'center' : align === 'r' ? 'right' : align === 'just' ? 'justify' : 'left'
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function runFontPx(run: Pick<TextRun, 'sizePt'>, scale: number): number {
+  return (run.sizePt ?? DEFAULT_TEXT_PT) * EMU_PER_PT * scale
+}
+
+function runCss(run: TextRun, scale: number): string {
+  return (
+    `font-weight:${run.bold ? 700 : 400};` +
+    `font-style:${run.italic ? 'italic' : 'normal'};` +
+    `text-decoration:${run.underline ? 'underline' : 'none'};` +
+    `font-size:${runFontPx(run, scale)}px;` +
+    `color:#${run.colorHex ?? '000000'};` +
+    `line-height:1.2`
+  )
+}
+
+function runDataAttrs(run: TextRun): string {
+  return (
+    ` data-b="${run.bold ? 1 : 0}" data-i="${run.italic ? 1 : 0}" data-u="${run.underline ? 1 : 0}"` +
+    ` data-pt="${run.sizePt ?? ''}" data-c="${run.colorHex ?? ''}"`
+  )
+}
+
+/**
+ * Builds the overlay's initial HTML. Provenance already on the shape (from an
+ * uncommitted edit) wins, so re-opening a box still points at the source runs.
+ */
+export function buildEditableHtml(shape: TextShape, scale: number): string {
+  return shape.paragraphs
+    .map((para, pi) => {
+      const ep = para as EditedParagraph
+      const paraSrc = ep.srcPara ?? pi
+      const inner = para.runs
+        .map((run, ri) => {
+          const er = run as EditedTextRun
+          const srcPara = er.srcPara ?? pi
+          const srcRun = er.srcRun ?? ri
+          const prov = ` data-op="${srcPara}" data-or="${srcRun}"`
+          if (run.text === '\n') return `<br data-cp="${pi}" data-cr="${ri}"${prov}>`
+          return (
+            `<span data-cp="${pi}" data-cr="${ri}"${prov}${runDataAttrs(run)}` +
+            ` style="${runCss(run, scale)}">${escapeHtml(run.text)}</span>`
+          )
+        })
+        .join('')
+      return (
+        `<div data-cp="${pi}" data-op="${paraSrc}" data-algn="${para.align ?? ''}"` +
+        ` style="margin:0;text-align:${alignToCss(para.align)}">${inner || '<br>'}</div>`
+      )
+    })
+    .join('')
+}
+
+// ------------------------------------------------------------- DOM reading
+
+function numAttr(el: Element, name: string): number | undefined {
+  const v = el.getAttribute(name)
+  if (v === null || v === '') return undefined
+  const n = Number(v)
+  return Number.isFinite(n) && n >= 0 ? n : undefined
+}
+
+function rgbToHex(css: string): string | undefined {
+  const rgb = css.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/)
+  if (rgb) {
+    return [rgb[1], rgb[2], rgb[3]]
+      .map((c) => Number(c).toString(16).padStart(2, '0'))
+      .join('')
+      .toUpperCase()
+  }
+  const hex = css.match(/^#([0-9a-fA-F]{6})$/)
+  return hex ? hex[1].toUpperCase() : undefined
+}
+
+/**
+ * Run properties for a span: the data attributes when present, otherwise the
+ * inline style (which is what pasted markup arrives with).
+ */
+function propsOfSpan(el: HTMLElement, scale: number): Omit<TextRun, 'text'> {
+  const out: Omit<TextRun, 'text'> = {}
+  const st = el.style
+
+  const dataB = el.getAttribute('data-b')
+  if (dataB !== null) {
+    if (dataB === '1') out.bold = true
+  } else if (st.fontWeight) {
+    const w = st.fontWeight
+    if (w === 'bold' || w === 'bolder' || Number(w) >= 600) out.bold = true
+  }
+
+  const dataI = el.getAttribute('data-i')
+  if (dataI !== null) {
+    if (dataI === '1') out.italic = true
+  } else if (st.fontStyle === 'italic' || st.fontStyle === 'oblique') {
+    out.italic = true
+  }
+
+  const dataU = el.getAttribute('data-u')
+  if (dataU !== null) {
+    if (dataU === '1') out.underline = true
+  } else if ((st.textDecorationLine || st.textDecoration || '').includes('underline')) {
+    out.underline = true
+  }
+
+  const dataPt = el.getAttribute('data-pt')
+  if (dataPt !== null) {
+    if (dataPt !== '') {
+      const pt = Number(dataPt)
+      if (Number.isFinite(pt) && pt > 0) out.sizePt = pt
+    }
+  } else if (st.fontSize.endsWith('px')) {
+    const px = parseFloat(st.fontSize)
+    if (px > 0 && scale > 0) out.sizePt = Math.round((px / (EMU_PER_PT * scale)) * 10) / 10
+  }
+
+  const dataC = el.getAttribute('data-c')
+  if (dataC !== null) {
+    if (dataC !== '') out.colorHex = dataC.toUpperCase()
+  } else if (st.color) {
+    const hex = rgbToHex(st.color)
+    // Plain black is the render default, not an authored color.
+    if (hex && hex !== '000000') out.colorHex = hex
+  }
+
+  return out
+}
+
+const NBSP = String.fromCharCode(0x00a0)
+const INVISIBLE_RE = new RegExp(`[${String.fromCharCode(0x200b)}${String.fromCharCode(0xfeff)}]`, 'g')
+
+/** contentEditable output -> model text. NBSP/CRLF normalized, zero-widths dropped. */
+function normText(s: string): string {
+  return s.split(NBSP).join(' ').replace(/\r\n?/g, '\n').replace(INVISIBLE_RE, '')
+}
+
+const isRunSpan = (n: Node): n is HTMLElement =>
+  n instanceof HTMLElement && n.tagName === 'SPAN' && n.getAttribute('data-cr') !== null
+
+/** Reads the committed paragraphs back out of the overlay's DOM. */
+export function extractParagraphs(
+  root: HTMLElement,
+  shape: TextShape,
+  scale: number,
+): EditedParagraph[] {
+  const paras: EditedParagraph[] = []
+  let loose: EditedTextRun[] = []
+
+  const flushLoose = () => {
+    if (loose.length) paras.push({ runs: loose })
+    loose = []
+  }
+
+  const runFromSpan = (el: HTMLElement): EditedTextRun | null => {
+    const text = normText(el.textContent ?? '')
+    if (!text) return null
+    return {
+      text,
+      ...propsOfSpan(el, scale),
+      srcPara: numAttr(el, 'data-op'),
+      srcRun: numAttr(el, 'data-or'),
+    }
+  }
+
+  const collectInline = (container: Node, into: EditedTextRun[]) => {
+    container.childNodes.forEach((n) => {
+      if (n.nodeType === Node.TEXT_NODE) {
+        const t = normText(n.nodeValue ?? '')
+        if (t) into.push({ text: t })
+      } else if (n instanceof Element) {
+        if (n.tagName === 'BR') {
+          into.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
+        } else if (isRunSpan(n)) {
+          const r = runFromSpan(n)
+          if (r) into.push(r)
+        } else {
+          // Pasted markup or a browser-inserted wrapper: keep the text.
+          collectInline(n, into)
+        }
+      }
+    })
+  }
+
+  root.childNodes.forEach((n) => {
+    if (n instanceof HTMLElement && (n.tagName === 'DIV' || n.tagName === 'P')) {
+      flushLoose()
+      const runs: EditedTextRun[] = []
+      collectInline(n, runs)
+
+      // `<div><br></div>` is contentEditable's empty paragraph.
+      const onlyBr =
+        n.childNodes.length === 1 && n.firstChild instanceof Element && n.firstChild.tagName === 'BR'
+      let finalRuns = onlyBr ? [] : runs
+      // Browsers keep a placeholder <br> at the end of non-empty blocks.
+      if (!onlyBr && finalRuns.length > 1) {
+        const lastRun = finalRuns[finalRuns.length - 1]
+        const lastChild = n.lastChild
+        if (
+          lastRun.text === '\n' &&
+          lastRun.srcRun === undefined &&
+          lastChild instanceof Element &&
+          lastChild.tagName === 'BR' &&
+          lastChild.getAttribute('data-cr') === null
+        ) {
+          finalRuns = finalRuns.slice(0, -1)
+        }
+      }
+
+      const cp = numAttr(n, 'data-cp')
+      const declared = n.getAttribute('data-algn')
+      const align = (declared || shape.paragraphs[cp ?? -1]?.align) as TextAlign | undefined
+      paras.push({ align: align || undefined, runs: finalRuns, srcPara: numAttr(n, 'data-op') })
+    } else if (n.nodeType === Node.TEXT_NODE) {
+      const t = normText(n.nodeValue ?? '')
+      if (t) loose.push({ text: t })
+    } else if (n instanceof Element) {
+      if (n.tagName === 'BR') {
+        loose.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
+      } else if (isRunSpan(n)) {
+        const r = runFromSpan(n)
+        if (r) loose.push(r)
+      } else {
+        collectInline(n, loose)
+      }
+    }
+  })
+  flushLoose()
+
+  // Everything replaced by unanchored content (select-all + type): keep the
+  // first original paragraph's identity rather than none at all.
+  if (paras.length > 0 && paras.every((p) => p.srcPara === undefined) && shape.paragraphs.length > 0) {
+    paras[0] = { ...paras[0], srcPara: 0, align: paras[0].align ?? shape.paragraphs[0].align }
+  }
+  if (paras.length === 0) {
+    paras.push({ align: shape.paragraphs[0]?.align, runs: [], srcPara: 0 })
+  }
+  return paras
+}
+
+// ------------------------------------------------------------ DOM writing
+
+/** Spans intersecting the current selection, or all of them when collapsed. */
+export function selectedRunSpans(root: HTMLElement): HTMLElement[] {
+  const spans = Array.from(root.querySelectorAll<HTMLElement>('span[data-cr]'))
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return spans
+  const range = sel.getRangeAt(0)
+  if (!root.contains(range.commonAncestorContainer)) return spans
+  if (range.collapsed) {
+    const anchor = sel.anchorNode
+    const span = anchor
+      ? (anchor instanceof Element ? anchor : anchor.parentElement)?.closest<HTMLElement>(
+          'span[data-cr]',
+        )
+      : null
+    return span ? [span] : spans
+  }
+  const hit = spans.filter((s) => range.intersectsNode(s))
+  return hit.length > 0 ? hit : spans
+}
+
+/** Paragraph blocks intersecting the current selection. */
+export function selectedParagraphBlocks(root: HTMLElement): HTMLElement[] {
+  const blocks = Array.from(root.querySelectorAll<HTMLElement>('div[data-cp]'))
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return blocks
+  const range = sel.getRangeAt(0)
+  if (!root.contains(range.commonAncestorContainer)) return blocks
+  if (range.collapsed) {
+    const anchor = sel.anchorNode
+    const block = anchor
+      ? (anchor instanceof Element ? anchor : anchor.parentElement)?.closest<HTMLElement>(
+          'div[data-cp]',
+        )
+      : null
+    return block ? [block] : blocks
+  }
+  const hit = blocks.filter((b) => range.intersectsNode(b))
+  return hit.length > 0 ? hit : blocks
+}
+
+/** Applies formatting to whole runs (run granularity), in the DOM only. */
+export function applyFormatToSpans(
+  spans: readonly HTMLElement[],
+  set: RunFormatOverrides,
+  scale: number,
+): void {
+  for (const el of spans) {
+    if (set.bold !== undefined) {
+      el.setAttribute('data-b', set.bold ? '1' : '0')
+      el.style.fontWeight = set.bold ? '700' : '400'
+    }
+    if (set.italic !== undefined) {
+      el.setAttribute('data-i', set.italic ? '1' : '0')
+      el.style.fontStyle = set.italic ? 'italic' : 'normal'
+    }
+    if (set.underline !== undefined) {
+      el.setAttribute('data-u', set.underline ? '1' : '0')
+      el.style.textDecoration = set.underline ? 'underline' : 'none'
+    }
+    if (set.sizePt !== undefined) {
+      el.setAttribute('data-pt', String(set.sizePt))
+      el.style.fontSize = `${set.sizePt * EMU_PER_PT * scale}px`
+    }
+    if (set.colorHex !== undefined) {
+      el.setAttribute('data-c', set.colorHex)
+      el.style.color = `#${set.colorHex}`
+    }
+  }
+}
+
+export function applyAlignToBlocks(blocks: readonly HTMLElement[], align: TextAlign): void {
+  for (const el of blocks) {
+    el.setAttribute('data-algn', align)
+    el.style.textAlign = alignToCss(align)
+  }
+}
+
+function aggregate(
+  items: ReadonlyArray<Omit<TextRun, 'text'>>,
+): RunFormatOverrides {
+  if (items.length === 0) return {}
+  let bold = Boolean(items[0].bold)
+  let italic = Boolean(items[0].italic)
+  let underline = Boolean(items[0].underline)
+  let sizePt: number | undefined = items[0].sizePt ?? DEFAULT_TEXT_PT
+  let colorHex: string | undefined = items[0].colorHex ?? '000000'
+  for (const p of items.slice(1)) {
+    bold = bold && Boolean(p.bold)
+    italic = italic && Boolean(p.italic)
+    underline = underline && Boolean(p.underline)
+    if ((p.sizePt ?? DEFAULT_TEXT_PT) !== sizePt) sizePt = undefined
+    if ((p.colorHex ?? '000000') !== colorHex) colorHex = undefined
+  }
+  return { bold, italic, underline, sizePt, colorHex }
+}
+
+/** Aggregate formatting of a set of spans, for reflecting toolbar state. */
+export function aggregateFormat(
+  spans: readonly HTMLElement[],
+  scale: number,
+): RunFormatOverrides {
+  return aggregate(spans.map((s) => propsOfSpan(s, scale)))
+}
+
+/** Aggregate formatting of model runs, for when nothing is being edited. */
+export function aggregateFormatOfParagraphs(paras: readonly Paragraph[]): RunFormatOverrides {
+  return aggregate(paras.flatMap((p) => p.runs).filter((r) => r.text !== '\n'))
+}

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -15,11 +15,13 @@
 import type { EditedParagraph, EditedTextRun, RunFormatOverrides } from '@/lib/pptx/serialize'
 import type {
   Paragraph,
+  ParagraphDisplay,
   ResolvedRunStyle,
   TextAlign,
   TextRun,
   TextShape,
 } from '@/lib/pptx/types'
+import { autoNumText } from '@/lib/pptx/textstyle'
 import { EMU_PER_PT } from './edit-model'
 
 export const DEFAULT_TEXT_PT = 18
@@ -95,10 +97,48 @@ function runDataAttrs(run: TextRun): string {
 }
 
 /**
+ * The paragraph's bullet, styled exactly as `TextShapeView` draws it. Marked
+ * `contenteditable="false"` and `data-bullet` so it is inert to typing and
+ * skipped by `extractParagraphs` — it is layout, never content.
+ */
+function bulletHtml(
+  shape: TextShape,
+  para: Paragraph,
+  dp: ParagraphDisplay | undefined,
+  indentPx: number,
+  scale: number,
+  counters: Record<number, number>,
+): string {
+  if (!dp || !para.runs.some((r) => r.text.trim() !== '')) return ''
+  let text: string
+  if (dp.bullet.kind === 'char') {
+    text = dp.bullet.char
+  } else if (dp.bullet.kind === 'auto') {
+    for (const k of Object.keys(counters)) {
+      if (Number(k) > dp.level) delete counters[Number(k)]
+    }
+    counters[dp.level] = (counters[dp.level] ?? dp.bullet.startAt - 1) + 1
+    text = autoNumText(dp.bullet.scheme, counters[dp.level])
+  } else {
+    return ''
+  }
+  const style = dp.defaultRun ?? shape.display?.defaultRun
+  const css =
+    'display:inline-block;text-indent:0;' +
+    (indentPx < 0 ? `min-width:${-indentPx}px;` : 'margin-right:0.35em;') +
+    `font-size:${(style?.sizePt ?? DEFAULT_TEXT_PT) * EMU_PER_PT * scale}px;` +
+    `color:#${style?.colorHex ?? '000000'};line-height:1.2`
+  return `<span data-bullet="1" contenteditable="false" style="${css}">${escapeHtml(text)}</span>`
+}
+
+/**
  * Builds the overlay's initial HTML. Provenance already on the shape (from an
  * uncommitted edit) wins, so re-opening a box still points at the source runs.
  */
 export function buildEditableHtml(shape: TextShape, scale: number): string {
+  // Auto-number counters accumulate down the shape, exactly as the rendered
+  // view does, so the editable shows the same numbers.
+  const counters: Record<number, number> = {}
   return shape.paragraphs
     .map((para, pi) => {
       const ep = para as EditedParagraph
@@ -119,9 +159,21 @@ export function buildEditableHtml(shape: TextShape, scale: number): string {
         })
         .join('')
       const align = displayAlign(shape, pi, para)
+      // Mirror the rendered paragraph box exactly — padding, indent and the
+      // bullet. The bullet is an inline box that takes real horizontal space,
+      // so leaving it out reflows every line and the point the user clicked
+      // stops mapping to the word they clicked.
+      const dp = shape.display?.paragraphs[paraSrc]
+      const marLPx = (dp?.marLEmu ?? 0) * scale
+      const indentPx = (dp?.indentEmu ?? 0) * scale
+      const boxCss =
+        (marLPx > 0 ? `padding-left:${marLPx}px;` : '') +
+        (indentPx !== 0 ? `text-indent:${indentPx}px;` : '')
       return (
         `<div data-cp="${pi}" data-op="${paraSrc}" data-algn="${para.align ?? ''}"` +
-        ` style="margin:0;text-align:${alignToCss(align)}">${inner || '<br>'}</div>`
+        ` style="margin:0;${boxCss}text-align:${alignToCss(align)}">` +
+        bulletHtml(shape, para, dp, indentPx, scale, counters) +
+        `${inner || '<br>'}</div>`
       )
     })
     .join('')
@@ -243,6 +295,8 @@ export function extractParagraphs(
         const t = normText(n.nodeValue ?? '')
         if (t) into.push({ text: t })
       } else if (n instanceof Element) {
+        // Bullets are drawn for layout only; they are not part of the text.
+        if (n.hasAttribute('data-bullet')) return
         if (n.tagName === 'BR') {
           into.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
         } else if (isRunSpan(n)) {
@@ -289,6 +343,7 @@ export function extractParagraphs(
       const t = normText(n.nodeValue ?? '')
       if (t) loose.push({ text: t })
     } else if (n instanceof Element) {
+      if (n.hasAttribute('data-bullet')) return
       if (n.tagName === 'BR') {
         loose.push({ text: '\n', srcPara: numAttr(n, 'data-op'), srcRun: numAttr(n, 'data-or') })
       } else if (isRunSpan(n)) {
@@ -310,6 +365,167 @@ export function extractParagraphs(
     paras.push({ align: shape.paragraphs[0]?.align, runs: [], srcPara: 0 })
   }
   return paras
+}
+
+// ------------------------------------------------------------ caret placing
+
+interface CaretSpot {
+  node: Node
+  offset: number
+}
+
+/**
+ * Caret spot for a viewport point. `caretPositionFromPoint` is the standard
+ * API; `caretRangeFromPoint` is the deprecated WebKit-era one Blink still
+ * carries, kept as the fallback.
+ */
+function caretSpotAt(x: number, y: number): CaretSpot | null {
+  if (typeof document.caretPositionFromPoint === 'function') {
+    const pos = document.caretPositionFromPoint(x, y)
+    if (pos) return { node: pos.offsetNode, offset: pos.offset }
+  }
+  if (typeof document.caretRangeFromPoint === 'function') {
+    const range = document.caretRangeFromPoint(x, y)
+    if (range) return { node: range.startContainer, offset: range.startOffset }
+  }
+  return null
+}
+
+/**
+ * Closest character position inside `root` to a viewport point, measured
+ * against the text's own rects. This is what keeps a near-miss — the click
+ * landed in a paragraph's indent, or in the empty band a vertically centered
+ * text block leaves above and below itself — from collapsing to the start of
+ * the box instead of the word next to the pointer.
+ */
+function nearestTextSpot(root: HTMLElement, x: number, y: number): CaretSpot | null {
+  const walker = textWalker(root)
+  const probe = document.createRange()
+  let best: CaretSpot | null = null
+  let bestDist = Infinity
+  for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+    const text = node as Text
+    for (let i = 0; i < text.length; i++) {
+      probe.setStart(text, i)
+      probe.setEnd(text, i + 1)
+      const rect = probe.getBoundingClientRect()
+      if (rect.width === 0 && rect.height === 0) continue
+      const dx = x < rect.left ? rect.left - x : x > rect.right ? x - rect.right : 0
+      const dy = y < rect.top ? rect.top - y : y > rect.bottom ? y - rect.bottom : 0
+      const dist = dx * dx + dy * dy
+      if (dist < bestDist) {
+        bestDist = dist
+        // Land on whichever side of the glyph the pointer is nearer.
+        best = { node: text, offset: x > (rect.left + rect.right) / 2 ? i + 1 : i }
+      }
+    }
+  }
+  return best
+}
+
+/** Where a click should leave the caret when the editor opens. */
+export interface CaretTarget {
+  /** Viewport coordinates of the click. */
+  x: number
+  y: number
+  /** Double-click: select the word under the pointer rather than collapse. */
+  selectWord: boolean
+}
+
+const WORD_CHAR = /[\p{L}\p{N}_]/u
+
+/** Walks editable text only — bullets are layout, never a caret target. */
+function textWalker(root: Node): TreeWalker {
+  return document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      node.parentElement?.closest('[data-bullet]')
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT,
+  })
+}
+
+/** Text nodes of the paragraph block holding `node`, in document order. */
+function paragraphTextNodes(root: HTMLElement, node: Text): Text[] {
+  const block = node.parentElement?.closest<HTMLElement>('div[data-cp]') ?? root
+  const walker = textWalker(block)
+  const out: Text[] = []
+  for (let n = walker.nextNode(); n !== null; n = walker.nextNode()) out.push(n as Text)
+  return out
+}
+
+/**
+ * The word around a spot, as a range. Spans run boundaries, because PowerPoint
+ * splits runs mid-word freely (language tags, spell-check state), and a
+ * double-click should still take the whole word.
+ */
+function wordRangeAt(root: HTMLElement, node: Text, offset: number): Range | null {
+  const nodes = paragraphTextNodes(root, node)
+  const home = nodes.indexOf(node)
+  if (home < 0) return null
+  const starts: number[] = []
+  let flat = ''
+  for (const n of nodes) {
+    starts.push(flat.length)
+    flat += n.data
+  }
+  const at = starts[home] + offset
+  let from = at
+  let to = at
+  while (from > 0 && WORD_CHAR.test(flat[from - 1])) from--
+  while (to < flat.length && WORD_CHAR.test(flat[to])) to++
+  // Landed on a space or punctuation: there is no word to take.
+  if (from === to) return null
+  const locate = (i: number): [Text, number] => {
+    for (let k = nodes.length - 1; k >= 0; k--) {
+      if (i >= starts[k]) return [nodes[k], i - starts[k]]
+    }
+    return [nodes[0], 0]
+  }
+  const [startNode, startOffset] = locate(from)
+  const [endNode, endOffset] = locate(to)
+  const range = document.createRange()
+  range.setStart(startNode, startOffset)
+  range.setEnd(endNode, endOffset)
+  return range
+}
+
+/**
+ * Resolves a click into a selection inside `root` — the word for a
+ * double-click, otherwise a caret.
+ *
+ * Call this BEFORE focusing the editable. `focus()` scrolls the element into
+ * view, and the canvas frame it lives in is a scrollable `overflow:hidden`
+ * box, so focusing first slides the text out from under the coordinates the
+ * click was captured at; the hit test then misses the glyphs and collapses to
+ * the very start of the box.
+ */
+export function caretSelectionAtPoint(root: HTMLElement, target: CaretTarget): Range | null {
+  const { x, y } = target
+  let spot = caretSpotAt(x, y)
+  // A hit test that misses the glyphs answers with the containing element, and
+  // taking that offset verbatim is the other way the caret ends up at 0. A hit
+  // on the bullet is no good either — it is inert.
+  const inBullet = (n: Node) =>
+    ((n instanceof Element ? n : n.parentElement)?.closest('[data-bullet]') ?? null) !== null
+  if (
+    spot === null ||
+    !root.contains(spot.node) ||
+    spot.node.nodeType !== Node.TEXT_NODE ||
+    inBullet(spot.node)
+  ) {
+    spot = nearestTextSpot(root, x, y)
+  }
+  if (spot === null || !root.contains(spot.node)) return null
+  const text = spot.node as Text
+  const offset = Math.min(spot.offset, text.length)
+  if (target.selectWord) {
+    const word = wordRangeAt(root, text, offset)
+    if (word !== null) return word
+  }
+  const range = document.createRange()
+  range.setStart(text, offset)
+  range.collapse(true)
+  return range
 }
 
 // ------------------------------------------------------------ DOM writing

--- a/apps/x/apps/renderer/src/components/pptx/text-dom.ts
+++ b/apps/x/apps/renderer/src/components/pptx/text-dom.ts
@@ -50,8 +50,10 @@ export function displayRunStyle(
     underline: run.underline ?? dr?.underline ?? false,
     colorHex: run.colorHex ?? dr?.colorHex ?? '000000',
   }
-  // The model never carries a typeface; the resolved cascade is the only source.
+  // The model carries neither typeface nor tracking; the resolved cascade is
+  // the only source for both.
   if (dr?.fontFamily) style.fontFamily = dr.fontFamily
+  if (dr?.letterSpacingPt !== undefined) style.letterSpacingPt = dr.letterSpacingPt
   return style
 }
 
@@ -137,7 +139,10 @@ function runCss(style: ResolvedRunStyle, scale: number, fontScale: number): stri
     `text-decoration:${style.underline ? 'underline' : 'none'};` +
     `font-size:${style.sizePt * fontScale * EMU_PER_PT * scale}px;` +
     `color:#${style.colorHex}` +
-    (style.fontFamily ? `;font-family:${style.fontFamily}` : '')
+    (style.fontFamily ? `;font-family:${style.fontFamily}` : '') +
+    (style.letterSpacingPt !== undefined
+      ? `;letter-spacing:${style.letterSpacingPt * EMU_PER_PT * scale}px`
+      : '')
   )
 }
 

--- a/apps/x/apps/renderer/src/components/pptx/text-overlay.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/text-overlay.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, type CSSProperties } from 'react'
+import type { EditedParagraph } from '@/lib/pptx/serialize'
+import type { TextShape } from '@/lib/pptx/types'
+import { buildEditableHtml, extractParagraphs, type TextOverlayHandle } from './text-dom'
+
+interface TextEditOverlayProps {
+  shape: TextShape
+  scale: number
+  style: CSSProperties
+  onAttach: (handle: TextOverlayHandle | null) => void
+  onCommit: (next: EditedParagraph[] | null) => void
+}
+
+/**
+ * The contentEditable surface for one text box. Content is built once per
+ * editing session — re-rendering it would clobber what the user has typed and
+ * reset the caret — and read back through `extractParagraphs` on the way out.
+ */
+export function TextEditOverlay({
+  shape,
+  scale,
+  style,
+  onAttach,
+  onCommit,
+}: TextEditOverlayProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const committedRef = useRef(false)
+  const htmlRef = useRef<string | null>(null)
+  if (htmlRef.current === null) htmlRef.current = buildEditableHtml(shape, scale)
+
+  const commit = useCallback(() => {
+    if (committedRef.current) return
+    committedRef.current = true
+    onCommit(ref.current ? extractParagraphs(ref.current, shape, scale) : null)
+  }, [onCommit, shape, scale])
+
+  // Focus on open; commit on unmount so switching slides can't drop an edit.
+  useEffect(() => {
+    const el = ref.current
+    if (el) {
+      el.focus()
+      const sel = window.getSelection()
+      if (sel) {
+        sel.selectAllChildren(el)
+        sel.collapseToEnd()
+      }
+      onAttach({ root: el, scale, shape })
+    }
+    return () => {
+      onAttach(null)
+      commit()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      contentEditable
+      suppressContentEditableWarning
+      spellCheck={false}
+      dangerouslySetInnerHTML={{ __html: htmlRef.current }}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          e.stopPropagation()
+          commit()
+          return
+        }
+        // Let the browser own undo inside the text box, and keep app-level
+        // shortcuts away from typing.
+        e.stopPropagation()
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
+      className="z-20 cursor-text overflow-hidden whitespace-pre-wrap outline-2 outline-offset-1 outline-[var(--ring)]"
+    />
+  )
+}

--- a/apps/x/apps/renderer/src/components/pptx/text-overlay.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/text-overlay.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, type CSSProperties } from 'react'
 import type { EditedParagraph } from '@/lib/pptx/serialize'
 import type { TextShape } from '@/lib/pptx/types'
 import {
+  anchorJustify,
   buildEditableHtml,
   caretSelectionAtPoint,
   extractParagraphs,
@@ -96,15 +97,21 @@ export function TextEditOverlay({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // The flex centering lives on a NON-editable wrapper. Chromium cannot drive
+  // The flex anchoring lives on a NON-editable wrapper. Chromium cannot drive
   // a native caret inside a flex-container contentEditable: clicks anchor the
   // selection on the container instead of a text node and arrow keys cannot
   // move it, so the caret pins to the start of the box. The editable itself
-  // must be a plain block.
+  // must be a plain block. Anchoring mirrors TextShapeView so the text does
+  // not jump when the editor opens.
   return (
     <div
-      style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
-      className="z-20 cursor-text overflow-hidden outline-2 outline-offset-1 outline-[var(--ring)]"
+      style={{
+        ...style,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: anchorJustify(shape.display?.anchor),
+      }}
+      className="z-20 cursor-text outline-2 outline-offset-1 outline-[var(--ring)]"
       onPointerDown={(e) => e.stopPropagation()}
       onMouseDown={(e) => {
         // A press on the empty band above/below the text would move focus out

--- a/apps/x/apps/renderer/src/components/pptx/text-overlay.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/text-overlay.tsx
@@ -1,12 +1,20 @@
 import { useCallback, useEffect, useRef, type CSSProperties } from 'react'
 import type { EditedParagraph } from '@/lib/pptx/serialize'
 import type { TextShape } from '@/lib/pptx/types'
-import { buildEditableHtml, extractParagraphs, type TextOverlayHandle } from './text-dom'
+import {
+  buildEditableHtml,
+  caretSelectionAtPoint,
+  extractParagraphs,
+  type CaretTarget,
+  type TextOverlayHandle,
+} from './text-dom'
 
 interface TextEditOverlayProps {
   shape: TextShape
   scale: number
   style: CSSProperties
+  /** Where the click landed; falls back to the end of the text when absent. */
+  caretAt?: CaretTarget | null
   onAttach: (handle: TextOverlayHandle | null) => void
   onCommit: (next: EditedParagraph[] | null) => void
 }
@@ -20,62 +28,125 @@ export function TextEditOverlay({
   shape,
   scale,
   style,
+  caretAt,
   onAttach,
   onCommit,
 }: TextEditOverlayProps) {
   const ref = useRef<HTMLDivElement>(null)
   const committedRef = useRef(false)
-  const htmlRef = useRef<string | null>(null)
-  if (htmlRef.current === null) htmlRef.current = buildEditableHtml(shape, scale)
+  // False between an unmount's cleanup and a possible StrictMode re-setup.
+  const aliveRef = useRef(false)
+  // The whole {__html} object is cached, not just the string. React 19 diffs
+  // dangerouslySetInnerHTML by object identity, so an inline `{{__html}}`
+  // makes every parent re-render rewrite innerHTML — destroying the text
+  // nodes the selection lives in. The toolbar bumps a selection tick on every
+  // selectionchange while editing, so that rewrite would fire on every caret
+  // move and typing session: the caret snaps to the start of the box and
+  // edits are wiped. A stable object means React never touches the content
+  // after mount.
+  const htmlRef = useRef<{ __html: string } | null>(null)
+  if (htmlRef.current === null) htmlRef.current = { __html: buildEditableHtml(shape, scale) }
 
-  const commit = useCallback(() => {
-    if (committedRef.current) return
-    committedRef.current = true
-    onCommit(ref.current ? extractParagraphs(ref.current, shape, scale) : null)
-  }, [onCommit, shape, scale])
+  const commitFrom = useCallback(
+    (el: HTMLElement | null) => {
+      if (committedRef.current) return
+      committedRef.current = true
+      onCommit(el ? extractParagraphs(el, shape, scale) : null)
+    },
+    [onCommit, shape, scale],
+  )
+  const commit = useCallback(() => commitFrom(ref.current), [commitFrom])
 
   // Focus on open; commit on unmount so switching slides can't drop an edit.
   useEffect(() => {
     const el = ref.current
-    if (el) {
-      el.focus()
-      const sel = window.getSelection()
-      if (sel) {
+    if (!el) return
+    // Re-arm: dev StrictMode runs this effect, its cleanup, then this again on
+    // mount. A commit from that simulated unmount would close the editor the
+    // moment it opens (onCommit clears editingKey) and latch committedRef so
+    // the real commit later becomes a no-op — text edits would never land.
+    aliveRef.current = true
+    committedRef.current = false
+    // Resolve the click BEFORE focusing: focus scrolls the editable into view,
+    // which moves the text out from under the coordinates it was captured at.
+    const clicked = caretAt ? caretSelectionAtPoint(el, caretAt) : null
+    el.focus({ preventScroll: true })
+    const sel = window.getSelection()
+    if (sel) {
+      if (clicked !== null) {
+        sel.removeAllRanges()
+        sel.addRange(clicked)
+      } else {
         sel.selectAllChildren(el)
         sel.collapseToEnd()
       }
-      onAttach({ root: el, scale, shape })
     }
+    onAttach({ root: el, scale, shape })
     return () => {
+      aliveRef.current = false
       onAttach(null)
-      commit()
+      // Defer one microtask: a StrictMode re-setup flips aliveRef back first
+      // and the commit is skipped; on a real unmount it goes through. `el` is
+      // captured because React nulls the ref before this cleanup runs, and the
+      // detached node still holds the text to commit.
+      queueMicrotask(() => {
+        if (!aliveRef.current) commitFrom(el)
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // The flex centering lives on a NON-editable wrapper. Chromium cannot drive
+  // a native caret inside a flex-container contentEditable: clicks anchor the
+  // selection on the container instead of a text node and arrow keys cannot
+  // move it, so the caret pins to the start of the box. The editable itself
+  // must be a plain block.
   return (
     <div
-      ref={ref}
-      contentEditable
-      suppressContentEditableWarning
-      spellCheck={false}
-      dangerouslySetInnerHTML={{ __html: htmlRef.current }}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          e.stopPropagation()
-          commit()
-          return
-        }
-        // Let the browser own undo inside the text box, and keep app-level
-        // shortcuts away from typing.
-        e.stopPropagation()
-      }}
-      onPointerDown={(e) => e.stopPropagation()}
-      onClick={(e) => e.stopPropagation()}
       style={{ ...style, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}
-      className="z-20 cursor-text overflow-hidden whitespace-pre-wrap outline-2 outline-offset-1 outline-[var(--ring)]"
-    />
+      className="z-20 cursor-text overflow-hidden outline-2 outline-offset-1 outline-[var(--ring)]"
+      onPointerDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => {
+        // A press on the empty band above/below the text would move focus out
+        // of the editable and blur-commit the session; keep the focus put.
+        if (e.target === e.currentTarget) e.preventDefault()
+      }}
+      onClick={(e) => {
+        e.stopPropagation()
+        // Band click: the editable doesn't cover it, so the browser places no
+        // caret. Snap to the nearest character instead.
+        const el = ref.current
+        if (e.target === e.currentTarget && el) {
+          const range = caretSelectionAtPoint(el, { x: e.clientX, y: e.clientY, selectWord: false })
+          const sel = window.getSelection()
+          if (range && sel) {
+            sel.removeAllRanges()
+            sel.addRange(range)
+          }
+          el.focus({ preventScroll: true })
+        }
+      }}
+    >
+      <div
+        ref={ref}
+        contentEditable
+        suppressContentEditableWarning
+        spellCheck={false}
+        dangerouslySetInnerHTML={htmlRef.current}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            e.stopPropagation()
+            commit()
+            return
+          }
+          // Let the browser own undo inside the text box, and keep app-level
+          // shortcuts away from typing.
+          e.stopPropagation()
+        }}
+        className="w-full whitespace-pre-wrap outline-none"
+      />
+    </div>
   )
 }

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.test.tsx
@@ -17,6 +17,11 @@ function toolbarProps(overrides: Partial<ToolbarProps> = {}): ToolbarProps {
     onZoomFit: () => {},
     format: { bold: false, italic: false, underline: false, sizePt: 20, colorHex: '000000' },
     formatDisabledReason: null,
+    onInsert: () => {},
+    shapeFill: null,
+    shapeLine: null,
+    onShapeFillChange: () => {},
+    onShapeLineChange: () => {},
     font: 'Tahoma',
     deckFonts: ['Tahoma'],
     onFontChange: () => {},
@@ -120,5 +125,77 @@ describe('font picker', () => {
     expect(trigger).toBeDisabled()
     fireEvent.click(trigger)
     expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})
+
+describe('shape fill / outline', () => {
+  it('is hidden entirely when the selection is not a restylable shape', () => {
+    render(<EditorToolbar {...toolbarProps()} />)
+    expect(screen.queryByLabelText('Shape fill')).toBeNull()
+    expect(screen.queryByLabelText('Shape outline')).toBeNull()
+  })
+
+  it('shows both swatches for a shape and reports the picked colour as RRGGBB', () => {
+    const onShapeFillChange = vi.fn()
+    const onShapeLineChange = vi.fn()
+    render(
+      <EditorToolbar
+        {...toolbarProps({
+          shapeFill: '#ff0000',
+          shapeLine: '#00ff00',
+          onShapeFillChange,
+          onShapeLineChange,
+        })}
+      />,
+    )
+    const fill = screen.getByLabelText('Shape fill') as HTMLInputElement
+    const line = screen.getByLabelText('Shape outline') as HTMLInputElement
+    expect(fill.value).toBe('#ff0000')
+    expect(line.value).toBe('#00ff00')
+
+    fireEvent.change(fill, { target: { value: '#336699' } })
+    expect(onShapeFillChange).toHaveBeenCalledWith('336699')
+    fireEvent.change(line, { target: { value: '#123456' } })
+    expect(onShapeLineChange).toHaveBeenCalledWith('123456')
+  })
+
+  it('shows outline alone for a connector, which has no fill', () => {
+    render(<EditorToolbar {...toolbarProps({ shapeFill: null, shapeLine: '#0000ff' })} />)
+    expect(screen.queryByLabelText('Shape fill')).toBeNull()
+    expect(screen.getByLabelText('Shape outline')).toBeInTheDocument()
+  })
+})
+
+describe('insert menu', () => {
+  it('portals its menu and reports the chosen kind', () => {
+    const onInsert = vi.fn()
+    render(<EditorToolbar {...toolbarProps({ onInsert })} />)
+    const trigger = screen.getByLabelText('Insert')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(trigger)
+    const menu = screen.getByRole('menu')
+    expect(menu.parentElement).toBe(document.body)
+    expect(menu.closest('.overflow-x-auto')).toBeNull()
+    expect(within(menu).getAllByRole('menuitem').map((i) => i.textContent)).toEqual([
+      'Text box',
+      'Rectangle',
+      'Rounded rectangle',
+      'Ellipse',
+      'Line',
+      'Image\u2026',
+    ])
+
+    // Focus must stay in the editor, as with every other toolbar control.
+    const item = within(menu).getByRole('menuitem', { name: 'Rounded rectangle' })
+    expect(fireEvent.mouseDown(item)).toBe(false)
+    fireEvent.click(item)
+    expect(onInsert).toHaveBeenCalledWith('roundRect')
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('stays available with no shape selected — insert is not a selection action', () => {
+    render(<EditorToolbar {...toolbarProps({ format: null, formatDisabledReason: 'none' })} />)
+    expect(screen.getByLabelText('Insert')).not.toBeDisabled()
   })
 })

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EditorToolbar, type ToolbarProps } from './toolbar'
+
+afterEach(cleanup)
+
+function toolbarProps(overrides: Partial<ToolbarProps> = {}): ToolbarProps {
+  return {
+    canUndo: false,
+    canRedo: false,
+    onUndo: () => {},
+    onRedo: () => {},
+    zoomPercent: 100,
+    isFitZoom: true,
+    onZoomIn: () => {},
+    onZoomOut: () => {},
+    onZoomFit: () => {},
+    format: { bold: false, italic: false, underline: false, sizePt: 20, colorHex: '000000' },
+    formatDisabledReason: null,
+    font: 'Tahoma',
+    deckFonts: ['Tahoma'],
+    onFontChange: () => {},
+    onToggleBold: () => {},
+    onToggleItalic: () => {},
+    onToggleUnderline: () => {},
+    onFontSizeStep: () => {},
+    onColorChange: () => {},
+    align: 'l',
+    onAlign: () => {},
+    slideNumber: 1,
+    slideCount: 3,
+    ...overrides,
+  }
+}
+
+describe('font picker', () => {
+  it('opens into a PORTAL, outside the toolbar row that would clip it', () => {
+    // The row is `overflow-x-auto`; per CSS that forces overflow-y from
+    // `visible` to `auto`, so a menu positioned inside it was mounted with
+    // aria-expanded=true and still invisible — clipped by the row's own
+    // scrollport. It has to live outside that subtree.
+    render(<EditorToolbar {...toolbarProps()} />)
+    const trigger = screen.getByLabelText('Font')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('listbox')).toBeNull()
+
+    fireEvent.click(trigger)
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    const menu = screen.getByRole('listbox')
+    expect(menu.parentElement).toBe(document.body)
+    expect(menu.closest('.overflow-x-auto')).toBeNull()
+  })
+
+  it('never takes focus, so the text selection survives a pick', () => {
+    // Every control is a plain button that cancels mousedown. Taking focus
+    // would blur the contentEditable, commit the edit and end the session, so
+    // the pick would land on the whole shape instead of the selected runs.
+    const onFontChange = vi.fn()
+    render(<EditorToolbar {...toolbarProps({ onFontChange })} />)
+    const trigger = screen.getByLabelText('Font')
+    // fireEvent returns false when the event was cancelled.
+    expect(fireEvent.mouseDown(trigger), 'trigger cancels mousedown').toBe(false)
+
+    fireEvent.click(trigger)
+    const menu = screen.getByRole('listbox')
+    const option = within(menu).getByRole('option', { name: /Georgia/ })
+    expect(fireEvent.mouseDown(option), 'option cancels mousedown').toBe(false)
+
+    fireEvent.click(option)
+    expect(onFontChange).toHaveBeenCalledWith('Georgia')
+    // Picking closes the menu.
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('lists the deck fonts first, then the common ones without duplicates', () => {
+    render(<EditorToolbar {...toolbarProps({ deckFonts: ['Tahoma', 'Poppins'] })} />)
+    fireEvent.click(screen.getByLabelText('Font'))
+    const names = within(screen.getByRole('listbox'))
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    expect(names.slice(0, 2)).toEqual(['Tahoma', 'Poppins'])
+    // Tahoma came from the deck group, so the common group must not repeat it.
+    expect(names.filter((n) => n === 'Tahoma')).toHaveLength(1)
+    expect(names).toContain('Calibri')
+  })
+
+  it('closes on Escape and on an outside pointerdown', () => {
+    render(<EditorToolbar {...toolbarProps()} />)
+    const trigger = screen.getByLabelText('Font')
+
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('listbox')).not.toBeNull()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).toBeNull()
+
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('listbox')).not.toBeNull()
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('keeps a pointerdown inside the portaled menu from closing it', () => {
+    render(<EditorToolbar {...toolbarProps()} />)
+    fireEvent.click(screen.getByLabelText('Font'))
+    const menu = screen.getByRole('listbox')
+    fireEvent.pointerDown(menu)
+    expect(screen.queryByRole('listbox')).not.toBeNull()
+  })
+
+  it('is disabled, and shows no menu, when the selection cannot take formatting', () => {
+    render(
+      <EditorToolbar
+        {...toolbarProps({ format: null, formatDisabledReason: 'Select a text box first' })}
+      />,
+    )
+    const trigger = screen.getByLabelText('Font')
+    expect(trigger).toBeDisabled()
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
@@ -6,6 +6,7 @@ import {
   BoldIcon,
   ItalicIcon,
   MinusIcon,
+  PlayIcon,
   PlusIcon,
   Redo2Icon,
   UnderlineIcon,
@@ -111,6 +112,8 @@ export interface ToolbarProps {
   align: TextAlign | null
   onAlign: (align: TextAlign) => void
 
+  onPlay: () => void
+
   slideNumber: number
   slideCount: number
   saveStatus: SaveStatus
@@ -135,6 +138,7 @@ export function EditorToolbar({
   onColorChange,
   align,
   onAlign,
+  onPlay,
   slideNumber,
   slideCount,
   saveStatus,
@@ -288,6 +292,9 @@ export function EditorToolbar({
       </Group>
 
       <div className="ml-auto flex items-center gap-3 pl-2">
+        <ToolButton label="Play from this slide" onClick={onPlay}>
+          <PlayIcon className="size-4" />
+        </ToolButton>
         <SavePill status={saveStatus} />
         <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
           Slide {slideNumber} of {slideCount}

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
@@ -1,0 +1,298 @@
+import type { ReactNode } from 'react'
+import {
+  AlignCenterIcon,
+  AlignLeftIcon,
+  AlignRightIcon,
+  BoldIcon,
+  ItalicIcon,
+  MinusIcon,
+  PlusIcon,
+  Redo2Icon,
+  UnderlineIcon,
+  Undo2Icon,
+} from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { RunFormatOverrides } from '@/lib/pptx/serialize'
+import type { TextAlign } from '@/lib/pptx/types'
+
+export type SaveStatus = 'clean' | 'saving' | 'saved' | 'error'
+
+export const ZOOM_STEPS = [50, 75, 100, 125, 150, 175, 200] as const
+export const MIN_ZOOM = ZOOM_STEPS[0]
+export const MAX_ZOOM = ZOOM_STEPS[ZOOM_STEPS.length - 1]
+
+interface ToolButtonProps {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  active?: boolean
+  children: ReactNode
+}
+
+function ToolButton({ label, onClick, disabled, active, children }: ToolButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          aria-pressed={active}
+          disabled={disabled}
+          // Keep focus in the text overlay so the selection survives the click.
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onClick}
+          className={`inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors disabled:pointer-events-none disabled:opacity-40 ${
+            active
+              ? 'bg-accent text-accent-foreground'
+              : 'hover:bg-accent hover:text-accent-foreground'
+          }`}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function Group({ children }: { children: ReactNode }) {
+  return <div className="flex items-center gap-0.5">{children}</div>
+}
+
+function Divider() {
+  return <div className="mx-1 h-5 w-px shrink-0 bg-border" aria-hidden="true" />
+}
+
+const SAVE_LABEL: Record<SaveStatus, string> = {
+  clean: 'All changes saved',
+  saving: 'Saving…',
+  saved: 'Saved',
+  error: 'Save failed',
+}
+
+function SavePill({ status }: { status: SaveStatus }) {
+  if (status === 'clean') return null
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+        status === 'error'
+          ? 'bg-destructive/15 text-destructive'
+          : status === 'saving'
+            ? 'bg-muted text-muted-foreground'
+            : 'bg-muted text-muted-foreground'
+      }`}
+    >
+      {SAVE_LABEL[status]}
+    </span>
+  )
+}
+
+export interface ToolbarProps {
+  canUndo: boolean
+  canRedo: boolean
+  onUndo: () => void
+  onRedo: () => void
+
+  zoomPercent: number
+  isFitZoom: boolean
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onZoomFit: () => void
+
+  /** Null when the selection can't take text formatting. */
+  format: RunFormatOverrides | null
+  formatDisabledReason: string | null
+  onToggleBold: () => void
+  onToggleItalic: () => void
+  onToggleUnderline: () => void
+  onFontSizeStep: (delta: number) => void
+  onColorChange: (hex: string) => void
+
+  align: TextAlign | null
+  onAlign: (align: TextAlign) => void
+
+  slideNumber: number
+  slideCount: number
+  saveStatus: SaveStatus
+}
+
+export function EditorToolbar({
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  zoomPercent,
+  isFitZoom,
+  onZoomIn,
+  onZoomOut,
+  onZoomFit,
+  format,
+  formatDisabledReason,
+  onToggleBold,
+  onToggleItalic,
+  onToggleUnderline,
+  onFontSizeStep,
+  onColorChange,
+  align,
+  onAlign,
+  slideNumber,
+  slideCount,
+  saveStatus,
+}: ToolbarProps) {
+  const fmtOff = format === null
+  const sizeLabel = format?.sizePt !== undefined ? String(Math.round(format.sizePt)) : '—'
+  const colorValue = `#${format?.colorHex ?? '000000'}`
+  const fmtHint = formatDisabledReason ?? undefined
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-1 border-b border-border bg-card/40 px-3 py-1.5">
+      <Group>
+        <ToolButton label="Undo (⌘Z)" onClick={onUndo} disabled={!canUndo}>
+          <Undo2Icon className="size-4" />
+        </ToolButton>
+        <ToolButton label="Redo (⇧⌘Z)" onClick={onRedo} disabled={!canRedo}>
+          <Redo2Icon className="size-4" />
+        </ToolButton>
+      </Group>
+
+      <Divider />
+
+      <Group>
+        <ToolButton label="Zoom out" onClick={onZoomOut} disabled={zoomPercent <= MIN_ZOOM}>
+          <MinusIcon className="size-4" />
+        </ToolButton>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={onZoomFit}
+              className={`min-w-14 rounded-md px-1.5 py-1 text-xs tabular-nums transition-colors hover:bg-accent hover:text-accent-foreground ${
+                isFitZoom ? 'text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              {isFitZoom ? 'Fit' : `${Math.round(zoomPercent)}%`}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Fit slide to window</TooltipContent>
+        </Tooltip>
+        <ToolButton label="Zoom in" onClick={onZoomIn} disabled={zoomPercent >= MAX_ZOOM}>
+          <PlusIcon className="size-4" />
+        </ToolButton>
+      </Group>
+
+      <Divider />
+
+      <Group>
+        <ToolButton
+          label={fmtHint ?? 'Decrease font size'}
+          onClick={() => onFontSizeStep(-2)}
+          disabled={fmtOff}
+        >
+          <MinusIcon className="size-4" />
+        </ToolButton>
+        <span
+          className="min-w-7 text-center text-xs tabular-nums text-muted-foreground"
+          title={fmtOff ? undefined : 'Font size (pt)'}
+        >
+          {fmtOff ? '—' : sizeLabel}
+        </span>
+        <ToolButton
+          label={fmtHint ?? 'Increase font size'}
+          onClick={() => onFontSizeStep(2)}
+          disabled={fmtOff}
+        >
+          <PlusIcon className="size-4" />
+        </ToolButton>
+      </Group>
+
+      <Group>
+        <ToolButton
+          label={fmtHint ?? 'Bold'}
+          onClick={onToggleBold}
+          disabled={fmtOff}
+          active={Boolean(format?.bold)}
+        >
+          <BoldIcon className="size-4" />
+        </ToolButton>
+        <ToolButton
+          label={fmtHint ?? 'Italic'}
+          onClick={onToggleItalic}
+          disabled={fmtOff}
+          active={Boolean(format?.italic)}
+        >
+          <ItalicIcon className="size-4" />
+        </ToolButton>
+        <ToolButton
+          label={fmtHint ?? 'Underline'}
+          onClick={onToggleUnderline}
+          disabled={fmtOff}
+          active={Boolean(format?.underline)}
+        >
+          <UnderlineIcon className="size-4" />
+        </ToolButton>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <label
+              className={`relative inline-flex size-7 items-center justify-center rounded-md ${
+                fmtOff ? 'pointer-events-none opacity-40' : 'hover:bg-accent'
+              }`}
+            >
+              <span className="text-[13px] font-semibold leading-none text-foreground">A</span>
+              <span
+                className="mt-3.5 absolute bottom-1 h-1 w-4 rounded-sm ring-1 ring-black/20"
+                style={{ backgroundColor: colorValue }}
+              />
+              <input
+                type="color"
+                aria-label="Text color"
+                value={colorValue}
+                disabled={fmtOff}
+                onMouseDown={(e) => e.stopPropagation()}
+                onChange={(e) => onColorChange(e.target.value.slice(1).toUpperCase())}
+                className="absolute inset-0 cursor-pointer opacity-0"
+              />
+            </label>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{fmtHint ?? 'Text color'}</TooltipContent>
+        </Tooltip>
+      </Group>
+
+      <Divider />
+
+      <Group>
+        <ToolButton
+          label={fmtHint ?? 'Align left'}
+          onClick={() => onAlign('l')}
+          disabled={fmtOff}
+          active={align === 'l'}
+        >
+          <AlignLeftIcon className="size-4" />
+        </ToolButton>
+        <ToolButton
+          label={fmtHint ?? 'Align center'}
+          onClick={() => onAlign('ctr')}
+          disabled={fmtOff}
+          active={align === 'ctr'}
+        >
+          <AlignCenterIcon className="size-4" />
+        </ToolButton>
+        <ToolButton
+          label={fmtHint ?? 'Align right'}
+          onClick={() => onAlign('r')}
+          disabled={fmtOff}
+          active={align === 'r'}
+        >
+          <AlignRightIcon className="size-4" />
+        </ToolButton>
+      </Group>
+
+      <div className="ml-auto flex items-center gap-3 pl-2">
+        <SavePill status={saveStatus} />
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+          Slide {slideNumber} of {slideCount}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
@@ -4,6 +4,7 @@ import {
   AlignLeftIcon,
   AlignRightIcon,
   BoldIcon,
+  DownloadIcon,
   ItalicIcon,
   MinusIcon,
   PlayIcon,
@@ -94,13 +95,21 @@ export interface EditorHeaderProps {
   filePath: string
   saveStatus: SaveStatus
   onPlay: () => void
+  onExport: () => void
 }
 
 /**
  * The slim identity row above the toolbar. Present is deliberately the only
- * accent-coloured control on the whole surface.
+ * accent-coloured control on the whole surface, so Export sits beside it as a
+ * quiet icon button.
  */
-export function EditorHeader({ fileName, filePath, saveStatus, onPlay }: EditorHeaderProps) {
+export function EditorHeader({
+  fileName,
+  filePath,
+  saveStatus,
+  onPlay,
+  onExport,
+}: EditorHeaderProps) {
   return (
     <header className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1.5">
       <PresentationIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -114,10 +123,25 @@ export function EditorHeader({ fileName, filePath, saveStatus, onPlay }: EditorH
         PPTX
       </Badge>
       <SaveState status={saveStatus} />
-      <Button size="xs" onClick={onPlay} className="ml-auto">
-        <PlayIcon />
-        Present
-      </Button>
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Export a copy"
+              onClick={onExport}
+              className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <DownloadIcon className="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Export a copy</TooltipContent>
+        </Tooltip>
+        <Button size="xs" onClick={onPlay}>
+          <PlayIcon />
+          Present
+        </Button>
+      </div>
     </header>
   )
 }

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
@@ -8,10 +8,13 @@ import {
   MinusIcon,
   PlayIcon,
   PlusIcon,
+  PresentationIcon,
   Redo2Icon,
   UnderlineIcon,
   Undo2Icon,
 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { RunFormatOverrides } from '@/lib/pptx/serialize'
 import type { TextAlign } from '@/lib/pptx/types'
@@ -42,9 +45,9 @@ function ToolButton({ label, onClick, disabled, active, children }: ToolButtonPr
           // Keep focus in the text overlay so the selection survives the click.
           onMouseDown={(e) => e.preventDefault()}
           onClick={onClick}
-          className={`inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors disabled:pointer-events-none disabled:opacity-40 ${
+          className={`inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors disabled:pointer-events-none disabled:opacity-40 ${
             active
-              ? 'bg-accent text-accent-foreground'
+              ? 'bg-primary/12 text-foreground'
               : 'hover:bg-accent hover:text-accent-foreground'
           }`}
         >
@@ -57,11 +60,11 @@ function ToolButton({ label, onClick, disabled, active, children }: ToolButtonPr
 }
 
 function Group({ children }: { children: ReactNode }) {
-  return <div className="flex items-center gap-0.5">{children}</div>
+  return <div className="flex shrink-0 items-center gap-0.5">{children}</div>
 }
 
 function Divider() {
-  return <div className="mx-1 h-5 w-px shrink-0 bg-border" aria-hidden="true" />
+  return <div className="mx-1.5 h-4 w-px shrink-0 bg-border" aria-hidden="true" />
 }
 
 const SAVE_LABEL: Record<SaveStatus, string> = {
@@ -71,20 +74,51 @@ const SAVE_LABEL: Record<SaveStatus, string> = {
   error: 'Save failed',
 }
 
-function SavePill({ status }: { status: SaveStatus }) {
+/** Quiet status text — nothing to say until the deck has actually been touched. */
+function SaveState({ status }: { status: SaveStatus }) {
   if (status === 'clean') return null
   return (
     <span
-      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
-        status === 'error'
-          ? 'bg-destructive/15 text-destructive'
-          : status === 'saving'
-            ? 'bg-muted text-muted-foreground'
-            : 'bg-muted text-muted-foreground'
+      className={`shrink-0 text-[11px] ${
+        status === 'error' ? 'text-destructive' : 'text-muted-foreground'
       }`}
     >
       {SAVE_LABEL[status]}
     </span>
+  )
+}
+
+export interface EditorHeaderProps {
+  fileName: string
+  /** Full path, shown on hover. */
+  filePath: string
+  saveStatus: SaveStatus
+  onPlay: () => void
+}
+
+/**
+ * The slim identity row above the toolbar. Present is deliberately the only
+ * accent-coloured control on the whole surface.
+ */
+export function EditorHeader({ fileName, filePath, saveStatus, onPlay }: EditorHeaderProps) {
+  return (
+    <header className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1.5">
+      <PresentationIcon className="size-4 shrink-0 text-muted-foreground" />
+      <span className="truncate text-sm font-medium text-foreground" title={filePath}>
+        {fileName}
+      </span>
+      <Badge
+        variant="outline"
+        className="rounded px-1 py-0 text-[10px] font-medium tracking-wide text-muted-foreground"
+      >
+        PPTX
+      </Badge>
+      <SaveState status={saveStatus} />
+      <Button size="xs" onClick={onPlay} className="ml-auto">
+        <PlayIcon />
+        Present
+      </Button>
+    </header>
   )
 }
 
@@ -112,11 +146,8 @@ export interface ToolbarProps {
   align: TextAlign | null
   onAlign: (align: TextAlign) => void
 
-  onPlay: () => void
-
   slideNumber: number
   slideCount: number
-  saveStatus: SaveStatus
 }
 
 export function EditorToolbar({
@@ -138,10 +169,8 @@ export function EditorToolbar({
   onColorChange,
   align,
   onAlign,
-  onPlay,
   slideNumber,
   slideCount,
-  saveStatus,
 }: ToolbarProps) {
   const fmtOff = format === null
   const sizeLabel = format?.sizePt !== undefined ? String(Math.round(format.sizePt)) : '—'
@@ -149,7 +178,7 @@ export function EditorToolbar({
   const fmtHint = formatDisabledReason ?? undefined
 
   return (
-    <div className="flex shrink-0 flex-wrap items-center gap-1 border-b border-border bg-card/40 px-3 py-1.5">
+    <div className="flex shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border px-3 py-1">
       <Group>
         <ToolButton label="Undo (⌘Z)" onClick={onUndo} disabled={!canUndo}>
           <Undo2Icon className="size-4" />
@@ -291,15 +320,9 @@ export function EditorToolbar({
         </ToolButton>
       </Group>
 
-      <div className="ml-auto flex items-center gap-3 pl-2">
-        <ToolButton label="Play from this slide" onClick={onPlay}>
-          <PlayIcon className="size-4" />
-        </ToolButton>
-        <SavePill status={saveStatus} />
-        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-          Slide {slideNumber} of {slideCount}
-        </span>
-      </div>
+      <span className="ml-auto shrink-0 pl-3 text-xs tabular-nums text-muted-foreground">
+        Slide {slideNumber} of {slideCount}
+      </span>
     </div>
   )
 }

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
@@ -1,9 +1,12 @@
-import type { ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import {
   AlignCenterIcon,
   AlignLeftIcon,
   AlignRightIcon,
   BoldIcon,
+  CheckIcon,
+  ChevronDownIcon,
   DownloadIcon,
   ItalicIcon,
   MinusIcon,
@@ -17,6 +20,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { isFontAvailable } from '@/components/pptx/text-dom'
 import type { RunFormatOverrides } from '@/lib/pptx/serialize'
 import type { TextAlign } from '@/lib/pptx/types'
 
@@ -62,6 +66,228 @@ function ToolButton({ label, onClick, disabled, active, children }: ToolButtonPr
 
 function Group({ children }: { children: ReactNode }) {
   return <div className="flex shrink-0 items-center gap-0.5">{children}</div>
+}
+
+/** Families offered on every deck, beneath the ones the deck already uses. */
+export const COMMON_FONTS = [
+  'Arial',
+  'Helvetica',
+  'Tahoma',
+  'Verdana',
+  'Georgia',
+  'Times New Roman',
+  'Courier New',
+  'Calibri',
+] as const
+
+/** Shown only for a family this machine cannot actually render. */
+const MISSING_SUFFIX =
+  'is not installed on this machine, so it renders with a substitute and its spacing may differ from PowerPoint.'
+
+interface FontPickerProps {
+  /** Resolved family of the selection; undefined means a mixed selection. */
+  value: string | undefined
+  /** Typefaces already used in this deck, listed first. */
+  deckFonts: readonly string[]
+  disabled: boolean
+  disabledReason: string | null
+  onChange: (family: string) => void
+}
+
+/** w-56 / max-h-72, needed up front to place and clamp the portaled menu. */
+const FONT_MENU_W = 224
+const FONT_MENU_MAX_H = 288
+const VIEWPORT_PAD = 8
+
+interface MenuPos {
+  left: number
+  top: number
+  maxHeight: number
+}
+
+/**
+ * Font family picker.
+ *
+ * The menu is PORTALED to document.body, not positioned inside the picker.
+ * The toolbar row is `overflow-x-auto`, and per CSS a non-visible overflow on
+ * one axis forces the other axis from `visible` to `auto` — so an absolutely
+ * positioned menu inside the row was clipped by the row's own scrollport and
+ * never appeared, even though it was mounted and `aria-expanded` was true.
+ *
+ * Every control in it is still a plain button that `preventDefault`s on
+ * mousedown, portal included: taking focus would blur the text overlay, which
+ * commits the edit and ends the session, so the pick would land on the whole
+ * shape instead of the selected runs.
+ */
+function FontPicker({ value, deckFonts, disabled, disabledReason, onChange }: FontPickerProps) {
+  const [pos, setPos] = useState<MenuPos | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const open = pos !== null
+
+  const close = useCallback(() => setPos(null), [])
+
+  const openMenu = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const left = Math.max(
+      VIEWPORT_PAD,
+      Math.min(rect.left, window.innerWidth - FONT_MENU_W - VIEWPORT_PAD),
+    )
+    const below = window.innerHeight - rect.bottom - VIEWPORT_PAD
+    const above = rect.top - VIEWPORT_PAD
+    // Flip up only when below is genuinely too cramped to be usable.
+    const flip = below < 160 && above > below
+    const maxHeight = Math.max(120, Math.min(FONT_MENU_MAX_H, flip ? above : below))
+    setPos({
+      left,
+      top: flip ? Math.max(VIEWPORT_PAD, rect.top - 4 - maxHeight) : rect.bottom + 4,
+      maxHeight,
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node
+      // The menu lives outside this component's DOM subtree now, so both the
+      // trigger and the portal have to count as "inside".
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return
+      close()
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    // Capture, so a scroll in any nested container (the toolbar row, the
+    // canvas) closes the menu rather than leaving it stranded mid-air.
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [open, close])
+
+  // Deck fonts first, then the common list minus anything already shown.
+  const extras = COMMON_FONTS.filter((f) => !deckFonts.includes(f))
+  const label = disabled ? '—' : (value ?? 'Mixed')
+  // Only warn about a font that genuinely does not resolve here. Saying it
+  // unconditionally read as a claim about the CURRENT font, which was wrong
+  // whenever that font was installed — the common case.
+  const missing = !disabled && value !== undefined && !isFontAvailable(value)
+  const tip = disabledReason ?? (missing ? `${value} ${MISSING_SUFFIX}` : 'Font')
+
+  const pick = (family: string): void => {
+    onChange(family)
+    close()
+  }
+
+  return (
+    <div className="relative shrink-0">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-label="Font"
+            aria-haspopup="listbox"
+            aria-expanded={open}
+            disabled={disabled}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => (open ? close() : openMenu())}
+            className="inline-flex h-7 w-32 items-center justify-between gap-1 rounded-md px-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40"
+          >
+            <span className="truncate" style={value ? { fontFamily: `'${value}'` } : undefined}>
+              {label}
+            </span>
+            {missing && <span className="shrink-0 text-[10px] text-amber-500">•</span>}
+            <ChevronDownIcon className="size-3 shrink-0" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{tip}</TooltipContent>
+      </Tooltip>
+
+      {pos !== null &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="listbox"
+            aria-label="Font"
+            onMouseDown={(e) => e.preventDefault()}
+            style={{
+              position: 'fixed',
+              left: pos.left,
+              top: pos.top,
+              width: FONT_MENU_W,
+              maxHeight: pos.maxHeight,
+            }}
+            className="z-[100] overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md"
+          >
+            {deckFonts.length > 0 && (
+              <>
+                <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  In this presentation
+                </div>
+                {deckFonts.map((f) => (
+                  <FontOption key={`deck:${f}`} family={f} selected={f === value} onPick={pick} />
+                ))}
+              </>
+            )}
+            {extras.length > 0 && (
+              <>
+                <div className="mt-1 border-t border-border px-2 pb-1 pt-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Common
+                </div>
+                {extras.map((f) => (
+                  <FontOption key={`common:${f}`} family={f} selected={f === value} onPick={pick} />
+                ))}
+              </>
+            )}
+          </div>,
+          document.body,
+        )}
+    </div>
+  )
+}
+
+function FontOption({
+  family,
+  selected,
+  onPick,
+}: {
+  family: string
+  selected: boolean
+  onPick: (family: string) => void
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      // Portal or not, focus must stay in the contentEditable.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => onPick(family)}
+      className={`flex w-full items-center justify-between gap-2 rounded px-2 py-1 text-left text-xs transition-colors hover:bg-accent hover:text-accent-foreground ${
+        selected ? 'text-foreground' : 'text-muted-foreground'
+      }`}
+    >
+      <span className="truncate" style={{ fontFamily: `'${family}'` }}>
+        {family}
+      </span>
+      <span className="flex shrink-0 items-center gap-1">
+        {!isFontAvailable(family) && (
+          <span className="text-[10px] text-amber-500" title={`${family} ${MISSING_SUFFIX}`}>
+            substituted
+          </span>
+        )}
+        {selected && <CheckIcon className="size-3" />}
+      </span>
+    </button>
+  )
 }
 
 function Divider() {
@@ -161,6 +387,11 @@ export interface ToolbarProps {
   /** Null when the selection can't take text formatting. */
   format: RunFormatOverrides | null
   formatDisabledReason: string | null
+  /** Resolved typeface of the selection; undefined renders as "Mixed". */
+  font: string | undefined
+  /** Typefaces already used in the deck, offered above the common list. */
+  deckFonts: readonly string[]
+  onFontChange: (family: string) => void
   onToggleBold: () => void
   onToggleItalic: () => void
   onToggleUnderline: () => void
@@ -186,6 +417,9 @@ export function EditorToolbar({
   onZoomFit,
   format,
   formatDisabledReason,
+  font,
+  deckFonts,
+  onFontChange,
   onToggleBold,
   onToggleItalic,
   onToggleUnderline,
@@ -239,6 +473,14 @@ export function EditorToolbar({
       </Group>
 
       <Divider />
+
+      <FontPicker
+        value={font}
+        deckFonts={deckFonts}
+        disabled={fmtOff}
+        disabledReason={formatDisabledReason}
+        onChange={onFontChange}
+      />
 
       <Group>
         <ToolButton

--- a/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/pptx/toolbar.tsx
@@ -290,6 +290,158 @@ function FontOption({
   )
 }
 
+interface ColorSwatchProps {
+  label: string
+  /** Glyph drawn above the colour bar. */
+  glyph: ReactNode
+  /** `#RRGGBB`. */
+  value: string
+  disabled: boolean
+  onChange: (hex: string) => void
+}
+
+/** The toolbar's colour control: a glyph over a colour bar, backed by an
+ * `<input type="color">` filling the whole hit area. */
+function ColorSwatch({ label, glyph, value, disabled, onChange }: ColorSwatchProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <label
+          className={`relative inline-flex size-7 shrink-0 items-center justify-center rounded-md ${
+            disabled ? 'pointer-events-none opacity-40' : 'hover:bg-accent'
+          }`}
+        >
+          {glyph}
+          <span
+            className="absolute bottom-1 h-1 w-4 rounded-sm ring-1 ring-black/20"
+            style={{ backgroundColor: value }}
+          />
+          <input
+            type="color"
+            aria-label={label}
+            value={value}
+            disabled={disabled}
+            onMouseDown={(e) => e.stopPropagation()}
+            onChange={(e) => onChange(e.target.value.slice(1).toUpperCase())}
+            className="absolute inset-0 cursor-pointer opacity-0"
+          />
+        </label>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+/** What the Insert menu offers. */
+export type InsertChoice = 'textbox' | 'rect' | 'roundRect' | 'ellipse' | 'line' | 'image'
+
+const INSERT_ITEMS: ReadonlyArray<{ choice: InsertChoice; label: string }> = [
+  { choice: 'textbox', label: 'Text box' },
+  { choice: 'rect', label: 'Rectangle' },
+  { choice: 'roundRect', label: 'Rounded rectangle' },
+  { choice: 'ellipse', label: 'Ellipse' },
+  { choice: 'line', label: 'Line' },
+  { choice: 'image', label: 'Image…' },
+]
+
+/**
+ * Insert menu. Portaled for the same reason the font picker is: the toolbar
+ * row is `overflow-x-auto`, which forces overflow-y to `auto` and clips any
+ * absolutely positioned child.
+ */
+function InsertMenu({ onInsert }: { onInsert: (choice: InsertChoice) => void }) {
+  const [pos, setPos] = useState<MenuPos | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const open = pos !== null
+  const close = useCallback(() => setPos(null), [])
+
+  const openMenu = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect) return
+    setPos({
+      left: Math.max(VIEWPORT_PAD, Math.min(rect.left, window.innerWidth - 200 - VIEWPORT_PAD)),
+      top: rect.bottom + 4,
+      maxHeight: Math.max(120, window.innerHeight - rect.bottom - VIEWPORT_PAD),
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return
+      close()
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [open, close])
+
+  return (
+    <div className="relative shrink-0">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-label="Insert"
+            aria-haspopup="menu"
+            aria-expanded={open}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => (open ? close() : openMenu())}
+            className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <PlusIcon className="size-3.5" />
+            Insert
+            <ChevronDownIcon className="size-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Insert a shape, text box or image</TooltipContent>
+      </Tooltip>
+
+      {pos !== null &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            aria-label="Insert"
+            onMouseDown={(e) => e.preventDefault()}
+            style={{ position: 'fixed', left: pos.left, top: pos.top, width: 200, maxHeight: pos.maxHeight }}
+            className="z-[100] overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md"
+          >
+            {INSERT_ITEMS.map((item) => (
+              <button
+                key={item.choice}
+                type="button"
+                role="menuitem"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onInsert(item.choice)
+                  close()
+                }}
+                className="flex w-full items-center rounded px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  )
+}
+
 function Divider() {
   return <div className="mx-1.5 h-4 w-px shrink-0 bg-border" aria-hidden="true" />
 }
@@ -388,6 +540,12 @@ export interface ToolbarProps {
   format: RunFormatOverrides | null
   formatDisabledReason: string | null
   /** Resolved typeface of the selection; undefined renders as "Mixed". */
+  onInsert: (choice: InsertChoice) => void
+  /** Shape fill / outline as `#RRGGBB`; null hides the control entirely. */
+  shapeFill: string | null
+  shapeLine: string | null
+  onShapeFillChange: (hex: string) => void
+  onShapeLineChange: (hex: string) => void
   font: string | undefined
   /** Typefaces already used in the deck, offered above the common list. */
   deckFonts: readonly string[]
@@ -417,6 +575,11 @@ export function EditorToolbar({
   onZoomFit,
   format,
   formatDisabledReason,
+  onInsert,
+  shapeFill,
+  shapeLine,
+  onShapeFillChange,
+  onShapeLineChange,
   font,
   deckFonts,
   onFontChange,
@@ -471,6 +634,10 @@ export function EditorToolbar({
           <PlusIcon className="size-4" />
         </ToolButton>
       </Group>
+
+      <Divider />
+
+      <InsertMenu onInsert={onInsert} />
 
       <Divider />
 
@@ -530,32 +697,47 @@ export function EditorToolbar({
         >
           <UnderlineIcon className="size-4" />
         </ToolButton>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <label
-              className={`relative inline-flex size-7 items-center justify-center rounded-md ${
-                fmtOff ? 'pointer-events-none opacity-40' : 'hover:bg-accent'
-              }`}
-            >
-              <span className="text-[13px] font-semibold leading-none text-foreground">A</span>
-              <span
-                className="mt-3.5 absolute bottom-1 h-1 w-4 rounded-sm ring-1 ring-black/20"
-                style={{ backgroundColor: colorValue }}
-              />
-              <input
-                type="color"
-                aria-label="Text color"
-                value={colorValue}
-                disabled={fmtOff}
-                onMouseDown={(e) => e.stopPropagation()}
-                onChange={(e) => onColorChange(e.target.value.slice(1).toUpperCase())}
-                className="absolute inset-0 cursor-pointer opacity-0"
-              />
-            </label>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{fmtHint ?? 'Text color'}</TooltipContent>
-        </Tooltip>
+        <ColorSwatch
+          label="Text color"
+          glyph={<span className="text-[13px] font-semibold leading-none text-foreground">A</span>}
+          value={colorValue}
+          disabled={fmtOff}
+          onChange={onColorChange}
+        />
       </Group>
+
+      {(shapeFill !== null || shapeLine !== null) && (
+        <>
+          <Divider />
+          <Group>
+            {shapeFill !== null && (
+              <ColorSwatch
+                label="Shape fill"
+                glyph={
+                  <span
+                    className="size-3 rounded-[2px] ring-1 ring-black/20"
+                    style={{ backgroundColor: shapeFill }}
+                  />
+                }
+                value={shapeFill}
+                disabled={false}
+                onChange={onShapeFillChange}
+              />
+            )}
+            {shapeLine !== null && (
+              <ColorSwatch
+                label="Shape outline"
+                glyph={
+                  <span className="size-3 rounded-[2px] border-2" style={{ borderColor: shapeLine }} />
+                }
+                value={shapeLine}
+                disabled={false}
+                onChange={onShapeLineChange}
+              />
+            )}
+          </Group>
+        </>
+      )}
 
       <Divider />
 

--- a/apps/x/apps/renderer/src/lib/file-types.ts
+++ b/apps/x/apps/renderer/src/lib/file-types.ts
@@ -6,7 +6,7 @@
  * also uses it to decide what to keep mounted.
  */
 
-export type ViewerType = 'html' | 'image' | 'video' | 'audio' | 'pdf' | 'docx'
+export type ViewerType = 'html' | 'image' | 'video' | 'audio' | 'pdf' | 'docx' | 'pptx'
 
 const VIEWER_BY_EXT: Record<string, ViewerType> = {
   html: 'html',
@@ -32,6 +32,7 @@ const VIEWER_BY_EXT: Record<string, ViewerType> = {
   aac: 'audio',
   pdf: 'pdf',
   docx: 'docx',
+  pptx: 'pptx',
 }
 
 function extensionOf(path: string): string {

--- a/apps/x/apps/renderer/src/lib/pptx/add-slide.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/add-slide.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parseAddedSlide, parsePptx } from './parse'
+import { writeDeck, type NewSlidePart } from './serialize'
+import { planNewSlide } from './add-slide'
+import type { TextShape } from './types'
+
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const NS_R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+const TITLE_RECT = { x: 100000, y: 200000, w: 3000000, h: 400000 }
+
+const LAYOUT_XML =
+  `<p:sldLayout ${NS_P} ${NS_A}><p:cSld><p:spTree>` +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>' +
+  `<p:spPr><a:xfrm><a:off x="${TITLE_RECT.x}" y="${TITLE_RECT.y}"/><a:ext cx="${TITLE_RECT.w}" cy="${TITLE_RECT.h}"/></a:xfrm></p:spPr>` +
+  '<p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr sz="4400"/></a:lvl1pPr></a:lstStyle></p:txBody></p:sp>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="3"/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="100000" y="700000"/><a:ext cx="3000000" cy="1500000"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/></p:txBody></p:sp>' +
+  // Chrome slots must NOT be instantiated on a new slide.
+  '<p:sp><p:nvSpPr><p:cNvPr id="4"/><p:nvPr><p:ph type="ftr" idx="5"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/></p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sldLayout>'
+
+const SLIDE = (n: number) =>
+  `<p:sld ${NS_P} ${NS_A}><p:cSld><p:spTree>` +
+  `<p:sp><p:nvSpPr><p:cNvPr id="2" name="T${n}"/></p:nvSpPr>` +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100" cy="100"/></a:xfrm></p:spPr>' +
+  `<p:txBody><a:bodyPr/><a:p><a:r><a:t>slide ${n}</a:t></a:r></a:p></p:txBody></p:sp>` +
+  '</p:spTree></p:cSld></p:sld>'
+
+const SLDID_1 = '<p:sldId id="256" r:id="rId2"/>'
+const PRESENTATION_XML =
+  `<p:presentation ${NS_P} ${NS_R}>` +
+  `<p:sldIdLst>${SLDID_1}<p:sldId id="257" r:id="rId3"/></p:sldIdLst>` +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId1" Type="${REL_TYPE}/theme" Target="theme/theme1.xml"/>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/>` +
+  `<Relationship Id="rId3" Type="${REL_TYPE}/slide" Target="slides/slide2.xml"/>` +
+  '</Relationships>'
+
+const SLIDE_CT = 'application/vnd.openxmlformats-officedocument.presentationml.slide+xml'
+const CONTENT_TYPES =
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  `<Override PartName="/ppt/slides/slide1.xml" ContentType="${SLIDE_CT}"/>` +
+  `<Override PartName="/ppt/slides/slide2.xml" ContentType="${SLIDE_CT}"/>` +
+  '</Types>'
+
+const slideRels = () =>
+  `<Relationships ${REL_NS}><Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/></Relationships>`
+
+async function buildFixtureZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('[Content_Types].xml', CONTENT_TYPES)
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE(1))
+  zip.file('ppt/slides/_rels/slide1.xml.rels', slideRels())
+  zip.file('ppt/slides/slide2.xml', SLIDE(2))
+  zip.file('ppt/slides/_rels/slide2.xml.rels', slideRels())
+  zip.file('ppt/slideLayouts/slideLayout1.xml', LAYOUT_XML)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+async function loadDeck() {
+  return parsePptx(await buildFixtureZip())
+}
+
+describe('planNewSlide', () => {
+  it('claims the next part name and instantiates the layout content placeholders', async () => {
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+    expect(plan.path).toBe('ppt/slides/slide3.xml')
+    expect(plan.afterPath).toBe('ppt/slides/slide1.xml')
+    // Title and body placeholders, but never the footer chrome.
+    expect(plan.xml).toContain('<p:ph type="title"/>')
+    expect(plan.xml).toContain('<p:ph type="body" idx="1"/>')
+    expect(plan.xml).not.toContain('type="ftr"')
+    // The rels reference the anchor's layout.
+    expect(plan.relsXml).toContain('Target="../slideLayouts/slideLayout1.xml"')
+    // Pending added paths are dodged too.
+    const next = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [plan.path])
+    expect(next.path).toBe('ppt/slides/slide4.xml')
+  })
+
+  it('renders through the real pipeline with layout geometry and empty text', async () => {
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+    const slide = await parseAddedSlide(deck, plan.path, plan.xml, plan.relsXml)
+    expect(slide.xmlPath).toBe(plan.path)
+    const [title, body] = slide.shapes as TextShape[]
+    expect(title.type).toBe('text')
+    // Placeholder geometry inherits from the layout slot.
+    expect(title.xfrmEmu).toEqual(TITLE_RECT)
+    // Empty text body: the editor shows its "Add text" affordance.
+    expect(title.paragraphs).toHaveLength(1)
+    expect(title.paragraphs[0].runs).toHaveLength(0)
+    // Text style cascades from the layout's lstStyle.
+    expect(title.display?.defaultRun.sizePt).toBe(44)
+    expect(body.type).toBe('text')
+  })
+
+  it('fails closed when the anchor has no layout to clone', async () => {
+    const zip = new JSZip()
+    zip.file('[Content_Types].xml', CONTENT_TYPES)
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', SLIDE(1))
+    zip.file('ppt/slides/slide2.xml', SLIDE(2))
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    await expect(planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])).rejects.toThrow(
+      /no relationships part/,
+    )
+  })
+})
+
+describe('writeDeck addSlides', () => {
+  it('adds the part + rels and splices sldId, Relationship and Override — nothing else', async () => {
+    const input = await buildFixtureZip()
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+    const out = await writeDeck(deck, new Map(), { addSlides: [plan] })
+
+    const inZip = await JSZip.loadAsync(input)
+    const outZip = await JSZip.loadAsync(out)
+
+    // The new sldId lands right after the anchor's, with fresh unique ids.
+    expect(await outZip.files['ppt/presentation.xml'].async('string')).toBe(
+      PRESENTATION_XML.replace(SLDID_1, `${SLDID_1}<p:sldId id="258" r:id="rId4"/>`),
+    )
+    expect(await outZip.files['ppt/_rels/presentation.xml.rels'].async('string')).toBe(
+      PRESENTATION_RELS.replace(
+        '</Relationships>',
+        `<Relationship Id="rId4" Type="${REL_TYPE}/slide" Target="slides/slide3.xml"/></Relationships>`,
+      ),
+    )
+    expect(await outZip.files['[Content_Types].xml'].async('string')).toBe(
+      CONTENT_TYPES.replace(
+        '</Types>',
+        `<Override PartName="/ppt/slides/slide3.xml" ContentType="${SLIDE_CT}"/></Types>`,
+      ),
+    )
+    expect(await outZip.files['ppt/slides/slide3.xml'].async('string')).toBe(plan.xml)
+    expect(await outZip.files['ppt/slides/_rels/slide3.xml.rels'].async('string')).toBe(plan.relsXml)
+
+    // Every pre-existing part is byte-identical.
+    for (const name of Object.keys(inZip.files)) {
+      if (inZip.files[name].dir) continue
+      if (
+        name === 'ppt/presentation.xml' ||
+        name === 'ppt/_rels/presentation.xml.rels' ||
+        name === '[Content_Types].xml'
+      ) {
+        continue
+      }
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `byte-identical: ${name}`).toBe(true)
+    }
+
+    // The result reopens as a three-slide deck in the right order.
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide1.xml',
+      'ppt/slides/slide3.xml',
+      'ppt/slides/slide2.xml',
+    ])
+  })
+
+  it('applies text edits addressed at the added slide against its synthesized XML', async () => {
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+    const slide = await parseAddedSlide(deck, plan.path, plan.xml, plan.relsXml)
+    const title = slide.shapes[0] as TextShape
+
+    const out = await writeDeck(
+      deck,
+      new Map([
+        [
+          plan.path,
+          [
+            {
+              kind: 'text' as const,
+              nodePath: title.nodePath,
+              original: title.paragraphs,
+              next: [{ srcPara: 0, runs: [{ text: 'Hello new slide' }] }],
+            },
+          ],
+        ],
+      ]),
+      { addSlides: [plan] },
+    )
+    const raw = await (await JSZip.loadAsync(out)).files[plan.path].async('string')
+    expect(raw).toContain('<a:t>Hello new slide</a:t>')
+
+    const reparsed = await parsePptx(out)
+    const added = reparsed.slides[1].shapes[0] as TextShape
+    expect(added.paragraphs[0].runs[0].text).toBe('Hello new slide')
+  })
+
+  it('chains an add anchored to another pending add, in order', async () => {
+    const deck = await loadDeck()
+    const a = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+    const b = await planNewSlide(deck, a.path, a.relsXml, [a.path])
+    expect(b.path).toBe('ppt/slides/slide4.xml')
+    const out = await writeDeck(deck, new Map(), { addSlides: [a, b] })
+
+    expect(await (await JSZip.loadAsync(out)).files['ppt/presentation.xml'].async('string')).toBe(
+      PRESENTATION_XML.replace(
+        SLDID_1,
+        `${SLDID_1}<p:sldId id="258" r:id="rId4"/><p:sldId id="259" r:id="rId5"/>`,
+      ),
+    )
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide1.xml',
+      'ppt/slides/slide3.xml',
+      'ppt/slides/slide4.xml',
+      'ppt/slides/slide2.xml',
+    ])
+  })
+
+  it('fails closed on collisions, unknown anchors, and anchors being deleted', async () => {
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+
+    await expect(
+      writeDeck(deck, new Map(), { addSlides: [{ ...plan, path: 'ppt/slides/slide2.xml' }] }),
+    ).rejects.toThrow(/collides/)
+    await expect(
+      writeDeck(deck, new Map(), { addSlides: [{ ...plan, afterPath: 'ppt/slides/slide9.xml' }] }),
+    ).rejects.toThrow(/unknown anchor/)
+    await expect(
+      writeDeck(deck, new Map(), {
+        addSlides: [plan],
+        deleteSlides: ['ppt/slides/slide1.xml'],
+      }),
+    ).rejects.toThrow(/being deleted/)
+  })
+
+  it('composes with a deletion elsewhere in the same save', async () => {
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, 'ppt/slides/slide1.xml', undefined, [])
+    const out = await writeDeck(deck, new Map(), {
+      addSlides: [plan] as readonly NewSlidePart[],
+      deleteSlides: ['ppt/slides/slide2.xml'],
+    })
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([
+      'ppt/slides/slide1.xml',
+      'ppt/slides/slide3.xml',
+    ])
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/add-slide.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/add-slide.ts
@@ -23,6 +23,7 @@ import {
   relsPathFor,
   tagNameOf,
 } from './parse'
+import { updateSlideXml, type SlideEdit } from './serialize'
 import type { SlideDeck } from './types'
 
 const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
@@ -169,4 +170,61 @@ export async function planNewSlide(
     relsXml: relsXmlFor(layoutPath),
     afterPath,
   }
+}
+
+/** A slide the editor can duplicate: its current bytes and its rels. */
+export interface DuplicateSource {
+  /**
+   * The anchor's part XML as retained: `deck.source.slideXml[path]` for a base
+   * slide, or the synthesized `xml` when duplicating an added slide.
+   */
+  xml: string
+  /** The anchor's .rels, when it has one (an added slide always does). */
+  relsXml?: string
+  /** The anchor's accumulated edits, applied to `xml` at plan time. */
+  edits?: readonly SlideEdit[]
+}
+
+const EMPTY_RELS =
+  XML_HEAD +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>'
+
+/**
+ * Plans a duplicate of `anchorPath`, capturing the slide AS CURRENTLY SHOWN:
+ * the anchor's pending edits are applied to its bytes here, once, and the
+ * result becomes the new part's content. The copy is a plain added slide from
+ * that point on, so later edits to either slide address different parts and
+ * cannot affect each other.
+ *
+ * The .rels are cloned verbatim, which means both slides reference the same
+ * media and layout parts — sharing targets is valid OPC, and copying media
+ * would bloat the package for no gain.
+ */
+export function planDuplicateSlide(
+  deck: SlideDeck,
+  anchorPath: string,
+  source: DuplicateSource,
+  usedPaths: readonly string[],
+): NewSlidePlan {
+  // updateSlideXml fails closed on any model/bytes disagreement, so a
+  // duplicate can never capture a half-applied edit.
+  const xml =
+    source.edits && source.edits.length > 0
+      ? updateSlideXml(source.xml, source.edits)
+      : source.xml
+  return {
+    path: nextSlidePath(deck.source.zip, usedPaths),
+    xml,
+    relsXml: source.relsXml ?? EMPTY_RELS,
+    afterPath: anchorPath,
+  }
+}
+
+/** Reads a base slide's .rels for duplication; undefined when it has none. */
+export async function readSlideRels(
+  deck: SlideDeck,
+  slidePath: string,
+): Promise<string | undefined> {
+  const file = deck.source.zip.file(relsPathFor(slidePath))
+  return file ? file.async('string') : undefined
 }

--- a/apps/x/apps/renderer/src/lib/pptx/add-slide.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/add-slide.ts
@@ -1,0 +1,172 @@
+/**
+ * Planning a NEW slide: a synthesized part + .rels that instantiate the
+ * anchor slide's layout, the way PowerPoint's "New Slide" does — one empty
+ * `p:sp` per layout placeholder (title/body/…, skipping the footer/date/number
+ * chrome), each referencing its slot via `p:ph`, so geometry and text style
+ * inherit through the existing cascade and the editor shows the familiar
+ * "Add text" boxes.
+ *
+ * Only strings are produced here. Nothing is written and no existing bytes
+ * are touched — `writeDeck` owns splicing the package parts, and the editor
+ * owns rendering the plan. Fail closed on anything surprising.
+ */
+
+import JSZip from 'jszip'
+import {
+  attr,
+  childByLocal,
+  childrenByLocal,
+  childrenOf,
+  descend,
+  localNameOf,
+  parseXml,
+  relsPathFor,
+  tagNameOf,
+} from './parse'
+import type { SlideDeck } from './types'
+
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+/** Everything writeDeck needs to add one slide to the package. */
+export interface NewSlidePlan {
+  /** New part path, e.g. `ppt/slides/slide18.xml`. Guaranteed unused. */
+  path: string
+  /** Complete synthesized slide XML. */
+  xml: string
+  /** Complete synthesized .rels (the slide's layout reference). */
+  relsXml: string
+  /** The slide this one follows; '' inserts at the front of the deck. */
+  afterPath: string
+}
+
+function fail(msg: string): never {
+  throw new Error(`pptx add-slide: ${msg}`)
+}
+
+/** Placeholder types that are slide chrome, not content — never instantiated. */
+const SKIPPED_PH_TYPES = new Set(['ftr', 'dt', 'sldNum'])
+
+/** `title` -> `Title 1`-style shape name, purely cosmetic. */
+function placeholderName(type: string | undefined, ordinal: number): string {
+  const base = type === 'title' || type === 'ctrTitle' ? 'Title' : type === 'subTitle' ? 'Subtitle' : 'Content Placeholder'
+  return `${base} ${ordinal}`
+}
+
+const XML_HEAD = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n'
+const NS =
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"' +
+  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"' +
+  ' xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+
+/** The `p:ph` slots of a layout worth instantiating, in document order. */
+function layoutPlaceholders(layoutXml: string): Array<{ type?: string; idx?: string }> {
+  const doc = parseXml(layoutXml)
+  const root = childByLocal(doc, 'sldLayout')
+  const spTree = root ? descend(root, 'cSld', 'spTree') : undefined
+  if (!spTree) return []
+  const out: Array<{ type?: string; idx?: string }> = []
+  for (const node of childrenOf(spTree)) {
+    const tag = tagNameOf(node)
+    if (!tag || localNameOf(tag) !== 'sp') continue
+    const ph = descend(node, 'nvSpPr', 'nvPr', 'ph')
+    if (!ph) continue
+    const type = attr(ph, 'type')
+    if (type && SKIPPED_PH_TYPES.has(type)) continue
+    out.push({ type, idx: attr(ph, 'idx') })
+  }
+  return out
+}
+
+function placeholderSp(ph: { type?: string; idx?: string }, id: number, ordinal: number): string {
+  const phAttrs =
+    (ph.type ? ` type="${ph.type}"` : '') + (ph.idx !== undefined ? ` idx="${ph.idx}"` : '')
+  return (
+    `<p:sp><p:nvSpPr><p:cNvPr id="${id}" name="${placeholderName(ph.type, ordinal)}"/>` +
+    '<p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>' +
+    `<p:nvPr><p:ph${phAttrs}/></p:nvPr></p:nvSpPr><p:spPr/>` +
+    '<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr/></a:p></p:txBody></p:sp>'
+  )
+}
+
+function slideXmlFor(placeholders: Array<{ type?: string; idx?: string }>): string {
+  const shapes = placeholders.map((ph, i) => placeholderSp(ph, i + 2, i + 1)).join('')
+  return (
+    XML_HEAD +
+    `<p:sld ${NS}><p:cSld><p:spTree>` +
+    '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+    '<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/>' +
+    '<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>' +
+    shapes +
+    '</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>'
+  )
+}
+
+function relsXmlFor(layoutPath: string): string {
+  // Slides live in ppt/slides, so any ppt/… layout is one directory up.
+  if (!layoutPath.startsWith('ppt/')) fail(`unexpected layout location ${layoutPath}`)
+  return (
+    XML_HEAD +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    `<Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../${layoutPath.slice(4)}"/>` +
+    '</Relationships>'
+  )
+}
+
+/** First unused `ppt/slides/slideN.xml`, also dodging pending added paths. */
+function nextSlidePath(zip: JSZip, usedPaths: readonly string[]): string {
+  let max = 0
+  const consider = (p: string): void => {
+    const m = p.match(/^ppt\/slides\/slide(\d+)\.xml$/)
+    if (m) max = Math.max(max, Number(m[1]))
+  }
+  Object.keys(zip.files).forEach(consider)
+  usedPaths.forEach(consider)
+  return `ppt/slides/slide${max + 1}.xml`
+}
+
+/** The slideLayout Target of a .rels document, resolved to a package path. */
+function layoutTargetOf(relsXml: string): string | undefined {
+  const root = childByLocal(parseXml(relsXml), 'Relationships')
+  if (!root) return undefined
+  for (const rel of childrenByLocal(childrenOf(root), 'Relationship')) {
+    const type = attr(rel, 'Type') ?? ''
+    const target = attr(rel, 'Target')
+    if (!type.endsWith('/slideLayout') || !target) continue
+    // Targets are relative to ppt/slides; normalize `../x` to `ppt/x`.
+    return target.startsWith('../') ? `ppt/${target.slice(3)}` : target.replace(/^\//, '')
+  }
+  return undefined
+}
+
+/**
+ * Plans one new slide after `afterPath`, on the same layout as the anchor.
+ * `anchorRelsXml` supplies the anchor's rels when the anchor is itself a
+ * pending added slide (its part is not in the zip yet); `usedPaths` are the
+ * part names already claimed by pending adds.
+ */
+export async function planNewSlide(
+  deck: SlideDeck,
+  afterPath: string,
+  anchorRelsXml: string | undefined,
+  usedPaths: readonly string[],
+): Promise<NewSlidePlan> {
+  const zip = deck.source.zip
+
+  let relsXml = anchorRelsXml
+  if (relsXml === undefined) {
+    const file = zip.file(relsPathFor(afterPath))
+    if (!file) fail(`slide ${afterPath} has no relationships part — cannot determine its layout`)
+    relsXml = await file.async('string')
+  }
+  const layoutPath = layoutTargetOf(relsXml) ?? fail(`slide ${afterPath} references no layout`)
+
+  const layoutFile = zip.file(layoutPath) ?? fail(`layout ${layoutPath} is missing from the package`)
+  const placeholders = layoutPlaceholders(await layoutFile.async('string'))
+
+  return {
+    path: nextSlidePath(zip, usedPaths),
+    xml: slideXmlFor(placeholders),
+    relsXml: relsXmlFor(layoutPath),
+    afterPath,
+  }
+}

--- a/apps/x/apps/renderer/src/lib/pptx/delete.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/delete.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx } from './parse'
+import { updateSlideXml, writeDeck, type DeleteShapeEdit, type SlideEdit } from './serialize'
+import type { GroupShape, ImageShape, PlaceholderShape, TextShape } from './types'
+
+// Realistic namespaces: the slide-relationship Type suffix and Target
+// resolution are part of what slide deletion validates.
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const NS_R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+// Slide 1's shapes as named constants, so "everything outside the removed
+// range is byte-identical" is provable with plain string surgery.
+const TEXT_SP =
+  '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Title"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="100" cy="200"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:p><a:pPr algn="ctr"/><a:r><a:rPr sz="2800"/><a:t>Keep me</a:t></a:r></a:p></p:txBody></p:sp>'
+
+const PIC =
+  '<p:pic><p:nvPicPr><p:cNvPr id="3" name="Photo"/></p:nvPicPr>' +
+  '<p:blipFill><a:blip r:embed="rId1"/></p:blipFill>' +
+  '<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm></p:spPr></p:pic>'
+
+const GROUP =
+  '<p:grpSp><p:nvGrpSpPr><p:cNvPr id="10" name="Group"/></p:nvGrpSpPr>' +
+  '<p:grpSpPr><a:xfrm><a:off x="5" y="6"/><a:ext cx="70" cy="80"/></a:xfrm></p:grpSpPr>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="11"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="5" y="6"/><a:ext cx="7" cy="8"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:p><a:r><a:t>inside</a:t></a:r></a:p></p:txBody></p:sp></p:grpSp>'
+
+const FRAME =
+  '<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="4" name="Chart"/></p:nvGraphicFramePr>' +
+  '<p:xfrm><a:off x="9" y="9"/><a:ext cx="9" cy="9"/></p:xfrm>' +
+  '<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"/></a:graphic></p:graphicFrame>'
+
+const SLIDE1_HEAD =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:sld ${NS_P} ${NS_A} ${NS_R}><p:cSld><p:spTree>` +
+  '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/>'
+const SLIDE1_TAIL = '</p:spTree></p:cSld></p:sld>'
+// A literal space between two shapes: whitespace OUTSIDE a removed element's
+// range must survive deletion byte-for-byte.
+const SLIDE1_XML = SLIDE1_HEAD + TEXT_SP + ' ' + PIC + GROUP + FRAME + SLIDE1_TAIL
+
+const SLIDE2_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:sld ${NS_P} ${NS_A} ${NS_R}><p:cSld><p:spTree>` +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2" name="T2"/></p:nvSpPr><p:spPr/>' +
+  '<p:txBody><a:bodyPr/><a:p><a:r><a:t>second slide</a:t></a:r></a:p></p:txBody></p:sp>' +
+  '<p:pic><p:nvPicPr><p:cNvPr id="3"/></p:nvPicPr><p:blipFill><a:blip r:embed="rId1"/></p:blipFill>' +
+  '<p:spPr><a:xfrm><a:off x="1" y="1"/><a:ext cx="2" cy="2"/></a:xfrm></p:spPr></p:pic>' +
+  '</p:spTree></p:cSld></p:sld>'
+
+const SLDID_2 = '<p:sldId id="257" r:id="rId3"/>'
+const PRESENTATION_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:presentation ${NS_P} ${NS_R}>` +
+  `<p:sldIdLst><p:sldId id="256" r:id="rId2"/>${SLDID_2}</p:sldIdLst>` +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+
+const REL_SLIDE2 = `<Relationship Id="rId3" Type="${REL_TYPE}/slide" Target="slides/slide2.xml"/>`
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId1" Type="${REL_TYPE}/theme" Target="theme/theme1.xml"/>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/>` +
+  REL_SLIDE2 +
+  '</Relationships>'
+
+const OVERRIDE_SLIDE2 =
+  '<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>'
+const CONTENT_TYPES =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  '<Default Extension="png" ContentType="image/png"/>' +
+  '<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>' +
+  OVERRIDE_SLIDE2 +
+  '</Types>'
+
+const slideRels = (target: string) =>
+  `<Relationships ${REL_NS}><Relationship Id="rId1" Type="${REL_TYPE}/image" Target="${target}"/></Relationships>`
+
+const PNG1 = Uint8Array.from([137, 80, 78, 71, 1, 2, 3])
+const PNG2 = Uint8Array.from([137, 80, 78, 71, 9, 8, 7])
+
+async function buildFixtureZip(contentTypes: string = CONTENT_TYPES): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('[Content_Types].xml', contentTypes)
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE1_XML)
+  zip.file('ppt/slides/_rels/slide1.xml.rels', slideRels('../media/image1.png'))
+  zip.file('ppt/slides/slide2.xml', SLIDE2_XML)
+  zip.file('ppt/slides/_rels/slide2.xml.rels', slideRels('../media/image2.png'))
+  zip.file('ppt/media/image1.png', PNG1)
+  zip.file('ppt/media/image2.png', PNG2)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+async function loadDeck(contentTypes?: string) {
+  const deck = await parsePptx(await buildFixtureZip(contentTypes))
+  const slide1 = deck.slides[0]
+  const [text, image, group, frame] = slide1.shapes as [
+    TextShape,
+    ImageShape,
+    GroupShape,
+    PlaceholderShape,
+  ]
+  return { deck, slide1, text, image, group, frame }
+}
+
+function deleteEditFor(
+  shape: { nodePath: number[]; id: string; type: DeleteShapeEdit['shapeType'] },
+  original?: TextShape['paragraphs'],
+): DeleteShapeEdit {
+  return {
+    kind: 'deleteShape',
+    nodePath: shape.nodePath,
+    shapeType: shape.type,
+    shapeId: shape.id,
+    original,
+  }
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  let n = 0
+  URL.createObjectURL = (() => `blob:mock/${n++}`) as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+describe('deleteShape', () => {
+  it('removes exactly the text shape element; whitespace and neighbours keep their bytes', async () => {
+    const { text } = await loadDeck()
+    expect(text.type).toBe('text')
+    const out = updateSlideXml(SLIDE1_XML, [deleteEditFor(text, text.paragraphs)])
+    // The space that followed the shape survives — only [start, end) went.
+    expect(out).toBe(SLIDE1_HEAD + ' ' + PIC + GROUP + FRAME + SLIDE1_TAIL)
+  })
+
+  it('removes a picture, a whole group, and a graphicFrame placeholder', async () => {
+    const { image, group, frame } = await loadDeck()
+    expect(updateSlideXml(SLIDE1_XML, [deleteEditFor(image)])).toBe(
+      SLIDE1_HEAD + TEXT_SP + ' ' + GROUP + FRAME + SLIDE1_TAIL,
+    )
+    expect(updateSlideXml(SLIDE1_XML, [deleteEditFor(group)])).toBe(
+      SLIDE1_HEAD + TEXT_SP + ' ' + PIC + FRAME + SLIDE1_TAIL,
+    )
+    expect(updateSlideXml(SLIDE1_XML, [deleteEditFor(frame)])).toBe(
+      SLIDE1_HEAD + TEXT_SP + ' ' + PIC + GROUP + SLIDE1_TAIL,
+    )
+  })
+
+  it('composes with other edits on the same slide without overlapping', async () => {
+    const { text, image } = await loadDeck()
+    const edits: SlideEdit[] = [
+      deleteEditFor(image),
+      { kind: 'shapeGeometry', nodePath: text.nodePath, offEmu: { x: 55, y: 66 } },
+    ]
+    const out = updateSlideXml(SLIDE1_XML, edits)
+    const movedTextSp = TEXT_SP.replace('x="10"', 'x="55"').replace('y="20"', 'y="66"')
+    expect(out).toBe(SLIDE1_HEAD + movedTextSp + ' ' + GROUP + FRAME + SLIDE1_TAIL)
+  })
+
+  it('fails closed on an id mismatch, a kind mismatch, and missing/stale text content', async () => {
+    const { text, image } = await loadDeck()
+
+    // The node at the path is not the shape the edit names.
+    expect(() =>
+      updateSlideXml(SLIDE1_XML, [{ ...deleteEditFor(text, text.paragraphs), shapeId: '99' }]),
+    ).toThrow(/delete target mismatch/)
+
+    // The model kind does not allow the element found at the path.
+    expect(() =>
+      updateSlideXml(SLIDE1_XML, [
+        { ...deleteEditFor(image), nodePath: text.nodePath },
+      ]),
+    ).toThrow(/unsupported shape/)
+
+    // A text deletion must carry its paragraphs…
+    expect(() => updateSlideXml(SLIDE1_XML, [deleteEditFor(text)])).toThrow(
+      /requires its original paragraphs/,
+    )
+    // …and they must still match the retained bytes.
+    const stale = text.paragraphs.map((p) => ({
+      ...p,
+      runs: p.runs.map((r) => ({ ...r, text: r.text + '!' })),
+    }))
+    expect(() => updateSlideXml(SLIDE1_XML, [deleteEditFor(text, stale)])).toThrow(
+      /does not match/,
+    )
+  })
+})
+
+describe('deleteSlide', () => {
+  it('removes the part, its rels, its sldId, its Relationship and its Override — nothing else', async () => {
+    const input = await buildFixtureZip()
+    const { deck } = await loadDeck()
+    const out = await writeDeck(deck, new Map(), { deleteSlides: ['ppt/slides/slide2.xml'] })
+
+    const inZip = await JSZip.loadAsync(input)
+    const outZip = await JSZip.loadAsync(out)
+    const outNames = Object.keys(outZip.files).filter((n) => !outZip.files[n].dir)
+
+    expect(outNames).not.toContain('ppt/slides/slide2.xml')
+    expect(outNames).not.toContain('ppt/slides/_rels/slide2.xml.rels')
+
+    // The three forced package parts are the input minus exactly one element.
+    expect(await outZip.files['ppt/presentation.xml'].async('string')).toBe(
+      PRESENTATION_XML.replace(SLDID_2, ''),
+    )
+    expect(await outZip.files['ppt/_rels/presentation.xml.rels'].async('string')).toBe(
+      PRESENTATION_RELS.replace(REL_SLIDE2, ''),
+    )
+    expect(await outZip.files['[Content_Types].xml'].async('string')).toBe(
+      CONTENT_TYPES.replace(OVERRIDE_SLIDE2, ''),
+    )
+
+    // Every surviving part is byte-identical — including slide2's media,
+    // which stays orphaned rather than being garbage-collected.
+    for (const name of outNames) {
+      if (
+        name === 'ppt/presentation.xml' ||
+        name === 'ppt/_rels/presentation.xml.rels' ||
+        name === '[Content_Types].xml'
+      ) {
+        continue
+      }
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `byte-identical: ${name}`).toBe(true)
+    }
+    expect(outNames).toContain('ppt/media/image2.png')
+
+    // The result opens as a one-slide deck with slide 1 intact.
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides).toHaveLength(1)
+    expect((reparsed.slides[0].shapes[0] as TextShape).paragraphs[0].runs[0].text).toBe('Keep me')
+  })
+
+  it('leaves [Content_Types].xml alone when it has no per-part Override for the slide', async () => {
+    const noOverrides = CONTENT_TYPES.replace(OVERRIDE_SLIDE2, '')
+    const { deck } = await loadDeck(noOverrides)
+    const out = await writeDeck(deck, new Map(), { deleteSlides: ['ppt/slides/slide2.xml'] })
+    const raw = await (await JSZip.loadAsync(out)).files['[Content_Types].xml'].async('string')
+    expect(raw).toBe(noOverrides)
+  })
+
+  it('fails closed on unknown slides, edited-and-deleted slides, and deleting every slide', async () => {
+    const { deck, text } = await loadDeck()
+    await expect(
+      writeDeck(deck, new Map(), { deleteSlides: ['ppt/slides/slide9.xml'] }),
+    ).rejects.toThrow(/unknown slide/)
+
+    const edits = new Map<string, SlideEdit[]>([
+      ['ppt/slides/slide1.xml', [{ kind: 'shapeGeometry', nodePath: text.nodePath, offEmu: { x: 1, y: 1 } }]],
+    ])
+    await expect(
+      writeDeck(deck, edits, { deleteSlides: ['ppt/slides/slide1.xml'] }),
+    ).rejects.toThrow(/both edited and marked deleted/)
+
+    await expect(
+      writeDeck(deck, new Map(), {
+        deleteSlides: ['ppt/slides/slide1.xml', 'ppt/slides/slide2.xml'],
+      }),
+    ).rejects.toThrow(/every slide/)
+  })
+
+  it('fails closed when a custom show still references the slide', async () => {
+    // p:custShowLst carries its own r:id list; deleting only the sldId would
+    // leave that reference dangling in the written file.
+    const withCustShow = PRESENTATION_XML.replace(
+      '</p:presentation>',
+      '<p:custShowLst><p:custShow name="short" id="0"><p:sldLst>' +
+        '<p:sld r:id="rId3"/></p:sldLst></p:custShow></p:custShowLst></p:presentation>',
+    )
+    const { deck } = await loadDeck()
+    deck.source.zip.file('ppt/presentation.xml', withCustShow)
+    await expect(
+      writeDeck(deck, new Map(), { deleteSlides: ['ppt/slides/slide2.xml'] }),
+    ).rejects.toThrow(/custom shows/)
+  })
+
+  it('fails closed when the retained rels disagree with the model', async () => {
+    // The deck parsed cleanly, but the retained bytes no longer carry the
+    // slide's Relationship — the splice must refuse, not guess.
+    const { deck } = await loadDeck()
+    deck.source.zip.file(
+      'ppt/_rels/presentation.xml.rels',
+      PRESENTATION_RELS.replace(REL_SLIDE2, ''),
+    )
+    await expect(
+      writeDeck(deck, new Map(), { deleteSlides: ['ppt/slides/slide2.xml'] }),
+    ).rejects.toThrow(/exactly one slide relationship/)
+  })
+
+  it('recomputing with an empty edit set restores every original byte (undo)', async () => {
+    const input = await buildFixtureZip()
+    const { deck } = await loadDeck()
+    // A deletion was written…
+    await writeDeck(deck, new Map(), { deleteSlides: ['ppt/slides/slide2.xml'] })
+    // …then undone: saves recompute from base bytes + current edits, so an
+    // empty set writes the original package back.
+    const restored = await writeDeck(deck, new Map())
+    const inZip = await JSZip.loadAsync(input)
+    const outZip = await JSZip.loadAsync(restored)
+    const inNames = Object.keys(inZip.files).filter((n) => !inZip.files[n].dir).sort()
+    const outNames = Object.keys(outZip.files).filter((n) => !outZip.files[n].dir).sort()
+    expect(outNames).toEqual(inNames)
+    for (const name of inNames) {
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `restored: ${name}`).toBe(true)
+    }
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/display.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/display.test.ts
@@ -465,6 +465,8 @@ describe('deck-level display resolution', () => {
       underline: false,
       colorHex: '44546A',
       fontFamily: "'BodyFace', sans-serif",
+      // The resolved primary family, which is what the font picker offers.
+      latinFont: 'BodyFace',
     })
     // Wingdings 'l' from the master maps to a round bullet, with hanging indent.
     expect(p0.bullet).toEqual({ kind: 'char', char: '●' })

--- a/apps/x/apps/renderer/src/lib/pptx/display.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/display.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx, parseXml } from './parse'
+import type { DrawingShape, TextShape } from './types'
+import {
+  DEFAULT_THEME,
+  applyColorTransforms,
+  clrMapOfMaster,
+  parseTheme,
+  resolveColorNode,
+  resolveFirstColor,
+  schemeColorHex,
+  type Theme,
+} from './theme'
+import {
+  autoNumText,
+  bulletCharFor,
+  layersOf,
+  levelStyleFromPPr,
+  mergeLevelStyles,
+  parseListStyle,
+  runLayerFromRPr,
+  txStyleKindFor,
+} from './textstyle'
+import { fillFromNode, isLinePreset, lineFromLn, shapeVisualOf } from './geometry'
+
+const A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+
+function firstNode(xml: string) {
+  return parseXml(xml)[0]
+}
+
+const TEST_THEME_XML =
+  `<a:theme ${A} name="T"><a:themeElements><a:clrScheme name="c">` +
+  '<a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>' +
+  '<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>' +
+  '<a:dk2><a:srgbClr val="44546A"/></a:dk2>' +
+  '<a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>' +
+  '<a:accent1><a:srgbClr val="4472C4"/></a:accent1>' +
+  '<a:accent2><a:srgbClr val="ED7D31"/></a:accent2>' +
+  '<a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>' +
+  '<a:accent4><a:srgbClr val="FFC000"/></a:accent4>' +
+  '<a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>' +
+  '<a:accent6><a:srgbClr val="70AD47"/></a:accent6>' +
+  '<a:hlink><a:srgbClr val="0563C1"/></a:hlink>' +
+  '<a:folHlink><a:srgbClr val="954F72"/></a:folHlink>' +
+  '</a:clrScheme><a:fontScheme name="f"><a:majorFont><a:latin typeface="X"/></a:majorFont><a:minorFont><a:latin typeface="X"/></a:minorFont></a:fontScheme>' +
+  '<a:fmtScheme name="fmt"><a:fillStyleLst>' +
+  '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+  '<a:gradFill><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="50000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"/></a:gs></a:gsLst><a:lin ang="5400000"/></a:gradFill>' +
+  '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+  '</a:fillStyleLst><a:lnStyleLst>' +
+  '<a:ln w="6350"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+  '<a:ln w="12700"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+  '<a:ln w="19050"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>' +
+  '</a:lnStyleLst><a:effectStyleLst/><a:bgFillStyleLst/></a:fmtScheme>' +
+  '</a:themeElements></a:theme>'
+
+function loadTheme(clrMapAttrs?: string): Theme {
+  const theme = parseTheme(parseXml(TEST_THEME_XML))
+  if (clrMapAttrs) {
+    const master = parseXml(
+      `<p:sldMaster xmlns:p="http://p"><p:clrMap ${clrMapAttrs}/></p:sldMaster>`,
+    )
+    const map = clrMapOfMaster(master)
+    if (map) theme.clrMap = map
+  }
+  return theme
+}
+
+describe('theme color resolution', () => {
+  it('parses the scheme and resolves schemeClr slots', () => {
+    const theme = loadTheme()
+    expect(theme.scheme.accent1).toBe('4472C4')
+    expect(theme.scheme.dk1).toBe('000000')
+    const node = firstNode(`<a:schemeClr ${A} val="accent1"/>`)
+    expect(resolveColorNode(node, theme)?.hex).toBe('4472C4')
+  })
+
+  it('routes tx1/bg1 aliases through the master clrMap', () => {
+    const theme = loadTheme(
+      'bg1="dk1" tx1="lt1" bg2="dk2" tx2="lt2" accent1="accent1" accent2="accent2" ' +
+        'accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"',
+    )
+    // A dark master swaps text/background: tx1 now maps to the LIGHT color.
+    expect(schemeColorHex(theme, 'tx1')).toBe('FFFFFF')
+    expect(schemeColorHex(theme, 'bg1')).toBe('000000')
+    // Default map goes the usual way.
+    expect(schemeColorHex(loadTheme(), 'tx1')).toBe('000000')
+  })
+
+  it('applies lumMod/lumOff (accent1, lighter 40%)', () => {
+    const node = firstNode(
+      `<a:schemeClr ${A} val="accent1"><a:lumMod val="60000"/><a:lumOff val="40000"/></a:schemeClr>`,
+    )
+    const out = resolveColorNode(node, loadTheme())?.hex
+    // HSL round-trip of 4472C4 with l' = l*0.6 + 0.4.
+    expect(out).toBe('8FAADC')
+  })
+
+  it('applies tint and shade in RGB space', () => {
+    // shade 50% of white -> mid gray; tint 50% of black -> mid gray.
+    expect(applyColorTransforms('FFFFFF', firstNode(`<a:srgbClr ${A} val="FFFFFF"><a:shade val="50000"/></a:srgbClr>`))).toBe('808080')
+    expect(applyColorTransforms('000000', firstNode(`<a:srgbClr ${A} val="000000"><a:tint val="50000"/></a:srgbClr>`))).toBe('808080')
+  })
+
+  it('reads alpha and phClr substitution', () => {
+    const node = firstNode(`<a:schemeClr ${A} val="phClr"><a:alpha val="50000"/></a:schemeClr>`)
+    const out = resolveColorNode(node, loadTheme(), 'ED7D31')
+    expect(out).toEqual({ hex: 'ED7D31', alpha: 0.5 })
+  })
+})
+
+describe('run property cascade', () => {
+  const theme = DEFAULT_THEME
+
+  it('parses defRPr layers out of list styles', () => {
+    const lst = firstNode(
+      `<a:lstStyle ${A}>` +
+        '<a:lvl1pPr marL="342900" indent="-342900" algn="ctr"><a:buChar char="•"/><a:defRPr sz="2400" b="1"><a:solidFill><a:srgbClr val="112233"/></a:solidFill></a:defRPr></a:lvl1pPr>' +
+        '<a:lvl2pPr><a:defRPr sz="2000"/></a:lvl2pPr>' +
+        '</a:lstStyle>',
+    )
+    const parsed = parseListStyle(lst, theme)
+    expect(parsed.levels[0]).toMatchObject({
+      marLEmu: 342900,
+      indentEmu: -342900,
+      align: 'ctr',
+      sizePt: 24,
+      bold: true,
+      colorHex: '112233',
+      bullet: { kind: 'char', char: '•' },
+    })
+    expect(parsed.levels[1]).toMatchObject({ sizePt: 20 })
+    expect(parsed.levels[2]).toBeUndefined()
+  })
+
+  it('merges layers nearest-first: rPr wins over shape over master', () => {
+    const shape = parseListStyle(
+      firstNode(`<a:lstStyle ${A}><a:lvl1pPr><a:defRPr sz="2800"/></a:lvl1pPr></a:lstStyle>`),
+      theme,
+    )
+    const master = parseListStyle(
+      firstNode(
+        `<a:lstStyle ${A}><a:lvl1pPr marL="457200"><a:defRPr sz="1800" i="1"/></a:lvl1pPr></a:lstStyle>`,
+      ),
+      theme,
+    )
+    const merged = mergeLevelStyles([...layersOf(shape, 0), ...layersOf(master, 0)])
+    expect(merged.sizePt).toBe(28) // nearest layer wins
+    expect(merged.italic).toBe(true) // inherited from the farther layer
+    expect(merged.marLEmu).toBe(457200)
+
+    // An explicit rPr overrides everything, including b="0" clearing bold.
+    const rPr = runLayerFromRPr(firstNode(`<a:rPr ${A} b="0" sz="1400"/>`), theme)
+    expect(rPr).toMatchObject({ bold: false, sizePt: 14 })
+  })
+
+  it('reads paragraph-level overrides including buNone and buAutoNum', () => {
+    const pPr = firstNode(
+      `<a:pPr ${A} lvl="1" marL="742950" indent="-285750"><a:buAutoNum type="arabicPeriod" startAt="3"/></a:pPr>`,
+    )
+    const style = levelStyleFromPPr(pPr, theme)
+    expect(style.bullet).toEqual({ kind: 'auto', scheme: 'arabicPeriod', startAt: 3 })
+    expect(style.marLEmu).toBe(742950)
+
+    const none = levelStyleFromPPr(firstNode(`<a:pPr ${A}><a:buNone/></a:pPr>`), theme)
+    expect(none.bullet).toEqual({ kind: 'none' })
+  })
+
+  it('routes placeholder types to the right master txStyles table', () => {
+    expect(txStyleKindFor('ctrTitle', true)).toBe('title')
+    expect(txStyleKindFor('body', true)).toBe('body')
+    expect(txStyleKindFor(undefined, true)).toBe('body')
+    expect(txStyleKindFor('ftr', true)).toBe('other')
+    expect(txStyleKindFor(undefined, false)).toBe('other')
+  })
+})
+
+describe('bullets', () => {
+  it('maps Wingdings glyphs (including the F0xx private-use forms)', () => {
+    expect(bulletCharFor('Wingdings', 'l')).toBe('●')
+    expect(bulletCharFor('Wingdings', 'n')).toBe('■')
+    expect(bulletCharFor('Wingdings', '')).toBe('▪')
+    expect(bulletCharFor('Wingdings', 'Ø')).toBe('➢')
+    expect(bulletCharFor('Wingdings', 'ü')).toBe('✓')
+    expect(bulletCharFor('Wingdings', '~')).toBe('•') // unknown -> generic
+    expect(bulletCharFor('Symbol', '')).toBe('•')
+    expect(bulletCharFor('Arial', '•')).toBe('•') // text fonts pass through
+    expect(bulletCharFor('Arial', '-')).toBe('-')
+  })
+
+  it('formats autonumber schemes', () => {
+    expect(autoNumText('arabicPeriod', 3)).toBe('3.')
+    expect(autoNumText('arabicParenR', 2)).toBe('2)')
+    expect(autoNumText('romanLcPeriod', 4)).toBe('iv.')
+    expect(autoNumText('romanUcPeriod', 9)).toBe('IX.')
+    expect(autoNumText('alphaLcParenR', 2)).toBe('b)')
+    expect(autoNumText('alphaUcPeriod', 27)).toBe('AA.')
+    expect(autoNumText('someUnknownScheme', 5)).toBe('5.')
+  })
+})
+
+describe('shape visuals', () => {
+  const theme = loadTheme()
+
+  it('resolves explicit solid fills, gradients and lines', () => {
+    const solid = fillFromNode(
+      firstNode(`<a:solidFill ${A}><a:schemeClr val="accent2"/></a:solidFill>`),
+      theme,
+    )
+    expect(solid).toEqual({ kind: 'solid', hex: 'ED7D31' })
+
+    const grad = fillFromNode(
+      firstNode(
+        `<a:gradFill ${A}><a:gsLst>` +
+          '<a:gs pos="100000"><a:srgbClr val="000000"/></a:gs>' +
+          '<a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs>' +
+          '</a:gsLst><a:lin ang="5400000"/></a:gradFill>',
+      ),
+      theme,
+    )
+    expect(grad).toMatchObject({
+      kind: 'gradient',
+      angleDeg: 90,
+      stops: [
+        { pos: 0, hex: 'FFFFFF' },
+        { pos: 1, hex: '000000' },
+      ],
+    })
+
+    const line = lineFromLn(
+      firstNode(
+        `<a:ln ${A} w="25400"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="sysDash"/></a:ln>`,
+      ),
+      theme,
+    )
+    expect(line).toEqual({ hex: 'FF0000', widthEmu: 25400, dash: 'dash', alpha: undefined })
+    expect(
+      lineFromLn(firstNode(`<a:ln ${A}><a:noFill/></a:ln>`), theme),
+    ).toBeNull()
+  })
+
+  it('resolves style fillRef/lnRef through the theme format scheme', () => {
+    const sp = firstNode(
+      `<p:sp xmlns:p="http://p" ${A}>` +
+        '<p:spPr><a:xfrm rot="2700000" flipH="1"><a:off x="0" y="0"/><a:ext cx="10" cy="10"/></a:xfrm>' +
+        '<a:prstGeom prst="roundRect"><a:avLst><a:gd name="adj" fmla="val 25000"/></a:avLst></a:prstGeom></p:spPr>' +
+        '<p:style><a:lnRef idx="2"><a:schemeClr val="accent6"/></a:lnRef>' +
+        '<a:fillRef idx="1"><a:schemeClr val="accent3"/></a:fillRef>' +
+        '<a:effectRef idx="0"><a:schemeClr val="accent3"/></a:effectRef>' +
+        '<a:fontRef idx="minor"/></p:style></p:sp>',
+    )
+    const visual = shapeVisualOf(sp, theme)
+    // fillRef idx 1 -> first fmtScheme fill (solid phClr) with accent3 substituted.
+    expect(visual.fill).toEqual({ kind: 'solid', hex: 'A5A5A5', alpha: undefined })
+    // lnRef idx 2 -> second fmtScheme line (w=12700) with accent6 substituted.
+    expect(visual.line).toEqual({ hex: '70AD47', widthEmu: 12700, dash: 'solid', alpha: undefined })
+    expect(visual.geom).toEqual({ preset: 'roundRect', adj: { adj: 25000 } })
+    expect(visual.rotDeg).toBe(45)
+    expect(visual.flipH).toBe(true)
+    expect(visual.flipV).toBeUndefined()
+  })
+
+  it('lets explicit spPr fills win over the style reference', () => {
+    const sp = firstNode(
+      `<p:sp xmlns:p="http://p" ${A}><p:spPr><a:noFill/></p:spPr>` +
+        '<p:style><a:fillRef idx="1"><a:schemeClr val="accent1"/></a:fillRef></p:style></p:sp>',
+    )
+    expect(shapeVisualOf(sp, theme).fill).toEqual({ kind: 'none' })
+  })
+
+  it('classifies line presets', () => {
+    expect(isLinePreset('line')).toBe(true)
+    expect(isLinePreset('straightConnector1')).toBe(true)
+    expect(isLinePreset('bentConnector3')).toBe(true)
+    expect(isLinePreset('roundRect')).toBe(false)
+  })
+})
+
+describe('theme defaults without a theme part', () => {
+  it('resolveFirstColor falls back to the stock Office scheme', () => {
+    const fill = firstNode(`<a:solidFill ${A}><a:schemeClr val="accent1"/></a:solidFill>`)
+    expect(resolveFirstColor(fill, DEFAULT_THEME)?.hex).toBe('4472C4')
+  })
+})
+
+// -------------------------------------------------------- deck integration
+
+const P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+const DECK_SLIDE =
+  `<p:sld ${P} ${A}><p:cSld><p:spTree>` +
+  // Body placeholder: no own size/color anywhere on the slide -> inherits.
+  `<p:sp><p:nvSpPr><p:cNvPr id="2" name="Body"/><p:nvSpPr/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>` +
+  '<p:spPr/><p:txBody><a:bodyPr/>' +
+  '<a:p><a:r><a:t>inherited</a:t></a:r></a:p>' +
+  '<a:p><a:pPr lvl="1"/><a:r><a:rPr sz="1200"/><a:t>explicit</a:t></a:r></a:p>' +
+  '<a:p><a:r><a:rPr><a:solidFill><a:schemeClr val="accent1"><a:lumMod val="60000"/><a:lumOff val="40000"/></a:schemeClr></a:solidFill></a:rPr><a:t>tinted</a:t></a:r></a:p>' +
+  '</p:txBody></p:sp>' +
+  // A themed rectangle with no txBody.
+  `<p:sp><p:nvSpPr><p:cNvPr id="3" name="Box"/></p:nvSpPr>` +
+  '<p:spPr><a:xfrm rot="5400000"><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm>' +
+  '<a:prstGeom prst="roundRect"><a:avLst/></a:prstGeom></p:spPr>' +
+  '<p:style><a:lnRef idx="1"><a:schemeClr val="accent2"/></a:lnRef>' +
+  '<a:fillRef idx="1"><a:schemeClr val="accent1"/></a:fillRef>' +
+  '<a:effectRef idx="0"><a:schemeClr val="accent1"/></a:effectRef><a:fontRef idx="minor"/></p:style></p:sp>' +
+  '</p:spTree></p:cSld></p:sld>'
+
+const DECK_LAYOUT =
+  `<p:sldLayout ${P} ${A}><p:cSld><p:spTree>` +
+  `<p:sp><p:nvSpPr><p:cNvPr id="9" name="ph"/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>` +
+  '<p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="30" cy="40"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr b="1"/></a:lvl1pPr></a:lstStyle></p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sldLayout>'
+
+const DECK_MASTER =
+  `<p:sldMaster ${P} ${A}>` +
+  '<p:cSld><p:spTree/></p:cSld>' +
+  '<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>' +
+  '<p:txStyles><p:titleStyle/><p:bodyStyle>' +
+  '<a:lvl1pPr marL="342900" indent="-342900"><a:buFont typeface="Wingdings"/><a:buChar char="l"/><a:defRPr sz="2400"><a:solidFill><a:schemeClr val="tx2"/></a:solidFill></a:defRPr></a:lvl1pPr>' +
+  '<a:lvl2pPr marL="742950" indent="-285750"><a:buAutoNum type="arabicPeriod"/><a:defRPr sz="2000"/></a:lvl2pPr>' +
+  '</p:bodyStyle><p:otherStyle/></p:txStyles></p:sldMaster>'
+
+async function buildDisplayFixture(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file(
+    'ppt/presentation.xml',
+    `<p:presentation ${P} ${R}><p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>` +
+      '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>',
+  )
+  zip.file(
+    'ppt/_rels/presentation.xml.rels',
+    `<Relationships ${REL_NS}><Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/></Relationships>`,
+  )
+  zip.file('ppt/slides/slide1.xml', DECK_SLIDE)
+  zip.file(
+    'ppt/slides/_rels/slide1.xml.rels',
+    `<Relationships ${REL_NS}><Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/></Relationships>`,
+  )
+  zip.file('ppt/slideLayouts/slideLayout1.xml', DECK_LAYOUT)
+  zip.file(
+    'ppt/slideLayouts/_rels/slideLayout1.xml.rels',
+    `<Relationships ${REL_NS}><Relationship Id="rId1" Type="${REL_TYPE}/slideMaster" Target="../slideMasters/slideMaster1.xml"/></Relationships>`,
+  )
+  zip.file('ppt/slideMasters/slideMaster1.xml', DECK_MASTER)
+  zip.file(
+    'ppt/slideMasters/_rels/slideMaster1.xml.rels',
+    `<Relationships ${REL_NS}><Relationship Id="rId1" Type="${REL_TYPE}/theme" Target="../theme/theme1.xml"/></Relationships>`,
+  )
+  zip.file('ppt/theme/theme1.xml', TEST_THEME_XML)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+describe('deck-level display resolution', () => {
+  it('cascades run properties and bullets from master through layout to the slide', async () => {
+    const deck = await parsePptx(await buildDisplayFixture())
+    const body = deck.slides[0].shapes[0] as TextShape
+
+    // The MODEL stays raw — this is what the serializer validates against.
+    expect(body.paragraphs[0].runs[0]).toEqual({ text: 'inherited' })
+
+    const display = body.display
+    expect(display).toBeDefined()
+    const p0 = display!.paragraphs[0]
+    // Size from master bodyStyle lvl1, bold from the layout override,
+    // color from tx2 -> dk2 -> theme.
+    expect(p0.runs[0]).toEqual({
+      sizePt: 24,
+      bold: true,
+      italic: false,
+      underline: false,
+      colorHex: '44546A',
+    })
+    // Wingdings 'l' from the master maps to a round bullet, with hanging indent.
+    expect(p0.bullet).toEqual({ kind: 'char', char: '●' })
+    expect(p0.marLEmu).toBe(342900)
+    expect(p0.indentEmu).toBe(-342900)
+
+    // Level 2: explicit sz wins over the lvl2 default; autonum from master.
+    const p1 = display!.paragraphs[1]
+    expect(p1.level).toBe(1)
+    expect(p1.runs[0].sizePt).toBe(12)
+    expect(p1.defaultRun.sizePt).toBe(20)
+    expect(p1.bullet).toEqual({ kind: 'auto', scheme: 'arabicPeriod', startAt: 1 })
+
+    // Theme transform on an explicit run color.
+    expect(display!.paragraphs[2].runs[0].colorHex).toBe('8FAADC')
+
+    // Inherited placeholder geometry still works (from the layout).
+    expect(body.xfrmEmu).toEqual({ x: 10, y: 20, w: 30, h: 40 })
+  })
+
+  it('renders plain sp without txBody as a drawing with themed fill/line/rotation', async () => {
+    const deck = await parsePptx(await buildDisplayFixture())
+    const box = deck.slides[0].shapes[1] as DrawingShape
+    expect(box.type).toBe('drawing')
+    expect(box.visual?.fill).toEqual({ kind: 'solid', hex: '4472C4', alpha: undefined })
+    expect(box.visual?.line).toMatchObject({ hex: 'ED7D31', widthEmu: 6350 })
+    expect(box.visual?.geom?.preset).toBe('roundRect')
+    expect(box.visual?.rotDeg).toBe(90)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/display.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/display.test.ts
@@ -210,6 +210,21 @@ describe('run property cascade', () => {
     expect(literal.eaFont).toBeUndefined()
   })
 
+  it('parses a:rPr@spc character tracking, hundredths of a point', () => {
+    const t = loadTheme()
+    // Canva authors negative tracking so a heading fits its box on one line;
+    // dropping it re-wraps the text and overflows the shape below.
+    expect(runLayerFromRPr(firstNode(`<a:rPr ${A} spc="-315"/>`), t).letterSpacingPt).toBe(-3.15)
+    expect(runLayerFromRPr(firstNode(`<a:rPr ${A} spc="300"/>`), t).letterSpacingPt).toBe(3)
+    expect(runLayerFromRPr(firstNode(`<a:rPr ${A}/>`), t).letterSpacingPt).toBeUndefined()
+    // It rides the cascade like every other run property.
+    const lst = parseListStyle(
+      firstNode(`<a:lstStyle ${A}><a:lvl1pPr><a:defRPr spc="-120"/></a:lvl1pPr></a:lstStyle>`),
+      t,
+    )
+    expect(mergeLevelStyles(layersOf(lst, 0)).letterSpacingPt).toBe(-1.2)
+  })
+
   it('parses lnSpc/spcBef/spcAft in both spcPct and spcPts forms', () => {
     const pPr = firstNode(
       `<a:pPr ${A}><a:lnSpc><a:spcPct val="150000"/></a:lnSpc>` +
@@ -361,7 +376,7 @@ const DECK_SLIDE =
   '<a:p><a:pPr lvl="1"/><a:r><a:rPr sz="1200"/><a:t>explicit</a:t></a:r></a:p>' +
   '<a:p><a:r><a:rPr><a:solidFill><a:schemeClr val="accent1"><a:lumMod val="60000"/><a:lumOff val="40000"/></a:schemeClr></a:solidFill></a:rPr><a:t>tinted</a:t></a:r></a:p>' +
   '<a:p><a:pPr><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="1200"/></a:spcBef><a:spcAft><a:spcPct val="50000"/></a:spcAft></a:pPr>' +
-  '<a:r><a:rPr><a:latin typeface="+mj-lt"/></a:rPr><a:t>spaced</a:t></a:r></a:p>' +
+  '<a:r><a:rPr spc="-315"><a:latin typeface="+mj-lt"/></a:rPr><a:t>spaced</a:t></a:r></a:p>' +
   '</p:txBody></p:sp>' +
   // A themed rectangle with no txBody.
   `<p:sp><p:nvSpPr><p:cNvPr id="3" name="Box"/></p:nvSpPr>` +
@@ -487,6 +502,8 @@ describe('deck-level display resolution', () => {
     expect(spaced.spaceAfterPt).toBe(12)
     // The run's own +mj-lt beats the inherited minor font.
     expect(spaced.runs[0].fontFamily).toBe("'TitleFace', sans-serif")
+    // Authored tracking survives the cascade onto the resolved run.
+    expect(spaced.runs[0].letterSpacingPt).toBe(-3.15)
 
     // normAutofit factors from the shape's own bodyPr.
     expect(display.autofit).toEqual({ fontScale: 0.625, lnSpcReduction: 0.2 })

--- a/apps/x/apps/renderer/src/lib/pptx/display.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/display.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
 import JSZip from 'jszip'
 import { parsePptx, parseXml } from './parse'
+import { updateSlideXml, writeDeck } from './serialize'
 import type { DrawingShape, TextShape } from './types'
 import {
   DEFAULT_THEME,
@@ -10,11 +11,13 @@ import {
   resolveColorNode,
   resolveFirstColor,
   schemeColorHex,
+  themeFontOf,
   type Theme,
 } from './theme'
 import {
   autoNumText,
   bulletCharFor,
+  cssFontFamily,
   layersOf,
   levelStyleFromPPr,
   mergeLevelStyles,
@@ -44,7 +47,7 @@ const TEST_THEME_XML =
   '<a:accent6><a:srgbClr val="70AD47"/></a:accent6>' +
   '<a:hlink><a:srgbClr val="0563C1"/></a:hlink>' +
   '<a:folHlink><a:srgbClr val="954F72"/></a:folHlink>' +
-  '</a:clrScheme><a:fontScheme name="f"><a:majorFont><a:latin typeface="X"/></a:majorFont><a:minorFont><a:latin typeface="X"/></a:minorFont></a:fontScheme>' +
+  '</a:clrScheme><a:fontScheme name="f"><a:majorFont><a:latin typeface="TitleFace"/></a:majorFont><a:minorFont><a:latin typeface="BodyFace"/><a:ea typeface="EastAsia"/></a:minorFont></a:fontScheme>' +
   '<a:fmtScheme name="fmt"><a:fillStyleLst>' +
   '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
   '<a:gradFill><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="50000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"/></a:gs></a:gsLst><a:lin ang="5400000"/></a:gradFill>' +
@@ -111,6 +114,32 @@ describe('theme color resolution', () => {
   })
 })
 
+describe('theme fonts', () => {
+  it('parses the font scheme and resolves +mj/+mn typeface tokens', () => {
+    const theme = loadTheme()
+    expect(theme.fonts.majorLatin).toBe('TitleFace')
+    expect(theme.fonts.minorLatin).toBe('BodyFace')
+    expect(theme.fonts.minorEa).toBe('EastAsia')
+    expect(themeFontOf(theme, '+mj-lt')).toBe('TitleFace')
+    expect(themeFontOf(theme, '+mn-lt')).toBe('BodyFace')
+    expect(themeFontOf(theme, '+mn-ea')).toBe('EastAsia')
+    // A slot the theme does not name resolves to nothing, not to a guess.
+    expect(themeFontOf(theme, '+mn-cs')).toBeUndefined()
+    // Literal names pass through; the stock defaults cover themeless decks.
+    expect(themeFontOf(theme, 'Georgia')).toBe('Georgia')
+    expect(themeFontOf(DEFAULT_THEME, '+mn-lt')).toBe('Calibri')
+  })
+
+  it('composes CSS font-family with a sensible generic fallback', () => {
+    expect(cssFontFamily('Georgia', undefined, undefined)).toBe("'Georgia', serif")
+    expect(cssFontFamily('Courier New', undefined, undefined)).toBe("'Courier New', monospace")
+    expect(cssFontFamily('Helvetica Neue', 'MS Gothic', undefined)).toBe(
+      "'Helvetica Neue', 'MS Gothic', sans-serif",
+    )
+    expect(cssFontFamily(undefined, undefined, undefined)).toBeUndefined()
+  })
+})
+
 describe('run property cascade', () => {
   const theme = DEFAULT_THEME
 
@@ -166,6 +195,37 @@ describe('run property cascade', () => {
 
     const none = levelStyleFromPPr(firstNode(`<a:pPr ${A}><a:buNone/></a:pPr>`), theme)
     expect(none.bullet).toEqual({ kind: 'none' })
+  })
+
+  it('resolves run typefaces, mapping theme tokens through the font scheme', () => {
+    const t = loadTheme()
+    const viaTheme = runLayerFromRPr(firstNode(`<a:rPr ${A}><a:latin typeface="+mn-lt"/></a:rPr>`), t)
+    expect(viaTheme.latinFont).toBe('BodyFace')
+    const literal = runLayerFromRPr(
+      firstNode(`<a:rPr ${A}><a:latin typeface="Georgia"/><a:cs typeface="Arial"/></a:rPr>`),
+      t,
+    )
+    expect(literal.latinFont).toBe('Georgia')
+    expect(literal.csFont).toBe('Arial')
+    expect(literal.eaFont).toBeUndefined()
+  })
+
+  it('parses lnSpc/spcBef/spcAft in both spcPct and spcPts forms', () => {
+    const pPr = firstNode(
+      `<a:pPr ${A}><a:lnSpc><a:spcPct val="150000"/></a:lnSpc>` +
+        '<a:spcBef><a:spcPts val="600"/></a:spcBef>' +
+        '<a:spcAft><a:spcPct val="50000"/></a:spcAft></a:pPr>',
+    )
+    const style = levelStyleFromPPr(pPr, theme)
+    expect(style.lnSpc).toEqual({ pct: 1.5 })
+    expect(style.spcBef).toEqual({ pt: 6 })
+    expect(style.spcAft).toEqual({ pct: 0.5 })
+
+    const fixed = levelStyleFromPPr(
+      firstNode(`<a:pPr ${A}><a:lnSpc><a:spcPts val="2000"/></a:lnSpc></a:pPr>`),
+      theme,
+    )
+    expect(fixed.lnSpc).toEqual({ pt: 20 })
   })
 
   it('routes placeholder types to the right master txStyles table', () => {
@@ -296,10 +356,12 @@ const DECK_SLIDE =
   `<p:sld ${P} ${A}><p:cSld><p:spTree>` +
   // Body placeholder: no own size/color anywhere on the slide -> inherits.
   `<p:sp><p:nvSpPr><p:cNvPr id="2" name="Body"/><p:nvSpPr/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>` +
-  '<p:spPr/><p:txBody><a:bodyPr/>' +
+  '<p:spPr/><p:txBody><a:bodyPr><a:normAutofit fontScale="62500" lnSpcReduction="20000"/></a:bodyPr>' +
   '<a:p><a:r><a:t>inherited</a:t></a:r></a:p>' +
   '<a:p><a:pPr lvl="1"/><a:r><a:rPr sz="1200"/><a:t>explicit</a:t></a:r></a:p>' +
   '<a:p><a:r><a:rPr><a:solidFill><a:schemeClr val="accent1"><a:lumMod val="60000"/><a:lumOff val="40000"/></a:schemeClr></a:solidFill></a:rPr><a:t>tinted</a:t></a:r></a:p>' +
+  '<a:p><a:pPr><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="1200"/></a:spcBef><a:spcAft><a:spcPct val="50000"/></a:spcAft></a:pPr>' +
+  '<a:r><a:rPr><a:latin typeface="+mj-lt"/></a:rPr><a:t>spaced</a:t></a:r></a:p>' +
   '</p:txBody></p:sp>' +
   // A themed rectangle with no txBody.
   `<p:sp><p:nvSpPr><p:cNvPr id="3" name="Box"/></p:nvSpPr>` +
@@ -322,7 +384,7 @@ const DECK_MASTER =
   '<p:cSld><p:spTree/></p:cSld>' +
   '<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>' +
   '<p:txStyles><p:titleStyle/><p:bodyStyle>' +
-  '<a:lvl1pPr marL="342900" indent="-342900"><a:buFont typeface="Wingdings"/><a:buChar char="l"/><a:defRPr sz="2400"><a:solidFill><a:schemeClr val="tx2"/></a:solidFill></a:defRPr></a:lvl1pPr>' +
+  '<a:lvl1pPr marL="342900" indent="-342900"><a:buFont typeface="Wingdings"/><a:buChar char="l"/><a:defRPr sz="2400"><a:solidFill><a:schemeClr val="tx2"/></a:solidFill><a:latin typeface="+mn-lt"/></a:defRPr></a:lvl1pPr>' +
   '<a:lvl2pPr marL="742950" indent="-285750"><a:buAutoNum type="arabicPeriod"/><a:defRPr sz="2000"/></a:lvl2pPr>' +
   '</p:bodyStyle><p:otherStyle/></p:txStyles></p:sldMaster>'
 
@@ -379,13 +441,15 @@ describe('deck-level display resolution', () => {
     expect(display).toBeDefined()
     const p0 = display!.paragraphs[0]
     // Size from master bodyStyle lvl1, bold from the layout override,
-    // color from tx2 -> dk2 -> theme.
+    // color from tx2 -> dk2 -> theme, typeface from the master's +mn-lt
+    // resolved through the theme font scheme.
     expect(p0.runs[0]).toEqual({
       sizePt: 24,
       bold: true,
       italic: false,
       underline: false,
       colorHex: '44546A',
+      fontFamily: "'BodyFace', sans-serif",
     })
     // Wingdings 'l' from the master maps to a round bullet, with hanging indent.
     expect(p0.bullet).toEqual({ kind: 'char', char: '●' })
@@ -404,6 +468,36 @@ describe('deck-level display resolution', () => {
 
     // Inherited placeholder geometry still works (from the layout).
     expect(body.xfrmEmu).toEqual({ x: 10, y: 20, w: 30, h: 40 })
+  })
+
+  it('resolves paragraph spacing, typefaces and normAutofit at deck level', async () => {
+    const deck = await parsePptx(await buildDisplayFixture())
+    const display = (deck.slides[0].shapes[0] as TextShape).display!
+
+    // No lnSpc/spcBef/spcAft on the first paragraph -> 1.2, zero spacing.
+    expect(display.paragraphs[0].lineHeight).toEqual({ kind: 'mult', value: 1.2 })
+    expect(display.paragraphs[0].spaceBeforePt).toBe(0)
+    expect(display.paragraphs[0].spaceAfterPt).toBe(0)
+
+    // spcPct scales the 1.2 base; spcPts is absolute; spcAft's pct resolves
+    // against the paragraph's own size (24pt from the master bodyStyle).
+    const spaced = display.paragraphs[3]
+    expect(spaced.lineHeight).toEqual({ kind: 'mult', value: 0.9 * 1.2 })
+    expect(spaced.spaceBeforePt).toBe(12)
+    expect(spaced.spaceAfterPt).toBe(12)
+    // The run's own +mj-lt beats the inherited minor font.
+    expect(spaced.runs[0].fontFamily).toBe("'TitleFace', sans-serif")
+
+    // normAutofit factors from the shape's own bodyPr.
+    expect(display.autofit).toEqual({ fontScale: 0.625, lnSpcReduction: 0.2 })
+  })
+
+  it('keeps unedited write-back byte-identical with typography features present', async () => {
+    expect(updateSlideXml(DECK_SLIDE, [])).toBe(DECK_SLIDE)
+    const deck = await parsePptx(await buildDisplayFixture())
+    const out = await writeDeck(deck, new Map())
+    const raw = await (await JSZip.loadAsync(out)).files['ppt/slides/slide1.xml'].async('string')
+    expect(raw).toBe(DECK_SLIDE)
   })
 
   it('renders plain sp without txBody as a drawing with themed fill/line/rotation', async () => {

--- a/apps/x/apps/renderer/src/lib/pptx/duplicate-reorder.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/duplicate-reorder.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parseAddedSlide, parsePptx, relsPathFor } from './parse'
+import { writeDeck, type ShapeTextEdit, type SlideEdit } from './serialize'
+import { planDuplicateSlide, planNewSlide, readSlideRels } from './add-slide'
+import type { TextShape } from './types'
+
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const NS_R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+const LAYOUT_XML =
+  `<p:sldLayout ${NS_P} ${NS_A}><p:cSld><p:spTree>` +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="100000" y="200000"/><a:ext cx="3000000" cy="400000"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/></p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sldLayout>'
+
+/** Slide N, with one editable text run. */
+const SLIDE = (n: number) =>
+  `<p:sld ${NS_P} ${NS_A} ${NS_R}><p:cSld><p:spTree>` +
+  `<p:sp><p:nvSpPr><p:cNvPr id="2" name="T${n}"/></p:nvSpPr>` +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100" cy="100"/></a:xfrm></p:spPr>' +
+  `<p:txBody><a:bodyPr/><a:p><a:r><a:rPr sz="2800"/><a:t>slide ${n}</a:t></a:r></a:p></p:txBody></p:sp>` +
+  '</p:spTree></p:cSld></p:sld>'
+
+// Three slides, and a sldIdLst with LITERAL WHITESPACE between elements so
+// reordering can be shown not to disturb it.
+const SLD_1 = '<p:sldId id="256" r:id="rId2"/>'
+const SLD_2 = '<p:sldId id="257" r:id="rId3"/>'
+const SLD_3 = '<p:sldId id="258" r:id="rId4"/>'
+const PRESENTATION_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:presentation ${NS_P} ${NS_R}>` +
+  `<p:sldIdLst>\n  ${SLD_1}\n  ${SLD_2}\n  ${SLD_3}\n</p:sldIdLst>` +
+  '<p:sldSz cx="12192000" cy="6858000"/><p:notesSz cx="1" cy="2"/></p:presentation>'
+
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId1" Type="${REL_TYPE}/theme" Target="theme/theme1.xml"/>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/>` +
+  `<Relationship Id="rId3" Type="${REL_TYPE}/slide" Target="slides/slide2.xml"/>` +
+  `<Relationship Id="rId4" Type="${REL_TYPE}/slide" Target="slides/slide3.xml"/>` +
+  '</Relationships>'
+
+const SLIDE_CT = 'application/vnd.openxmlformats-officedocument.presentationml.slide+xml'
+const CONTENT_TYPES =
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Default Extension="png" ContentType="image/png"/>' +
+  `<Override PartName="/ppt/slides/slide1.xml" ContentType="${SLIDE_CT}"/>` +
+  `<Override PartName="/ppt/slides/slide2.xml" ContentType="${SLIDE_CT}"/>` +
+  `<Override PartName="/ppt/slides/slide3.xml" ContentType="${SLIDE_CT}"/>` +
+  '</Types>'
+
+/** Slide 1's rels also carry an image, to prove media is shared not copied. */
+const SLIDE1_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/image" Target="../media/image1.png"/>` +
+  '</Relationships>'
+const PLAIN_RELS =
+  `<Relationships ${REL_NS}><Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/></Relationships>`
+
+async function buildFixtureZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('[Content_Types].xml', CONTENT_TYPES)
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  for (const n of [1, 2, 3]) {
+    zip.file(`ppt/slides/slide${n}.xml`, SLIDE(n))
+    zip.file(`ppt/slides/_rels/slide${n}.xml.rels`, n === 1 ? SLIDE1_RELS : PLAIN_RELS)
+  }
+  zip.file('ppt/slideLayouts/slideLayout1.xml', LAYOUT_XML)
+  zip.file('ppt/media/image1.png', Uint8Array.from([137, 80, 78, 71]))
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+const loadDeck = async () => parsePptx(await buildFixtureZip())
+
+const P1 = 'ppt/slides/slide1.xml'
+const P2 = 'ppt/slides/slide2.xml'
+const P3 = 'ppt/slides/slide3.xml'
+
+/** A text edit renaming slide 1's run, as the editor would commit it. */
+function renameEdit(shape: TextShape, text: string): ShapeTextEdit {
+  return {
+    kind: 'text',
+    nodePath: shape.nodePath,
+    original: shape.paragraphs,
+    next: [{ srcPara: 0, runs: [{ ...shape.paragraphs[0].runs[0], text, srcPara: 0, srcRun: 0 }] }],
+  }
+}
+
+describe('duplicate slide', () => {
+  it('captures the anchor AS SHOWN, including pending edits, and clones its rels verbatim', async () => {
+    const deck = await loadDeck()
+    const shape = deck.slides[0].shapes[0] as TextShape
+
+    // Slide 1 has an uncommitted-to-disk text edit at plan time.
+    const edits = [renameEdit(shape, 'edited before duplicating')]
+    const plan = planDuplicateSlide(
+      deck,
+      P1,
+      { xml: deck.source.slideXml[P1], relsXml: await readSlideRels(deck, P1), edits },
+      [],
+    )
+    expect(plan.path).toBe('ppt/slides/slide4.xml')
+    expect(plan.afterPath).toBe(P1)
+    // The copy's bytes carry the edit…
+    expect(plan.xml).toContain('<a:t>edited before duplicating</a:t>')
+    expect(plan.xml).not.toContain('<a:t>slide 1</a:t>')
+    // …and the rels are byte-identical to the anchor's, so the image target is
+    // shared rather than copied.
+    expect(plan.relsXml).toBe(SLIDE1_RELS)
+  })
+
+  it('is independent of the original afterwards, in both directions', async () => {
+    const deck = await loadDeck()
+    const shape = deck.slides[0].shapes[0] as TextShape
+    const plan = planDuplicateSlide(
+      deck,
+      P1,
+      { xml: deck.source.slideXml[P1], relsXml: await readSlideRels(deck, P1) },
+      [],
+    )
+    const copy = await parseAddedSlide(deck, plan.path, plan.xml, plan.relsXml)
+    const copyShape = copy.shapes[0] as TextShape
+
+    // Edit the ORIGINAL and the COPY differently in one save.
+    const out = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([
+        [P1, [renameEdit(shape, 'original changed')]],
+        [plan.path, [renameEdit(copyShape, 'copy changed')]],
+      ]),
+      { addSlides: [plan] },
+    )
+    const zip = await JSZip.loadAsync(out)
+    expect(await zip.files[P1].async('string')).toContain('<a:t>original changed</a:t>')
+    expect(await zip.files[plan.path].async('string')).toContain('<a:t>copy changed</a:t>')
+    // Neither leaked into the other.
+    expect(await zip.files[P1].async('string')).not.toContain('copy changed')
+    expect(await zip.files[plan.path].async('string')).not.toContain('original changed')
+
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => (s.shapes[0] as TextShape).paragraphs[0].runs[0].text)).toEqual(
+      ['original changed', 'copy changed', 'slide 2', 'slide 3'],
+    )
+  })
+
+  it('duplicates an ADDED slide by copying its synthesized strings', async () => {
+    const deck = await loadDeck()
+    const added = await planNewSlide(deck, P1, undefined, [])
+    const dup = planDuplicateSlide(
+      deck,
+      added.path,
+      { xml: added.xml, relsXml: added.relsXml },
+      [added.path],
+    )
+    expect(dup.xml).toBe(added.xml)
+    expect(dup.relsXml).toBe(added.relsXml)
+    expect(dup.path).not.toBe(added.path)
+
+    const out = await writeDeck(deck, new Map(), { addSlides: [added, dup] })
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([P1, added.path, dup.path, P2, P3])
+  })
+
+  it('fails closed on a stale anchor edit and on a part-name collision', async () => {
+    const deck = await loadDeck()
+    const shape = deck.slides[0].shapes[0] as TextShape
+    const stale = renameEdit(shape, 'x')
+    stale.original = stale.original.map((p) => ({
+      ...p,
+      runs: p.runs.map((r) => ({ ...r, text: `${r.text}!` })),
+    }))
+    // The anchor's edits are applied through updateSlideXml, which refuses a
+    // mismatch — a duplicate can never capture a half-applied edit.
+    expect(() =>
+      planDuplicateSlide(deck, P1, { xml: deck.source.slideXml[P1], edits: [stale] }, []),
+    ).toThrow(/does not match/)
+
+    const plan = planDuplicateSlide(deck, P1, { xml: deck.source.slideXml[P1] }, [])
+    await expect(
+      writeDeck(deck, new Map(), { addSlides: [{ ...plan, path: P2 }] }),
+    ).rejects.toThrow(/collides/)
+    await expect(
+      writeDeck(deck, new Map(), { addSlides: [plan], deleteSlides: [P1] }),
+    ).rejects.toThrow(/being deleted/)
+  })
+
+  it('duplicating a slide with no rels part still produces a valid part', async () => {
+    const zip = new JSZip()
+    zip.file('[Content_Types].xml', CONTENT_TYPES)
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    for (const n of [1, 2, 3]) zip.file(`ppt/slides/slide${n}.xml`, SLIDE(n))
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    expect(await readSlideRels(deck, P1)).toBeUndefined()
+    const plan = planDuplicateSlide(deck, P1, { xml: deck.source.slideXml[P1] }, [])
+    expect(plan.relsXml).toContain('<Relationships')
+    const reparsed = await parsePptx(await writeDeck(deck, new Map(), { addSlides: [plan] }))
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([P1, plan.path, P2, P3])
+  })
+})
+
+describe('slide reorder', () => {
+  it('moves sldId element ranges, leaving their bytes and all whitespace intact', async () => {
+    const input = await buildFixtureZip()
+    const deck = await loadDeck()
+    const out = await writeDeck(deck, new Map(), { slideOrder: [P3, P1, P2] })
+
+    const outZip = await JSZip.loadAsync(out)
+    const pres = await outZip.files['ppt/presentation.xml'].async('string')
+
+    // Each element keeps its OWN bytes (id and r:id unchanged) — only the
+    // sequence differs — and the newlines/indent between slots are untouched.
+    expect(pres).toBe(
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+        `<p:presentation ${NS_P} ${NS_R}>` +
+        `<p:sldIdLst>\n  ${SLD_3}\n  ${SLD_1}\n  ${SLD_2}\n</p:sldIdLst>` +
+        '<p:sldSz cx="12192000" cy="6858000"/><p:notesSz cx="1" cy="2"/></p:presentation>',
+    )
+
+    // Everything else in the package is byte-identical.
+    const inZip = await JSZip.loadAsync(input)
+    for (const name of Object.keys(inZip.files)) {
+      if (inZip.files[name].dir || name === 'ppt/presentation.xml') continue
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `byte-identical: ${name}`).toBe(true)
+    }
+
+    // And it reparses in the new order.
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([P3, P1, P2])
+  })
+
+  it('an order equal to document order rewrites nothing', async () => {
+    const input = await buildFixtureZip()
+    const deck = await loadDeck()
+    const out = await writeDeck(deck, new Map(), { slideOrder: [P1, P2, P3] })
+    const inZip = await JSZip.loadAsync(input)
+    const outZip = await JSZip.loadAsync(out)
+    expect(await outZip.files['ppt/presentation.xml'].async('string')).toBe(PRESENTATION_XML)
+    for (const name of Object.keys(inZip.files)) {
+      if (inZip.files[name].dir) continue
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `byte-identical: ${name}`).toBe(true)
+    }
+  })
+
+  it('places added slides at their position in the order, including before all base slides', async () => {
+    const deck = await loadDeck()
+    const plan = await planNewSlide(deck, P1, undefined, [])
+    const out = await writeDeck(deck, new Map(), {
+      addSlides: [plan],
+      slideOrder: [plan.path, P2, P1, P3],
+    })
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([plan.path, P2, P1, P3])
+  })
+
+  it('fails closed when the order is not an exact permutation of survivors + adds', async () => {
+    const deck = await loadDeck()
+    await expect(writeDeck(deck, new Map(), { slideOrder: [P1, P2] })).rejects.toThrow(
+      /exact permutation/,
+    )
+    await expect(
+      writeDeck(deck, new Map(), { slideOrder: [P1, P2, P3, 'ppt/slides/slide9.xml'] }),
+    ).rejects.toThrow(/exact permutation/)
+    await expect(writeDeck(deck, new Map(), { slideOrder: [P1, P2, P2] })).rejects.toThrow(
+      /more than once/,
+    )
+    // A deleted slide must not appear in the order.
+    await expect(
+      writeDeck(deck, new Map(), { deleteSlides: [P2], slideOrder: [P1, P2, P3] }),
+    ).rejects.toThrow(/exact permutation/)
+  })
+})
+
+describe('composition: delete + duplicate + reorder in one save', () => {
+  it('produces a valid deck with every part consistent', async () => {
+    const deck = await loadDeck()
+    const shape = deck.slides[0].shapes[0] as TextShape
+
+    // Duplicate slide 1 (capturing a pending edit), delete slide 2, and put
+    // the copy first — all in a single write.
+    const edits = [renameEdit(shape, 'kept and copied')]
+    const dup = planDuplicateSlide(
+      deck,
+      P1,
+      { xml: deck.source.slideXml[P1], relsXml: await readSlideRels(deck, P1), edits },
+      [],
+    )
+    const out = await writeDeck(deck, new Map<string, SlideEdit[]>([[P1, edits]]), {
+      addSlides: [dup],
+      deleteSlides: [P2],
+      slideOrder: [dup.path, P3, P1],
+    })
+
+    const outZip = await JSZip.loadAsync(out)
+    const names = Object.keys(outZip.files).filter((n) => !outZip.files[n].dir)
+    // The deleted slide's part and rels are gone; the copy's are present.
+    expect(names).not.toContain(P2)
+    expect(names).not.toContain(relsPathFor(P2))
+    expect(names).toContain(dup.path)
+    expect(names).toContain(relsPathFor(dup.path))
+
+    // presentation.xml lists exactly the three survivors, in the new order.
+    const pres = await outZip.files['ppt/presentation.xml'].async('string')
+    expect(pres).not.toContain(SLD_2)
+    // rels and Content_Types agree with the parts on disk.
+    const rels = await outZip.files['ppt/_rels/presentation.xml.rels'].async('string')
+    expect(rels).not.toContain('Target="slides/slide2.xml"')
+    expect(rels).toContain('Target="slides/slide4.xml"')
+    const types = await outZip.files['[Content_Types].xml'].async('string')
+    expect(types).not.toContain('/ppt/slides/slide2.xml')
+    expect(types).toContain(`<Override PartName="/${dup.path}" ContentType="${SLIDE_CT}"/>`)
+
+    // The whole thing reopens as the intended deck.
+    const reparsed = await parsePptx(out)
+    expect(reparsed.slides.map((s) => s.xmlPath)).toEqual([dup.path, P3, P1])
+    expect(
+      reparsed.slides.map((s) => (s.shapes[0] as TextShape).paragraphs[0].runs[0].text),
+    ).toEqual(['kept and copied', 'slide 3', 'kept and copied'])
+
+    // Media the deleted slide referenced stays (orphans are valid OOXML).
+    expect(names).toContain('ppt/media/image1.png')
+  })
+
+  it('an empty edit set after all of it restores every original byte (undo)', async () => {
+    const input = await buildFixtureZip()
+    const deck = await loadDeck()
+    const dup = planDuplicateSlide(deck, P1, { xml: deck.source.slideXml[P1] }, [])
+    await writeDeck(deck, new Map(), {
+      addSlides: [dup],
+      deleteSlides: [P2],
+      slideOrder: [dup.path, P3, P1],
+    })
+    // Saves recompute from base bytes + current edits, so undoing to a clean
+    // set writes the original package back.
+    const restored = await writeDeck(deck, new Map())
+    const inZip = await JSZip.loadAsync(input)
+    const outZip = await JSZip.loadAsync(restored)
+    expect(Object.keys(outZip.files).filter((n) => !outZip.files[n].dir).sort()).toEqual(
+      Object.keys(inZip.files).filter((n) => !inZip.files[n].dir).sort(),
+    )
+    for (const name of Object.keys(inZip.files)) {
+      if (inZip.files[name].dir) continue
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `restored: ${name}`).toBe(true)
+    }
+  })
+
+  it('leaves an unrelated slide edit on the in-place splice path throughout', async () => {
+    const deck = await loadDeck()
+    const shape3 = deck.slides[2].shapes[0] as TextShape
+    const out = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([[P3, [renameEdit(shape3, 'third')]]]),
+      { slideOrder: [P3, P2, P1] },
+    )
+    const raw = await (await JSZip.loadAsync(out)).files[P3].async('string')
+    // Only the a:t content moved; the rPr bytes are untouched.
+    expect(raw).toBe(SLIDE(3).replace('<a:t>slide 3</a:t>', '<a:t>third</a:t>'))
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/font.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/font.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx } from './parse'
+import { updateSlideXml, writeDeck, type FormatRunsEdit } from './serialize'
+import type { TextShape } from './types'
+
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+// Four runs covering every rPr shape the typeface splice has to handle:
+//  0 — rPr WITH an existing a:latin (plus siblings on both sides of it)
+//  1 — rPr with attributes and a fill, but NO a:latin
+//  2 — self-closing rPr
+//  3 — no rPr at all
+const RUN_0 =
+  '<a:r><a:rPr lang="en-US" sz="2800" b="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>' +
+  '<a:latin typeface="Tahoma" pitchFamily="34"/><a:cs typeface="Tahoma"/></a:rPr><a:t>first</a:t></a:r>'
+const RUN_1 =
+  '<a:r><a:rPr lang="en-US" i="1"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:rPr>' +
+  '<a:t>second</a:t></a:r>'
+const RUN_2 = '<a:r><a:rPr lang="en-US" u="sng"/><a:t>third</a:t></a:r>'
+const RUN_3 = '<a:r><a:t>fourth</a:t></a:r>'
+
+const SLIDE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:sld ${NS_P} ${NS_A}><p:cSld><p:spTree>` +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Body"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="100" cy="100"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:lstStyle/><a:p>' +
+  RUN_0 +
+  RUN_1 +
+  RUN_2 +
+  RUN_3 +
+  '</a:p></p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sld>'
+
+const PRESENTATION_XML =
+  `<p:presentation ${NS_P} xmlns:r="${REL_TYPE}">` +
+  '<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>' +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/></Relationships>`
+
+async function buildZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE_XML)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+async function loadDeck() {
+  const deck = await parsePptx(await buildZip())
+  return { deck, shape: deck.slides[0].shapes[0] as TextShape }
+}
+
+function fontEdit(shape: TextShape, run: number, latinFont: string): FormatRunsEdit {
+  return {
+    kind: 'formatRuns',
+    nodePath: shape.nodePath,
+    original: shape.paragraphs,
+    targets: [{ para: 0, run }],
+    set: { latinFont },
+  }
+}
+
+describe('a:latin parsing', () => {
+  it('reads the run typeface verbatim into the byte-anchored model', async () => {
+    const { shape } = await loadDeck()
+    expect(shape.paragraphs[0].runs.map((r) => r.latinFont)).toEqual([
+      'Tahoma',
+      undefined,
+      undefined,
+      undefined,
+    ])
+  })
+})
+
+describe('formatRuns latinFont', () => {
+  it('splices the typeface ATTRIBUTE when a:latin exists, leaving every neighbour byte-identical', async () => {
+    const { shape } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [fontEdit(shape, 0, 'Georgia')])
+    // Exactly one attribute value changed: pitchFamily, the sibling a:cs, the
+    // fill, the rPr attributes and all three other runs keep their bytes.
+    expect(out).toBe(SLIDE_XML.replace('typeface="Tahoma" pitchFamily="34"', 'typeface="Georgia" pitchFamily="34"'))
+    expect(out).toContain('<a:cs typeface="Tahoma"/>')
+    expect(out).toContain(RUN_1)
+    expect(out).toContain(RUN_2)
+    expect(out).toContain(RUN_3)
+  })
+
+  it('inserts a:latin at its schema position when the rPr has other children', async () => {
+    const { shape } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [fontEdit(shape, 1, 'Verdana')])
+    // After the fill, and the rPr's attributes and fill are untouched.
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:rPr>',
+        '<a:solidFill><a:srgbClr val="00FF00"/></a:solidFill><a:latin typeface="Verdana"/></a:rPr>',
+      ),
+    )
+    expect(out).toContain(RUN_0)
+  })
+
+  it('reopens a self-closing rPr, preserving its attributes', async () => {
+    const { shape } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [fontEdit(shape, 2, 'Verdana')])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:rPr lang="en-US" u="sng"/>',
+        '<a:rPr lang="en-US" u="sng"><a:latin typeface="Verdana"/></a:rPr>',
+      ),
+    )
+  })
+
+  it('a run with no rPr gains one containing only a:latin', async () => {
+    const { shape } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [fontEdit(shape, 3, 'Courier New')])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:r><a:t>fourth</a:t></a:r>',
+        '<a:r><a:rPr><a:latin typeface="Courier New"/></a:rPr><a:t>fourth</a:t></a:r>',
+      ),
+    )
+  })
+
+  it('combines with a colour change in one rPr without overlapping', async () => {
+    const { shape } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'formatRuns',
+        nodePath: shape.nodePath,
+        original: shape.paragraphs,
+        targets: [{ para: 0, run: 2 }],
+        set: { latinFont: 'Georgia', colorHex: '112233', bold: true },
+      },
+    ])
+    // Self-closing rPr reopens with attributes first, then fill, then latin.
+    expect(out).toContain(
+      '<a:rPr lang="en-US" u="sng" b="1"><a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:latin typeface="Georgia"/></a:rPr>',
+    )
+  })
+
+  it('escapes a typeface that would otherwise break the attribute', async () => {
+    const { shape } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [fontEdit(shape, 3, 'A & B "C"')])
+    expect(out).toContain('<a:latin typeface="A &amp; B &quot;C&quot;"/>')
+  })
+
+  it('fails closed on an empty typeface and on a stale original', async () => {
+    const { shape } = await loadDeck()
+    expect(() => updateSlideXml(SLIDE_XML, [fontEdit(shape, 3, '   ')])).toThrow(/must not be empty/)
+
+    // The validation derivation compares the typeface, so an edit whose
+    // `original` disagrees with the retained bytes is refused.
+    const stale = fontEdit(shape, 1, 'Georgia')
+    stale.original = stale.original.map((p) => ({
+      ...p,
+      runs: p.runs.map((r, i) => (i === 0 ? { ...r, latinFont: 'Helvetica' } : r)),
+    }))
+    expect(() => updateSlideXml(SLIDE_XML, [stale])).toThrow(/does not match/)
+  })
+
+  it('re-parses to the new font after a full save', async () => {
+    const { deck, shape } = await loadDeck()
+    const out = await writeDeck(
+      deck,
+      new Map([
+        [
+          'ppt/slides/slide1.xml',
+          [fontEdit(shape, 0, 'Georgia'), fontEdit(shape, 3, 'Courier New')],
+        ],
+      ]),
+    )
+    const reparsed = (await parsePptx(out)).slides[0].shapes[0] as TextShape
+    expect(reparsed.paragraphs[0].runs.map((r) => r.latinFont)).toEqual([
+      'Georgia',
+      undefined,
+      undefined,
+      'Courier New',
+    ])
+    // And the display cascade picks the new families up for rendering. Run 0
+    // keeps its untouched a:cs slot in the stack — only a:latin was edited.
+    const display = reparsed.display!.paragraphs[0]
+    expect(display.runs[0].latinFont).toBe('Georgia')
+    expect(display.runs[0].fontFamily).toBe("'Georgia', 'Tahoma', serif")
+    expect(display.runs[3].fontFamily).toBe("'Courier New', monospace")
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/geometry.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/geometry.ts
@@ -1,0 +1,200 @@
+/**
+ * Shape visuals: fill, line, preset geometry, rotation/flips.
+ *
+ * Style references (`p:style`/`a:fillRef`/`a:lnRef`) resolve through the
+ * theme's fmtScheme with the reference color substituted for `phClr` — that
+ * lazy substitution mirrors how pptx-viewer (Apache-2.0) treats the format
+ * scheme; the parsing here is our own. Explicit spPr fills always win over
+ * style references, per ECMA-376.
+ *
+ * Display-only: nothing here feeds the serializer's validation derivation.
+ */
+
+import {
+  attr,
+  childByLocal,
+  childrenOf,
+  descend,
+  localNameOf,
+  num,
+  tagNameOf,
+  type XmlNode,
+} from './parse'
+import { resolveFirstColor, type Theme } from './theme'
+import type { Fill, GradientStop, LineStyle, PresetGeometry, ShapeVisual } from './types'
+
+const FILL_LOCALS = ['noFill', 'solidFill', 'gradFill', 'blipFill', 'pattFill', 'grpFill']
+
+// ------------------------------------------------------------------- fills
+
+function gradientFrom(gradNode: XmlNode, theme: Theme, phClr?: string): Fill {
+  const stops: GradientStop[] = []
+  const gsLst = descend(gradNode, 'gsLst')
+  if (gsLst) {
+    for (const gs of childrenOf(gsLst)) {
+      const tag = tagNameOf(gs)
+      if (!tag || localNameOf(tag) !== 'gs') continue
+      const pos = (num(attr(gs, 'pos')) ?? 0) / 100000
+      const color = resolveFirstColor(gs, theme, phClr)
+      if (color) stops.push({ pos, hex: color.hex, alpha: color.alpha })
+    }
+  }
+  stops.sort((a, b) => a.pos - b.pos)
+  if (stops.length === 0) return { kind: 'none' }
+  if (stops.length === 1) return { kind: 'solid', hex: stops[0].hex, alpha: stops[0].alpha }
+  const lin = descend(gradNode, 'lin')
+  const angDeg = lin ? (num(attr(lin, 'ang')) ?? 0) / 60000 : 0
+  return { kind: 'gradient', stops, angleDeg: angDeg }
+}
+
+/** Resolves one fill node (`a:solidFill`, `a:gradFill`, `a:noFill`, …). */
+export function fillFromNode(fillNode: XmlNode, theme: Theme, phClr?: string): Fill {
+  const tag = tagNameOf(fillNode)
+  const name = tag ? localNameOf(tag) : ''
+  if (name === 'solidFill') {
+    const color = resolveFirstColor(fillNode, theme, phClr)
+    return color ? { kind: 'solid', hex: color.hex, alpha: color.alpha } : { kind: 'none' }
+  }
+  if (name === 'gradFill') return gradientFrom(fillNode, theme, phClr)
+  // noFill, and the fills we can't draw yet (blip/pattern/group).
+  return { kind: 'none' }
+}
+
+function firstFillChild(kids: XmlNode[]): XmlNode | undefined {
+  return kids.find((n) => {
+    const tag = tagNameOf(n)
+    return tag !== null && FILL_LOCALS.includes(localNameOf(tag))
+  })
+}
+
+// ------------------------------------------------------------------- lines
+
+const DASH_MAP: Record<string, LineStyle['dash']> = {
+  solid: 'solid',
+  dash: 'dash',
+  lgDash: 'dash',
+  sysDash: 'dash',
+  dashDot: 'dash',
+  lgDashDot: 'dash',
+  lgDashDotDot: 'dash',
+  sysDashDot: 'dash',
+  sysDashDotDot: 'dash',
+  dot: 'dot',
+  sysDot: 'dot',
+}
+
+/** Default line width when `a:ln` has no @w: 0.75pt. */
+const DEFAULT_LINE_EMU = 9525
+
+/** Resolves an `a:ln` node to a line style, or null for explicit noFill. */
+export function lineFromLn(lnNode: XmlNode, theme: Theme, phClr?: string): LineStyle | null {
+  const kids = childrenOf(lnNode)
+  if (childByLocal(kids, 'noFill')) return null
+  const solid = childByLocal(kids, 'solidFill')
+  const grad = childByLocal(kids, 'gradFill')
+  const color = resolveFirstColor(solid ?? grad, theme, phClr)
+  if (!color) return null
+  const dashNode = childByLocal(kids, 'prstDash')
+  const dash = dashNode ? (DASH_MAP[attr(dashNode, 'val') ?? 'solid'] ?? 'solid') : 'solid'
+  return {
+    hex: color.hex,
+    widthEmu: num(attr(lnNode, 'w')) ?? DEFAULT_LINE_EMU,
+    dash,
+    alpha: color.alpha,
+  }
+}
+
+// ---------------------------------------------------------------- geometry
+
+function geomFrom(spPrKids: XmlNode[]): PresetGeometry | undefined {
+  const prstGeom = childByLocal(spPrKids, 'prstGeom')
+  if (prstGeom) {
+    const adj: Record<string, number> = {}
+    const avLst = descend(prstGeom, 'avLst')
+    if (avLst) {
+      for (const gd of childrenOf(avLst)) {
+        const tag = tagNameOf(gd)
+        if (!tag || localNameOf(tag) !== 'gd') continue
+        const name = attr(gd, 'name')
+        const fmla = attr(gd, 'fmla') ?? ''
+        const m = fmla.match(/^val\s+(-?\d+)/)
+        if (name && m) adj[name] = Number(m[1])
+      }
+    }
+    return { preset: attr(prstGeom, 'prst') ?? 'rect', adj }
+  }
+  if (childByLocal(spPrKids, 'custGeom')) return { preset: 'custom', adj: {} }
+  return undefined
+}
+
+/** Presets we draw as a single stroked line rather than an outlined box. */
+export function isLinePreset(preset: string): boolean {
+  return preset === 'line' || preset === 'straightConnector1' || preset.startsWith('bentConnector')
+}
+
+// -------------------------------------------------------------- shape visual
+
+/**
+ * The visual properties of a `p:sp` / `p:cxnSp` / `p:pic` node: explicit spPr
+ * values first, then `p:style` fillRef/lnRef resolved through the theme's
+ * format scheme with the reference color as phClr.
+ */
+export function shapeVisualOf(shapeNode: XmlNode, theme: Theme): ShapeVisual {
+  const spPr = childByLocal(childrenOf(shapeNode), 'spPr')
+  const style = childByLocal(childrenOf(shapeNode), 'style')
+  const out: ShapeVisual = {}
+  if (!spPr) return out
+  const spPrKids = childrenOf(spPr)
+
+  // Rotation / flips.
+  const xfrm = childByLocal(spPrKids, 'xfrm')
+  if (xfrm) {
+    const rot = num(attr(xfrm, 'rot'))
+    if (rot !== undefined && rot !== 0) out.rotDeg = rot / 60000
+    if (attr(xfrm, 'flipH') === '1') out.flipH = true
+    if (attr(xfrm, 'flipV') === '1') out.flipV = true
+  }
+
+  out.geom = geomFrom(spPrKids)
+
+  // Fill: explicit spPr fill wins; otherwise the style fillRef.
+  const explicitFill = firstFillChild(spPrKids)
+  if (explicitFill) {
+    out.fill = fillFromNode(explicitFill, theme)
+  } else if (style) {
+    const fillRef = descend(style, 'fillRef')
+    const idx = fillRef ? (num(attr(fillRef, 'idx')) ?? 0) : 0
+    if (fillRef && idx >= 1 && idx < 1000) {
+      const phClr = resolveFirstColor(fillRef, theme)?.hex
+      const themeFill = theme.fillStyleNodes[idx - 1]
+      out.fill = themeFill
+        ? fillFromNode(themeFill, theme, phClr)
+        : phClr
+          ? { kind: 'solid', hex: phClr }
+          : undefined
+    }
+    // idx 0 = no fill from style; idx >= 1000 = background fills (not drawn).
+  }
+
+  // Line: explicit a:ln wins; otherwise the style lnRef.
+  const ln = childByLocal(spPrKids, 'ln')
+  if (ln) {
+    const line = lineFromLn(ln, theme)
+    if (line) out.line = line
+  } else if (style) {
+    const lnRef = descend(style, 'lnRef')
+    const idx = lnRef ? (num(attr(lnRef, 'idx')) ?? 0) : 0
+    if (lnRef && idx >= 1) {
+      const phClr = resolveFirstColor(lnRef, theme)?.hex
+      const themeLn = theme.lineStyleNodes[idx - 1]
+      const line = themeLn
+        ? lineFromLn(themeLn, theme, phClr)
+        : phClr
+          ? { hex: phClr, widthEmu: DEFAULT_LINE_EMU, dash: 'solid' as const }
+          : null
+      if (line) out.line = line
+    }
+  }
+
+  return out
+}

--- a/apps/x/apps/renderer/src/lib/pptx/geometry.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/geometry.ts
@@ -111,7 +111,7 @@ const DASH_MAP: Record<string, LineStyle['dash']> = {
 }
 
 /** Default line width when `a:ln` has no @w: 0.75pt. */
-const DEFAULT_LINE_EMU = 9525
+export const DEFAULT_LINE_EMU = 9525
 
 /** Resolves an `a:ln` node to a line style, or null for explicit noFill. */
 export function lineFromLn(lnNode: XmlNode, theme: Theme, phClr?: string): LineStyle | null {
@@ -157,6 +157,69 @@ function geomFrom(spPrKids: XmlNode[]): PresetGeometry | undefined {
 /** Presets we draw as a single stroked line rather than an outlined box. */
 export function isLinePreset(preset: string): boolean {
   return preset === 'line' || preset === 'straightConnector1' || preset.startsWith('bentConnector')
+}
+
+// ----------------------------------------------------- byte-anchored style
+
+/**
+ * A shape's OWN spPr fill/line, with no theme resolution and no `p:style`
+ * reference inheritance — the write-back anchor for fill and outline edits,
+ * exactly as `parseParagraph` anchors text edits. `ShapeVisual` is the
+ * opposite: fully resolved, display-only, and never read by the serializer.
+ */
+export interface ShapeStyleSnapshot {
+  /** Local name of spPr's fill child (`solidFill`, `gradFill`, …); null = none. */
+  fill: string | null
+  /** Literal `a:srgbClr@val`; absent for theme colours and non-solid fills. */
+  fillHex?: string
+  hasLine: boolean
+  /** Local name of the fill child inside `a:ln`; null when it has none. */
+  lineFill: string | null
+  lineHex?: string
+  /** `a:ln@w` verbatim, so preserving the stroke width is checkable. */
+  lineW?: string
+}
+
+/** Literal srgbClr directly under a fill element, if any. */
+function literalHexOf(fillNode: XmlNode | undefined): string | undefined {
+  const srgb = fillNode && descend(fillNode, 'srgbClr')
+  const val = srgb && attr(srgb, 'val')
+  return val ? val.toUpperCase() : undefined
+}
+
+export function shapeStyleSnapshotOf(shapeNode: XmlNode): ShapeStyleSnapshot {
+  const out: ShapeStyleSnapshot = { fill: null, hasLine: false, lineFill: null }
+  const spPr = childByLocal(childrenOf(shapeNode), 'spPr')
+  if (!spPr) return out
+  const kids = childrenOf(spPr)
+
+  const fill = firstFillChild(kids)
+  if (fill) {
+    const tag = tagNameOf(fill)
+    out.fill = tag ? localNameOf(tag) : null
+    const hex = literalHexOf(fill)
+    if (hex) out.fillHex = hex
+  }
+
+  const ln = childByLocal(kids, 'ln')
+  if (ln) {
+    out.hasLine = true
+    const lnFill = firstFillChild(childrenOf(ln))
+    if (lnFill) {
+      const tag = tagNameOf(lnFill)
+      out.lineFill = tag ? localNameOf(tag) : null
+      const hex = literalHexOf(lnFill)
+      if (hex) out.lineHex = hex
+    }
+    const w = attr(ln, 'w')
+    if (w) out.lineW = w
+  }
+  return out
+}
+
+/** Canonical form for the serializer's fail-closed comparison. */
+export function normalizeShapeStyle(s: ShapeStyleSnapshot): string {
+  return JSON.stringify([s.fill, s.fillHex, s.hasLine, s.lineFill, s.lineHex, s.lineW])
 }
 
 // -------------------------------------------------------------- shape visual

--- a/apps/x/apps/renderer/src/lib/pptx/geometry.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/geometry.ts
@@ -67,6 +67,33 @@ function firstFillChild(kids: XmlNode[]): XmlNode | undefined {
   })
 }
 
+/**
+ * Resolves a `p:bg` node to a page fill. `p:bgPr` carries a literal fill;
+ * `p:bgRef` points into the theme's format scheme by idx (1..999 →
+ * fillStyleLst, ≥1001 → bgFillStyleLst) with its color child as phClr.
+ * Best-effort: anything unresolvable comes back `{ kind: 'none' }`, which the
+ * renderer draws as the plain white page.
+ */
+export function backgroundFillOf(bgNode: XmlNode, theme: Theme): Fill {
+  const kids = childrenOf(bgNode)
+  const bgPr = childByLocal(kids, 'bgPr')
+  if (bgPr) {
+    const fill = firstFillChild(childrenOf(bgPr))
+    return fill ? fillFromNode(fill, theme) : { kind: 'none' }
+  }
+  const bgRef = childByLocal(kids, 'bgRef')
+  if (bgRef) {
+    const idx = num(attr(bgRef, 'idx')) ?? 0
+    const phClr = resolveFirstColor(bgRef, theme)?.hex
+    if (idx === 0 || idx === 1000) return { kind: 'none' }
+    const styleNode =
+      idx >= 1001 ? theme.bgFillStyleNodes[idx - 1001] : theme.fillStyleNodes[idx - 1]
+    if (styleNode) return fillFromNode(styleNode, theme, phClr)
+    if (phClr) return { kind: 'solid', hex: phClr }
+  }
+  return { kind: 'none' }
+}
+
 // ------------------------------------------------------------------- lines
 
 const DASH_MAP: Record<string, LineStyle['dash']> = {

--- a/apps/x/apps/renderer/src/lib/pptx/insert-shape.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/insert-shape.test.ts
@@ -1,0 +1,456 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx } from './parse'
+import { updateSlideXml, writeDeck, type SlideEdit } from './serialize'
+import type { ImageShape, TextShape } from './types'
+
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const NS_R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+const XFRM = '<a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm>'
+const EXISTING_SP =
+  '<p:sp><p:nvSpPr><p:cNvPr id="7" name="Existing"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>' +
+  `<p:spPr>${XFRM}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>` +
+  '<p:txBody><a:bodyPr/><a:p><a:r><a:t>hello</a:t></a:r></a:p></p:txBody></p:sp>'
+
+const SLIDE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:sld ${NS_P} ${NS_A} ${NS_R}><p:cSld><p:spTree>` +
+  '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+  '<p:grpSpPr/>' +
+  EXISTING_SP +
+  '</p:spTree></p:cSld></p:sld>'
+
+const PRESENTATION_XML =
+  `<p:presentation ${NS_P} ${NS_R}>` +
+  '<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>' +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/></Relationships>`
+/** The slide already owns rId1 (its layout) and an image, so ids must skip. */
+const SLIDE_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/image" Target="../media/image3.png"/>` +
+  '</Relationships>'
+
+const PNG = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10])
+const PNG_B64 = Buffer.from(PNG).toString('base64')
+
+/** png already typed; webp deliberately NOT, to prove the Default is added. */
+const CONTENT_TYPES =
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Default Extension="png" ContentType="image/png"/>' +
+  '<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>' +
+  '</Types>'
+
+async function buildZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('[Content_Types].xml', CONTENT_TYPES)
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE_XML)
+  zip.file('ppt/slides/_rels/slide1.xml.rels', SLIDE_RELS)
+  // image3 exists, so the next free name is image4 — not image1.
+  zip.file('ppt/media/image3.png', PNG)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+const P1 = 'ppt/slides/slide1.xml'
+const RECT = { x: 100, y: 200, w: 300, h: 400 }
+
+const textboxEdit: SlideEdit = { kind: 'insertShape', spec: { kind: 'textbox', xfrmEmu: RECT } }
+
+describe('insert non-picture shapes', () => {
+  it('appends exactly one element before </p:spTree>, leaving every other byte alone', () => {
+    const out = updateSlideXml(SLIDE_XML, [textboxEdit])
+    // Everything before spTree's close tag is unchanged, and the new element
+    // sits after the existing shape — i.e. on top of the z-order.
+    expect(out.startsWith(SLIDE_XML.slice(0, SLIDE_XML.indexOf('</p:spTree>')))).toBe(true)
+    expect(out.endsWith('</p:spTree></p:cSld></p:sld>')).toBe(true)
+    expect(out).toContain(EXISTING_SP)
+    const inserted = out.slice(
+      SLIDE_XML.indexOf('</p:spTree>'),
+      out.indexOf('</p:spTree>'),
+    )
+    expect(inserted).toContain('<p:cNvSpPr txBox="1"/>')
+    expect(inserted).toContain('<a:noFill/>')
+    expect(inserted).toContain('<a:defRPr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:defRPr>')
+    expect(inserted).toContain('<a:off x="100" y="200"/><a:ext cx="300" cy="400"/>')
+    // A text box has no outline.
+    expect(inserted).not.toContain('<a:ln')
+    // Exactly one new top-level element.
+    expect(inserted.match(/<p:sp>/g)).toHaveLength(1)
+  })
+
+  it('assigns ids above every existing cNvPr, including pending inserts', () => {
+    const out = updateSlideXml(SLIDE_XML, [
+      textboxEdit,
+      { kind: 'insertShape', spec: { kind: 'shape', preset: 'ellipse', xfrmEmu: RECT } },
+      { kind: 'insertShape', spec: { kind: 'shape', preset: 'roundRect', xfrmEmu: RECT } },
+    ])
+    // Existing ids are 1 and 7, so the three inserts take 8, 9, 10.
+    expect(out).toContain('<p:cNvPr id="8" name="TextBox 8"/>')
+    expect(out).toContain('<p:cNvPr id="9" name="Oval 9"/>')
+    expect(out).toContain('<p:cNvPr id="10" name="Rounded Rectangle 10"/>')
+    const ids = [...out.matchAll(/cNvPr id="(\d+)"/g)].map((m) => m[1])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('gives a shape a theme accent fill, and a line a stroke instead', () => {
+    const rect = updateSlideXml(SLIDE_XML, [
+      { kind: 'insertShape', spec: { kind: 'shape', preset: 'rect', xfrmEmu: RECT } },
+    ])
+    expect(rect).toContain('<a:solidFill><a:schemeClr val="accent1"/></a:solidFill>')
+    expect(rect).toContain('<a:prstGeom prst="rect">')
+
+    const line = updateSlideXml(SLIDE_XML, [
+      { kind: 'insertShape', spec: { kind: 'shape', preset: 'line', xfrmEmu: RECT } },
+    ])
+    expect(line).toContain(
+      '<a:noFill/><a:ln><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln>',
+    )
+    // A line carries no text body.
+    expect(line.slice(line.indexOf('Straight Connector'))).not.toContain('<p:txBody>')
+  })
+
+  it('re-parses as an ordinary, editable model shape', async () => {
+    const deck = await parsePptx(await buildZip())
+    const out = await writeDeck(deck, new Map([[P1, [textboxEdit]]]))
+    const shapes = (await parsePptx(out)).slides[0].shapes
+    expect(shapes).toHaveLength(2)
+    const added = shapes[1] as TextShape
+    expect(added.type).toBe('text')
+    expect(added.id).toBe('8')
+    expect(added.xfrmEmu).toEqual(RECT)
+    // One empty paragraph, and a style snapshot so it can be recoloured.
+    expect(added.paragraphs).toHaveLength(1)
+    expect(added.paragraphs[0].runs).toHaveLength(0)
+    expect(added.style).toEqual({ fill: 'noFill', hasLine: false, lineFill: null })
+    // An explicit tx1 default, so typed text is the theme's body colour rather
+    // than whatever the master cascade happens to resolve — which on some
+    // decks is white, i.e. invisible.
+    expect(added.display?.defaultRun.colorHex).toBe('000000')
+  })
+})
+
+describe('insert image', () => {
+  it('writes the media part and the relationship exactly, touching nothing else', async () => {
+    const input = await buildZip()
+    const deck = await parsePptx(input)
+    const out = await writeDeck(
+      deck,
+      new Map([
+        [
+          P1,
+          [
+            {
+              kind: 'insertShape',
+              spec: {
+                kind: 'image',
+                xfrmEmu: RECT,
+                ext: 'png',
+                dataBase64: PNG_B64,
+                name: 'photo.png',
+              },
+            } as SlideEdit,
+          ],
+        ],
+      ]),
+    )
+    const outZip = await JSZip.loadAsync(out)
+
+    // image3 was taken, so the new part is image4 — with the exact bytes.
+    const bytes = await outZip.files['ppt/media/image4.png'].async('uint8array')
+    expect(Buffer.from(bytes).equals(Buffer.from(PNG))).toBe(true)
+
+    // Exactly one Relationship appended, before </Relationships>; rId1/rId2
+    // were taken, so it is rId3.
+    expect(await outZip.files['ppt/slides/_rels/slide1.xml.rels'].async('string')).toBe(
+      SLIDE_RELS.replace(
+        '</Relationships>',
+        `<Relationship Id="rId3" Type="${REL_TYPE}/image" Target="../media/image4.png"/></Relationships>`,
+      ),
+    )
+    // The p:pic references that id.
+    const slide = await outZip.files[P1].async('string')
+    expect(slide).toContain('<a:blip r:embed="rId3"/>')
+    expect(slide).toContain('name="photo.png"')
+
+    // Every pre-existing part is byte-identical.
+    const inZip = await JSZip.loadAsync(input)
+    for (const name of Object.keys(inZip.files)) {
+      if (inZip.files[name].dir) continue
+      if (name === P1 || name === 'ppt/slides/_rels/slide1.xml.rels') continue
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      expect(Buffer.from(a).equals(Buffer.from(b)), `byte-identical: ${name}`).toBe(true)
+    }
+
+    // And it reopens as a real image shape pointing at the new part.
+    const added = (await parsePptx(out)).slides[0].shapes[1] as ImageShape
+    expect(added.type).toBe('image')
+    expect(added.mediaPath).toBe('ppt/media/image4.png')
+  })
+
+  it('claims distinct parts and ids for several images in one save', async () => {
+    const deck = await parsePptx(await buildZip())
+    const image = (name: string): SlideEdit => ({
+      kind: 'insertShape',
+      spec: { kind: 'image', xfrmEmu: RECT, ext: 'png', dataBase64: PNG_B64, name },
+    })
+    const out = await writeDeck(deck, new Map([[P1, [image('a.png'), image('b.png')]]]))
+    const outZip = await JSZip.loadAsync(out)
+    expect(outZip.files['ppt/media/image4.png']).toBeDefined()
+    expect(outZip.files['ppt/media/image5.png']).toBeDefined()
+    const rels = await outZip.files['ppt/slides/_rels/slide1.xml.rels'].async('string')
+    expect(rels).toContain('Id="rId3"')
+    expect(rels).toContain('Id="rId4"')
+    const slide = await outZip.files[P1].async('string')
+    expect(slide).toContain('r:embed="rId3"')
+    expect(slide).toContain('r:embed="rId4"')
+  })
+
+  it('fails closed when an image insert reaches the writer with no extension', async () => {
+    const deck = await parsePptx(await buildZip())
+    await expect(
+      writeDeck(
+        deck,
+        new Map([
+          [
+            P1,
+            [
+              {
+                kind: 'insertShape',
+                spec: { kind: 'image', xfrmEmu: RECT, ext: '', dataBase64: PNG_B64 },
+              } as SlideEdit,
+            ],
+          ],
+        ]),
+      ),
+    ).rejects.toThrow(/no usable file extension/)
+
+    // And an insert addressed at a slide that does not exist.
+    await expect(
+      writeDeck(deck, new Map([['ppt/slides/slide9.xml', [textboxEdit]]])),
+    ).rejects.toThrow(/unknown slide/)
+  })
+
+  it('refuses a picture whose relationship was never planned', () => {
+    // updateSlideXml on its own cannot mint relationships, so it must not
+    // silently emit a dangling r:embed.
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        {
+          kind: 'insertShape',
+          spec: { kind: 'image', xfrmEmu: RECT, ext: 'png', dataBase64: PNG_B64 },
+        },
+      ]),
+    ).toThrow(/no relationship id/)
+  })
+})
+
+describe('insert composes with the other edit kinds', () => {
+  it('insert + edit + delete of the same shape nets out to the original bytes', async () => {
+    const input = await buildZip()
+    const deck = await parsePptx(await buildZip())
+
+    // Insert a text box, and confirm it lands.
+    const inserted = await writeDeck(deck, new Map([[P1, [textboxEdit]]]))
+    expect((await parsePptx(inserted)).slides[0].shapes).toHaveLength(2)
+
+    // The edit set is the unit of truth: dropping the insert from it — which
+    // is exactly what undo does — recomputes the original bytes from base.
+    const undone = await writeDeck(deck, new Map())
+    const a = await (await JSZip.loadAsync(input)).files[P1].async('uint8array')
+    const b = await (await JSZip.loadAsync(undone)).files[P1].async('uint8array')
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true)
+
+    // A save that inserts and then deletes the PRE-EXISTING shape still only
+    // touches what it owns: the survivor is the inserted one.
+    const existing = deck.slides[0].shapes[0] as TextShape
+    const both = await writeDeck(
+      deck,
+      new Map([
+        [
+          P1,
+          [
+            textboxEdit,
+            {
+              kind: 'deleteShape',
+              nodePath: existing.nodePath,
+              shapeType: 'text',
+              shapeId: existing.id,
+              original: existing.paragraphs,
+            },
+          ],
+        ],
+      ]),
+    )
+    const after = (await parsePptx(both)).slides[0].shapes
+    expect(after).toHaveLength(1)
+    expect(after[0].id).toBe('8')
+  })
+})
+
+describe('an inserted shape is addressable like any other', () => {
+  it('type + bold into a freshly inserted text box saves and round-trips', async () => {
+    const deck = await parsePptx(await buildZip())
+    const slide = deck.slides[0]
+    // The node path the box WILL occupy: the next spTree CHILD index, not the
+    // next model-shape index — spTree also holds nvGrpSpPr/grpSpPr.
+    const last = slide.shapes[slide.shapes.length - 1]
+    const insertedPath = [...slide.spTreePath, last.nodePath[last.nodePath.length - 1] + 1]
+
+    const out = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([
+        [
+          P1,
+          [
+            textboxEdit,
+            // Typing into the box that this same save is creating.
+            {
+              kind: 'text',
+              nodePath: insertedPath,
+              original: [{ runs: [] }],
+              next: [{ runs: [{ text: 'typed', bold: true, colorHex: 'FF0000' }] }],
+            },
+          ],
+        ],
+      ]),
+    )
+
+    const shapes = (await parsePptx(out)).slides[0].shapes
+    expect(shapes).toHaveLength(2)
+    const box = shapes[1] as TextShape
+    expect(box.paragraphs[0].runs[0].text).toBe('typed')
+    expect(box.paragraphs[0].runs[0].bold).toBe(true)
+    expect(box.paragraphs[0].runs[0].colorHex).toBe('FF0000')
+    // The pre-existing shape is untouched.
+    expect((shapes[0] as TextShape).paragraphs[0].runs[0].text).toBe('hello')
+  })
+
+  it('accepts geometry, style and deletion edits on a shape inserted in the same save', async () => {
+    const deck = await parsePptx(await buildZip())
+    const slide = deck.slides[0]
+    const last = slide.shapes[slide.shapes.length - 1]
+    const insertedPath = [...slide.spTreePath, last.nodePath[last.nodePath.length - 1] + 1]
+
+    const moved = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([
+        [
+          P1,
+          [
+            { kind: 'insertShape', spec: { kind: 'shape', preset: 'rect', xfrmEmu: RECT } },
+            {
+              kind: 'shapeGeometry',
+              nodePath: insertedPath,
+              offEmu: { x: 999, y: 888 },
+              extEmu: { w: 777, h: 666 },
+            },
+          ],
+        ],
+      ]),
+    )
+    const shape = (await parsePptx(moved)).slides[0].shapes[1]
+    expect(shape.xfrmEmu).toEqual({ x: 999, y: 888, w: 777, h: 666 })
+
+    // Deleting it in the same save leaves the slide as it started.
+    const netZero = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([
+        [
+          P1,
+          [
+            textboxEdit,
+            {
+              kind: 'deleteShape',
+              nodePath: insertedPath,
+              shapeType: 'text',
+              shapeId: '8',
+              // A synthesized text box has exactly one empty paragraph, and
+              // deletion revalidates that against the bytes like any other.
+              original: [{ runs: [] }],
+            },
+          ],
+        ],
+      ]),
+    )
+    expect((await parsePptx(netZero)).slides[0].shapes).toHaveLength(1)
+  })
+})
+
+describe('inserted media is typed in [Content_Types].xml', () => {
+  it('adds a Default for a new extension and leaves an already-typed one alone', async () => {
+    const deck = await parsePptx(await buildZip())
+    const image = (ext: string): SlideEdit => ({
+      kind: 'insertShape',
+      spec: { kind: 'image', xfrmEmu: RECT, ext, dataBase64: PNG_B64 },
+    })
+
+    // png is already typed: CT must stay byte-identical.
+    const pngOnly = await JSZip.loadAsync(await writeDeck(deck, new Map([[P1, [image('png')]]])))
+    expect(await pngOnly.files['[Content_Types].xml'].async('string')).toBe(CONTENT_TYPES)
+
+    // webp is not: exactly one Default appears, before </Types>.
+    const withWebp = await JSZip.loadAsync(await writeDeck(deck, new Map([[P1, [image('webp')]]])))
+    expect(await withWebp.files['[Content_Types].xml'].async('string')).toBe(
+      CONTENT_TYPES.replace('</Types>', '<Default Extension="webp" ContentType="image/webp"/></Types>'),
+    )
+  })
+})
+
+describe('restyling a shape inserted in the same save', () => {
+  it('validates against the synthesized snapshot and recolours it', async () => {
+    const deck = await parsePptx(await buildZip())
+    const slide = deck.slides[0]
+    const last = slide.shapes[slide.shapes.length - 1]
+    const insertedPath = [...last.nodePath.slice(0, -1), last.nodePath[last.nodePath.length - 1] + 1]
+
+    const out = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([
+        [
+          P1,
+          [
+            { kind: 'insertShape', spec: { kind: 'shape', preset: 'rect', xfrmEmu: RECT } },
+            {
+              kind: 'setShapeStyle',
+              nodePath: insertedPath,
+              shapeType: 'text',
+              shapeId: '8',
+              // Exactly what the preview snapshot claims the synthesized
+              // rect parses to — the fail-closed comparison runs against it.
+              original: { fill: 'solidFill', hasLine: false, lineFill: null },
+              fillHex: '112233',
+            },
+          ],
+        ],
+      ]),
+    )
+    const shape = (await parsePptx(out)).slides[0].shapes[1]
+    expect(shape.style?.fillHex).toBe('112233')
+    // The theme reference is gone; a literal colour took its place.
+    const raw = await (await JSZip.loadAsync(out)).files[P1].async('string')
+    expect(raw).not.toContain('schemeClr val="accent1"')
+    expect(raw).toContain('<a:srgbClr val="112233"/>')
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/parse.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx, parseXml, resolveNodePath, resolveRelTarget, tagNameOf } from './parse'
+import type { ImageShape, PlaceholderShape, TextShape } from './types'
+
+const SLIDE_W = 12192000
+const SLIDE_H = 6858000
+
+const TEXT_RECT = { x: 838200, y: 365125, w: 10515600, h: 1325563 }
+const IMAGE_RECT = { x: 1000000, y: 2000000, w: 3000000, h: 2000000 }
+
+const PRESENTATION_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>
+  <p:sldSz cx="${SLIDE_W}" cy="${SLIDE_H}"/>
+</p:presentation>`
+
+const PRESENTATION_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>`
+
+const SLIDE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
+</Relationships>`
+
+const SLIDE_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2" name="Title 1"/></p:nvSpPr>
+      <p:spPr><a:xfrm>
+        <a:off x="${TEXT_RECT.x}" y="${TEXT_RECT.y}"/>
+        <a:ext cx="${TEXT_RECT.w}" cy="${TEXT_RECT.h}"/>
+      </a:xfrm></p:spPr>
+      <p:txBody>
+        <a:p>
+          <a:pPr algn="ctr"/>
+          <a:r>
+            <a:rPr lang="en-US" b="1" sz="2800">
+              <a:solidFill><a:srgbClr val="ff0000"/></a:solidFill>
+            </a:rPr>
+            <a:t>Hello </a:t>
+          </a:r>
+          <a:r>
+            <a:rPr lang="en-US" i="1" u="sng"/>
+            <a:t>world</a:t>
+          </a:r>
+        </a:p>
+      </p:txBody>
+    </p:sp>
+    <p:pic>
+      <p:nvPicPr><p:cNvPr id="3" name="Picture 2"/></p:nvPicPr>
+      <p:blipFill><a:blip r:embed="rId1"/></p:blipFill>
+      <p:spPr><a:xfrm>
+        <a:off x="${IMAGE_RECT.x}" y="${IMAGE_RECT.y}"/>
+        <a:ext cx="${IMAGE_RECT.w}" cy="${IMAGE_RECT.h}"/>
+      </a:xfrm></p:spPr>
+    </p:pic>
+    <p:graphicFrame>
+      <p:nvGraphicFramePr><p:cNvPr id="4" name="Chart 3"/></p:nvGraphicFramePr>
+      <p:xfrm><a:off x="10" y="20"/><a:ext cx="30" cy="40"/></p:xfrm>
+      <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"/></a:graphic>
+    </p:graphicFrame>
+  </p:spTree></p:cSld>
+</p:sld>`
+
+/** 1x1 transparent PNG. */
+const PNG_BYTES = Uint8Array.from(
+  atob(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk' +
+      'YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  ),
+  (c) => c.charCodeAt(0),
+)
+
+async function buildFixture(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE_XML)
+  zip.file('ppt/slides/_rels/slide1.xml.rels', SLIDE_RELS)
+  zip.file('ppt/media/image1.png', PNG_BYTES)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+// jsdom implements neither of these.
+const createdUrls: string[] = []
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+
+beforeAll(() => {
+  URL.createObjectURL = (() => {
+    const url = `blob:mock/${createdUrls.length}`
+    createdUrls.push(url)
+    return url
+  }) as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+describe('parsePptx', () => {
+  it('reads slide size, shapes, coordinates and run formatting', async () => {
+    const deck = await parsePptx(await buildFixture())
+
+    expect(deck.slideSizeEmu).toEqual({ w: SLIDE_W, h: SLIDE_H })
+    expect(deck.slides).toHaveLength(1)
+
+    const slide = deck.slides[0]
+    expect(slide.xmlPath).toBe('ppt/slides/slide1.xml')
+    // Document order is preserved, which is also z-order.
+    expect(slide.shapes.map((s) => s.type)).toEqual(['text', 'image', 'placeholder'])
+
+    const text = slide.shapes[0] as TextShape
+    expect(text.id).toBe('2')
+    expect(text.xfrmEmu).toEqual(TEXT_RECT)
+    expect(text.paragraphs).toHaveLength(1)
+    expect(text.paragraphs[0].align).toBe('ctr')
+
+    const runs = text.paragraphs[0].runs
+    expect(runs).toHaveLength(2)
+    // Trailing space inside a:t must survive parsing.
+    expect(runs[0]).toEqual({ text: 'Hello ', bold: true, sizePt: 28, colorHex: 'FF0000' })
+    expect(runs[1]).toEqual({ text: 'world', italic: true, underline: true })
+
+    const image = slide.shapes[1] as ImageShape
+    expect(image.xfrmEmu).toEqual(IMAGE_RECT)
+    expect(image.mediaPath).toBe('ppt/media/image1.png')
+    expect(image.blobUrl).toMatch(/^blob:mock\//)
+
+    // graphicFrame keeps its xfrm directly, not under spPr.
+    const frame = slide.shapes[2] as PlaceholderShape
+    expect(frame.kind).toBe('chart')
+    expect(frame.xfrmEmu).toEqual({ x: 10, y: 20, w: 30, h: 40 })
+  })
+
+  it('records a node path that resolves back to the shape it came from', async () => {
+    const deck = await parsePptx(await buildFixture())
+    const slide = deck.slides[0]
+    // Re-parse from the retained raw XML exactly as Phase B will, then walk each
+    // recorded path and confirm it lands on the element the shape came from.
+    const doc = parseXml(deck.source.slideXml[slide.xmlPath])
+    const landedOn = slide.shapes.map((s) => {
+      const node = resolveNodePath(doc, s.nodePath)
+      return node ? tagNameOf(node) : null
+    })
+    expect(landedOn).toEqual(['p:sp', 'p:pic', 'p:graphicFrame'])
+    for (const shape of slide.shapes) {
+      expect(shape.slideXmlPath).toBe('ppt/slides/slide1.xml')
+    }
+    // The raw XML is retained verbatim for surgical write-back.
+    expect(deck.source.slideXml['ppt/slides/slide1.xml']).toBe(SLIDE_XML)
+  })
+
+  it('rejects a package that is not a presentation', async () => {
+    const zip = new JSZip()
+    zip.file('hello.txt', 'not a deck')
+    await expect(parsePptx(await zip.generateAsync({ type: 'uint8array' }))).rejects.toThrow(
+      /presentation\.xml/,
+    )
+  })
+})
+
+describe('placeholder geometry inheritance', () => {
+  const LAYOUT_TITLE = { x: 100000, y: 200000, w: 300000, h: 400000 }
+  const MASTER_BODY = { x: 11, y: 22, w: 33, h: 44 }
+
+  /** How PowerPoint really authors it: placeholders carry no a:xfrm at all. */
+  const SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2"/><p:nvPr><p:ph type="ctrTitle"/></p:nvPr></p:nvSpPr>
+      <p:spPr/>
+      <p:txBody><a:p><a:r><a:t>Inherited title</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="3"/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>
+      <p:spPr/>
+      <p:txBody><a:p><a:r><a:t>Inherited body</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld></p:sld>`
+
+  const LAYOUT = `<p:sldLayout xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="9"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+      <p:spPr><a:xfrm>
+        <a:off x="${LAYOUT_TITLE.x}" y="${LAYOUT_TITLE.y}"/>
+        <a:ext cx="${LAYOUT_TITLE.w}" cy="${LAYOUT_TITLE.h}"/>
+      </a:xfrm></p:spPr>
+    </p:sp>
+  </p:spTree></p:cSld></p:sldLayout>`
+
+  const MASTER = `<p:sldMaster xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="8"/><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr>
+      <p:spPr><a:xfrm>
+        <a:off x="${MASTER_BODY.x}" y="${MASTER_BODY.y}"/>
+        <a:ext cx="${MASTER_BODY.w}" cy="${MASTER_BODY.h}"/>
+      </a:xfrm></p:spPr>
+    </p:sp>
+  </p:spTree></p:cSld></p:sldMaster>`
+
+  const rels = (entries: string) =>
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${entries}</Relationships>`
+
+  it('resolves a placeholder rect from the layout, and from the master via the layout', async () => {
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', SLIDE)
+    zip.file(
+      'ppt/slides/_rels/slide1.xml.rels',
+      rels(
+        '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>',
+      ),
+    )
+    zip.file('ppt/slideLayouts/slideLayout1.xml', LAYOUT)
+    zip.file(
+      'ppt/slideLayouts/_rels/slideLayout1.xml.rels',
+      rels(
+        '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>',
+      ),
+    )
+    zip.file('ppt/slideMasters/slideMaster1.xml', MASTER)
+
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    const [title, body] = deck.slides[0].shapes as TextShape[]
+
+    // ctrTitle on the slide matches the layout's `title` slot.
+    expect(title.xfrmEmu).toEqual(LAYOUT_TITLE)
+    // Not present on the layout, so it falls through to the master by idx.
+    expect(body.xfrmEmu).toEqual(MASTER_BODY)
+  })
+})
+
+describe('resolveRelTarget', () => {
+  it('resolves relative, parent and absolute targets', () => {
+    expect(resolveRelTarget('ppt', 'slides/slide1.xml')).toBe('ppt/slides/slide1.xml')
+    expect(resolveRelTarget('ppt/slides', '../media/image1.png')).toBe('ppt/media/image1.png')
+    expect(resolveRelTarget('ppt/slides', '/ppt/media/image1.png')).toBe('ppt/media/image1.png')
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/parse.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
 import JSZip from 'jszip'
 import { parsePptx, parseXml, resolveNodePath, resolveRelTarget, tagNameOf } from './parse'
-import type { ImageShape, PlaceholderShape, TextShape } from './types'
+import { writeDeck } from './serialize'
+import type { GroupShape, ImageShape, PlaceholderShape, TextShape } from './types'
 
 const SLIDE_W = 12192000
 const SLIDE_H = 6858000
@@ -237,6 +238,228 @@ describe('placeholder geometry inheritance', () => {
     expect(title.xfrmEmu).toEqual(LAYOUT_TITLE)
     // Not present on the layout, so it falls through to the master by idx.
     expect(body.xfrmEmu).toEqual(MASTER_BODY)
+  })
+})
+
+describe('group shapes', () => {
+  // Children live in a 6096000×3048000 child space (chOff 100000/200000)
+  // mapped onto a 3048000×1524000 box at (914400, 457200): scale 0.5 per axis.
+  const GROUP_SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:grpSp>
+      <p:nvGrpSpPr><p:cNvPr id="10" name="Group 9"/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm>
+        <a:off x="914400" y="457200"/><a:ext cx="3048000" cy="1524000"/>
+        <a:chOff x="100000" y="200000"/><a:chExt cx="6096000" cy="3048000"/>
+      </a:xfrm></p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="11"/></p:nvSpPr>
+        <p:spPr><a:xfrm>
+          <a:off x="2100000" y="1200000"/><a:ext cx="1000000" cy="600000"/>
+        </a:xfrm><a:solidFill><a:srgbClr val="1B2A4A"/></a:solidFill></p:spPr>
+        <p:txBody><a:p><a:r><a:t>Inside the group</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+    </p:grpSp>
+  </p:spTree></p:cSld></p:sld>`
+
+  // Outer maps a 12192000×6096000 child space onto 6096000×3048000 at the
+  // origin (scale 0.5); the inner group halves again — 0.25 through both.
+  const NESTED_SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:grpSp>
+      <p:nvGrpSpPr><p:cNvPr id="20"/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm>
+        <a:off x="0" y="0"/><a:ext cx="6096000" cy="3048000"/>
+        <a:chOff x="0" y="0"/><a:chExt cx="12192000" cy="6096000"/>
+      </a:xfrm></p:grpSpPr>
+      <p:grpSp>
+        <p:nvGrpSpPr><p:cNvPr id="21"/></p:nvGrpSpPr>
+        <p:grpSpPr><a:xfrm>
+          <a:off x="2000000" y="1000000"/><a:ext cx="4000000" cy="2000000"/>
+          <a:chOff x="0" y="0"/><a:chExt cx="8000000" cy="4000000"/>
+        </a:xfrm></p:grpSpPr>
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="22"/></p:nvSpPr>
+          <p:spPr><a:xfrm>
+            <a:off x="1000000" y="2000000"/><a:ext cx="4000000" cy="1000000"/>
+          </a:xfrm></p:spPr>
+        </p:sp>
+      </p:grpSp>
+    </p:grpSp>
+  </p:spTree></p:cSld></p:sld>`
+
+  async function loadSlide(xml: string) {
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', xml)
+    return parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+  }
+
+  it('walks a group and maps children through chOff/chExt to final slide EMU', async () => {
+    const deck = await loadSlide(GROUP_SLIDE)
+    const [group] = deck.slides[0].shapes as [GroupShape]
+
+    expect(group.type).toBe('group')
+    // The group's own box passes through untransformed (top level).
+    expect(group.xfrmEmu).toEqual({ x: 914400, y: 457200, w: 3048000, h: 1524000 })
+
+    const child = group.children[0] as TextShape
+    expect(child.type).toBe('text')
+    // off + (child − chOff) · 0.5 per axis; extents halve.
+    expect(child.xfrmEmu).toEqual({ x: 1914400, y: 957200, w: 500000, h: 300000 })
+    // The child renders through the full pipeline: text and fill intact.
+    expect(child.paragraphs[0].runs[0].text).toBe('Inside the group')
+    expect(child.visual?.fill).toEqual({ kind: 'solid', hex: '1B2A4A' })
+    // Its nodePath stays well-formed (resolves back through the group)…
+    const doc = parseXml(deck.source.slideXml['ppt/slides/slide1.xml'])
+    expect(tagNameOf(resolveNodePath(doc, child.nodePath)!)).toBe('p:sp')
+  })
+
+  it('multiplies nested group transforms through', async () => {
+    const deck = await loadSlide(NESTED_SLIDE)
+    const [outer] = deck.slides[0].shapes as [GroupShape]
+    const inner = outer.children[0] as GroupShape
+
+    expect(inner.type).toBe('group')
+    // Inner group's box mapped through the outer transform alone.
+    expect(inner.xfrmEmu).toEqual({ x: 1000000, y: 500000, w: 2000000, h: 1000000 })
+
+    // Leaf: through inner (0.5, offset 2000000/1000000) then outer (0.5).
+    const leaf = inner.children[0]
+    expect(leaf.xfrmEmu).toEqual({ x: 1250000, y: 1000000, w: 1000000, h: 250000 })
+  })
+
+  it('keeps unedited write-back of a deck with groups byte-identical', async () => {
+    const deck = await loadSlide(GROUP_SLIDE)
+    const out = await writeDeck(deck, new Map())
+    const raw = await (await JSZip.loadAsync(out)).files['ppt/slides/slide1.xml'].async('string')
+    expect(raw).toBe(GROUP_SLIDE)
+  })
+})
+
+describe('slide background', () => {
+  const BG_SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld>
+    <p:bg><p:bgPr><a:solidFill><a:srgbClr val="1B2A4A"/></a:solidFill><a:effectLst/></p:bgPr></p:bg>
+    <p:spTree></p:spTree>
+  </p:cSld></p:sld>`
+
+  const PLAIN_SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree></p:spTree></p:cSld></p:sld>`
+
+  const BG_LAYOUT = `<p:sldLayout xmlns:p="p" xmlns:a="a"><p:cSld>
+    <p:bg><p:bgPr><a:solidFill><a:srgbClr val="102030"/></a:solidFill></p:bgPr></p:bg>
+    <p:spTree></p:spTree>
+  </p:cSld></p:sldLayout>`
+
+  const rels = (entries: string) =>
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${entries}</Relationships>`
+
+  it('resolves a slide-level solidFill background', async () => {
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', BG_SLIDE)
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    expect(deck.slides[0].background).toEqual({ kind: 'solid', hex: '1B2A4A' })
+  })
+
+  it('cascades to the layout background when the slide has none', async () => {
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', PLAIN_SLIDE)
+    zip.file(
+      'ppt/slides/_rels/slide1.xml.rels',
+      rels(
+        '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>',
+      ),
+    )
+    zip.file('ppt/slideLayouts/slideLayout1.xml', BG_LAYOUT)
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    expect(deck.slides[0].background).toEqual({ kind: 'solid', hex: '102030' })
+  })
+})
+
+describe('layout decoration underlay', () => {
+  // Canva-style layout: a real photo/panel drawn on the layout part itself,
+  // alongside a placeholder slot that must NOT render.
+  const DECOR_LAYOUT = `<p:sldLayout xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="30" name="Panel"/></p:nvSpPr>
+      <p:spPr><a:xfrm>
+        <a:off x="0" y="0"/><a:ext cx="4000000" cy="6858000"/>
+      </a:xfrm><a:prstGeom prst="rect"/><a:solidFill><a:srgbClr val="222F44"/></a:solidFill></p:spPr>
+    </p:sp>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="31"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+      <p:spPr/>
+      <p:txBody><a:p><a:r><a:t>Click to edit title</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld></p:sldLayout>`
+
+  const SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+      <p:spPr/>
+      <p:txBody><a:p><a:r><a:t>Real title</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld></p:sld>`
+
+  const rels = (entries: string) =>
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${entries}</Relationships>`
+
+  it('renders layout decoration as an inert underlay, skipping placeholder slots', async () => {
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', SLIDE)
+    zip.file(
+      'ppt/slides/_rels/slide1.xml.rels',
+      rels(
+        '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>',
+      ),
+    )
+    zip.file('ppt/slideLayouts/slideLayout1.xml', DECOR_LAYOUT)
+
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    const slide = deck.slides[0]
+
+    // Only the decoration panel — the "Click to edit title" prompt is a slot.
+    expect(slide.underlay).toHaveLength(1)
+    const panel = slide.underlay![0]
+    expect(panel.type).toBe('drawing')
+    expect(panel.xfrmEmu).toEqual({ x: 0, y: 0, w: 4000000, h: 6858000 })
+    expect(panel.visual?.fill).toEqual({ kind: 'solid', hex: '222F44' })
+    // Provenance is the layout part, never the slide — read-only by contract.
+    expect(panel.slideXmlPath).toBe('ppt/slideLayouts/slideLayout1.xml')
+
+    // The slide's own editable shapes are unaffected.
+    expect(slide.shapes.map((s) => s.type)).toEqual(['text'])
+  })
+})
+
+describe('text anchor', () => {
+  const ANCHOR_SLIDE = `<p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2"/></p:nvSpPr>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm></p:spPr>
+      <p:txBody><a:bodyPr anchor="ctr"/><a:p><a:r><a:t>Centered</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="3"/></p:nvSpPr>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm></p:spPr>
+      <p:txBody><a:bodyPr/><a:p><a:r><a:t>Defaulted</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld></p:sld>`
+
+  it('honours an explicit bodyPr anchor and defaults to top', async () => {
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', ANCHOR_SLIDE)
+    const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    const [centered, defaulted] = deck.slides[0].shapes as TextShape[]
+    expect(centered.display?.anchor).toBe('ctr')
+    // The OOXML default is top — forcing center clipped top-anchored decks.
+    expect(defaulted.display?.anchor).toBe('t')
   })
 })
 

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -13,28 +13,31 @@
 
 import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
-import type {
-  DrawingShape,
-  Fill,
-  GroupShape,
-  ImageShape,
-  NodePath,
-  Paragraph,
-  ParagraphDisplay,
-  PlaceholderKind,
-  PlaceholderShape,
-  RectEmu,
-  ResolvedRunStyle,
-  Shape,
-  Slide,
-  SlideDeck,
-  TextAlign,
-  TextDisplay,
-  TextRun,
-  TextShape,
+import {
+  DEFAULT_LINE_HEIGHT,
+  type DrawingShape,
+  type Fill,
+  type GroupShape,
+  type ImageShape,
+  type LineSpacing,
+  type NodePath,
+  type Paragraph,
+  type ParagraphDisplay,
+  type PlaceholderKind,
+  type PlaceholderShape,
+  type RectEmu,
+  type ResolvedRunStyle,
+  type Shape,
+  type Slide,
+  type SlideDeck,
+  type TextAlign,
+  type TextDisplay,
+  type TextRun,
+  type TextShape,
 } from './types'
 import { DEFAULT_THEME, clrMapOfMaster, parseTheme, schemeColorHex, type Theme } from './theme'
 import {
+  cssFontFamily,
   keptRunNodesOf,
   layersOf,
   levelStyleFromPPr,
@@ -43,6 +46,7 @@ import {
   runLayerFromRPr,
   txStyleKindFor,
   type ParsedListStyle,
+  type SpacingSpec,
 } from './textstyle'
 import { backgroundFillOf, shapeVisualOf } from './geometry'
 
@@ -688,6 +692,13 @@ function resolveRect(node: XmlNode, ctx: ShapeContext): RectEmu {
 
 const HARD_DEFAULT_SIZE_PT = 18
 
+/** spcPts is absolute; spcPct is a fraction of the paragraph's text size. */
+function spacingPt(spec: SpacingSpec | undefined, sizePt: number): number {
+  if (!spec) return 0
+  if (spec.pt !== undefined) return spec.pt
+  return (spec.pct ?? 0) * sizePt
+}
+
 /**
  * Resolves the display styling for one text shape: run rPr -> paragraph
  * defRPr -> shape lstStyle -> layout placeholder -> master placeholder ->
@@ -727,13 +738,22 @@ function resolveTextDisplay(
   const runStyleOf = (
     explicit: ReturnType<typeof runLayerFromRPr>,
     merged: ReturnType<typeof mergeLevelStyles>,
-  ): ResolvedRunStyle => ({
-    sizePt: explicit.sizePt ?? merged.sizePt ?? HARD_DEFAULT_SIZE_PT,
-    bold: explicit.bold ?? merged.bold ?? false,
-    italic: explicit.italic ?? merged.italic ?? false,
-    underline: explicit.underline ?? merged.underline ?? false,
-    colorHex: explicit.colorHex ?? merged.colorHex ?? fallbackColor,
-  })
+  ): ResolvedRunStyle => {
+    const style: ResolvedRunStyle = {
+      sizePt: explicit.sizePt ?? merged.sizePt ?? HARD_DEFAULT_SIZE_PT,
+      bold: explicit.bold ?? merged.bold ?? false,
+      italic: explicit.italic ?? merged.italic ?? false,
+      underline: explicit.underline ?? merged.underline ?? false,
+      colorHex: explicit.colorHex ?? merged.colorHex ?? fallbackColor,
+    }
+    const fontFamily = cssFontFamily(
+      explicit.latinFont ?? merged.latinFont,
+      explicit.eaFont ?? merged.eaFont,
+      explicit.csFont ?? merged.csFont,
+    )
+    if (fontFamily) style.fontFamily = fontFamily
+    return style
+  }
 
   const paragraphs: ParagraphDisplay[] = []
   for (const pNode of childrenByLocal(childrenOf(txBody), 'p')) {
@@ -744,12 +764,20 @@ function resolveTextDisplay(
     const runs = keptRunNodesOf(pNode).map((item) =>
       item.kind === 'br' ? defaultRun : runStyleOf(runLayerFromRPr(item.rPr, theme), merged),
     )
+    // spcPct scales the 1.2 base so an explicit 100% renders like the default.
+    const lineHeight: LineSpacing =
+      merged.lnSpc?.pt !== undefined
+        ? { kind: 'pt', pt: merged.lnSpc.pt }
+        : { kind: 'mult', value: (merged.lnSpc?.pct ?? 1) * DEFAULT_LINE_HEIGHT }
     paragraphs.push({
       level,
       marLEmu: merged.marLEmu ?? 0,
       indentEmu: merged.indentEmu ?? 0,
       align: merged.align,
       bullet: merged.bullet ?? { kind: 'none' },
+      lineHeight,
+      spaceBeforePt: spacingPt(merged.spcBef, defaultRun.sizePt),
+      spaceAfterPt: spacingPt(merged.spcAft, defaultRun.sizePt),
       runs,
       defaultRun,
     })
@@ -761,7 +789,21 @@ function resolveTextDisplay(
   const rawAnchor = bodyPr ? attr(bodyPr, 'anchor') : undefined
   const anchor = rawAnchor === 'ctr' || rawAnchor === 'b' ? rawAnchor : 't'
 
-  return { paragraphs, defaultRun: runStyleOf({}, resolveLevel({}, 0)), anchor }
+  const out: TextDisplay = { paragraphs, defaultRun: runStyleOf({}, resolveLevel({}, 0)), anchor }
+
+  // normAutofit: PowerPoint precomputes the shrink factors and stores them on
+  // the shape's own bodyPr; they scale rendered sizes, never the model.
+  const autofit = bodyPr ? childByLocal(childrenOf(bodyPr), 'normAutofit') : undefined
+  if (autofit) {
+    // Clamped: these only ever shrink, and a corrupt 0 would render the whole
+    // shape's text invisible rather than merely mis-sized.
+    const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v))
+    out.autofit = {
+      fontScale: clamp((num(attr(autofit, 'fontScale')) ?? 100000) / 100000, 0.01, 1),
+      lnSpcReduction: clamp((num(attr(autofit, 'lnSpcReduction')) ?? 0) / 100000, 0, 0.99),
+    }
+  }
+  return out
 }
 
 /** grpSp children we walk; anything else inside a group is silently skipped. */

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -15,6 +15,8 @@ import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
 import type {
   DrawingShape,
+  Fill,
+  GroupShape,
   ImageShape,
   NodePath,
   Paragraph,
@@ -42,7 +44,7 @@ import {
   txStyleKindFor,
   type ParsedListStyle,
 } from './textstyle'
-import { shapeVisualOf } from './geometry'
+import { backgroundFillOf, shapeVisualOf } from './geometry'
 
 const ATTRS = ':@'
 const ATTR_PREFIX = '@_'
@@ -291,6 +293,61 @@ function isEmptyRect(r: RectEmu): boolean {
 }
 
 /**
+ * Axis-aligned affine from a group's child coordinate space to slide space:
+ * `slide = t + child · s`, per axis. Rotation/flip on groups is out of scope —
+ * the group walk renders unrotated.
+ */
+interface GroupXform {
+  sx: number
+  sy: number
+  tx: number
+  ty: number
+}
+
+const IDENTITY_XFORM: GroupXform = { sx: 1, sy: 1, tx: 0, ty: 0 }
+
+function mapRect(r: RectEmu, t: GroupXform): RectEmu {
+  if (t === IDENTITY_XFORM) return r
+  return {
+    x: Math.round(t.tx + r.x * t.sx),
+    y: Math.round(t.ty + r.y * t.sy),
+    w: Math.round(r.w * t.sx),
+    h: Math.round(r.h * t.sy),
+  }
+}
+
+/**
+ * Composes a group's own transform under an outer one. A child coordinate `c`
+ * maps to `off + (c - chOff) · ext/chExt` in the group's parent space, then
+ * through `outer` — nested groups multiply through. Missing chOff/chExt
+ * default to off/ext (identity mapping), per CT_GroupTransform2D.
+ */
+function childXformOf(xfrm: XmlNode | undefined, outer: GroupXform): GroupXform {
+  if (!xfrm) return outer
+  const kids = childrenOf(xfrm)
+  const at = (name: string, key: string): number | undefined => {
+    const node = childByLocal(kids, name)
+    return node ? num(attr(node, key)) : undefined
+  }
+  const offX = at('off', 'x') ?? 0
+  const offY = at('off', 'y') ?? 0
+  const extW = at('ext', 'cx') ?? 0
+  const extH = at('ext', 'cy') ?? 0
+  const chOffX = at('chOff', 'x') ?? offX
+  const chOffY = at('chOff', 'y') ?? offY
+  const chExtW = at('chExt', 'cx') ?? extW
+  const chExtH = at('chExt', 'cy') ?? extH
+  const sx = outer.sx * (chExtW !== 0 ? extW / chExtW : 1)
+  const sy = outer.sy * (chExtH !== 0 ? extH / chExtH : 1)
+  return {
+    sx,
+    sy,
+    tx: outer.tx + outer.sx * offX - sx * chOffX,
+    ty: outer.ty + outer.sy * offY - sy * chOffY,
+  }
+}
+
+/**
  * Placeholder geometry inherited from a slide's layout, and the layout's master.
  *
  * PowerPoint omits `a:xfrm` on title/body placeholders and expects the reader to
@@ -346,6 +403,21 @@ interface SlideStyleContext {
   masterPh: PhListStyles
   masterTx: { title?: ParsedListStyle; body?: ParsedListStyle; other?: ParsedListStyle }
   presDefault?: ParsedListStyle
+  /** Page background from the layout, or the master when the layout has none. */
+  background?: Fill
+  /** Non-placeholder decoration shapes from the master's spTree. Render-only. */
+  masterUnderlay: Shape[]
+  /** Non-placeholder decoration shapes from the layout's spTree. Render-only. */
+  layoutUnderlay: Shape[]
+  /** `p:sldLayout@showMasterSp` — false hides master decorations entirely. */
+  layoutShowsMaster: boolean
+}
+
+/** The `p:bg` of a slide/layout/master part, or undefined when not declared. */
+function bgNodeOf(doc: XmlNode[], rootLocal: string): XmlNode | undefined {
+  const root = childByLocal(doc, rootLocal)
+  const cSld = root ? childByLocal(childrenOf(root), 'cSld') : undefined
+  return cSld ? childByLocal(childrenOf(cSld), 'bg') : undefined
 }
 
 function emptyPhListStyles(): PhListStyles {
@@ -380,6 +452,7 @@ async function loadSlideContext(
   slideRels: Map<string, Relationship>,
   presDefaultNode: XmlNode | undefined,
   cache: Map<string, SlideStyleContext>,
+  blobUrls: string[],
 ): Promise<SlideStyleContext> {
   const layoutPath = relTargetOfType(slideRels, '/slideLayout') ?? ''
   const cached = cache.get(layoutPath)
@@ -391,6 +464,9 @@ async function loadSlideContext(
     layoutPh: emptyPhListStyles(),
     masterPh: emptyPhListStyles(),
     masterTx: {},
+    masterUnderlay: [],
+    layoutUnderlay: [],
+    layoutShowsMaster: true,
   }
 
   const layoutFile = layoutPath ? zip.file(layoutPath) : null
@@ -400,11 +476,12 @@ async function loadSlideContext(
     const masterPath = relTargetOfType(layoutRels, '/slideMaster')
     const masterFile = masterPath ? zip.file(masterPath) : null
     let masterDoc: XmlNode[] | null = null
+    let masterRels = new Map<string, Relationship>()
     if (masterFile && masterPath) {
       masterDoc = parseXml(await masterFile.async('string'))
 
       // Theme first: every list style below resolves colors against it.
-      const masterRels = await readRels(zip, masterPath)
+      masterRels = await readRels(zip, masterPath)
       const themePath = relTargetOfType(masterRels, '/theme')
       const themeFile = themePath ? zip.file(themePath) : null
       if (themeFile) out.theme = parseTheme(parseXml(await themeFile.async('string')))
@@ -429,6 +506,26 @@ async function loadSlideContext(
     }
     collectPlaceholderRects(layoutDoc, out.rects)
     collectPlaceholderListStyles(layoutDoc, out.theme, out.layoutPh)
+
+    // Background cascade below the slide: layout wins, then master.
+    const bgNode =
+      bgNodeOf(layoutDoc, 'sldLayout') ?? (masterDoc ? bgNodeOf(masterDoc, 'sldMaster') : undefined)
+    if (bgNode) out.background = backgroundFillOf(bgNode, out.theme)
+
+    // Decoration underlay: real content (photos, panels, footers) that decks
+    // — Canva exports especially — author on the layout/master rather than the
+    // slide. Placeholder slots are templates, not content, and are skipped.
+    // Media resolves against the owning part's own rels.
+    const layoutRoot = childByLocal(layoutDoc, 'sldLayout')
+    out.layoutShowsMaster = !layoutRoot || attr(layoutRoot, 'showMasterSp') !== '0'
+    if (masterDoc && masterPath && out.layoutShowsMaster) {
+      out.masterUnderlay = await collectDecorations(
+        masterDoc, 'sldMaster', masterPath, masterRels, out, zip, blobUrls,
+      )
+    }
+    out.layoutUnderlay = await collectDecorations(
+      layoutDoc, 'sldLayout', layoutPath, layoutRels, out, zip, blobUrls,
+    )
   }
 
   if (presDefaultNode) out.presDefault = parseListStyle(presDefaultNode, out.theme)
@@ -437,13 +534,51 @@ async function loadSlideContext(
   return out
 }
 
+const NV_PR_LOCALS = ['nvSpPr', 'nvPicPr', 'nvGraphicFramePr', 'nvGrpSpPr', 'nvCxnSpPr']
+
 function shapeIdOf(node: XmlNode, fallbackIndex: number): string {
-  for (const nv of ['nvSpPr', 'nvPicPr', 'nvGraphicFramePr', 'nvGrpSpPr']) {
+  for (const nv of NV_PR_LOCALS) {
     const cNvPr = descend(node, nv, 'cNvPr')
     const id = cNvPr && attr(cNvPr, 'id')
     if (id) return id
   }
   return `idx:${fallbackIndex}`
+}
+
+/** True when the node is a placeholder slot (`p:ph`), whatever its shape kind. */
+function isPlaceholderNode(node: XmlNode): boolean {
+  return NV_PR_LOCALS.some((nv) => descend(node, nv, 'nvPr', 'ph') !== undefined)
+}
+
+/**
+ * Parses a layout/master part's non-placeholder spTree shapes for the render
+ * underlay. The nodePaths produced here index into the OWNING PART's spTree,
+ * not the slide — underlay shapes are render-only and must never be handed to
+ * the serializer.
+ */
+async function collectDecorations(
+  doc: XmlNode[],
+  rootLocal: string,
+  partPath: string,
+  rels: Map<string, Relationship>,
+  styles: SlideStyleContext,
+  zip: JSZip,
+  blobUrls: string[],
+): Promise<Shape[]> {
+  const root = childByLocal(doc, rootLocal)
+  const spTree = root ? descend(root, 'cSld', 'spTree') : undefined
+  if (!spTree) return []
+  const ctx: ShapeContext = { slideXmlPath: partPath, rels, styles, zip, blobUrls }
+  const out: Shape[] = []
+  const kids = childrenOf(spTree)
+  for (let i = 0; i < kids.length; i++) {
+    const tag = tagNameOf(kids[i])
+    if (!tag || !GROUP_CHILD_LOCALS.includes(local(tag))) continue
+    if (isPlaceholderNode(kids[i])) continue
+    const shape = await shapeFromNode(kids[i], [i], i, ctx)
+    if (shape) out.push(shape)
+  }
+  return out
 }
 
 // ------------------------------------------------------------------ text
@@ -620,14 +755,24 @@ function resolveTextDisplay(
     })
   }
 
-  return { paragraphs, defaultRun: runStyleOf({}, resolveLevel({}, 0)) }
+  // Vertical anchor: the shape's own bodyPr, else the OOXML default (top).
+  // `just`/`dist` justify content across the height; top is the nearest draw.
+  const bodyPr = childByLocal(childrenOf(txBody), 'bodyPr')
+  const rawAnchor = bodyPr ? attr(bodyPr, 'anchor') : undefined
+  const anchor = rawAnchor === 'ctr' || rawAnchor === 'b' ? rawAnchor : 't'
+
+  return { paragraphs, defaultRun: runStyleOf({}, resolveLevel({}, 0)), anchor }
 }
+
+/** grpSp children we walk; anything else inside a group is silently skipped. */
+const GROUP_CHILD_LOCALS = ['sp', 'pic', 'grpSp', 'cxnSp', 'graphicFrame']
 
 async function shapeFromNode(
   node: XmlNode,
   nodePath: NodePath,
   index: number,
   ctx: ShapeContext,
+  xform: GroupXform = IDENTITY_XFORM,
 ): Promise<Shape | null> {
   const tag = tagNameOf(node)
   if (!tag) return null
@@ -637,7 +782,7 @@ async function shapeFromNode(
     id: shapeIdOf(node, index),
     slideXmlPath: ctx.slideXmlPath,
     nodePath,
-    xfrmEmu: resolveRect(node, ctx),
+    xfrmEmu: mapRect(resolveRect(node, ctx), xform),
   }
 
   if (name === 'sp') {
@@ -679,7 +824,20 @@ async function shapeFromNode(
   }
 
   if (name === 'grpSp') {
-    return { ...base, type: 'placeholder', kind: 'group' } satisfies PlaceholderShape
+    // Walk the children instead of stubbing the group. Each child's rect maps
+    // through this group's chOff/chExt transform composed under any outer
+    // groups, so every descendant lands in final slide-space EMU. Children are
+    // read-only — see GroupShape.
+    const inner = childXformOf(descend(node, 'grpSpPr', 'xfrm'), xform)
+    const kids = childrenOf(node)
+    const children: Shape[] = []
+    for (let i = 0; i < kids.length; i++) {
+      const childTag = tagNameOf(kids[i])
+      if (!childTag || !GROUP_CHILD_LOCALS.includes(local(childTag))) continue
+      const child = await shapeFromNode(kids[i], [...nodePath, i], i, ctx, inner)
+      if (child) children.push(child)
+    }
+    return { ...base, type: 'group', children } satisfies GroupShape
   }
 
   if (name === 'cxnSp') {
@@ -702,7 +860,7 @@ async function parseSlide(
 ): Promise<Slide> {
   const doc = parseXml(xml)
   const rels = await readRels(zip, xmlPath)
-  const styles = await loadSlideContext(zip, rels, presDefaultNode, styleCache)
+  const styles = await loadSlideContext(zip, rels, presDefaultNode, styleCache, blobUrls)
   const ctx: ShapeContext = { slideXmlPath: xmlPath, rels, styles, zip, blobUrls }
 
   const sldIndex = doc.findIndex((n) => {
@@ -734,7 +892,19 @@ async function parseSlide(
     if (shape) shapes.push(shape)
   }
 
-  return { id: xmlPath, xmlPath, shapes }
+  // Page background: the slide's own p:bg wins over the layout/master's.
+  const ownBg = childByLocal(spTreeKids, 'bg')
+  const background = ownBg ? backgroundFillOf(ownBg, styles.theme) : styles.background
+
+  // Layout/master decoration beneath the slide's own shapes. `p:sld` can opt
+  // out of the master's with showMasterSp="0"; the layout's always paint.
+  const showMaster = attr(sld, 'showMasterSp') !== '0'
+  const underlay = [...(showMaster ? styles.masterUnderlay : []), ...styles.layoutUnderlay]
+
+  const slide: Slide = { id: xmlPath, xmlPath, shapes }
+  if (background !== undefined) slide.background = background
+  if (underlay.length > 0) slide.underlay = underlay
+  return slide
 }
 
 // ------------------------------------------------------------------ entry
@@ -814,11 +984,16 @@ export function resolveNodePath(doc: XmlNode[], path: NodePath): XmlNode | undef
   return node
 }
 
-/** Releases the object URLs held by a deck's image shapes. */
+/** Releases the object URLs held by a deck's image shapes, groups included. */
 export function disposeDeck(deck: SlideDeck): void {
+  const revoke = (shape: Shape): void => {
+    if (shape.type === 'image') URL.revokeObjectURL(shape.blobUrl)
+    else if (shape.type === 'group') shape.children.forEach(revoke)
+  }
   for (const slide of deck.slides) {
-    for (const shape of slide.shapes) {
-      if (shape.type === 'image') URL.revokeObjectURL(shape.blobUrl)
-    }
+    slide.shapes.forEach(revoke)
+    // Underlay arrays are shared across slides on the same layout; revoking an
+    // already-revoked URL is a harmless no-op.
+    slide.underlay?.forEach(revoke)
   }
 }

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -48,7 +48,7 @@ import {
   type ParsedListStyle,
   type SpacingSpec,
 } from './textstyle'
-import { backgroundFillOf, shapeVisualOf } from './geometry'
+import { backgroundFillOf, shapeStyleSnapshotOf, shapeVisualOf } from './geometry'
 
 const ATTRS = ':@'
 const ATTR_PREFIX = '@_'
@@ -850,14 +850,15 @@ async function shapeFromNode(
 
   if (name === 'sp') {
     const visual = shapeVisualOf(node, ctx.styles.theme)
+    const style = shapeStyleSnapshotOf(node)
     const txBody = childByLocal(childrenOf(node), 'txBody')
     if (!txBody) {
       // A shape with geometry but no text — an arrow, a divider, a colored box.
-      return { ...base, type: 'drawing', visual } satisfies DrawingShape
+      return { ...base, type: 'drawing', visual, style } satisfies DrawingShape
     }
     const paragraphs = childrenByLocal(childrenOf(txBody), 'p').map(parseParagraph)
     const display = resolveTextDisplay(node, txBody, ctx)
-    return { ...base, type: 'text', paragraphs, visual, display } satisfies TextShape
+    return { ...base, type: 'text', paragraphs, visual, display, style } satisfies TextShape
   }
 
   if (name === 'pic') {
@@ -907,7 +908,7 @@ async function shapeFromNode(
     // Connectors: lines/arrows with real stroke styling.
     const visual = shapeVisualOf(node, ctx.styles.theme)
     if (!visual.geom) visual.geom = { preset: 'straightConnector1', adj: {} }
-    return { ...base, type: 'drawing', visual } satisfies DrawingShape
+    return { ...base, type: 'drawing', visual, style: shapeStyleSnapshotOf(node) } satisfies DrawingShape
   }
 
   return null
@@ -933,7 +934,7 @@ async function parseSlide(
     return t !== null && local(t) === 'sld'
   })
   const shapes: Shape[] = []
-  if (sldIndex < 0) return { id: xmlPath, xmlPath, shapes }
+  if (sldIndex < 0) return { id: xmlPath, xmlPath, shapes, spTreePath: [] }
 
   const sld = doc[sldIndex]
   const cSldKids = childrenOf(sld)
@@ -941,14 +942,14 @@ async function parseSlide(
     const t = tagNameOf(n)
     return t !== null && local(t) === 'cSld'
   })
-  if (cSldIndex < 0) return { id: xmlPath, xmlPath, shapes }
+  if (cSldIndex < 0) return { id: xmlPath, xmlPath, shapes, spTreePath: [] }
 
   const spTreeKids = childrenOf(cSldKids[cSldIndex])
   const spTreeIndex = spTreeKids.findIndex((n) => {
     const t = tagNameOf(n)
     return t !== null && local(t) === 'spTree'
   })
-  if (spTreeIndex < 0) return { id: xmlPath, xmlPath, shapes }
+  if (spTreeIndex < 0) return { id: xmlPath, xmlPath, shapes, spTreePath: [] }
 
   const children = childrenOf(spTreeKids[spTreeIndex])
   for (let i = 0; i < children.length; i++) {
@@ -966,7 +967,12 @@ async function parseSlide(
   const showMaster = attr(sld, 'showMasterSp') !== '0'
   const underlay = [...(showMaster ? styles.masterUnderlay : []), ...styles.layoutUnderlay]
 
-  const slide: Slide = { id: xmlPath, xmlPath, shapes }
+  const slide: Slide = {
+    id: xmlPath,
+    xmlPath,
+    shapes,
+    spTreePath: [sldIndex, cSldIndex, spTreeIndex],
+  }
   if (background !== undefined) slide.background = background
   if (underlay.length > 0) slide.underlay = underlay
   return slide
@@ -1030,7 +1036,15 @@ export async function parsePptx(bytes: Uint8Array): Promise<SlideDeck> {
     slides.push(await parseSlide(zip, path, xml, blobUrls, presDefaultNode, styleCache))
   }
 
-  return { slideSizeEmu, slides, source: { zip, slideXml } }
+  const deck: SlideDeck = { slideSizeEmu, slides, source: { zip, slideXml } }
+  const firstCtx = styleCache.values().next().value as SlideStyleContext | undefined
+  if (firstCtx) {
+    deck.themeColors = {
+      accent1: schemeColorHex(firstCtx.theme, 'accent1'),
+      tx1: schemeColorHex(firstCtx.theme, 'tx1'),
+    }
+  }
+  return deck
 }
 
 /**

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -14,19 +14,35 @@
 import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
 import type {
+  DrawingShape,
   ImageShape,
   NodePath,
   Paragraph,
+  ParagraphDisplay,
   PlaceholderKind,
   PlaceholderShape,
   RectEmu,
+  ResolvedRunStyle,
   Shape,
   Slide,
   SlideDeck,
   TextAlign,
+  TextDisplay,
   TextRun,
   TextShape,
 } from './types'
+import { DEFAULT_THEME, clrMapOfMaster, parseTheme, schemeColorHex, type Theme } from './theme'
+import {
+  keptRunNodesOf,
+  layersOf,
+  levelStyleFromPPr,
+  mergeLevelStyles,
+  parseListStyle,
+  runLayerFromRPr,
+  txStyleKindFor,
+  type ParsedListStyle,
+} from './textstyle'
+import { shapeVisualOf } from './geometry'
 
 const ATTRS = ':@'
 const ATTR_PREFIX = '@_'
@@ -49,10 +65,11 @@ export function parseXml(xml: string): XmlNode[] {
 }
 
 /** Strips the namespace prefix: `p:sp` -> `sp`. Prefixes are not guaranteed. */
-function local(name: string): string {
+export function localNameOf(name: string): string {
   const i = name.indexOf(':')
   return i >= 0 ? name.slice(i + 1) : name
 }
+const local = localNameOf
 
 export function tagNameOf(node: XmlNode): string | null {
   for (const k of Object.keys(node)) {
@@ -72,7 +89,7 @@ function attrsOf(node: XmlNode): Record<string, string> {
   return (node[ATTRS] as Record<string, string> | undefined) ?? {}
 }
 
-function attr(node: XmlNode, name: string): string | undefined {
+export function attr(node: XmlNode, name: string): string | undefined {
   const a = attrsOf(node)
   const direct = a[ATTR_PREFIX + name]
   if (direct !== undefined) return String(direct)
@@ -95,14 +112,14 @@ function prefixedAttr(node: XmlNode, name: string): string | undefined {
   return undefined
 }
 
-function childByLocal(nodes: XmlNode[], name: string): XmlNode | undefined {
+export function childByLocal(nodes: XmlNode[], name: string): XmlNode | undefined {
   return nodes.find((n) => {
     const t = tagNameOf(n)
     return t !== null && local(t) === name
   })
 }
 
-function childrenByLocal(nodes: XmlNode[], name: string): XmlNode[] {
+export function childrenByLocal(nodes: XmlNode[], name: string): XmlNode[] {
   return nodes.filter((n) => {
     const t = tagNameOf(n)
     return t !== null && local(t) === name
@@ -110,7 +127,7 @@ function childrenByLocal(nodes: XmlNode[], name: string): XmlNode[] {
 }
 
 /** Follows a chain of local names down from a node. */
-function descend(node: XmlNode, ...path: string[]): XmlNode | undefined {
+export function descend(node: XmlNode, ...path: string[]): XmlNode | undefined {
   let current: XmlNode | undefined = node
   for (const step of path) {
     if (!current) return undefined
@@ -150,7 +167,7 @@ function textOf(node: XmlNode): string {
   return decodeNumericRefs(out)
 }
 
-function num(value: string | undefined): number | undefined {
+export function num(value: string | undefined): number | undefined {
   if (value === undefined) return undefined
   const n = Number(value)
   return Number.isFinite(n) ? n : undefined
@@ -306,25 +323,108 @@ function collectPlaceholderRects(doc: XmlNode[], into: InheritedRects): void {
   }
 }
 
-/** Walks slide -> layout -> master, letting the nearer part win. */
-async function loadInheritedRects(
+/** Placeholder list styles collected from a layout or master part. */
+interface PhListStyles {
+  byIdx: Map<string, ParsedListStyle>
+  byType: Map<string, ParsedListStyle>
+}
+
+/** Everything a slide inherits from its layout/master/theme chain. */
+interface SlideStyleContext {
+  rects: InheritedRects
+  theme: Theme
+  layoutPh: PhListStyles
+  masterPh: PhListStyles
+  masterTx: { title?: ParsedListStyle; body?: ParsedListStyle; other?: ParsedListStyle }
+  presDefault?: ParsedListStyle
+}
+
+function emptyPhListStyles(): PhListStyles {
+  return { byIdx: new Map(), byType: new Map() }
+}
+
+function collectPlaceholderListStyles(doc: XmlNode[], theme: Theme, into: PhListStyles): void {
+  const spTree = (() => {
+    const root = childByLocal(doc, 'sldLayout') ?? childByLocal(doc, 'sldMaster')
+    return root ? descend(root, 'cSld', 'spTree') : undefined
+  })()
+  if (!spTree) return
+  for (const node of childrenOf(spTree)) {
+    const tag = tagNameOf(node)
+    if (!tag || local(tag) !== 'sp') continue
+    const key = phKeyOf(node)
+    if (!key) continue
+    const lstStyle = descend(node, 'txBody', 'lstStyle')
+    if (!lstStyle) continue
+    const parsed = parseListStyle(lstStyle, theme)
+    if (key.idx !== undefined) into.byIdx.set(key.idx, parsed)
+    into.byType.set(normalizePhType(key.type), parsed)
+  }
+}
+
+/**
+ * Walks slide -> layout -> master -> theme, letting the nearer part win.
+ * Cached per layout path: decks reuse a handful of layouts across many slides.
+ */
+async function loadSlideContext(
   zip: JSZip,
   slideRels: Map<string, Relationship>,
-): Promise<InheritedRects> {
-  const out: InheritedRects = { byIdx: new Map(), byType: new Map() }
-  const layoutPath = relTargetOfType(slideRels, '/slideLayout')
-  if (!layoutPath) return out
+  presDefaultNode: XmlNode | undefined,
+  cache: Map<string, SlideStyleContext>,
+): Promise<SlideStyleContext> {
+  const layoutPath = relTargetOfType(slideRels, '/slideLayout') ?? ''
+  const cached = cache.get(layoutPath)
+  if (cached) return cached
 
-  const layoutFile = zip.file(layoutPath)
-  if (!layoutFile) return out
-  const layoutDoc = parseXml(await layoutFile.async('string'))
+  const out: SlideStyleContext = {
+    rects: { byIdx: new Map(), byType: new Map() },
+    theme: DEFAULT_THEME,
+    layoutPh: emptyPhListStyles(),
+    masterPh: emptyPhListStyles(),
+    masterTx: {},
+  }
 
-  // Master first so the layout's own values overwrite it.
-  const layoutRels = await readRels(zip, layoutPath)
-  const masterPath = relTargetOfType(layoutRels, '/slideMaster')
-  const masterFile = masterPath ? zip.file(masterPath) : null
-  if (masterFile) collectPlaceholderRects(parseXml(await masterFile.async('string')), out)
-  collectPlaceholderRects(layoutDoc, out)
+  const layoutFile = layoutPath ? zip.file(layoutPath) : null
+  if (layoutFile) {
+    const layoutDoc = parseXml(await layoutFile.async('string'))
+    const layoutRels = await readRels(zip, layoutPath)
+    const masterPath = relTargetOfType(layoutRels, '/slideMaster')
+    const masterFile = masterPath ? zip.file(masterPath) : null
+    let masterDoc: XmlNode[] | null = null
+    if (masterFile && masterPath) {
+      masterDoc = parseXml(await masterFile.async('string'))
+
+      // Theme first: every list style below resolves colors against it.
+      const masterRels = await readRels(zip, masterPath)
+      const themePath = relTargetOfType(masterRels, '/theme')
+      const themeFile = themePath ? zip.file(themePath) : null
+      if (themeFile) out.theme = parseTheme(parseXml(await themeFile.async('string')))
+      const clrMap = clrMapOfMaster(masterDoc)
+      if (clrMap) out.theme = { ...out.theme, clrMap }
+    }
+
+    if (masterDoc) {
+      // Master first so the layout's own values overwrite the rects.
+      collectPlaceholderRects(masterDoc, out.rects)
+      collectPlaceholderListStyles(masterDoc, out.theme, out.masterPh)
+      const master = childByLocal(masterDoc, 'sldMaster')
+      const txStyles = master ? childByLocal(childrenOf(master), 'txStyles') : undefined
+      if (txStyles) {
+        const kids = childrenOf(txStyles)
+        out.masterTx = {
+          title: parseListStyle(childByLocal(kids, 'titleStyle'), out.theme),
+          body: parseListStyle(childByLocal(kids, 'bodyStyle'), out.theme),
+          other: parseListStyle(childByLocal(kids, 'otherStyle'), out.theme),
+        }
+      }
+    }
+    collectPlaceholderRects(layoutDoc, out.rects)
+    collectPlaceholderListStyles(layoutDoc, out.theme, out.layoutPh)
+  }
+
+  if (presDefaultNode) out.presDefault = parseListStyle(presDefaultNode, out.theme)
+
+  cache.set(layoutPath, out)
   return out
 }
 
@@ -421,7 +521,7 @@ function isVideoPic(node: XmlNode): boolean {
 interface ShapeContext {
   slideXmlPath: string
   rels: Map<string, Relationship>
-  inherited: InheritedRects
+  styles: SlideStyleContext
   zip: JSZip
   blobUrls: string[]
 }
@@ -433,11 +533,85 @@ function resolveRect(node: XmlNode, ctx: ShapeContext): RectEmu {
   const key = phKeyOf(node)
   if (!key) return own
   if (key.idx !== undefined) {
-    const byIdx = ctx.inherited.byIdx.get(key.idx)
+    const byIdx = ctx.styles.rects.byIdx.get(key.idx)
     if (byIdx) return { ...byIdx }
   }
-  const byType = ctx.inherited.byType.get(normalizePhType(key.type))
+  const byType = ctx.styles.rects.byType.get(normalizePhType(key.type))
   return byType ? { ...byType } : own
+}
+
+// ------------------------------------------------------------ text display
+
+const HARD_DEFAULT_SIZE_PT = 18
+
+/**
+ * Resolves the display styling for one text shape: run rPr -> paragraph
+ * defRPr -> shape lstStyle -> layout placeholder -> master placeholder ->
+ * master txStyles (by placeholder type) -> presentation default. Display
+ * only — the model paragraphs the serializer validates are untouched.
+ */
+function resolveTextDisplay(
+  spNode: XmlNode,
+  txBody: XmlNode,
+  ctx: ShapeContext,
+): TextDisplay {
+  const { theme } = ctx.styles
+  const key = phKeyOf(spNode)
+  const phType = key ? normalizePhType(key.type) : undefined
+
+  const shapeLst = parseListStyle(childByLocal(childrenOf(txBody), 'lstStyle'), theme)
+  const layoutPh =
+    (key?.idx !== undefined ? ctx.styles.layoutPh.byIdx.get(key.idx) : undefined) ??
+    (phType ? ctx.styles.layoutPh.byType.get(phType) : undefined)
+  const masterPh =
+    (key?.idx !== undefined ? ctx.styles.masterPh.byIdx.get(key.idx) : undefined) ??
+    (phType ? ctx.styles.masterPh.byType.get(phType) : undefined)
+  const masterTx = ctx.styles.masterTx[txStyleKindFor(key?.type, key !== null)]
+
+  const fallbackColor = schemeColorHex(theme, 'tx1')
+
+  const resolveLevel = (own: ReturnType<typeof levelStyleFromPPr>, lvl: number) =>
+    mergeLevelStyles([
+      own,
+      ...layersOf(shapeLst, lvl),
+      ...layersOf(layoutPh, lvl),
+      ...layersOf(masterPh, lvl),
+      ...layersOf(masterTx, lvl),
+      ...layersOf(ctx.styles.presDefault, lvl),
+    ])
+
+  const runStyleOf = (
+    explicit: ReturnType<typeof runLayerFromRPr>,
+    merged: ReturnType<typeof mergeLevelStyles>,
+  ): ResolvedRunStyle => ({
+    sizePt: explicit.sizePt ?? merged.sizePt ?? HARD_DEFAULT_SIZE_PT,
+    bold: explicit.bold ?? merged.bold ?? false,
+    italic: explicit.italic ?? merged.italic ?? false,
+    underline: explicit.underline ?? merged.underline ?? false,
+    colorHex: explicit.colorHex ?? merged.colorHex ?? fallbackColor,
+  })
+
+  const paragraphs: ParagraphDisplay[] = []
+  for (const pNode of childrenByLocal(childrenOf(txBody), 'p')) {
+    const pPr = childByLocal(childrenOf(pNode), 'pPr')
+    const level = Math.min(8, Math.max(0, num(pPr ? attr(pPr, 'lvl') : undefined) ?? 0))
+    const merged = resolveLevel(levelStyleFromPPr(pPr, theme), level)
+    const defaultRun = runStyleOf({}, merged)
+    const runs = keptRunNodesOf(pNode).map((item) =>
+      item.kind === 'br' ? defaultRun : runStyleOf(runLayerFromRPr(item.rPr, theme), merged),
+    )
+    paragraphs.push({
+      level,
+      marLEmu: merged.marLEmu ?? 0,
+      indentEmu: merged.indentEmu ?? 0,
+      align: merged.align,
+      bullet: merged.bullet ?? { kind: 'none' },
+      runs,
+      defaultRun,
+    })
+  }
+
+  return { paragraphs, defaultRun: runStyleOf({}, resolveLevel({}, 0)) }
 }
 
 async function shapeFromNode(
@@ -458,13 +632,15 @@ async function shapeFromNode(
   }
 
   if (name === 'sp') {
+    const visual = shapeVisualOf(node, ctx.styles.theme)
     const txBody = childByLocal(childrenOf(node), 'txBody')
     if (!txBody) {
-      // A shape with geometry but no text — an arrow, a divider, a background box.
-      return { ...base, type: 'placeholder', kind: 'unknown' } satisfies PlaceholderShape
+      // A shape with geometry but no text — an arrow, a divider, a colored box.
+      return { ...base, type: 'drawing', visual } satisfies DrawingShape
     }
     const paragraphs = childrenByLocal(childrenOf(txBody), 'p').map(parseParagraph)
-    return { ...base, type: 'text', paragraphs } satisfies TextShape
+    const display = resolveTextDisplay(node, txBody, ctx)
+    return { ...base, type: 'text', paragraphs, visual, display } satisfies TextShape
   }
 
   if (name === 'pic') {
@@ -485,7 +661,8 @@ async function shapeFromNode(
     const blob = new Blob([bytes], { type: mimeFor(mediaPath) })
     const blobUrl = URL.createObjectURL(blob)
     ctx.blobUrls.push(blobUrl)
-    return { ...base, type: 'image', blobUrl, mediaPath } satisfies ImageShape
+    const visual = shapeVisualOf(node, ctx.styles.theme)
+    return { ...base, type: 'image', blobUrl, mediaPath, visual } satisfies ImageShape
   }
 
   if (name === 'graphicFrame') {
@@ -497,8 +674,10 @@ async function shapeFromNode(
   }
 
   if (name === 'cxnSp') {
-    // Connectors (lines/arrows) have geometry but nothing we draw yet.
-    return { ...base, type: 'placeholder', kind: 'unknown' } satisfies PlaceholderShape
+    // Connectors: lines/arrows with real stroke styling.
+    const visual = shapeVisualOf(node, ctx.styles.theme)
+    if (!visual.geom) visual.geom = { preset: 'straightConnector1', adj: {} }
+    return { ...base, type: 'drawing', visual } satisfies DrawingShape
   }
 
   return null
@@ -509,11 +688,13 @@ async function parseSlide(
   xmlPath: string,
   xml: string,
   blobUrls: string[],
+  presDefaultNode: XmlNode | undefined,
+  styleCache: Map<string, SlideStyleContext>,
 ): Promise<Slide> {
   const doc = parseXml(xml)
   const rels = await readRels(zip, xmlPath)
-  const inherited = await loadInheritedRects(zip, rels)
-  const ctx: ShapeContext = { slideXmlPath: xmlPath, rels, inherited, zip, blobUrls }
+  const styles = await loadSlideContext(zip, rels, presDefaultNode, styleCache)
+  const ctx: ShapeContext = { slideXmlPath: xmlPath, rels, styles, zip, blobUrls }
 
   const sldIndex = doc.findIndex((n) => {
     const t = tagNameOf(n)
@@ -592,6 +773,8 @@ export async function parsePptx(bytes: Uint8Array): Promise<SlideDeck> {
     slidePaths.push(...found)
   }
 
+  const presDefaultNode = childByLocal(childrenOf(pres), 'defaultTextStyle')
+  const styleCache = new Map<string, SlideStyleContext>()
   const blobUrls: string[] = []
   const slideXml: Record<string, string> = {}
   const slides: Slide[] = []
@@ -600,7 +783,7 @@ export async function parsePptx(bytes: Uint8Array): Promise<SlideDeck> {
     if (!file) continue
     const xml = await file.async('string')
     slideXml[path] = xml
-    slides.push(await parseSlide(zip, path, xml, blobUrls))
+    slides.push(await parseSlide(zip, path, xml, blobUrls, presDefaultNode, styleCache))
   }
 
   return { slideSizeEmu, slides, source: { zip, slideXml } }

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -335,7 +335,7 @@ function parseRunProps(rPr: XmlNode | undefined): Omit<TextRun, 'text'> {
   return out
 }
 
-function parseParagraph(p: XmlNode): Paragraph {
+export function parseParagraph(p: XmlNode): Paragraph {
   const kids = childrenOf(p)
   const pPr = childByLocal(kids, 'pPr')
   const algn = pPr ? attr(pPr, 'algn') : undefined

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -752,6 +752,8 @@ function resolveTextDisplay(
       explicit.csFont ?? merged.csFont,
     )
     if (fontFamily) style.fontFamily = fontFamily
+    const spc = explicit.letterSpacingPt ?? merged.letterSpacingPt
+    if (spc !== undefined && spc !== 0) style.letterSpacingPt = spc
     return style
   }
 

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -227,14 +227,12 @@ interface Relationship {
   type: string
 }
 
-async function readRels(zip: JSZip, partPath: string): Promise<Map<string, Relationship>> {
+/** Parses a .rels document, resolving Targets against the owning part's dir. */
+function parseRelsXml(relsXml: string, baseDir: string): Map<string, Relationship> {
   const map = new Map<string, Relationship>()
-  const file = zip.file(relsPathFor(partPath))
-  if (!file) return map
-  const doc = parseXml(await file.async('string'))
+  const doc = parseXml(relsXml)
   const root = childByLocal(doc, 'Relationships')
   if (!root) return map
-  const baseDir = dirNameOf(partPath)
   for (const rel of childrenByLocal(childrenOf(root), 'Relationship')) {
     const id = attr(rel, 'Id')
     const target = attr(rel, 'Target')
@@ -243,6 +241,12 @@ async function readRels(zip: JSZip, partPath: string): Promise<Map<string, Relat
     map.set(id, { target: resolveRelTarget(baseDir, target), type: attr(rel, 'Type') ?? '' })
   }
   return map
+}
+
+async function readRels(zip: JSZip, partPath: string): Promise<Map<string, Relationship>> {
+  const file = zip.file(relsPathFor(partPath))
+  if (!file) return new Map()
+  return parseRelsXml(await file.async('string'), dirNameOf(partPath))
 }
 
 function relTargetOfType(rels: Map<string, Relationship>, suffix: string): string | undefined {
@@ -909,9 +913,11 @@ async function parseSlide(
   blobUrls: string[],
   presDefaultNode: XmlNode | undefined,
   styleCache: Map<string, SlideStyleContext>,
+  /** For parts not (yet) in the zip — a freshly synthesized slide's rels. */
+  relsOverride?: Map<string, Relationship>,
 ): Promise<Slide> {
   const doc = parseXml(xml)
-  const rels = await readRels(zip, xmlPath)
+  const rels = relsOverride ?? (await readRels(zip, xmlPath))
   const styles = await loadSlideContext(zip, rels, presDefaultNode, styleCache, blobUrls)
   const ctx: ShapeContext = { slideXmlPath: xmlPath, rels, styles, zip, blobUrls }
 
@@ -1018,6 +1024,32 @@ export async function parsePptx(bytes: Uint8Array): Promise<SlideDeck> {
   }
 
   return { slideSizeEmu, slides, source: { zip, slideXml } }
+}
+
+/**
+ * Parses a slide that exists only in the edit set — a freshly added slide
+ * whose part and .rels are synthesized strings, not zip entries yet. Renders
+ * through the exact pipeline real slides use (layout underlay, placeholder
+ * geometry, style cascade), so an added slide looks right before its first
+ * save. The returned Slide's nodePaths index into `xml`, which is what the
+ * serializer applies this slide's edits against.
+ */
+export async function parseAddedSlide(
+  deck: SlideDeck,
+  xmlPath: string,
+  xml: string,
+  relsXml: string,
+): Promise<Slide> {
+  const zip = deck.source.zip
+  const rels = parseRelsXml(relsXml, dirNameOf(xmlPath))
+  // The presentation-level default text style, re-read since parsePptx's
+  // local doesn't survive parsing.
+  const presFile = zip.file('ppt/presentation.xml')
+  const presDoc = presFile ? parseXml(await presFile.async('string')) : []
+  const pres = childByLocal(presDoc, 'presentation')
+  const presDefaultNode = pres ? childByLocal(childrenOf(pres), 'defaultTextStyle') : undefined
+  const blobUrls: string[] = []
+  return parseSlide(zip, xmlPath, xml, blobUrls, presDefaultNode, new Map(), rels)
 }
 
 /**

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -614,6 +614,11 @@ function parseRunProps(rPr: XmlNode | undefined): Omit<TextRun, 'text'> {
   const srgb = descend(rPr, 'solidFill', 'srgbClr')
   const val = srgb && attr(srgb, 'val')
   if (val) out.colorHex = val.toUpperCase()
+  // Verbatim: a `+mn-lt` token stays a token here. Display resolution maps it
+  // through the theme; this model stays anchored to what the bytes say.
+  const latin = childByLocal(childrenOf(rPr), 'latin')
+  const typeface = latin && attr(latin, 'typeface')
+  if (typeface) out.latinFont = typeface
   return out
 }
 
@@ -758,12 +763,14 @@ function resolveTextDisplay(
       underline: explicit.underline ?? merged.underline ?? false,
       colorHex: explicit.colorHex ?? merged.colorHex ?? fallbackColor,
     }
+    const latin = explicit.latinFont ?? merged.latinFont
     const fontFamily = cssFontFamily(
-      explicit.latinFont ?? merged.latinFont,
+      latin,
       explicit.eaFont ?? merged.eaFont,
       explicit.csFont ?? merged.csFont,
     )
     if (fontFamily) style.fontFamily = fontFamily
+    if (latin) style.latinFont = latin
     const spc = explicit.letterSpacingPt ?? merged.letterSpacingPt
     if (spc !== undefined && spc !== 0) style.letterSpacingPt = spc
     return style

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -1,0 +1,610 @@
+/**
+ * Minimal PPTX reader built directly on jszip + fast-xml-parser.
+ *
+ * Scope is deliberately narrow: enough of DrawingML to lay out and render a
+ * slide read-only. Anything we recognize but can't draw becomes a
+ * PlaceholderShape rather than being dropped, so a deck never renders as a
+ * silently empty canvas.
+ *
+ * The XML is parsed with `preserveOrder` so shapes keep document order (which
+ * is z-order) and so every shape can record an index path back to its own node
+ * for Phase B write-back.
+ */
+
+import JSZip from 'jszip'
+import { XMLParser } from 'fast-xml-parser'
+import type {
+  ImageShape,
+  NodePath,
+  Paragraph,
+  PlaceholderKind,
+  PlaceholderShape,
+  RectEmu,
+  Shape,
+  Slide,
+  SlideDeck,
+  TextAlign,
+  TextRun,
+  TextShape,
+} from './types'
+
+const ATTRS = ':@'
+const ATTR_PREFIX = '@_'
+
+/** A node is `{ <tag>: children[], ':@'?: attrs }`, or `{ '#text': string }`. */
+export type XmlNode = Record<string, unknown>
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: ATTR_PREFIX,
+  preserveOrder: true,
+  // Runs carry significant whitespace, and ids/values must stay strings.
+  trimValues: false,
+  parseTagValue: false,
+  parseAttributeValue: false,
+})
+
+export function parseXml(xml: string): XmlNode[] {
+  return parser.parse(xml) as XmlNode[]
+}
+
+/** Strips the namespace prefix: `p:sp` -> `sp`. Prefixes are not guaranteed. */
+function local(name: string): string {
+  const i = name.indexOf(':')
+  return i >= 0 ? name.slice(i + 1) : name
+}
+
+export function tagNameOf(node: XmlNode): string | null {
+  for (const k of Object.keys(node)) {
+    if (k !== ATTRS && k !== '#text') return k
+  }
+  return null
+}
+
+export function childrenOf(node: XmlNode): XmlNode[] {
+  const tag = tagNameOf(node)
+  if (!tag) return []
+  const kids = node[tag]
+  return Array.isArray(kids) ? (kids as XmlNode[]) : []
+}
+
+function attrsOf(node: XmlNode): Record<string, string> {
+  return (node[ATTRS] as Record<string, string> | undefined) ?? {}
+}
+
+function attr(node: XmlNode, name: string): string | undefined {
+  const a = attrsOf(node)
+  const direct = a[ATTR_PREFIX + name]
+  if (direct !== undefined) return String(direct)
+  // Fall back to a local-name match so unusual prefixes still resolve.
+  for (const [k, v] of Object.entries(a)) {
+    if (local(k.slice(ATTR_PREFIX.length)) === local(name)) return String(v)
+  }
+  return undefined
+}
+
+/**
+ * Reads a namespaced attribute by local name, ignoring unprefixed ones. Needed
+ * where an element carries both (e.g. `<p:sldId id="256" r:id="rId2"/>`).
+ */
+function prefixedAttr(node: XmlNode, name: string): string | undefined {
+  for (const [k, v] of Object.entries(attrsOf(node))) {
+    const raw = k.slice(ATTR_PREFIX.length)
+    if (raw.includes(':') && local(raw) === name) return String(v)
+  }
+  return undefined
+}
+
+function childByLocal(nodes: XmlNode[], name: string): XmlNode | undefined {
+  return nodes.find((n) => {
+    const t = tagNameOf(n)
+    return t !== null && local(t) === name
+  })
+}
+
+function childrenByLocal(nodes: XmlNode[], name: string): XmlNode[] {
+  return nodes.filter((n) => {
+    const t = tagNameOf(n)
+    return t !== null && local(t) === name
+  })
+}
+
+/** Follows a chain of local names down from a node. */
+function descend(node: XmlNode, ...path: string[]): XmlNode | undefined {
+  let current: XmlNode | undefined = node
+  for (const step of path) {
+    if (!current) return undefined
+    current = childByLocal(childrenOf(current), step)
+  }
+  return current
+}
+
+function textOf(node: XmlNode): string {
+  let out = ''
+  for (const child of childrenOf(node)) {
+    const t = child['#text']
+    if (typeof t === 'string') out += t
+  }
+  return out
+}
+
+function num(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function isTruthyAttr(value: string | undefined): boolean {
+  return value === '1' || value === 'true'
+}
+
+// ---------------------------------------------------------------- zip paths
+
+function dirNameOf(path: string): string {
+  const i = path.lastIndexOf('/')
+  return i >= 0 ? path.slice(0, i) : ''
+}
+
+/** Resolves a relationship Target against the directory owning the .rels file. */
+export function resolveRelTarget(baseDir: string, target: string): string {
+  if (target.startsWith('/')) return target.slice(1)
+  const segments = (baseDir ? baseDir.split('/') : []).concat(target.split('/'))
+  const out: string[] = []
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') out.pop()
+    else out.push(seg)
+  }
+  return out.join('/')
+}
+
+/** `ppt/slides/slide1.xml` -> `ppt/slides/_rels/slide1.xml.rels` */
+function relsPathFor(partPath: string): string {
+  const dir = dirNameOf(partPath)
+  const file = partPath.slice(dir.length + 1)
+  return `${dir}/_rels/${file}.rels`
+}
+
+interface Relationship {
+  target: string
+  type: string
+}
+
+async function readRels(zip: JSZip, partPath: string): Promise<Map<string, Relationship>> {
+  const map = new Map<string, Relationship>()
+  const file = zip.file(relsPathFor(partPath))
+  if (!file) return map
+  const doc = parseXml(await file.async('string'))
+  const root = childByLocal(doc, 'Relationships')
+  if (!root) return map
+  const baseDir = dirNameOf(partPath)
+  for (const rel of childrenByLocal(childrenOf(root), 'Relationship')) {
+    const id = attr(rel, 'Id')
+    const target = attr(rel, 'Target')
+    // External targets (linked images, web video) have no part in the package.
+    if (!id || !target || attr(rel, 'TargetMode') === 'External') continue
+    map.set(id, { target: resolveRelTarget(baseDir, target), type: attr(rel, 'Type') ?? '' })
+  }
+  return map
+}
+
+function relTargetOfType(rels: Map<string, Relationship>, suffix: string): string | undefined {
+  for (const rel of rels.values()) {
+    if (rel.type.endsWith(suffix)) return rel.target
+  }
+  return undefined
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  bmp: 'image/bmp',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+}
+
+function mimeFor(path: string): string {
+  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase()
+  return MIME_BY_EXT[ext] ?? 'application/octet-stream'
+}
+
+// -------------------------------------------------------------- geometry
+
+const ZERO_RECT: RectEmu = { x: 0, y: 0, w: 0, h: 0 }
+
+function rectFromXfrm(xfrm: XmlNode | undefined): RectEmu {
+  if (!xfrm) return { ...ZERO_RECT }
+  const kids = childrenOf(xfrm)
+  const off = childByLocal(kids, 'off')
+  const ext = childByLocal(kids, 'ext')
+  return {
+    x: (off && num(attr(off, 'x'))) ?? 0,
+    y: (off && num(attr(off, 'y'))) ?? 0,
+    w: (ext && num(attr(ext, 'cx'))) ?? 0,
+    h: (ext && num(attr(ext, 'cy'))) ?? 0,
+  }
+}
+
+/** `a:xfrm` sits under `spPr`/`grpSpPr` for shapes, but directly on graphicFrame. */
+function rectOfShapeNode(node: XmlNode): RectEmu {
+  const xfrm =
+    descend(node, 'spPr', 'xfrm') ??
+    descend(node, 'grpSpPr', 'xfrm') ??
+    childByLocal(childrenOf(node), 'xfrm')
+  return rectFromXfrm(xfrm)
+}
+
+function isEmptyRect(r: RectEmu): boolean {
+  return r.w === 0 && r.h === 0
+}
+
+/**
+ * Placeholder geometry inherited from a slide's layout, and the layout's master.
+ *
+ * PowerPoint omits `a:xfrm` on title/body placeholders and expects the reader to
+ * inherit it, so without this nearly every real deck lays out at 0x0.
+ */
+interface InheritedRects {
+  byIdx: Map<string, RectEmu>
+  byType: Map<string, RectEmu>
+}
+
+function phKeyOf(node: XmlNode): { idx?: string; type?: string } | null {
+  const ph = descend(node, 'nvSpPr', 'nvPr', 'ph')
+  if (!ph) return null
+  return { idx: attr(ph, 'idx'), type: attr(ph, 'type') }
+}
+
+/** Title variants address the same slot; normalize so a lookup finds either. */
+function normalizePhType(type: string | undefined): string {
+  if (!type) return 'body'
+  if (type === 'ctrTitle') return 'title'
+  return type
+}
+
+function collectPlaceholderRects(doc: XmlNode[], into: InheritedRects): void {
+  const spTree = (() => {
+    const root = childByLocal(doc, 'sldLayout') ?? childByLocal(doc, 'sldMaster')
+    return root ? descend(root, 'cSld', 'spTree') : undefined
+  })()
+  if (!spTree) return
+  for (const node of childrenOf(spTree)) {
+    const tag = tagNameOf(node)
+    if (!tag || local(tag) !== 'sp') continue
+    const key = phKeyOf(node)
+    if (!key) continue
+    const rect = rectOfShapeNode(node)
+    if (isEmptyRect(rect)) continue
+    if (key.idx !== undefined) into.byIdx.set(key.idx, rect)
+    into.byType.set(normalizePhType(key.type), rect)
+  }
+}
+
+/** Walks slide -> layout -> master, letting the nearer part win. */
+async function loadInheritedRects(
+  zip: JSZip,
+  slideRels: Map<string, Relationship>,
+): Promise<InheritedRects> {
+  const out: InheritedRects = { byIdx: new Map(), byType: new Map() }
+  const layoutPath = relTargetOfType(slideRels, '/slideLayout')
+  if (!layoutPath) return out
+
+  const layoutFile = zip.file(layoutPath)
+  if (!layoutFile) return out
+  const layoutDoc = parseXml(await layoutFile.async('string'))
+
+  // Master first so the layout's own values overwrite it.
+  const layoutRels = await readRels(zip, layoutPath)
+  const masterPath = relTargetOfType(layoutRels, '/slideMaster')
+  const masterFile = masterPath ? zip.file(masterPath) : null
+  if (masterFile) collectPlaceholderRects(parseXml(await masterFile.async('string')), out)
+  collectPlaceholderRects(layoutDoc, out)
+  return out
+}
+
+function shapeIdOf(node: XmlNode, fallbackIndex: number): string {
+  for (const nv of ['nvSpPr', 'nvPicPr', 'nvGraphicFramePr', 'nvGrpSpPr']) {
+    const cNvPr = descend(node, nv, 'cNvPr')
+    const id = cNvPr && attr(cNvPr, 'id')
+    if (id) return id
+  }
+  return `idx:${fallbackIndex}`
+}
+
+// ------------------------------------------------------------------ text
+
+function parseRunProps(rPr: XmlNode | undefined): Omit<TextRun, 'text'> {
+  if (!rPr) return {}
+  const out: Omit<TextRun, 'text'> = {}
+  if (isTruthyAttr(attr(rPr, 'b'))) out.bold = true
+  if (isTruthyAttr(attr(rPr, 'i'))) out.italic = true
+  const u = attr(rPr, 'u')
+  if (u && u !== 'none') out.underline = true
+  const sz = num(attr(rPr, 'sz'))
+  // sz is in hundredths of a point.
+  if (sz !== undefined) out.sizePt = sz / 100
+  // Only literal colors resolve here; theme colors (a:schemeClr) need the
+  // theme part and are left to inherit.
+  const srgb = descend(rPr, 'solidFill', 'srgbClr')
+  const val = srgb && attr(srgb, 'val')
+  if (val) out.colorHex = val.toUpperCase()
+  return out
+}
+
+function parseParagraph(p: XmlNode): Paragraph {
+  const kids = childrenOf(p)
+  const pPr = childByLocal(kids, 'pPr')
+  const algn = pPr ? attr(pPr, 'algn') : undefined
+  const runs: TextRun[] = []
+
+  for (const child of kids) {
+    const tag = tagNameOf(child)
+    if (!tag) continue
+    const name = local(tag)
+    if (name === 'r' || name === 'fld') {
+      // a:fld is a generated field (slide number, date) but carries a:t like a run.
+      const t = childByLocal(childrenOf(child), 't')
+      const text = t ? textOf(t) : ''
+      if (text === '') continue
+      runs.push({ text, ...parseRunProps(childByLocal(childrenOf(child), 'rPr')) })
+    } else if (name === 'br') {
+      runs.push({ text: '\n' })
+    }
+  }
+
+  const para: Paragraph = { runs }
+  if (algn === 'l' || algn === 'ctr' || algn === 'r' || algn === 'just') {
+    para.align = algn as TextAlign
+  }
+  return para
+}
+
+// ------------------------------------------------------------- shape kinds
+
+const GRAPHIC_URI_KINDS: Array<[string, PlaceholderKind]> = [
+  ['/table', 'table'],
+  ['/chart', 'chart'],
+  ['/diagram', 'smartart'],
+]
+
+function graphicFrameKind(node: XmlNode): PlaceholderKind {
+  const data = descend(node, 'graphic', 'graphicData')
+  const uri = data ? attr(data, 'uri') : undefined
+  if (uri) {
+    for (const [needle, kind] of GRAPHIC_URI_KINDS) {
+      if (uri.includes(needle)) return kind
+    }
+  }
+  return 'unknown'
+}
+
+/** A `p:pic` whose nvPr carries a video/media reference is a movie, not a still. */
+function isVideoPic(node: XmlNode): boolean {
+  const nvPr = descend(node, 'nvPicPr', 'nvPr')
+  if (!nvPr) return false
+  return childrenOf(nvPr).some((c) => {
+    const t = tagNameOf(c)
+    if (!t) return false
+    const n = local(t)
+    return n === 'videoFile' || n === 'media'
+  })
+}
+
+// ------------------------------------------------------------------ walk
+
+interface ShapeContext {
+  slideXmlPath: string
+  rels: Map<string, Relationship>
+  inherited: InheritedRects
+  zip: JSZip
+  blobUrls: string[]
+}
+
+/** Falls back to the layout/master slot when the shape carries no geometry. */
+function resolveRect(node: XmlNode, ctx: ShapeContext): RectEmu {
+  const own = rectOfShapeNode(node)
+  if (!isEmptyRect(own)) return own
+  const key = phKeyOf(node)
+  if (!key) return own
+  if (key.idx !== undefined) {
+    const byIdx = ctx.inherited.byIdx.get(key.idx)
+    if (byIdx) return { ...byIdx }
+  }
+  const byType = ctx.inherited.byType.get(normalizePhType(key.type))
+  return byType ? { ...byType } : own
+}
+
+async function shapeFromNode(
+  node: XmlNode,
+  nodePath: NodePath,
+  index: number,
+  ctx: ShapeContext,
+): Promise<Shape | null> {
+  const tag = tagNameOf(node)
+  if (!tag) return null
+  const name = local(tag)
+
+  const base = {
+    id: shapeIdOf(node, index),
+    slideXmlPath: ctx.slideXmlPath,
+    nodePath,
+    xfrmEmu: resolveRect(node, ctx),
+  }
+
+  if (name === 'sp') {
+    const txBody = childByLocal(childrenOf(node), 'txBody')
+    if (!txBody) {
+      // A shape with geometry but no text — an arrow, a divider, a background box.
+      return { ...base, type: 'placeholder', kind: 'unknown' } satisfies PlaceholderShape
+    }
+    const paragraphs = childrenByLocal(childrenOf(txBody), 'p').map(parseParagraph)
+    return { ...base, type: 'text', paragraphs } satisfies TextShape
+  }
+
+  if (name === 'pic') {
+    if (isVideoPic(node)) {
+      return { ...base, type: 'placeholder', kind: 'video' } satisfies PlaceholderShape
+    }
+    const blip = descend(node, 'blipFill', 'blip')
+    const embed = blip && attr(blip, 'embed')
+    const mediaPath = embed ? ctx.rels.get(embed)?.target : undefined
+    const file = mediaPath ? ctx.zip.file(mediaPath) : null
+    if (!file || !mediaPath) {
+      // Linked-but-absent media, or an external relationship we skipped.
+      return { ...base, type: 'placeholder', kind: 'unknown' } satisfies PlaceholderShape
+    }
+    // Copy into a plain ArrayBuffer-backed view: jszip's output is typed as
+    // possibly shared-buffer-backed, which Blob does not accept.
+    const bytes = new Uint8Array(await file.async('uint8array'))
+    const blob = new Blob([bytes], { type: mimeFor(mediaPath) })
+    const blobUrl = URL.createObjectURL(blob)
+    ctx.blobUrls.push(blobUrl)
+    return { ...base, type: 'image', blobUrl, mediaPath } satisfies ImageShape
+  }
+
+  if (name === 'graphicFrame') {
+    return { ...base, type: 'placeholder', kind: graphicFrameKind(node) } satisfies PlaceholderShape
+  }
+
+  if (name === 'grpSp') {
+    return { ...base, type: 'placeholder', kind: 'group' } satisfies PlaceholderShape
+  }
+
+  if (name === 'cxnSp') {
+    // Connectors (lines/arrows) have geometry but nothing we draw yet.
+    return { ...base, type: 'placeholder', kind: 'unknown' } satisfies PlaceholderShape
+  }
+
+  return null
+}
+
+async function parseSlide(
+  zip: JSZip,
+  xmlPath: string,
+  xml: string,
+  blobUrls: string[],
+): Promise<Slide> {
+  const doc = parseXml(xml)
+  const rels = await readRels(zip, xmlPath)
+  const inherited = await loadInheritedRects(zip, rels)
+  const ctx: ShapeContext = { slideXmlPath: xmlPath, rels, inherited, zip, blobUrls }
+
+  const sldIndex = doc.findIndex((n) => {
+    const t = tagNameOf(n)
+    return t !== null && local(t) === 'sld'
+  })
+  const shapes: Shape[] = []
+  if (sldIndex < 0) return { id: xmlPath, xmlPath, shapes }
+
+  const sld = doc[sldIndex]
+  const cSldKids = childrenOf(sld)
+  const cSldIndex = cSldKids.findIndex((n) => {
+    const t = tagNameOf(n)
+    return t !== null && local(t) === 'cSld'
+  })
+  if (cSldIndex < 0) return { id: xmlPath, xmlPath, shapes }
+
+  const spTreeKids = childrenOf(cSldKids[cSldIndex])
+  const spTreeIndex = spTreeKids.findIndex((n) => {
+    const t = tagNameOf(n)
+    return t !== null && local(t) === 'spTree'
+  })
+  if (spTreeIndex < 0) return { id: xmlPath, xmlPath, shapes }
+
+  const children = childrenOf(spTreeKids[spTreeIndex])
+  for (let i = 0; i < children.length; i++) {
+    const nodePath: NodePath = [sldIndex, cSldIndex, spTreeIndex, i]
+    const shape = await shapeFromNode(children[i], nodePath, i, ctx)
+    if (shape) shapes.push(shape)
+  }
+
+  return { id: xmlPath, xmlPath, shapes }
+}
+
+// ------------------------------------------------------------------ entry
+
+/** Default 4:3 deck, used only when presentation.xml omits or corrupts sldSz. */
+const FALLBACK_SIZE = { w: 9144000, h: 6858000 }
+
+export async function parsePptx(bytes: Uint8Array): Promise<SlideDeck> {
+  const zip = await JSZip.loadAsync(bytes)
+
+  const presFile = zip.file('ppt/presentation.xml')
+  if (!presFile) throw new Error('Not a PowerPoint package: ppt/presentation.xml is missing')
+  const presDoc = parseXml(await presFile.async('string'))
+  const pres = childByLocal(presDoc, 'presentation')
+  if (!pres) throw new Error('Malformed presentation.xml: no p:presentation element')
+
+  const sldSz = childByLocal(childrenOf(pres), 'sldSz')
+  const slideSizeEmu = {
+    w: (sldSz && num(attr(sldSz, 'cx'))) ?? FALLBACK_SIZE.w,
+    h: (sldSz && num(attr(sldSz, 'cy'))) ?? FALLBACK_SIZE.h,
+  }
+
+  // Slide order comes from sldIdLst, resolved through the presentation's rels.
+  const presRels = await readRels(zip, 'ppt/presentation.xml')
+  const sldIdLst = childByLocal(childrenOf(pres), 'sldIdLst')
+  const slidePaths: string[] = []
+  if (sldIdLst) {
+    for (const sldId of childrenByLocal(childrenOf(sldIdLst), 'sldId')) {
+      // sldId carries both a plain numeric `id` and the `r:id` we want, so match
+      // on a *prefixed* attribute whose local name is `id`.
+      const rid = prefixedAttr(sldId, 'id')
+      const target = rid ? presRels.get(rid)?.target : undefined
+      if (target) slidePaths.push(target)
+    }
+  }
+  if (slidePaths.length === 0) {
+    // No usable sldIdLst — fall back to whatever slide parts exist, in name order.
+    const found = Object.keys(zip.files)
+      .filter((p) => /^ppt\/slides\/slide\d+\.xml$/.test(p))
+      .sort((a, b) => {
+        const na = Number(a.match(/(\d+)\.xml$/)?.[1] ?? 0)
+        const nb = Number(b.match(/(\d+)\.xml$/)?.[1] ?? 0)
+        return na - nb
+      })
+    slidePaths.push(...found)
+  }
+
+  const blobUrls: string[] = []
+  const slideXml: Record<string, string> = {}
+  const slides: Slide[] = []
+  for (const path of slidePaths) {
+    const file = zip.file(path)
+    if (!file) continue
+    const xml = await file.async('string')
+    slideXml[path] = xml
+    slides.push(await parseSlide(zip, path, xml, blobUrls))
+  }
+
+  return { slideSizeEmu, slides, source: { zip, slideXml } }
+}
+
+/**
+ * Walks a shape's `nodePath` back to its node in a freshly parsed slide tree.
+ * This is the read half of the Phase B write-back contract: re-parse the raw
+ * XML, resolve the path, mutate that node, re-serialize only this slide.
+ */
+export function resolveNodePath(doc: XmlNode[], path: NodePath): XmlNode | undefined {
+  let nodes = doc
+  let node: XmlNode | undefined
+  for (const index of path) {
+    node = nodes[index]
+    if (!node) return undefined
+    nodes = childrenOf(node)
+  }
+  return node
+}
+
+/** Releases the object URLs held by a deck's image shapes. */
+export function disposeDeck(deck: SlideDeck): void {
+  for (const slide of deck.slides) {
+    for (const shape of slide.shapes) {
+      if (shape.type === 'image') URL.revokeObjectURL(shape.blobUrl)
+    }
+  }
+}

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -119,13 +119,35 @@ function descend(node: XmlNode, ...path: string[]): XmlNode | undefined {
   return current
 }
 
+/**
+ * Decodes numeric character references (`&#8217;` / `&#x2019;`) that
+ * fast-xml-parser leaves as literal text (it only decodes the five named XML
+ * entities). Only code points valid in XML 1.0 are decoded; anything else
+ * stays literal. Write-back for untouched runs is unaffected — it copies the
+ * original bytes, never this decoded form.
+ */
+function decodeNumericRefs(s: string): string {
+  if (!s.includes('&#')) return s
+  return s.replace(/&#(x[0-9a-fA-F]+|\d+);/g, (match, code: string) => {
+    const cp = code[0] === 'x' ? parseInt(code.slice(1), 16) : parseInt(code, 10)
+    const valid =
+      cp === 0x9 ||
+      cp === 0xa ||
+      cp === 0xd ||
+      (cp >= 0x20 && cp <= 0xd7ff) ||
+      (cp >= 0xe000 && cp <= 0xfffd) ||
+      (cp >= 0x10000 && cp <= 0x10ffff)
+    return valid ? String.fromCodePoint(cp) : match
+  })
+}
+
 function textOf(node: XmlNode): string {
   let out = ''
   for (const child of childrenOf(node)) {
     const t = child['#text']
     if (typeof t === 'string') out += t
   }
-  return out
+  return decodeNumericRefs(out)
 }
 
 function num(value: string | undefined): number | undefined {

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -212,8 +212,11 @@ export function resolveRelTarget(baseDir: string, target: string): string {
   return out.join('/')
 }
 
-/** `ppt/slides/slide1.xml` -> `ppt/slides/_rels/slide1.xml.rels` */
-function relsPathFor(partPath: string): string {
+/**
+ * `ppt/slides/slide1.xml` -> `ppt/slides/_rels/slide1.xml.rels`
+ * Exported for the serializer: deleting a slide removes its rels part too.
+ */
+export function relsPathFor(partPath: string): string {
   const dir = dirNameOf(partPath)
   const file = partPath.slice(dir.length + 1)
   return `${dir}/_rels/${file}.rels`
@@ -540,7 +543,12 @@ async function loadSlideContext(
 
 const NV_PR_LOCALS = ['nvSpPr', 'nvPicPr', 'nvGraphicFramePr', 'nvGrpSpPr', 'nvCxnSpPr']
 
-function shapeIdOf(node: XmlNode, fallbackIndex: number): string {
+/**
+ * The model's shape id: `p:cNvPr@id` when present, else the synthesized
+ * ordinal form. Exported so the serializer can replay this exact derivation on
+ * a re-parsed node and cross-check a deletion against the model's target.
+ */
+export function shapeIdOf(node: XmlNode, fallbackIndex: number): string {
   for (const nv of NV_PR_LOCALS) {
     const cNvPr = descend(node, nv, 'cNvPr')
     const id = cNvPr && attr(cNvPr, 'id')

--- a/apps/x/apps/renderer/src/lib/pptx/parse.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/parse.ts
@@ -89,13 +89,22 @@ function attrsOf(node: XmlNode): Record<string, string> {
   return (node[ATTRS] as Record<string, string> | undefined) ?? {}
 }
 
+/**
+ * Attribute value, with numeric character references decoded — the parser
+ * leaves them literal in attributes just as it does in text, so `buChar
+ * char="&#x2022;"` would otherwise render as that markup instead of a bullet.
+ * Read-only: the serializer scans raw bytes and never reads attributes through
+ * here, so write-back is unaffected.
+ */
 export function attr(node: XmlNode, name: string): string | undefined {
   const a = attrsOf(node)
   const direct = a[ATTR_PREFIX + name]
-  if (direct !== undefined) return String(direct)
+  if (direct !== undefined) return decodeNumericRefs(String(direct))
   // Fall back to a local-name match so unusual prefixes still resolve.
   for (const [k, v] of Object.entries(a)) {
-    if (local(k.slice(ATTR_PREFIX.length)) === local(name)) return String(v)
+    if (local(k.slice(ATTR_PREFIX.length)) === local(name)) {
+      return decodeNumericRefs(String(v))
+    }
   }
   return undefined
 }

--- a/apps/x/apps/renderer/src/lib/pptx/rebuild-formatting.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/rebuild-formatting.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parseAddedSlide, parsePptx } from './parse'
+import { planDuplicateSlide, readSlideRels } from './add-slide'
+import { updateSlideXml, writeDeck, type EditedParagraph, type SlideEdit } from './serialize'
+import type { TextShape } from './types'
+
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const NS_R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+/**
+ * The shape of the real bug: a title placeholder whose LAYOUT default colour
+ * is white, while its authored runs are dark. A rebuilt run that carries no
+ * rPr therefore renders invisible on the light slide.
+ */
+const LAYOUT_XML =
+  `<p:sldLayout ${NS_P} ${NS_A}><p:cSld><p:spTree>` +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2"/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="9000000" cy="1000000"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr sz="4000">' +
+  '<a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>' +
+  '</a:defRPr></a:lvl1pPr></a:lstStyle></p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sldLayout>'
+
+/** Two runs, both explicitly dark, with extra rPr attributes worth preserving. */
+const TITLE_SP =
+  '<p:sp><p:nvSpPr><p:cNvPr id="7" name="Title"/><p:cNvSpPr/>' +
+  '<p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="9000000" cy="1000000"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:lstStyle/><a:p>' +
+  '<a:r><a:rPr lang="en-US" dirty="0" spc="-170"><a:solidFill><a:srgbClr val="0C414B"/></a:solidFill></a:rPr><a:t>Welcome</a:t></a:r>' +
+  '<a:r><a:rPr lang="en-US" dirty="0" spc="-170"><a:solidFill><a:srgbClr val="0C414B"/></a:solidFill></a:rPr><a:t> To</a:t></a:r>' +
+  '</a:p></p:txBody></p:sp>'
+
+const OTHER_SP =
+  '<p:sp><p:nvSpPr><p:cNvPr id="8" name="Body"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="0" y="2000000"/><a:ext cx="500000" cy="500000"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:p><a:r><a:t>untouched</a:t></a:r></a:p></p:txBody></p:sp>'
+
+const SLIDE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:sld ${NS_P} ${NS_A} ${NS_R}><p:cSld><p:spTree>` +
+  '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/>' +
+  TITLE_SP +
+  OTHER_SP +
+  '</p:spTree></p:cSld></p:sld>'
+
+const PRESENTATION_XML =
+  `<p:presentation ${NS_P} ${NS_R}><p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>` +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/></Relationships>`
+const SLIDE_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId1" Type="${REL_TYPE}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+  '</Relationships>'
+
+const SLIDE_CT = 'application/vnd.openxmlformats-officedocument.presentationml.slide+xml'
+const CONTENT_TYPES =
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  `<Override PartName="/ppt/slides/slide1.xml" ContentType="${SLIDE_CT}"/></Types>`
+
+async function buildZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('[Content_Types].xml', CONTENT_TYPES)
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE_XML)
+  zip.file('ppt/slides/_rels/slide1.xml.rels', SLIDE_RELS)
+  zip.file('ppt/slideLayouts/slideLayout1.xml', LAYOUT_XML)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const oc = URL.createObjectURL
+const orv = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:m') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = oc
+  URL.revokeObjectURL = orv
+})
+
+const P1 = 'ppt/slides/slide1.xml'
+async function loadTitle() {
+  const deck = await parsePptx(await buildZip())
+  return { deck, title: deck.slides[0].shapes[0] as TextShape }
+}
+
+/** Re-parse a slide after swapping its bytes, as a save-then-reopen would. */
+async function reparseWith(deck: Awaited<ReturnType<typeof loadTitle>>['deck'], xml: string) {
+  deck.source.zip.file(P1, xml)
+  const re = await parsePptx(await deck.source.zip.generateAsync({ type: 'uint8array' }))
+  deck.source.zip.file(P1, SLIDE_XML)
+  return re
+}
+
+describe('the layout default is genuinely white', () => {
+  it('so a run with no rPr of its own is invisible — the premise of the bug', async () => {
+    const { title } = await loadTitle()
+    expect(title.display?.paragraphs[0].defaultRun.colorHex).toBe('FFFFFF')
+    expect(title.paragraphs[0].runs[0].colorHex).toBe('0C414B')
+  })
+})
+
+describe('SYMPTOM 1: typing on a new line rendered white', () => {
+  it('inherits the neighbouring paragraph rPr instead of emitting a bare run', async () => {
+    const { deck, title } = await loadTitle()
+    // Enter at the end, then type: paragraph 1 has NO source paragraph.
+    const next: EditedParagraph[] = [
+      { srcPara: 0, runs: title.paragraphs[0].runs.map((r, i) => ({ ...r, srcPara: 0, srcRun: i })) },
+      { runs: [{ text: 'Typed on a new line' }] },
+    ]
+    const written = updateSlideXml(SLIDE_XML, [
+      { kind: 'text', nodePath: title.nodePath, original: title.paragraphs, next },
+    ])
+    // The new run carries the inherited colour rather than nothing at all.
+    expect(written).toContain(
+      '<a:r><a:rPr lang="en-US" dirty="0" spc="-170"><a:solidFill><a:srgbClr val="0C414B"/></a:solidFill></a:rPr>' +
+        '<a:t>Typed on a new line</a:t></a:r>',
+    )
+    const re = await reparseWith(deck, written)
+    const rs = re.slides[0].shapes[0] as TextShape
+    expect(rs.display?.paragraphs[1].runs[0].colorHex).toBe('0C414B')
+    expect(rs.display?.paragraphs[1].runs[0].colorHex).not.toBe('FFFFFF')
+    // The untouched shape keeps its bytes.
+    expect(written).toContain(OTHER_SP)
+  })
+
+  it('falls back to the shape own bytes when NO paragraph has a source', async () => {
+    const { title } = await loadTitle()
+    const written = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'text',
+        nodePath: title.nodePath,
+        original: title.paragraphs,
+        next: [{ runs: [{ text: 'wholly new' }] }],
+      },
+    ])
+    expect(written).toContain('<a:srgbClr val="0C414B"/></a:solidFill></a:rPr><a:t>wholly new</a:t>')
+  })
+})
+
+describe('SYMPTOM 2: a colour pick on a restructured box was dropped', () => {
+  it('emits the override onto the inherited rPr, preserving its other bytes', async () => {
+    const { deck, title } = await loadTitle()
+    const written = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'text',
+        nodePath: title.nodePath,
+        original: title.paragraphs,
+        // Select-all + retype (structural) with a colour the user picked.
+        next: [{ srcPara: 0, runs: [{ text: 'My New Title', colorHex: 'FF0000' }] }],
+      },
+    ])
+    // The picked colour lands, and dirty/spc/lang from the donor survive.
+    expect(written).toContain(
+      '<a:r><a:rPr lang="en-US" dirty="0" spc="-170"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr>' +
+        '<a:t>My New Title</a:t></a:r>',
+    )
+    const rs = (await reparseWith(deck, written)).slides[0].shapes[0] as TextShape
+    expect(rs.display?.paragraphs[0].runs[0].colorHex).toBe('FF0000')
+  })
+
+  it('carries bold / size / font on a provenance-less run too', async () => {
+    const { title } = await loadTitle()
+    const written = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'text',
+        nodePath: title.nodePath,
+        original: title.paragraphs,
+        next: [{ runs: [{ text: 'styled', bold: true, sizePt: 32, latinFont: 'Georgia' }] }],
+      },
+    ])
+    const run = written.match(/<a:r>(?:(?!<\/a:r>).)*styled.*?<\/a:r>/s)?.[0] ?? ''
+    expect(run).toContain('b="1"')
+    expect(run).toContain('sz="3200"')
+    expect(run).toContain('<a:latin typeface="Georgia"/>')
+  })
+
+  it('a run whose props match its original still copies bytes verbatim', async () => {
+    const { title } = await loadTitle()
+    // Structural (one run removed), but the survivor is unchanged.
+    const written = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'text',
+        nodePath: title.nodePath,
+        original: title.paragraphs,
+        next: [
+          { srcPara: 0, runs: [{ ...title.paragraphs[0].runs[0], srcPara: 0, srcRun: 0 }] },
+        ],
+      },
+    ])
+    // No rPr rewriting: exactly the original run bytes.
+    expect(written).toContain(
+      '<a:r><a:rPr lang="en-US" dirty="0" spc="-170"><a:solidFill><a:srgbClr val="0C414B"/></a:solidFill></a:rPr><a:t>Welcome</a:t></a:r>',
+    )
+    expect(written).not.toContain('<a:t> To</a:t>')
+  })
+})
+
+describe('compose paths on a DUPLICATED slide', () => {
+  it('formatRuns, setShapeStyle and insertShape all apply to the copy in one save', async () => {
+    const deck = await parsePptx(await buildZip())
+    const plan = planDuplicateSlide(
+      deck,
+      P1,
+      { xml: deck.source.slideXml[P1], relsXml: await readSlideRels(deck, P1) },
+      [],
+    )
+    const dup = await parseAddedSlide(deck, plan.path, plan.xml, plan.relsXml)
+    const dupTitle = dup.shapes[0] as TextShape
+    // The duplicate resolves the same cascade as the original.
+    expect(dupTitle.display?.paragraphs[0].defaultRun.colorHex).toBe('FFFFFF')
+
+    const out = await writeDeck(
+      deck,
+      new Map<string, SlideEdit[]>([
+        [
+          plan.path,
+          [
+            // Structural retype WITH formatting carried on the run itself —
+            // the path the editor uses while a box is open. A separate
+            // formatRuns edit on the same shape would overlap this rebuild,
+            // and the serializer rightly refuses that (see the fail-closed
+            // case below).
+            {
+              kind: 'text',
+              nodePath: dupTitle.nodePath,
+              original: dupTitle.paragraphs,
+              next: [{ runs: [{ text: 'Renamed on the copy', bold: true }] }],
+            },
+            // formatRuns against an UNrestructured shape on the same copy.
+            {
+              kind: 'formatRuns',
+              nodePath: (dup.shapes[1] as TextShape).nodePath,
+              original: (dup.shapes[1] as TextShape).paragraphs,
+              targets: [{ para: 0, run: 0 }],
+              set: { italic: true },
+            },
+            {
+              kind: 'setShapeStyle',
+              nodePath: (dup.shapes[1] as TextShape).nodePath,
+              shapeType: 'text',
+              shapeId: dup.shapes[1].id,
+              original: dup.shapes[1].style!,
+              fillHex: '336699',
+            },
+            { kind: 'insertShape', spec: { kind: 'textbox', xfrmEmu: { x: 1, y: 2, w: 3, h: 4 } } },
+          ],
+        ],
+      ]),
+      { addSlides: [plan] },
+    )
+
+    const re = await parsePptx(out)
+    expect(re.slides.map((s) => s.xmlPath)).toEqual([P1, plan.path])
+    const copy = re.slides[1]
+    // The retyped title is dark (not the white default) and bold.
+    const t = copy.shapes[0] as TextShape
+    expect(t.paragraphs[0].runs[0].text).toBe('Renamed on the copy')
+    expect(t.display?.paragraphs[0].runs[0].colorHex).toBe('0C414B')
+    expect(t.paragraphs[0].runs[0].bold).toBe(true)
+    // The recoloured shape and the inserted box both landed.
+    expect((copy.shapes[1] as TextShape).style?.fillHex).toBe('336699')
+    expect((copy.shapes[1] as TextShape).paragraphs[0].runs[0].italic).toBe(true)
+    expect(copy.shapes).toHaveLength(3)
+    expect((copy.shapes[2] as TextShape).type).toBe('text')
+    // And the ORIGINAL slide is untouched.
+    const orig = re.slides[0].shapes[0] as TextShape
+    expect(orig.paragraphs[0].runs[0].text).toBe('Welcome')
+  })
+})
+
+describe('the fail-closed invariant still holds', () => {
+  it('refuses a formatRuns that would overlap a structural rebuild of the same shape', async () => {
+    const { title } = await loadTitle()
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        {
+          kind: 'text',
+          nodePath: title.nodePath,
+          original: title.paragraphs,
+          next: [{ runs: [{ text: 'restructured' }] }],
+        },
+        {
+          kind: 'formatRuns',
+          nodePath: title.nodePath,
+          original: title.paragraphs,
+          targets: [{ para: 0, run: 0 }],
+          set: { bold: true },
+        },
+      ]),
+    ).toThrow(/overlapping splices/)
+  })
+
+  it('still refuses a text edit whose original disagrees with the bytes', async () => {
+    const { title } = await loadTitle()
+    const stale = title.paragraphs.map((p) => ({
+      ...p,
+      runs: p.runs.map((r) => ({ ...r, text: r.text + '!' })),
+    }))
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        {
+          kind: 'text',
+          nodePath: title.nodePath,
+          original: stale,
+          next: [{ runs: [{ text: 'x' }] }],
+        },
+      ]),
+    ).toThrow(/does not match/)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.test.ts
@@ -6,7 +6,9 @@ import type { TextShape } from './types'
 
 // Real-PowerPoint-shaped slide: CRLF after the declaration, one line, mixed
 // self-closing forms, an undecoded NCR (&#8217;), entities in attributes and
-// in a second (never-edited) shape, xml:space, endParaRPr, and a fld.
+// in a second shape, xml:space, endParaRPr, a fld, rot on the title xfrm, a
+// pPr with children (buChar), a plain paragraph with no pPr, and an empty
+// self-closing spPr on the second shape.
 const SLIDE_XML =
   '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
   '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"' +
@@ -14,7 +16,7 @@ const SLIDE_XML =
   ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
   '<p:cSld><p:spTree>' +
   '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Bob&apos;s &amp; Co"/></p:nvSpPr>' +
-  '<p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="100" cy="200"/></a:xfrm></p:spPr>' +
+  '<p:spPr><a:xfrm rot="60000"><a:off x="10" y="20"/><a:ext cx="100" cy="200"/></a:xfrm></p:spPr>' +
   '<p:txBody><a:bodyPr/><a:lstStyle/>' +
   '<a:p><a:pPr algn="ctr"/>' +
   '<a:r><a:rPr lang="en-US" b="1" sz="2800"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr><a:t>Hello</a:t></a:r>' +
@@ -25,8 +27,10 @@ const SLIDE_XML =
   '</a:p></p:txBody></p:sp>' +
   '<p:sp><p:nvSpPr><p:cNvPr id="3" name="Notes"/></p:nvSpPr><p:spPr/>' +
   '<p:txBody><a:bodyPr/>' +
-  '<a:p><a:fld id="{X}" type="slidenum"><a:t>7</a:t></a:fld>' +
+  '<a:p><a:pPr marL="342900" indent="-342900"><a:buChar char="•"/></a:pPr>' +
+  '<a:fld id="{X}" type="slidenum"><a:t>7</a:t></a:fld>' +
   '<a:r><a:t>A &amp; B &lt;kept&gt;</a:t></a:r></a:p>' +
+  '<a:p><a:r><a:t>plain</a:t></a:r></a:p>' +
   '</p:txBody></p:sp>' +
   '</p:spTree></p:cSld></p:sld>'
 
@@ -67,9 +71,21 @@ async function loadDeck() {
   return { deck, slide, title, notes }
 }
 
+/** Rebuilds the fixture zip with the given slide XML, then re-parses it. */
+async function reparseWithSlide(slideXml: string) {
+  const zip = new JSZip()
+  const src = await JSZip.loadAsync(await buildFixtureZip())
+  for (const [name, entry] of Object.entries(src.files)) {
+    if (!entry.dir) zip.file(name, await entry.async('uint8array'))
+  }
+  zip.file('ppt/slides/slide1.xml', slideXml)
+  return parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+}
+
 /** A text-only edit: same structure/props, one run's text replaced. */
 function textOnlyEdit(title: TextShape, newText: string): ShapeTextEdit {
   return {
+    kind: 'text',
     nodePath: title.nodePath,
     original: title.paragraphs,
     next: title.paragraphs.map((p) => ({
@@ -126,15 +142,24 @@ describe('updateSlideXml round-trip contract', () => {
 
   it('refuses a nodePath that is not a text shape and an empty next', async () => {
     const { title } = await loadDeck()
-    const bad = { ...textOnlyEdit(title, 'x'), nodePath: [...title.nodePath.slice(0, -1), 0] }
-    // Index 0 in spTree children is a whitespace-free doc, so 0 is the first
-    // shape itself here; point at a guaranteed non-sp node instead: the pPr
-    // path inside the shape.
-    bad.nodePath = [...title.nodePath, 0]
+    const bad = { ...textOnlyEdit(title, 'x'), nodePath: [...title.nodePath, 0] }
     expect(() => updateSlideXml(SLIDE_XML, [bad])).toThrow(/pptx write-back/)
     expect(() => updateSlideXml(SLIDE_XML, [{ ...textOnlyEdit(title, 'x'), next: [] }])).toThrow(
       /at least one paragraph/,
     )
+  })
+})
+
+describe('numeric character references', () => {
+  it('decodes NCRs in the model but keeps unedited write-back byte-identical', async () => {
+    const { title } = await loadDeck()
+    // The model sees the real character…
+    expect(title.paragraphs[0].runs[1].text).toBe('It’s')
+    // …while zero-edit write-back returns the exact original bytes.
+    expect(updateSlideXml(SLIDE_XML, [])).toBe(SLIDE_XML)
+    // And an edit elsewhere leaves the NCR run's bytes untouched.
+    const out = updateSlideXml(SLIDE_XML, [textOnlyEdit(title, 'x')])
+    expect(out).toContain('<a:r><a:rPr lang="en-US" i="1"/><a:t>It&#8217;s</a:t></a:r>')
   })
 })
 
@@ -143,6 +168,7 @@ describe('updateSlideXml structural rebuild', () => {
     const { title } = await loadDeck()
     const orig = title.paragraphs[0]
     const edit: ShapeTextEdit = {
+      kind: 'text',
       nodePath: title.nodePath,
       original: title.paragraphs,
       next: [
@@ -178,20 +204,159 @@ describe('updateSlideXml structural rebuild', () => {
     expect(out.startsWith('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n')).toBe(true)
     expect(out).toContain('<a:t>A &amp; B &lt;kept&gt;</a:t>')
 
-    // And the result re-parses into the intended model.
-    const zip = new JSZip()
-    const src = await JSZip.loadAsync(await buildFixtureZip())
-    for (const [name, entry] of Object.entries(src.files)) {
-      if (!entry.dir) zip.file(name, await entry.async('uint8array'))
-    }
-    zip.file('ppt/slides/slide1.xml', out)
-    const deck2 = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    // And the result re-parses into the intended model (NCR decoded).
+    const deck2 = await reparseWithSlide(out)
     const shape2 = deck2.slides[0].shapes[0] as TextShape
     expect(shape2.paragraphs.map((p) => p.runs.map((r) => r.text))).toEqual([
       ['Hello'],
-      ['It&#8217;s', '\n', ' spaced '],
+      ['It’s', '\n', ' spaced '],
     ])
     expect(shape2.paragraphs[0].runs[0].bold).toBe(true)
+  })
+})
+
+describe('formatRuns', () => {
+  it('rewrites only the targeted rPr, preserving other attrs, children and neighbours', async () => {
+    const { title } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'formatRuns',
+        nodePath: title.nodePath,
+        original: title.paragraphs,
+        targets: [{ para: 0, run: 0 }],
+        set: { bold: false, italic: true, sizePt: 32, colorHex: '00ff00' },
+      },
+      {
+        kind: 'formatRuns',
+        nodePath: title.nodePath,
+        original: title.paragraphs,
+        targets: [{ para: 0, run: 3 }],
+        set: { underline: true },
+      },
+    ])
+    const expected = SLIDE_XML.replace(
+      '<a:rPr lang="en-US" b="1" sz="2800"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr>',
+      // lang preserved; b/sz replaced in place; i appended; fill replaced.
+      '<a:rPr lang="en-US" b="0" sz="3200" i="1"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:rPr>',
+    ).replace(
+      '<a:r><a:t xml:space="preserve"> tail </a:t></a:r>',
+      // Run without rPr gets a synthesized one, first in the run.
+      '<a:r><a:rPr u="sng"/><a:t xml:space="preserve"> tail </a:t></a:r>',
+    )
+    expect(out).toBe(expected)
+    // Neighbouring run byte-identical, text bytes untouched.
+    expect(out).toContain('<a:r><a:rPr lang="en-US" i="1"/><a:t>It&#8217;s</a:t></a:r>')
+    expect(out).toContain('<a:t>Hello</a:t>')
+  })
+
+  it('fails closed on a line-break target', async () => {
+    const { title } = await loadDeck()
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        {
+          kind: 'formatRuns',
+          nodePath: title.nodePath,
+          original: title.paragraphs,
+          targets: [{ para: 0, run: 2 }],
+          set: { bold: true },
+        },
+      ]),
+    ).toThrow(/line break/)
+  })
+})
+
+describe('setParagraphAlign', () => {
+  it('replaces an existing algn value in place', async () => {
+    const { title } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      { kind: 'paragraphAlign', nodePath: title.nodePath, original: title.paragraphs, paraIndex: 0, align: 'r' },
+    ])
+    expect(out).toBe(SLIDE_XML.replace('algn="ctr"', 'algn="r"'))
+  })
+
+  it('inserts algn on a pPr with children, leaving the children byte-intact', async () => {
+    const { notes } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      { kind: 'paragraphAlign', nodePath: notes.nodePath, original: notes.paragraphs, paraIndex: 0, align: 'r' },
+    ])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:pPr marL="342900" indent="-342900">',
+        '<a:pPr marL="342900" indent="-342900" algn="r">',
+      ),
+    )
+    expect(out).toContain('<a:buChar char="•"/>')
+  })
+
+  it('synthesizes pPr as the first child of a:p when absent', async () => {
+    const { notes } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      { kind: 'paragraphAlign', nodePath: notes.nodePath, original: notes.paragraphs, paraIndex: 1, align: 'just' },
+    ])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:p><a:r><a:t>plain</a:t></a:r></a:p>',
+        '<a:p><a:pPr algn="just"/><a:r><a:t>plain</a:t></a:r></a:p>',
+      ),
+    )
+  })
+
+  it('fails closed on an out-of-range paragraph', async () => {
+    const { title } = await loadDeck()
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        { kind: 'paragraphAlign', nodePath: title.nodePath, original: title.paragraphs, paraIndex: 9, align: 'l' },
+      ]),
+    ).toThrow(/out of range/)
+  })
+})
+
+describe('setShapeGeometry', () => {
+  it('splices off/ext numbers in place, rounding and clamping, leaving rot intact', async () => {
+    const { title } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'shapeGeometry',
+        nodePath: title.nodePath,
+        offEmu: { x: 111.4, y: 222 },
+        extEmu: { w: -5, h: 0.2 },
+      },
+    ])
+    const expected = SLIDE_XML.replace('x="10"', 'x="111"')
+      .replace('y="20"', 'y="222"')
+      .replace('cx="100"', 'cx="1"')
+      .replace('cy="200"', 'cy="1"')
+    expect(out).toBe(expected)
+    expect(out).toContain('<a:xfrm rot="60000">')
+  })
+
+  it('synthesizes xfrm as the first child of spPr when absent, and it re-parses', async () => {
+    const { notes } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [
+      {
+        kind: 'shapeGeometry',
+        nodePath: notes.nodePath,
+        offEmu: { x: 5, y: 6 },
+        extEmu: { w: 7, h: 8 },
+      },
+    ])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<p:spPr/>',
+        '<p:spPr><a:xfrm><a:off x="5" y="6"/><a:ext cx="7" cy="8"/></a:xfrm></p:spPr>',
+      ),
+    )
+    const deck2 = await reparseWithSlide(out)
+    expect(deck2.slides[0].shapes[1].xfrmEmu).toEqual({ x: 5, y: 6, w: 7, h: 8 })
+  })
+
+  it('fails closed when xfrm is absent and only one of off/ext is provided', async () => {
+    const { notes } = await loadDeck()
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        { kind: 'shapeGeometry', nodePath: notes.nodePath, offEmu: { x: 5, y: 6 } },
+      ]),
+    ).toThrow(/both offEmu and extEmu/)
   })
 })
 

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx, parseXml } from './parse'
+import { updateSlideXml, writeDeck, type ShapeTextEdit } from './serialize'
+import type { TextShape } from './types'
+
+// Real-PowerPoint-shaped slide: CRLF after the declaration, one line, mixed
+// self-closing forms, an undecoded NCR (&#8217;), entities in attributes and
+// in a second (never-edited) shape, xml:space, endParaRPr, and a fld.
+const SLIDE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"' +
+  ' xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"' +
+  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+  '<p:cSld><p:spTree>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Bob&apos;s &amp; Co"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="100" cy="200"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:lstStyle/>' +
+  '<a:p><a:pPr algn="ctr"/>' +
+  '<a:r><a:rPr lang="en-US" b="1" sz="2800"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr><a:t>Hello</a:t></a:r>' +
+  '<a:r><a:rPr lang="en-US" i="1"/><a:t>It&#8217;s</a:t></a:r>' +
+  '<a:br/>' +
+  '<a:r><a:t xml:space="preserve"> tail </a:t></a:r>' +
+  '<a:endParaRPr lang="en-US" dirty="0"/>' +
+  '</a:p></p:txBody></p:sp>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="3" name="Notes"/></p:nvSpPr><p:spPr/>' +
+  '<p:txBody><a:bodyPr/>' +
+  '<a:p><a:fld id="{X}" type="slidenum"><a:t>7</a:t></a:fld>' +
+  '<a:r><a:t>A &amp; B &lt;kept&gt;</a:t></a:r></a:p>' +
+  '</p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sld>'
+
+const PRESENTATION_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  '<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"' +
+  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+  '<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>' +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+
+const PRESENTATION_RELS =
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>' +
+  '</Relationships>'
+
+/** Bytes 0..255, twice — a binary part that must survive untouched. */
+const BLOB_BYTES = Uint8Array.from({ length: 512 }, (_, i) => i % 256)
+
+const CORE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  '<cp:coreProperties xmlns:cp="http://c"><dc:title xmlns:dc="http://d">A &amp; B</dc:title></cp:coreProperties>'
+
+async function buildFixtureZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE_XML)
+  zip.file('ppt/media/blob.bin', BLOB_BYTES)
+  zip.file('docProps/core.xml', CORE_XML)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+async function loadDeck() {
+  const deck = await parsePptx(await buildFixtureZip())
+  const slide = deck.slides[0]
+  const title = slide.shapes[0] as TextShape
+  const notes = slide.shapes[1] as TextShape
+  return { deck, slide, title, notes }
+}
+
+/** A text-only edit: same structure/props, one run's text replaced. */
+function textOnlyEdit(title: TextShape, newText: string): ShapeTextEdit {
+  return {
+    nodePath: title.nodePath,
+    original: title.paragraphs,
+    next: title.paragraphs.map((p) => ({
+      align: p.align,
+      runs: p.runs.map((r, ri) => (ri === 0 && r.text === 'Hello' ? { ...r, text: newText } : { ...r })),
+      srcPara: 0,
+    })),
+  }
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  let n = 0
+  URL.createObjectURL = (() => `blob:mock/${n++}`) as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+describe('updateSlideXml round-trip contract', () => {
+  it('returns the exact input bytes for zero edits', () => {
+    const out = updateSlideXml(SLIDE_XML, [])
+    expect(out).toBe(SLIDE_XML)
+    expect(parseXml(out)).toEqual(parseXml(SLIDE_XML))
+  })
+
+  it('a text-only edit changes exactly the targeted <a:t> content and nothing else', async () => {
+    const { title } = await loadDeck()
+    const out = updateSlideXml(SLIDE_XML, [textOnlyEdit(title, 'Hi & <bye> "q" \'z\'')])
+    // Everything outside the one a:t is untouched: the expected output is the
+    // input with a single substring replaced.
+    const expected = SLIDE_XML.replace(
+      '<a:t>Hello</a:t>',
+      '<a:t>Hi &amp; &lt;bye&gt; "q" \'z\'</a:t>',
+    )
+    expect(out).toBe(expected)
+    // The evidence trail: CRLF after the declaration, the NCR in the adjacent
+    // run, attribute entities, and the fld all survive byte-identically.
+    expect(out.startsWith('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n')).toBe(true)
+    expect(out).toContain('<a:t>It&#8217;s</a:t>')
+    expect(out).toContain('name="Bob&apos;s &amp; Co"')
+    expect(out).toContain('<a:fld id="{X}" type="slidenum"><a:t>7</a:t></a:fld>')
+  })
+
+  it('refuses to write when the edit original does not match the slide XML', async () => {
+    const { title } = await loadDeck()
+    const edit = textOnlyEdit(title, 'x')
+    edit.original = edit.original.map((p) => ({ ...p, runs: p.runs.map((r) => ({ ...r, text: r.text + '!' })) }))
+    expect(() => updateSlideXml(SLIDE_XML, [edit])).toThrow(/does not match/)
+  })
+
+  it('refuses a nodePath that is not a text shape and an empty next', async () => {
+    const { title } = await loadDeck()
+    const bad = { ...textOnlyEdit(title, 'x'), nodePath: [...title.nodePath.slice(0, -1), 0] }
+    // Index 0 in spTree children is a whitespace-free doc, so 0 is the first
+    // shape itself here; point at a guaranteed non-sp node instead: the pPr
+    // path inside the shape.
+    bad.nodePath = [...title.nodePath, 0]
+    expect(() => updateSlideXml(SLIDE_XML, [bad])).toThrow(/pptx write-back/)
+    expect(() => updateSlideXml(SLIDE_XML, [{ ...textOnlyEdit(title, 'x'), next: [] }])).toThrow(
+      /at least one paragraph/,
+    )
+  })
+})
+
+describe('updateSlideXml structural rebuild', () => {
+  it('splits a paragraph, preserving pPr/rPr/NCR bytes and adding xml:space where needed', async () => {
+    const { title } = await loadDeck()
+    const orig = title.paragraphs[0]
+    const edit: ShapeTextEdit = {
+      nodePath: title.nodePath,
+      original: title.paragraphs,
+      next: [
+        {
+          align: orig.align,
+          srcPara: 0,
+          runs: [{ ...orig.runs[0], srcPara: 0, srcRun: 0 }], // 'Hello' unchanged
+        },
+        {
+          align: orig.align,
+          srcPara: 0,
+          runs: [
+            { ...orig.runs[1], srcPara: 0, srcRun: 1 }, // NCR run, unchanged text
+            { text: '\n' }, // new break, no provenance
+            { text: ' spaced ' }, // new run, no provenance
+          ],
+        },
+      ],
+    }
+    const out = updateSlideXml(SLIDE_XML, [edit])
+
+    // Both halves reuse the original pPr and endParaRPr bytes.
+    expect(out.match(/<a:pPr algn="ctr"\/>/g)).toHaveLength(2)
+    expect(out.match(/<a:endParaRPr lang="en-US" dirty="0"\/>/g)).toHaveLength(2)
+    // The unchanged NCR run is copied verbatim — the entity byte form survives.
+    expect(out).toContain('<a:r><a:rPr lang="en-US" i="1"/><a:t>It&#8217;s</a:t></a:r>')
+    // The new break and the new run with edge whitespace.
+    expect(out).toContain('<a:br/>')
+    expect(out).toContain('<a:t xml:space="preserve"> spaced </a:t>')
+    // The dropped runs (original br + ' tail ') are gone.
+    expect(out).not.toContain('<a:t xml:space="preserve"> tail </a:t>')
+    // Outside the txBody nothing moved.
+    expect(out.startsWith('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n')).toBe(true)
+    expect(out).toContain('<a:t>A &amp; B &lt;kept&gt;</a:t>')
+
+    // And the result re-parses into the intended model.
+    const zip = new JSZip()
+    const src = await JSZip.loadAsync(await buildFixtureZip())
+    for (const [name, entry] of Object.entries(src.files)) {
+      if (!entry.dir) zip.file(name, await entry.async('uint8array'))
+    }
+    zip.file('ppt/slides/slide1.xml', out)
+    const deck2 = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+    const shape2 = deck2.slides[0].shapes[0] as TextShape
+    expect(shape2.paragraphs.map((p) => p.runs.map((r) => r.text))).toEqual([
+      ['Hello'],
+      ['It&#8217;s', '\n', ' spaced '],
+    ])
+    expect(shape2.paragraphs[0].runs[0].bold).toBe(true)
+  })
+})
+
+describe('writeDeck', () => {
+  it('copies every unedited entry byte-for-byte and rewrites only edited slides', async () => {
+    const input = await buildFixtureZip()
+    const { deck, title } = await loadDeck()
+    const out = await writeDeck(
+      deck,
+      new Map([['ppt/slides/slide1.xml', [textOnlyEdit(title, 'Changed')]]]),
+    )
+
+    const inZip = await JSZip.loadAsync(input)
+    const outZip = await JSZip.loadAsync(out)
+    const inNames = Object.keys(inZip.files).filter((n) => !inZip.files[n].dir).sort()
+    const outNames = Object.keys(outZip.files).filter((n) => !outZip.files[n].dir).sort()
+    expect(outNames).toEqual(inNames)
+
+    for (const name of inNames) {
+      const a = await inZip.files[name].async('uint8array')
+      const b = await outZip.files[name].async('uint8array')
+      if (name === 'ppt/slides/slide1.xml') {
+        expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false)
+      } else {
+        expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true)
+      }
+    }
+    expect(await outZip.files['ppt/slides/slide1.xml'].async('string')).toContain(
+      '<a:t>Changed</a:t>',
+    )
+  })
+
+  it('escapes user text and round-trips emoji and Devanagari through a full save', async () => {
+    const wild = 'A & B < C > "D" \'E\' 🚀 नमस्ते'
+    const { deck, title } = await loadDeck()
+    const out = await writeDeck(
+      deck,
+      new Map([['ppt/slides/slide1.xml', [textOnlyEdit(title, wild)]]]),
+    )
+
+    const raw = await (await JSZip.loadAsync(out)).files['ppt/slides/slide1.xml'].async('string')
+    expect(raw).toContain('<a:t>A &amp; B &lt; C &gt; "D" \'E\' 🚀 नमस्ते</a:t>')
+
+    const deck2 = await parsePptx(out)
+    const shape2 = deck2.slides[0].shapes[0] as TextShape
+    expect(shape2.paragraphs[0].runs[0].text).toBe(wild)
+  })
+
+  it('rejects edits that reference a slide the deck does not contain', async () => {
+    const { deck, title } = await loadDeck()
+    await expect(
+      writeDeck(deck, new Map([['ppt/slides/slide9.xml', [textOnlyEdit(title, 'x')]]])),
+    ).rejects.toThrow(/unknown slide/)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.test.ts
@@ -412,3 +412,98 @@ describe('writeDeck', () => {
     ).rejects.toThrow(/unknown slide/)
   })
 })
+
+// ------------------------------------------------- numeric character refs
+
+// fast-xml-parser decodes only the five named XML entities, so NCRs arrive as
+// literal text in BOTH element content and attributes.
+const NCR_SLIDE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  '<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"' +
+  ' xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+  '<p:cSld><p:spTree>' +
+  '<p:sp><p:nvSpPr><p:cNvPr id="2" name="NCR"/></p:nvSpPr>' +
+  '<p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="100" cy="200"/></a:xfrm></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:lstStyle/>' +
+  '<a:p><a:pPr marL="342900" indent="-342900"><a:buChar char="&#x2022;"/></a:pPr>' +
+  '<a:r><a:rPr lang="en-US"/><a:t>It&#8217;s a &#x2022; bullet</a:t></a:r>' +
+  '</a:p></p:txBody></p:sp>' +
+  '</p:spTree></p:cSld></p:sld>'
+
+async function loadNcrDeck() {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', NCR_SLIDE_XML)
+  const deck = await parsePptx(await zip.generateAsync({ type: 'uint8array' }))
+  return { deck, shape: deck.slides[0].shapes[0] as TextShape }
+}
+
+describe('numeric character references', () => {
+  it('models &#8217; and &#x2022; in run text as the real characters', async () => {
+    const { shape } = await loadNcrDeck()
+    expect(shape.paragraphs[0].runs[0].text).toBe('It’s a • bullet')
+  })
+
+  it('decodes an NCR in an attribute, so buChar resolves to a real bullet', async () => {
+    const { shape } = await loadNcrDeck()
+    expect(shape.display?.paragraphs[0].bullet).toEqual({ kind: 'char', char: '•' })
+  })
+
+  it('leaves an unedited write-back byte-identical', async () => {
+    expect(updateSlideXml(NCR_SLIDE_XML, [])).toBe(NCR_SLIDE_XML)
+
+    const { deck } = await loadNcrDeck()
+    const out = await writeDeck(deck, new Map())
+    const raw = await (await JSZip.loadAsync(out)).files['ppt/slides/slide1.xml'].async('string')
+    // The decoded model never leaks back out: the original NCR bytes survive.
+    expect(raw).toBe(NCR_SLIDE_XML)
+  })
+
+  it('keeps the validation derivation in step, so a text edit still splices in place', async () => {
+    const { shape } = await loadNcrDeck()
+    // The deep-equal check compares the decoded model against a derivation of
+    // the raw XML; if only one side decoded, this would fall back to a rebuild.
+    const edit: ShapeTextEdit = {
+      kind: 'text',
+      nodePath: shape.nodePath,
+      original: shape.paragraphs,
+      next: [{ align: shape.paragraphs[0].align, srcPara: 0, runs: [{ text: 'Prabal’s • text' }] }],
+    }
+    const out = updateSlideXml(NCR_SLIDE_XML, [edit])
+    // Only the a:t content moved; the pPr, the buChar NCR and the rPr are intact.
+    expect(out).toBe(
+      NCR_SLIDE_XML.replace(
+        '<a:t>It&#8217;s a &#x2022; bullet</a:t>',
+        '<a:t>Prabal’s • text</a:t>',
+      ),
+    )
+    expect(out).toContain('<a:buChar char="&#x2022;"/>')
+  })
+
+  it('re-encodes an edited run to valid XML that reparses to the same text', async () => {
+    const { deck, shape } = await loadNcrDeck()
+    const next = 'Ampersand & <angle> ’ • done'
+    const out = await writeDeck(
+      deck,
+      new Map([
+        [
+          'ppt/slides/slide1.xml',
+          [
+            {
+              kind: 'text',
+              nodePath: shape.nodePath,
+              original: shape.paragraphs,
+              next: [{ align: shape.paragraphs[0].align, srcPara: 0, runs: [{ text: next }] }],
+            } satisfies ShapeTextEdit,
+          ],
+        ],
+      ]),
+    )
+    const raw = await (await JSZip.loadAsync(out)).files['ppt/slides/slide1.xml'].async('string')
+    expect(raw).toContain('<a:t>Ampersand &amp; &lt;angle&gt; ’ • done</a:t>')
+
+    const shape2 = (await parsePptx(out)).slides[0].shapes[0] as TextShape
+    expect(shape2.paragraphs[0].runs[0].text).toBe(next)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -1000,6 +1000,7 @@ async function packageReplacements(
   zip: JSZip,
   deletions: readonly string[],
   adds: readonly NewSlidePart[],
+  order: readonly string[] | undefined,
 ): Promise<Map<string, string>> {
   const relsRaw = await requiredPart(zip, PRESENTATION_RELS_PATH)
   const relsRoot = childElementsIn(relsRaw, 0, relsRaw.length).find(
@@ -1098,9 +1099,9 @@ async function packageReplacements(
     }
   }
 
-  // ---- additions -----------------------------------------------------------
+  // ---- additions and reordering --------------------------------------------
 
-  if (adds.length > 0) {
+  if (adds.length > 0 || order !== undefined) {
     // New sldIds copy the anchor list's element prefix; the r: prefix comes
     // from whatever the root binds to the officeDocument relationship NS.
     const pPfx = prefixOf(sldIdLst.name)
@@ -1109,14 +1110,14 @@ async function packageReplacements(
       if (a.value === OFFICE_REL_NS && a.name.startsWith('xmlns:')) rPfx = a.name.slice(6)
     }
 
-    // The new part must be typed like the slides already in the package.
+    // A new part must be typed like the slides already in the package.
     const slideOverride = overrides.find((e) =>
       (rawAttrOf(openTagInfo(typesRaw, e), 'PartName') ?? '').startsWith('/ppt/slides/'),
     )
     const slideContentType = slideOverride
       ? rawAttrOf(openTagInfo(typesRaw, slideOverride), 'ContentType')
       : undefined
-    if (!slideContentType) {
+    if (adds.length > 0 && !slideContentType) {
       fail('no existing slide Override in [Content_Types].xml to type the new slide after')
     }
 
@@ -1126,58 +1127,135 @@ async function packageReplacements(
       if (Number.isFinite(n)) nextSldIdNum = Math.max(nextSldIdNum, n)
     }
 
-    const addsByAnchor = new Map<string, NewSlidePart[]>()
-    for (const a of adds) {
-      const list = addsByAnchor.get(a.afterPath) ?? []
-      list.push(a)
-      addsByAnchor.set(a.afterPath, list)
-    }
-
-    // Insertion offsets group by the nearest BASE anchor (an added anchor
-    // shares its parent's offset and simply follows it in the group), so each
-    // offset gets ONE insert op with the chain concatenated in order.
-    const groups = new Map<number, string[]>()
     const relInserts: string[] = []
     const typeInserts: string[] = []
-    const placed = new Set<string>()
-    const emit = (anchorPath: string, offset: number): void => {
-      for (const a of addsByAnchor.get(anchorPath) ?? []) {
-        if (placed.has(a.path)) fail(`added slide ${a.path} appears twice`)
-        placed.add(a.path)
-        const rId = `rId${++maxRelNum}`
-        const sldTag = pPfx ? `${pPfx}:sldId` : 'sldId'
-        const rAttr = rPfx ? `${rPfx}:id` : 'id'
-        const group = groups.get(offset) ?? []
-        group.push(`<${sldTag} id="${++nextSldIdNum}" ${rAttr}="${rId}"/>`)
-        groups.set(offset, group)
-        if (!a.path.startsWith('ppt/')) fail(`unexpected added slide location ${a.path}`)
-        relInserts.push(
-          `<Relationship Id="${rId}" Type="${OFFICE_REL_NS}/slide" Target="${a.path.slice(4)}"/>`,
-        )
-        typeInserts.push(`<Override PartName="/${a.path}" ContentType="${slideContentType}"/>`)
-        emit(a.path, offset)
-      }
-    }
-    emit('', sldIdLst.contentStart)
-    for (const [slidePath, rId] of rIdBySlidePath) {
-      if (!addsByAnchor.has(slidePath)) continue
-      const anchor = sldIds.find((e) => rawPrefixedAttrOf(openTagInfo(presRaw, e), 'id') === rId)
-      if (!anchor) fail(`anchor slide ${slidePath} has no p:sldId`)
-      emit(slidePath, anchor.end)
-    }
-    for (const a of adds) {
-      if (!placed.has(a.path)) fail(`added slide ${a.path} has an unknown anchor ${a.afterPath}`)
+    /** Mints one added slide's sldId element, recording its rel and Override. */
+    const mint = (a: NewSlidePart): string => {
+      if (!a.path.startsWith('ppt/')) fail(`unexpected added slide location ${a.path}`)
+      const rId = `rId${++maxRelNum}`
+      relInserts.push(
+        `<Relationship Id="${rId}" Type="${OFFICE_REL_NS}/slide" Target="${a.path.slice(4)}"/>`,
+      )
+      typeInserts.push(`<Override PartName="/${a.path}" ContentType="${slideContentType}"/>`)
+      const sldTag = pPfx ? `${pPfx}:sldId` : 'sldId'
+      const rAttr = rPfx ? `${rPfx}:id` : 'id'
+      return `<${sldTag} id="${++nextSldIdNum}" ${rAttr}="${rId}"/>`
     }
 
-    for (const [offset, inserts] of groups) {
-      presOps.push({ start: offset, end: offset, insert: inserts.join('') })
+    if (order === undefined) {
+      // No explicit order: place each add after its anchor. Insertion offsets
+      // group by the nearest BASE anchor (an added anchor shares its parent's
+      // offset and simply follows it), so each offset gets ONE insert op with
+      // the chain concatenated in order.
+      const addsByAnchor = new Map<string, NewSlidePart[]>()
+      for (const a of adds) {
+        const list = addsByAnchor.get(a.afterPath) ?? []
+        list.push(a)
+        addsByAnchor.set(a.afterPath, list)
+      }
+      const groups = new Map<number, string[]>()
+      const placed = new Set<string>()
+      const emit = (anchorPath: string, offset: number): void => {
+        for (const a of addsByAnchor.get(anchorPath) ?? []) {
+          if (placed.has(a.path)) fail(`added slide ${a.path} appears twice`)
+          placed.add(a.path)
+          const group = groups.get(offset) ?? []
+          group.push(mint(a))
+          groups.set(offset, group)
+          emit(a.path, offset)
+        }
+      }
+      emit('', sldIdLst.contentStart)
+      for (const [slidePath, rId] of rIdBySlidePath) {
+        if (!addsByAnchor.has(slidePath)) continue
+        const anchor = sldIds.find((e) => rawPrefixedAttrOf(openTagInfo(presRaw, e), 'id') === rId)
+        if (!anchor) fail(`anchor slide ${slidePath} has no p:sldId`)
+        emit(slidePath, anchor.end)
+      }
+      for (const a of adds) {
+        if (!placed.has(a.path)) fail(`added slide ${a.path} has an unknown anchor ${a.afterPath}`)
+      }
+      for (const [offset, inserts] of groups) {
+        presOps.push({ start: offset, end: offset, insert: inserts.join('') })
+      }
+    } else {
+      // Explicit order: the surviving p:sldId elements are SLOTS, and the
+      // order decides which element's bytes occupy each one. Reordering is
+      // therefore a permutation of exact element slices — every element keeps
+      // its own bytes (and its id/r:id), and the whitespace BETWEEN slots is
+      // never touched, because each op replaces exactly one element's range.
+      const deletedSet = new Set(deletions)
+      const survivorSlots: Array<{ path: string; elem: Elem }> = []
+      for (const [slidePath, rId] of rIdBySlidePath) {
+        if (deletedSet.has(slidePath)) continue
+        const elem = sldIds.find((e) => rawPrefixedAttrOf(openTagInfo(presRaw, e), 'id') === rId)
+        if (!elem) fail(`slide ${slidePath} has no p:sldId`)
+        survivorSlots.push({ path: slidePath, elem })
+      }
+      survivorSlots.sort((a, b) => a.elem.start - b.elem.start)
+      const bytesOfBase = new Map(
+        survivorSlots.map((s) => [s.path, presRaw.slice(s.elem.start, s.elem.end)]),
+      )
+
+      // The order must be an exact permutation of survivors + adds.
+      const addPaths = adds.map((a) => a.path)
+      const expected = [...survivorSlots.map((s) => s.path), ...addPaths]
+      const seen = new Set<string>()
+      for (const p of order) {
+        if (seen.has(p)) fail(`slide order lists ${p} more than once`)
+        seen.add(p)
+      }
+      if (order.length !== expected.length || expected.some((p) => !seen.has(p))) {
+        fail(
+          `slide order must be an exact permutation of the ${expected.length} surviving and added ` +
+            `slides (got ${order.length})`,
+        )
+      }
+
+      // Walk the order, filling one slot per base slide and folding any adds
+      // that follow it into the SAME op. Folding rather than emitting separate
+      // zero-length inserts is what keeps ops from colliding at a slot
+      // boundary, which applySplices would (correctly) reject as overlapping.
+      const addByPath = new Map(adds.map((a) => [a.path, a]))
+      const fills: string[] = survivorSlots.map(() => '')
+      let slotIdx = -1
+      let leading = ''
+      for (const p of order) {
+        const add = addByPath.get(p)
+        if (add) {
+          const xml = mint(add)
+          if (slotIdx < 0) leading += xml
+          else fills[slotIdx] += xml
+          continue
+        }
+        slotIdx += 1
+        const bytes = bytesOfBase.get(p) ?? fail(`slide order references unknown slide ${p}`)
+        fills[slotIdx] = bytes + fills[slotIdx]
+      }
+      fills[0] = leading + fills[0]
+
+      for (let i = 0; i < survivorSlots.length; i++) {
+        const slot = survivorSlots[i]
+        const original = presRaw.slice(slot.elem.start, slot.elem.end)
+        // Unchanged slots emit nothing, so an order equal to the document
+        // order leaves presentation.xml byte-identical.
+        if (fills[i] === original) continue
+        presOps.push({ start: slot.elem.start, end: slot.elem.end, insert: fills[i] })
+      }
     }
-    relOps.push({ start: relsRoot.contentEnd, end: relsRoot.contentEnd, insert: relInserts.join('') })
-    typeOps.push({
-      start: typesRoot.contentEnd,
-      end: typesRoot.contentEnd,
-      insert: typeInserts.join(''),
-    })
+
+    if (relInserts.length > 0) {
+      relOps.push({
+        start: relsRoot.contentEnd,
+        end: relsRoot.contentEnd,
+        insert: relInserts.join(''),
+      })
+      typeOps.push({
+        start: typesRoot.contentEnd,
+        end: typesRoot.contentEnd,
+        insert: typeInserts.join(''),
+      })
+    }
   }
 
   const replacements = new Map<string, string>()
@@ -1203,6 +1281,13 @@ export interface WriteDeckOptions {
    * path apply against its synthesized XML.
    */
   addSlides?: readonly NewSlidePart[]
+  /**
+   * Explicit final slide order as part paths. Must be an exact permutation of
+   * the surviving slides plus `addSlides`. When given it governs `sldIdLst`
+   * placement (existing elements are moved, added ones inserted at their
+   * positions) and `addSlides[].afterPath` is ignored.
+   */
+  slideOrder?: readonly string[]
 }
 
 /**
@@ -1247,17 +1332,21 @@ export async function writeDeck(
     if (deleted.has(a.afterPath)) {
       fail(`added slide ${a.path} is anchored to ${a.afterPath}, which is being deleted`)
     }
+    // With an explicit order the anchor no longer places anything, so it only
+    // has to be meaningful when there is no order.
     const anchorKnown =
+      options?.slideOrder !== undefined ||
       a.afterPath === '' ||
       deck.source.slideXml[a.afterPath] !== undefined ||
       addByPath.has(a.afterPath)
     if (!anchorKnown) fail(`added slide ${a.path} has an unknown anchor ${a.afterPath}`)
   }
 
+  const order = options?.slideOrder
   const removedParts = new Set(deletions.flatMap((p) => [p, relsPathFor(p)]))
   const replacements =
-    deletions.length > 0 || adds.length > 0
-      ? await packageReplacements(deck.source.zip, deletions, adds)
+    deletions.length > 0 || adds.length > 0 || order !== undefined
+      ? await packageReplacements(deck.source.zip, deletions, adds, order)
       : new Map<string, string>()
 
   const out = new JSZip()

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -942,11 +942,24 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[])
   return applySplices(slideXmlRaw, ops)
 }
 
-// ------------------------------------------------------------ slide deletion
+// ------------------------------------------- slide addition / deletion
 
 const PRESENTATION_PATH = 'ppt/presentation.xml'
 const PRESENTATION_RELS_PATH = 'ppt/_rels/presentation.xml.rels'
 const CONTENT_TYPES_PATH = '[Content_Types].xml'
+const OFFICE_REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+/** A synthesized slide to add to the package (see lib/pptx/add-slide.ts). */
+export interface NewSlidePart {
+  /** New part path; must not collide with any existing entry. */
+  path: string
+  /** Complete slide XML; slide edits addressed at `path` apply on top of it. */
+  xml: string
+  /** Complete .rels for the part. */
+  relsXml: string
+  /** Existing or previously-added slide this one follows; '' = deck front. */
+  afterPath: string
+}
 
 /** Attribute value from a scanned open tag, by exact raw name. */
 function rawAttrOf(info: OpenTagInfo, name: string): string | undefined {
@@ -969,30 +982,51 @@ async function requiredPart(zip: JSZip, path: string): Promise<string> {
 }
 
 /**
- * The three package-part rewrites a slide deletion forces, computed as element
- * -range splices so every byte outside the removed elements is untouched:
+ * The three package-part rewrites slide addition and deletion force, computed
+ * as element-range splices (removals) and point insertions so every byte
+ * outside the touched elements is untouched:
  *
- *  - `ppt/_rels/presentation.xml.rels`: the slide's `<Relationship>` goes, and
- *    resolving its Target is how the slide's `r:id` is found in the first place;
- *  - `ppt/presentation.xml`: the `<p:sldId>` carrying that `r:id` goes;
- *  - `[Content_Types].xml`: the slide's per-part `<Override>` goes when one
- *    exists; a package typed some other way is left alone.
+ *  - `ppt/_rels/presentation.xml.rels`: a deleted slide's `<Relationship>`
+ *    goes (resolving its Target is how the slide's `r:id` is found); an added
+ *    slide appends one with a freshly assigned unique `rId`;
+ *  - `ppt/presentation.xml`: the `<p:sldId>` carrying that `r:id` goes /
+ *    a new one is inserted right after its anchor's, with a unique numeric id;
+ *  - `[Content_Types].xml`: the per-part `<Override>` goes when one exists /
+ *    a new one is appended, typed like the existing slide Overrides.
  *
  * Every lookup must resolve to exactly one element or the save fails closed.
  */
-async function slideRemovalReplacements(
+async function packageReplacements(
   zip: JSZip,
   deletions: readonly string[],
+  adds: readonly NewSlidePart[],
 ): Promise<Map<string, string>> {
   const relsRaw = await requiredPart(zip, PRESENTATION_RELS_PATH)
   const relsRoot = childElementsIn(relsRaw, 0, relsRaw.length).find(
     (e) => localOf(e.name) === 'Relationships',
   )
   if (!relsRoot) fail(`no <Relationships> element in ${PRESENTATION_RELS_PATH}`)
+  if (relsRoot.selfClosing) fail(`empty <Relationships/> in ${PRESENTATION_RELS_PATH}`)
   const relElems = childElemsOf(relsRaw, relsRoot).filter((e) => localOf(e.name) === 'Relationship')
 
+  /** Slide part path -> its relationship's rId, for every slide Relationship. */
+  const rIdBySlidePath = new Map<string, string>()
+  let maxRelNum = 0
+  for (const e of relElems) {
+    const info = openTagInfo(relsRaw, e)
+    const rId = rawAttrOf(info, 'Id')
+    if (!rId) continue
+    const m = rId.match(/^rId(\d+)$/)
+    if (m) maxRelNum = Math.max(maxRelNum, Number(m[1]))
+    const target = rawAttrOf(info, 'Target')
+    const type = rawAttrOf(info, 'Type') ?? ''
+    if (target !== undefined && type.endsWith('/slide')) {
+      rIdBySlidePath.set(resolveRelTarget('ppt', target), rId)
+    }
+  }
+
   const relOps: SpliceOp[] = []
-  const rIds: string[] = []
+  const deletedRIds: string[] = []
   for (const slidePath of deletions) {
     const matches = relElems.filter((e) => {
       const info = openTagInfo(relsRaw, e)
@@ -1008,7 +1042,7 @@ async function slideRemovalReplacements(
       fail(`expected exactly one slide relationship for ${slidePath}, found ${matches.length}`)
     }
     const rId = rawAttrOf(openTagInfo(relsRaw, matches[0]), 'Id') ?? fail('slide relationship has no Id')
-    rIds.push(rId)
+    deletedRIds.push(rId)
     relOps.push({ start: matches[0].start, end: matches[0].end, insert: '' })
   }
 
@@ -1018,10 +1052,13 @@ async function slideRemovalReplacements(
   )
   if (!presRoot) fail('no <p:presentation> element in presentation.xml')
   const sldIdLst = childElemByLocal(presRaw, presRoot, 'sldIdLst') ?? fail('presentation.xml has no sldIdLst')
-  const sldIds = childElemsOf(presRaw, sldIdLst).filter((e) => localOf(e.name) === 'sldId')
+  if (adds.length > 0 && sldIdLst.selfClosing) fail('presentation.xml has an empty <p:sldIdLst/>')
+  const sldIds = sldIdLst.selfClosing
+    ? []
+    : childElemsOf(presRaw, sldIdLst).filter((e) => localOf(e.name) === 'sldId')
 
   const presOps: SpliceOp[] = []
-  for (const rId of rIds) {
+  for (const rId of deletedRIds) {
     const matches = sldIds.filter((e) => rawPrefixedAttrOf(openTagInfo(presRaw, e), 'id') === rId)
     if (matches.length !== 1) {
       fail(`expected exactly one p:sldId with r:id ${rId}, found ${matches.length}`)
@@ -1045,6 +1082,7 @@ async function slideRemovalReplacements(
     (e) => localOf(e.name) === 'Types',
   )
   if (!typesRoot) fail('no <Types> element in [Content_Types].xml')
+  if (typesRoot.selfClosing) fail('empty <Types/> in [Content_Types].xml')
   const overrides = childElemsOf(typesRaw, typesRoot).filter((e) => localOf(e.name) === 'Override')
 
   const typeOps: SpliceOp[] = []
@@ -1058,6 +1096,88 @@ async function slideRemovalReplacements(
     if (matches.length === 1) {
       typeOps.push({ start: matches[0].start, end: matches[0].end, insert: '' })
     }
+  }
+
+  // ---- additions -----------------------------------------------------------
+
+  if (adds.length > 0) {
+    // New sldIds copy the anchor list's element prefix; the r: prefix comes
+    // from whatever the root binds to the officeDocument relationship NS.
+    const pPfx = prefixOf(sldIdLst.name)
+    let rPfx = 'r'
+    for (const a of openTagInfo(presRaw, presRoot).attrs) {
+      if (a.value === OFFICE_REL_NS && a.name.startsWith('xmlns:')) rPfx = a.name.slice(6)
+    }
+
+    // The new part must be typed like the slides already in the package.
+    const slideOverride = overrides.find((e) =>
+      (rawAttrOf(openTagInfo(typesRaw, e), 'PartName') ?? '').startsWith('/ppt/slides/'),
+    )
+    const slideContentType = slideOverride
+      ? rawAttrOf(openTagInfo(typesRaw, slideOverride), 'ContentType')
+      : undefined
+    if (!slideContentType) {
+      fail('no existing slide Override in [Content_Types].xml to type the new slide after')
+    }
+
+    let nextSldIdNum = 255
+    for (const e of sldIds) {
+      const n = Number(rawAttrOf(openTagInfo(presRaw, e), 'id'))
+      if (Number.isFinite(n)) nextSldIdNum = Math.max(nextSldIdNum, n)
+    }
+
+    const addsByAnchor = new Map<string, NewSlidePart[]>()
+    for (const a of adds) {
+      const list = addsByAnchor.get(a.afterPath) ?? []
+      list.push(a)
+      addsByAnchor.set(a.afterPath, list)
+    }
+
+    // Insertion offsets group by the nearest BASE anchor (an added anchor
+    // shares its parent's offset and simply follows it in the group), so each
+    // offset gets ONE insert op with the chain concatenated in order.
+    const groups = new Map<number, string[]>()
+    const relInserts: string[] = []
+    const typeInserts: string[] = []
+    const placed = new Set<string>()
+    const emit = (anchorPath: string, offset: number): void => {
+      for (const a of addsByAnchor.get(anchorPath) ?? []) {
+        if (placed.has(a.path)) fail(`added slide ${a.path} appears twice`)
+        placed.add(a.path)
+        const rId = `rId${++maxRelNum}`
+        const sldTag = pPfx ? `${pPfx}:sldId` : 'sldId'
+        const rAttr = rPfx ? `${rPfx}:id` : 'id'
+        const group = groups.get(offset) ?? []
+        group.push(`<${sldTag} id="${++nextSldIdNum}" ${rAttr}="${rId}"/>`)
+        groups.set(offset, group)
+        if (!a.path.startsWith('ppt/')) fail(`unexpected added slide location ${a.path}`)
+        relInserts.push(
+          `<Relationship Id="${rId}" Type="${OFFICE_REL_NS}/slide" Target="${a.path.slice(4)}"/>`,
+        )
+        typeInserts.push(`<Override PartName="/${a.path}" ContentType="${slideContentType}"/>`)
+        emit(a.path, offset)
+      }
+    }
+    emit('', sldIdLst.contentStart)
+    for (const [slidePath, rId] of rIdBySlidePath) {
+      if (!addsByAnchor.has(slidePath)) continue
+      const anchor = sldIds.find((e) => rawPrefixedAttrOf(openTagInfo(presRaw, e), 'id') === rId)
+      if (!anchor) fail(`anchor slide ${slidePath} has no p:sldId`)
+      emit(slidePath, anchor.end)
+    }
+    for (const a of adds) {
+      if (!placed.has(a.path)) fail(`added slide ${a.path} has an unknown anchor ${a.afterPath}`)
+    }
+
+    for (const [offset, inserts] of groups) {
+      presOps.push({ start: offset, end: offset, insert: inserts.join('') })
+    }
+    relOps.push({ start: relsRoot.contentEnd, end: relsRoot.contentEnd, insert: relInserts.join('') })
+    typeOps.push({
+      start: typesRoot.contentEnd,
+      end: typesRoot.contentEnd,
+      insert: typeInserts.join(''),
+    })
   }
 
   const replacements = new Map<string, string>()
@@ -1077,6 +1197,12 @@ export interface WriteDeckOptions {
    * slide stays in the package — orphaned media is valid OOXML.
    */
   deleteSlides?: readonly string[]
+  /**
+   * Synthesized slides to add, in order. Each contributes its part + .rels and
+   * an inserted sldId / Relationship / Override; edits addressed at an added
+   * path apply against its synthesized XML.
+   */
+  addSlides?: readonly NewSlidePart[]
 }
 
 /**
@@ -1089,8 +1215,12 @@ export async function writeDeck(
   editsBySlide: ReadonlyMap<string, readonly SlideEdit[]>,
   options?: WriteDeckOptions,
 ): Promise<Uint8Array> {
+  const adds = options?.addSlides ?? []
+  const addByPath = new Map(adds.map((a) => [a.path, a]))
+  if (addByPath.size !== adds.length) fail('duplicate added slide paths')
+
   for (const slidePath of editsBySlide.keys()) {
-    if (deck.source.slideXml[slidePath] === undefined) {
+    if (deck.source.slideXml[slidePath] === undefined && !addByPath.has(slidePath)) {
       fail(`edits reference unknown slide ${slidePath}`)
     }
   }
@@ -1108,10 +1238,26 @@ export async function writeDeck(
     fail('cannot delete every slide in the deck')
   }
 
+  const deleted = new Set(deletions)
+  for (const a of adds) {
+    if (deck.source.zip.file(a.path) || deck.source.slideXml[a.path] !== undefined) {
+      fail(`added slide ${a.path} collides with an existing part`)
+    }
+    if (deleted.has(a.path)) fail(`added slide ${a.path} is also marked deleted`)
+    if (deleted.has(a.afterPath)) {
+      fail(`added slide ${a.path} is anchored to ${a.afterPath}, which is being deleted`)
+    }
+    const anchorKnown =
+      a.afterPath === '' ||
+      deck.source.slideXml[a.afterPath] !== undefined ||
+      addByPath.has(a.afterPath)
+    if (!anchorKnown) fail(`added slide ${a.path} has an unknown anchor ${a.afterPath}`)
+  }
+
   const removedParts = new Set(deletions.flatMap((p) => [p, relsPathFor(p)]))
   const replacements =
-    deletions.length > 0
-      ? await slideRemovalReplacements(deck.source.zip, deletions)
+    deletions.length > 0 || adds.length > 0
+      ? await packageReplacements(deck.source.zip, deletions, adds)
       : new Map<string, string>()
 
   const out = new JSZip()
@@ -1135,6 +1281,15 @@ export async function writeDeck(
     } else {
       out.file(name, await entry.async('uint8array'), { ...meta, binary: true })
     }
+  }
+  // Added slides: brand-new parts, with any of their own edits applied against
+  // the synthesized XML they were parsed from.
+  for (const a of adds) {
+    const edits = editsBySlide.get(a.path)
+    out.file(a.path, edits && edits.length > 0 ? updateSlideXml(a.xml, edits) : a.xml, {
+      createFolders: false,
+    })
+    out.file(relsPathFor(a.path), a.relsXml, { createFolders: false })
   }
   return out.generateAsync({
     type: 'uint8array',

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -1,0 +1,550 @@
+/**
+ * Surgical write-back for text edits.
+ *
+ * The invariant this module exists to uphold: saving can NEVER corrupt or lose
+ * content the editor doesn't understand. fast-xml-parser's XMLBuilder cannot
+ * re-serialize losslessly (measured: it drops the CRLF after the XML
+ * declaration, normalizes every empty element to one form, and re-escapes the
+ * `&` of numeric character references it never decoded, so `&#8217;` in an
+ * UNTOUCHED run becomes `&amp;#8217;` — silent corruption). It also exposes no
+ * node byte positions.
+ *
+ * So instead of rebuilding documents, edits are applied as string splices on
+ * the retained raw XML. A small quote-aware scanner locates byte ranges; its
+ * view of the document is cross-validated against the fast-xml-parser tree the
+ * model came from, and any disagreement throws — the save fails closed and the
+ * file on disk is untouched.
+ *
+ * Two write strategies per edited shape:
+ *  - text-only (paragraph/run structure unchanged): splice each changed run's
+ *    `<a:t>` content in place. Nothing else in the file moves.
+ *  - structural (paragraphs/runs added, removed, split): rebuild only the
+ *    `<a:p>…</a:p>` region of that shape's txBody, reusing the original bytes
+ *    of every pPr/endParaRPr/rPr — and of every unchanged run — verbatim via
+ *    the srcPara/srcRun provenance the editor stamps on committed runs.
+ */
+
+import JSZip from 'jszip'
+import {
+  childrenOf,
+  parseParagraph,
+  parseXml,
+  resolveNodePath,
+  tagNameOf,
+  type XmlNode,
+} from './parse'
+import type { NodePath, Paragraph, SlideDeck, TextAlign, TextRun } from './types'
+
+// ------------------------------------------------------------------- types
+
+/** A committed run, optionally anchored to the run it derives from. */
+export interface EditedTextRun extends TextRun {
+  /** Index into the ORIGINAL (as-parsed) paragraphs of this shape. */
+  srcPara?: number
+  /** Index into that original paragraph's runs. */
+  srcRun?: number
+}
+
+export interface EditedParagraph {
+  align?: TextAlign
+  runs: EditedTextRun[]
+  srcPara?: number
+}
+
+export interface ShapeTextEdit {
+  /** The shape's node path, from the parsed model. */
+  nodePath: NodePath
+  /** The shape's paragraphs as originally parsed from the retained XML. */
+  original: Paragraph[]
+  /** The committed replacement. */
+  next: EditedParagraph[]
+}
+
+// -------------------------------------------------------------- normalizing
+
+/**
+ * Canonical, comparison-safe form of a paragraph list: provenance stripped,
+ * absent flags dropped. Used for equality checks here and by the editor.
+ */
+export function normalizeParagraphs(paras: readonly Paragraph[]): string {
+  return JSON.stringify(
+    paras.map((p) => ({
+      align: p.align,
+      runs: p.runs.map((r) => ({
+        text: r.text,
+        bold: r.bold || undefined,
+        italic: r.italic || undefined,
+        underline: r.underline || undefined,
+        sizePt: r.sizePt,
+        colorHex: r.colorHex,
+      })),
+    })),
+  )
+}
+
+function runPropsEqual(a: TextRun, b: TextRun): boolean {
+  return (
+    Boolean(a.bold) === Boolean(b.bold) &&
+    Boolean(a.italic) === Boolean(b.italic) &&
+    Boolean(a.underline) === Boolean(b.underline) &&
+    a.sizePt === b.sizePt &&
+    a.colorHex === b.colorHex
+  )
+}
+
+// ------------------------------------------------------------------ escaping
+
+/** Escapes text for XML element content. Quotes stay literal, as Office writes them. */
+function escapeXmlText(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    // Characters invalid in XML 1.0 (contentEditable can leak controls).
+    // eslint-disable-next-line no-control-regex -- stripping them is the point
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g, '')
+}
+
+// ------------------------------------------------------- raw XML scanning
+
+/**
+ * Byte ranges of one element in the raw string. `start` is the index of `<`;
+ * `end` is the index just past the final `>` (of the close tag, or of the
+ * self-closing tag itself).
+ */
+interface Elem {
+  name: string
+  start: number
+  end: number
+  selfClosing: boolean
+  /** Content bounds; -1/-1 when self-closing. */
+  contentStart: number
+  contentEnd: number
+}
+
+function fail(msg: string): never {
+  throw new Error(`pptx write-back: ${msg}`)
+}
+
+const localOf = (name: string): string => {
+  const i = name.indexOf(':')
+  return i >= 0 ? name.slice(i + 1) : name
+}
+
+const prefixOf = (name: string): string => {
+  const i = name.indexOf(':')
+  return i >= 0 ? name.slice(0, i) : ''
+}
+
+/** Finds the `>` ending the tag opened at `lt`, respecting quoted attributes. */
+function scanTagEnd(s: string, lt: number): { gt: number; selfClosing: boolean } {
+  let quote: string | null = null
+  for (let i = lt + 1; i < s.length; i++) {
+    const c = s[i]
+    if (quote) {
+      if (c === quote) quote = null
+    } else if (c === '"' || c === "'") {
+      quote = c
+    } else if (c === '>') {
+      return { gt: i, selfClosing: s[i - 1] === '/' }
+    }
+  }
+  fail('unterminated tag')
+}
+
+/** If `lt` starts a comment/CDATA/PI/doctype, returns the index just past it. */
+function skipSpecial(s: string, lt: number): number | null {
+  if (s.startsWith('<!--', lt)) {
+    const e = s.indexOf('-->', lt + 4)
+    if (e < 0) fail('unterminated comment')
+    return e + 3
+  }
+  if (s.startsWith('<![CDATA[', lt)) {
+    const e = s.indexOf(']]>', lt + 9)
+    if (e < 0) fail('unterminated CDATA')
+    return e + 3
+  }
+  if (s.startsWith('<?', lt)) {
+    const e = s.indexOf('?>', lt + 2)
+    if (e < 0) fail('unterminated processing instruction')
+    return e + 2
+  }
+  if (s.startsWith('<!', lt)) return scanTagEnd(s, lt).gt + 1
+  return null
+}
+
+function tagNameAt(s: string, lt: number): string {
+  let i = lt + 1
+  if (s[i] === '/') i++
+  let j = i
+  while (j < s.length && !' \t\r\n/>'.includes(s[j])) j++
+  return s.slice(i, j)
+}
+
+/** Reads the full element whose `<` is at `lt`, including all descendants. */
+function readElementAt(s: string, lt: number): Elem {
+  const name = tagNameAt(s, lt)
+  const open = scanTagEnd(s, lt)
+  if (open.selfClosing) {
+    return { name, start: lt, end: open.gt + 1, selfClosing: true, contentStart: -1, contentEnd: -1 }
+  }
+  const contentStart = open.gt + 1
+  let depth = 1
+  let i = contentStart
+  while (i < s.length) {
+    const next = s.indexOf('<', i)
+    if (next < 0) break
+    const special = skipSpecial(s, next)
+    if (special !== null) {
+      i = special
+      continue
+    }
+    const tag = scanTagEnd(s, next)
+    if (s[next + 1] === '/') {
+      depth--
+      if (depth === 0) {
+        return { name, start: lt, end: tag.gt + 1, selfClosing: false, contentStart, contentEnd: next }
+      }
+    } else if (!tag.selfClosing) {
+      depth++
+    }
+    i = tag.gt + 1
+  }
+  fail(`unterminated <${name}>`)
+}
+
+/** Direct child elements within a content window, in document order. */
+function childElementsIn(s: string, from: number, to: number): Elem[] {
+  const out: Elem[] = []
+  let i = from
+  while (i >= 0 && i < to) {
+    const lt = s.indexOf('<', i)
+    if (lt < 0 || lt >= to) break
+    const special = skipSpecial(s, lt)
+    if (special !== null) {
+      i = special
+      continue
+    }
+    if (s[lt + 1] === '/') break // parent's close tag — window bounds are wrong
+    const el = readElementAt(s, lt)
+    out.push(el)
+    i = el.end
+  }
+  return out
+}
+
+const childElemsOf = (s: string, el: Elem): Elem[] =>
+  el.selfClosing ? [] : childElementsIn(s, el.contentStart, el.contentEnd)
+
+const childElemByLocal = (s: string, el: Elem, name: string): Elem | undefined =>
+  childElemsOf(s, el).find((c) => localOf(c.name) === name)
+
+// ------------------------------------------- raw shape structure extraction
+
+interface RawRunItem {
+  kind: 'r' | 'fld' | 'br'
+  elem: Elem
+  rPr?: Elem
+  /** Present (and non-empty) for kept r/fld items. */
+  t?: Elem
+}
+
+interface RawParagraph {
+  elem: Elem
+  prefix: string
+  pPr?: Elem
+  endParaRPr?: Elem
+  /** Kept items only, mirroring the model's skip rule (empty runs dropped). */
+  items: RawRunItem[]
+}
+
+function rawParagraphsOf(s: string, txBody: Elem): RawParagraph[] {
+  const out: RawParagraph[] = []
+  for (const p of childElemsOf(s, txBody)) {
+    if (localOf(p.name) !== 'p') continue
+    const para: RawParagraph = { elem: p, prefix: prefixOf(p.name), items: [] }
+    for (const kid of childElemsOf(s, p)) {
+      const name = localOf(kid.name)
+      if (name === 'pPr') para.pPr = kid
+      else if (name === 'endParaRPr') para.endParaRPr = kid
+      else if (name === 'br') para.items.push({ kind: 'br', elem: kid })
+      else if (name === 'r' || name === 'fld') {
+        const t = childElemByLocal(s, kid, 't')
+        // The model skips runs whose text is empty; mirror it exactly so
+        // model index k always pairs with kept item k.
+        if (!t || t.selfClosing || t.contentEnd <= t.contentStart) continue
+        para.items.push({ kind: name, elem: kid, rPr: childElemByLocal(s, kid, 'rPr'), t })
+      }
+    }
+    out.push(para)
+  }
+  return out
+}
+
+// --------------------------------------------------------- model utilities
+
+function fxpChildByLocal(nodes: XmlNode[], name: string): XmlNode | undefined {
+  return nodes.find((n) => {
+    const t = tagNameOf(n)
+    return t !== null && localOf(t) === name
+  })
+}
+
+/** Model paragraphs of a `p:sp` node, by the exact rules the parser used. */
+function modelParagraphsOfSp(sp: XmlNode): Paragraph[] | null {
+  const txBody = fxpChildByLocal(childrenOf(sp), 'txBody')
+  if (!txBody) return null
+  return childrenOf(txBody)
+    .filter((n) => {
+      const t = tagNameOf(n)
+      return t !== null && localOf(t) === 'p'
+    })
+    .map(parseParagraph)
+}
+
+const isBr = (r: TextRun): boolean => r.text === '\n'
+
+/**
+ * True when the edit changes no paragraph/run structure — only text inside
+ * existing runs — so it can be applied as in-place `<a:t>` splices.
+ */
+function isTextOnlyEdit(original: Paragraph[], next: EditedParagraph[]): boolean {
+  if (original.length !== next.length) return false
+  for (let i = 0; i < original.length; i++) {
+    const o = original[i]
+    const n = next[i]
+    if ((o.align ?? null) !== (n.align ?? null)) return false
+    if (o.runs.length !== n.runs.length) return false
+    for (let j = 0; j < o.runs.length; j++) {
+      const or = o.runs[j]
+      const nr = n.runs[j]
+      if (isBr(or) !== isBr(nr)) return false
+      // A newline inside replacement text means new <a:br/> structure.
+      if (!isBr(nr) && nr.text.includes('\n')) return false
+      if (!runPropsEqual(or, nr)) return false
+    }
+  }
+  return true
+}
+
+// ------------------------------------------------------------------ splicing
+
+interface SpliceOp {
+  start: number
+  end: number
+  insert: string
+}
+
+function applySplices(s: string, ops: SpliceOp[]): string {
+  const sorted = [...ops].sort((a, b) => b.start - a.start)
+  let out = s
+  let lastStart = Infinity
+  for (const op of sorted) {
+    if (op.end > lastStart) fail('internal error: overlapping splices')
+    lastStart = op.start
+    out = out.slice(0, op.start) + op.insert + out.slice(op.end)
+  }
+  return out
+}
+
+// --------------------------------------------------------------- rebuilding
+
+/** `<a:t>` open tag, adding xml:space when edge whitespace must survive. */
+function tOpen(tag: (n: string) => string, seg: string): string {
+  const preserve = /^\s|\s$/.test(seg) ? ' xml:space="preserve"' : ''
+  return `<${tag('t')}${preserve}>`
+}
+
+function rebuildParagraphs(
+  s: string,
+  rawParas: RawParagraph[],
+  original: Paragraph[],
+  next: EditedParagraph[],
+): string {
+  const prefix = rawParas[0].prefix
+  const tag = (n: string): string => (prefix ? `${prefix}:${n}` : n)
+  const slice = (e: Elem): string => s.slice(e.start, e.end)
+
+  const srcParaOf = (idx: number | undefined): RawParagraph | undefined =>
+    idx !== undefined ? rawParas[idx] : undefined
+
+  const buildRun = (nr: EditedTextRun, para: EditedParagraph): string => {
+    const srcP = nr.srcPara !== undefined ? rawParas[nr.srcPara] : undefined
+    const item = srcP && nr.srcRun !== undefined ? srcP.items[nr.srcRun] : undefined
+    const origRun =
+      nr.srcPara !== undefined && nr.srcRun !== undefined
+        ? original[nr.srcPara]?.runs[nr.srcRun]
+        : undefined
+
+    if (nr.text === '\n') {
+      // Reuse the original <a:br/> bytes when this is still that break.
+      if (item?.kind === 'br') return slice(item.elem)
+      return `<${tag('br')}/>`
+    }
+
+    // Unchanged run: copy its bytes verbatim, preserving entity forms, fld
+    // elements, CDATA — whatever was there.
+    if (item && item.kind !== 'br' && origRun && nr.text === origRun.text) {
+      return slice(item.elem)
+    }
+
+    // Changed or new run: synthesize <a:r>, reusing the best-matching rPr
+    // bytes we have (own provenance, else the source paragraph's first run's).
+    let rPrBytes = ''
+    if (item?.rPr) rPrBytes = slice(item.rPr)
+    else {
+      const fallbackPara = srcP ?? srcParaOf(para.srcPara)
+      const donor = fallbackPara?.items.find((it) => it.kind !== 'br' && it.rPr)
+      if (donor?.rPr) rPrBytes = slice(donor.rPr)
+    }
+
+    // Embedded newlines become <a:br/> between text segments.
+    return nr.text
+      .split('\n')
+      .map((seg) =>
+        seg === '' ? '' : `<${tag('r')}>${rPrBytes}${tOpen(tag, seg)}${escapeXmlText(seg)}</${tag('t')}></${tag('r')}>`,
+      )
+      .join(`<${tag('br')}/>`)
+  }
+
+  return next
+    .map((np) => {
+      const srcP = srcParaOf(np.srcPara)
+      const pPr = srcP?.pPr ? slice(srcP.pPr) : ''
+      const endPr = srcP?.endParaRPr ? slice(srcP.endParaRPr) : ''
+      const runs = np.runs.map((r) => buildRun(r, np)).join('')
+      return `<${tag('p')}>${pPr}${runs}${endPr}</${tag('p')}>`
+    })
+    .join('')
+}
+
+// -------------------------------------------------------------- updateSlideXml
+
+/**
+ * Applies text edits to one slide's raw XML. Returns the raw string unchanged
+ * when there is nothing to change. Throws (leaving the caller's file
+ * untouched) on any inconsistency between the model, the edit, and the raw
+ * bytes.
+ */
+export function updateSlideXml(slideXmlRaw: string, edits: readonly ShapeTextEdit[]): string {
+  if (edits.length === 0) return slideXmlRaw
+
+  const doc = parseXml(slideXmlRaw)
+
+  // Scanner view of the same document, cross-validated below.
+  const rootElems = childElementsIn(slideXmlRaw, 0, slideXmlRaw.length)
+  const sldElem = rootElems.find((e) => localOf(e.name) === 'sld') ?? fail('no <p:sld> element')
+  const cSldElem = childElemByLocal(slideXmlRaw, sldElem, 'cSld') ?? fail('no <p:cSld> element')
+  const spTreeElem = childElemByLocal(slideXmlRaw, cSldElem, 'spTree') ?? fail('no <p:spTree> element')
+  const spTreeShapes = childElemsOf(slideXmlRaw, spTreeElem)
+
+  const ops: SpliceOp[] = []
+
+  for (const edit of edits) {
+    if (edit.next.length === 0) fail('a text shape must keep at least one paragraph')
+
+    // --- model side: resolve the shape node and re-derive its paragraphs.
+    const node = resolveNodePath(doc, edit.nodePath) ?? fail('node path no longer resolves')
+    const nodeTag = tagNameOf(node) ?? fail('node path resolves to a text node')
+    if (localOf(nodeTag) !== 'sp') fail(`not a text shape (<${nodeTag}>)`)
+
+    const modelParas = modelParagraphsOfSp(node) ?? fail('shape has no txBody')
+    if (normalizeParagraphs(modelParas) !== normalizeParagraphs(edit.original)) {
+      fail('edit original does not match the retained slide XML — refusing to write')
+    }
+
+    // --- locate the same shape in the raw bytes, by element ordinal.
+    const parent = resolveNodePath(doc, edit.nodePath.slice(0, -1)) ?? fail('spTree path broken')
+    const siblings = childrenOf(parent)
+    const last = edit.nodePath[edit.nodePath.length - 1]
+    let ordinal = 0
+    for (let j = 0; j < last; j++) if (tagNameOf(siblings[j]) !== null) ordinal++
+
+    const shapeElem = spTreeShapes[ordinal] ?? fail('shape ordinal out of range in raw XML')
+    if (localOf(shapeElem.name) !== 'sp') {
+      fail(`raw XML disagrees with model at shape ordinal ${ordinal} (<${shapeElem.name}>)`)
+    }
+    const txBodyElem =
+      childElemByLocal(slideXmlRaw, shapeElem, 'txBody') ?? fail('raw shape has no txBody')
+    const rawParas = rawParagraphsOf(slideXmlRaw, txBodyElem)
+
+    // --- cross-validate scanner structure against the model.
+    if (rawParas.length !== modelParas.length) fail('paragraph count mismatch between scanner and model')
+    for (let i = 0; i < rawParas.length; i++) {
+      const raw = rawParas[i]
+      const model = modelParas[i]
+      if (raw.items.length !== model.runs.length) fail(`run count mismatch in paragraph ${i}`)
+      for (let j = 0; j < raw.items.length; j++) {
+        if ((raw.items[j].kind === 'br') !== isBr(model.runs[j])) {
+          fail(`run kind mismatch at paragraph ${i}, run ${j}`)
+        }
+      }
+    }
+
+    // --- choose strategy.
+    if (isTextOnlyEdit(edit.original, edit.next)) {
+      for (let i = 0; i < edit.next.length; i++) {
+        for (let j = 0; j < edit.next[i].runs.length; j++) {
+          const nr = edit.next[i].runs[j]
+          const or = edit.original[i].runs[j]
+          if (nr.text === or.text) continue
+          const t = rawParas[i].items[j].t ?? fail('changed run has no <a:t> in raw XML')
+          ops.push({ start: t.contentStart, end: t.contentEnd, insert: escapeXmlText(nr.text) })
+        }
+      }
+    } else {
+      if (rawParas.length === 0) fail('cannot rebuild a txBody with no paragraphs')
+      ops.push({
+        start: rawParas[0].elem.start,
+        end: rawParas[rawParas.length - 1].elem.end,
+        insert: rebuildParagraphs(slideXmlRaw, rawParas, edit.original, edit.next),
+      })
+    }
+  }
+
+  if (ops.length === 0) return slideXmlRaw
+  return applySplices(slideXmlRaw, ops)
+}
+
+// ------------------------------------------------------------------ writeDeck
+
+/**
+ * Produces the full .pptx bytes with edits applied. Every entry except the
+ * edited slides is copied byte-for-byte from the source archive (raw bytes,
+ * never re-encoded); entry order, dates, permissions and comments carry over.
+ */
+export async function writeDeck(
+  deck: SlideDeck,
+  editsBySlide: ReadonlyMap<string, readonly ShapeTextEdit[]>,
+): Promise<Uint8Array> {
+  for (const slidePath of editsBySlide.keys()) {
+    if (deck.source.slideXml[slidePath] === undefined) {
+      fail(`edits reference unknown slide ${slidePath}`)
+    }
+  }
+
+  const out = new JSZip()
+  const files = deck.source.zip.files
+  for (const name of Object.keys(files)) {
+    const entry = files[name]
+    if (entry.dir) continue
+    const meta = {
+      date: entry.date,
+      comment: entry.comment ?? undefined,
+      unixPermissions: entry.unixPermissions ?? undefined,
+      dosPermissions: entry.dosPermissions ?? undefined,
+      createFolders: false,
+    }
+    const edits = editsBySlide.get(name)
+    if (edits && edits.length > 0) {
+      out.file(name, updateSlideXml(deck.source.slideXml[name], edits), meta)
+    } else {
+      out.file(name, await entry.async('uint8array'), { ...meta, binary: true })
+    }
+  }
+  return out.generateAsync({
+    type: 'uint8array',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 6 },
+  })
+}

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -29,11 +29,14 @@ import {
   childrenOf,
   parseParagraph,
   parseXml,
+  relsPathFor,
   resolveNodePath,
+  resolveRelTarget,
+  shapeIdOf,
   tagNameOf,
   type XmlNode,
 } from './parse'
-import type { NodePath, Paragraph, SlideDeck, TextAlign, TextRun } from './types'
+import type { NodePath, Paragraph, Shape, SlideDeck, TextAlign, TextRun } from './types'
 
 // ------------------------------------------------------------------- types
 
@@ -104,7 +107,29 @@ export interface ShapeGeometryEdit {
   extEmu?: { w: number; h: number }
 }
 
-export type SlideEdit = ShapeTextEdit | FormatRunsEdit | ParagraphAlignEdit | ShapeGeometryEdit
+/**
+ * Removes one shape's entire element range from its slide. The edit carries
+ * what the editor believed about the target — its model kind, its id, and for
+ * text shapes its as-parsed paragraphs — and all of it is re-derived from the
+ * retained bytes and compared before anything is spliced.
+ */
+export interface DeleteShapeEdit {
+  kind: 'deleteShape'
+  nodePath: NodePath
+  /** The model's shape kind; constrains which element names may sit there. */
+  shapeType: Shape['type']
+  /** The model's shape id (`p:cNvPr@id`, or the synthesized `idx:<n>`). */
+  shapeId: string
+  /** Text shapes only: as-parsed paragraphs, revalidated before removal. */
+  original?: Paragraph[]
+}
+
+export type SlideEdit =
+  | ShapeTextEdit
+  | FormatRunsEdit
+  | ParagraphAlignEdit
+  | ShapeGeometryEdit
+  | DeleteShapeEdit
 
 // -------------------------------------------------------------- normalizing
 
@@ -769,6 +794,39 @@ function paragraphAlignOps(ctx: SlideCtx, edit: ParagraphAlignEdit): SpliceOp[] 
   return [{ start: info.closeStart, end: para.elem.end, insert: `>${pPrXml}</${para.elem.name}>` }]
 }
 
+/** Element names each model shape kind can occupy in the spTree. */
+const DELETE_TAGS: Record<Shape['type'], readonly string[]> = {
+  text: ['sp'],
+  drawing: ['sp', 'cxnSp'],
+  image: ['pic'],
+  // Chart/table/diagram placeholders are graphicFrames; video (and missing
+  // media) placeholders are p:pic.
+  placeholder: ['graphicFrame', 'pic'],
+  group: ['grpSp'],
+}
+
+function deleteShapeOps(ctx: SlideCtx, edit: DeleteShapeEdit): SpliceOp[] {
+  const allowed = DELETE_TAGS[edit.shapeType] ?? fail(`unknown shape type "${edit.shapeType}"`)
+  const { node, elem } = locateShape(ctx, edit.nodePath, allowed)
+
+  // Replay the model's id derivation on the re-parsed node. A mismatch means
+  // the path no longer points at the shape the user deleted.
+  const derivedId = shapeIdOf(node, edit.nodePath[edit.nodePath.length - 1])
+  if (derivedId !== edit.shapeId) {
+    fail(`delete target mismatch: edit names shape "${edit.shapeId}", slide XML has "${derivedId}"`)
+  }
+
+  // Text shapes carry their content; re-derive it from the bytes and compare.
+  if (edit.shapeType === 'text') {
+    if (!edit.original) fail('deleting a text shape requires its original paragraphs')
+    validateTextShape(ctx, node, elem, edit.original)
+  }
+
+  // Exactly the element's own byte range: whitespace between siblings sits
+  // outside [start, end) and survives untouched.
+  return [{ start: elem.start, end: elem.end, insert: '' }]
+}
+
 function shapeGeometryOps(ctx: SlideCtx, edit: ShapeGeometryEdit): SpliceOp[] {
   if (!edit.offEmu && !edit.extEmu) return []
   const { elem } = locateShape(ctx, edit.nodePath, ['sp', 'pic', 'cxnSp'])
@@ -874,6 +932,9 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[])
       case 'shapeGeometry':
         ops.push(...shapeGeometryOps(ctx, edit))
         break
+      case 'deleteShape':
+        ops.push(...deleteShapeOps(ctx, edit))
+        break
     }
   }
 
@@ -881,7 +942,142 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[])
   return applySplices(slideXmlRaw, ops)
 }
 
+// ------------------------------------------------------------ slide deletion
+
+const PRESENTATION_PATH = 'ppt/presentation.xml'
+const PRESENTATION_RELS_PATH = 'ppt/_rels/presentation.xml.rels'
+const CONTENT_TYPES_PATH = '[Content_Types].xml'
+
+/** Attribute value from a scanned open tag, by exact raw name. */
+function rawAttrOf(info: OpenTagInfo, name: string): string | undefined {
+  return info.attrs.find((a) => a.name === name)?.value
+}
+
+/**
+ * The prefixed attribute whose local name matches, mirroring the parser's
+ * `prefixedAttr`: `p:sldId` carries both a plain `id` and the `r:id` we want.
+ */
+function rawPrefixedAttrOf(info: OpenTagInfo, localName: string): string | undefined {
+  const a = info.attrs.find((x) => x.name.includes(':') && localOf(x.name) === localName)
+  return a?.value
+}
+
+async function requiredPart(zip: JSZip, path: string): Promise<string> {
+  const file = zip.file(path)
+  if (!file) fail(`package part ${path} is missing`)
+  return file.async('string')
+}
+
+/**
+ * The three package-part rewrites a slide deletion forces, computed as element
+ * -range splices so every byte outside the removed elements is untouched:
+ *
+ *  - `ppt/_rels/presentation.xml.rels`: the slide's `<Relationship>` goes, and
+ *    resolving its Target is how the slide's `r:id` is found in the first place;
+ *  - `ppt/presentation.xml`: the `<p:sldId>` carrying that `r:id` goes;
+ *  - `[Content_Types].xml`: the slide's per-part `<Override>` goes when one
+ *    exists; a package typed some other way is left alone.
+ *
+ * Every lookup must resolve to exactly one element or the save fails closed.
+ */
+async function slideRemovalReplacements(
+  zip: JSZip,
+  deletions: readonly string[],
+): Promise<Map<string, string>> {
+  const relsRaw = await requiredPart(zip, PRESENTATION_RELS_PATH)
+  const relsRoot = childElementsIn(relsRaw, 0, relsRaw.length).find(
+    (e) => localOf(e.name) === 'Relationships',
+  )
+  if (!relsRoot) fail(`no <Relationships> element in ${PRESENTATION_RELS_PATH}`)
+  const relElems = childElemsOf(relsRaw, relsRoot).filter((e) => localOf(e.name) === 'Relationship')
+
+  const relOps: SpliceOp[] = []
+  const rIds: string[] = []
+  for (const slidePath of deletions) {
+    const matches = relElems.filter((e) => {
+      const info = openTagInfo(relsRaw, e)
+      const target = rawAttrOf(info, 'Target')
+      const type = rawAttrOf(info, 'Type') ?? ''
+      return (
+        target !== undefined &&
+        type.endsWith('/slide') &&
+        resolveRelTarget('ppt', target) === slidePath
+      )
+    })
+    if (matches.length !== 1) {
+      fail(`expected exactly one slide relationship for ${slidePath}, found ${matches.length}`)
+    }
+    const rId = rawAttrOf(openTagInfo(relsRaw, matches[0]), 'Id') ?? fail('slide relationship has no Id')
+    rIds.push(rId)
+    relOps.push({ start: matches[0].start, end: matches[0].end, insert: '' })
+  }
+
+  const presRaw = await requiredPart(zip, PRESENTATION_PATH)
+  const presRoot = childElementsIn(presRaw, 0, presRaw.length).find(
+    (e) => localOf(e.name) === 'presentation',
+  )
+  if (!presRoot) fail('no <p:presentation> element in presentation.xml')
+  const sldIdLst = childElemByLocal(presRaw, presRoot, 'sldIdLst') ?? fail('presentation.xml has no sldIdLst')
+  const sldIds = childElemsOf(presRaw, sldIdLst).filter((e) => localOf(e.name) === 'sldId')
+
+  const presOps: SpliceOp[] = []
+  for (const rId of rIds) {
+    const matches = sldIds.filter((e) => rawPrefixedAttrOf(openTagInfo(presRaw, e), 'id') === rId)
+    if (matches.length !== 1) {
+      fail(`expected exactly one p:sldId with r:id ${rId}, found ${matches.length}`)
+    }
+    // sldIdLst is not the only place a slide can be referenced: custom shows
+    // (p:custShowLst) carry their own r:id lists. Removing only the sldId
+    // would write a dangling reference, so any extra occurrence of the rId
+    // anywhere in presentation.xml refuses the save.
+    const refs = presRaw.split(`"${rId}"`).length - 1
+    if (refs !== 1) {
+      fail(
+        `slide relationship ${rId} is referenced ${refs} times in presentation.xml ` +
+          '(custom shows?) — refusing to delete',
+      )
+    }
+    presOps.push({ start: matches[0].start, end: matches[0].end, insert: '' })
+  }
+
+  const typesRaw = await requiredPart(zip, CONTENT_TYPES_PATH)
+  const typesRoot = childElementsIn(typesRaw, 0, typesRaw.length).find(
+    (e) => localOf(e.name) === 'Types',
+  )
+  if (!typesRoot) fail('no <Types> element in [Content_Types].xml')
+  const overrides = childElemsOf(typesRaw, typesRoot).filter((e) => localOf(e.name) === 'Override')
+
+  const typeOps: SpliceOp[] = []
+  for (const slidePath of deletions) {
+    const matches = overrides.filter(
+      (e) => rawAttrOf(openTagInfo(typesRaw, e), 'PartName') === `/${slidePath}`,
+    )
+    // Absence is fine — the part may be typed via a Default — but duplicate
+    // Overrides mean a package we don't understand well enough to edit.
+    if (matches.length > 1) fail(`duplicate [Content_Types].xml Override for /${slidePath}`)
+    if (matches.length === 1) {
+      typeOps.push({ start: matches[0].start, end: matches[0].end, insert: '' })
+    }
+  }
+
+  const replacements = new Map<string, string>()
+  replacements.set(PRESENTATION_RELS_PATH, applySplices(relsRaw, relOps))
+  replacements.set(PRESENTATION_PATH, applySplices(presRaw, presOps))
+  if (typeOps.length > 0) replacements.set(CONTENT_TYPES_PATH, applySplices(typesRaw, typeOps))
+  return replacements
+}
+
 // ------------------------------------------------------------------ writeDeck
+
+export interface WriteDeckOptions {
+  /**
+   * Slide part paths (e.g. `ppt/slides/slide2.xml`) to remove. The slide part
+   * and its own .rels are dropped; presentation.xml, its rels and any per-part
+   * Content_Types Override are spliced. Media referenced only by a removed
+   * slide stays in the package — orphaned media is valid OOXML.
+   */
+  deleteSlides?: readonly string[]
+}
 
 /**
  * Produces the full .pptx bytes with edits applied. Every entry except the
@@ -891,6 +1087,7 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[])
 export async function writeDeck(
   deck: SlideDeck,
   editsBySlide: ReadonlyMap<string, readonly SlideEdit[]>,
+  options?: WriteDeckOptions,
 ): Promise<Uint8Array> {
   for (const slidePath of editsBySlide.keys()) {
     if (deck.source.slideXml[slidePath] === undefined) {
@@ -898,11 +1095,30 @@ export async function writeDeck(
     }
   }
 
+  const deletions = [...new Set(options?.deleteSlides ?? [])]
+  for (const slidePath of deletions) {
+    if (deck.source.slideXml[slidePath] === undefined) {
+      fail(`cannot delete unknown slide ${slidePath}`)
+    }
+    if ((editsBySlide.get(slidePath)?.length ?? 0) > 0) {
+      fail(`slide ${slidePath} is both edited and marked deleted`)
+    }
+  }
+  if (deletions.length > 0 && deletions.length >= deck.slides.length) {
+    fail('cannot delete every slide in the deck')
+  }
+
+  const removedParts = new Set(deletions.flatMap((p) => [p, relsPathFor(p)]))
+  const replacements =
+    deletions.length > 0
+      ? await slideRemovalReplacements(deck.source.zip, deletions)
+      : new Map<string, string>()
+
   const out = new JSZip()
   const files = deck.source.zip.files
   for (const name of Object.keys(files)) {
     const entry = files[name]
-    if (entry.dir) continue
+    if (entry.dir || removedParts.has(name)) continue
     const meta = {
       date: entry.date,
       comment: entry.comment ?? undefined,
@@ -911,8 +1127,11 @@ export async function writeDeck(
       createFolders: false,
     }
     const edits = editsBySlide.get(name)
+    const replaced = replacements.get(name)
     if (edits && edits.length > 0) {
       out.file(name, updateSlideXml(deck.source.slideXml[name], edits), meta)
+    } else if (replaced !== undefined) {
+      out.file(name, replaced, meta)
     } else {
       out.file(name, await entry.async('uint8array'), { ...meta, binary: true })
     }

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -36,6 +36,8 @@ import {
   tagNameOf,
   type XmlNode,
 } from './parse'
+import { normalizeShapeStyle, shapeStyleSnapshotOf, type ShapeStyleSnapshot } from './geometry'
+import { newPictureXml, newShapeXml, type NewShapeSpec, type XmlPrefixes } from './shape-xml'
 import type { NodePath, Paragraph, Shape, SlideDeck, TextAlign, TextRun } from './types'
 
 // ------------------------------------------------------------------- types
@@ -130,8 +132,43 @@ export interface DeleteShapeEdit {
   original?: Paragraph[]
 }
 
+/**
+ * Recolours a shape's fill and/or outline. Only `p:sp` and `p:cxnSp` qualify
+ * (a connector has no fill), and the edit carries the shape's identity plus
+ * its as-parsed spPr style so both are re-derived and compared before any
+ * splice — images, graphicFrames and groups are rejected outright.
+ */
+export interface SetShapeStyleEdit {
+  kind: 'setShapeStyle'
+  nodePath: NodePath
+  /** The model's shape kind; only text/drawing can be restyled. */
+  shapeType: Shape['type']
+  /** The model's shape id (`p:cNvPr@id`, or the synthesized `idx:<n>`). */
+  shapeId: string
+  /** The shape's as-parsed spPr fill/line; the fail-closed anchor. */
+  original: ShapeStyleSnapshot
+  /** Six-digit RRGGBB for the shape fill. */
+  fillHex?: string
+  /** Six-digit RRGGBB for the outline. */
+  lineHex?: string
+}
+
+/**
+ * Adds a wholly new shape to a slide, spliced immediately before
+ * `</p:spTree>` so it lands on top of the z-order. The element's `p:cNvPr@id`
+ * is assigned at write time from the slide's existing ids plus every other
+ * pending insert; a picture additionally claims a media part and a
+ * relationship, which `writeDeck` splices into that slide's .rels.
+ */
+export interface InsertShapeEdit {
+  kind: 'insertShape'
+  spec: NewShapeSpec
+}
+
 export type SlideEdit =
   | ShapeTextEdit
+  | InsertShapeEdit
+  | SetShapeStyleEdit
   | FormatRunsEdit
   | ParagraphAlignEdit
   | ShapeGeometryEdit
@@ -653,6 +690,36 @@ function synthesizedRPr(prefix: string, set: RunFormatOverrides): string {
   return `<${t('rPr')}${attrs}>${children}</${t('rPr')}>`
 }
 
+/**
+ * The run properties a rebuilt run must carry in its own rPr: everything that
+ * differs from the run it derives from. A run with no provenance has no
+ * original, so every property it carries is its own.
+ */
+function runOverridesOf(nr: EditedTextRun, origRun: TextRun | undefined): RunFormatOverrides {
+  const set: RunFormatOverrides = {}
+  if (Boolean(nr.bold) !== Boolean(origRun?.bold)) set.bold = Boolean(nr.bold)
+  if (Boolean(nr.italic) !== Boolean(origRun?.italic)) set.italic = Boolean(nr.italic)
+  if (Boolean(nr.underline) !== Boolean(origRun?.underline)) set.underline = Boolean(nr.underline)
+  if (nr.sizePt !== undefined && nr.sizePt !== origRun?.sizePt) set.sizePt = nr.sizePt
+  if (nr.colorHex !== undefined && nr.colorHex !== origRun?.colorHex) set.colorHex = nr.colorHex
+  if (nr.latinFont !== undefined && nr.latinFont !== origRun?.latinFont) set.latinFont = nr.latinFont
+  return set
+}
+
+/**
+ * Donor rPr bytes with a run's own overrides applied on top, reusing the very
+ * same transform the in-place formatting path uses — so a rebuilt run ends up
+ * with exactly the rPr an in-place edit would have produced. Without this a
+ * structurally-new run silently lost every property the user had set on it.
+ */
+function rPrWithOverrides(prefix: string, donorBytes: string, set: RunFormatOverrides): string {
+  if (!hasOverride(set)) return donorBytes
+  if (!donorBytes) return synthesizedRPr(prefix, set)
+  const rPr = childElementsIn(donorBytes, 0, donorBytes.length)[0]
+  if (!rPr || localOf(rPr.name) !== 'rPr') return synthesizedRPr(prefix, set)
+  return applySplices(donorBytes, transformRPrOps(donorBytes, rPr, set))
+}
+
 // --------------------------------------------------------------- rebuilding
 
 /** `<a:t>` open tag, adding xml:space when edge whitespace must survive. */
@@ -674,7 +741,36 @@ function rebuildParagraphs(
   const srcParaOf = (idx: number | undefined): RawParagraph | undefined =>
     idx !== undefined ? rawParas[idx] : undefined
 
-  const buildRun = (nr: EditedTextRun, para: EditedParagraph): string => {
+  /**
+   * rPr bytes to inherit from when a run has none of its own. A paragraph the
+   * user created (Enter) has no source, so without walking to a NEIGHBOURING
+   * paragraph the run would be written bare — and a bare run takes the
+   * shape's cascade default, which for a title placeholder is routinely white
+   * on a light slide. That is the "typing does nothing" report.
+   */
+  const donorRPrFor = (paraIndex: number): string => {
+    const firstRPrOf = (rp: RawParagraph | undefined): string | undefined => {
+      const item = rp?.items.find((it) => it.kind !== 'br' && it.rPr)
+      return item?.rPr ? slice(item.rPr) : undefined
+    }
+    // Nearest preceding paragraph with a source, then nearest following.
+    for (let i = paraIndex; i >= 0; i--) {
+      const got = firstRPrOf(srcParaOf(next[i]?.srcPara))
+      if (got) return got
+    }
+    for (let i = paraIndex + 1; i < next.length; i++) {
+      const got = firstRPrOf(srcParaOf(next[i]?.srcPara))
+      if (got) return got
+    }
+    // Nothing in this edit has a source: fall back to the shape's own bytes.
+    for (const rp of rawParas) {
+      const got = firstRPrOf(rp)
+      if (got) return got
+    }
+    return ''
+  }
+
+  const buildRun = (nr: EditedTextRun, para: EditedParagraph, paraIndex: number): string => {
     const srcP = nr.srcPara !== undefined ? rawParas[nr.srcPara] : undefined
     const item = srcP && nr.srcRun !== undefined ? srcP.items[nr.srcRun] : undefined
     const origRun =
@@ -695,14 +791,17 @@ function rebuildParagraphs(
     }
 
     // Changed or new run: synthesize <a:r>, reusing the best-matching rPr
-    // bytes we have (own provenance, else the source paragraph's first run's).
+    // bytes we have (own provenance, else the source paragraph's first run's,
+    // else a neighbouring paragraph's).
     let rPrBytes = ''
     if (item?.rPr) rPrBytes = slice(item.rPr)
     else {
       const fallbackPara = srcP ?? srcParaOf(para.srcPara)
       const donor = fallbackPara?.items.find((it) => it.kind !== 'br' && it.rPr)
-      if (donor?.rPr) rPrBytes = slice(donor.rPr)
+      rPrBytes = donor?.rPr ? slice(donor.rPr) : donorRPrFor(paraIndex)
     }
+    // Then the run's OWN properties on top of whatever it inherited.
+    rPrBytes = rPrWithOverrides(prefix, rPrBytes, runOverridesOf(nr, origRun))
 
     // Embedded newlines become <a:br/> between text segments.
     return nr.text
@@ -714,11 +813,11 @@ function rebuildParagraphs(
   }
 
   return next
-    .map((np) => {
+    .map((np, pi) => {
       const srcP = srcParaOf(np.srcPara)
       const pPr = srcP?.pPr ? slice(srcP.pPr) : ''
       const endPr = srcP?.endParaRPr ? slice(srcP.endParaRPr) : ''
-      const runs = np.runs.map((r) => buildRun(r, np)).join('')
+      const runs = np.runs.map((r) => buildRun(r, np, pi)).join('')
       return `<${tag('p')}>${pPr}${runs}${endPr}</${tag('p')}>`
     })
     .join('')
@@ -731,6 +830,8 @@ interface SlideCtx {
   s: string
   doc: XmlNode[]
   sldElem: Elem
+  /** The `p:spTree` element; inserts append just inside its close tag. */
+  spTreeElem: Elem
   /** Element children of p:spTree, in document order. */
   spTreeShapes: Elem[]
 }
@@ -911,6 +1012,188 @@ function deleteShapeOps(ctx: SlideCtx, edit: DeleteShapeEdit): SpliceOp[] {
   return [{ start: elem.start, end: elem.end, insert: '' }]
 }
 
+/**
+ * spPr children the schema orders AFTER the fill group, per
+ * CT_ShapeProperties (xfrm, geometry, fill, ln, effects, 3-D, extLst). A
+ * synthesized fill goes before the first of these — i.e. after prstGeom /
+ * custGeom and before a:ln.
+ */
+const AFTER_FILL_LOCALS = ['ln', 'effectLst', 'effectDag', 'scene3d', 'sp3d', 'extLst']
+/** And the same for a:ln itself, which sits between the fill and the effects. */
+const AFTER_LN_LOCALS = ['effectLst', 'effectDag', 'scene3d', 'sp3d', 'extLst']
+
+function setShapeStyleOps(ctx: SlideCtx, edit: SetShapeStyleEdit): SpliceOp[] {
+  if (edit.fillHex === undefined && edit.lineHex === undefined) return []
+  for (const hex of [edit.fillHex, edit.lineHex]) {
+    if (hex !== undefined && !/^[0-9A-Fa-f]{6}$/.test(hex)) {
+      fail(`shape style colors must be RRGGBB (got "${hex}")`)
+    }
+  }
+  // Only shapes the model calls text or drawing can be restyled; that maps to
+  // p:sp and p:cxnSp, so images / graphicFrames / groups never get this far.
+  if (edit.shapeType !== 'text' && edit.shapeType !== 'drawing') {
+    fail(`shape type "${edit.shapeType}" cannot be restyled`)
+  }
+  const { node, elem } = locateShape(ctx, edit.nodePath, ['sp', 'cxnSp'])
+
+  const derivedId = shapeIdOf(node, edit.nodePath[edit.nodePath.length - 1])
+  if (derivedId !== edit.shapeId) {
+    fail(`style target mismatch: edit names shape "${edit.shapeId}", slide XML has "${derivedId}"`)
+  }
+  // A connector carries no fill of its own.
+  if (edit.fillHex !== undefined && localOf(elem.name) === 'cxnSp') {
+    fail('a connector (p:cxnSp) has no fill — only its outline can be set')
+  }
+
+  // Re-derive the shape's own spPr style from the retained bytes; if it does
+  // not match what the editor believed, the splice ranges below are not the
+  // ones the user was looking at.
+  const derived = shapeStyleSnapshotOf(node)
+  if (normalizeShapeStyle(derived) !== normalizeShapeStyle(edit.original)) {
+    fail(
+      `shape style does not match the slide XML for shape "${edit.shapeId}" ` +
+        `(expected ${normalizeShapeStyle(edit.original)}, found ${normalizeShapeStyle(derived)})`,
+    )
+  }
+
+  const spPr = childElemByLocal(ctx.s, elem, 'spPr') ?? fail('shape has no spPr')
+  const aPfx = drawingPrefixOf(ctx.s, ctx.sldElem)
+  const t = (n: string): string => (aPfx ? `${aPfx}:${n}` : n)
+  const ops: SpliceOp[] = []
+
+  // Everything below reopens spPr at most once; collect what a self-closing
+  // spPr must be reopened with, in schema order.
+  let reopen = ''
+  const spPrKids = spPr.selfClosing ? [] : childElemsOf(ctx.s, spPr)
+
+  // Zero-length inserts merged per offset. A fill and a synthesized a:ln both
+  // land at spPr.contentEnd, and as two separate ops applySplices would break
+  // the tie by processing order — emitting a:ln BEFORE the fill, which is
+  // invalid CT_ShapeProperties order.
+  const inserts = new Map<number, string>()
+  const addInsert = (at: number, xml: string): void => {
+    inserts.set(at, (inserts.get(at) ?? '') + xml)
+  }
+
+  if (edit.fillHex !== undefined) {
+    const fillXml = solidFillXml(aPfx, edit.fillHex.toUpperCase())
+    const existing = spPrKids.find((c) => FILL_LOCALS.includes(localOf(c.name)))
+    if (existing) {
+      // Replace the ENTIRE fill element — solidFill, gradFill or noFill alike.
+      // Its whole range goes, so a gradient's stop list cannot survive as
+      // orphaned children of the new solid fill.
+      ops.push({ start: existing.start, end: existing.end, insert: fillXml })
+    } else if (spPr.selfClosing) {
+      reopen += fillXml
+    } else {
+      const after = spPrKids.find((c) => AFTER_FILL_LOCALS.includes(localOf(c.name)))
+      addInsert(after ? after.start : spPr.contentEnd, fillXml)
+    }
+  }
+
+  if (edit.lineHex !== undefined) {
+    const lineFillXml = solidFillXml(aPfx, edit.lineHex.toUpperCase())
+    const ln = spPr.selfClosing ? undefined : spPrKids.find((c) => localOf(c.name) === 'ln')
+    if (!ln) {
+      // No outline authored: a minimal a:ln holding just the colour, so the
+      // shape gains a stroke without inventing a width or a dash.
+      const lnXml = `<${t('ln')}>${lineFillXml}</${t('ln')}>`
+      if (spPr.selfClosing) {
+        reopen += lnXml
+      } else {
+        const after = spPrKids.find((c) => AFTER_LN_LOCALS.includes(localOf(c.name)))
+        addInsert(after ? after.start : spPr.contentEnd, lnXml)
+      }
+    } else if (ln.selfClosing) {
+      // `<a:ln w="12700"/>`: reopen it, keeping its attributes (w, cap, cmpd).
+      const info = openTagInfo(ctx.s, ln)
+      ops.push({ start: info.closeStart, end: ln.end, insert: `>${lineFillXml}</${ln.name}>` })
+    } else {
+      const lnKids = childElemsOf(ctx.s, ln)
+      const existing = lnKids.find((c) => FILL_LOCALS.includes(localOf(c.name)))
+      if (existing) {
+        // Only the fill child moves; a:ln's own w/cap/cmpd attributes and its
+        // prstDash / join / head-tail children are all outside this range.
+        ops.push({ start: existing.start, end: existing.end, insert: lineFillXml })
+      } else {
+        // CT_LineProperties puts the fill group first.
+        ops.push({ start: ln.contentStart, end: ln.contentStart, insert: lineFillXml })
+      }
+    }
+  }
+
+  for (const [at, xml] of inserts) ops.push({ start: at, end: at, insert: xml })
+  if (reopen) {
+    const info = openTagInfo(ctx.s, spPr)
+    ops.push({ start: info.closeStart, end: spPr.end, insert: `>${reopen}</${spPr.name}>` })
+  }
+  return ops
+}
+
+// ------------------------------------------------------------ inserting
+
+/** Namespace prefix bound to a URI on the slide root, for synthesized XML. */
+function prefixForNs(s: string, sldElem: Elem, uri: string, fallback: string): string {
+  for (const a of openTagInfo(s, sldElem).attrs) {
+    if (a.value === uri && a.name.startsWith('xmlns:')) return a.name.slice(6)
+    if (a.value === uri && a.name === 'xmlns') return ''
+  }
+  return fallback
+}
+
+const PML_NS = 'http://schemas.openxmlformats.org/presentationml/2006/main'
+const DML_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main'
+const OREL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+function prefixesOf(ctx: SlideCtx): XmlPrefixes {
+  return {
+    p: prefixForNs(ctx.s, ctx.sldElem, PML_NS, prefixOf(ctx.spTreeElem.name)),
+    a: prefixForNs(ctx.s, ctx.sldElem, DML_NS, drawingPrefixOf(ctx.s, ctx.sldElem)),
+    r: prefixForNs(ctx.s, ctx.sldElem, OREL_NS, 'r'),
+  }
+}
+
+/**
+ * The highest `p:cNvPr@id` anywhere in the slide. Scanned over the raw bytes
+ * rather than the shape list, because ids must be unique across the WHOLE
+ * part — group children and the spTree's own nvGrpSpPr included.
+ */
+function maxShapeIdIn(s: string): number {
+  let max = 0
+  for (const m of s.matchAll(/<[^<>]*?cNvPr\b[^<>]*?\bid="(\d+)"/g)) {
+    const n = Number(m[1])
+    if (Number.isFinite(n)) max = Math.max(max, n)
+  }
+  return max
+}
+
+/**
+ * ALL inserts for a slide, as ONE op at the end of spTree. Emitting one op per
+ * insert would tie at the same offset, and applySplices breaks ties by
+ * processing order — which would silently reverse the z-order the user chose.
+ */
+function insertShapeOps(
+  ctx: SlideCtx,
+  inserts: readonly InsertShapeEdit[],
+  rIdFor: (edit: InsertShapeEdit) => string,
+): SpliceOp[] {
+  if (inserts.length === 0) return []
+  if (ctx.spTreeElem.selfClosing) fail('slide has an empty <p:spTree/>')
+  const px = prefixesOf(ctx)
+  let nextId = maxShapeIdIn(ctx.s)
+
+  let xml = ''
+  for (const edit of inserts) {
+    const id = ++nextId
+    xml +=
+      edit.spec.kind === 'image'
+        ? newPictureXml(edit.spec, id, rIdFor(edit), px)
+        : newShapeXml(edit.spec, id, px)
+  }
+  const at = ctx.spTreeElem.contentEnd
+  return [{ start: at, end: at, insert: xml }]
+}
+
 function shapeGeometryOps(ctx: SlideCtx, edit: ShapeGeometryEdit): SpliceOp[] {
   if (!edit.offEmu && !edit.extEmu) return []
   const { elem } = locateShape(ctx, edit.nodePath, ['sp', 'pic', 'cxnSp'])
@@ -984,25 +1267,59 @@ function shapeGeometryOps(ctx: SlideCtx, edit: ShapeGeometryEdit): SpliceOp[] {
  * there is nothing to change. Throws (leaving the caller's file untouched) on
  * any inconsistency between the model, the edit, and the raw bytes.
  */
-export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[]): string {
+export interface UpdateSlideOptions {
+  /**
+   * Relationship id for an image insert. `writeDeck` supplies this after
+   * claiming the media part and splicing the slide's .rels; a caller that
+   * inserts no images never needs it.
+   */
+  rIdFor?: (edit: InsertShapeEdit) => string | undefined
+}
+
+export function updateSlideXml(
+  slideXmlRaw: string,
+  edits: readonly SlideEdit[],
+  options?: UpdateSlideOptions,
+): string {
   if (edits.length === 0) return slideXmlRaw
 
-  const doc = parseXml(slideXmlRaw)
-
-  // Scanner view of the same document, cross-validated per edit.
-  const rootElems = childElementsIn(slideXmlRaw, 0, slideXmlRaw.length)
-  const sldElem = rootElems.find((e) => localOf(e.name) === 'sld') ?? fail('no <p:sld> element')
-  const cSldElem = childElemByLocal(slideXmlRaw, sldElem, 'cSld') ?? fail('no <p:cSld> element')
-  const spTreeElem = childElemByLocal(slideXmlRaw, cSldElem, 'spTree') ?? fail('no <p:spTree> element')
-  const ctx: SlideCtx = {
-    s: slideXmlRaw,
-    doc,
-    sldElem,
-    spTreeShapes: childElemsOf(slideXmlRaw, spTreeElem),
+  const buildCtx = (s: string): SlideCtx => {
+    // Scanner view of the same document, cross-validated per edit.
+    const rootElems = childElementsIn(s, 0, s.length)
+    const sldElem = rootElems.find((e) => localOf(e.name) === 'sld') ?? fail('no <p:sld> element')
+    const cSldElem = childElemByLocal(s, sldElem, 'cSld') ?? fail('no <p:cSld> element')
+    const spTreeElem = childElemByLocal(s, cSldElem, 'spTree') ?? fail('no <p:spTree> element')
+    return {
+      s,
+      doc: parseXml(s),
+      sldElem,
+      spTreeElem,
+      spTreeShapes: childElemsOf(s, spTreeElem),
+    }
   }
 
+  // Inserts run in their OWN pass, first. Every other edit addresses a shape
+  // by node path, and a shape inserted in this same save does not exist in
+  // the base bytes — so its path would not resolve. Applying inserts first
+  // and re-scanning makes an inserted shape addressable exactly like any
+  // other, which is what "inserted shapes are ordinary shapes" has to mean.
+  const inserts = edits.filter((e): e is InsertShapeEdit => e.kind === 'insertShape')
+  let working = slideXmlRaw
+  if (inserts.length > 0) {
+    const insertOps = insertShapeOps(buildCtx(working), inserts, (edit) => {
+      const rId = options?.rIdFor?.(edit)
+      if (!rId) fail('an image insert reached the writer with no relationship id')
+      return rId
+    })
+    if (insertOps.length > 0) working = applySplices(working, insertOps)
+  }
+
+  const rest = edits.filter((e) => e.kind !== 'insertShape')
+  if (rest.length === 0) return working
+
+  const ctx = buildCtx(working)
   const ops: SpliceOp[] = []
-  for (const edit of edits) {
+  for (const edit of rest) {
     switch (edit.kind) {
       case 'text':
         ops.push(...textEditOps(ctx, edit))
@@ -1013,6 +1330,9 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[])
       case 'paragraphAlign':
         ops.push(...paragraphAlignOps(ctx, edit))
         break
+      case 'setShapeStyle':
+        ops.push(...setShapeStyleOps(ctx, edit))
+        break
       case 'shapeGeometry':
         ops.push(...shapeGeometryOps(ctx, edit))
         break
@@ -1022,8 +1342,8 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[])
     }
   }
 
-  if (ops.length === 0) return slideXmlRaw
-  return applySplices(slideXmlRaw, ops)
+  if (ops.length === 0) return working
+  return applySplices(working, ops)
 }
 
 // ------------------------------------------- slide addition / deletion
@@ -1349,6 +1669,159 @@ async function packageReplacements(
   return replacements
 }
 
+/** Base64 -> bytes, for media parts handed in from the renderer. */
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}
+
+interface MediaPlan {
+  /** New media part path -> its bytes. */
+  parts: Map<string, Uint8Array>
+  /** Slide path -> its rewritten .rels XML. */
+  relsXml: Map<string, string>
+  /** Per-edit relationship id, keyed by edit object identity. */
+  rIdByEdit: Map<InsertShapeEdit, string>
+}
+
+/**
+ * Claims a media part and a relationship for every image insert.
+ *
+ * Media names are unique across the WHOLE package plus everything claimed in
+ * this same save; relationship ids are unique within the owning slide's .rels.
+ * Each slide's Relationships element gets exactly one insertion, immediately
+ * before its close tag, so no existing relationship byte moves.
+ */
+async function planInsertedMedia(
+  zip: JSZip,
+  editsBySlide: ReadonlyMap<string, readonly SlideEdit[]>,
+  addedRels: ReadonlyMap<string, string>,
+): Promise<MediaPlan> {
+  const plan: MediaPlan = { parts: new Map(), relsXml: new Map(), rIdByEdit: new Map() }
+
+  let maxMedia = 0
+  for (const name of Object.keys(zip.files)) {
+    const m = name.match(/^ppt\/media\/image(\d+)\./i)
+    if (m) maxMedia = Math.max(maxMedia, Number(m[1]))
+  }
+
+  for (const [slidePath, edits] of editsBySlide) {
+    const images = edits.filter(
+      (e): e is InsertShapeEdit => e.kind === 'insertShape' && e.spec.kind === 'image',
+    )
+    if (images.length === 0) continue
+
+    const relsPath = relsPathFor(slidePath)
+    let relsRaw = addedRels.get(slidePath)
+    if (relsRaw === undefined) {
+      const file = zip.file(relsPath)
+      relsRaw =
+        (await file?.async('string')) ??
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+          '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>'
+    }
+
+    const root = childElementsIn(relsRaw, 0, relsRaw.length).find(
+      (e) => localOf(e.name) === 'Relationships',
+    )
+    if (!root) fail(`no <Relationships> element in ${relsPath}`)
+
+    let maxRel = 0
+    const existingIds = new Set<string>()
+    if (!root.selfClosing) {
+      for (const e of childElemsOf(relsRaw, root)) {
+        const id = rawAttrOf(openTagInfo(relsRaw, e), 'Id')
+        if (!id) continue
+        existingIds.add(id)
+        const m = id.match(/^rId(\d+)$/)
+        if (m) maxRel = Math.max(maxRel, Number(m[1]))
+      }
+    }
+
+    let additions = ''
+    for (const edit of images) {
+      const spec = edit.spec as Extract<NewShapeSpec, { kind: 'image' }>
+      const ext = spec.ext.toLowerCase().replace(/[^a-z0-9]/g, '')
+      if (!ext) fail('an inserted image has no usable file extension')
+      const mediaPath = `ppt/media/image${++maxMedia}.${ext}`
+      if (zip.file(mediaPath) || plan.parts.has(mediaPath)) {
+        fail(`media part ${mediaPath} already exists`)
+      }
+      const rId = `rId${++maxRel}`
+      if (existingIds.has(rId)) fail(`relationship ${rId} already exists in ${relsPath}`)
+      existingIds.add(rId)
+
+      plan.parts.set(mediaPath, base64ToBytes(spec.dataBase64))
+      plan.rIdByEdit.set(edit, rId)
+      additions +=
+        `<Relationship Id="${rId}" Type="${OFFICE_REL_NS}/image" ` +
+        `Target="../media/image${maxMedia}.${ext}"/>`
+    }
+
+    if (root.selfClosing) {
+      const info = openTagInfo(relsRaw, root)
+      plan.relsXml.set(
+        slidePath,
+        applySplices(relsRaw, [
+          { start: info.closeStart, end: root.end, insert: `>${additions}</${root.name}>` },
+        ]),
+      )
+    } else {
+      plan.relsXml.set(
+        slidePath,
+        applySplices(relsRaw, [
+          { start: root.contentEnd, end: root.contentEnd, insert: additions },
+        ]),
+      )
+    }
+  }
+  return plan
+}
+
+const MEDIA_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  bmp: 'image/bmp',
+  webp: 'image/webp',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+}
+
+/**
+ * [Content_Types].xml with a `<Default>` for every inserted media extension
+ * that lacks one. Without this, inserting (say) a .webp into a deck that has
+ * never held one produces an untyped part — a package PowerPoint refuses to
+ * open. `current` may already carry this save's slide-add/delete rewrites;
+ * the Defaults splice on top of it.
+ */
+function withMediaDefaults(current: string, exts: ReadonlySet<string>): string {
+  const root = childElementsIn(current, 0, current.length).find((e) => localOf(e.name) === 'Types')
+  if (!root) fail('no <Types> element in [Content_Types].xml')
+  if (root.selfClosing) fail('empty <Types/> in [Content_Types].xml')
+
+  const present = new Set<string>()
+  for (const e of childElemsOf(current, root)) {
+    if (localOf(e.name) !== 'Default') continue
+    const ext = rawAttrOf(openTagInfo(current, e), 'Extension')
+    if (ext) present.add(ext.toLowerCase())
+  }
+
+  let additions = ''
+  for (const ext of [...exts].sort()) {
+    if (present.has(ext)) continue
+    const mime = MEDIA_MIME[ext] ?? fail(`no known content type for inserted media ".${ext}"`)
+    additions += `<Default Extension="${ext}" ContentType="${mime}"/>`
+  }
+  if (!additions) return current
+  return applySplices(current, [
+    { start: root.contentEnd, end: root.contentEnd, insert: additions },
+  ])
+}
+
 // ------------------------------------------------------------------ writeDeck
 
 export interface WriteDeckOptions {
@@ -1427,11 +1900,31 @@ export async function writeDeck(
   }
 
   const order = options?.slideOrder
+  // Image inserts claim media parts and relationships before anything is
+  // written, so the p:pic elements can reference ids that are already fixed.
+  const mediaPlan = await planInsertedMedia(
+    deck.source.zip,
+    editsBySlide,
+    new Map(adds.map((a) => [a.path, a.relsXml])),
+  )
+  const rIdFor = (edit: InsertShapeEdit): string | undefined => mediaPlan.rIdByEdit.get(edit)
   const removedParts = new Set(deletions.flatMap((p) => [p, relsPathFor(p)]))
   const replacements =
     deletions.length > 0 || adds.length > 0 || order !== undefined
       ? await packageReplacements(deck.source.zip, deletions, adds, order)
       : new Map<string, string>()
+
+  // Inserted media must be typed: add missing Defaults on top of whatever the
+  // slide add/delete path already did to [Content_Types].xml.
+  if (mediaPlan.parts.size > 0) {
+    const exts = new Set(
+      [...mediaPlan.parts.keys()].map((p) => p.slice(p.lastIndexOf('.') + 1).toLowerCase()),
+    )
+    const currentCt =
+      replacements.get(CONTENT_TYPES_PATH) ?? (await requiredPart(deck.source.zip, CONTENT_TYPES_PATH))
+    const nextCt = withMediaDefaults(currentCt, exts)
+    if (nextCt !== currentCt) replacements.set(CONTENT_TYPES_PATH, nextCt)
+  }
 
   const out = new JSZip()
   const files = deck.source.zip.files
@@ -1447,8 +1940,11 @@ export async function writeDeck(
     }
     const edits = editsBySlide.get(name)
     const replaced = replacements.get(name)
+    const newRels = [...mediaPlan.relsXml].find(([slide]) => relsPathFor(slide) === name)?.[1]
     if (edits && edits.length > 0) {
-      out.file(name, updateSlideXml(deck.source.slideXml[name], edits), meta)
+      out.file(name, updateSlideXml(deck.source.slideXml[name], edits, { rIdFor }), meta)
+    } else if (newRels !== undefined) {
+      out.file(name, newRels, meta)
     } else if (replaced !== undefined) {
       out.file(name, replaced, meta)
     } else {
@@ -1459,10 +1955,20 @@ export async function writeDeck(
   // the synthesized XML they were parsed from.
   for (const a of adds) {
     const edits = editsBySlide.get(a.path)
-    out.file(a.path, edits && edits.length > 0 ? updateSlideXml(a.xml, edits) : a.xml, {
+    out.file(
+      a.path,
+      edits && edits.length > 0 ? updateSlideXml(a.xml, edits, { rIdFor }) : a.xml,
+      { createFolders: false },
+    )
+    // An image inserted onto an added slide rewrites that slide's synthesized
+    // rels string rather than a part on disk.
+    out.file(relsPathFor(a.path), mediaPlan.relsXml.get(a.path) ?? a.relsXml, {
       createFolders: false,
     })
-    out.file(relsPathFor(a.path), a.relsXml, { createFolders: false })
+  }
+  // Brand-new media parts.
+  for (const [mediaPath, bytes] of mediaPlan.parts) {
+    out.file(mediaPath, bytes, { createFolders: false, binary: true })
   }
   return out.generateAsync({
     type: 'uint8array',

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -52,6 +52,7 @@ export interface EditedParagraph {
 }
 
 export interface ShapeTextEdit {
+  kind: 'text'
   /** The shape's node path, from the parsed model. */
   nodePath: NodePath
   /** The shape's paragraphs as originally parsed from the retained XML. */
@@ -59,6 +60,51 @@ export interface ShapeTextEdit {
   /** The committed replacement. */
   next: EditedParagraph[]
 }
+
+/** Addresses one run: paragraph index, then run index within it. */
+export interface RunRef {
+  para: number
+  run: number
+}
+
+/** Formatting to apply. A field left undefined is left untouched in the rPr. */
+export interface RunFormatOverrides {
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  sizePt?: number
+  /** Six-digit RRGGBB; replaces the run's fill with a solid color. */
+  colorHex?: string
+}
+
+export interface FormatRunsEdit {
+  kind: 'formatRuns'
+  nodePath: NodePath
+  /** The shape's paragraphs as originally parsed from the retained XML. */
+  original: Paragraph[]
+  targets: RunRef[]
+  set: RunFormatOverrides
+}
+
+export interface ParagraphAlignEdit {
+  kind: 'paragraphAlign'
+  nodePath: NodePath
+  /** The shape's paragraphs as originally parsed from the retained XML. */
+  original: Paragraph[]
+  paraIndex: number
+  align: TextAlign
+}
+
+export interface ShapeGeometryEdit {
+  kind: 'shapeGeometry'
+  nodePath: NodePath
+  /** New offset in EMU. Rounded to integers. */
+  offEmu?: { x: number; y: number }
+  /** New extent in EMU. Rounded to integers and clamped to >= 1. */
+  extEmu?: { w: number; h: number }
+}
+
+export type SlideEdit = ShapeTextEdit | FormatRunsEdit | ParagraphAlignEdit | ShapeGeometryEdit
 
 // -------------------------------------------------------------- normalizing
 
@@ -347,6 +393,157 @@ function applySplices(s: string, ops: SpliceOp[]): string {
   return out
 }
 
+// ------------------------------------------------- open-tag attribute edits
+
+interface OpenTagInfo {
+  /** Insertion point for new attributes: index of `>`, or of the `/` in `/>`. */
+  closeStart: number
+  selfClosing: boolean
+  attrs: Array<{ name: string; valueStart: number; valueEnd: number; value: string }>
+}
+
+function openTagInfo(s: string, elem: Elem): OpenTagInfo {
+  const { gt, selfClosing } = scanTagEnd(s, elem.start)
+  const closeStart = selfClosing ? gt - 1 : gt
+  const attrs: OpenTagInfo['attrs'] = []
+  let i = elem.start + 1 + elem.name.length
+  while (i < closeStart) {
+    while (i < closeStart && ' \t\r\n'.includes(s[i])) i++
+    if (i >= closeStart) break
+    const nameStart = i
+    while (i < closeStart && !' \t\r\n=/>'.includes(s[i])) i++
+    const name = s.slice(nameStart, i)
+    if (!name) break
+    while (i < closeStart && ' \t\r\n'.includes(s[i])) i++
+    if (s[i] !== '=') fail(`malformed attribute ${name} in <${elem.name}>`)
+    i++
+    while (i < closeStart && ' \t\r\n'.includes(s[i])) i++
+    const quote = s[i]
+    if (quote !== '"' && quote !== "'") fail(`unquoted attribute ${name} in <${elem.name}>`)
+    const valueStart = i + 1
+    const valueEnd = s.indexOf(quote, valueStart)
+    if (valueEnd < 0 || valueEnd >= closeStart) fail(`unterminated attribute ${name}`)
+    attrs.push({ name, valueStart, valueEnd, value: s.slice(valueStart, valueEnd) })
+    i = valueEnd + 1
+  }
+  return { closeStart, selfClosing, attrs }
+}
+
+/**
+ * Ops that set attributes on one open tag: existing values replaced in place,
+ * missing attributes appended (as one insert, preserving the given order)
+ * before the tag close. Attribute order is insignificant in XML, so appending
+ * is safe; nothing outside the open tag is touched. Values must not need
+ * escaping (enums and integers only).
+ */
+function setAttrOps(s: string, elem: Elem, pairs: ReadonlyArray<[string, string]>): SpliceOp[] {
+  const info = openTagInfo(s, elem)
+  const ops: SpliceOp[] = []
+  let inserts = ''
+  for (const [name, value] of pairs) {
+    const existing = info.attrs.find((a) => a.name === name)
+    if (existing) ops.push({ start: existing.valueStart, end: existing.valueEnd, insert: value })
+    else inserts += ` ${name}="${value}"`
+  }
+  if (inserts) ops.push({ start: info.closeStart, end: info.closeStart, insert: inserts })
+  return ops
+}
+
+const DRAWINGML_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main'
+
+/** Prefix bound to the DrawingML namespace on the root element; 'a' if unfound. */
+function drawingPrefixOf(s: string, sldElem: Elem): string {
+  for (const a of openTagInfo(s, sldElem).attrs) {
+    if (a.value === DRAWINGML_NS) {
+      if (a.name === 'xmlns') return ''
+      if (a.name.startsWith('xmlns:')) return a.name.slice(6)
+    }
+  }
+  return 'a'
+}
+
+// -------------------------------------------------------------- rPr rewriting
+
+const FILL_LOCALS = ['noFill', 'solidFill', 'gradFill', 'blipFill', 'pattFill', 'grpFill']
+
+const hasOverride = (set: RunFormatOverrides): boolean =>
+  set.bold !== undefined ||
+  set.italic !== undefined ||
+  set.underline !== undefined ||
+  set.sizePt !== undefined ||
+  set.colorHex !== undefined
+
+/** sz is hundredths of a point, schema-bounded to [1pt, 4000pt]. */
+function szValue(sizePt: number): string {
+  return String(Math.min(400000, Math.max(100, Math.round(sizePt * 100))))
+}
+
+function attrPairsFor(set: RunFormatOverrides): Array<[string, string]> {
+  const pairs: Array<[string, string]> = []
+  if (set.bold !== undefined) pairs.push(['b', set.bold ? '1' : '0'])
+  if (set.italic !== undefined) pairs.push(['i', set.italic ? '1' : '0'])
+  if (set.underline !== undefined) pairs.push(['u', set.underline ? 'sng' : 'none'])
+  if (set.sizePt !== undefined) pairs.push(['sz', szValue(set.sizePt)])
+  return pairs
+}
+
+function solidFillXml(prefix: string, colorHex: string): string {
+  const t = (n: string): string => (prefix ? `${prefix}:${n}` : n)
+  return `<${t('solidFill')}><${t('srgbClr')} val="${colorHex}"/></${t('solidFill')}>`
+}
+
+/**
+ * Ops that rewrite an existing rPr per the overrides: overridden attributes
+ * are set on the open tag, an overridden color replaces the fill-group child
+ * in place (or is inserted after `a:ln`, the only child the schema orders
+ * before it). Every attribute and child the override doesn't own keeps its
+ * bytes.
+ */
+function transformRPrOps(s: string, rPr: Elem, set: RunFormatOverrides): SpliceOp[] {
+  const info = openTagInfo(s, rPr)
+  const ops: SpliceOp[] = []
+  let attrInserts = ''
+  for (const [name, value] of attrPairsFor(set)) {
+    const existing = info.attrs.find((a) => a.name === name)
+    if (existing) ops.push({ start: existing.valueStart, end: existing.valueEnd, insert: value })
+    else attrInserts += ` ${name}="${value}"`
+  }
+
+  if (set.colorHex === undefined) {
+    if (attrInserts) ops.push({ start: info.closeStart, end: info.closeStart, insert: attrInserts })
+    return ops
+  }
+
+  const fill = solidFillXml(prefixOf(rPr.name), set.colorHex)
+  if (rPr.selfClosing) {
+    // `<a:rPr .../>` must reopen to hold the fill; fold new attributes into
+    // the same op so nothing overlaps.
+    ops.push({ start: info.closeStart, end: rPr.end, insert: `${attrInserts}>${fill}</${rPr.name}>` })
+    return ops
+  }
+  if (attrInserts) ops.push({ start: info.closeStart, end: info.closeStart, insert: attrInserts })
+  const children = childElemsOf(s, rPr)
+  const existingFill = children.find((c) => FILL_LOCALS.includes(localOf(c.name)))
+  if (existingFill) {
+    ops.push({ start: existingFill.start, end: existingFill.end, insert: fill })
+  } else {
+    const ln = children.find((c) => localOf(c.name) === 'ln')
+    const at = ln ? ln.end : rPr.contentStart
+    ops.push({ start: at, end: at, insert: fill })
+  }
+  return ops
+}
+
+/** A fresh rPr for a run that had none. `prefix` is the run element's own. */
+function synthesizedRPr(prefix: string, set: RunFormatOverrides): string {
+  const t = (n: string): string => (prefix ? `${prefix}:${n}` : n)
+  const attrs = attrPairsFor(set)
+    .map(([n, v]) => ` ${n}="${v}"`)
+    .join('')
+  if (set.colorHex === undefined) return `<${t('rPr')}${attrs}/>`
+  return `<${t('rPr')}${attrs}>${solidFillXml(prefix, set.colorHex)}</${t('rPr')}>`
+}
+
 // --------------------------------------------------------------- rebuilding
 
 /** `<a:t>` open tag, adding xml:space when edge whitespace must survive. */
@@ -418,87 +615,257 @@ function rebuildParagraphs(
     .join('')
 }
 
+// ------------------------------------------------------------ edit dispatch
+
+interface SlideCtx {
+  /** The slide's raw XML. */
+  s: string
+  doc: XmlNode[]
+  sldElem: Elem
+  /** Element children of p:spTree, in document order. */
+  spTreeShapes: Elem[]
+}
+
+/**
+ * Resolves an edit's node path on both the model and the scanner view, and
+ * cross-checks that they agree on what kind of shape sits there.
+ */
+function locateShape(
+  ctx: SlideCtx,
+  nodePath: NodePath,
+  allowed: readonly string[],
+): { node: XmlNode; elem: Elem } {
+  const node = resolveNodePath(ctx.doc, nodePath) ?? fail('node path no longer resolves')
+  const nodeTag = tagNameOf(node) ?? fail('node path resolves to a text node')
+  if (!allowed.includes(localOf(nodeTag))) fail(`unsupported shape for this edit (<${nodeTag}>)`)
+
+  const parent = resolveNodePath(ctx.doc, nodePath.slice(0, -1)) ?? fail('spTree path broken')
+  const siblings = childrenOf(parent)
+  const last = nodePath[nodePath.length - 1]
+  let ordinal = 0
+  for (let j = 0; j < last; j++) if (tagNameOf(siblings[j]) !== null) ordinal++
+
+  const elem = ctx.spTreeShapes[ordinal] ?? fail('shape ordinal out of range in raw XML')
+  if (localOf(elem.name) !== localOf(nodeTag)) {
+    fail(`raw XML disagrees with model at shape ordinal ${ordinal} (<${elem.name}>)`)
+  }
+  return { node, elem }
+}
+
+/** Shared text-shape validation: original matches model, scanner matches model. */
+function validateTextShape(
+  ctx: SlideCtx,
+  node: XmlNode,
+  elem: Elem,
+  original: Paragraph[],
+): RawParagraph[] {
+  const modelParas = modelParagraphsOfSp(node) ?? fail('shape has no txBody')
+  if (normalizeParagraphs(modelParas) !== normalizeParagraphs(original)) {
+    fail('edit original does not match the retained slide XML — refusing to write')
+  }
+  const txBodyElem = childElemByLocal(ctx.s, elem, 'txBody') ?? fail('raw shape has no txBody')
+  const rawParas = rawParagraphsOf(ctx.s, txBodyElem)
+  if (rawParas.length !== modelParas.length) fail('paragraph count mismatch between scanner and model')
+  for (let i = 0; i < rawParas.length; i++) {
+    const raw = rawParas[i]
+    const model = modelParas[i]
+    if (raw.items.length !== model.runs.length) fail(`run count mismatch in paragraph ${i}`)
+    for (let j = 0; j < raw.items.length; j++) {
+      if ((raw.items[j].kind === 'br') !== isBr(model.runs[j])) {
+        fail(`run kind mismatch at paragraph ${i}, run ${j}`)
+      }
+    }
+  }
+  return rawParas
+}
+
+function textEditOps(ctx: SlideCtx, edit: ShapeTextEdit): SpliceOp[] {
+  if (edit.next.length === 0) fail('a text shape must keep at least one paragraph')
+  const { node, elem } = locateShape(ctx, edit.nodePath, ['sp'])
+  const rawParas = validateTextShape(ctx, node, elem, edit.original)
+
+  const ops: SpliceOp[] = []
+  if (isTextOnlyEdit(edit.original, edit.next)) {
+    for (let i = 0; i < edit.next.length; i++) {
+      for (let j = 0; j < edit.next[i].runs.length; j++) {
+        const nr = edit.next[i].runs[j]
+        const or = edit.original[i].runs[j]
+        if (nr.text === or.text) continue
+        const t = rawParas[i].items[j].t ?? fail('changed run has no <a:t> in raw XML')
+        ops.push({ start: t.contentStart, end: t.contentEnd, insert: escapeXmlText(nr.text) })
+      }
+    }
+  } else {
+    if (rawParas.length === 0) fail('cannot rebuild a txBody with no paragraphs')
+    ops.push({
+      start: rawParas[0].elem.start,
+      end: rawParas[rawParas.length - 1].elem.end,
+      insert: rebuildParagraphs(ctx.s, rawParas, edit.original, edit.next),
+    })
+  }
+  return ops
+}
+
+function formatRunsOps(ctx: SlideCtx, edit: FormatRunsEdit): SpliceOp[] {
+  if (!hasOverride(edit.set) || edit.targets.length === 0) return []
+  let set = edit.set
+  if (set.colorHex !== undefined) {
+    if (!/^[0-9A-Fa-f]{6}$/.test(set.colorHex)) fail(`colorHex must be RRGGBB (got "${set.colorHex}")`)
+    set = { ...set, colorHex: set.colorHex.toUpperCase() }
+  }
+
+  const { node, elem } = locateShape(ctx, edit.nodePath, ['sp'])
+  const rawParas = validateTextShape(ctx, node, elem, edit.original)
+
+  const seen = new Set<string>()
+  const ops: SpliceOp[] = []
+  for (const target of edit.targets) {
+    const key = `${target.para}:${target.run}`
+    if (seen.has(key)) fail(`duplicate format target ${key}`)
+    seen.add(key)
+    const para = edit.original[target.para] ?? fail(`format target paragraph ${target.para} out of range`)
+    const run = para.runs[target.run] ?? fail(`format target run ${key} out of range`)
+    if (isBr(run)) fail('cannot format a line break')
+    const item = rawParas[target.para].items[target.run]
+    if (item.rPr) {
+      ops.push(...transformRPrOps(ctx.s, item.rPr, set))
+    } else {
+      // rPr is the first child of a:r / a:fld; the run always has content
+      // (kept items carry a non-empty <a:t>).
+      ops.push({
+        start: item.elem.contentStart,
+        end: item.elem.contentStart,
+        insert: synthesizedRPr(prefixOf(item.elem.name), set),
+      })
+    }
+  }
+  return ops
+}
+
+function paragraphAlignOps(ctx: SlideCtx, edit: ParagraphAlignEdit): SpliceOp[] {
+  const { node, elem } = locateShape(ctx, edit.nodePath, ['sp'])
+  const rawParas = validateTextShape(ctx, node, elem, edit.original)
+  const para = rawParas[edit.paraIndex] ?? fail(`paragraph ${edit.paraIndex} out of range`)
+
+  // Attribute-level splice on the pPr open tag; children stay byte-identical.
+  if (para.pPr) return setAttrOps(ctx.s, para.pPr, [['algn', edit.align]])
+
+  // No pPr: synthesize one as the FIRST child of a:p (schema position).
+  const t = para.prefix ? `${para.prefix}:` : ''
+  const pPrXml = `<${t}pPr algn="${edit.align}"/>`
+  if (!para.elem.selfClosing) {
+    return [{ start: para.elem.contentStart, end: para.elem.contentStart, insert: pPrXml }]
+  }
+  // `<a:p/>`: reopen it.
+  const info = openTagInfo(ctx.s, para.elem)
+  return [{ start: info.closeStart, end: para.elem.end, insert: `>${pPrXml}</${para.elem.name}>` }]
+}
+
+function shapeGeometryOps(ctx: SlideCtx, edit: ShapeGeometryEdit): SpliceOp[] {
+  if (!edit.offEmu && !edit.extEmu) return []
+  const { elem } = locateShape(ctx, edit.nodePath, ['sp', 'pic', 'cxnSp'])
+  const spPr = childElemByLocal(ctx.s, elem, 'spPr') ?? fail('shape has no spPr')
+
+  const off = edit.offEmu && {
+    x: String(Math.round(edit.offEmu.x)),
+    y: String(Math.round(edit.offEmu.y)),
+  }
+  const ext = edit.extEmu && {
+    cx: String(Math.max(1, Math.round(edit.extEmu.w))),
+    cy: String(Math.max(1, Math.round(edit.extEmu.h))),
+  }
+
+  const xfrm = spPr.selfClosing ? undefined : childElemByLocal(ctx.s, spPr, 'xfrm')
+
+  if (!xfrm || xfrm.selfClosing) {
+    // Inherited (or empty) geometry: synthesize the transform. The schema
+    // requires both off and ext, so partial input cannot be honored here.
+    if (!off || !ext) {
+      fail('shape has no explicit xfrm — geometry edits must provide both offEmu and extEmu')
+    }
+    const aPfx = drawingPrefixOf(ctx.s, ctx.sldElem)
+    const t = (n: string): string => (aPfx ? `${aPfx}:${n}` : n)
+    const inner = `<${t('off')} x="${off.x}" y="${off.y}"/><${t('ext')} cx="${ext.cx}" cy="${ext.cy}"/>`
+    if (xfrm) {
+      // `<a:xfrm/>`: reopen it; its own attributes (rot, flips) are untouched.
+      const info = openTagInfo(ctx.s, xfrm)
+      return [{ start: info.closeStart, end: xfrm.end, insert: `>${inner}</${xfrm.name}>` }]
+    }
+    const xfrmXml = `<${t('xfrm')}>${inner}</${t('xfrm')}>`
+    if (!spPr.selfClosing) {
+      // FIRST child of spPr — CT_ShapeProperties orders xfrm before geometry.
+      return [{ start: spPr.contentStart, end: spPr.contentStart, insert: xfrmXml }]
+    }
+    const info = openTagInfo(ctx.s, spPr)
+    return [{ start: info.closeStart, end: spPr.end, insert: `>${xfrmXml}</${spPr.name}>` }]
+  }
+
+  // Existing xfrm: numeric attribute splices only. rot/flipH/flipV live on the
+  // xfrm open tag, which these ops never touch.
+  const ops: SpliceOp[] = []
+  const offElem = childElemByLocal(ctx.s, xfrm, 'off')
+  const extElem = childElemByLocal(ctx.s, xfrm, 'ext')
+  const aPfx = prefixOf(xfrm.name)
+  const t = (n: string): string => (aPfx ? `${aPfx}:${n}` : n)
+  let insertAtStart = ''
+  if (off) {
+    if (offElem) ops.push(...setAttrOps(ctx.s, offElem, [['x', off.x], ['y', off.y]]))
+    else insertAtStart += `<${t('off')} x="${off.x}" y="${off.y}"/>`
+  }
+  if (ext) {
+    if (extElem) {
+      ops.push(...setAttrOps(ctx.s, extElem, [['cx', ext.cx], ['cy', ext.cy]]))
+    } else if (offElem) {
+      ops.push({ start: offElem.end, end: offElem.end, insert: `<${t('ext')} cx="${ext.cx}" cy="${ext.cy}"/>` })
+    } else {
+      insertAtStart += `<${t('ext')} cx="${ext.cx}" cy="${ext.cy}"/>`
+    }
+  }
+  if (insertAtStart) {
+    ops.push({ start: xfrm.contentStart, end: xfrm.contentStart, insert: insertAtStart })
+  }
+  return ops
+}
+
 // -------------------------------------------------------------- updateSlideXml
 
 /**
- * Applies text edits to one slide's raw XML. Returns the raw string unchanged
- * when there is nothing to change. Throws (leaving the caller's file
- * untouched) on any inconsistency between the model, the edit, and the raw
- * bytes.
+ * Applies edits to one slide's raw XML. Returns the raw string unchanged when
+ * there is nothing to change. Throws (leaving the caller's file untouched) on
+ * any inconsistency between the model, the edit, and the raw bytes.
  */
-export function updateSlideXml(slideXmlRaw: string, edits: readonly ShapeTextEdit[]): string {
+export function updateSlideXml(slideXmlRaw: string, edits: readonly SlideEdit[]): string {
   if (edits.length === 0) return slideXmlRaw
 
   const doc = parseXml(slideXmlRaw)
 
-  // Scanner view of the same document, cross-validated below.
+  // Scanner view of the same document, cross-validated per edit.
   const rootElems = childElementsIn(slideXmlRaw, 0, slideXmlRaw.length)
   const sldElem = rootElems.find((e) => localOf(e.name) === 'sld') ?? fail('no <p:sld> element')
   const cSldElem = childElemByLocal(slideXmlRaw, sldElem, 'cSld') ?? fail('no <p:cSld> element')
   const spTreeElem = childElemByLocal(slideXmlRaw, cSldElem, 'spTree') ?? fail('no <p:spTree> element')
-  const spTreeShapes = childElemsOf(slideXmlRaw, spTreeElem)
+  const ctx: SlideCtx = {
+    s: slideXmlRaw,
+    doc,
+    sldElem,
+    spTreeShapes: childElemsOf(slideXmlRaw, spTreeElem),
+  }
 
   const ops: SpliceOp[] = []
-
   for (const edit of edits) {
-    if (edit.next.length === 0) fail('a text shape must keep at least one paragraph')
-
-    // --- model side: resolve the shape node and re-derive its paragraphs.
-    const node = resolveNodePath(doc, edit.nodePath) ?? fail('node path no longer resolves')
-    const nodeTag = tagNameOf(node) ?? fail('node path resolves to a text node')
-    if (localOf(nodeTag) !== 'sp') fail(`not a text shape (<${nodeTag}>)`)
-
-    const modelParas = modelParagraphsOfSp(node) ?? fail('shape has no txBody')
-    if (normalizeParagraphs(modelParas) !== normalizeParagraphs(edit.original)) {
-      fail('edit original does not match the retained slide XML — refusing to write')
-    }
-
-    // --- locate the same shape in the raw bytes, by element ordinal.
-    const parent = resolveNodePath(doc, edit.nodePath.slice(0, -1)) ?? fail('spTree path broken')
-    const siblings = childrenOf(parent)
-    const last = edit.nodePath[edit.nodePath.length - 1]
-    let ordinal = 0
-    for (let j = 0; j < last; j++) if (tagNameOf(siblings[j]) !== null) ordinal++
-
-    const shapeElem = spTreeShapes[ordinal] ?? fail('shape ordinal out of range in raw XML')
-    if (localOf(shapeElem.name) !== 'sp') {
-      fail(`raw XML disagrees with model at shape ordinal ${ordinal} (<${shapeElem.name}>)`)
-    }
-    const txBodyElem =
-      childElemByLocal(slideXmlRaw, shapeElem, 'txBody') ?? fail('raw shape has no txBody')
-    const rawParas = rawParagraphsOf(slideXmlRaw, txBodyElem)
-
-    // --- cross-validate scanner structure against the model.
-    if (rawParas.length !== modelParas.length) fail('paragraph count mismatch between scanner and model')
-    for (let i = 0; i < rawParas.length; i++) {
-      const raw = rawParas[i]
-      const model = modelParas[i]
-      if (raw.items.length !== model.runs.length) fail(`run count mismatch in paragraph ${i}`)
-      for (let j = 0; j < raw.items.length; j++) {
-        if ((raw.items[j].kind === 'br') !== isBr(model.runs[j])) {
-          fail(`run kind mismatch at paragraph ${i}, run ${j}`)
-        }
-      }
-    }
-
-    // --- choose strategy.
-    if (isTextOnlyEdit(edit.original, edit.next)) {
-      for (let i = 0; i < edit.next.length; i++) {
-        for (let j = 0; j < edit.next[i].runs.length; j++) {
-          const nr = edit.next[i].runs[j]
-          const or = edit.original[i].runs[j]
-          if (nr.text === or.text) continue
-          const t = rawParas[i].items[j].t ?? fail('changed run has no <a:t> in raw XML')
-          ops.push({ start: t.contentStart, end: t.contentEnd, insert: escapeXmlText(nr.text) })
-        }
-      }
-    } else {
-      if (rawParas.length === 0) fail('cannot rebuild a txBody with no paragraphs')
-      ops.push({
-        start: rawParas[0].elem.start,
-        end: rawParas[rawParas.length - 1].elem.end,
-        insert: rebuildParagraphs(slideXmlRaw, rawParas, edit.original, edit.next),
-      })
+    switch (edit.kind) {
+      case 'text':
+        ops.push(...textEditOps(ctx, edit))
+        break
+      case 'formatRuns':
+        ops.push(...formatRunsOps(ctx, edit))
+        break
+      case 'paragraphAlign':
+        ops.push(...paragraphAlignOps(ctx, edit))
+        break
+      case 'shapeGeometry':
+        ops.push(...shapeGeometryOps(ctx, edit))
+        break
     }
   }
 
@@ -515,7 +882,7 @@ export function updateSlideXml(slideXmlRaw: string, edits: readonly ShapeTextEdi
  */
 export async function writeDeck(
   deck: SlideDeck,
-  editsBySlide: ReadonlyMap<string, readonly ShapeTextEdit[]>,
+  editsBySlide: ReadonlyMap<string, readonly SlideEdit[]>,
 ): Promise<Uint8Array> {
   for (const slidePath of editsBySlide.keys()) {
     if (deck.source.slideXml[slidePath] === undefined) {

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -78,6 +78,12 @@ export interface RunFormatOverrides {
   sizePt?: number
   /** Six-digit RRGGBB; replaces the run's fill with a solid color. */
   colorHex?: string
+  /**
+   * Latin typeface. Unlike the others this is a CHILD ELEMENT of rPr
+   * (`<a:latin typeface="…"/>`), not an attribute: an existing one is spliced
+   * at the attribute level, an absent one is inserted at its schema position.
+   */
+  latinFont?: string
 }
 
 export interface FormatRunsEdit {
@@ -148,6 +154,7 @@ export function normalizeParagraphs(paras: readonly Paragraph[]): string {
         underline: r.underline || undefined,
         sizePt: r.sizePt,
         colorHex: r.colorHex,
+        latinFont: r.latinFont,
       })),
     })),
   )
@@ -159,11 +166,29 @@ function runPropsEqual(a: TextRun, b: TextRun): boolean {
     Boolean(a.italic) === Boolean(b.italic) &&
     Boolean(a.underline) === Boolean(b.underline) &&
     a.sizePt === b.sizePt &&
-    a.colorHex === b.colorHex
+    a.colorHex === b.colorHex &&
+    a.latinFont === b.latinFont
   )
 }
 
 // ------------------------------------------------------------------ escaping
+
+/**
+ * Escapes a value for a double-quoted XML attribute. Font family names are
+ * arbitrary user/OS strings, so unlike the enum and integer attributes
+ * elsewhere in this module they genuinely need escaping.
+ */
+function escapeXmlAttr(s: string): string {
+  return (
+    s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      // eslint-disable-next-line no-control-regex -- stripping them is the point
+      .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g, '')
+  )
+}
 
 /** Escapes text for XML element content. Quotes stay literal, as Office writes them. */
 function escapeXmlText(s: string): string {
@@ -499,12 +524,20 @@ function drawingPrefixOf(s: string, sldElem: Elem): string {
 
 const FILL_LOCALS = ['noFill', 'solidFill', 'gradFill', 'blipFill', 'pattFill', 'grpFill']
 
+/**
+ * rPr children the schema orders AFTER `a:latin`, per CT_TextCharacterProperties
+ * (ln, fill, effects, highlight, underline fill/line, latin, ea, cs, sym,
+ * hlink*, rtl, extLst). A synthesized `a:latin` goes before the first of these.
+ */
+const AFTER_LATIN_LOCALS = ['ea', 'cs', 'sym', 'hlinkClick', 'hlinkMouseOver', 'rtl', 'extLst']
+
 const hasOverride = (set: RunFormatOverrides): boolean =>
   set.bold !== undefined ||
   set.italic !== undefined ||
   set.underline !== undefined ||
   set.sizePt !== undefined ||
-  set.colorHex !== undefined
+  set.colorHex !== undefined ||
+  set.latinFont !== undefined
 
 /** sz is hundredths of a point, schema-bounded to [1pt, 4000pt]. */
 function szValue(sizePt: number): string {
@@ -525,6 +558,11 @@ function solidFillXml(prefix: string, colorHex: string): string {
   return `<${t('solidFill')}><${t('srgbClr')} val="${colorHex}"/></${t('solidFill')}>`
 }
 
+function latinXml(prefix: string, typeface: string): string {
+  const t = (n: string): string => (prefix ? `${prefix}:${n}` : n)
+  return `<${t('latin')} typeface="${escapeXmlAttr(typeface)}"/>`
+}
+
 /**
  * Ops that rewrite an existing rPr per the overrides: overridden attributes
  * are set on the open tag, an overridden color replaces the fill-group child
@@ -542,28 +580,62 @@ function transformRPrOps(s: string, rPr: Elem, set: RunFormatOverrides): SpliceO
     else attrInserts += ` ${name}="${value}"`
   }
 
-  if (set.colorHex === undefined) {
+  const prefix = prefixOf(rPr.name)
+  const fill = set.colorHex !== undefined ? solidFillXml(prefix, set.colorHex) : ''
+  const wantsLatin = set.latinFont !== undefined
+
+  // Attributes only: nothing inside the element moves.
+  if (!fill && !wantsLatin) {
     if (attrInserts) ops.push({ start: info.closeStart, end: info.closeStart, insert: attrInserts })
     return ops
   }
 
-  const fill = solidFillXml(prefixOf(rPr.name), set.colorHex)
   if (rPr.selfClosing) {
-    // `<a:rPr .../>` must reopen to hold the fill; fold new attributes into
-    // the same op so nothing overlaps.
-    ops.push({ start: info.closeStart, end: rPr.end, insert: `${attrInserts}>${fill}</${rPr.name}>` })
+    // `<a:rPr .../>` must reopen to hold children; fold the new attributes and
+    // every child into ONE op, in schema order, so nothing overlaps.
+    const inner = fill + (wantsLatin ? latinXml(prefix, set.latinFont as string) : '')
+    ops.push({
+      start: info.closeStart,
+      end: rPr.end,
+      insert: `${attrInserts}>${inner}</${rPr.name}>`,
+    })
     return ops
   }
+
   if (attrInserts) ops.push({ start: info.closeStart, end: info.closeStart, insert: attrInserts })
   const children = childElemsOf(s, rPr)
-  const existingFill = children.find((c) => FILL_LOCALS.includes(localOf(c.name)))
-  if (existingFill) {
-    ops.push({ start: existingFill.start, end: existingFill.end, insert: fill })
-  } else {
-    const ln = children.find((c) => localOf(c.name) === 'ln')
-    const at = ln ? ln.end : rPr.contentStart
-    ops.push({ start: at, end: at, insert: fill })
+
+  // Zero-length inserts are merged per offset: two children inserted at the
+  // same point as separate ops would tie in applySplices, which resolves ties
+  // by array order rather than schema order.
+  const inserts = new Map<number, string>()
+  const addInsert = (at: number, xml: string): void => {
+    inserts.set(at, (inserts.get(at) ?? '') + xml)
   }
+
+  if (fill) {
+    const existingFill = children.find((c) => FILL_LOCALS.includes(localOf(c.name)))
+    if (existingFill) {
+      ops.push({ start: existingFill.start, end: existingFill.end, insert: fill })
+    } else {
+      const ln = children.find((c) => localOf(c.name) === 'ln')
+      addInsert(ln ? ln.end : rPr.contentStart, fill)
+    }
+  }
+
+  if (wantsLatin) {
+    const existingLatin = children.find((c) => localOf(c.name) === 'latin')
+    if (existingLatin) {
+      // Attribute-level splice: every other byte of the element — and of its
+      // neighbours — is left exactly as authored.
+      ops.push(...setAttrOps(s, existingLatin, [['typeface', escapeXmlAttr(set.latinFont as string)]]))
+    } else {
+      const after = children.find((c) => AFTER_LATIN_LOCALS.includes(localOf(c.name)))
+      addInsert(after ? after.start : rPr.contentEnd, latinXml(prefix, set.latinFont as string))
+    }
+  }
+
+  for (const [at, xml] of inserts) ops.push({ start: at, end: at, insert: xml })
   return ops
 }
 
@@ -573,8 +645,12 @@ function synthesizedRPr(prefix: string, set: RunFormatOverrides): string {
   const attrs = attrPairsFor(set)
     .map(([n, v]) => ` ${n}="${v}"`)
     .join('')
-  if (set.colorHex === undefined) return `<${t('rPr')}${attrs}/>`
-  return `<${t('rPr')}${attrs}>${solidFillXml(prefix, set.colorHex)}</${t('rPr')}>`
+  // Children in schema order: the fill group precedes a:latin.
+  const children =
+    (set.colorHex !== undefined ? solidFillXml(prefix, set.colorHex) : '') +
+    (set.latinFont !== undefined ? latinXml(prefix, set.latinFont) : '')
+  if (!children) return `<${t('rPr')}${attrs}/>`
+  return `<${t('rPr')}${attrs}>${children}</${t('rPr')}>`
 }
 
 // --------------------------------------------------------------- rebuilding
@@ -745,6 +821,14 @@ function formatRunsOps(ctx: SlideCtx, edit: FormatRunsEdit): SpliceOp[] {
   if (set.colorHex !== undefined) {
     if (!/^[0-9A-Fa-f]{6}$/.test(set.colorHex)) fail(`colorHex must be RRGGBB (got "${set.colorHex}")`)
     set = { ...set, colorHex: set.colorHex.toUpperCase() }
+  }
+  if (set.latinFont !== undefined) {
+    // The value reaches an attribute, so it is escaped on the way out; an
+    // empty typeface is meaningless and would write an unusable a:latin.
+    const typeface = set.latinFont.trim()
+    if (!typeface) fail('latinFont must not be empty')
+    if (typeface.length > 64) fail(`latinFont is implausibly long (${typeface.length} chars)`)
+    set = { ...set, latinFont: typeface }
   }
 
   const { node, elem } = locateShape(ctx, edit.nodePath, ['sp'])

--- a/apps/x/apps/renderer/src/lib/pptx/serialize.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/serialize.ts
@@ -353,8 +353,16 @@ const isBr = (r: TextRun): boolean => r.text === '\n'
 /**
  * True when the edit changes no paragraph/run structure — only text inside
  * existing runs — so it can be applied as in-place `<a:t>` splices.
+ *
+ * Exported because the editor must gate formatting on the SAME predicate: a
+ * `formatRuns` splice lives inside the `<a:p>` range a rebuild replaces, so if
+ * the editor believed formatting was still addressable while this returned
+ * false, both edits would be emitted and every save would fail closed forever.
  */
-function isTextOnlyEdit(original: Paragraph[], next: EditedParagraph[]): boolean {
+export function isTextOnlyEdit(
+  original: readonly Paragraph[],
+  next: readonly EditedParagraph[],
+): boolean {
   if (original.length !== next.length) return false
   for (let i = 0; i < original.length; i++) {
     const o = original[i]

--- a/apps/x/apps/renderer/src/lib/pptx/shape-style.test.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/shape-style.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import JSZip from 'jszip'
+import { parsePptx } from './parse'
+import { updateSlideXml, writeDeck, type SetShapeStyleEdit } from './serialize'
+import type { DrawingShape, Shape, TextShape } from './types'
+
+const NS_P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+const NS_A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const REL_NS = 'xmlns="http://schemas.openxmlformats.org/package/2006/relationships"'
+const REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+const XFRM = '<a:xfrm><a:off x="0" y="0"/><a:ext cx="1000" cy="1000"/></a:xfrm>'
+const GEOM = '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+
+/** 0: solid fill + an a:ln carrying a width and a dash to preserve. */
+const SP_SOLID =
+  '<p:sp><p:nvSpPr><p:cNvPr id="2" name="Solid"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>' +
+  `<p:spPr>${XFRM}${GEOM}<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>` +
+  '<a:ln w="12700" cap="rnd"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill>' +
+  '<a:prstDash val="dash"/></a:ln>' +
+  '<a:effectLst/></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:p><a:r><a:t>hello</a:t></a:r></a:p></p:txBody></p:sp>'
+
+/** 1: a gradient fill, which must be replaced across its WHOLE range. */
+const SP_GRAD =
+  '<p:sp><p:nvSpPr><p:cNvPr id="3" name="Grad"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>' +
+  `<p:spPr>${XFRM}${GEOM}<a:gradFill rotWithShape="1"><a:gsLst>` +
+  '<a:gs pos="0"><a:srgbClr val="111111"/></a:gs>' +
+  '<a:gs pos="100000"><a:srgbClr val="222222"/></a:gs>' +
+  '</a:gsLst><a:lin ang="5400000" scaled="0"/></a:gradFill></p:spPr>' +
+  '<p:txBody><a:bodyPr/><a:p><a:r><a:t>grad</a:t></a:r></a:p></p:txBody></p:sp>'
+
+/** 2: no fill and no a:ln at all — both get synthesized. */
+const SP_BARE =
+  '<p:sp><p:nvSpPr><p:cNvPr id="4" name="Bare"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>' +
+  `<p:spPr>${XFRM}${GEOM}</p:spPr>` +
+  '<p:txBody><a:bodyPr/><a:p><a:r><a:t>bare</a:t></a:r></a:p></p:txBody></p:sp>'
+
+/** 3: a connector — outline only, never a fill. */
+const CXN =
+  '<p:cxnSp><p:nvCxnSpPr><p:cNvPr id="5" name="Conn"/><p:cNvCxnSpPr/><p:nvPr/></p:nvCxnSpPr>' +
+  `<p:spPr>${XFRM}<a:prstGeom prst="line"><a:avLst/></a:prstGeom>` +
+  '<a:ln w="19050"><a:solidFill><a:srgbClr val="0000FF"/></a:solidFill></a:ln></p:spPr>' +
+  '</p:cxnSp>'
+
+/** 4: an image, which must be rejected. */
+const PIC =
+  '<p:pic><p:nvPicPr><p:cNvPr id="6" name="Pic"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>' +
+  '<p:blipFill><a:blip/></p:blipFill>' +
+  `<p:spPr>${XFRM}${GEOM}</p:spPr></p:pic>`
+
+const SLIDE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' +
+  `<p:sld ${NS_P} ${NS_A}><p:cSld><p:spTree>` +
+  '<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>' +
+  '<p:grpSpPr/>' +
+  SP_SOLID +
+  SP_GRAD +
+  SP_BARE +
+  CXN +
+  PIC +
+  '</p:spTree></p:cSld></p:sld>'
+
+const PRESENTATION_XML =
+  `<p:presentation ${NS_P} xmlns:r="${REL_TYPE}">` +
+  '<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>' +
+  '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>'
+const PRESENTATION_RELS =
+  `<Relationships ${REL_NS}>` +
+  `<Relationship Id="rId2" Type="${REL_TYPE}/slide" Target="slides/slide1.xml"/></Relationships>`
+
+async function buildZip(): Promise<Uint8Array> {
+  const zip = new JSZip()
+  zip.file('ppt/presentation.xml', PRESENTATION_XML)
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+  zip.file('ppt/slides/slide1.xml', SLIDE_XML)
+  return zip.generateAsync({ type: 'uint8array' })
+}
+
+const originalCreate = URL.createObjectURL
+const originalRevoke = URL.revokeObjectURL
+beforeAll(() => {
+  URL.createObjectURL = (() => 'blob:mock/0') as typeof URL.createObjectURL
+  URL.revokeObjectURL = (() => {}) as typeof URL.revokeObjectURL
+})
+afterAll(() => {
+  URL.createObjectURL = originalCreate
+  URL.revokeObjectURL = originalRevoke
+})
+
+async function loadShapes(): Promise<Shape[]> {
+  return (await parsePptx(await buildZip())).slides[0].shapes
+}
+
+function styleEdit(shape: Shape, set: { fillHex?: string; lineHex?: string }): SetShapeStyleEdit {
+  return {
+    kind: 'setShapeStyle',
+    nodePath: shape.nodePath,
+    shapeType: shape.type,
+    shapeId: shape.id,
+    original: shape.style!,
+    ...set,
+  }
+}
+
+describe('shape style snapshot', () => {
+  it('is byte-anchored: the shape own spPr fill/line, unresolved', async () => {
+    const [solid, grad, bare, cxn, pic] = await loadShapes()
+    expect(solid.style).toEqual({
+      fill: 'solidFill',
+      fillHex: 'FF0000',
+      hasLine: true,
+      lineFill: 'solidFill',
+      lineHex: '00FF00',
+      lineW: '12700',
+    })
+    expect(grad.style).toEqual({ fill: 'gradFill', hasLine: false, lineFill: null })
+    expect(bare.style).toEqual({ fill: null, hasLine: false, lineFill: null })
+    expect(cxn.style?.lineHex).toBe('0000FF')
+    // Only restylable kinds carry one.
+    expect(pic.style).toBeUndefined()
+  })
+})
+
+describe('setShapeStyle fill', () => {
+  it('replaces a solid fill and leaves every other byte of the slide alone', async () => {
+    const [solid] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(solid, { fillHex: '336699' })])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>',
+        '<a:solidFill><a:srgbClr val="336699"/></a:solidFill>',
+      ),
+    )
+    // The outline, its width, its dash and the effect list are untouched.
+    expect(out).toContain('<a:ln w="12700" cap="rnd">')
+    expect(out).toContain('<a:prstDash val="dash"/>')
+    expect(out).toContain('<a:effectLst/>')
+  })
+
+  it('replaces a gradient across its ENTIRE range, orphaning no stops', async () => {
+    const [, grad] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(grad, { fillHex: 'ABCDEF' })])
+    expect(out).toContain('<a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill>')
+    // Nothing of the gradient survives.
+    expect(out).not.toContain('gradFill')
+    expect(out).not.toContain('a:gsLst')
+    expect(out).not.toContain('val="111111"')
+    expect(out).not.toContain('<a:lin ang="5400000"')
+    // And the other shapes are untouched.
+    expect(out).toContain(SP_SOLID)
+    expect(out).toContain(SP_BARE)
+  })
+
+  it('inserts a fill at the schema position when the shape has none', async () => {
+    const [, , bare] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(bare, { fillHex: '010203' })])
+    // After prstGeom, at the end of spPr (there is no a:ln to precede).
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        `<p:spPr>${XFRM}${GEOM}</p:spPr>`,
+        `<p:spPr>${XFRM}${GEOM}<a:solidFill><a:srgbClr val="010203"/></a:solidFill></p:spPr>`,
+      ),
+    )
+  })
+
+  it('puts a synthesized fill BEFORE an existing a:ln', async () => {
+    // Strip the solid shape's fill, keeping its a:ln, so the insert has to
+    // choose a position rather than replace.
+    const xml = SLIDE_XML.replace('<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>', '')
+    const zip = new JSZip()
+    zip.file('ppt/presentation.xml', PRESENTATION_XML)
+    zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS)
+    zip.file('ppt/slides/slide1.xml', xml)
+    const shape = (await parsePptx(await zip.generateAsync({ type: 'uint8array' }))).slides[0]
+      .shapes[0]
+    const out = updateSlideXml(xml, [styleEdit(shape, { fillHex: '445566' })])
+    expect(out).toContain(
+      `${GEOM}<a:solidFill><a:srgbClr val="445566"/></a:solidFill><a:ln w="12700"`,
+    )
+  })
+})
+
+describe('setShapeStyle outline', () => {
+  it('changes the line colour while preserving a:ln width, cap and dash', async () => {
+    const [solid] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(solid, { lineHex: '123456' })])
+    expect(out).toBe(
+      SLIDE_XML.replace(
+        '<a:ln w="12700" cap="rnd"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill>',
+        '<a:ln w="12700" cap="rnd"><a:solidFill><a:srgbClr val="123456"/></a:solidFill>',
+      ),
+    )
+    expect(out).toContain('<a:ln w="12700" cap="rnd">')
+    expect(out).toContain('<a:prstDash val="dash"/>')
+    // The shape fill is untouched.
+    expect(out).toContain('<a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>')
+  })
+
+  it('creates a minimal a:ln when the shape has none', async () => {
+    const [, , bare] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(bare, { lineHex: '778899' })])
+    expect(out).toContain(
+      `${GEOM}<a:ln><a:solidFill><a:srgbClr val="778899"/></a:solidFill></a:ln></p:spPr>`,
+    )
+  })
+
+  it('sets fill and outline together, fill first', async () => {
+    const [, , bare] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(bare, { fillHex: 'AAAAAA', lineHex: 'BBBBBB' })])
+    expect(out).toContain(
+      `${GEOM}<a:solidFill><a:srgbClr val="AAAAAA"/></a:solidFill>` +
+        '<a:ln><a:solidFill><a:srgbClr val="BBBBBB"/></a:solidFill></a:ln></p:spPr>',
+    )
+  })
+
+  it('restyles a connector outline but refuses to give it a fill', async () => {
+    const [, , , cxn] = await loadShapes()
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(cxn, { lineHex: 'FEDCBA' })])
+    expect(out).toContain('<a:ln w="19050"><a:solidFill><a:srgbClr val="FEDCBA"/></a:solidFill>')
+    expect(() => updateSlideXml(SLIDE_XML, [styleEdit(cxn, { fillHex: 'FEDCBA' })])).toThrow(
+      /connector .* has no fill/,
+    )
+  })
+})
+
+describe('setShapeStyle fails closed', () => {
+  it('rejects images, and a style that no longer matches the bytes', async () => {
+    const [solid, , , , pic] = await loadShapes()
+    expect(() =>
+      updateSlideXml(SLIDE_XML, [
+        {
+          kind: 'setShapeStyle',
+          nodePath: pic.nodePath,
+          shapeType: pic.type,
+          shapeId: pic.id,
+          original: { fill: null, hasLine: false, lineFill: null },
+          fillHex: 'FFFFFF',
+        },
+      ]),
+    ).toThrow(/cannot be restyled/)
+
+    // Stale snapshot: the editor believed a different fill than the file has.
+    const stale = styleEdit(solid, { fillHex: '000000' })
+    stale.original = { ...stale.original, fillHex: '00FFFF' }
+    expect(() => updateSlideXml(SLIDE_XML, [stale])).toThrow(/does not match the slide XML/)
+
+    // Wrong identity at the same path.
+    const misId = styleEdit(solid, { fillHex: '000000' })
+    misId.shapeId = '999'
+    expect(() => updateSlideXml(SLIDE_XML, [misId])).toThrow(/style target mismatch/)
+
+    // Not a colour.
+    expect(() => updateSlideXml(SLIDE_XML, [styleEdit(solid, { fillHex: 'nope' })])).toThrow(
+      /must be RRGGBB/,
+    )
+  })
+})
+
+describe('setShapeStyle end to end', () => {
+  it('re-parses to the new colours, and an empty edit set restores the bytes', async () => {
+    const input = await buildZip()
+    const deck = await parsePptx(input)
+    const [solid] = deck.slides[0].shapes
+    const out = await writeDeck(
+      deck,
+      new Map([['ppt/slides/slide1.xml', [styleEdit(solid, { fillHex: '336699', lineHex: '123456' })]]]),
+    )
+    const reshaped = (await parsePptx(out)).slides[0].shapes[0] as TextShape
+    expect(reshaped.style?.fillHex).toBe('336699')
+    expect(reshaped.style?.lineHex).toBe('123456')
+    // The display layer picks it up for the canvas.
+    expect(reshaped.visual?.fill).toEqual({ kind: 'solid', hex: '336699' })
+    expect(reshaped.visual?.line?.hex).toBe('123456')
+    // Width survived the colour change.
+    expect(reshaped.style?.lineW).toBe('12700')
+
+    // Undo = an empty edit set, which rewrites the original bytes.
+    const restored = await writeDeck(deck, new Map())
+    const a = await (await JSZip.loadAsync(input)).files['ppt/slides/slide1.xml'].async('uint8array')
+    const b = await (await JSZip.loadAsync(restored)).files['ppt/slides/slide1.xml'].async('uint8array')
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true)
+  })
+
+  it('leaves a drawing shape with no text on the same path', async () => {
+    const shapes = await loadShapes()
+    const cxn = shapes[3] as DrawingShape
+    expect(cxn.type).toBe('drawing')
+    const out = updateSlideXml(SLIDE_XML, [styleEdit(cxn, { lineHex: 'FEDCBA' })])
+    // Every other shape byte-identical.
+    expect(out).toContain(SP_SOLID)
+    expect(out).toContain(SP_GRAD)
+    expect(out).toContain(SP_BARE)
+    expect(out).toContain(PIC)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/pptx/shape-xml.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/shape-xml.ts
@@ -1,0 +1,152 @@
+/**
+ * Synthesized XML for shapes inserted into an existing slide.
+ *
+ * Pure string building: no scanning, no splicing, no id allocation. The
+ * serializer owns where these land, which id they get, and (for pictures)
+ * which relationship they reference — this module only decides what the new
+ * element looks like, so the shapes it produces re-parse as ordinary model
+ * shapes and are then movable, stylable and deletable like any other.
+ */
+
+import type { RectEmu } from './types'
+
+/** Preset geometries the insert menu offers. */
+export type InsertPreset = 'rect' | 'roundRect' | 'ellipse' | 'line'
+
+export type NewShapeSpec =
+  | { kind: 'textbox'; xfrmEmu: RectEmu }
+  | { kind: 'shape'; preset: InsertPreset; xfrmEmu: RectEmu }
+  | {
+      kind: 'image'
+      xfrmEmu: RectEmu
+      /** Lowercase extension without the dot, e.g. `png`. */
+      ext: string
+      /** The file's bytes, base64. Written verbatim as a new media part. */
+      dataBase64: string
+      /** Original file name, used only for the shape's display name. */
+      name?: string
+    }
+
+/** Namespace prefixes taken from the slide being written into. */
+export interface XmlPrefixes {
+  /** presentationml, usually `p`. */
+  p: string
+  /** drawingml, usually `a`. */
+  a: string
+  /** officeDocument relationships, usually `r`. Only pictures need it. */
+  r: string
+}
+
+const tag = (prefix: string, name: string): string => (prefix ? `${prefix}:${name}` : name)
+
+/** Escapes a value for a double-quoted XML attribute. */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    // eslint-disable-next-line no-control-regex -- stripping them is the point
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g, '')
+}
+
+function xfrmXml(a: string, rect: RectEmu): string {
+  const x = Math.round(rect.x)
+  const y = Math.round(rect.y)
+  const cx = Math.max(1, Math.round(rect.w))
+  const cy = Math.max(1, Math.round(rect.h))
+  return (
+    `<${tag(a, 'xfrm')}><${tag(a, 'off')} x="${x}" y="${y}"/>` +
+    `<${tag(a, 'ext')} cx="${cx}" cy="${cy}"/></${tag(a, 'xfrm')}>`
+  )
+}
+
+const prstGeomXml = (a: string, preset: string): string =>
+  `<${tag(a, 'prstGeom')} prst="${preset}"><${tag(a, 'avLst')}/></${tag(a, 'prstGeom')}>`
+
+/**
+ * An empty text body: one paragraph, no runs — the editor's "Add text" state.
+ *
+ * The lstStyle seeds an explicit `tx1` default. Without it the run inherits
+ * from the master's otherStyle, which routinely authors no colour at all, so
+ * the text fell through to whatever the cascade happened to resolve — white on
+ * some decks, i.e. invisible. `tx1` is the theme's own body-text colour (dark
+ * on a light theme), so this follows the deck rather than hardcoding black.
+ */
+const emptyTxBodyXml = (p: string, a: string, anchor?: string): string =>
+  `<${tag(p, 'txBody')}><${tag(a, 'bodyPr')} wrap="square" rtlCol="0"${
+    anchor ? ` anchor="${anchor}"` : ''
+  }/><${tag(a, 'lstStyle')}><${tag(a, 'lvl1pPr')}><${tag(a, 'defRPr')}>` +
+  `<${tag(a, 'solidFill')}><${tag(a, 'schemeClr')} val="tx1"/></${tag(a, 'solidFill')}>` +
+  `</${tag(a, 'defRPr')}></${tag(a, 'lvl1pPr')}></${tag(a, 'lstStyle')}>` +
+  `<${tag(a, 'p')}><${tag(a, 'endParaRPr')} lang="en-US"/></${tag(a, 'p')}></${tag(p, 'txBody')}>`
+
+/** Theme-following accent fill, so an inserted shape matches the deck. */
+const accentFillXml = (a: string): string =>
+  `<${tag(a, 'solidFill')}><${tag(a, 'schemeClr')} val="accent1"/></${tag(a, 'solidFill')}>`
+
+const PRESET_NAMES: Record<InsertPreset, string> = {
+  rect: 'Rectangle',
+  roundRect: 'Rounded Rectangle',
+  ellipse: 'Oval',
+  line: 'Straight Connector',
+}
+
+/**
+ * The element to splice in, for a shape that is not a picture. `id` must
+ * already be unique within the slide.
+ */
+export function newShapeXml(spec: NewShapeSpec, id: number, px: XmlPrefixes): string {
+  const { p, a } = px
+  if (spec.kind === 'image') throw new Error('newShapeXml: pictures use newPictureXml')
+
+  if (spec.kind === 'textbox') {
+    // txBox="1" is what marks it a text box rather than a shape with text;
+    // no fill and no a:ln, so only the text shows.
+    return (
+      `<${tag(p, 'sp')}><${tag(p, 'nvSpPr')}>` +
+      `<${tag(p, 'cNvPr')} id="${id}" name="TextBox ${id}"/>` +
+      `<${tag(p, 'cNvSpPr')} txBox="1"/><${tag(p, 'nvPr')}/></${tag(p, 'nvSpPr')}>` +
+      `<${tag(p, 'spPr')}>${xfrmXml(a, spec.xfrmEmu)}${prstGeomXml(a, 'rect')}` +
+      `<${tag(a, 'noFill')}/></${tag(p, 'spPr')}>` +
+      emptyTxBodyXml(p, a) +
+      `</${tag(p, 'sp')}>`
+    )
+  }
+
+  const isLine = spec.preset === 'line'
+  // A line is a stroke, not a filled region: colour goes on a:ln instead.
+  const style = isLine
+    ? `<${tag(a, 'noFill')}/><${tag(a, 'ln')}>${accentFillXml(a)}</${tag(a, 'ln')}>`
+    : accentFillXml(a)
+  return (
+    `<${tag(p, 'sp')}><${tag(p, 'nvSpPr')}>` +
+    `<${tag(p, 'cNvPr')} id="${id}" name="${PRESET_NAMES[spec.preset]} ${id}"/>` +
+    `<${tag(p, 'cNvSpPr')}/><${tag(p, 'nvPr')}/></${tag(p, 'nvSpPr')}>` +
+    `<${tag(p, 'spPr')}>${xfrmXml(a, spec.xfrmEmu)}${prstGeomXml(a, spec.preset)}${style}` +
+    `</${tag(p, 'spPr')}>` +
+    (isLine ? '' : emptyTxBodyXml(p, a, 'ctr')) +
+    `</${tag(p, 'sp')}>`
+  )
+}
+
+/** The `p:pic` element for an inserted image, referencing an assigned rId. */
+export function newPictureXml(
+  spec: Extract<NewShapeSpec, { kind: 'image' }>,
+  id: number,
+  rId: string,
+  px: XmlPrefixes,
+): string {
+  const { p, a, r } = px
+  const name = spec.name ? esc(spec.name) : `Picture ${id}`
+  return (
+    `<${tag(p, 'pic')}><${tag(p, 'nvPicPr')}>` +
+    `<${tag(p, 'cNvPr')} id="${id}" name="${name}"/>` +
+    `<${tag(p, 'cNvPicPr')}><${tag(a, 'picLocks')} noChangeAspect="1"/></${tag(p, 'cNvPicPr')}>` +
+    `<${tag(p, 'nvPr')}/></${tag(p, 'nvPicPr')}>` +
+    `<${tag(p, 'blipFill')}><${tag(a, 'blip')} ${tag(r, 'embed')}="${rId}"/>` +
+    `<${tag(a, 'stretch')}><${tag(a, 'fillRect')}/></${tag(a, 'stretch')}></${tag(p, 'blipFill')}>` +
+    `<${tag(p, 'spPr')}>${xfrmXml(a, spec.xfrmEmu)}${prstGeomXml(a, 'rect')}</${tag(p, 'spPr')}>` +
+    `</${tag(p, 'pic')}>`
+  )
+}

--- a/apps/x/apps/renderer/src/lib/pptx/textstyle.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/textstyle.ts
@@ -34,6 +34,12 @@ export interface RunLayerProps {
   latinFont?: string
   eaFont?: string
   csFont?: string
+  /**
+   * Character tracking in points from `a:rPr@spc` (authored in hundredths).
+   * Negative tightens. Design tools author this to make a heading fit its box
+   * on exactly one line, so ignoring it re-wraps the text and overflows.
+   */
+  letterSpacingPt?: number
 }
 
 /** One a:lnSpc / a:spcBef / a:spcAft value. Exactly one field is set. */
@@ -195,6 +201,8 @@ export function runLayerFromRPr(rPr: XmlNode | undefined, theme: Theme): RunLaye
   if (u !== undefined) out.underline = u !== 'none'
   const sz = num(attr(rPr, 'sz'))
   if (sz !== undefined) out.sizePt = sz / 100
+  const spc = num(attr(rPr, 'spc'))
+  if (spc !== undefined) out.letterSpacingPt = spc / 100
   const kids = childrenOf(rPr)
   const fill = childByLocal(kids, 'solidFill')
   const color = resolveFirstColor(fill, theme)
@@ -314,6 +322,9 @@ export function mergeLevelStyles(layers: readonly LevelStyle[]): LevelStyle {
     if (out.latinFont === undefined && layer.latinFont !== undefined) out.latinFont = layer.latinFont
     if (out.eaFont === undefined && layer.eaFont !== undefined) out.eaFont = layer.eaFont
     if (out.csFont === undefined && layer.csFont !== undefined) out.csFont = layer.csFont
+    if (out.letterSpacingPt === undefined && layer.letterSpacingPt !== undefined) {
+      out.letterSpacingPt = layer.letterSpacingPt
+    }
     if (out.lnSpc === undefined && layer.lnSpc !== undefined) out.lnSpc = layer.lnSpc
     if (out.spcBef === undefined && layer.spcBef !== undefined) out.spcBef = layer.spcBef
     if (out.spcAft === undefined && layer.spcAft !== undefined) out.spcAft = layer.spcAft

--- a/apps/x/apps/renderer/src/lib/pptx/textstyle.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/textstyle.ts
@@ -1,0 +1,303 @@
+/**
+ * Text style inheritance: run rPr -> paragraph defRPr(lvl) -> shape lstStyle
+ * -> layout placeholder -> master placeholder -> master txStyles (by
+ * placeholder type) -> presentation defaultTextStyle -> built-in default.
+ *
+ * The cascade order follows ECMA-376 Part 1 §21.1.2 as implemented across
+ * open-source readers; the merge itself (nearest defined layer wins, per
+ * property) is our own code. Bullet glyph and autonumber mapping are our own,
+ * from public Wingdings/Symbol tables.
+ *
+ * Display-only: nothing here feeds the serializer's validation derivation.
+ */
+
+import {
+  attr,
+  childByLocal,
+  childrenOf,
+  descend,
+  localNameOf,
+  num,
+  tagNameOf,
+  type XmlNode,
+} from './parse'
+import { resolveFirstColor, type Theme } from './theme'
+import type { ResolvedBullet, TextAlign } from './types'
+
+export interface RunLayerProps {
+  sizePt?: number
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  colorHex?: string
+}
+
+/** One layer's contribution for one indent level. undefined = inherit. */
+export interface LevelStyle extends RunLayerProps {
+  marLEmu?: number
+  indentEmu?: number
+  align?: TextAlign
+  bullet?: ResolvedBullet
+}
+
+export interface ParsedListStyle {
+  /** From a:defPPr — applies to every level, below the level-specific entry. */
+  def?: LevelStyle
+  /** Index 0..8 from a:lvl1pPr..a:lvl9pPr. */
+  levels: Array<LevelStyle | undefined>
+}
+
+export const EMPTY_LIST_STYLE: ParsedListStyle = { levels: [] }
+
+const ALIGNS: readonly TextAlign[] = ['l', 'ctr', 'r', 'just']
+
+// ------------------------------------------------------------------ bullets
+
+/**
+ * Wingdings/Symbol private-use glyphs mapped to close Unicode equivalents.
+ * PowerPoint stores either the raw byte char or its F0xx private-use form.
+ */
+const WINGDINGS_MAP: Record<number, string> = {
+  0x6c: '●',
+  0x6d: '○',
+  0x6e: '■',
+  0x6f: '□',
+  0x70: '◻',
+  0x71: '❑',
+  0x72: '❒',
+  0x73: '▲',
+  0x74: '▼',
+  0x75: '◆',
+  0x76: '❖',
+  0x77: '⬥',
+  0xa7: '▪',
+  0xa8: '□',
+  0xd8: '➢',
+  0xde: '➔',
+  0xe0: '⇨',
+  0xfc: '✓',
+  0xfb: '✗',
+}
+
+const SYMBOL_MAP: Record<number, string> = {
+  0xb7: '•',
+  0x2d: '–',
+  0xa8: '♦',
+}
+
+/** Maps a buChar glyph to something renderable, per its declared font. */
+export function bulletCharFor(fontTypeface: string | undefined, char: string): string {
+  if (!char) return '•'
+  let code = char.codePointAt(0) ?? 0
+  // Office often stores symbol-font chars in the F0xx private-use area.
+  if (code >= 0xf000 && code <= 0xf0ff) code -= 0xf000
+  const font = (fontTypeface ?? '').toLowerCase()
+  if (font.startsWith('wingdings')) return WINGDINGS_MAP[code] ?? '•'
+  if (font.startsWith('symbol')) return SYMBOL_MAP[code] ?? '•'
+  // A regular text font: the character is what it claims to be.
+  return code === (char.codePointAt(0) ?? 0) ? char : String.fromCodePoint(code)
+}
+
+function toRoman(n: number): string {
+  const table: Array<[number, string]> = [
+    [1000, 'm'],
+    [900, 'cm'],
+    [500, 'd'],
+    [400, 'cd'],
+    [100, 'c'],
+    [90, 'xc'],
+    [50, 'l'],
+    [40, 'xl'],
+    [10, 'x'],
+    [9, 'ix'],
+    [5, 'v'],
+    [4, 'iv'],
+    [1, 'i'],
+  ]
+  let out = ''
+  let rest = Math.max(1, Math.round(n))
+  for (const [value, glyph] of table) {
+    while (rest >= value) {
+      out += glyph
+      rest -= value
+    }
+  }
+  return out
+}
+
+function toAlpha(n: number): string {
+  let out = ''
+  let rest = Math.max(1, Math.round(n))
+  while (rest > 0) {
+    rest--
+    out = String.fromCharCode(97 + (rest % 26)) + out
+    rest = Math.floor(rest / 26)
+  }
+  return out
+}
+
+/** Formats one auto-number ordinal per the buAutoNum scheme. */
+export function autoNumText(scheme: string, n: number): string {
+  switch (scheme) {
+    case 'arabicPeriod':
+      return `${n}.`
+    case 'arabicParenR':
+      return `${n})`
+    case 'arabicParenBoth':
+      return `(${n})`
+    case 'arabicPlain':
+      return String(n)
+    case 'romanUcPeriod':
+      return `${toRoman(n).toUpperCase()}.`
+    case 'romanLcPeriod':
+      return `${toRoman(n)}.`
+    case 'romanLcParenR':
+      return `${toRoman(n)})`
+    case 'alphaUcPeriod':
+      return `${toAlpha(n).toUpperCase()}.`
+    case 'alphaLcPeriod':
+      return `${toAlpha(n)}.`
+    case 'alphaLcParenR':
+      return `${toAlpha(n)})`
+    case 'alphaUcParenR':
+      return `${toAlpha(n).toUpperCase()})`
+    default:
+      return `${n}.`
+  }
+}
+
+// ------------------------------------------------------------------ parsing
+
+/** Run-level properties from an rPr/defRPr node, theme colors resolved. */
+export function runLayerFromRPr(rPr: XmlNode | undefined, theme: Theme): RunLayerProps {
+  if (!rPr) return {}
+  const out: RunLayerProps = {}
+  const b = attr(rPr, 'b')
+  if (b !== undefined) out.bold = b === '1' || b === 'true'
+  const i = attr(rPr, 'i')
+  if (i !== undefined) out.italic = i === '1' || i === 'true'
+  const u = attr(rPr, 'u')
+  if (u !== undefined) out.underline = u !== 'none'
+  const sz = num(attr(rPr, 'sz'))
+  if (sz !== undefined) out.sizePt = sz / 100
+  const fill = childByLocal(childrenOf(rPr), 'solidFill')
+  const color = resolveFirstColor(fill, theme)
+  if (color) out.colorHex = color.hex
+  return out
+}
+
+function bulletOf(pPrKids: XmlNode[], theme: Theme): ResolvedBullet | undefined {
+  void theme
+  if (childByLocal(pPrKids, 'buNone')) return { kind: 'none' }
+  const auto = childByLocal(pPrKids, 'buAutoNum')
+  if (auto) {
+    return {
+      kind: 'auto',
+      scheme: attr(auto, 'type') ?? 'arabicPeriod',
+      startAt: num(attr(auto, 'startAt')) ?? 1,
+    }
+  }
+  const buChar = childByLocal(pPrKids, 'buChar')
+  if (buChar) {
+    const font = childByLocal(pPrKids, 'buFont')
+    return {
+      kind: 'char',
+      char: bulletCharFor(font ? attr(font, 'typeface') : undefined, attr(buChar, 'char') ?? '•'),
+    }
+  }
+  return undefined
+}
+
+/** One pPr/defPPr/lvlNpPr node -> one cascade layer. */
+export function levelStyleFromPPr(pPr: XmlNode | undefined, theme: Theme): LevelStyle {
+  if (!pPr) return {}
+  const kids = childrenOf(pPr)
+  const out: LevelStyle = { ...runLayerFromRPr(childByLocal(kids, 'defRPr'), theme) }
+  const marL = num(attr(pPr, 'marL'))
+  if (marL !== undefined) out.marLEmu = marL
+  const indent = num(attr(pPr, 'indent'))
+  if (indent !== undefined) out.indentEmu = indent
+  const algn = attr(pPr, 'algn')
+  if (algn && (ALIGNS as readonly string[]).includes(algn)) out.align = algn as TextAlign
+  const bullet = bulletOf(kids, theme)
+  if (bullet) out.bullet = bullet
+  return out
+}
+
+/** An a:lstStyle / p:titleStyle / p:bodyStyle / p:otherStyle / defaultTextStyle. */
+export function parseListStyle(node: XmlNode | undefined, theme: Theme): ParsedListStyle {
+  if (!node) return EMPTY_LIST_STYLE
+  const kids = childrenOf(node)
+  const levels: Array<LevelStyle | undefined> = []
+  for (let lvl = 0; lvl < 9; lvl++) {
+    const pPr = childByLocal(kids, `lvl${lvl + 1}pPr`)
+    levels[lvl] = pPr ? levelStyleFromPPr(pPr, theme) : undefined
+  }
+  const defPPr = childByLocal(kids, 'defPPr')
+  return { def: defPPr ? levelStyleFromPPr(defPPr, theme) : undefined, levels }
+}
+
+/** The two layers a ParsedListStyle contributes for a given level. */
+export function layersOf(style: ParsedListStyle | undefined, level: number): LevelStyle[] {
+  if (!style) return []
+  const out: LevelStyle[] = []
+  const lvl = style.levels[level]
+  if (lvl) out.push(lvl)
+  if (style.def) out.push(style.def)
+  return out
+}
+
+/** First defined value wins, walking layers nearest-first. */
+export function mergeLevelStyles(layers: readonly LevelStyle[]): LevelStyle {
+  const out: LevelStyle = {}
+  for (const layer of layers) {
+    if (out.marLEmu === undefined && layer.marLEmu !== undefined) out.marLEmu = layer.marLEmu
+    if (out.indentEmu === undefined && layer.indentEmu !== undefined) out.indentEmu = layer.indentEmu
+    if (out.align === undefined && layer.align !== undefined) out.align = layer.align
+    if (out.bullet === undefined && layer.bullet !== undefined) out.bullet = layer.bullet
+    if (out.sizePt === undefined && layer.sizePt !== undefined) out.sizePt = layer.sizePt
+    if (out.bold === undefined && layer.bold !== undefined) out.bold = layer.bold
+    if (out.italic === undefined && layer.italic !== undefined) out.italic = layer.italic
+    if (out.underline === undefined && layer.underline !== undefined) out.underline = layer.underline
+    if (out.colorHex === undefined && layer.colorHex !== undefined) out.colorHex = layer.colorHex
+  }
+  return out
+}
+
+// -------------------------------------------------- placeholder style routing
+
+/**
+ * Which master txStyles table a shape inherits from, per its placeholder type.
+ * Title variants use titleStyle, body-ish placeholders bodyStyle, everything
+ * else (including plain text boxes) otherStyle.
+ */
+export function txStyleKindFor(phType: string | undefined, isPlaceholder: boolean): 'title' | 'body' | 'other' {
+  if (!isPlaceholder) return 'other'
+  const t = phType ?? 'body'
+  if (t === 'title' || t === 'ctrTitle') return 'title'
+  if (t === 'body' || t === 'subTitle' || t === 'obj' || t === 'txBody') return 'body'
+  return 'other'
+}
+
+/** Kept-run walk of an a:p node, mirroring parseParagraph's skip rule exactly. */
+export function keptRunNodesOf(pNode: XmlNode): Array<{ kind: 'r' | 'fld' | 'br'; rPr?: XmlNode }> {
+  const out: Array<{ kind: 'r' | 'fld' | 'br'; rPr?: XmlNode }> = []
+  for (const child of childrenOf(pNode)) {
+    const tag = tagNameOf(child)
+    if (!tag) continue
+    const name = localNameOf(tag)
+    if (name === 'r' || name === 'fld') {
+      const t = childByLocal(childrenOf(child), 't')
+      const text = t
+        ? childrenOf(t)
+            .map((n) => (typeof n['#text'] === 'string' ? (n['#text'] as string) : ''))
+            .join('')
+        : ''
+      if (text === '') continue
+      out.push({ kind: name, rPr: childByLocal(childrenOf(child), 'rPr') })
+    } else if (name === 'br') {
+      out.push({ kind: 'br', rPr: descend(child, 'rPr') })
+    }
+  }
+  return out
+}

--- a/apps/x/apps/renderer/src/lib/pptx/textstyle.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/textstyle.ts
@@ -21,7 +21,7 @@ import {
   tagNameOf,
   type XmlNode,
 } from './parse'
-import { resolveFirstColor, type Theme } from './theme'
+import { resolveFirstColor, themeFontOf, type Theme } from './theme'
 import type { ResolvedBullet, TextAlign } from './types'
 
 export interface RunLayerProps {
@@ -30,6 +30,18 @@ export interface RunLayerProps {
   italic?: boolean
   underline?: boolean
   colorHex?: string
+  /** Resolved family names — theme +mj/+mn tokens already mapped. */
+  latinFont?: string
+  eaFont?: string
+  csFont?: string
+}
+
+/** One a:lnSpc / a:spcBef / a:spcAft value. Exactly one field is set. */
+export interface SpacingSpec {
+  /** Fraction, from a:spcPct (val=100000 -> 1). */
+  pct?: number
+  /** Points, from a:spcPts (val is hundredths of a point). */
+  pt?: number
 }
 
 /** One layer's contribution for one indent level. undefined = inherit. */
@@ -38,6 +50,9 @@ export interface LevelStyle extends RunLayerProps {
   indentEmu?: number
   align?: TextAlign
   bullet?: ResolvedBullet
+  lnSpc?: SpacingSpec
+  spcBef?: SpacingSpec
+  spcAft?: SpacingSpec
 }
 
 export interface ParsedListStyle {
@@ -168,7 +183,7 @@ export function autoNumText(scheme: string, n: number): string {
 
 // ------------------------------------------------------------------ parsing
 
-/** Run-level properties from an rPr/defRPr node, theme colors resolved. */
+/** Run-level properties from an rPr/defRPr node, theme colors/fonts resolved. */
 export function runLayerFromRPr(rPr: XmlNode | undefined, theme: Theme): RunLayerProps {
   if (!rPr) return {}
   const out: RunLayerProps = {}
@@ -180,10 +195,40 @@ export function runLayerFromRPr(rPr: XmlNode | undefined, theme: Theme): RunLaye
   if (u !== undefined) out.underline = u !== 'none'
   const sz = num(attr(rPr, 'sz'))
   if (sz !== undefined) out.sizePt = sz / 100
-  const fill = childByLocal(childrenOf(rPr), 'solidFill')
+  const kids = childrenOf(rPr)
+  const fill = childByLocal(kids, 'solidFill')
   const color = resolveFirstColor(fill, theme)
   if (color) out.colorHex = color.hex
+  const face = (name: string): string | undefined => {
+    const node = childByLocal(kids, name)
+    const typeface = node ? attr(node, 'typeface')?.trim() : undefined
+    return typeface ? themeFontOf(theme, typeface) : undefined
+  }
+  const latin = face('latin')
+  if (latin) out.latinFont = latin
+  const ea = face('ea')
+  if (ea) out.eaFont = ea
+  const cs = face('cs')
+  if (cs) out.csFont = cs
   return out
+}
+
+/** The a:spcPct / a:spcPts child of one spacing element, or undefined. */
+function spacingOf(pPrKids: XmlNode[], name: string): SpacingSpec | undefined {
+  const node = childByLocal(pPrKids, name)
+  if (!node) return undefined
+  const kids = childrenOf(node)
+  const pctNode = childByLocal(kids, 'spcPct')
+  if (pctNode) {
+    const v = num(attr(pctNode, 'val'))
+    if (v !== undefined) return { pct: v / 100000 }
+  }
+  const ptsNode = childByLocal(kids, 'spcPts')
+  if (ptsNode) {
+    const v = num(attr(ptsNode, 'val'))
+    if (v !== undefined) return { pt: v / 100 }
+  }
+  return undefined
 }
 
 function bulletOf(pPrKids: XmlNode[], theme: Theme): ResolvedBullet | undefined {
@@ -221,6 +266,12 @@ export function levelStyleFromPPr(pPr: XmlNode | undefined, theme: Theme): Level
   if (algn && (ALIGNS as readonly string[]).includes(algn)) out.align = algn as TextAlign
   const bullet = bulletOf(kids, theme)
   if (bullet) out.bullet = bullet
+  const lnSpc = spacingOf(kids, 'lnSpc')
+  if (lnSpc) out.lnSpc = lnSpc
+  const spcBef = spacingOf(kids, 'spcBef')
+  if (spcBef) out.spcBef = spcBef
+  const spcAft = spacingOf(kids, 'spcAft')
+  if (spcAft) out.spcAft = spcAft
   return out
 }
 
@@ -260,8 +311,44 @@ export function mergeLevelStyles(layers: readonly LevelStyle[]): LevelStyle {
     if (out.italic === undefined && layer.italic !== undefined) out.italic = layer.italic
     if (out.underline === undefined && layer.underline !== undefined) out.underline = layer.underline
     if (out.colorHex === undefined && layer.colorHex !== undefined) out.colorHex = layer.colorHex
+    if (out.latinFont === undefined && layer.latinFont !== undefined) out.latinFont = layer.latinFont
+    if (out.eaFont === undefined && layer.eaFont !== undefined) out.eaFont = layer.eaFont
+    if (out.csFont === undefined && layer.csFont !== undefined) out.csFont = layer.csFont
+    if (out.lnSpc === undefined && layer.lnSpc !== undefined) out.lnSpc = layer.lnSpc
+    if (out.spcBef === undefined && layer.spcBef !== undefined) out.spcBef = layer.spcBef
+    if (out.spcAft === undefined && layer.spcAft !== undefined) out.spcAft = layer.spcAft
   }
   return out
+}
+
+// ------------------------------------------------------------- font families
+
+/** Generic CSS family guessed from the primary name, for missing-font fallback. */
+function genericFamilyFor(name: string): string {
+  const n = name.toLowerCase()
+  if (/(courier|consolas|menlo|monaco|mono)/.test(n)) return 'monospace'
+  if (/sans/.test(n)) return 'sans-serif'
+  if (/(times|georgia|garamond|palatino|baskerville|didot|cambria|bookman|serif)/.test(n)) {
+    return 'serif'
+  }
+  return 'sans-serif'
+}
+
+/**
+ * CSS font-family for a resolved latin/ea/cs trio: authored families in order
+ * (CSS falls back per character, which is what the ea/cs slots are for), then
+ * a generic guessed from the primary name. Names are sanitized so the result
+ * can be embedded in inline-style HTML attributes.
+ */
+export function cssFontFamily(
+  latin: string | undefined,
+  ea: string | undefined,
+  cs: string | undefined,
+): string | undefined {
+  const names = [...new Set([latin, ea, cs].filter((n): n is string => Boolean(n)))]
+  if (names.length === 0) return undefined
+  const quoted = names.map((n) => `'${n.replace(/['"\\;{}<>&]/g, '')}'`)
+  return `${quoted.join(', ')}, ${genericFamilyFor(names[0])}`
 }
 
 // -------------------------------------------------- placeholder style routing

--- a/apps/x/apps/renderer/src/lib/pptx/theme.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/theme.ts
@@ -40,6 +40,8 @@ export interface Theme {
   fillStyleNodes: XmlNode[]
   /** Raw a:ln nodes from a:fmtScheme/a:lnStyleLst, for style lnRef. */
   lineStyleNodes: XmlNode[]
+  /** Raw fill nodes from a:fmtScheme/a:bgFillStyleLst, for p:bgRef idx ≥ 1001. */
+  bgFillStyleNodes: XmlNode[]
 }
 
 export const DEFAULT_CLR_MAP: Record<string, string> = {
@@ -78,6 +80,7 @@ export const DEFAULT_THEME: Theme = {
   clrMap: DEFAULT_CLR_MAP,
   fillStyleNodes: [],
   lineStyleNodes: [],
+  bgFillStyleNodes: [],
 }
 
 // ------------------------------------------------------------- primitives
@@ -418,18 +421,17 @@ export function parseTheme(themeDoc: XmlNode[]): Theme {
   }
 
   const fmtScheme = elements ? descend(elements, 'fmtScheme') : undefined
-  const fillStyleNodes = fmtScheme
-    ? childrenOf(descend(fmtScheme, 'fillStyleLst') ?? {})
-    : []
-  const lineStyleNodes = fmtScheme
-    ? childrenOf(descend(fmtScheme, 'lnStyleLst') ?? {})
-    : []
+  const fmtNodes = (list: string) =>
+    (fmtScheme ? childrenOf(descend(fmtScheme, list) ?? {}) : []).filter(
+      (n) => tagNameOf(n) !== null,
+    )
 
   return {
     scheme,
     clrMap: { ...DEFAULT_CLR_MAP },
-    fillStyleNodes: fillStyleNodes.filter((n) => tagNameOf(n) !== null),
-    lineStyleNodes: lineStyleNodes.filter((n) => tagNameOf(n) !== null),
+    fillStyleNodes: fmtNodes('fillStyleLst'),
+    lineStyleNodes: fmtNodes('lnStyleLst'),
+    bgFillStyleNodes: fmtNodes('bgFillStyleLst'),
   }
 }
 

--- a/apps/x/apps/renderer/src/lib/pptx/theme.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/theme.ts
@@ -31,11 +31,23 @@ export interface ResolvedColor {
   alpha?: number
 }
 
+/** Typeface per script slot of a:fontScheme's majorFont/minorFont. */
+export interface ThemeFonts {
+  majorLatin?: string
+  majorEa?: string
+  majorCs?: string
+  minorLatin?: string
+  minorEa?: string
+  minorCs?: string
+}
+
 export interface Theme {
   /** dk1/lt1/dk2/lt2/accent1..6/hlink/folHlink -> RRGGBB. */
   scheme: Record<string, string>
   /** Alias -> scheme slot, from the master's p:clrMap (bg1 -> lt1, …). */
   clrMap: Record<string, string>
+  /** From a:fontScheme, for +mj-lt / +mn-lt style typeface references. */
+  fonts: ThemeFonts
   /** Raw fill nodes from a:fmtScheme/a:fillStyleLst, for style fillRef. */
   fillStyleNodes: XmlNode[]
   /** Raw a:ln nodes from a:fmtScheme/a:lnStyleLst, for style lnRef. */
@@ -75,12 +87,30 @@ const DEFAULT_SCHEME: Record<string, string> = {
   folHlink: '954F72',
 }
 
+/** The stock Office fonts, used when a theme names none. */
+const DEFAULT_FONTS: ThemeFonts = { majorLatin: 'Calibri Light', minorLatin: 'Calibri' }
+
 export const DEFAULT_THEME: Theme = {
   scheme: DEFAULT_SCHEME,
   clrMap: DEFAULT_CLR_MAP,
+  fonts: DEFAULT_FONTS,
   fillStyleNodes: [],
   lineStyleNodes: [],
   bgFillStyleNodes: [],
+}
+
+/**
+ * Resolves a typeface token: `+mj-lt` / `+mn-ea`-style references map through
+ * the theme's font scheme (undefined when that slot names nothing); anything
+ * else is already a literal family name.
+ */
+export function themeFontOf(theme: Theme, typeface: string): string | undefined {
+  const m = typeface.match(/^\+(mj|mn)-(lt|ea|cs)$/)
+  if (!m) return typeface
+  const key = `${m[1] === 'mj' ? 'major' : 'minor'}${
+    m[2] === 'lt' ? 'Latin' : m[2] === 'ea' ? 'Ea' : 'Cs'
+  }` as keyof ThemeFonts
+  return theme.fonts[key]
 }
 
 // ------------------------------------------------------------- primitives
@@ -404,7 +434,7 @@ const SCHEME_SLOTS = [
   'folHlink',
 ]
 
-/** Parses `ppt/theme/themeN.xml` (clrScheme + fmtScheme; fonts out of scope). */
+/** Parses `ppt/theme/themeN.xml` (clrScheme + fontScheme + fmtScheme). */
 export function parseTheme(themeDoc: XmlNode[]): Theme {
   const root = childByLocal(themeDoc, 'theme')
   const elements = root ? descend(root, 'themeElements') : undefined
@@ -420,6 +450,27 @@ export function parseTheme(themeDoc: XmlNode[]): Theme {
     }
   }
 
+  const fonts: ThemeFonts = { ...DEFAULT_FONTS }
+  const fontScheme = elements ? descend(elements, 'fontScheme') : undefined
+  if (fontScheme) {
+    for (const [group, prefix] of [
+      ['majorFont', 'major'],
+      ['minorFont', 'minor'],
+    ] as const) {
+      const groupNode = childByLocal(childrenOf(fontScheme), group)
+      if (!groupNode) continue
+      for (const [slot, suffix] of [
+        ['latin', 'Latin'],
+        ['ea', 'Ea'],
+        ['cs', 'Cs'],
+      ] as const) {
+        const slotNode = childByLocal(childrenOf(groupNode), slot)
+        const typeface = slotNode ? attr(slotNode, 'typeface')?.trim() : undefined
+        if (typeface) fonts[`${prefix}${suffix}`] = typeface
+      }
+    }
+  }
+
   const fmtScheme = elements ? descend(elements, 'fmtScheme') : undefined
   const fmtNodes = (list: string) =>
     (fmtScheme ? childrenOf(descend(fmtScheme, list) ?? {}) : []).filter(
@@ -429,6 +480,7 @@ export function parseTheme(themeDoc: XmlNode[]): Theme {
   return {
     scheme,
     clrMap: { ...DEFAULT_CLR_MAP },
+    fonts,
     fillStyleNodes: fmtNodes('fillStyleLst'),
     lineStyleNodes: fmtNodes('lnStyleLst'),
     bgFillStyleNodes: fmtNodes('bgFillStyleLst'),

--- a/apps/x/apps/renderer/src/lib/pptx/theme.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/theme.ts
@@ -1,0 +1,447 @@
+/**
+ * Theme parsing and OOXML color resolution.
+ *
+ * Portions adapted from pptx-viewer (Apache-2.0), specifically the color
+ * transform application order and math (`color-transforms.ts`,
+ * `color-primitives.ts`) and the lazy clrMap alias routing
+ * (`PptxHandlerRuntimeThemeLoading.ts`): the theme scheme stays the source of
+ * truth and `tx1/bg1/tx2/bg2` route through the master's `p:clrMap` at lookup
+ * time, so masters that swap text/background mappings resolve correctly.
+ *
+ * The XML access layer differs from the reference (we use fast-xml-parser's
+ * preserveOrder arrays), so the traversal code here is our own; the semantics
+ * are the reference's.
+ */
+
+import {
+  attr,
+  childByLocal,
+  childrenOf,
+  descend,
+  localNameOf,
+  num,
+  tagNameOf,
+  type XmlNode,
+} from './parse'
+
+export interface ResolvedColor {
+  /** RRGGBB, uppercase, no '#'. */
+  hex: string
+  /** 0..1 when an a:alpha transform is present. */
+  alpha?: number
+}
+
+export interface Theme {
+  /** dk1/lt1/dk2/lt2/accent1..6/hlink/folHlink -> RRGGBB. */
+  scheme: Record<string, string>
+  /** Alias -> scheme slot, from the master's p:clrMap (bg1 -> lt1, …). */
+  clrMap: Record<string, string>
+  /** Raw fill nodes from a:fmtScheme/a:fillStyleLst, for style fillRef. */
+  fillStyleNodes: XmlNode[]
+  /** Raw a:ln nodes from a:fmtScheme/a:lnStyleLst, for style lnRef. */
+  lineStyleNodes: XmlNode[]
+}
+
+export const DEFAULT_CLR_MAP: Record<string, string> = {
+  bg1: 'lt1',
+  tx1: 'dk1',
+  bg2: 'lt2',
+  tx2: 'dk2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hlink: 'hlink',
+  folHlink: 'folHlink',
+}
+
+/** The stock Office theme, used when a deck has no theme part. */
+const DEFAULT_SCHEME: Record<string, string> = {
+  dk1: '000000',
+  lt1: 'FFFFFF',
+  dk2: '44546A',
+  lt2: 'E7E6E6',
+  accent1: '4472C4',
+  accent2: 'ED7D31',
+  accent3: 'A5A5A5',
+  accent4: 'FFC000',
+  accent5: '5B9BD5',
+  accent6: '70AD47',
+  hlink: '0563C1',
+  folHlink: '954F72',
+}
+
+export const DEFAULT_THEME: Theme = {
+  scheme: DEFAULT_SCHEME,
+  clrMap: DEFAULT_CLR_MAP,
+  fillStyleNodes: [],
+  lineStyleNodes: [],
+}
+
+// ------------------------------------------------------------- primitives
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v))
+
+function toHex2(value: number): string {
+  return Math.min(255, Math.max(0, Math.round(value)))
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase()
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const s = hex.replace('#', '')
+  if (!/^[0-9a-fA-F]{6}$/.test(s)) return null
+  return {
+    r: parseInt(s.slice(0, 2), 16),
+    g: parseInt(s.slice(2, 4), 16),
+    b: parseInt(s.slice(4, 6), 16),
+  }
+}
+
+function rgbToHsl(r: number, g: number, b: number): { h: number; s: number; l: number } {
+  const rN = r / 255
+  const gN = g / 255
+  const bN = b / 255
+  const cMax = Math.max(rN, gN, bN)
+  const cMin = Math.min(rN, gN, bN)
+  const delta = cMax - cMin
+  const l = (cMax + cMin) / 2
+  let s = 0
+  if (delta !== 0) s = delta / (1 - Math.abs(2 * l - 1))
+  let h = 0
+  if (delta !== 0) {
+    if (cMax === rN) h = 60 * (((gN - bN) / delta) % 6)
+    else if (cMax === gN) h = 60 * ((bN - rN) / delta + 2)
+    else h = 60 * ((rN - gN) / delta + 4)
+  }
+  if (h < 0) h += 360
+  return { h, s: clamp01(s), l: clamp01(l) }
+}
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const sC = clamp01(s)
+  const lC = clamp01(l)
+  const hN = ((h % 360) + 360) % 360
+  const c = (1 - Math.abs(2 * lC - 1)) * sC
+  const x = c * (1 - Math.abs(((hN / 60) % 2) - 1))
+  const m = lC - c / 2
+  let rP = 0
+  let gP = 0
+  let bP = 0
+  if (hN < 60) [rP, gP, bP] = [c, x, 0]
+  else if (hN < 120) [rP, gP, bP] = [x, c, 0]
+  else if (hN < 180) [rP, gP, bP] = [0, c, x]
+  else if (hN < 240) [rP, gP, bP] = [0, x, c]
+  else if (hN < 300) [rP, gP, bP] = [x, 0, c]
+  else [rP, gP, bP] = [c, 0, x]
+  return {
+    r: Math.round((rP + m) * 255),
+    g: Math.round((gP + m) * 255),
+    b: Math.round((bP + m) * 255),
+  }
+}
+
+/** OOXML thousandth-percent -> unclamped fraction (lumMod can exceed 100%). */
+function fraction(value: string | undefined): number | undefined {
+  const n = num(value)
+  return n === undefined ? undefined : n / 100000
+}
+
+/** OOXML 60000ths-of-a-degree angle -> degrees. */
+function degrees(value: string | undefined): number | undefined {
+  const n = num(value)
+  return n === undefined ? undefined : n / 60000
+}
+
+// ------------------------------------------------------------- transforms
+
+function transformChild(kids: XmlNode[], name: string): XmlNode | undefined {
+  return childByLocal(kids, name)
+}
+
+function transformVal(kids: XmlNode[], name: string): string | undefined {
+  const node = transformChild(kids, name)
+  return node ? attr(node, 'val') : undefined
+}
+
+/**
+ * Applies the OOXML color transforms found among a color node's children to a
+ * base RRGGBB color. Transform order (structural -> shade/tint -> batched HSL
+ * -> direct RGB channels) is adapted from pptx-viewer (Apache-2.0), which
+ * matches PowerPoint's rendering behaviour; gamma and the rare channel
+ * transforms are omitted as out of scope here.
+ */
+export function applyColorTransforms(baseHex: string, colorNode: XmlNode): string {
+  const rgb = hexToRgb(baseHex)
+  if (!rgb) return baseHex
+  const kids = childrenOf(colorNode)
+  let { r, g, b } = rgb
+
+  // 1. Structural.
+  if (transformChild(kids, 'comp')) {
+    const hsl = rgbToHsl(r, g, b)
+    const out = hslToRgb((hsl.h + 180) % 360, hsl.s, hsl.l)
+    ;({ r, g, b } = out)
+  }
+  if (transformChild(kids, 'inv')) {
+    r = 255 - r
+    g = 255 - g
+    b = 255 - b
+  }
+  if (transformChild(kids, 'gray')) {
+    const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b)
+    r = gray
+    g = gray
+    b = gray
+  }
+
+  // 2. Shade & tint: RGB-space mixing toward black / white.
+  const shade = fraction(transformVal(kids, 'shade'))
+  if (shade !== undefined) {
+    const f = clamp01(shade)
+    r *= f
+    g *= f
+    b *= f
+  }
+  const tint = fraction(transformVal(kids, 'tint'))
+  if (tint !== undefined) {
+    const f = clamp01(tint)
+    r += (255 - r) * f
+    g += (255 - g) * f
+    b += (255 - b) * f
+  }
+
+  // 3. HSL transforms, batched into one round-trip.
+  const hueAbs = degrees(transformVal(kids, 'hue'))
+  const hueMod = fraction(transformVal(kids, 'hueMod'))
+  const hueOff = degrees(transformVal(kids, 'hueOff'))
+  const satAbs = fraction(transformVal(kids, 'sat'))
+  const satMod = fraction(transformVal(kids, 'satMod'))
+  const satOff = fraction(transformVal(kids, 'satOff'))
+  const lumAbs = fraction(transformVal(kids, 'lum'))
+  const lumMod = fraction(transformVal(kids, 'lumMod'))
+  const lumOff = fraction(transformVal(kids, 'lumOff'))
+  if (
+    hueAbs !== undefined ||
+    hueMod !== undefined ||
+    hueOff !== undefined ||
+    satAbs !== undefined ||
+    satMod !== undefined ||
+    satOff !== undefined ||
+    lumAbs !== undefined ||
+    lumMod !== undefined ||
+    lumOff !== undefined
+  ) {
+    const hsl = rgbToHsl(r, g, b)
+    if (hueAbs !== undefined) hsl.h = ((hueAbs % 360) + 360) % 360
+    if (hueMod !== undefined) hsl.h = (((hsl.h * hueMod) % 360) + 360) % 360
+    if (hueOff !== undefined) hsl.h = (((hsl.h + hueOff) % 360) + 360) % 360
+    if (satAbs !== undefined) hsl.s = clamp01(satAbs)
+    if (satMod !== undefined) hsl.s = clamp01(hsl.s * satMod)
+    if (satOff !== undefined) hsl.s = clamp01(hsl.s + satOff)
+    if (lumAbs !== undefined) hsl.l = clamp01(lumAbs)
+    if (lumMod !== undefined) hsl.l = clamp01(hsl.l * lumMod)
+    if (lumOff !== undefined) hsl.l = clamp01(hsl.l + lumOff)
+    const out = hslToRgb(hsl.h, hsl.s, hsl.l)
+    r = out.r
+    g = out.g
+    b = out.b
+  }
+
+  return `${toHex2(r)}${toHex2(g)}${toHex2(b)}`
+}
+
+// ---------------------------------------------------------- color choices
+
+/** Windows system colors that appear in themes; lastClr usually wins anyway. */
+const SYSTEM_COLOR_MAP: Record<string, string> = {
+  windowText: '000000',
+  window: 'FFFFFF',
+  btnFace: 'F0F0F0',
+  btnText: '000000',
+  grayText: '6D6D6D',
+  highlight: '0078D7',
+  highlightText: 'FFFFFF',
+  infoBk: 'FFFFE1',
+  infoText: '000000',
+  menuText: '000000',
+  captionText: '000000',
+}
+
+/** The presets that actually show up in decks; unknowns fall back to gray. */
+const PRESET_COLOR_MAP: Record<string, string> = {
+  black: '000000',
+  white: 'FFFFFF',
+  red: 'FF0000',
+  green: '008000',
+  lime: '00FF00',
+  blue: '0000FF',
+  yellow: 'FFFF00',
+  cyan: '00FFFF',
+  magenta: 'FF00FF',
+  gray: '808080',
+  grey: '808080',
+  dkGray: 'A9A9A9',
+  ltGray: 'D3D3D3',
+  darkGray: 'A9A9A9',
+  lightGray: 'D3D3D3',
+  orange: 'FFA500',
+  purple: '800080',
+  brown: 'A52A2A',
+  silver: 'C0C0C0',
+  maroon: '800000',
+  navy: '000080',
+  teal: '008080',
+  olive: '808000',
+}
+
+/** scRGB linear-light channel fraction -> companded sRGB byte (IEC 61966-2-1). */
+function scrgbToByte(linear: number): number {
+  const l = clamp01(linear)
+  const companded = l <= 0.0031308 ? 12.92 * l : 1.055 * l ** (1 / 2.4) - 0.055
+  return Math.min(255, Math.max(0, Math.round(companded * 255)))
+}
+
+/**
+ * Resolves a scheme slot name through the clrMap alias layer to a theme hex.
+ * `tx1` -> clrMap -> `dk1` -> scheme table. Unknown slots fall back to black.
+ */
+export function schemeColorHex(theme: Theme, slotName: string): string {
+  const slot = theme.clrMap[slotName] ?? slotName
+  return theme.scheme[slot] ?? theme.scheme[slotName] ?? '000000'
+}
+
+/**
+ * Resolves one color-choice node (`a:srgbClr` / `a:schemeClr` / `a:sysClr` /
+ * `a:prstClr` / `a:scrgbClr` / `a:hslClr`) to a hex color, applying any child
+ * transforms. `phClr` supplies the substitution color for style references.
+ */
+export function resolveColorNode(
+  colorNode: XmlNode,
+  theme: Theme,
+  phClr?: string,
+): ResolvedColor | undefined {
+  const tag = tagNameOf(colorNode)
+  if (!tag) return undefined
+  const name = localNameOf(tag)
+  const kids = childrenOf(colorNode)
+
+  let base: string | undefined
+  if (name === 'srgbClr') {
+    const val = (attr(colorNode, 'val') ?? '').trim()
+    if (/^[0-9a-fA-F]{6}$/.test(val)) base = val.toUpperCase()
+  } else if (name === 'schemeClr') {
+    const val = (attr(colorNode, 'val') ?? '').trim()
+    if (val === 'phClr') base = phClr ?? schemeColorHex(theme, 'accent1')
+    else if (val) base = schemeColorHex(theme, val)
+  } else if (name === 'sysClr') {
+    const last = (attr(colorNode, 'lastClr') ?? '').trim()
+    if (/^[0-9a-fA-F]{6}$/.test(last)) base = last.toUpperCase()
+    else base = SYSTEM_COLOR_MAP[(attr(colorNode, 'val') ?? '').trim()]
+  } else if (name === 'prstClr') {
+    base = PRESET_COLOR_MAP[(attr(colorNode, 'val') ?? '').trim()] ?? '808080'
+  } else if (name === 'scrgbClr') {
+    const r = fraction(attr(colorNode, 'r'))
+    const g = fraction(attr(colorNode, 'g'))
+    const b = fraction(attr(colorNode, 'b'))
+    if (r !== undefined && g !== undefined && b !== undefined) {
+      base = `${toHex2(scrgbToByte(r))}${toHex2(scrgbToByte(g))}${toHex2(scrgbToByte(b))}`
+    }
+  } else if (name === 'hslClr') {
+    const hue = degrees(attr(colorNode, 'hue'))
+    const sat = fraction(attr(colorNode, 'sat'))
+    const lum = fraction(attr(colorNode, 'lum'))
+    if (hue !== undefined && sat !== undefined && lum !== undefined) {
+      const rgb = hslToRgb(hue, clamp01(sat), clamp01(lum))
+      base = `${toHex2(rgb.r)}${toHex2(rgb.g)}${toHex2(rgb.b)}`
+    }
+  }
+  if (base === undefined) return undefined
+
+  const hex = applyColorTransforms(base, colorNode)
+  const alpha = fraction(transformVal(kids, 'alpha'))
+  return alpha === undefined ? { hex } : { hex, alpha: clamp01(alpha) }
+}
+
+const COLOR_CHOICE_LOCALS = ['srgbClr', 'schemeClr', 'sysClr', 'prstClr', 'scrgbClr', 'hslClr']
+
+/** Resolves the first color-choice child of a container (solidFill, gs, buClr…). */
+export function resolveFirstColor(
+  container: XmlNode | undefined,
+  theme: Theme,
+  phClr?: string,
+): ResolvedColor | undefined {
+  if (!container) return undefined
+  for (const child of childrenOf(container)) {
+    const tag = tagNameOf(child)
+    if (tag && COLOR_CHOICE_LOCALS.includes(localNameOf(tag))) {
+      return resolveColorNode(child, theme, phClr)
+    }
+  }
+  return undefined
+}
+
+// ------------------------------------------------------------ theme parts
+
+const SCHEME_SLOTS = [
+  'dk1',
+  'lt1',
+  'dk2',
+  'lt2',
+  'accent1',
+  'accent2',
+  'accent3',
+  'accent4',
+  'accent5',
+  'accent6',
+  'hlink',
+  'folHlink',
+]
+
+/** Parses `ppt/theme/themeN.xml` (clrScheme + fmtScheme; fonts out of scope). */
+export function parseTheme(themeDoc: XmlNode[]): Theme {
+  const root = childByLocal(themeDoc, 'theme')
+  const elements = root ? descend(root, 'themeElements') : undefined
+  const scheme: Record<string, string> = { ...DEFAULT_SCHEME }
+
+  const clrScheme = elements ? descend(elements, 'clrScheme') : undefined
+  if (clrScheme) {
+    for (const slot of SCHEME_SLOTS) {
+      const slotNode = childByLocal(childrenOf(clrScheme), slot)
+      if (!slotNode) continue
+      const resolved = resolveFirstColor(slotNode, DEFAULT_THEME)
+      if (resolved) scheme[slot] = resolved.hex
+    }
+  }
+
+  const fmtScheme = elements ? descend(elements, 'fmtScheme') : undefined
+  const fillStyleNodes = fmtScheme
+    ? childrenOf(descend(fmtScheme, 'fillStyleLst') ?? {})
+    : []
+  const lineStyleNodes = fmtScheme
+    ? childrenOf(descend(fmtScheme, 'lnStyleLst') ?? {})
+    : []
+
+  return {
+    scheme,
+    clrMap: { ...DEFAULT_CLR_MAP },
+    fillStyleNodes: fillStyleNodes.filter((n) => tagNameOf(n) !== null),
+    lineStyleNodes: lineStyleNodes.filter((n) => tagNameOf(n) !== null),
+  }
+}
+
+/** Reads the alias routing from a master's `p:clrMap`, or null when absent. */
+export function clrMapOfMaster(masterDoc: XmlNode[]): Record<string, string> | null {
+  const master = childByLocal(masterDoc, 'sldMaster')
+  const clrMap = master ? childByLocal(childrenOf(master), 'clrMap') : undefined
+  if (!clrMap) return null
+  const out: Record<string, string> = { ...DEFAULT_CLR_MAP }
+  for (const alias of Object.keys(DEFAULT_CLR_MAP)) {
+    const mapped = attr(clrMap, alias)?.trim()
+    if (mapped) out[alias] = mapped
+  }
+  return out
+}

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Model for the in-house PPTX reader.
+ *
+ * Phase A renders this read-only. Phase B will edit slides in place, so the
+ * model deliberately keeps everything needed to get back to the bytes it came
+ * from: the loaded zip, each slide's raw XML, and a stable path from a slide's
+ * parsed tree to the node each shape came from.
+ */
+
+import type JSZip from 'jszip'
+
+/** English Metric Units per inch — the unit every OOXML coordinate is in. */
+export const EMU_PER_INCH = 914400
+
+/** A rectangle in EMU, exactly as authored. Scale at render time, not here. */
+export interface RectEmu {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/**
+ * Index chain from a slide's parsed document array down to a shape's node.
+ * Walk it as: `let nodes = doc; for (const i of path) { node = nodes[i]; nodes = childrenOf(node) }`.
+ * Stable across re-parses of the same XML, which is what Phase B writes through.
+ */
+export type NodePath = number[]
+
+export type TextAlign = 'l' | 'ctr' | 'r' | 'just'
+
+export interface TextRun {
+  text: string
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  sizePt?: number
+  /** Six-digit RRGGBB. Absent when the run inherits or uses a theme color. */
+  colorHex?: string
+}
+
+export interface Paragraph {
+  align?: TextAlign
+  runs: TextRun[]
+}
+
+interface ShapeBase {
+  /** `p:cNvPr@id` when present, else a synthesized `idx:<n>`. */
+  id: string
+  /** Zip path of the slide this shape lives on, e.g. `ppt/slides/slide1.xml`. */
+  slideXmlPath: string
+  nodePath: NodePath
+  xfrmEmu: RectEmu
+}
+
+export interface TextShape extends ShapeBase {
+  type: 'text'
+  paragraphs: Paragraph[]
+}
+
+export interface ImageShape extends ShapeBase {
+  type: 'image'
+  /** Object URL for the media part. Revoke via `disposeDeck`. */
+  blobUrl: string
+  /** Zip path of the backing media part, e.g. `ppt/media/image1.png`. */
+  mediaPath: string
+}
+
+/** What we recognized but do not render yet. */
+export type PlaceholderKind =
+  | 'chart'
+  | 'smartart'
+  | 'table'
+  | 'group'
+  | 'video'
+  | 'unknown'
+
+export interface PlaceholderShape extends ShapeBase {
+  type: 'placeholder'
+  kind: PlaceholderKind
+}
+
+export type Shape = TextShape | ImageShape | PlaceholderShape
+
+export interface Slide {
+  id: string
+  /** Zip path, e.g. `ppt/slides/slide1.xml`. */
+  xmlPath: string
+  /** In document order, which is also z-order: later shapes paint on top. */
+  shapes: Shape[]
+}
+
+export interface SlideDeck {
+  slideSizeEmu: { w: number; h: number }
+  slides: Slide[]
+  /** Everything Phase B needs to write back without touching untouched parts. */
+  source: {
+    zip: JSZip
+    /** Raw XML per slide, keyed by zip path. */
+    slideXml: Record<string, string>
+  }
+}

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -97,6 +97,12 @@ export interface ResolvedRunStyle {
   colorHex: string
   /** Ready-to-use CSS font-family. Absent when nothing is authored anywhere. */
   fontFamily?: string
+  /**
+   * `a:rPr@spc` character tracking in points; negative tightens. Absolute, so
+   * unlike the size it is not scaled by normAutofit — same rule as a fixed
+   * `a:spcPts` line height.
+   */
+  letterSpacingPt?: number
 }
 
 /** CSS line-height used when no a:lnSpc is authored anywhere in the cascade. */

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -37,6 +37,13 @@ export interface TextRun {
   sizePt?: number
   /** Six-digit RRGGBB. Absent when the run inherits or uses a theme color. */
   colorHex?: string
+  /**
+   * The run's own `a:latin@typeface`, VERBATIM — a literal family name, or a
+   * theme token like `+mn-lt`. Absent when the run inherits its typeface.
+   * Byte-anchored like the rest of this model: the serializer re-derives it
+   * from the retained XML and compares, so a stale edit fails closed.
+   */
+  latinFont?: string
 }
 
 export interface Paragraph {
@@ -97,6 +104,12 @@ export interface ResolvedRunStyle {
   colorHex: string
   /** Ready-to-use CSS font-family. Absent when nothing is authored anywhere. */
   fontFamily?: string
+  /**
+   * The resolved primary latin typeface (theme tokens already mapped), which
+   * is what the font picker shows and offers. `fontFamily` is this plus the
+   * ea/cs slots and a generic fallback.
+   */
+  latinFont?: string
   /**
    * `a:rPr@spc` character tracking in points; negative tightens. Absolute, so
    * unlike the size it is not scaled by normAutofit — same rule as a fixed

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -95,6 +95,23 @@ export interface ResolvedRunStyle {
   italic: boolean
   underline: boolean
   colorHex: string
+  /** Ready-to-use CSS font-family. Absent when nothing is authored anywhere. */
+  fontFamily?: string
+}
+
+/** CSS line-height used when no a:lnSpc is authored anywhere in the cascade. */
+export const DEFAULT_LINE_HEIGHT = 1.2
+
+/**
+ * Resolved a:lnSpc. `mult` is a unitless CSS line-height (spcPct scales the
+ * 1.2 default, so 100% keeps today's rendering); `pt` is fixed (a:spcPts).
+ */
+export type LineSpacing = { kind: 'mult'; value: number } | { kind: 'pt'; pt: number }
+
+/** `a:normAutofit` shrink factors, as fractions (fontScale 1 = unscaled). */
+export interface TextAutofit {
+  fontScale: number
+  lnSpcReduction: number
 }
 
 export type ResolvedBullet =
@@ -109,6 +126,11 @@ export interface ParagraphDisplay {
   /** Resolved fallback used when the paragraph itself declares no algn. */
   align?: TextAlign
   bullet: ResolvedBullet
+  /** Resolved a:lnSpc; `{ kind: 'mult', value: 1.2 }` when unspecified. */
+  lineHeight: LineSpacing
+  /** Resolved a:spcBef/a:spcAft in points (spcPct is taken of defaultRun's size). */
+  spaceBeforePt: number
+  spaceAfterPt: number
   /** Fully resolved style per ORIGINAL run index (explicit rPr over cascade). */
   runs: ResolvedRunStyle[]
   /** The cascade result at this level, for runs with no original anchor. */
@@ -125,6 +147,8 @@ export interface TextDisplay {
   defaultRun: ResolvedRunStyle
   /** OOXML defaults to top; `just`/`dist` render as top. */
   anchor: TextAnchor
+  /** Shrink-to-fit factors from the shape's own bodyPr, applied at render. */
+  autofit?: TextAutofit
 }
 
 // ------------------------------------------------------------------- shapes

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -44,6 +44,86 @@ export interface Paragraph {
   runs: TextRun[]
 }
 
+// ------------------------------------------------------------- display model
+//
+// Everything below the "display" line is derived presentation data (theme
+// colors, inherited text styles, fills, rotation). The serializer never reads
+// it — its validation derives from raw XML via `parseParagraph`, which stays
+// byte-anchored — so display resolution can improve without touching the
+// write-back invariants.
+
+export type Fill =
+  | { kind: 'solid'; hex: string; alpha?: number }
+  | { kind: 'gradient'; stops: GradientStop[]; angleDeg: number }
+  | { kind: 'none' }
+
+export interface GradientStop {
+  /** 0..1 position along the gradient. */
+  pos: number
+  hex: string
+  alpha?: number
+}
+
+export interface LineStyle {
+  hex: string
+  widthEmu: number
+  dash: 'solid' | 'dash' | 'dot'
+  alpha?: number
+}
+
+export interface PresetGeometry {
+  /** OOXML preset name (`rect`, `roundRect`, `ellipse`, `line`, …) or `custom`. */
+  preset: string
+  /** Adjust values from `a:avLst`, e.g. `{ adj: 16667 }`. */
+  adj: Record<string, number>
+}
+
+/** Visual properties shared by every shape kind; display only. */
+export interface ShapeVisual {
+  fill?: Fill
+  line?: LineStyle
+  geom?: PresetGeometry
+  /** Degrees clockwise. */
+  rotDeg?: number
+  flipH?: boolean
+  flipV?: boolean
+}
+
+export interface ResolvedRunStyle {
+  sizePt: number
+  bold: boolean
+  italic: boolean
+  underline: boolean
+  colorHex: string
+}
+
+export type ResolvedBullet =
+  | { kind: 'none' }
+  | { kind: 'char'; char: string }
+  | { kind: 'auto'; scheme: string; startAt: number }
+
+export interface ParagraphDisplay {
+  level: number
+  marLEmu: number
+  indentEmu: number
+  /** Resolved fallback used when the paragraph itself declares no algn. */
+  align?: TextAlign
+  bullet: ResolvedBullet
+  /** Fully resolved style per ORIGINAL run index (explicit rPr over cascade). */
+  runs: ResolvedRunStyle[]
+  /** The cascade result at this level, for runs with no original anchor. */
+  defaultRun: ResolvedRunStyle
+}
+
+export interface TextDisplay {
+  /** By ORIGINAL paragraph index, matching the as-parsed `paragraphs`. */
+  paragraphs: ParagraphDisplay[]
+  /** Level-0 cascade result, for wholly new content. */
+  defaultRun: ResolvedRunStyle
+}
+
+// ------------------------------------------------------------------- shapes
+
 interface ShapeBase {
   /** `p:cNvPr@id` when present, else a synthesized `idx:<n>`. */
   id: string
@@ -51,11 +131,20 @@ interface ShapeBase {
   slideXmlPath: string
   nodePath: NodePath
   xfrmEmu: RectEmu
+  /** Display-only visual properties (fill, line, geometry, rotation). */
+  visual?: ShapeVisual
 }
 
 export interface TextShape extends ShapeBase {
   type: 'text'
   paragraphs: Paragraph[]
+  /** Display-only resolved text styling (theme + inheritance cascade). */
+  display?: TextDisplay
+}
+
+/** A `p:sp` without a txBody, or a `p:cxnSp` — pure geometry, no text. */
+export interface DrawingShape extends ShapeBase {
+  type: 'drawing'
 }
 
 export interface ImageShape extends ShapeBase {
@@ -80,7 +169,7 @@ export interface PlaceholderShape extends ShapeBase {
   kind: PlaceholderKind
 }
 
-export type Shape = TextShape | ImageShape | PlaceholderShape
+export type Shape = TextShape | ImageShape | PlaceholderShape | DrawingShape
 
 export interface Slide {
   id: string

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type JSZip from 'jszip'
+import type { ShapeStyleSnapshot } from './geometry'
 
 /** English Metric Units per inch — the unit every OOXML coordinate is in. */
 export const EMU_PER_INCH = 914400
@@ -181,6 +182,12 @@ interface ShapeBase {
   xfrmEmu: RectEmu
   /** Display-only visual properties (fill, line, geometry, rotation). */
   visual?: ShapeVisual
+  /**
+   * The shape's OWN spPr fill/line, unresolved. Present for the kinds that
+   * can be restyled (`p:sp`, `p:cxnSp`); this is the write-back anchor the
+   * serializer re-derives and compares, never the display `visual`.
+   */
+  style?: ShapeStyleSnapshot
 }
 
 export interface TextShape extends ShapeBase {
@@ -241,6 +248,12 @@ export interface Slide {
   /** In document order, which is also z-order: later shapes paint on top. */
   shapes: Shape[]
   /**
+   * Node path of this slide's `p:spTree`. Inserted shapes append to it, so
+   * this is what gives a not-yet-written shape its real node path — the model
+   * shape list cannot supply it, since spTree also holds nvGrpSpPr/grpSpPr.
+   */
+  spTreePath: NodePath
+  /**
    * Resolved page background (slide → layout → master cascade), display only.
    * Absent when no part in the chain declares one; `{ kind: 'none' }` when one
    * is declared but can't be drawn — both render as the white page.
@@ -259,6 +272,14 @@ export interface Slide {
 export interface SlideDeck {
   slideSizeEmu: { w: number; h: number }
   slides: Slide[]
+  /**
+   * Display-only: key scheme colours of the FIRST slide's theme, so inserted
+   * shapes can be previewed in the colour the file will actually get
+   * (`schemeClr accent1`) before any save. Multi-master decks with different
+   * themes per slide will preview with slide 1's accent; the written XML is a
+   * theme reference either way, so the saved file is always right.
+   */
+  themeColors?: { accent1: string; tx1: string }
   /** Everything Phase B needs to write back without touching untouched parts. */
   source: {
     zip: JSZip

--- a/apps/x/apps/renderer/src/lib/pptx/types.ts
+++ b/apps/x/apps/renderer/src/lib/pptx/types.ts
@@ -115,11 +115,16 @@ export interface ParagraphDisplay {
   defaultRun: ResolvedRunStyle
 }
 
+/** Vertical anchoring of a text body inside its box (`a:bodyPr@anchor`). */
+export type TextAnchor = 't' | 'ctr' | 'b'
+
 export interface TextDisplay {
   /** By ORIGINAL paragraph index, matching the as-parsed `paragraphs`. */
   paragraphs: ParagraphDisplay[]
   /** Level-0 cascade result, for wholly new content. */
   defaultRun: ResolvedRunStyle
+  /** OOXML defaults to top; `just`/`dist` render as top. */
+  anchor: TextAnchor
 }
 
 // ------------------------------------------------------------------- shapes
@@ -160,7 +165,6 @@ export type PlaceholderKind =
   | 'chart'
   | 'smartart'
   | 'table'
-  | 'group'
   | 'video'
   | 'unknown'
 
@@ -169,7 +173,23 @@ export interface PlaceholderShape extends ShapeBase {
   kind: PlaceholderKind
 }
 
-export type Shape = TextShape | ImageShape | PlaceholderShape | DrawingShape
+/**
+ * A `p:grpSp`, walked rather than stubbed. `xfrmEmu` is the group's bounding
+ * box in slide space; each child's `xfrmEmu` is likewise already mapped to
+ * final slide-space EMU through the group's chOff/chExt transform (nested
+ * groups multiply through), so the renderer draws children with no further
+ * coordinate work.
+ *
+ * Children are READ-ONLY: their nodePaths point through the group and must
+ * never be handed to the serializer, and the editor exposes no way to select
+ * or edit them individually.
+ */
+export interface GroupShape extends ShapeBase {
+  type: 'group'
+  children: Shape[]
+}
+
+export type Shape = TextShape | ImageShape | PlaceholderShape | DrawingShape | GroupShape
 
 export interface Slide {
   id: string
@@ -177,6 +197,20 @@ export interface Slide {
   xmlPath: string
   /** In document order, which is also z-order: later shapes paint on top. */
   shapes: Shape[]
+  /**
+   * Resolved page background (slide → layout → master cascade), display only.
+   * Absent when no part in the chain declares one; `{ kind: 'none' }` when one
+   * is declared but can't be drawn — both render as the white page.
+   */
+  background?: Fill
+  /**
+   * Decoration shapes inherited from the master and layout (non-placeholder
+   * spTree content), in paint order beneath `shapes`. Render-only and fully
+   * inert: their nodePaths point into the layout/master parts — never into
+   * this slide — and must never be handed to the serializer. Shared across
+   * slides that use the same layout.
+   */
+  underlay?: Shape[]
 }
 
 export interface SlideDeck {

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -173,6 +173,18 @@ const ipcSchemas = {
       ok: z.literal(true),
     }),
   },
+  // Copy a workspace file OUT to a user-chosen location. The destination comes
+  // from the OS save dialog, which is also what confirms any overwrite.
+  'workspace:exportCopy': {
+    req: z.object({
+      path: RelPath,
+    }),
+    res: z.object({
+      saved: z.boolean(),
+      dest: z.string().optional(),
+      error: z.string().optional(),
+    }),
+  },
   'workspace:didChange': {
     req: WorkspaceChangeEvent,
     res: z.null(),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -173,6 +173,19 @@ const ipcSchemas = {
       ok: z.literal(true),
     }),
   },
+  // Pick an image from disk for insertion into a document. Returns the bytes
+  // rather than a path: the renderer holds them in its edit set until save.
+  'workspace:pickImage': {
+    req: z.object({}),
+    res: z.object({
+      picked: z.boolean(),
+      name: z.string().optional(),
+      /** Lowercase extension without the dot. */
+      ext: z.string().optional(),
+      dataBase64: z.string().optional(),
+      error: z.string().optional(),
+    }),
+  },
   // Copy a workspace file OUT to a user-chosen location. The destination comes
   // from the OS save dialog, which is also what confirms any overwrite.
   'workspace:exportCopy': {

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -288,6 +288,12 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      fast-xml-parser:
+        specifier: ^5.10.1
+        version: 5.10.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -2199,6 +2205,9 @@ packages:
   '@napi-rs/canvas@0.1.80':
     resolution: {integrity: sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==}
     engines: {node: '>= 10'}
+
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4612,6 +4621,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   appdmg@0.6.6:
     resolution: {integrity: sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==}
     engines: {node: '>=8.5'}
@@ -5791,6 +5803,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
+
   fast-xml-parser@5.2.5:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
     hasBin: true
@@ -6509,6 +6528,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -7580,6 +7602,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -8493,6 +8519,9 @@ packages:
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -9169,6 +9198,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   xmlbuilder2@2.1.2:
     resolution: {integrity: sha512-PI710tmtVlQ5VmwzbRTuhmVhKnj9pM8Si+iOZCV2g2SNo3gCrpzR2Ka9wNzZtqfD+mnP+xkrqoNy0sjKZqP4Dg==}
@@ -11543,6 +11576,8 @@ snapshots:
       '@napi-rs/canvas-linux-x64-gnu': 0.1.80
       '@napi-rs/canvas-linux-x64-musl': 0.1.80
       '@napi-rs/canvas-win32-x64-msvc': 0.1.80
+
+  '@nodable/entities@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14252,6 +14287,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  anynum@1.0.1: {}
+
   appdmg@0.6.6:
     dependencies:
       async: 1.5.2
@@ -15611,6 +15648,20 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+
   fast-xml-parser@5.2.5:
     dependencies:
       strnum: 2.1.2
@@ -16481,6 +16532,8 @@ snapshots:
       which-typed-array: 1.1.20
 
   is-unicode-supported@0.1.0: {}
+
+  is-unsafe@2.0.0: {}
 
   is-url@1.2.4: {}
 
@@ -17813,6 +17866,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.6.2: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@2.0.1: {}
@@ -18968,6 +19023,10 @@ snapshots:
 
   strnum@2.1.2: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -19674,6 +19733,8 @@ snapshots:
       sax: 1.6.0
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.3.0: {}
 
   xmlbuilder2@2.1.2:
     dependencies:


### PR DESCRIPTION
Replaces #809, which used a third-party viewer. Per Arjun's call, this is built
in-house — the only new deps are `jszip` and `fast-xml-parser`. No pptx
component library.

## What works
- Open a `.pptx` from a workspace: slides render with theme colors, shape fills,
  images, bullets, and inherited placeholder geometry.
- Double-click text to edit it; move and resize shapes; undo/redo.
- Autosaves back to the same file.
- Play button: full-screen presentation, arrow keys to navigate, Esc to exit.

## The part that matters — surgical write-back
Saving does **not** re-serialize the deck. Only the edited `slideN.xml` is
touched, and inside it only the targeted `<a:t>` nodes; every other zip entry is
copied byte-for-byte. Every edit is cross-validated three ways before writing and
**fails closed** on any mismatch, leaving the file on disk untouched.

Consequence: file size stays flat across saves (the previous library approach grew
the file ~11% on first save), and content the editor doesn't understand — charts,
SmartArt, animations — is structurally incapable of being corrupted.

## Needs a founder call
Some rendering algorithms (theme colour resolution, the run-property cascade) are
adapted from **Apache-2.0 / MIT** sources, attributed in-file and in
`renderer/NOTICE.md`. No runtime dependency; the code is ours to maintain. AGPL/GPL
sources were deliberately not consulted. Flagging since it's a licensing decision.

## Known limitations
- Charts, SmartArt, tables and groups render as labelled placeholders. Their XML is
  preserved untouched, so they survive saves intact — they just aren't drawn yet.
- Legacy `.ppt` stays unsupported.
- Some decks produced by earlier tooling contain pre-garbled text; this is not
  auto-repaired (repairing untouched runs would violate the byte-copy invariant).
- Windows/Linux and packaged-build passes still pending.

<details>
<summary>Implementation notes</summary>

**Structure** — parser and serializer in `renderer/src/lib/pptx/`; editor UI in
`renderer/src/components/pptx/` + `pptx-editor.tsx`. Routing mirrors the docx
viewer (`file-types.ts` + `App.tsx`), and file load/save reuse the same
`workspace:readFile` / `workspace:writeFile` IPC.

**Parser** — jszip + fast-xml-parser with `preserveOrder` (correct z-order, and a
stable node path from each shape back to its XML). Resolves theme colours through
`clrMap` incl. lumMod/tint/shade, the full run-property cascade
(run → paragraph → shape → layout → master → presentation defaults), and
placeholder geometry inherited from layout/master — without that last one, real
decks render their titles as 0×0 boxes.

**Serializer** — `XMLBuilder` round-tripping was tested first and rejected: it drops
the CRLF PowerPoint writes after the declaration, normalises empty-element form
globally, and re-escapes numeric character refs in runs no edit touched. Targeted
string splicing is used instead, via a quote-aware tag scanner. Text-only edits
splice `<a:t>` contents in place; structural changes (Enter, run merges) rebuild
only that shape's `<a:p>` range, reusing original bytes for `pPr`, `rPr`,
`endParaRPr` and unchanged runs.

**Editing model** — undo/redo is a stack of immutable edit sets; the rendered deck
is always `applyEditSet(baseDeck, current)` and the base deck is never mutated.
Saves are idempotent recomputations from original bytes plus the accumulated set,
so a late save can never write a partial state.

**Tests** — 130+ across parser and serializer, including: zero-edit write-back is
byte-identical; a single text edit differs by exactly one substring; every unedited
zip entry is byte-for-byte identical; `& < > " '`, emoji and Devanagari round-trip
exactly; fail-closed paths throw.

**Manually verified** — two real 15/19-slide decks; edit → mtime and content change
on disk; relaunch → edits persist; saved file opens in Keynote with no repair
prompt and untouched slides intact; file size flat across repeated saves.
</details>