### PR TITLE
feat(x): render the side-pane chat identically to the full-screen chat

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7607,6 +7607,7 @@ function App() {
                 isWaitingOnHuman={activeIsWaitingOnHuman}
                 onPermissionResponse={handlePermissionResponse}
                 onAskHumanResponse={handleAskHumanResponse}
+                onCodePermissionResponse={handleCodePermissionResponse}
                 isToolOpenForTab={isToolOpenForTab}
                 onToolOpenChangeForTab={setToolOpenForTab}
                 onOpenKnowledgeFile={(path) => { navigateToFile(path) }}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -51,34 +51,7 @@ export interface ChatSessionPaneProps {
   activeIsWorking: boolean
   activeIsProcessing: boolean
   activeIsReasoning: boolean
-  /** Extra classes appended to ConversationContent (the side-pane chat adds `px-3`). */
-  contentClassName?: string
-  /** Vertically center the empty state (default true). The side-pane chat only centers when maximized. */
-  centerEmptyState?: boolean
-  /** `wide` flag for ChatEmptyState (default true). The side-pane chat is wide only when maximized. */
-  emptyStateWide?: boolean
-  /**
-   * How the in-flight assistant message is rendered. 'smooth' (default, App)
-   * animates via useSmoothedText and strips <voice> tags; 'plain' (side-pane
-   * chat) renders the raw text directly.
-   */
-  streamingRenderer?: 'smooth' | 'plain'
-  /** Render quick-reply option buttons on ask-human requests (default true). The side-pane chat renders free-text only. */
-  askHumanShowOptions?: boolean
-  /**
-   * Render the rich tool cards — CodingRunBlock for `code_agent_run`,
-   * SubAgentBlock for `spawn-agent`, and AppActionCard for app actions
-   * (default true, App). The side-pane chat sets this to false and shows those
-   * tool calls as generic collapsible Tool rows instead.
-   */
-  richToolCards?: boolean
-  /**
-   * Surface the tool's actual error output (via getToolErrorText) on generic
-   * tool rows (side-pane chat). Default false (App): a plain 'Tool error'
-   * label when the call errored.
-   */
-  detailedToolErrors?: boolean
-  /** Answer a mid-run permission ask from a `code_agent_run` coding turn (App; used by CodingRunBlock). */
+  /** Answer a mid-run permission ask from a `code_agent_run` coding turn (used by CodingRunBlock). */
   onCodePermissionResponse?: (toolCallId: string, requestId: string, decision: PermissionDecision) => void | Promise<void>
   /** Notified when a ComposioConnectCard finishes connecting a toolkit. */
   onComposioConnected?: (toolkitSlug: string) => void
@@ -97,13 +70,6 @@ export function ChatSessionPane({
   activeIsWorking,
   activeIsProcessing,
   activeIsReasoning,
-  contentClassName,
-  centerEmptyState = true,
-  emptyStateWide = true,
-  streamingRenderer = 'smooth',
-  askHumanShowOptions = true,
-  richToolCards = true,
-  detailedToolErrors = false,
   onCodePermissionResponse,
   onComposioConnected,
 }: ChatSessionPaneProps) {
@@ -128,9 +94,8 @@ export function ChatSessionPane({
   const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
   const tabConversationContentClassName = cn(
     'mx-auto w-full max-w-4xl',
-    contentClassName,
     tabHasConversation ? 'pb-28' : 'pb-0',
-    !tabHasConversation && centerEmptyState && 'min-h-full items-center justify-center',
+    !tabHasConversation && 'min-h-full items-center justify-center',
   )
   return (
     <div
@@ -151,7 +116,7 @@ export function ChatSessionPane({
         <ConversationContent className={tabConversationContentClassName}>
           {!tabHasConversation ? (
             <ChatEmptyState
-              wide={emptyStateWide}
+              wide
               onPickPrompt={onPickPrompt}
             />
           ) : (
@@ -160,8 +125,6 @@ export function ChatSessionPane({
                 items={tabState.conversation}
                 isToolOpen={(toolId) => isToolOpenForTab(tab.id, toolId)}
                 onToolOpenChange={(toolId, open) => setToolOpenForTab(tab.id, toolId, open)}
-                richToolCards={richToolCards}
-                detailedToolErrors={detailedToolErrors}
                 permissionRequests={tabState.allPermissionRequests}
                 permissionResponses={tabState.permissionResponses}
                 autoPermissionDecisions={tabState.autoPermissionDecisions}
@@ -176,7 +139,7 @@ export function ChatSessionPane({
                 <AskHumanRequest
                   key={request.toolCallId}
                   query={request.query}
-                  options={askHumanShowOptions ? request.options : undefined}
+                  options={request.options}
                   onResponse={(response) => onAskHumanResponse(request.toolCallId, request.subflow, response)}
                   isProcessing={isActive && activeIsWorking}
                 />
@@ -185,11 +148,7 @@ export function ChatSessionPane({
               {tabState.currentAssistantMessage && (
                 <Message from="assistant">
                   <MessageContent>
-                    {streamingRenderer === 'plain' ? (
-                      <MessageResponse components={streamdownComponents}>{tabState.currentAssistantMessage}</MessageResponse>
-                    ) : (
-                      <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />
-                    )}
+                    <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />
                   </MessageContent>
                 </Message>
               )}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -13,6 +13,7 @@ import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
 import { useTabMeta } from '@/lib/tab-meta'
 import { useSidebar } from '@/components/ui/sidebar'
 import type { ChatPaneSize } from '@/contexts/theme-context'
+import type { PermissionDecision } from '@x/shared/src/code-mode.js'
 import {
   type ChatViewportAnchorState,
   type ChatTabViewState,
@@ -102,6 +103,7 @@ interface ChatSidebarProps {
   autoPermissionDecisions?: ChatTabViewState['autoPermissionDecisions']
   onPermissionResponse?: (toolCallId: string, subflow: string[], response: PermissionResponse) => void
   onAskHumanResponse?: (toolCallId: string, subflow: string[], response: string) => void
+  onCodePermissionResponse?: (toolCallId: string, requestId: string, decision: PermissionDecision) => void | Promise<void>
   isToolOpenForTab?: (tabId: string, toolId: string) => boolean
   onToolOpenChangeForTab?: (tabId: string, toolId: string, open: boolean) => void
   onOpenKnowledgeFile?: (path: string) => void
@@ -170,6 +172,7 @@ export function ChatSidebar({
   autoPermissionDecisions = new Map(),
   onPermissionResponse,
   onAskHumanResponse,
+  onCodePermissionResponse,
   isToolOpenForTab,
   onToolOpenChangeForTab,
   onOpenKnowledgeFile,
@@ -411,7 +414,8 @@ export function ChatSidebar({
 
           <FileCardProvider onOpenKnowledgeFile={onOpenKnowledgeFile ?? (() => {})}>
             <div className="flex min-h-0 flex-1 flex-col">
-              <div className="relative min-h-0 flex-1">
+              {/* Pane padding lives here, on the container — the shared chat pane renders identically on every surface. */}
+              <div className="relative min-h-0 flex-1 px-3">
                 {chatTabs.map((tab) => {
                   const isActive = tab.id === activeChatTabId
                   return (
@@ -430,13 +434,7 @@ export function ChatSidebar({
                       activeIsWorking={isProcessing && !isWaitingOnHuman}
                       activeIsProcessing={isProcessing}
                       activeIsReasoning={isReasoning}
-                      contentClassName="px-3"
-                      centerEmptyState={isMaximized}
-                      emptyStateWide={isMaximized}
-                      streamingRenderer="plain"
-                      askHumanShowOptions={false}
-                      richToolCards={false}
-                      detailedToolErrors
+                      onCodePermissionResponse={onCodePermissionResponse}
                       onComposioConnected={onComposioConnected}
                     />
                   )

--- a/apps/x/apps/renderer/src/components/turn-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.tsx
@@ -94,19 +94,6 @@ export interface TurnConversationProps {
    */
   isToolOpen?: (toolId: string) => boolean
   onToolOpenChange?: (toolId: string, open: boolean) => void
-  /**
-   * Render the rich tool cards — CodingRunBlock for `code_agent_run`,
-   * SubAgentBlock for `spawn-agent`, and AppActionCard for app actions
-   * (default true). The side-pane chat sets this to false and shows those
-   * tool calls as generic collapsible Tool rows instead.
-   */
-  richToolCards?: boolean
-  /**
-   * Surface the tool's actual error output (via getToolErrorText) on generic
-   * tool rows (side-pane chat). Default false: a plain 'Tool error' label
-   * when the call errored.
-   */
-  detailedToolErrors?: boolean
   /** Live-chat permission state (from ChatTabViewState); omitted on read-only surfaces. */
   permissionRequests?: ChatTabViewState['allPermissionRequests']
   permissionResponses?: ChatTabViewState['permissionResponses']
@@ -126,8 +113,6 @@ export function TurnConversation({
   items,
   isToolOpen: isToolOpenProp,
   onToolOpenChange: onToolOpenChangeProp,
-  richToolCards = true,
-  detailedToolErrors = false,
   permissionRequests = EMPTY_PERMISSION_REQUESTS,
   permissionResponses = EMPTY_PERMISSION_RESPONSES,
   autoPermissionDecisions = EMPTY_AUTO_DECISIONS,
@@ -218,36 +203,34 @@ export function TurnConversation({
     }
 
     if (isToolCall(item)) {
-      if (richToolCards) {
-        if (item.name === 'code_agent_run') {
-          return (
-            <CodingRunBlock
-              key={item.id}
-              item={item}
-              open={isToolOpen(item.id)}
-              onOpenChange={(open) => onToolOpenChange(item.id, open)}
-              onPermissionDecision={(decision) => {
-                if (item.pendingCodePermission) {
-                  onCodePermissionResponse?.(item.id, item.pendingCodePermission.requestId, decision)
-                }
-              }}
-            />
-          )
-        }
-        if (item.name === 'spawn-agent') {
-          return (
-            <SubAgentBlock
-              key={item.id}
-              item={item}
-              open={isToolOpen(item.id)}
-              onOpenChange={(open) => onToolOpenChange(item.id, open)}
-            />
-          )
-        }
-        const appActionData = getAppActionCardData(item)
-        if (appActionData) {
-          return <AppActionCard key={item.id} data={appActionData} status={item.status} />
-        }
+      if (item.name === 'code_agent_run') {
+        return (
+          <CodingRunBlock
+            key={item.id}
+            item={item}
+            open={isToolOpen(item.id)}
+            onOpenChange={(open) => onToolOpenChange(item.id, open)}
+            onPermissionDecision={(decision) => {
+              if (item.pendingCodePermission) {
+                onCodePermissionResponse?.(item.id, item.pendingCodePermission.requestId, decision)
+              }
+            }}
+          />
+        )
+      }
+      if (item.name === 'spawn-agent') {
+        return (
+          <SubAgentBlock
+            key={item.id}
+            item={item}
+            open={isToolOpen(item.id)}
+            onOpenChange={(open) => onToolOpenChange(item.id, open)}
+          />
+        )
+      }
+      const appActionData = getAppActionCardData(item)
+      if (appActionData) {
+        return <AppActionCard key={item.id} data={appActionData} status={item.status} />
       }
       const webSearchData = getWebSearchCardData(item)
       if (webSearchData) {
@@ -276,9 +259,7 @@ export function TurnConversation({
           />
         )
       }
-      const errorText = detailedToolErrors
-        ? getToolErrorText(item)
-        : (item.status === 'error' ? 'Tool error' : '')
+      const errorText = getToolErrorText(item)
       const output = normalizeToolOutput(item.result, item.status)
       const input = normalizeToolInput(item.input)
       return (


### PR DESCRIPTION
## Summary

The side-pane chat diverged from the full-screen chat through per-surface props on `ChatSessionPane` / `TurnConversation`: a spawn-agent call showed a generic `spawn-agent chicago-analyst` row in the sidebar while the main chat showed the named SubAgentBlock card, plus plain (unanimated) streaming, free-text-only ask-human, and sidebar-specific padding/empty-state variants.

This PR deletes every appearance-configuring prop so parity is structural — the shared pane has exactly one rendering and no surface can drift again:

- **`TurnConversation`**: drop `richToolCards` / `detailedToolErrors`. The rich cards (`SubAgentBlock`, `CodingRunBlock`, `AppActionCard`) always render, and the expanded tool row always shows the tool's actual error output (`getToolErrorText`) on every surface — the main chat previously showed a flat "Tool error" label.
- **`ChatSessionPane`**: drop `streamingRenderer`, `askHumanShowOptions`, `contentClassName`, `centerEmptyState`, `emptyStateWide`. Smooth streaming, ask-human quick-reply options, and the wide centered empty state everywhere. The pane now takes only data and handlers.
- **`ChatSidebar`**: stop overriding; the pane padding (`px-3`) now lives on the sidebar's own container instead of being injected into the shared component, and `onCodePermissionResponse` is wired from App so the coding card's permission buttons work in the side pane.

## Visible changes

- Sidebar sub-agent calls show the humanized name + task, and expand into the child turn's live transcript (same as main chat).
- Sidebar coding runs / app actions get their rich cards.
- Main chat tool rows now show detailed error output when expanded.
- Sidebar empty state is the wide, vertically-centered variant even when the pane is narrow; the sidebar scrollbar sits inside the container padding.

## Test plan

- `npm run lint` and `npm run typecheck` pass.
- Manual: spawn sub-agents from the side-pane chat and confirm the named cards render and expand; trigger a failing tool and confirm the expanded row shows the real error text on both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)