### PR TITLE
Fix all apps/x lint errors and gate CI on the root eslint run

### DIFF
--- a/.github/workflows/x-tests.yml
+++ b/.github/workflows/x-tests.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Covers apps/main, apps/preload, and packages/*; apps/renderer is
+      # excluded until its lint debt is paid down (see eslint.config.mts).
+      - name: Lint apps/x
+        run: npm run lint
+
       # Builds @x/shared (core/renderer tests import its dist), then runs
       # the shared, core, and renderer vitest suites in order.
       - name: Run apps/x Vitest suites

--- a/apps/x/apps/main/src/composio-handler.ts
+++ b/apps/x/apps/main/src/composio-handler.ts
@@ -152,7 +152,7 @@ export async function initiateConnection(toolkitSlug: string): Promise<{
         // Set up callback server
         const timeoutRef: { current: NodeJS.Timeout | null } = { current: null };
         let callbackHandled = false;
-        const { server } = await createAuthServer(8081, async (_callbackUrl) => {
+        const { server } = await createAuthServer(8081, async () => {
             // Guard against duplicate callbacks (browser may send multiple requests)
             if (callbackHandled) return;
             callbackHandled = true;

--- a/apps/x/packages/core/src/background-tasks/scheduler.ts
+++ b/apps/x/packages/core/src/background-tasks/scheduler.ts
@@ -16,7 +16,7 @@ function humanMs(ms: number): string {
 async function processScheduledTasks(): Promise<void> {
     const { items } = await listTasks({ limit: 10_000 });
 
-    let scannedCount = items.length;
+    const scannedCount = items.length;
     let activeCount = 0;
     let pausedCount = 0;
     let firedCount = 0;

--- a/apps/x/packages/core/src/code-mode/acp/client.ts
+++ b/apps/x/packages/core/src/code-mode/acp/client.ts
@@ -328,21 +328,20 @@ export class AcpClient {
     }
 
     // The client side of ACP: the agent calls these on us. These read the CURRENT
-    // handlers off `self` so follow-up prompts can swap them via setHandlers().
+    // handlers off `this` so follow-up prompts can swap them via setHandlers().
     private buildClient(): Client {
-        const self = this;
         return {
-            async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
-                return self.broker.resolve(params);
+            requestPermission: async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
+                return this.broker.resolve(params);
             },
-            async sessionUpdate(params: SessionNotification): Promise<void> {
-                self.onEvent(toEvent(params.update));
+            sessionUpdate: async (params: SessionNotification): Promise<void> => {
+                this.onEvent(toEvent(params.update));
             },
-            async readTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
+            readTextFile: async (params: ReadTextFileRequest): Promise<ReadTextFileResponse> => {
                 const content = await fs.readFile(params.path, 'utf8');
                 return { content };
             },
-            async writeTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
+            writeTextFile: async (params: WriteTextFileRequest): Promise<WriteTextFileResponse> => {
                 await fs.writeFile(params.path, params.content);
                 return {};
             },

--- a/apps/x/packages/core/src/config/config.ts
+++ b/apps/x/packages/core/src/config/config.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import fs from "fs";
 import { homedir } from "os";
-import { fileURLToPath } from "url";
 
 function resolveWorkDir(): string {
     const configured = process.env.ROWBOAT_WORKDIR;
@@ -22,10 +21,6 @@ function resolveWorkDir(): string {
 // Allow override via ROWBOAT_WORKDIR env var for standalone pipeline usage.
 // Normalize to an absolute path so workspace boundary checks behave consistently.
 export const WorkDir = resolveWorkDir();
-
-// Get the directory of this file (for locating bundled assets)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 function ensureDirs() {
     const ensure = (p: string) => { if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true }); };

--- a/apps/x/packages/core/src/config/strictness_analyzer.ts
+++ b/apps/x/packages/core/src/config/strictness_analyzer.ts
@@ -390,9 +390,6 @@ export function analyzeEmailsAndRecommend(): AnalysisResult {
     let reason: string;
 
     const totalHumanSenders = lowWouldCreate;
-    const noiseRatio = uniqueSenders.size > 0
-        ? (newsletterSenders.size + automatedSenders.size) / uniqueSenders.size
-        : 0;
     const consumerRatio = totalHumanSenders > 0
         ? consumerServiceSenders.size / totalHumanSenders
         : 0;

--- a/apps/x/packages/core/src/knowledge/chrome-extension/server/server.ts
+++ b/apps/x/packages/core/src/knowledge/chrome-extension/server/server.ts
@@ -43,7 +43,7 @@ function pathToSlug(url: string): string {
         const parsed = new URL(url);
         const p = parsed.pathname + (parsed.search || '');
         if (!p || p === '/') return 'index';
-        let slug = p.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_|_$/g, '');
+        const slug = p.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_|_$/g, '');
         return slug.substring(0, 80) || 'index';
     } catch {
         return 'index';
@@ -184,12 +184,13 @@ function saveConfig(config: Config): void {
     fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), 'utf-8');
 }
 
-function validateConfig(data: any): data is Config {
+function validateConfig(data: unknown): data is Config {
     if (typeof data !== 'object' || data === null) return false;
-    if (data.mode !== 'all' && data.mode !== 'ask') return false;
-    if (!Array.isArray(data.whitelist)) return false;
-    if (!Array.isArray(data.blacklist)) return false;
-    if (typeof data.enabled !== 'boolean') return false;
+    const d = data as Record<string, unknown>;
+    if (d.mode !== 'all' && d.mode !== 'ask') return false;
+    if (!Array.isArray(d.whitelist)) return false;
+    if (!Array.isArray(d.blacklist)) return false;
+    if (typeof d.enabled !== 'boolean') return false;
     return true;
 }
 

--- a/apps/x/packages/core/src/models/catalog.test.ts
+++ b/apps/x/packages/core/src/models/catalog.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   listCodexModels: vi.fn(async () => ({
     providers: [{ id: 'codex', name: 'OpenAI Codex', models: [{ id: 'gpt-5.6-sol', reasoning: true }] }],
   })),
-  listModelsForProvider: vi.fn(async (_config: unknown) => ['live-model-1']),
+  listModelsForProvider: vi.fn<(config: unknown) => Promise<string[]>>(async () => ['live-model-1']),
   listOnboardingModels: vi.fn(async () => ({ providers: [] as Array<{ id: string; name: string; models: Array<{ id: string; name?: string; reasoning?: boolean }> }> })),
   getDefaultModelAndProvider: vi.fn(async () => ({ provider: 'openai', model: 'gpt-5.4' })),
   getConfig: vi.fn(async (): Promise<unknown> => {

--- a/apps/x/packages/core/src/pre_built/runner.ts
+++ b/apps/x/packages/core/src/pre_built/runner.ts
@@ -75,8 +75,6 @@ Process new items and use the user context above to identify yourself when draft
  * Check all agents and run those that are due
  */
 async function checkAndRunAgents(): Promise<void> {
-    const config = loadConfig();
-
     for (const agentName of PREBUILT_AGENTS) {
         try {
             if (shouldRunAgent(agentName)) {
@@ -135,7 +133,7 @@ export async function init(): Promise<void> {
  * Manually trigger an agent run (useful for testing)
  */
 export async function triggerAgent(agentName: string): Promise<void> {
-    if (!PREBUILT_AGENTS.includes(agentName as any)) {
+    if (!(PREBUILT_AGENTS as readonly string[]).includes(agentName)) {
         throw new Error(`Unknown agent: ${agentName}. Available: ${PREBUILT_AGENTS.join(', ')}`);
     }
     await runAgent(agentName);

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -24,7 +24,7 @@ import { AppSummarySchema, RegistryRecordSchema, RowboatAppManifestSchema } from
 import { BrowserStateSchema, DisplayMediaRequestSchema, HttpAuthRequestSchema } from './browser-control.js';
 import { BillingInfoSchema } from './billing.js';
 import { CreditActivatedEventSchema, CreditsStateSchema, ReferralClaimResultSchema } from './credits.js';
-import { EmailBlockSchema, GmailThreadSchema } from './blocks.js';
+import { GmailThreadSchema } from './blocks.js';
 import { PermissionDecision, ApprovalPolicy, CodingAgent, type CodeRunFeedEvent } from './code-mode.js';
 import { NotificationSettingsSchema } from './notification-settings.js';
 import { TurnLimitsSettingsSchema } from './turn-limits.js';


### PR DESCRIPTION
## Summary
- Fixes all 11 recurring eslint errors in apps/x with real fixes (no suppressions): dead vars/imports removed, `let`→`const`, both `any`s replaced (an `unknown` type guard in the chrome-extension server, readonly-array widening for `PREBUILT_AGENTS.includes`), and the `self = this` alias in the ACP client replaced with lexically-bound arrow callbacks (same swap-handlers-at-call-time behavior).
- Adds a lint step to the `apps-x-vitest` CI job so these can't silently recur. It runs first (cheapest check, needs no built packages) and covers apps/main, apps/preload, and packages/*.

## Notes
- The unused `_config` param in `catalog.test.ts` was load-bearing — it typed the mock's call signature for a `mock.calls` assertion — so the typing moved into the `vi.fn` generic.
- apps/renderer remains excluded from the root lint (its block in `eslint.config.mts` is commented out) — it has ~141 standalone lint issues, mostly react-hooks rules, tracked as a separate burn-down. The exclusion is now documented in the workflow instead of silent.

## Test plan
- `cd apps/x && npm run lint` — clean
- `cd apps/x && npm run typecheck` — exit 0
- `catalog.test.ts` suite (7 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)