### PR TITLE
fix(x): persist LLM use-case attribution on turns

### DIFF
--- a/apps/x/ANALYTICS.md
+++ b/apps/x/ANALYTICS.md
@@ -24,9 +24,9 @@ Emitted whenever ai-sdk returns token usage (one event per LLM call, not per run
 
 | Property | Type | Notes |
 |---|---|---|
-| `use_case` | enum | `copilot_chat` / `live_note_agent` / `meeting_note` / `knowledge_sync` / `code_session` |
+| `use_case` | enum | Defined by `UseCase` in `packages/shared/src/analytics.ts` |
 | `sub_use_case` | string? | Refines `use_case` — see taxonomy table below |
-| `agent_name` | string? | Present when the call goes through an agent run (`createRun`); omitted for direct `generateText`/`generateObject` |
+| `agent_name` | string? | Present when the call goes through an agent run; derived from the turn's immutable resolved agent id and omitted for direct `generateText`/`generateObject` |
 | `model` | string | e.g. `claude-sonnet-4-6` |
 | `provider` | string | The provider FLAVOR: `rowboat` = cloud LLM gateway, `codex` = ChatGPT subscription, else the BYOK flavor (`openai`, `anthropic`, `ollama`, …). Call sites pass instance ids; `captureLlmUsage` maps id → flavor so charts never fracture if user-named provider instances ship (ids never leave the app) |
 | `input_tokens` | number | |
@@ -35,28 +35,36 @@ Emitted whenever ai-sdk returns token usage (one event per LLM call, not per run
 | `cached_input_tokens` | number? | When the provider reports it |
 | `reasoning_tokens` | number? | When the provider reports it |
 
+For the turn runtime, `{ useCase, subUseCase }` is persisted on
+`turn_created.analytics`. Every advance restores that context and combines it
+with `turn_created.agent.resolved.agentId`, so initial calls, permission
+continuations, and crash recovery all have identical attribution. The Rowboat
+gateway receives the same values through `x-rowboat-use-case`,
+`x-rowboat-sub-use-case`, and `x-rowboat-agent-name`.
+
 #### Use-case taxonomy
 
 Every `llm_usage` emit point in the codebase:
 
 | `use_case` | `sub_use_case` | `agent_name`? | Where | File:line |
 |---|---|---|---|---|
-| `copilot_chat` | (none) | yes | User chat in renderer (turn runtime; the ALS default when no caller set a use case) | `packages/core/src/runtime/turns/bridges/real-usage-reporter.ts` (`reportModelUsage`); legacy runs (code-mode carve-out) still emit from `packages/core/src/runtime/legacy/engine.ts` (`streamLlm` finish-step) |
+| `copilot_chat` | (none) | yes | User chat in renderer (the durable default when no caller sets a use case) | `packages/core/src/runtime/turns/bridges/real-usage-reporter.ts` (`reportModelUsage`); legacy runs (code-mode carve-out) still emit from `packages/core/src/runtime/legacy/engine.ts` (`streamLlm` finish-step) |
 | `copilot_chat` | `scheduled` | yes | Background scheduled agent runner | `packages/core/src/agent-schedule/runner.ts:167` |
 | `copilot_chat` | `file_parse` | inherits | `parseFile` builtin tool inside any chat | `packages/core/src/runtime/tools/domains/parsing.ts:179` |
 | `copilot_chat` | `chat_title` | no | Auto-naming a chat from its first user message (`generateText`) | `packages/core/src/knowledge/generate_title.ts` |
 | `live_note_agent` | `routing` | no | Pass 1 routing classifier (`generateObject`) | `packages/core/src/knowledge/live-note/routing.ts:93` |
-| `live_note_agent` | `manual` | yes | Pass 2 agent run — user clicked Run / called the `run-live-note-agent` tool | `packages/core/src/knowledge/live-note/runner.ts:140` (createRun, `subUseCase: trigger`) |
+| `live_note_agent` | `manual` | yes | Pass 2 agent run — user clicked Run / called the `run-live-note-agent` tool | `packages/core/src/knowledge/live-note/runner.ts` (`startHeadlessAgent`, `subUseCase: trigger`) |
 | `live_note_agent` | `cron` | yes | Pass 2 agent run — cron expression matched | same call site |
 | `live_note_agent` | `window` | yes | Pass 2 agent run — fired inside a configured time-of-day window | same call site |
 | `live_note_agent` | `event` | yes | Pass 2 agent run — Pass 1 routing flagged the note for an incoming event | same call site |
 | `meeting_note` | (none) | no | Meeting transcript summarizer (`generateText`) | `packages/core/src/knowledge/summarize_meeting.ts:161` |
-| `knowledge_sync` | `agent_notes` | yes | Agent notes learning service | `packages/core/src/knowledge/agent_notes.ts:309` (createRun) |
-| `knowledge_sync` | `tag_notes` | yes | Note tagging | `packages/core/src/knowledge/tag_notes.ts:86` (createRun) |
-| `knowledge_sync` | `build_graph` | yes | Knowledge graph note creation | `packages/core/src/knowledge/build_graph.ts:253` (createRun) |
-| `knowledge_sync` | `inline_task_run` | yes | Inline `@rowboat` task execution (two call sites) | `packages/core/src/knowledge/inline_tasks.ts:471, 552` (createRun) |
+| `knowledge_sync` | `agent_notes` | yes | Agent notes learning service | `packages/core/src/knowledge/agent_notes.ts` (`runWhenPossible`) |
+| `knowledge_sync` | `tag_notes` | yes | Note tagging | `packages/core/src/knowledge/tag_notes.ts` (`runWhenPossible`) |
+| `knowledge_sync` | `build_graph` | yes | Knowledge graph note creation | `packages/core/src/knowledge/build_graph.ts` (`runWhenPossible`) |
+| `knowledge_sync` | `curation` | yes | Knowledge-note curation | `packages/core/src/knowledge/build_graph.ts` (`runWhenPossible`) |
+| `knowledge_sync` | `inline_task_run` | yes | Inline `@rowboat` task execution (two call sites) | `packages/core/src/knowledge/inline_tasks.ts` (`runWhenPossible`) |
 | `knowledge_sync` | `inline_task_classify` | no | Inline task scheduling classifier (`generateText`) | `packages/core/src/knowledge/inline_tasks.ts:673` |
-| `knowledge_sync` | `pre_built` | yes | Pre-built scheduled agents | `packages/core/src/pre_built/runner.ts:43` (createRun) |
+| `knowledge_sync` | `pre_built` | yes | Pre-built scheduled agents | `packages/core/src/pre_built/runner.ts` (`runWhenPossible`) |
 | `code_session` | (none) | yes | Code-section coding session in Rowboat mode (direct mode talks to the on-device coding agent and emits no `llm_usage`) | `packages/core/src/code-mode/sessions/service.ts` (createRun) |
 
 ##### `live_note_agent` sub-use-case shape
@@ -230,15 +238,16 @@ Persistent across sessions for the same user. Set via `posthog.people.set` or as
    - Anything else from main → `capture()` from `@x/core/dist/analytics/posthog.js`.
    - Anything else from renderer → add a typed wrapper to `apps/renderer/src/lib/analytics.ts` and call it from the UI code (don't call `posthog.capture()` directly from components).
 3. **If it's a new LLM call site**:
-   - Goes through `createRun`? Pass `useCase` (and optionally `subUseCase`) to the create call. The runtime auto-emits at every `finish-step` — no further code needed.
+   - Goes through the turn runtime? Pass `useCase` (and optionally `subUseCase`) to `sessions.sendMessage` or the headless runner. It is persisted on `turn_created`, and the runtime emits once per completed model call.
+   - Goes through legacy `createRun`? Pass the same fields to the create call.
    - Direct `generateText` / `generateObject`? Call `captureLlmUsage` after the call with `model`, `provider`, `usage` from the result.
-   - Inside a builtin tool? Call `getCurrentUseCase()` from `analytics/use_case.ts` first — the parent run's tag is propagated via `AsyncLocalStorage`. Use `ctx?.useCase ?? 'copilot_chat'` as fallback.
+   - Inside a builtin tool? Call `getCurrentUseCase()` from `analytics/use_case.ts`; the turn runtime restores the persisted context around every advance.
 4. **Update this file in the same PR.** That's the contract — without it, dashboards and downstream consumers drift.
 
 ## How to add a new use-case sub-case
 
 - **New `sub_use_case` under an existing top-level case**: just pick a string and add a row to the taxonomy table above. No code changes beyond the call site.
-- **New top-level `use_case`**: edit the `UseCase` enum in `packages/shared/src/runs.ts` and the matching `UseCase` type in `packages/core/src/analytics/use_case.ts`. Then update this doc.
+- **New top-level `use_case`**: edit the `UseCase` enum in `packages/shared/src/analytics.ts`. Then update this doc.
 
 ## Configuration
 
@@ -265,6 +274,7 @@ If unset, analytics no-op silently — you'll see `[Analytics] POSTHOG_KEY not s
 | `packages/core/src/analytics/posthog.ts` | Main-process client (`capture`, `identify`, `reset`, `shutdown`) |
 | `packages/core/src/analytics/usage.ts` | `captureLlmUsage()` helper |
 | `packages/core/src/analytics/use_case.ts` | `AsyncLocalStorage` for tool-internal LLM call inheritance |
+| `packages/shared/src/analytics.ts` | Shared use-case taxonomy and durable turn analytics schema |
 | `apps/renderer/src/lib/analytics.ts` | Renderer event wrappers |
 | `apps/renderer/src/hooks/useAnalyticsIdentity.ts` | Renderer identify/reset on OAuth events |
 | `apps/main/src/oauth-handler.ts` | Main-side identify/reset/sign-in/sign-out events |

--- a/apps/x/apps/renderer/src/lib/session-chat/client.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/client.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod'
+import type { UseCase } from '@x/shared/src/analytics.js'
 import type { UserMessage } from '@x/shared/src/message.js'
 import type { SessionIndexEntry, SessionState } from '@x/shared/src/sessions.js'
 import type { JsonValue, RequestedAgent, TurnEvent } from '@x/shared/src/turns.js'
@@ -7,6 +8,8 @@ import type { JsonValue, RequestedAgent, TurnEvent } from '@x/shared/src/turns.j
 // testable with a plain fake instead of a window.ipc stub.
 export interface SendMessageConfig {
   agent: z.infer<typeof RequestedAgent>
+  useCase?: UseCase
+  subUseCase?: string
   autoPermission?: boolean
   maxModelCalls?: number
 }

--- a/apps/x/packages/core/src/agent-schedule/runner.ts
+++ b/apps/x/packages/core/src/agent-schedule/runner.ts
@@ -5,7 +5,6 @@ import { IAgentScheduleStateRepo } from "./state-repo.js";
 import { AgentScheduleConfig, AgentScheduleEntry } from "@x/shared/dist/agent-schedule.js";
 import { AgentScheduleState, AgentScheduleStateEntry } from "@x/shared/dist/agent-schedule-state.js";
 import { startWhenPossible } from "../runtime/assembly/headless-app.js";
-import { withUseCase } from "../analytics/use_case.js";
 import z from "zod";
 
 const DEFAULT_STARTING_MESSAGE = "go";
@@ -163,14 +162,13 @@ async function runAgent(
         // The signal caps a hung turn at the same TIMEOUT_MS the state-based
         // watchdog uses.
         const startingMessage = entry.startingMessage ?? DEFAULT_STARTING_MESSAGE;
-        const handle = await withUseCase(
-            { useCase: 'copilot_chat', subUseCase: 'scheduled' },
-            () => startWhenPossible({
-                agentId: agentName,
-                message: startingMessage,
-                signal: AbortSignal.timeout(TIMEOUT_MS),
-            }),
-        );
+        const handle = await startWhenPossible({
+            agentId: agentName,
+            message: startingMessage,
+            useCase: 'copilot_chat',
+            subUseCase: 'scheduled',
+            signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
         console.log(`[AgentRunner] Started turn ${handle.turnId} for agent ${agentName}: "${startingMessage}"`);
         void handle.done
             .then((result) => console.log(`[AgentRunner] Turn ${handle.turnId} (${agentName}) settled: ${result.outcome.status}`))

--- a/apps/x/packages/core/src/analytics/use_case.ts
+++ b/apps/x/packages/core/src/analytics/use_case.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { UseCase } from '@x/shared/dist/analytics.js';
 
-export type UseCase = 'copilot_chat' | 'live_note_agent' | 'background_task_agent' | 'todo_item_agent' | 'meeting_note' | 'meeting_prep' | 'knowledge_sync' | 'code_session' | 'app_llm_generate' | 'app_copilot_run';
+export type { UseCase } from '@x/shared/dist/analytics.js';
 
 export interface UseCaseContext {
   useCase: UseCase;

--- a/apps/x/packages/core/src/background-tasks/runner.ts
+++ b/apps/x/packages/core/src/background-tasks/runner.ts
@@ -5,7 +5,6 @@ import { getBackgroundTaskAgentModel } from '../models/defaults.js';
 import { startHeadlessAgent, startWhenPossible } from '../runtime/assembly/headless-app.js';
 import { buildTriggerBlock } from '../runtime/assembly/build-trigger-block.js';
 import { backgroundTaskBus } from './bus.js';
-import { withUseCase } from '../analytics/use_case.js';
 import { capture } from '../analytics/posthog.js';
 
 const log = new PrefixLogger('BgTask:Agent');
@@ -160,21 +159,16 @@ export async function runBackgroundTask(
         // so deferring here would deadlock the turn. Only autonomous
         // triggers (cron/window/event) defer.
         const start = trigger === 'manual' ? startHeadlessAgent : startWhenPossible;
-        // Establish the use-case context for the whole turn so every tool the
-        // agent calls (notably notify-user) reads `background_task_agent` via
-        // getCurrentUseCase(); the AsyncLocalStorage context set here flows
-        // through the turn's async execution chain.
-        const handle = await withUseCase(
-            { useCase: 'background_task_agent', subUseCase: trigger },
-            () => start({
-                agentId: 'background-task-agent',
-                message: buildMessage(slug, task, trigger, context, codeProject),
-                model,
-                ...(provider ? { provider } : {}),
-                ...(effort ? { reasoningEffort: effort } : {}),
-                throwOnError: true,
-            }),
-        );
+        const handle = await start({
+            agentId: 'background-task-agent',
+            message: buildMessage(slug, task, trigger, context, codeProject),
+            useCase: 'background_task_agent',
+            subUseCase: trigger,
+            model,
+            ...(provider ? { provider } : {}),
+            ...(effort ? { reasoningEffort: effort } : {}),
+            throwOnError: true,
+        });
 
         const runId = handle.turnId;
         // Record this turn in the task's runs.log pointer file (newest first).

--- a/apps/x/packages/core/src/di/container.ts
+++ b/apps/x/packages/core/src/di/container.ts
@@ -128,7 +128,9 @@ container.register({
     // Process-wide turn event spine: every turn's events, tagged with
     // sessionId and durable file offsets, regardless of who started the turn.
     turnEventBus: asClass<ITurnEventBus>(TurnEventHub).singleton(),
-    usageReporter: asClass<IUsageReporter>(RealUsageReporter).singleton(),
+    usageReporter: asFunction<IUsageReporter>(
+        () => new RealUsageReporter(),
+    ).singleton(),
     agentResolver: asFunction<IAgentResolver>(
         () =>
             new DispatchingAgentResolver(

--- a/apps/x/packages/core/src/knowledge/agent_notes.ts
+++ b/apps/x/packages/core/src/knowledge/agent_notes.ts
@@ -284,6 +284,8 @@ async function processAgentNotes(): Promise<void> {
         await runWhenPossible({
             agentId: AGENT_ID,
             message,
+            useCase: 'knowledge_sync',
+            subUseCase: 'agent_notes',
             ...asRunModelOptions(await getKgModel()),
             throwOnError: true,
         });

--- a/apps/x/packages/core/src/knowledge/build_graph.ts
+++ b/apps/x/packages/core/src/knowledge/build_graph.ts
@@ -409,6 +409,8 @@ async function createNotesFromBatch(
     const { turnId, state } = await runWhenPossible({
         agentId: NOTE_CREATION_AGENT,
         message,
+        useCase: 'knowledge_sync',
+        subUseCase: 'build_graph',
         ...asRunModelOptions(await getKgModel()),
         throwOnError: true,
     });
@@ -967,6 +969,8 @@ export async function curateNotes(): Promise<void> {
             await runWhenPossible({
                 agentId: CURATION_AGENT,
                 message,
+                useCase: 'knowledge_sync',
+                subUseCase: 'curation',
                 ...asRunModelOptions(await getKgModel()),
                 throwOnError: true,
             });

--- a/apps/x/packages/core/src/knowledge/inline_tasks.ts
+++ b/apps/x/packages/core/src/knowledge/inline_tasks.ts
@@ -482,6 +482,8 @@ async function processInlineTasks(): Promise<void> {
                 const { summary: result } = await runWhenPossible({
                     agentId: INLINE_TASK_AGENT,
                     message,
+                    useCase: 'knowledge_sync',
+                    subUseCase: 'inline_task_run',
                     ...asRunModelOptions(await getKgModel()),
                 });
                 if (result) {
@@ -561,6 +563,8 @@ export async function processRowboatInstruction(
     const { summary: rawResponse } = await runWhenPossible({
         agentId: INLINE_TASK_AGENT,
         message,
+        useCase: 'knowledge_sync',
+        subUseCase: 'inline_task_run',
         ...asRunModelOptions(await getKgModel()),
     });
     if (!rawResponse) {

--- a/apps/x/packages/core/src/knowledge/live-note/runner.ts
+++ b/apps/x/packages/core/src/knowledge/live-note/runner.ts
@@ -2,7 +2,6 @@ import type { LiveNote, LiveNoteTriggerType } from '@x/shared/dist/live-note.js'
 import { fetchLiveNote, patchLiveNote, readNoteBody } from './fileops.js';
 import { getLiveNoteAgentModel } from '../../models/defaults.js';
 import { startHeadlessAgent, startWhenPossible } from '../../runtime/assembly/headless-app.js';
-import { withUseCase } from '../../analytics/use_case.js';
 import { buildTriggerBlock } from '../../runtime/assembly/build-trigger-block.js';
 import { liveNoteBus } from './bus.js';
 import { PrefixLogger } from '@x/shared/dist/prefix-logger.js';
@@ -124,20 +123,16 @@ export async function runLiveNoteAgent(
         // here would deadlock the turn. Only autonomous triggers
         // (cron/window/event) defer.
         const start = trigger === 'manual' ? startHeadlessAgent : startWhenPossible;
-        // The use-case context propagates to every tool the agent calls; the
-        // granular trigger doubles as the sub-use-case (manual / cron /
-        // window / event) so dashboards can break down what woke the agent.
-        const handle = await withUseCase(
-            { useCase: 'live_note_agent', subUseCase: trigger },
-            () => start({
-                agentId: 'live-note-agent',
-                message: buildMessage(filePath, live, trigger, context),
-                model,
-                ...(provider ? { provider } : {}),
-                ...(effort ? { reasoningEffort: effort } : {}),
-                throwOnError: true,
-            }),
-        );
+        const handle = await start({
+            agentId: 'live-note-agent',
+            message: buildMessage(filePath, live, trigger, context),
+            useCase: 'live_note_agent',
+            subUseCase: trigger,
+            model,
+            ...(provider ? { provider } : {}),
+            ...(effort ? { reasoningEffort: effort } : {}),
+            throwOnError: true,
+        });
         const agentRun = { id: handle.turnId };
 
         log.log(`${filePath} — start trigger=${trigger} runId=${agentRun.id}`);

--- a/apps/x/packages/core/src/knowledge/tag_notes.ts
+++ b/apps/x/packages/core/src/knowledge/tag_notes.ts
@@ -100,6 +100,8 @@ async function tagNoteBatch(
     const { turnId, state } = await runWhenPossible({
         agentId: NOTE_TAGGING_AGENT,
         message,
+        useCase: 'knowledge_sync',
+        subUseCase: 'tag_notes',
         ...asRunModelOptions(await getKgModel()),
         throwOnError: true,
     });

--- a/apps/x/packages/core/src/migrations/runs/convert.ts
+++ b/apps/x/packages/core/src/migrations/runs/convert.ts
@@ -392,6 +392,12 @@ function buildTurn(
         },
         context: previousTurnId ? { previousTurnId } : [],
         input: plan.input,
+        analytics: {
+            useCase: start.useCase ?? "copilot_chat",
+            ...(start.subUseCase
+                ? { subUseCase: start.subUseCase }
+                : {}),
+        },
         config: {
             autoPermission: start.permissionMode === "auto",
             humanAvailable: true,

--- a/apps/x/packages/core/src/models/gateway.test.ts
+++ b/apps/x/packages/core/src/models/gateway.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withUseCase } from "../analytics/use_case.js";
+
+vi.mock("../auth/tokens.js", () => ({
+    getAccessToken: async () => "access-token",
+}));
+
+import { authedFetch } from "./gateway.js";
+
+describe("Rowboat gateway request attribution", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("sends the complete turn-scoped analytics context", async () => {
+        const fetchMock = vi.fn(
+            async (
+                input: Parameters<typeof fetch>[0],
+                init?: Parameters<typeof fetch>[1],
+            ) => {
+                void input;
+                void init;
+                return new Response(null, { status: 200 });
+            },
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await withUseCase(
+            {
+                useCase: "background_task_agent",
+                subUseCase: "cron",
+                agentName: "background-task-agent",
+            },
+            () => authedFetch("https://api.example.test/v1/llm/chat/completions"),
+        );
+
+        const [, init] = fetchMock.mock.calls[0];
+        const headers = new Headers(init?.headers);
+        expect(Object.fromEntries(headers.entries())).toMatchObject({
+            authorization: "Bearer access-token",
+            "x-rowboat-use-case": "background_task_agent",
+            "x-rowboat-sub-use-case": "cron",
+            "x-rowboat-agent-name": "background-task-agent",
+        });
+    });
+});

--- a/apps/x/packages/core/src/models/gateway.ts
+++ b/apps/x/packages/core/src/models/gateway.ts
@@ -5,7 +5,9 @@ import { getCurrentUseCase } from '../analytics/use_case.js';
 import { API_URL } from '../config/env.js';
 import { annotateReasoningFlags } from './models-dev.js';
 
-const authedFetch: typeof fetch = async (input, init) => {
+// Exported for transport-level verification; production passes this directly
+// to the Rowboat OpenRouter provider.
+export const authedFetch: typeof fetch = async (input, init) => {
     const token = await getAccessToken();
     const headers = new Headers(init?.headers);
     headers.set('Authorization', `Bearer ${token}`);

--- a/apps/x/packages/core/src/pre_built/runner.ts
+++ b/apps/x/packages/core/src/pre_built/runner.ts
@@ -55,6 +55,8 @@ Process new items and use the user context above to identify yourself when draft
         await runWhenPossible({
             agentId: agentName,
             message,
+            useCase: 'knowledge_sync',
+            subUseCase: 'pre_built',
             ...asRunModelOptions(await getKgModel()),
         });
 

--- a/apps/x/packages/core/src/runtime/assembly/headless.test.ts
+++ b/apps/x/packages/core/src/runtime/assembly/headless.test.ts
@@ -230,6 +230,8 @@ describe("HeadlessAgentRunner", () => {
         const handle = await runner.start({
             agentId: "worker",
             message: "go",
+            useCase: "knowledge_sync",
+            subUseCase: "tag_notes",
             model: "m",
             provider: "fake",
         });
@@ -240,6 +242,10 @@ describe("HeadlessAgentRunner", () => {
             sessionId: null,
             context: [],
             input: { role: "user", content: "go" },
+            analytics: {
+                useCase: "knowledge_sync",
+                subUseCase: "tag_notes",
+            },
             config: { autoPermission: true, humanAvailable: false },
         });
         const result = await handle.done;

--- a/apps/x/packages/core/src/runtime/assembly/headless.ts
+++ b/apps/x/packages/core/src/runtime/assembly/headless.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { UseCase } from "@x/shared/dist/analytics.js";
 import type { AssistantMessage } from "@x/shared/dist/message.js";
 import {
     type RequestedAgent,
@@ -32,6 +33,8 @@ export interface HeadlessAgentOptions {
     // overrides). Takes precedence over agentId/model/provider.
     agent?: z.infer<typeof RequestedAgent>;
     message: string;
+    useCase?: UseCase;
+    subUseCase?: string;
     // Model id; when set without provider, the app-default provider applies.
     model?: string;
     provider?: string;
@@ -154,6 +157,12 @@ export class HeadlessAgentRunner implements IHeadlessAgentRunner {
             sessionId: null,
             context: [],
             input: { role: "user", content: options.message },
+            analytics: {
+                useCase: options.useCase ?? "copilot_chat",
+                ...(options.subUseCase
+                    ? { subUseCase: options.subUseCase }
+                    : {}),
+            },
             config: {
                 autoPermission: true,
                 humanAvailable: false,

--- a/apps/x/packages/core/src/runtime/assembly/spawn-agent.test.ts
+++ b/apps/x/packages/core/src/runtime/assembly/spawn-agent.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { z } from "zod";
+import type { TurnAnalytics } from "@x/shared/dist/analytics.js";
 import type { TurnEvent, TurnState } from "@x/shared/dist/turns.js";
 import type { ITurnRuntime } from "../turns/api.js";
 import type {
@@ -25,6 +26,7 @@ const TS = "2026-07-07T10:00:00Z";
 function parentCreated(
     overrides: {
         requested?: z.infer<typeof TurnEvent> extends never ? never : unknown;
+        analytics?: TurnAnalytics;
     } & Record<string, unknown> = {},
 ): Array<z.infer<typeof TurnEvent>> {
     return [
@@ -45,6 +47,7 @@ function parentCreated(
             },
             context: [],
             input: { role: "user", content: "hi" },
+            analytics: overrides.analytics,
             config: {
                 autoPermission: true,
                 humanAvailable: false,
@@ -134,7 +137,14 @@ describe("runSpawnedAgent", () => {
     });
 
     it("runs an inline child on the parent's model and returns the result envelope", async () => {
-        const { services, started } = fakeServices({});
+        const { services, started } = fakeServices({
+            parentEvents: parentCreated({
+                analytics: {
+                    useCase: "knowledge_sync",
+                    subUseCase: "build_graph",
+                },
+            }),
+        });
         const progress: unknown[] = [];
         const result = await runSpawnedAgent(
             { task: "find things", name: "researcher", instructions: "You research." },
@@ -156,6 +166,10 @@ describe("runSpawnedAgent", () => {
         });
         expect(started[0].maxModelCalls).toBe(50);
         expect(started[0].signal).toBe(signal);
+        expect(started[0]).toMatchObject({
+            useCase: "knowledge_sync",
+            subUseCase: "build_graph",
+        });
         expect(progress).toEqual([
             { childTurnId: "child-1", agentName: "researcher", task: "find things" },
         ]);

--- a/apps/x/packages/core/src/runtime/assembly/spawn-agent.ts
+++ b/apps/x/packages/core/src/runtime/assembly/spawn-agent.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { TurnAnalytics } from "@x/shared/dist/analytics.js";
 import {
     DEFAULT_MAX_MODEL_CALLS,
     type JsonValue,
@@ -118,6 +119,7 @@ export async function runSpawnedAgent(
         opts.services ?? (await resolveServices());
 
     let parentModel: z.infer<typeof ModelDescriptor> | undefined;
+    let parentAnalytics: TurnAnalytics = { useCase: "copilot_chat" };
     try {
         const parent = reduceTurn(
             (await turnRuntime.getTurn(opts.parentTurnId)).events,
@@ -130,6 +132,7 @@ export async function runSpawnedAgent(
             return spawnError("sub-agents cannot spawn further sub-agents");
         }
         parentModel = parentAgent.resolved.model;
+        parentAnalytics = parent.definition.analytics ?? parentAnalytics;
     } catch {
         // Parent unreadable (legacy runs path): fall back to app defaults.
         parentModel = undefined;
@@ -194,6 +197,7 @@ export async function runSpawnedAgent(
         handle = await headlessRunner.start({
             agent,
             message: input.task,
+            ...parentAnalytics,
             maxModelCalls,
             ...(reasoningEffort === undefined ? {} : { reasoningEffort }),
             signal: opts.signal,

--- a/apps/x/packages/core/src/runtime/sessions/api.ts
+++ b/apps/x/packages/core/src/runtime/sessions/api.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { UseCase } from "@x/shared/dist/analytics.js";
 import type { UserMessage } from "@x/shared/dist/message.js";
 import type {
     SessionIndexEntry,
@@ -14,6 +15,8 @@ import type { Turn } from "../turns/api.js";
 // Per-message configuration; it lands on the turn (sessions store none).
 export interface SendMessageConfig {
     agent: z.infer<typeof RequestedAgent>;
+    useCase?: UseCase;
+    subUseCase?: string;
     autoPermission?: boolean;
     maxModelCalls?: number;
     reasoningEffort?: "low" | "medium" | "high";

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -59,6 +59,7 @@ function createdEvent(turnId: string, input: CreateTurnInput): TEvent {
         agent: { requested: input.agent, resolved: FIXTURE_AGENT },
         context: input.context,
         input: input.input,
+        analytics: input.analytics,
         config: {
             autoPermission: input.config.autoPermission ?? false,
             humanAvailable: input.config.humanAvailable,
@@ -366,6 +367,8 @@ describe("sendMessage (13.3)", () => {
         const sessionId = await sessions.createSession();
         const { turnId } = await sessions.sendMessage(sessionId, user("Fix the bug in parser"), {
             agent: { agentId: "copilot", overrides: { model: { provider: "x", model: "y" } } },
+            useCase: "todo_item_agent",
+            subUseCase: "manual",
             autoPermission: true,
             maxModelCalls: 5,
         });
@@ -375,6 +378,10 @@ describe("sendMessage (13.3)", () => {
             sessionId,
             context: [],
             input: user("Fix the bug in parser"),
+            analytics: {
+                useCase: "todo_item_agent",
+                subUseCase: "manual",
+            },
             config: { humanAvailable: true, autoPermission: true, maxModelCalls: 5 },
         });
 

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -192,6 +192,12 @@ export class SessionsImpl implements ISessions {
                     ? { previousTurnId: state.latestTurnId }
                     : [],
                 input,
+                analytics: {
+                    useCase: config.useCase ?? "copilot_chat",
+                    ...(config.subUseCase
+                        ? { subUseCase: config.subUseCase }
+                        : {}),
+                },
                 config: {
                     humanAvailable: true,
                     ...(config.autoPermission === undefined

--- a/apps/x/packages/core/src/runtime/turns/api.ts
+++ b/apps/x/packages/core/src/runtime/turns/api.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { TurnAnalytics } from "@x/shared/dist/analytics.js";
 import type { AssistantMessage, UserMessage } from "@x/shared/dist/message.js";
 import type {
     JsonValue,
@@ -16,6 +17,7 @@ export interface CreateTurnInput {
     sessionId?: string | null;
     context: z.infer<typeof TurnContext>;
     input: z.infer<typeof UserMessage>;
+    analytics?: TurnAnalytics;
     config: {
         autoPermission?: boolean;
         humanAvailable: boolean;

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-usage-reporter.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-usage-reporter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CaptureLlmUsageArgs } from "../../../analytics/usage.js";
+import { RealUsageReporter } from "./real-usage-reporter.js";
+
+describe("RealUsageReporter", () => {
+    it("reports the durable turn attribution without consulting ambient context", () => {
+        const capture = vi.fn<(args: CaptureLlmUsageArgs) => void>();
+        const reporter = new RealUsageReporter({ capture });
+
+        reporter.reportModelUsage({
+            agentId: "live-note-agent",
+            analytics: {
+                useCase: "live_note_agent",
+                subUseCase: "cron",
+            },
+            model: {
+                provider: "rowboat",
+                model: "google/gemini-3.5-flash",
+            },
+            usage: {
+                inputTokens: 12,
+                outputTokens: 4,
+                totalTokens: 16,
+            },
+        });
+
+        expect(capture).toHaveBeenCalledWith({
+            useCase: "live_note_agent",
+            subUseCase: "cron",
+            agentName: "live-note-agent",
+            provider: "rowboat",
+            model: "google/gemini-3.5-flash",
+            usage: {
+                inputTokens: 12,
+                outputTokens: 4,
+                totalTokens: 16,
+            },
+        });
+    });
+});

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-usage-reporter.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-usage-reporter.ts
@@ -1,18 +1,26 @@
 import { captureLlmUsage } from "../../../analytics/usage.js";
-import { getCurrentUseCase } from "../../../analytics/use_case.js";
 import type { IUsageReporter, ModelUsageReport } from "../usage-reporter.js";
 
-// Reports each completed model call as the same `llm_usage` PostHog event
-// the old run loop emitted. The use case comes from the AsyncLocalStorage
-// context the caller established (headless runners wrap startHeadlessAgent
-// in withUseCase); UI-driven session turns have no context and default to
-// copilot_chat — matching the old createRun default.
+export interface RealUsageReporterDependencies {
+    capture?: typeof captureLlmUsage;
+}
+
+// Reports each completed model call from the attribution persisted on its
+// turn. It deliberately does not consult ambient async context: resumes and
+// external-input advances must report exactly what turn_created recorded.
 export class RealUsageReporter implements IUsageReporter {
+    private readonly capture: typeof captureLlmUsage;
+
+    constructor(deps: RealUsageReporterDependencies = {}) {
+        this.capture = deps.capture ?? captureLlmUsage;
+    }
+
     reportModelUsage(report: ModelUsageReport): void {
-        const context = getCurrentUseCase();
-        captureLlmUsage({
-            useCase: context?.useCase ?? "copilot_chat",
-            ...(context?.subUseCase ? { subUseCase: context.subUseCase } : {}),
+        this.capture({
+            useCase: report.analytics.useCase,
+            ...(report.analytics.subUseCase
+                ? { subUseCase: report.analytics.subUseCase }
+                : {}),
             agentName: report.agentId,
             model: report.model.model,
             provider: report.model.provider,

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -34,6 +34,7 @@ import type {
 } from "./permission.js";
 import { composeModelRequest } from "./compose-model-request.js";
 import { TurnRuntime } from "./runtime.js";
+import { getCurrentUseCase } from "../../analytics/use_case.js";
 import type {
     IToolRegistry,
     RuntimeTool,
@@ -408,11 +409,13 @@ async function advanceAndSettle(
 class FakeUsageReporter {
     reports: Array<{
         agentId: string;
+        analytics: { useCase: string; subUseCase?: string };
         model: { provider: string; model: string };
         usage: Record<string, number | undefined>;
     }> = [];
     reportModelUsage(report: {
         agentId: string;
+        analytics: { useCase: string; subUseCase?: string };
         model: { provider: string; model: string };
         usage: Record<string, number | undefined>;
     }): void {
@@ -445,6 +448,34 @@ async function persisted(
 // ---------------------------------------------------------------------------
 
 describe("plain model response (26.1)", () => {
+    it("defaults pre-attribution turn records to copilot_chat", async () => {
+        const contexts: Array<ReturnType<typeof getCurrentUseCase>> = [];
+        const legacyCall: ScriptedCall = async function* () {
+            contexts.push(getCurrentUseCase());
+            yield completedResp(assistantText("done"));
+        };
+        const { runtime, repo, usage } = makeRuntime({
+            models: [legacyCall],
+        });
+        const turnId = await newTurn(runtime);
+        const legacyLog = await repo.read(turnId);
+        if (legacyLog[0].type !== "turn_created") {
+            throw new Error("fixture has no turn_created event");
+        }
+        delete legacyLog[0].analytics;
+        repo.seed(legacyLog);
+
+        const { outcome } = await advanceAndSettle(runtime, turnId);
+
+        expect(outcome?.status).toBe("completed");
+        expect(contexts).toEqual([
+            { useCase: "copilot_chat", agentName: "copilot" },
+        ]);
+        expect(usage.reports[0].analytics).toEqual({
+            useCase: "copilot_chat",
+        });
+    });
+
     it("runs one model step to completion with exact persisted request", async () => {
         const { runtime, repo, models, bus, usage } = makeRuntime({
             models: [
@@ -486,6 +517,7 @@ describe("plain model response (26.1)", () => {
         expect(usage.reports).toEqual([
             {
                 agentId: "copilot",
+                analytics: { useCase: "copilot_chat" },
                 model: defaultAgent.model,
                 usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
             },
@@ -994,6 +1026,50 @@ describe("automatic permission classification (26.4)", () => {
 // ---------------------------------------------------------------------------
 
 describe("human-dependent tools", () => {
+    it("restores persisted analytics for the initial and resumed advances", async () => {
+        const contexts: Array<ReturnType<typeof getCurrentUseCase>> = [];
+        const respondWithContext = (...events: LlmStreamEvent[]): ScriptedCall =>
+            async function* () {
+                contexts.push(getCurrentUseCase());
+                yield* events;
+            };
+        const { runtime, repo, usage } = makeRuntime({
+            models: [
+                respondWithContext(
+                    completedResp(assistantCalls(toolCallPart("H", "ask-human"))),
+                ),
+                respondWithContext(completedResp(assistantText("done"))),
+            ],
+        });
+        const analytics = {
+            useCase: "live_note_agent" as const,
+            subUseCase: "manual",
+        };
+        const turnId = await newTurn(runtime, { analytics });
+
+        const first = await advanceAndSettle(runtime, turnId);
+        expect(first.outcome?.status).toBe("suspended");
+
+        const second = await advanceAndSettle(runtime, turnId, {
+            type: "async_tool_result",
+            toolCallId: "H",
+            result: { output: "42", isError: false },
+        });
+        expect(second.outcome?.status).toBe("completed");
+
+        const [created] = await persisted(repo, turnId);
+        expect(created).toMatchObject({ type: "turn_created", analytics });
+        expect(contexts).toEqual([
+            { ...analytics, agentName: "copilot" },
+            { ...analytics, agentName: "copilot" },
+        ]);
+        expect(usage.reports).toHaveLength(2);
+        expect(usage.reports.map((report) => report.analytics)).toEqual([
+            analytics,
+            analytics,
+        ]);
+    });
+
     it("ask-human suspends as a pending async tool when a human is available", async () => {
         const { runtime } = makeRuntime({
             models: [

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { TurnAnalytics } from "@x/shared/dist/analytics.js";
 import {
     DEFAULT_MAX_MODEL_CALLS,
     MODEL_CALL_LIMIT_ERROR_CODE,
@@ -28,6 +29,7 @@ import {
     reduceTurn,
 } from "@x/shared/dist/turns.js";
 import type { IMonotonicallyIncreasingIdGenerator } from "../../application/lib/id-gen.js";
+import { withUseCase } from "../../analytics/use_case.js";
 import type { IAgentResolver } from "./agent-resolver.js";
 import {
     type CreateTurnInput,
@@ -160,6 +162,7 @@ export class TurnRuntime implements ITurnRuntime {
             agent: { requested: input.agent, resolved: snapshot },
             context: input.context,
             input: input.input,
+            analytics: input.analytics ?? { useCase: "copilot_chat" },
             config: {
                 autoPermission: input.config.autoPermission ?? false,
                 humanAvailable: input.config.humanAvailable,
@@ -242,6 +245,9 @@ export class TurnRuntime implements ITurnRuntime {
         }
 
         const definition = state.definition;
+        const analytics: TurnAnalytics = definition.analytics ?? {
+            useCase: "copilot_chat",
+        };
         const materialize = async (): Promise<MaterializedEnv> => {
             const resolvedContext = await this.contextResolver.resolve(
                 definition.context,
@@ -291,6 +297,7 @@ export class TurnRuntime implements ITurnRuntime {
             state,
             stream,
             materialize,
+            analytics,
             usageReporter: this.usageReporter,
             resolveTool: (descriptor) => this.toolRegistry.resolve(descriptor),
             signal: controller.signal,
@@ -301,7 +308,13 @@ export class TurnRuntime implements ITurnRuntime {
             turnEventBus: this.turnEventBus,
         });
         try {
-            return await run.run(input);
+            return await withUseCase(
+                {
+                    ...analytics,
+                    agentName: definition.agent.resolved.agentId,
+                },
+                () => run.run(input),
+            );
         } finally {
             // Drain any queued commits before withLock releases the turn, so
             // no append (straggler tool, un-awaited progress) can run after
@@ -333,6 +346,7 @@ class TurnAdvance {
     private state: TurnState;
     private readonly stream: HotStream<TurnStreamEvent, TurnOutcome>;
     private readonly materialize: () => Promise<MaterializedEnv>;
+    private readonly analytics: TurnAnalytics;
     // Assigned by run() immediately after the cancel fast-path, before any
     // loop phase can touch them. cancel() must never read these.
     private resolvedContext!: Array<z.infer<typeof ConversationMessage>>;
@@ -362,6 +376,7 @@ class TurnAdvance {
         state: TurnState;
         stream: HotStream<TurnStreamEvent, TurnOutcome>;
         materialize: () => Promise<MaterializedEnv>;
+        analytics: TurnAnalytics;
         usageReporter: IUsageReporter;
         resolveTool: (
             descriptor: z.infer<typeof ToolDescriptor>,
@@ -378,6 +393,7 @@ class TurnAdvance {
         this.state = init.state;
         this.stream = init.stream;
         this.materialize = init.materialize;
+        this.analytics = init.analytics;
         this.usageReporter = init.usageReporter;
         this.resolveTool = init.resolveTool;
         this.signal = init.signal;
@@ -1290,6 +1306,7 @@ class TurnAdvance {
         try {
             this.usageReporter.reportModelUsage({
                 agentId: this.resolvedAgent.agentId,
+                analytics: this.analytics,
                 model: this.resolvedAgent.model,
                 usage: completion.usage,
             });

--- a/apps/x/packages/core/src/runtime/turns/usage-reporter.ts
+++ b/apps/x/packages/core/src/runtime/turns/usage-reporter.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { TurnAnalytics } from "@x/shared/dist/analytics.js";
 import type { ModelDescriptor, TurnUsage } from "@x/shared/dist/turns.js";
 
 // Analytics seam for the turn loop: invoked once per completed model call,
@@ -6,6 +7,7 @@ import type { ModelDescriptor, TurnUsage } from "@x/shared/dist/turns.js";
 // throw into the loop and must not block it (fire-and-forget).
 export interface ModelUsageReport {
     agentId: string;
+    analytics: TurnAnalytics;
     model: z.infer<typeof ModelDescriptor>;
     usage: z.infer<typeof TurnUsage>;
 }

--- a/apps/x/packages/core/src/todo/runner.ts
+++ b/apps/x/packages/core/src/todo/runner.ts
@@ -1,5 +1,4 @@
 import { getDefaultModelAndProvider } from '../models/defaults.js';
-import { withUseCase } from '../analytics/use_case.js';
 import { notifyIfEnabled } from '../application/notification/notifier.js';
 import { PrefixLogger } from '@x/shared/dist/prefix-logger.js';
 import type { TurnStreamEvent } from '@x/shared/dist/turns.js';
@@ -285,20 +284,19 @@ async function driveTurn(
             const selection: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' } =
                 modelOverride ?? await getDefaultModelAndProvider();
             const { model, provider } = selection;
-            sent = await withUseCase(
-                { useCase: 'todo_item_agent', subUseCase },
-                () => sessions.sendMessage(
-                    sessionId,
-                    { role: 'user', content: message },
-                    {
-                        agent: {
-                            agentId: 'todo-item-agent',
-                            overrides: { model: { provider, model } },
-                        },
-                        ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
-                        autoPermission,
+            sent = await sessions.sendMessage(
+                sessionId,
+                { role: 'user', content: message },
+                {
+                    agent: {
+                        agentId: 'todo-item-agent',
+                        overrides: { model: { provider, model } },
                     },
-                ),
+                    useCase: 'todo_item_agent',
+                    subUseCase,
+                    ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
+                    autoPermission,
+                },
             );
         } catch (err) {
             if (err instanceof TurnNotSettledError) {
@@ -422,20 +420,19 @@ async function driveChatTurn(
             const selection: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' } =
                 modelOverride ?? await getDefaultModelAndProvider();
             const { model, provider } = selection;
-            sent = await withUseCase(
-                { useCase: 'copilot_chat', subUseCase: 'home_stream' },
-                () => sessions.sendMessage(
-                    sessionId,
-                    { role: 'user', content: message },
-                    {
-                        agent: {
-                            agentId: 'copilot',
-                            overrides: { model: { provider, model } },
-                        },
-                        ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
-                        autoPermission,
+            sent = await sessions.sendMessage(
+                sessionId,
+                { role: 'user', content: message },
+                {
+                    agent: {
+                        agentId: 'copilot',
+                        overrides: { model: { provider, model } },
                     },
-                ),
+                    useCase: 'copilot_chat',
+                    subUseCase: 'home_stream',
+                    ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
+                    autoPermission,
+                },
             );
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);

--- a/apps/x/packages/shared/src/analytics.ts
+++ b/apps/x/packages/shared/src/analytics.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+// One taxonomy shared by legacy runs, durable turns, PostHog, and the
+// Rowboat gateway. A use case describes why an LLM request was made; the
+// optional sub-use-case refines that reason without changing the top-level
+// reporting bucket.
+export const UseCase = z.enum([
+    "copilot_chat",
+    "live_note_agent",
+    "background_task_agent",
+    "todo_item_agent",
+    "meeting_note",
+    "meeting_prep",
+    "knowledge_sync",
+    "code_session",
+    "app_llm_generate",
+    "app_copilot_run",
+]);
+
+export type UseCase = z.infer<typeof UseCase>;
+
+export const TurnAnalytics = z.object({
+    useCase: UseCase,
+    subUseCase: z.string().optional(),
+});
+
+export type TurnAnalytics = z.infer<typeof TurnAnalytics>;

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { UseCase } from './analytics.js';
 import { RelPath, Encoding, Stat, DirEntry, ReaddirOptions, ReadFileResult, WorkspaceChangeEvent, WriteFileOptions, WriteFileResult, RemoveOptions } from './workspace.js';
 import { ListToolsResponse } from './mcp.js';
 import { AskHumanResponsePayload, CreateRunOptions, Run, ListRunsResponse, ToolPermissionAuthorizePayload } from './runs.js';
@@ -557,6 +558,8 @@ const ipcSchemas = {
       input: UserMessage,
       config: z.object({
         agent: RequestedAgent,
+        useCase: UseCase.optional(),
+        subUseCase: z.string().optional(),
         autoPermission: z.boolean().optional(),
         maxModelCalls: z.number().int().positive().optional(),
         reasoningEffort: ReasoningEffort.optional(),

--- a/apps/x/packages/shared/src/runs.ts
+++ b/apps/x/packages/shared/src/runs.ts
@@ -1,7 +1,10 @@
 import { LlmStepStreamEvent } from "./llm-step-events.js";
 import { Message, ToolCallPart } from "./message.js";
 import { CodeRunEvent as CodeRunEventSchema, PermissionAsk } from "./code-mode.js";
+import { UseCase } from "./analytics.js";
 import z from "zod";
+
+export { UseCase } from "./analytics.js";
 
 const BaseRunEvent = z.object({
     runId: z.string(),
@@ -25,16 +28,7 @@ export const StartEvent = BaseRunEvent.extend({
     permissionMode: z.enum(["manual", "auto"]).optional(),
     // useCase/subUseCase tag the run for analytics. Optional on read so legacy
     // run files written before these fields existed still parse cleanly.
-    useCase: z.enum([
-        "copilot_chat",
-        "live_note_agent",
-        "background_task_agent",
-        "meeting_note",
-        "knowledge_sync",
-        "code_session",
-        "app_llm_generate",
-        "app_copilot_run",
-    ]).optional(),
+    useCase: UseCase.optional(),
     subUseCase: z.string().optional(),
 });
 
@@ -214,17 +208,6 @@ export const AskHumanResponsePayload = AskHumanResponseEvent.pick({
     toolCallId: true,
     response: true,
 });
-
-export const UseCase = z.enum([
-    "copilot_chat",
-    "live_note_agent",
-    "background_task_agent",
-    "meeting_note",
-    "knowledge_sync",
-    "code_session",
-    "app_llm_generate",
-    "app_copilot_run",
-]);
 
 export const Run = z.object({
     id: z.string(),

--- a/apps/x/packages/shared/src/turns.ts
+++ b/apps/x/packages/shared/src/turns.ts
@@ -6,6 +6,7 @@ import {
     UserMessage,
 } from "./message.js";
 import { ReasoningEffort } from "./models.js";
+import { TurnAnalytics } from "./analytics.js";
 
 // Durable turn contract for the turn runtime (see
 // packages/core/docs/turn-runtime-design.md). This module is the
@@ -173,6 +174,11 @@ export const TurnCreated = z.object({
     }),
     context: TurnContext,
     input: UserMessage,
+    // Why this turn ran. The orthogonal "which agent ran" dimension is already
+    // durable as agent.resolved.agentId; keeping one canonical copy prevents
+    // analytics agent_name from drifting from the actual resolved agent.
+    // Optional on read for turn files written before durable attribution.
+    analytics: TurnAnalytics.optional(),
     config: z.object({
         autoPermission: z.boolean(),
         humanAvailable: z.boolean(),


### PR DESCRIPTION
## Summary

- persist use-case and sub-use-case attribution on each durable turn
- restore that context, plus the canonical resolved agent id, around every turn advance
- report PostHog usage from the durable record and send complete Rowboat gateway headers
- migrate session, headless, knowledge-sync, background, live-note, todo, scheduled, and child-agent paths
- preserve compatibility for older turn records and migrated legacy runs

## RCA

The runtime refactor removed use-case metadata from the durable run definition and replaced it with AsyncLocalStorage at selected call sites. Unwrapped and resumed turns therefore lost attribution: PostHog fell back to copilot_chat, while Rowboat gateway headers were omitted. Agent attribution was also unavailable to the gateway on the new runtime.

## Design

TurnAnalytics is now a shared durable value containing only why the turn ran: useCase and optional subUseCase. The orthogonal which agent ran dimension remains canonical at turn_created.agent.resolved.agentId, avoiding duplicate values that can drift.

New turns always persist analytics. The field is optional on read so existing turn files remain valid and default to copilot_chat. TurnRuntime restores the persisted context on every advance, including permission/async continuations and recovery. Usage reporting receives attribution explicitly rather than consulting ambient context.

## Verification

- full apps/x typecheck
- shared, core, and renderer suites: 820 tests passing
- core production build
- git diff --check
- regression coverage for initial and resumed advances, legacy fallback, PostHog payloads, Rowboat headers, headless/session creation, and child-turn inheritance

Repository-wide lint still has 11 pre-existing failures; this change introduces no new lint errors.