### PR TITLE
feat(x): quiet one-line tool rows in the chat transcript

### DIFF
--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -1477,3 +1477,18 @@
 .bidi-auto :is(p,h1,h2,h3,h4,h5,h6,li,blockquote,td,th){unicode-bidi:plaintext;text-align:start;}
 /* Code is inherently LTR — keep it stable inside RTL messages. */
 .bidi-auto :is(pre,code,kbd,samp){direction:ltr;unicode-bidi:isolate;text-align:left;}
+
+/* Turn usage footer (token menu + effort label): hidden until the turn is
+   hovered. `*:hover + …` reveals it when the element directly above it — the
+   turn's last message — is hovered; the :has() keeps it pinned while its
+   dropdown is open. */
+[data-turn-usage] {
+  opacity: 0;
+  transition: opacity 0.15s ease-out;
+}
+[data-turn-usage]:hover,
+[data-turn-usage]:focus-within,
+[data-turn-usage]:has([data-state="open"]),
+*:hover + [data-turn-usage] {
+  opacity: 1;
+}

--- a/apps/x/apps/renderer/src/components/ai-elements/app-action-card.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/app-action-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  CheckCircleIcon,
   FileTextIcon,
   FilterIcon,
   LayoutGridIcon,
@@ -9,6 +8,8 @@ import {
   NetworkIcon,
   PlusCircleIcon,
 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { quietRowGlyphSlotClass } from "@/components/ai-elements/tool";
 import type { AppActionCardData } from "@/lib/chat-conversation";
 
 interface AppActionCardProps {
@@ -17,29 +18,34 @@ interface AppActionCardProps {
 }
 
 const actionIcons: Record<string, React.ReactNode> = {
-  "open-note": <FileTextIcon className="size-4" />,
-  "open-view": <NetworkIcon className="size-4" />,
-  "update-base-view": <FilterIcon className="size-4" />,
-  "create-base": <PlusCircleIcon className="size-4" />,
+  "open-note": <FileTextIcon className="size-3.5" />,
+  "open-view": <NetworkIcon className="size-3.5" />,
+  "update-base-view": <FilterIcon className="size-3.5" />,
+  "create-base": <PlusCircleIcon className="size-3.5" />,
 };
 
+// Quiet one-line row matching the tool rows: spinner while running, then the
+// label fades to muted. Not expandable — the label is the whole story.
 export function AppActionCard({ data, status }: AppActionCardProps) {
   const isRunning = status === "pending" || status === "running";
   const isError = status === "error";
 
   return (
-    <div className="not-prose mb-4 flex items-center gap-2 rounded-md border px-3 py-2">
-      <span className="text-muted-foreground">
-        {actionIcons[data.action] || <LayoutGridIcon className="size-4" />}
+    <div className="not-prose -my-3 flex w-full items-center gap-2 px-1.5 py-[3px] -mx-1.5 text-[13px] leading-5">
+      <span className={quietRowGlyphSlotClass}>
+        {isRunning ? (
+          <LoaderIcon className="size-3 animate-spin text-muted-foreground" />
+        ) : isError ? (
+          <span className="size-1.5 rounded-full bg-red-600 dark:bg-red-500" />
+        ) : null}
       </span>
-      <span className="text-sm flex-1">{data.label}</span>
-      {isRunning ? (
-        <LoaderIcon className="size-3.5 animate-spin text-muted-foreground" />
-      ) : isError ? (
-        <span className="text-xs text-destructive">Failed</span>
-      ) : (
-        <CheckCircleIcon className="size-3.5 text-green-600" />
-      )}
+      <span className="shrink-0 text-muted-foreground">
+        {actionIcons[data.action] || <LayoutGridIcon className="size-3.5" />}
+      </span>
+      <span className={cn("min-w-0 truncate", isRunning ? "text-foreground" : "text-muted-foreground")}>
+        {data.label}
+      </span>
+      {isError && <span className="shrink-0 text-xs text-red-600 dark:text-red-500">failed</span>}
     </div>
   );
 }

--- a/apps/x/apps/renderer/src/components/ai-elements/auto-permission-decision.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/auto-permission-decision.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { CheckCircle2Icon, ShieldAlertIcon, Terminal } from "lucide-react";
-import type { ComponentProps } from "react";
+import { ChevronDownIcon } from "lucide-react";
+import { useState, type ComponentProps } from "react";
+import { quietRowContainerClass, quietRowGlyphSlotClass, quietRowTriggerClass } from "@/components/ai-elements/tool";
 import { ToolCallPart } from "@x/shared/dist/message.js";
 import { ToolPermissionMetadata } from "@x/shared/dist/runs.js";
 import z from "zod";
@@ -16,13 +16,16 @@ export type AutoPermissionDecisionProps = ComponentProps<"div"> & {
 };
 
 const fileActionLabels: Record<string, string> = {
-  read: "Read file",
-  list: "List folder",
-  search: "Search files",
-  write: "Write files",
-  delete: "Delete path",
+  read: "read",
+  list: "list",
+  search: "search",
+  write: "write to",
+  delete: "delete",
 };
 
+// Quiet row for an automatic permission decision. In practice only denials
+// render here — allowed calls carry a shield glyph on the tool row itself
+// (ToolHeader autoApproved) instead of a separate transcript entry.
 export function AutoPermissionDecision({
   className,
   toolCall,
@@ -38,63 +41,64 @@ export function AutoPermissionDecision({
     : null;
   const filePermission = permission?.kind === "file" ? permission : null;
   const allowed = decision === "allow";
+  const [expanded, setExpanded] = useState(false);
+
+  const detail = command
+    ? command.split("\n")[0]
+    : filePermission
+      ? `${fileActionLabels[filePermission.operation] ?? filePermission.operation} ${filePermission.paths[0] ?? filePermission.pathPrefix}`
+      : toolCall.toolName;
 
   return (
-    <div
-      className={cn(
-        "not-prose mb-4 w-full rounded-md border",
-        allowed
-          ? "border-green-500/50 bg-green-50/80 dark:border-green-500/35 dark:bg-green-950/30"
-          : "border-[#fa2525]/60 bg-[#fa2525]/15 dark:border-[#fa2525]/50 dark:bg-[#fa2525]/20",
-        className,
-      )}
-      {...props}
-    >
-      <div className="space-y-3 p-4">
-        <div className="flex items-start gap-3">
-          {allowed ? (
-            <CheckCircle2Icon className="mt-0.5 size-5 shrink-0 text-green-600 dark:text-green-400" />
-          ) : (
-            <ShieldAlertIcon className="mt-0.5 size-5 shrink-0 text-destructive" />
+    <div className={cn(quietRowContainerClass, className)} {...props}>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className={quietRowTriggerClass}
+      >
+        <span className={quietRowGlyphSlotClass}>
+          {!allowed && <span className="size-1.5 rounded-full bg-red-600 dark:bg-red-500" />}
+        </span>
+        <span className={cn("shrink-0 font-medium", allowed ? "text-muted-foreground" : "text-foreground")}>
+          {allowed ? "Auto-allowed" : "Auto-denied"}
+        </span>
+        <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">{detail}</span>
+        <ChevronDownIcon
+          className={cn(
+            "ml-auto size-3 shrink-0 text-muted-foreground/50 opacity-0 transition-[opacity,transform] group-hover/row:opacity-100",
+            expanded && "rotate-180 opacity-100",
           )}
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-sm font-semibold text-foreground">
-                {allowed ? "Auto Allowed" : "Auto Denied"}
-              </h3>
-              <Badge variant="secondary" className="bg-secondary text-foreground">
-                <Terminal className="mr-1 size-3" />
-                {toolCall.toolName}
-              </Badge>
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground">{reason}</p>
+        />
+      </button>
+      {!allowed && !expanded && (
+        <p className="mb-0.5 ml-5 truncate text-xs text-muted-foreground" title={reason}>
+          {reason}
+        </p>
+      )}
+      {expanded && (
+        <div className="my-1 ml-[2.5px] flex flex-col gap-2 border-l-2 border-border pl-3">
+          <div className="min-w-0">
+            <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">Reason</p>
+            <p className="text-xs text-muted-foreground">{reason}</p>
           </div>
-        </div>
-        {command && (
-          <div className="rounded-md border bg-background/50 p-3">
-            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Command</p>
-            <pre className="whitespace-pre-wrap break-all font-mono text-xs text-foreground">{command}</pre>
-          </div>
-        )}
-        {filePermission && (
-          <div className="space-y-3 rounded-md border bg-background/50 p-3">
-            <div>
-              <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Action</p>
-              <p className="text-xs font-medium text-foreground">
-                {fileActionLabels[filePermission.operation] ?? filePermission.operation}
-              </p>
+          {command && (
+            <div className="min-w-0">
+              <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">Command</p>
+              <pre className="whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">{command}</pre>
             </div>
-            <div>
-              <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          )}
+          {filePermission && (
+            <div className="min-w-0">
+              <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">
                 Path{filePermission.paths.length === 1 ? "" : "s"}
               </p>
-              <pre className="whitespace-pre-wrap break-all font-mono text-xs text-foreground">
+              <pre className="whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
                 {filePermission.paths.join("\n")}
               </pre>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/x/apps/renderer/src/components/ai-elements/permission-request.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/permission-request.tsx
@@ -8,8 +8,9 @@ import {
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { AlertTriangleIcon, CheckIcon, ChevronDownIcon, XIcon } from "lucide-react";
-import { useState, type ComponentProps } from "react";
+import { CheckIcon, ChevronDownIcon, ShieldQuestionIcon, XIcon } from "lucide-react";
+import { useState, type ComponentProps, type ReactNode } from "react";
+import { quietRowContainerClass, quietRowGlyphSlotClass, quietRowTriggerClass } from "@/components/ai-elements/tool";
 import { ToolCallPart } from "@x/shared/dist/message.js";
 import { ToolPermissionMetadata } from "@x/shared/dist/runs.js";
 import z from "zod";
@@ -26,12 +27,29 @@ export type PermissionRequestProps = ComponentProps<"div"> & {
 };
 
 const fileActionLabels: Record<string, string> = {
-  read: "Read file",
-  list: "List folder",
-  search: "Search files",
-  write: "Write files",
-  delete: "Delete path",
+  read: "Read",
+  list: "List",
+  search: "Search",
+  write: "Write to",
+  delete: "Delete",
 };
+
+const truncateMiddle = (value: string, max = 64): string => {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1).trim()}…`;
+};
+
+const DetailSection = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className="min-w-0">
+    <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">
+      {label}
+    </p>
+    <pre className="whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
+      {children}
+    </pre>
+  </div>
+);
 
 export const PermissionRequest = ({
   className,
@@ -74,160 +92,138 @@ export const PermissionRequest = ({
     Boolean(onApproveSession || onApproveAlways) &&
     Boolean(command || filePermission);
 
-  // Once a response is chosen, collapse the details to just the header.
-  // Users can click the header to expand them again.
+  // Once a response is chosen the ask collapses to a quiet one-line row;
+  // clicking it re-expands the request details.
   const [expanded, setExpanded] = useState(false);
-  const showDetails = !isResponded || expanded;
+
+  // One-line ask: "Run `npm test`?" / "Write to `~/notes/plan.md`?"
+  const summary: ReactNode = command ? (
+    <>Run <code className="rounded bg-muted px-1 py-px font-mono text-xs">{truncateMiddle(command)}</code>?</>
+  ) : filePermission ? (
+    <>
+      {fileActionLabels[filePermission.operation] ?? filePermission.operation}{" "}
+      <code className="rounded bg-muted px-1 py-px font-mono text-xs">
+        {truncateMiddle(filePermission.paths[0] ?? filePermission.pathPrefix)}
+      </code>
+      {filePermission.paths.length > 1 && ` +${filePermission.paths.length - 1} more`}?
+    </>
+  ) : externalAction ? (
+    <>Use <code className="rounded bg-muted px-1 py-px font-mono text-xs">{truncateMiddle(externalAction.detail)}</code>?</>
+  ) : (
+    <>Run <code className="rounded bg-muted px-1 py-px font-mono text-xs">{toolCall.toolName}</code>?</>
+  );
+
+  const details = (
+    <div className="flex flex-col gap-2">
+      {command && <DetailSection label="Command">{command}</DetailSection>}
+      {filePermission && (
+        <>
+          <DetailSection label={`Path${filePermission.paths.length === 1 ? "" : "s"}`}>
+            {filePermission.paths.join("\n")}
+          </DetailSection>
+          <DetailSection label="Approval scope">{filePermission.pathPrefix}</DetailSection>
+        </>
+      )}
+      {externalAction && <DetailSection label={externalAction.label}>{externalAction.detail}</DetailSection>}
+      {!command && !filePermission && toolCall.arguments != null && (
+        <DetailSection label="Arguments">{JSON.stringify(toolCall.arguments, null, 2)}</DetailSection>
+      )}
+    </div>
+  );
+
+  if (isResponded) {
+    return (
+      <div className={cn(quietRowContainerClass, className)} {...props}>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className={quietRowTriggerClass}
+        >
+          <span className={quietRowGlyphSlotClass}>
+            {!isApproved && <span className="size-1.5 rounded-full bg-red-600 dark:bg-red-500" />}
+          </span>
+          <span className="shrink-0 font-medium text-muted-foreground">
+            {isApproved ? "Allowed" : "Denied"}
+          </span>
+          <span className="min-w-0 truncate text-muted-foreground">{summary}</span>
+          <ChevronDownIcon
+            className={cn(
+              "ml-auto size-3 shrink-0 text-muted-foreground/50 opacity-0 transition-[opacity,transform] group-hover/row:opacity-100",
+              expanded && "rotate-180 opacity-100",
+            )}
+          />
+        </button>
+        {expanded && <div className="my-1 ml-[2.5px] border-l-2 border-border pl-3">{details}</div>}
+      </div>
+    );
+  }
 
   return (
     <div
       className={cn(
-        "not-prose mb-4 w-full rounded-md border",
-        isResponded
-          ? isApproved
-            ? "border-green-500/60 bg-green-200/80 dark:border-green-500/40 dark:bg-green-900/40"
-            : "border-[#fa2525]/70 bg-[#fa2525]/30 dark:border-[#fa2525]/60 dark:bg-[#fa2525]/30"
-          : "border-amber-500/50 bg-amber-50/50 dark:bg-amber-950/20",
+        "not-prose my-1 w-full rounded-[10px] border border-l-2 border-l-amber-500/70 px-3 py-2 text-[13px]",
         className
       )}
       {...props}
     >
-      <div className="p-4 space-y-4">
-        <div className="flex items-start gap-3">
-          {!isResponded && (
-            <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-500 shrink-0 mt-0.5" />
-          )}
-          <div className="flex-1 space-y-2">
-            <div
-              className={cn("flex items-center gap-2", isResponded && "cursor-pointer select-none")}
-              onClick={isResponded ? () => setExpanded((v) => !v) : undefined}
-            >
-              <div className="flex-1">
-                <h3 className="font-semibold text-sm text-foreground">
-                  {isResponded ? (isApproved ? "Permission Granted" : "Permission Denied") : "Permission Required"}
-                </h3>
-                <p className="text-sm text-muted-foreground mt-1">
-                  {isResponded ? "Requested:" : "The agent wants to execute:"} <span className="font-mono font-medium">{toolCall.toolName}</span>
-                </p>
-              </div>
-              {isResponded && (
-                <ChevronDownIcon
-                  className={cn(
-                    "size-4 shrink-0 text-muted-foreground transition-transform",
-                    expanded ? "rotate-180" : "rotate-0"
-                  )}
-                />
-              )}
-            </div>
-            {showDetails && command && (
-              <div className="rounded-md border bg-background/50 p-3 mt-3">
-                <p className="text-xs font-medium text-muted-foreground mb-1.5 uppercase tracking-wide">
-                  Command
-                </p>
-                <pre className="whitespace-pre-wrap text-xs font-mono text-foreground break-all">
-                  {command}
-                </pre>
-              </div>
-            )}
-            {showDetails && filePermission && (
-              <div className="rounded-md border bg-background/50 p-3 mt-3 space-y-3">
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-1.5 uppercase tracking-wide">
-                    Action
-                  </p>
-                  <p className="text-xs font-medium text-foreground">
-                    {fileActionLabels[filePermission.operation] ?? filePermission.operation}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-1.5 uppercase tracking-wide">
-                    Path{filePermission.paths.length === 1 ? "" : "s"}
-                  </p>
-                  <pre className="whitespace-pre-wrap text-xs font-mono text-foreground break-all">
-                    {filePermission.paths.join("\n")}
-                  </pre>
-                </div>
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-1.5 uppercase tracking-wide">
-                    Approval Scope
-                  </p>
-                  <pre className="whitespace-pre-wrap text-xs font-mono text-foreground break-all">
-                    {filePermission.pathPrefix}
-                  </pre>
-                </div>
-              </div>
-            )}
-            {showDetails && externalAction && (
-              <div className="rounded-md border bg-background/50 p-3 mt-3">
-                <p className="text-xs font-medium text-muted-foreground mb-1.5 uppercase tracking-wide">
-                  {externalAction.label}
-                </p>
-                <p className="text-xs font-mono font-medium text-foreground break-all">
-                  {externalAction.detail}
-                </p>
-              </div>
-            )}
-            {showDetails && !command && !filePermission && toolCall.arguments && (
-              <div className="rounded-md border bg-background/50 p-3 mt-3">
-                <p className="text-xs font-medium text-muted-foreground mb-1.5 uppercase tracking-wide">
-                  Arguments
-                </p>
-                <pre className="whitespace-pre-wrap text-xs font-mono text-foreground break-all">
-                  {JSON.stringify(toolCall.arguments, null, 2)}
-                </pre>
-              </div>
-            )}
-          </div>
-        </div>
-        {!isResponded && (
-          <div className="flex items-center gap-2 pt-2">
-            <div className="flex flex-1 items-center">
-              <Button
-                variant="default"
-                size="sm"
-                onClick={onApprove}
-                disabled={isProcessing}
-                className={cn("flex-1", hasScopeActions && "rounded-r-none")}
-              >
-                <CheckIcon className="size-4" />
-                Approve
-              </Button>
-              {hasScopeActions && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="default"
-                      size="sm"
-                      disabled={isProcessing}
-                      className="rounded-l-none border-l border-l-primary-foreground/20 px-1.5"
-                    >
-                      <ChevronDownIcon className="size-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={onApproveSession}>
-                      Allow for Session
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={onApproveAlways}>
-                      Always Allow
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-2">
+        <ShieldQuestionIcon className="size-3.5 shrink-0 text-amber-600 dark:text-amber-500" />
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="min-w-0 flex-1 cursor-pointer truncate text-left"
+          title="Show request details"
+        >
+          {summary}
+        </button>
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <div className="flex items-center">
             <Button
-              variant="destructive"
+              variant="default"
               size="sm"
-              onClick={onDeny}
+              onClick={onApprove}
               disabled={isProcessing}
-              className="flex-1"
+              className={cn("h-7 rounded-full px-3 text-xs", hasScopeActions && "rounded-r-none")}
             >
-              <XIcon className="size-4" />
-              Deny
+              <CheckIcon className="size-3.5" />
+              Allow
             </Button>
+            {hasScopeActions && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    disabled={isProcessing}
+                    className="h-7 rounded-l-none rounded-r-full border-l border-l-primary-foreground/20 px-1.5"
+                  >
+                    <ChevronDownIcon className="size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={onApproveSession}>
+                    Allow for Session
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={onApproveAlways}>
+                    Always Allow
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
-        )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDeny}
+            disabled={isProcessing}
+            className="h-7 rounded-full px-3 text-xs text-red-600 hover:bg-red-500/10 hover:text-red-600 dark:text-red-500"
+          >
+            <XIcon className="size-3.5" />
+            Deny
+          </Button>
+        </div>
       </div>
+      {expanded && <div className="mt-2 border-t pt-2">{details}</div>}
     </div>
   );
 };

--- a/apps/x/apps/renderer/src/components/ai-elements/tool.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/tool.tsx
@@ -12,17 +12,10 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { ToolUIPart } from "ai";
-import {
-  ChevronDownIcon,
-  CircleCheck,
-  LoaderIcon,
-  ShieldCheckIcon,
-  XCircleIcon,
-} from "lucide-react";
-import { type ComponentProps, type ReactNode, isValidElement, useState } from "react";
-import { AnimatePresence, motion } from "motion/react";
-import type { ToolCall, ToolGroup as ToolGroupType } from "@/lib/chat-conversation";
-import { getToolActionsSummary, getToolDisplayName, getToolErrorText, getToolGroupSummary, toToolState } from "@/lib/chat-conversation";
+import { ChevronDownIcon, LoaderIcon, ShieldCheckIcon } from "lucide-react";
+import { type ComponentProps, type ReactNode, isValidElement, useEffect, useRef, useState } from "react";
+import type { ToolCall, ToolGroup as ToolGroupType, ToolRowSummary } from "@/lib/chat-conversation";
+import { getToolActionsSummary, getToolErrorText, getToolRowSummary, toToolState } from "@/lib/chat-conversation";
 
 const formatToolValue = (value: unknown) => {
   if (typeof value === "string") return value;
@@ -34,309 +27,297 @@ const formatToolValue = (value: unknown) => {
   }
 };
 
-const ToolCode = ({
-  code,
-  className,
-}: {
-  code: string;
-  className?: string;
-}) => (
-  <pre
-    className={cn(
-      "whitespace-pre-wrap text-xs font-mono break-all",
-      className
-    )}
-  >
-    {code || "(empty)"}
-  </pre>
+/* ── Quiet tool rows ─────────────────────────────────────────────────
+ * A tool call is one borderless 13px line: status glyph, medium-weight
+ * verb, muted detail, faint trailing stat. The whole row is the expand
+ * trigger; the chevron only appears on hover. Completed rows fade to
+ * muted so a finished read is unremarkable and a failure stands out.
+ *
+ * Every quiet surface in the transcript (generic tools, web search,
+ * permissions, app actions) shares these two classes so the row look is
+ * defined once. Custom surfaces compose them instead of re-deriving.
+ */
+
+// Outer wrapper: negative margins pull adjacent rows through the
+// conversation's gap-8 so consecutive tool lines pack tightly; nested
+// contexts (group children, compact panels) override with my-0.
+export const quietRowContainerClass = "not-prose -my-3 w-full";
+
+// The one-line row itself (also the collapse trigger where clickable).
+export const quietRowTriggerClass =
+  "group/row -mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-[3px] text-left text-[13px] leading-5 hover:bg-muted/50";
+
+export type ToolProps = ComponentProps<typeof Collapsible>;
+
+export const Tool = ({ className, children, ...props }: ToolProps) => (
+  <Collapsible className={cn(quietRowContainerClass, className)} {...props}>
+    {children}
+  </Collapsible>
 );
 
-export type ToolAutoPermissionDetail = {
-  decision: "allow";
-  reason: string;
-};
+// Fixed-width glyph slot so the verb column doesn't shift as a row moves
+// through running → settled. Shared by the custom quiet surfaces too.
+export const quietRowGlyphSlotClass = "flex size-3 shrink-0 items-center justify-center";
 
-export type ToolProps = ComponentProps<typeof Collapsible> & {
-  autoPermissionDetail?: ToolAutoPermissionDetail;
-};
-
-export const Tool = ({ className, children, autoPermissionDetail, ...props }: ToolProps) => {
-  const toolCard = (
-    <Collapsible
-      className={cn(
-        autoPermissionDetail
-          ? "w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30"
-          : "not-prose mb-4 w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </Collapsible>
-  );
-
-  if (!autoPermissionDetail) return toolCard;
-
-  return (
-    <div className="not-prose mb-4 w-full">
-      {toolCard}
-      <div className="mt-1 flex justify-end px-3">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex cursor-help items-center gap-1 text-[11px] text-muted-foreground/70">
-              <ShieldCheckIcon className="size-3 text-muted-foreground/70" />
-              Auto-approved
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" align="end" className="max-w-sm">
-            {autoPermissionDetail.reason}
-          </TooltipContent>
-        </Tooltip>
-      </div>
-    </div>
-  );
-};
+// Lead glyph: spinner while running, a red dot on failure — success is
+// the unremarkable default and leaves the slot empty.
+const ToolLeadGlyph = ({ state }: { state: ToolUIPart["state"] }) => (
+  <span className={quietRowGlyphSlotClass}>
+    {state === "output-error" ? (
+      <span className="size-1.5 rounded-full bg-red-600 dark:bg-red-500" />
+    ) : state !== "output-available" ? (
+      <LoaderIcon className="size-3 animate-spin text-muted-foreground" />
+    ) : null}
+  </span>
+);
 
 export type ToolHeaderProps = {
+  /** Plain title (legacy callers); prefer `summary` for structured rows. */
   title?: string;
+  summary?: ToolRowSummary;
   type: ToolUIPart["type"];
   state: ToolUIPart["state"];
   className?: string;
-  /** Hide the leading status icon (used for child rows inside a tool group). */
+  /** Hide the leading status glyph (nested rows that carry their own). */
   hideLeadIcon?: boolean;
-};
-
-// Lead icon shown to the left of the tool label: spinner while running, a
-// green check when done, a red cross on error. Shared by ToolHeader (single
-// tools) and the tool-call group.
-const getLeadIcon = (state: ToolUIPart["state"]): ReactNode => {
-  if (state === "output-available") return <CircleCheck className="size-4 shrink-0 text-green-600" />;
-  if (state === "output-error") return <XCircleIcon className="size-4 shrink-0 text-red-600" />;
-  return <LoaderIcon className="size-4 shrink-0 animate-spin text-muted-foreground" />;
+  /** Shield glyph + reason tooltip for auto-approved permission calls. */
+  autoApproved?: { reason: string };
+  /** First line of the error, rendered inline under the row (no click needed). */
+  errorLine?: string;
 };
 
 export const ToolHeader = ({
   className,
   title,
+  summary,
   type,
   state,
   hideLeadIcon,
+  autoApproved,
+  errorLine,
   ...props
 }: ToolHeaderProps) => {
-  const displayTitle = title ?? type.split("-").slice(1).join("-")
+  const row: ToolRowSummary = summary ?? { verb: title ?? type.split("-").slice(1).join("-") };
+  const done = state === "output-available";
+  const failed = state === "output-error";
+  const hoverTitle = [row.verb, row.dimPrefix, row.detail, row.stat].filter(Boolean).join(" ");
 
   return (
-    <CollapsibleTrigger
-      className={cn(
-        "group flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-2.5",
-        className
-      )}
-      {...props}
-    >
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        {!hideLeadIcon && getLeadIcon(state)}
+    <>
+      <CollapsibleTrigger
+        className={cn(quietRowTriggerClass, className)}
+        title={hoverTitle}
+        {...props}
+      >
+        {!hideLeadIcon && <ToolLeadGlyph state={state} />}
         <span
-          className="min-w-0 flex-1 truncate text-left font-medium text-sm"
-          title={displayTitle}
+          className={cn(
+            "shrink-0 font-medium",
+            done ? "text-muted-foreground" : "text-foreground",
+            failed && "text-foreground",
+            row.verbMono && "font-mono text-xs"
+          )}
         >
-          {displayTitle}
+          {row.verb}
         </span>
-      </div>
-      <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
-    </CollapsibleTrigger>
-  )
+        {(row.detail || row.dimPrefix) && (
+          <span
+            className={cn(
+              "min-w-0 truncate text-muted-foreground",
+              row.detailMono && "font-mono text-xs"
+            )}
+          >
+            {row.dimPrefix && <span className="text-muted-foreground/50">{row.dimPrefix}</span>}
+            {row.detail}
+          </span>
+        )}
+        {row.diff && (row.diff.added > 0 || row.diff.removed > 0) && (
+          <span className="shrink-0 font-mono text-xs tabular-nums">
+            <span className="text-green-600 dark:text-green-500">+{row.diff.added}</span>{" "}
+            <span className="text-red-600 dark:text-red-500">-{row.diff.removed}</span>
+          </span>
+        )}
+        {row.stat && (
+          <span className={cn("shrink-0 tabular-nums", failed ? "text-red-600 dark:text-red-500" : "text-muted-foreground/60")}>
+            {row.stat}
+          </span>
+        )}
+        <span className="ml-auto flex shrink-0 items-center gap-1.5">
+          {autoApproved && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ShieldCheckIcon className="size-3 text-muted-foreground/50" />
+              </TooltipTrigger>
+              <TooltipContent side="bottom" align="end" className="max-w-sm">
+                Auto-approved: {autoApproved.reason}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <ChevronDownIcon className="size-3 text-muted-foreground/50 opacity-0 transition-[opacity,transform] group-hover/row:opacity-100 group-data-[state=open]/row:rotate-180 group-data-[state=open]/row:opacity-100" />
+        </span>
+      </CollapsibleTrigger>
+      {failed && errorLine && (
+        <p className="mb-0.5 ml-5 truncate font-mono text-xs text-red-600 dark:text-red-500" title={errorLine}>
+          {errorLine}
+        </p>
+      )}
+    </>
+  );
 };
 
 export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
 
-export const ToolContent = ({ className, ...props }: ToolContentProps) => (
+// Expanded detail hangs off a hairline left rule, aligned under the glyph.
+export const ToolContent = ({ className, children, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
       "overflow-hidden text-popover-foreground outline-none data-[state=open]:animate-[collapsible-down_0.09s_ease-out] data-[state=closed]:animate-[collapsible-up_0.08s_ease-in]",
       className
     )}
     {...props}
-  />
+  >
+    <div className="my-1 ml-[2.5px] border-l-2 border-border pl-3">{children}</div>
+  </CollapsibleContent>
 );
 
-/* ── Tabbed content (Parameters / Result) ────────────────────────── */
+/* ── Expanded parameters / result ────────────────────────────────── */
 
-export type ToolTabbedContentProps = {
+export type ToolIODetailsProps = {
   input: ToolUIPart["input"];
   output: ToolUIPart["output"];
   errorText?: ToolUIPart["errorText"];
 };
 
-export const ToolTabbedContent = ({
-  input,
-  output,
-  errorText,
-}: ToolTabbedContentProps) => {
-  const [activeTab, setActiveTab] = useState<"parameters" | "result">("parameters");
+const ToolIOSection = ({ label, children, error }: { label: string; children: ReactNode; error?: boolean }) => (
+  <div className="min-w-0">
+    <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60">
+      {label}
+    </p>
+    <div
+      className={cn(
+        "max-h-64 overflow-auto whitespace-pre-wrap break-all font-mono text-xs",
+        error ? "text-destructive" : "text-muted-foreground"
+      )}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+export const ToolIODetails = ({ input, output, errorText }: ToolIODetailsProps) => {
   const hasOutput = output != null || !!errorText;
 
-  let OutputNode: ReactNode = null;
+  let outputNode: ReactNode = null;
   if (errorText) {
-    OutputNode = <ToolCode code={errorText} className="text-destructive" />;
+    outputNode = errorText;
   } else if (output != null) {
     if (typeof output === "object" && !isValidElement(output)) {
-      OutputNode = <ToolCode code={formatToolValue(output)} />;
+      outputNode = formatToolValue(output);
     } else if (typeof output === "string") {
-      OutputNode = <ToolCode code={output} />;
+      outputNode = output;
     } else {
-      OutputNode = <div>{output as ReactNode}</div>;
+      outputNode = <div>{output as ReactNode}</div>;
     }
   }
 
   return (
-    <div className="border-t">
-      {/* Tabs */}
-      <div className="flex">
-        <button
-          type="button"
-          className={cn(
-            "px-4 py-2 text-xs font-medium transition-colors border-b-2",
-            activeTab === "parameters"
-              ? "border-foreground text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          )}
-          onClick={() => setActiveTab("parameters")}
-        >
-          Parameters
-        </button>
-        <button
-          type="button"
-          className={cn(
-            "px-4 py-2 text-xs font-medium transition-colors border-b-2",
-            activeTab === "result"
-              ? "border-foreground text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          )}
-          onClick={() => setActiveTab("result")}
-        >
-          Result
-        </button>
-      </div>
-
-      {/* Tab content */}
-      <div className="p-3">
-        {activeTab === "parameters" && (
-          <div className="rounded-md border bg-muted/50 p-3 max-h-64 overflow-auto">
-            <ToolCode code={formatToolValue(input ?? {})} />
-          </div>
-        )}
-        {activeTab === "result" && (
-          <div
-            className={cn(
-              "rounded-md border p-3 max-h-64 overflow-auto",
-              errorText ? "bg-destructive/10" : "bg-muted/50"
-            )}
-          >
-            {hasOutput ? (
-              <div className={cn(errorText && "text-destructive")}>
-                {OutputNode}
-              </div>
-            ) : (
-              <span className="text-xs text-muted-foreground">(pending...)</span>
-            )}
-          </div>
-        )}
-      </div>
+    <div className="flex flex-col gap-2 py-0.5">
+      <ToolIOSection label="Parameters">{formatToolValue(input ?? {}) || "(empty)"}</ToolIOSection>
+      {hasOutput ? (
+        <ToolIOSection label={errorText ? "Error" : "Result"} error={!!errorText}>
+          {outputNode}
+        </ToolIOSection>
+      ) : (
+        <ToolIOSection label="Result">(pending...)</ToolIOSection>
+      )}
     </div>
   );
 };
 
+/* ── Tool group ──────────────────────────────────────────────────────
+ * Consecutive plain tool calls share one collapsible header row. While
+ * the turn streams the children stay visible so per-tool labels are
+ * readable in real time; the group auto-collapses once every call has
+ * settled (and loads collapsed from history).
+ */
+
 export type ToolGroupProps = {
-  group: ToolGroupType
-  isToolOpen: (toolId: string) => boolean
-  onToolOpenChange: (toolId: string, open: boolean) => void
-}
+  group: ToolGroupType;
+  isToolOpen: (toolId: string) => boolean;
+  onToolOpenChange: (toolId: string, open: boolean) => void;
+  /** Auto-approved permission info for a child row's shield glyph. */
+  getAutoApproved?: (toolId: string) => { reason: string } | undefined;
+};
 
 const getGroupState = (tools: ToolCall[]): ToolUIPart["state"] => {
-  if (tools.some(t => t.status === 'error')) return 'output-error'
-  if (tools.some(t => t.status === 'running')) return 'input-available'
-  if (tools.some(t => t.status === 'pending')) return 'input-streaming'
-  return 'output-available'
-}
+  if (tools.some((t) => t.status === "error")) return "output-error";
+  if (tools.some((t) => t.status === "running")) return "input-available";
+  if (tools.some((t) => t.status === "pending")) return "input-streaming";
+  return "output-available";
+};
 
-export const ToolGroupComponent = ({ group, isToolOpen, onToolOpenChange }: ToolGroupProps) => {
-  const [open, setOpen] = useState(false)
-  const state = getGroupState(group.items)
-  const isCompleted = state === 'output-available' || state === 'output-error'
-  const runningTool = group.items.find(t => t.status === 'running' || t.status === 'pending')
-  const currentTool = runningTool ?? group.items[group.items.length - 1]
-  const toolCount = group.items.length
-  const ranLabel = `Ran ${toolCount} tool${toolCount !== 1 ? 's' : ''}`
-  const actions = isCompleted ? getToolActionsSummary(group.items) : ''
-  // Plain string used as the AnimatePresence key + tooltip; the rendered node
-  // shows the action summary in a lighter gray than the "Ran N tools" prefix.
+export const ToolGroupComponent = ({ group, isToolOpen, onToolOpenChange, getAutoApproved }: ToolGroupProps) => {
+  const state = getGroupState(group.items);
+  const isCompleted = state === "output-available" || state === "output-error";
+  // Live groups start expanded; history-loaded (already settled) start closed.
+  const [open, setOpen] = useState(!isCompleted);
+  const wasCompleted = useRef(isCompleted);
+  useEffect(() => {
+    if (!wasCompleted.current && isCompleted) setOpen(false);
+    wasCompleted.current = isCompleted;
+  }, [isCompleted]);
+
+  const toolCount = group.items.length;
   const summaryText = isCompleted
-    ? `${ranLabel} · ${actions}`
-    : currentTool ? getToolDisplayName(currentTool) : getToolGroupSummary(group.items)
-  const summaryNode: ReactNode = isCompleted
-    ? <>{ranLabel} <span className="font-normal text-muted-foreground">{`· ${actions}`}</span></>
-    : summaryText
-
-  const leadIcon = getLeadIcon(state)
+    ? `Ran ${toolCount} tool${toolCount !== 1 ? "s" : ""}`
+    : `Running ${toolCount} tool${toolCount !== 1 ? "s" : ""}…`;
+  const actions = isCompleted ? getToolActionsSummary(group.items) : "";
 
   return (
-    <Collapsible
-      open={open}
-      onOpenChange={setOpen}
-      className="not-prose mb-4 w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30"
-    >
-      <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-2.5">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          {leadIcon}
-          <div className="relative min-w-0 flex-1 overflow-hidden" style={{ height: '1.25rem' }}>
-            <AnimatePresence mode="popLayout" initial={false}>
-              <motion.span
-                key={summaryText}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -10 }}
-                transition={{ duration: 0.18, ease: 'easeOut' }}
-                className="absolute inset-0 truncate text-left font-medium text-sm leading-5"
-                title={summaryText}
-              >
-                {summaryNode}
-              </motion.span>
-            </AnimatePresence>
-          </div>
-        </div>
-        <ChevronDownIcon className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
+    <Collapsible open={open} onOpenChange={setOpen} className={quietRowContainerClass}>
+      <CollapsibleTrigger
+        className={quietRowTriggerClass}
+        title={actions ? `${summaryText} · ${actions}` : summaryText}
+      >
+        {isCompleted ? (
+          <ChevronDownIcon
+            className={cn("size-3 shrink-0 text-muted-foreground/50 transition-transform", open && "rotate-180")}
+          />
+        ) : (
+          <LoaderIcon className="size-3 shrink-0 animate-spin text-muted-foreground" />
+        )}
+        <span className={cn("shrink-0 font-medium", isCompleted ? "text-muted-foreground" : "text-foreground")}>
+          {summaryText}
+        </span>
+        {actions && <span className="min-w-0 truncate text-muted-foreground/60">· {actions}</span>}
       </CollapsibleTrigger>
       <CollapsibleContent className="overflow-hidden data-[state=open]:animate-[collapsible-down_0.09s_ease-out] data-[state=closed]:animate-[collapsible-up_0.08s_ease-in]">
-        <div className="flex flex-col gap-2 p-2">
+        <div className="ml-[5px] flex flex-col border-l border-border/70 pl-2.5">
           {group.items.map((tool) => {
-            const toolState = toToolState(tool.status)
-            const isOpen = isToolOpen(tool.id)
+            const toolState = toToolState(tool.status);
+            const isOpen = isToolOpen(tool.id);
+            const errorText = getToolErrorText(tool);
             return (
-              <Tool
-                key={tool.id}
-                open={isOpen}
-                onOpenChange={(o) => onToolOpenChange(tool.id, o)}
-                className="mb-0 rounded-[20px] border-border/60 bg-transparent hover:border-border/60"
-              >
+              <Tool key={tool.id} open={isOpen} onOpenChange={(o) => onToolOpenChange(tool.id, o)} className="my-0">
                 <ToolHeader
-                  title={getToolDisplayName(tool)}
+                  summary={getToolRowSummary(tool)}
                   type={`tool-${tool.name}`}
                   state={toolState}
-                  className="text-muted-foreground"
-                  hideLeadIcon
+                  autoApproved={getAutoApproved?.(tool.id)}
+                  errorLine={errorText?.split("\n")[0]}
                 />
                 <ToolContent>
-                  <ToolTabbedContent
+                  <ToolIODetails
                     input={tool.input as ToolUIPart["input"]}
                     output={tool.result as ToolUIPart["output"]}
-                    errorText={getToolErrorText(tool)}
+                    errorText={errorText}
                   />
                 </ToolContent>
               </Tool>
-            )
+            );
           })}
         </div>
       </CollapsibleContent>
     </Collapsible>
-  )
-}
+  );
+};

--- a/apps/x/apps/renderer/src/components/ai-elements/web-search-result.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/web-search-result.tsx
@@ -5,7 +5,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { cn } from "@/lib/utils";
 import {
   ChevronDownIcon,
   GlobeIcon,
@@ -13,6 +12,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
+import { quietRowContainerClass, quietRowTriggerClass } from "@/components/ai-elements/tool";
 
 interface WebSearchResultProps {
   query: string;
@@ -144,7 +144,7 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
     headerKey = "searching";
     headerContent = (
       <span className="flex min-w-0 flex-1 items-center gap-2 text-muted-foreground">
-        <LoaderIcon className="size-4 shrink-0 animate-spin" />
+        <LoaderIcon className="size-3 shrink-0 animate-spin" />
         <span className="truncate">Searching the web&hellip;</span>
       </span>
     );
@@ -154,7 +154,7 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
     headerKey = `roll-${rollIndex}`;
     headerContent = (
       <span className="flex min-w-0 flex-1 items-center gap-2">
-        <img src={faviconUrl(domain)} alt="" className="size-4 shrink-0 rounded-sm bg-muted/60" />
+        <img src={faviconUrl(domain)} alt="" className="size-3.5 shrink-0 rounded-sm bg-muted/60" />
         <span className="truncate">
           <span className="text-muted-foreground">{domain}</span>
           <span className="text-muted-foreground/50"> &middot; </span>
@@ -177,20 +177,20 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
                 key={domain}
                 src={faviconUrl(domain)}
                 alt=""
-                className="size-5 rounded-full bg-muted object-cover -ml-[5px] first:ml-0"
+                className="size-4 rounded-full bg-muted object-cover -ml-[4px] first:ml-0"
                 style={{ zIndex: stack.length - i }}
               />
             ))}
             {overflow > 0 && (
-              <span className="ml-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-foreground/10 dark:bg-muted text-[10px] font-medium text-muted-foreground">
+              <span className="ml-0.5 flex size-4 shrink-0 items-center justify-center rounded-full bg-foreground/10 dark:bg-muted text-[9px] font-medium text-muted-foreground">
                 +{overflow}
               </span>
             )}
           </span>
         ) : (
-          <GlobeIcon className="size-4 shrink-0 text-muted-foreground" />
+          <GlobeIcon className="size-3.5 shrink-0 text-muted-foreground" />
         )}
-        <span className="truncate text-sm">
+        <span className="truncate">
           {domains.length > 0 ? buildSearchedSummary(domains) : title}
         </span>
       </span>
@@ -198,14 +198,10 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
   }
 
   return (
-    <Collapsible
-      open={open}
-      onOpenChange={setOpen}
-      className="not-prose mb-4 w-full rounded-[28px] border bg-[var(--card-surface)] transition-colors duration-150 ease-out hover:border-foreground/30"
-    >
-      <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-2.5">
+    <Collapsible open={open} onOpenChange={setOpen} className={quietRowContainerClass}>
+      <CollapsibleTrigger className={quietRowTriggerClass}>
         {/* Rolling header: clipped, fixed height so sliding lines stay contained */}
-        <div className="relative min-w-0 flex-1 overflow-hidden" style={{ height: "1.5rem" }}>
+        <div className="relative min-w-0 flex-1 overflow-hidden" style={{ height: "1.25rem" }}>
           <AnimatePresence mode="popLayout" initial={false}>
             <motion.span
               key={headerKey}
@@ -213,32 +209,32 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.18, ease: "easeOut" }}
-              className="absolute inset-0 flex items-center text-left font-medium text-sm"
+              className="absolute inset-0 flex items-center text-left"
             >
               {headerContent}
             </motion.span>
           </AnimatePresence>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center gap-1.5">
           {phase === "settled" && domains.length > 0 && (
-            <span className="whitespace-nowrap text-xs text-muted-foreground">
+            <span className="whitespace-nowrap text-muted-foreground/60 tabular-nums">
               {domains.length} source{domains.length !== 1 ? "s" : ""}
             </span>
           )}
-          <ChevronDownIcon className={cn("size-4 text-muted-foreground transition-transform", open && "rotate-180")} />
+          <ChevronDownIcon className="size-3 text-muted-foreground/50 opacity-0 transition-[opacity,transform] group-hover/row:opacity-100 group-data-[state=open]/row:rotate-180 group-data-[state=open]/row:opacity-100" />
         </div>
       </CollapsibleTrigger>
       <CollapsibleContent className="overflow-hidden data-[state=open]:animate-[collapsible-down_0.09s_ease-out] data-[state=closed]:animate-[collapsible-up_0.08s_ease-in]">
-        <div className="px-4 pb-3 space-y-3">
+        <div className="my-1 ml-[2.5px] space-y-2 border-l-2 border-border pl-3">
           {/* Query */}
-          <div className="flex items-center gap-2 text-sm text-muted-foreground min-w-0">
-            <GlobeIcon className="size-3.5 shrink-0" />
+          <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+            <GlobeIcon className="size-3 shrink-0" />
             <span className="truncate">{query}</span>
           </div>
 
           {/* Results list */}
           {results.length > 0 && (
-            <div className="rounded-md border max-h-64 overflow-y-auto">
+            <div className="max-h-64 overflow-y-auto">
               {results.map((result, index) => {
                 const domain = getDomain(result.url);
                 return (
@@ -251,17 +247,17 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
                       e.preventDefault();
                       window.open(result.url, "_blank");
                     }}
-                    className="flex items-center justify-between gap-3 px-3 py-2 text-sm hover:bg-muted/50 transition-colors border-b last:border-b-0"
+                    className="-mx-1.5 flex items-center justify-between gap-3 rounded-md px-1.5 py-1 text-[13px] transition-colors hover:bg-muted/50"
                   >
-                    <div className="flex items-center gap-2 min-w-0">
+                    <div className="flex min-w-0 items-center gap-2">
                       <img
                         src={faviconUrl(domain)}
                         alt=""
-                        className="size-4 shrink-0"
+                        className="size-3.5 shrink-0"
                       />
                       <span className="truncate">{result.title}</span>
                     </div>
-                    <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
+                    <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
                       {domain}
                     </span>
                   </a>
@@ -273,7 +269,7 @@ export function WebSearchResult({ query, results, status, title = "Searched the 
           {/* Status — only while the search is still running. */}
           {isRunning && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <LoaderIcon className="size-3.5 animate-spin" />
+              <LoaderIcon className="size-3 animate-spin" />
               <span>Searching...</span>
             </div>
           )}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -15,7 +15,7 @@ import {
   type PromptInputMessage,
   type FileMention,
 } from '@/components/ai-elements/prompt-input'
-import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolTabbedContent } from '@/components/ai-elements/tool'
+import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolIODetails } from '@/components/ai-elements/tool'
 import { PermissionRequest } from '@/components/ai-elements/permission-request'
 import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
 import { AskHumanRequest } from '@/components/ai-elements/ask-human-request'
@@ -46,8 +46,8 @@ import {
   type ConversationItem,
   getAppActionCardData,
   getComposioConnectCardData,
-  getToolDisplayName,
   getToolErrorText,
+  getToolRowSummary,
   getWebSearchCardData,
   groupConversationItems,
   isChatMessage,
@@ -306,7 +306,6 @@ export function ChatSessionPane({
           />
         )
       }
-      const toolTitle = getToolDisplayName(item)
       const errorText = detailedToolErrors
         ? getToolErrorText(item)
         : (item.status === 'error' ? 'Tool error' : '')
@@ -317,16 +316,21 @@ export function ChatSessionPane({
           key={item.id}
           open={isToolOpenForTab(tab.id, item.id)}
           onOpenChange={(open) => setToolOpenForTab(tab.id, item.id, open)}
-          autoPermissionDetail={options?.autoPermissionDetail}
         >
-          <ToolHeader title={toolTitle} type={`tool-${item.name}`} state={toToolState(item.status)} />
+          <ToolHeader
+            summary={getToolRowSummary(item)}
+            type={`tool-${item.name}`}
+            state={toToolState(item.status)}
+            autoApproved={options?.autoPermissionDetail}
+            errorLine={getToolErrorText(item)?.split('\n')[0]}
+          />
           <ToolContent>
             {item.streamingOutput ? (
-              <AutoScrollPre className="max-h-80 overflow-auto px-4 py-3 font-mono text-xs whitespace-pre-wrap text-foreground/90">
+              <AutoScrollPre className="max-h-80 overflow-auto py-1 font-mono text-xs whitespace-pre-wrap text-foreground/90">
                 <TerminalOutput raw={item.streamingOutput} />
               </AutoScrollPre>
             ) : (
-              <ToolTabbedContent input={input} output={output} errorText={errorText} />
+              <ToolIODetails input={input} output={output} errorText={errorText} />
             )}
           </ToolContent>
         </Tool>
@@ -334,19 +338,38 @@ export function ChatSessionPane({
     }
 
     if (isTurnUsageMessage(item)) {
+      // Right-aligned, hover-revealed footer for the turn (see the
+      // [data-turn-usage] rules in App.css: shown when the row itself or the
+      // element just above it is hovered, or while the menu is open). The
+      // menu sits last so per-turn actions (copy) slot in before it.
+      // The copy target is the turn's final assistant message — the last one
+      // before this usage marker — copied verbatim, no transformation.
+      const usageIndex = tabState.conversation.findIndex((entry) => entry.id === item.id)
+      const finalOutput = tabState.conversation
+        .slice(0, usageIndex === -1 ? undefined : usageIndex)
+        .reduceRight<string | null>(
+          (found, entry) => found ?? (isChatMessage(entry) && entry.role === 'assistant' ? entry.content : null),
+          null,
+        )
       return (
-        <div key={item.id} className="-mt-6 -ml-1 flex items-center justify-start gap-1" data-message-id={item.id}>
-          <TokenUsageMenu
-            usage={item.usage}
-            scope="turn"
-            modelCallCount={item.modelCallCount}
-            align="start"
-          />
+        <div
+          key={item.id}
+          className="-mt-6 -mr-1 flex items-center justify-end gap-1"
+          data-turn-usage
+          data-message-id={item.id}
+        >
           {item.reasoningEffort && (
             <span className="text-xs text-muted-foreground/70">
               {REASONING_EFFORT_LABELS[item.reasoningEffort]}
             </span>
           )}
+          {finalOutput && <MessageCopyButton text={finalOutput} className="opacity-100" />}
+          <TokenUsageMenu
+            usage={item.usage}
+            scope="turn"
+            modelCallCount={item.modelCallCount}
+            align="end"
+          />
         </div>
       )
     }
@@ -401,7 +424,10 @@ export function ChatSessionPane({
             <>
               {groupConversationItems(
                 tabState.conversation,
-                (id) => !!tabState.allPermissionRequests.get(id) || !!tabState.autoPermissionDecisions.get(id)
+                // Only an interactive permission card (ask or denial) breaks a
+                // tool out of a group — auto-approved calls group fine, since
+                // their approval renders as a shield glyph on the row itself.
+                (id) => !!tabState.allPermissionRequests.get(id) || tabState.autoPermissionDecisions.get(id)?.decision === 'deny'
               ).map(item => {
                 if (isToolGroup(item)) {
                   return (
@@ -410,6 +436,10 @@ export function ChatSessionPane({
                       group={item}
                       isToolOpen={(toolId) => isToolOpenForTab(tab.id, toolId)}
                       onToolOpenChange={(toolId, open) => setToolOpenForTab(tab.id, toolId, open)}
+                      getAutoApproved={(toolId) => {
+                        const decision = tabState.autoPermissionDecisions.get(toolId)
+                        return decision?.decision === 'allow' ? { reason: decision.reason } : undefined
+                      }}
                     />
                   )
                 }

--- a/apps/x/apps/renderer/src/components/coding-run.tsx
+++ b/apps/x/apps/renderer/src/components/coding-run.tsx
@@ -125,7 +125,7 @@ export function CodingRunTimeline({
   if (rows.length === 0) {
     if (error) {
       return (
-        <div className="px-4 py-3">
+        <div className="py-1">
           <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
             <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
             <span className="min-w-0 whitespace-pre-wrap break-words">{error}</span>
@@ -133,10 +133,10 @@ export function CodingRunTimeline({
         </div>
       )
     }
-    return <div className="px-4 py-3 text-xs text-muted-foreground">Starting the agent…</div>
+    return <div className="py-1 text-xs text-muted-foreground">Starting the agent…</div>
   }
   return (
-    <div className="flex flex-col gap-2 px-4 py-3">
+    <div className="flex flex-col gap-2 py-1">
       {rows.map((row) => {
         if (row.kind === 'text') {
           return (
@@ -233,17 +233,14 @@ export function CodeRunPermissionRequest({
     setBusy(true)
     onDecide(d)
   }
-  const btn = 'rounded-full px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50'
+  const btn = 'rounded-full px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50'
   return (
-    <div className="mb-4 rounded-[20px] border border-amber-500/40 bg-amber-500/5 p-4">
-      <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-        <ShieldQuestion className="size-4 shrink-0 text-amber-600" />
-        Permission needed
-      </div>
-      <p className="mt-1 text-sm text-muted-foreground">
-        The agent wants to: <span className="font-medium text-foreground">{ask.title}</span>
-      </p>
-      <div className="mt-3 flex flex-wrap gap-2">
+    <div className="my-1 flex flex-wrap items-center gap-x-2.5 gap-y-2 rounded-[10px] border border-l-2 border-l-amber-500/70 px-3 py-2 text-[13px]">
+      <ShieldQuestion className="size-3.5 shrink-0 text-amber-600 dark:text-amber-500" />
+      <span className="min-w-0 flex-1 truncate" title={ask.title}>
+        Allow <span className="font-medium">{ask.title}</span>?
+      </span>
+      <div className="ml-auto flex shrink-0 flex-wrap gap-1.5">
         <button type="button" disabled={busy} onClick={() => decide('allow_once')}
           className={cn(btn, 'bg-foreground text-background hover:bg-foreground/90')}>
           Allow
@@ -283,6 +280,8 @@ export function CodingRunBlock({
     (item.result as { agent?: string } | undefined)?.agent ??
     (item.input as { agent?: string } | undefined)?.agent
   const title = AGENT_LABEL[agent ?? ''] ?? 'Coding agent'
+  const task = (item.input as { task?: string; prompt?: string } | undefined)
+  const taskText = (task?.task ?? task?.prompt ?? '').trim()
   const error = getToolErrorText(item)
   // Timeline source: the durable record (item.codeRunEvents — the settle-time
   // batch, or the legacy path's inline accumulation) wins; while it's absent
@@ -297,7 +296,11 @@ export function CodingRunBlock({
   return (
     <>
       <Tool open={open} onOpenChange={onOpenChange}>
-        <ToolHeader title={title} type="tool-code_agent_run" state={toToolState(item.status)} />
+        <ToolHeader
+          summary={{ verb: title, detail: taskText || undefined }}
+          type="tool-code_agent_run"
+          state={toToolState(item.status)}
+        />
         <ToolContent>
           <CodingRunTimeline events={events} error={error} />
         </ToolContent>

--- a/apps/x/apps/renderer/src/components/compact-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/compact-conversation.tsx
@@ -7,13 +7,13 @@ import {
     isErrorMessage,
     isToolCall,
     isTurnUsageMessage,
-    getToolDisplayName,
     getToolErrorText,
+    getToolRowSummary,
     REASONING_EFFORT_LABELS,
     toToolState,
     normalizeToolOutput,
 } from '@/lib/chat-conversation'
-import { Tool, ToolHeader, ToolContent, ToolTabbedContent } from '@/components/ai-elements/tool'
+import { Tool, ToolHeader, ToolContent, ToolIODetails } from '@/components/ai-elements/tool'
 import { TokenUsageMenu } from '@/components/token-usage-menu'
 
 /**
@@ -82,14 +82,18 @@ export function CompactConversation({ items }: { items: ConversationItem[] }) {
 
 function CompactToolRow({ tool }: { tool: ToolCall }) {
     const [open, setOpen] = useState(false)
-    const title = getToolDisplayName(tool)
     const state = toToolState(tool.status)
     const errorText = getToolErrorText(tool)
     return (
-        <Tool open={open} onOpenChange={setOpen} className="mb-0 text-xs">
-            <ToolHeader title={title} type={`tool-${tool.name}` as `tool-${string}`} state={state} />
+        <Tool open={open} onOpenChange={setOpen} className="my-0 text-xs">
+            <ToolHeader
+                summary={getToolRowSummary(tool)}
+                type={`tool-${tool.name}` as `tool-${string}`}
+                state={state}
+                errorLine={errorText?.split('\n')[0]}
+            />
             <ToolContent>
-                <ToolTabbedContent
+                <ToolIODetails
                     input={tool.input}
                     output={normalizeToolOutput(tool.result, tool.status) ?? undefined}
                     errorText={errorText}

--- a/apps/x/apps/renderer/src/components/sub-agent-block.tsx
+++ b/apps/x/apps/renderer/src/components/sub-agent-block.tsx
@@ -42,18 +42,18 @@ export function SubAgentBlock({
   const rawName = item.subAgent?.agentName || input?.agent_id || input?.name || ''
   const name = rawName === 'subagent' ? '' : humanizeName(rawName)
   const task = (item.subAgent?.task || input?.task || '').trim()
-  // The collapsed row must say what is happening, not just that an agent
-  // exists: lead with the name when the model gave one, then the task (the
-  // header truncates with a hover tooltip carrying the full text).
-  const title = task ? `${name || 'Agent'}: ${task}` : name || 'Agent'
   const running = item.status === 'pending' || item.status === 'running'
   const transcript = useChildTranscript(item.subAgent?.childTurnId, open)
 
   return (
     <Tool open={open} onOpenChange={onOpenChange}>
-      <ToolHeader title={title} type="tool-spawn-agent" state={toToolState(item.status)} />
+      <ToolHeader
+        summary={{ verb: name || 'Agent', detail: task || undefined }}
+        type="tool-spawn-agent"
+        state={toToolState(item.status)}
+      />
       <ToolContent>
-        <div className="flex flex-col gap-3 px-4 pb-4">
+        <div className="flex flex-col gap-3 py-1">
           {transcript ? (
             // The transcript opens with the child's user message — the task —
             // so no separate task chip is rendered here.

--- a/apps/x/apps/renderer/src/lib/chat-conversation.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.ts
@@ -625,6 +625,238 @@ export const getToolDisplayName = (tool: ToolCall): string => {
   return TOOL_DISPLAY_NAMES[tool.name] || tool.name
 }
 
+/* ── Quiet tool-row summaries ─────────────────────────────────────────
+ * Structured collapsed label for the one-line tool row: a medium-weight
+ * verb, a muted detail (path/pattern/query, optionally with a dimmed
+ * parent-path prefix), and a faint trailing stat ("9 matches", "exit 0").
+ * Derived from tool.input and tool.result — unlike TOOL_DISPLAY_NAMES,
+ * which is name-keyed only and kept for group summaries / status lines.
+ */
+export type ToolRowSummary = {
+  verb: string
+  /** Render the verb in the mono face (shell commands). */
+  verbMono?: boolean
+  /** Dimmed prefix rendered just before `detail` (parent directory). */
+  dimPrefix?: string
+  detail?: string
+  detailMono?: boolean
+  stat?: string
+  /** Line-diff stat for edits, rendered as colored +N -M. */
+  diff?: { added: number; removed: number }
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() ? value : undefined
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined
+
+/** "a/b/c/d.ts" → { dimPrefix: "b/c/", base: "d.ts" } (last 2 parent segments). */
+const splitDisplayPath = (p: string): { dimPrefix?: string; base: string } => {
+  const segments = p.replace(/\/+$/, '').split('/').filter(Boolean)
+  if (segments.length <= 1) return { base: p }
+  const base = segments[segments.length - 1]
+  const parents = segments.slice(Math.max(0, segments.length - 3), segments.length - 1)
+  return { dimPrefix: `${parents.join('/')}/`, base }
+}
+
+const plural = (count: number, unit: string): string =>
+  `${count} ${unit}${count === 1 ? '' : 's'}`
+
+// Cheap line diff for the edit stat: trim common prefix/suffix lines, count
+// what's left. Not a real LCS, but right for the focused edits models make.
+export const countLineDiff = (
+  oldStr: string,
+  newStr: string,
+): { added: number; removed: number } => {
+  const a = oldStr.split('\n')
+  const b = newStr.split('\n')
+  let start = 0
+  while (start < a.length && start < b.length && a[start] === b[start]) start++
+  let endA = a.length
+  let endB = b.length
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA--
+    endB--
+  }
+  return { removed: endA - start, added: endB - start }
+}
+
+const fileRowSummary = (verb: string, rawPath: unknown, stat?: string): ToolRowSummary => {
+  const path = asString(rawPath)
+  if (!path) return { verb, stat }
+  const { dimPrefix, base } = splitDisplayPath(path)
+  return { verb, dimPrefix, detail: base, stat }
+}
+
+export const getToolRowSummary = (tool: ToolCall): ToolRowSummary => {
+  const input = asRecord(normalizeToolInput(tool.input))
+  const result = tool.status === 'completed' ? asRecord(tool.result) : undefined
+  const done = tool.status === 'completed'
+
+  switch (tool.name) {
+    case 'file-readText': {
+      const totalLines = asNumber(result?.totalLines)
+      return fileRowSummary('Read', input?.path, totalLines !== undefined ? plural(totalLines, 'line') : undefined)
+    }
+    case 'file-writeText': {
+      const content = asString(input?.content)
+      const stat = done && content ? plural(content.split('\n').length, 'line') : undefined
+      return fileRowSummary('Write', input?.path, stat)
+    }
+    case 'file-editText': {
+      const summary = fileRowSummary('Edit', input?.path)
+      const oldString = asString(input?.oldString)
+      const newString = typeof input?.newString === 'string' ? input.newString : undefined
+      if (done && oldString !== undefined && newString !== undefined) {
+        const diff = countLineDiff(oldString, newString)
+        const replacements = asNumber(result?.replacements)
+        const times = replacements && replacements > 1 ? replacements : 1
+        summary.diff = { added: diff.added * times, removed: diff.removed * times }
+      }
+      return summary
+    }
+    case 'file-list': {
+      const count =
+        (Array.isArray(result?.entries) ? result.entries.length : undefined) ??
+        (Array.isArray(result?.files) ? result.files.length : undefined)
+      return {
+        verb: 'List',
+        detail: asString(input?.path) ?? '.',
+        stat: count !== undefined ? plural(count, 'item') : undefined,
+      }
+    }
+    case 'file-exists':
+      return fileRowSummary('Check', input?.path, done ? (result?.exists ? 'exists' : 'not found') : undefined)
+    case 'file-stat':
+      return fileRowSummary('Inspect', input?.path)
+    case 'file-glob': {
+      const count = asNumber(result?.count)
+      return {
+        verb: 'Find',
+        detail: asString(input?.pattern) ? `"${input!.pattern}"` : undefined,
+        detailMono: true,
+        stat: count !== undefined ? plural(count, 'file') : undefined,
+      }
+    }
+    case 'file-grep': {
+      const count = asNumber(result?.count)
+      return {
+        verb: 'Search',
+        detail: asString(input?.pattern) ? `"${input!.pattern}"` : undefined,
+        detailMono: true,
+        stat: count !== undefined ? plural(count, 'match') : undefined,
+      }
+    }
+    case 'file-mkdir':
+      return fileRowSummary('Create folder', input?.path)
+    case 'file-rename': {
+      const from = asString(input?.from)
+      const to = asString(input?.to)
+      return {
+        verb: 'Rename',
+        detail: from && to ? `${splitDisplayPath(from).base} → ${splitDisplayPath(to).base}` : from,
+      }
+    }
+    case 'file-copy':
+      return fileRowSummary('Copy', input?.from ?? input?.path)
+    case 'file-remove':
+      return fileRowSummary('Delete', input?.path)
+    case 'file-getRoot':
+      return { verb: 'Locate workspace' }
+    case 'executeCommand': {
+      const command = asString(input?.command)
+      const exitCode = asNumber(result?.exitCode)
+      return {
+        verb: '$',
+        verbMono: true,
+        detail: command ? command.split('\n')[0] : undefined,
+        detailMono: true,
+        stat: exitCode !== undefined ? `exit ${exitCode}` : done ? undefined : tool.status === 'running' ? 'running…' : undefined,
+      }
+    }
+    case 'loadSkill': {
+      // Input is `skillName` (id or catalog path); the result echoes the
+      // resolved id and names any tools the skill attached.
+      const requested = asString(input?.skillName)
+      const name =
+        asString(result?.skillName) ??
+        (requested ? splitDisplayPath(requested.replace(/\/skill\.ts$/, '')).base : undefined)
+      const failed = done && asRecord(tool.result)?.success === false
+      const attached = Array.isArray(result?.attachedTools) ? result.attachedTools.length : undefined
+      return {
+        verb: 'Load skill',
+        detail: name,
+        stat: failed ? 'not found' : attached !== undefined ? `${plural(attached, 'tool')} attached` : undefined,
+      }
+    }
+    case 'parseFile':
+      return fileRowSummary('Parse', input?.path)
+    case 'LLMParse':
+      return fileRowSummary('Extract', input?.path)
+    case 'analyzeAgent':
+      return { verb: 'Analyze agent' }
+    case 'addMcpServer':
+      return { verb: 'Add MCP server', detail: asString(input?.name) ?? asString(input?.url) }
+    case 'listMcpServers':
+      return { verb: 'List MCP servers' }
+    case 'listMcpTools':
+      return { verb: 'List MCP tools', detail: asString(input?.serverName) ?? asString(input?.server) }
+    case 'executeMcpTool': {
+      const server = asString(input?.serverName) ?? asString(input?.server)
+      const toolName = asString(input?.toolName) ?? asString(input?.tool)
+      return { verb: server ?? 'MCP', detail: toolName, detailMono: true }
+    }
+    case 'web-search': {
+      const results = Array.isArray(asRecord(tool.result)?.results)
+        ? (asRecord(tool.result)!.results as unknown[]).length
+        : undefined
+      return {
+        verb: 'Web search',
+        detail: asString(input?.query) ? `"${input!.query}"` : undefined,
+        stat: done && results !== undefined ? plural(results, 'result') : undefined,
+      }
+    }
+    case 'save-to-memory':
+      return { verb: 'Memory', detail: asString(input?.title) ?? asString(input?.content)?.slice(0, 64) }
+    case 'composio-execute-tool': {
+      const toolkitSlug = asString(input?.toolkitSlug) ?? ''
+      const toolkit = COMPOSIO_DISPLAY_NAMES[toolkitSlug] || toolkitSlug
+      const readable = (asString(input?.toolSlug) ?? '')
+        .replace(/^[A-Z0-9]+_/, '')
+        .toLowerCase()
+        .replace(/_/g, ' ')
+        .replace(/^\w/, (c) => c.toUpperCase())
+      const failed = done && asRecord(tool.result)?.successful === false
+      return {
+        verb: toolkit || 'Integration',
+        detail: readable || undefined,
+        stat: failed ? 'failed' : undefined,
+      }
+    }
+    default: {
+      // Sentence-style dynamic labels (browser, app-navigation, composio
+      // search/list) become the whole row title.
+      const dynamicLabel =
+        getBrowserControlLabel(tool) ??
+        getAppActionCardData(tool)?.label ??
+        getComposioActionCardData(tool)?.label
+      if (dynamicLabel) return { verb: dynamicLabel }
+      const named = TOOL_DISPLAY_NAMES[tool.name]
+      if (named) return { verb: named }
+      // Unknown/MCP-style tools: tool name + first meaningful primitive arg.
+      const primary = input
+        ? asString(input.description) ?? asString(input.query) ?? asString(input.url) ??
+          asString(input.filePath) ?? asString(input.path) ?? asString(input.pattern) ?? asString(input.name)
+        : undefined
+      return { verb: tool.name, detail: primary }
+    }
+  }
+}
+
 // Composio action card data (for search, execute, list tools)
 export type ComposioActionCardData = {
   actionType: 'search' | 'execute' | 'list'


### PR DESCRIPTION
## What

Replaces the loud bordered tool-call pills in the chat transcript with a quiet row grammar (Claude Code / Codex style): one borderless 13px line per tool, with a label that actually says what happened.

**Before:** every tool was a full-width `rounded-[28px]` bordered card with a green check icon and a name-only label ("Reading file"), stacked with 1rem gaps.

**After:** `Read chat-conversation.ts · 824 lines`, `Search "pattern" · 9 matches`, `Edit turn-view.ts +12 -3`, `$ npm run lint · exit 0` — muted one-liners that pack tightly and expand in place.

Visual before/after (shareable mockup used to spec this): https://claude.ai/code/artifact/9fdd8f75-f1cf-4a9b-bb0e-d5bdccc0c717

## How

- **Label layer** — new `getToolRowSummary()` in `chat-conversation.ts` maps `tool.input`/`tool.result` to `{verb, detail, stat, diff}` per builtin tool; unknown/MCP tools fall back to name + first meaningful argument. Edit diffs (`+N -M`) are computed client-side from `oldString`/`newString` (prefix/suffix line trim), scaled by `replacements`.
- **One presentation path** — `Tool`/`ToolHeader`/`ToolContent` in `tool.tsx` render every row: fixed 12px glyph slot (spinner running, red dot failure, empty success — success is the unmarked default), hover-revealed chevron, first error line inline, stacked Parameters/Result under a hairline left rule (tab strip removed). Shared `quietRowContainerClass`/`quietRowTriggerClass`/`quietRowGlyphSlotClass` define the geometry once; all custom surfaces import them.
- **Grouping** — consecutive plain tools still group; children stay visible while streaming and auto-collapse to `Ran N tools · read 2 files, searched…` on settle. Auto-approved tools now group too (approval = shield glyph + reason tooltip on the row); only interactive permission asks/denials break a group.
- **Special surfaces** — web search keeps its rolling-favicon animation in row form; app actions, sub-agents, and coding runs use the same grammar; the pending permission ask shrinks to an amber left-rule chip (the only card left in the transcript); resolved and auto decisions are quiet rows.
- **Turn footer** — token menu + effort label move to the right edge, hidden until the turn is hovered, with a new copy button (verbatim final assistant markdown) slotted before the menu.
- `loadSkill` rows read `Load skill <id> · N tools attached`.

## Testing

- `npm run lint` and `npm run typecheck` green in `apps/x`.
- Exercised live in dev: single tools, groups (incl. auto-approved members), errors, streaming command output, web search, permission ask/deny, turn footer hover + copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)