### PR TITLE
fix(x): nine Home fixes from user testing

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -140,7 +140,7 @@ import {
   listLiveNotes,
 } from '@x/core/dist/knowledge/live-note/fileops.js';
 import { runBackgroundTask } from '@x/core/dist/background-tasks/runner.js';
-import { runTodoItem, commentOnTodoItem, startHomeChat, replyHomeChat, runningItemKeys } from '@x/core/dist/todo/runner.js';
+import { runTodoItem, stopTodoRun, commentOnTodoItem, startHomeChat, replyHomeChat, runningItemKeys } from '@x/core/dist/todo/runner.js';
 import { getSessionIndex as getTodoSessionIndex } from '@x/core/dist/todo/session-index.js';
 import { getConversation as getTodoConversation, deriveConversation as deriveSessionConversation } from '@x/core/dist/todo/conversation.js';
 import { recordPlannerSignal, addYourRule as addPlannerRule, listSuggestions as listTodoSuggestions, takeSuggestion as takeTodoSuggestion } from '@x/core/dist/todo/planner-memory.js';
@@ -2720,6 +2720,14 @@ export function setupIpcHandlers() {
       try {
         void runTodoItem(args.key, args.context).catch(() => {});
         return { success: true };
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    'todo:stopRun': async (_event, args) => {
+      try {
+        const stopped = await stopTodoRun(args.key);
+        return stopped ? { success: true } : { success: false, error: 'No live run to stop' };
       } catch (err) {
         return { success: false, error: err instanceof Error ? err.message : String(err) };
       }

--- a/apps/x/apps/renderer/src/components/todo-view.tsx
+++ b/apps/x/apps/renderer/src/components/todo-view.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowUpRight, Bot, Check, ChevronDown, FileText, LayoutGrid, ListPlus, Loader2, MessageCircle, Plus, RotateCcw, Sparkles, Trash2, X } from 'lucide-react'
+import { ArrowUpRight, Bot, Check, ChevronDown, FileText, LayoutGrid, ListPlus, Loader2, MessageCircle, Plus, RotateCcw, Sparkles, Square, Trash2, X } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { toast } from 'sonner'
 import type { TodoBlock, TodoChatBubble, TodoEventType, TodoItem, TodoLink, TodoList } from '@x/shared/dist/todo.js'
@@ -280,7 +280,11 @@ function SubComposer({ onSubmit, onCancel, onHandoff }: {
           if (e.key === 'Enter' && text.trim()) {
             e.preventDefault()
             onSubmit(text.trim())
+            // Stay open, like the main add-row: Enter lands the step and
+            // the cursor is already on the next one. Escape closes.
+            setText('')
           }
+          if (e.key === 'Enter' && !text.trim()) onCancel()
           if (e.key === 'Escape') onCancel()
         }}
         placeholder="Add a step… mention @rowboat to hand it off"
@@ -424,7 +428,7 @@ function ConversationView({ bubbles, sessionId, onOpenNote, onOpenInChat, onRetr
   )
 }
 
-function ItemRow({ item, isRunning, needsApproval = null, commentOpen, sessionId, bubbles, depth = 0, changed = false, dimmed = false, spotlight = false, collapsed = false, onToggleCollapsed, childRows, onAddSub, onToggle, onCommitText, onDismiss, onRun, onOpenNote, onToggleComment, onComment, onOpenInChat }: {
+function ItemRow({ item, isRunning, needsApproval = null, commentOpen, sessionId, bubbles, depth = 0, changed = false, dimmed = false, spotlight = false, collapsed = false, onToggleCollapsed, childRows, onAddSub, onToggle, onCommitText, onDismiss, onRun, onStop, onOpenNote, onToggleComment, onComment, onOpenInChat, onEnterNext }: {
   item: TodoItem
   isRunning: boolean
   /** The live run is suspended on a permission prompt — approve from the chat. */
@@ -451,10 +455,16 @@ function ItemRow({ item, isRunning, needsApproval = null, commentOpen, sessionId
   onCommitText: (text: string) => void
   onDismiss: () => void
   onRun: () => void
+  /** Stop the live run — the mistaken-assign escape hatch. */
+  onStop?: () => void
   onOpenNote: (path: string) => void
   onToggleComment: () => void
   onComment: (message: string) => void
   onOpenInChat: (sessionId: string) => void
+  /** Sub-items only: Enter while editing continues the indented list —
+   * commit this line, open the next step's composer (bullet-list muscle
+   * memory). */
+  onEnterNext?: () => void
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(item.text)
@@ -525,7 +535,10 @@ function ItemRow({ item, isRunning, needsApproval = null, commentOpen, sessionId
               onBlur={commit}
               onKeyDown={(e) => {
                 if (e.key === 'Tab' && mention.show) { e.preventDefault(); mention.complete(); return }
-                if (e.key === 'Enter') commit()
+                if (e.key === 'Enter') {
+                  commit()
+                  if (draft.trim() && onEnterNext) onEnterNext()
+                }
                 if (e.key === 'Escape') { setDraft(item.text); setEditing(false) }
               }}
               className="w-full bg-transparent text-sm outline-none"
@@ -564,6 +577,20 @@ function ItemRow({ item, isRunning, needsApproval = null, commentOpen, sessionId
               <span className={`${CHIP} ml-2 animate-pulse bg-primary/10 text-primary`}>
                 <Loader2 className="size-3 animate-spin" /> working…
               </span>
+            )}
+            {isRunning && onStop && (
+              /* Always visible while running — a mistaken assign must be
+                 stoppable without hunting through a hover tray. */
+              <IconTip label="Stop this run">
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); onStop() }}
+                  aria-label="Stop this run"
+                  className={`${CHIP} ml-1 border border-border text-muted-foreground hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400`}
+                >
+                  <Square className="size-2.5 fill-current" /> stop
+                </button>
+              </IconTip>
             )}
             {showGoChip && !lastReceipt && (
               <button type="button" onClick={(e) => { e.stopPropagation(); onRun() }} className={`${CHIP} ml-2 border border-border text-muted-foreground hover:bg-accent hover:text-foreground`}>
@@ -623,8 +650,9 @@ function ItemRow({ item, isRunning, needsApproval = null, commentOpen, sessionId
         )}
       </div>
       {/* One floating action tray on hover — Slack's grammar: zero
-          resting clutter, one surface to learn. */}
-      <div className="absolute -top-3 right-1 z-10 hidden items-center gap-0.5 rounded-lg border border-border bg-background p-0.5 shadow-md group-hover/todo:flex">
+          resting clutter, one surface to learn. Kept inside the row's own
+          band so it never reads as the previous row's controls. */}
+      <div className="absolute right-1 top-1 z-10 hidden items-center gap-0.5 rounded-lg border border-border bg-background p-0.5 shadow-md group-hover/todo:flex">
         {!showConversation && (
           <IconTip label="Reply — tell @rowboat something about this">
             <button
@@ -902,8 +930,9 @@ function ConversationsSection({ threads, total = 0, running, needsApproval, conv
                 )}
                 {isRunning && !approvalMsg && <Loader2 className="size-3.5 shrink-0 animate-spin text-primary" />}
                 <span className="shrink-0 text-[11px] text-muted-foreground/60">{relativeTime(t.updatedAt)}</span>
-                {/* Same floating tray as items — one grammar everywhere. */}
-                <div className="absolute -top-3 right-1 z-10 hidden items-center gap-0.5 rounded-lg border border-border bg-background p-0.5 shadow-md group-hover/thread:flex">
+                {/* Same floating tray as items — one grammar everywhere,
+                    inside the row's own band (never over the previous row). */}
+                <div className="absolute right-1 top-1 z-10 hidden items-center gap-0.5 rounded-lg border border-border bg-background p-0.5 shadow-md group-hover/thread:flex">
                   <IconTip label="Reply">
                     <button
                       type="button"
@@ -1129,6 +1158,26 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
   const [seenBaseline, setSeenBaseline] = useState<string>(() => localStorage.getItem('todo.seenBaseline') ?? new Date(0).toISOString())
   const seenBaselineRef = useRef(seenBaseline)
   useEffect(() => { seenBaselineRef.current = seenBaseline }, [seenBaseline])
+  // Per-session read marks: opening a thread (expand, or into the sidebar)
+  // clears its dot immediately — the global baseline only advances on blur.
+  const [sessionSeenAt, setSessionSeenAt] = useState<Record<string, string>>(() => {
+    try { return JSON.parse(localStorage.getItem('todo.sessionSeenAt') ?? '{}') as Record<string, string> } catch { return {} }
+  })
+  const sessionSeenAtRef = useRef(sessionSeenAt)
+  useEffect(() => { sessionSeenAtRef.current = sessionSeenAt }, [sessionSeenAt])
+  const markSessionSeen = useCallback((sessionId: string) => {
+    setSessionSeenAt((m) => {
+      const next = { ...m, [sessionId]: new Date().toISOString() }
+      // Bounded: drop the oldest marks past 300 — old sessions age out of
+      // the dot logic via the blur baseline anyway.
+      const keys = Object.keys(next)
+      if (keys.length > 300) {
+        for (const k of keys.sort((a, b) => next[a].localeCompare(next[b])).slice(0, keys.length - 300)) delete next[k]
+      }
+      localStorage.setItem('todo.sessionSeenAt', JSON.stringify(next))
+      return next
+    })
+  }, [])
   // Threads hidden from Home — an attention filter, never a record: the
   // sessions stay whole in chat history; losing this file just makes
   // threads reappear.
@@ -1173,7 +1222,8 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
         .filter((s) => !todoSessionIds.has(s.sessionId) && !hiddenThreadsRef.current.has(s.sessionId))
         .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
       const isActive = (s: (typeof candidates)[number]) =>
-        res.running.includes(`chat:${s.sessionId}`) || s.updatedAt > seenBaselineRef.current
+        res.running.includes(`chat:${s.sessionId}`)
+        || (s.updatedAt > seenBaselineRef.current && s.updatedAt > (sessionSeenAtRef.current[s.sessionId] ?? ''))
       const active = candidates.filter(isActive)
       const rest = candidates.filter((s) => !isActive(s))
       const threads = [...active, ...rest]
@@ -1391,13 +1441,21 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
   }, [])
 
   const toggleThread = useCallback((sessionId: string) => {
+    // Opening IS reading — the dot clears the moment the thread expands.
+    markSessionSeen(sessionId)
     setExpandedThread((cur) => {
       const next = cur === sessionId ? null : sessionId
       if (next) void fetchStreamConv(next)
       return next
     })
     setChatReplyFor(null)
-  }, [fetchStreamConv])
+  }, [fetchStreamConv, markSessionSeen])
+
+  // Every door into a session marks it read — expand, or off to the sidebar.
+  const openInChat = useCallback((sessionId: string) => {
+    markSessionSeen(sessionId)
+    onOpenInChat(sessionId)
+  }, [markSessionSeen, onOpenInChat])
 
   const startChat = useCallback(async (text: string) => {
     const res = await window.ipc.invoke('todo:startChat', { text })
@@ -1461,7 +1519,8 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
   }, [refetch])
 
   const addSub = useCallback(async (parentKey: string, text: string) => {
-    setSubDraftFor(null)
+    // The composer stays open — Enter lands this step with the cursor
+    // already on the next one (bullet-list muscle memory); Escape ends it.
     if (dirtyRef.current) await saveNowRef.current()
     await window.ipc.invoke('todo:addSubItem', { parentKey, text, run: mentionsRowboat(text) })
     await refetch()
@@ -1503,7 +1562,9 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
 
   const isChanged = (key: string): boolean => {
     const sid = sessions[key]
-    return !!sid && (sessionUpdatedAt[sid] ?? '') > seenBaseline
+    if (!sid) return false
+    const updatedAt = sessionUpdatedAt[sid] ?? ''
+    return updatedAt > seenBaseline && updatedAt > (sessionSeenAt[sid] ?? '')
   }
 
   // ---- Spotlight: connect the composer's destination to its source row ----
@@ -1726,12 +1787,22 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
                     dimmed={(triageFilter !== null && !blockMatches(item)) || (spotKey !== null && !blockContainsSpot(item))}
                     spotlight={item.key === spotKey}
                     collapsed={collapsedRows[item.key] ?? (conversations[item.key]?.length ?? 0) > 0}
-                    onToggleCollapsed={() => setRowCollapsed(item.key, !(collapsedRows[item.key] ?? (conversations[item.key]?.length ?? 0) > 0))}
+                    onToggleCollapsed={() => {
+                      const wasCollapsed = collapsedRows[item.key] ?? (conversations[item.key]?.length ?? 0) > 0
+                      // Expanding is reading — clear the row's dot.
+                      if (wasCollapsed && sessions[item.key]) markSessionSeen(sessions[item.key])
+                      setRowCollapsed(item.key, !wasCollapsed)
+                    }}
                     isRunning={running.has(item.key)}
                     needsApproval={needsApproval[item.key] ?? null}
                     onToggle={(checked) => {
                       const next = [...blocksRef.current!]
-                      next[index] = { kind: 'item', item: { ...item, checked } }
+                      // The parent carries its steps, both ways: checking it
+                      // completes them, unchecking reopens them.
+                      next[index] = {
+                        kind: 'item',
+                        item: { ...item, checked, children: item.children.map((c) => (c.checked === checked ? c : { ...c, checked })) },
+                      }
                       mutate(next)
                     }}
                     onCommitText={(text) => {
@@ -1752,6 +1823,7 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
                     }}
                     onDismiss={() => void dismissKey(item.key)}
                     onRun={() => runItem(item.key)}
+                    onStop={() => void window.ipc.invoke('todo:stopRun', { key: item.key })}
                     onOpenNote={onOpenNote}
                     commentOpen={commentKey === item.key}
                     sessionId={sessions[item.key] ?? null}
@@ -1762,7 +1834,7 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
                       else setCommentKey(commentKey === item.key ? null : item.key)
                     }}
                     onComment={(message) => commentOnItem(item.key, message)}
-                    onOpenInChat={onOpenInChat}
+                    onOpenInChat={openInChat}
                     onAddSub={() => {
                       setRowCollapsed(item.key, false)
                       setSubDraftFor(subDraftFor === item.key ? null : item.key)
@@ -1778,7 +1850,11 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
                             dimmed={triageFilter !== null && !triageMatch(child)}
                             spotlight={child.key === spotKey}
                             collapsed={collapsedRows[child.key] ?? (conversations[child.key]?.length ?? 0) > 0}
-                            onToggleCollapsed={() => setRowCollapsed(child.key, !(collapsedRows[child.key] ?? (conversations[child.key]?.length ?? 0) > 0))}
+                            onToggleCollapsed={() => {
+                              const wasCollapsed = collapsedRows[child.key] ?? (conversations[child.key]?.length ?? 0) > 0
+                              if (wasCollapsed && sessions[child.key]) markSessionSeen(sessions[child.key])
+                              setRowCollapsed(child.key, !wasCollapsed)
+                            }}
                             isRunning={running.has(child.key)}
                             needsApproval={needsApproval[child.key] ?? null}
                             onToggle={(checked) => updateChild(index, ci, (c) => ({ ...c, checked }))}
@@ -1796,7 +1872,9 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
                             }}
                             onDismiss={() => void dismissKey(child.key)}
                             onRun={() => runItem(child.key)}
+                            onStop={() => void window.ipc.invoke('todo:stopRun', { key: child.key })}
                             onOpenNote={onOpenNote}
+                            onEnterNext={() => setSubDraftFor(item.key)}
                             commentOpen={commentKey === child.key}
                             sessionId={sessions[child.key] ?? null}
                             bubbles={conversations[child.key] ?? []}
@@ -1804,7 +1882,7 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
                               ? onComposeTodo({ kind: 'comment', key: child.key, itemText: child.text, quote: lastBubbleText(conversations[child.key]) })
                               : setCommentKey(commentKey === child.key ? null : child.key))}
                             onComment={(message) => commentOnItem(child.key, message)}
-                            onOpenInChat={onOpenInChat}
+                            onOpenInChat={openInChat}
                           />
                         ))}
                         {subDraftFor === item.key && (
@@ -1885,7 +1963,9 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
             replyFor={chatReplyFor}
             spotlightSessionId={spotSession}
             dimAll={spotKey !== null}
-            changedSessionIds={new Set(streamThreads.filter((t) => t.updatedAt > seenBaseline).map((t) => t.sessionId))}
+            changedSessionIds={new Set(streamThreads
+              .filter((t) => t.updatedAt > seenBaseline && t.updatedAt > (sessionSeenAt[t.sessionId] ?? ''))
+              .map((t) => t.sessionId))}
             onHide={hideThread}
             onViewAll={onOpenChatHistory}
             onToggle={toggleThread}
@@ -1894,7 +1974,7 @@ export function TodoView({ onOpenNote, onOpenInChat, onShowOverview, composer, o
               : setChatReplyFor(chatReplyFor === sid ? null : sid))}
             onSendReply={sendChatReply}
             onOpenNote={onOpenNote}
-            onOpenInChat={onOpenInChat}
+            onOpenInChat={openInChat}
           />
 
           {/* Done & dismissed — the archive, restorable */}

--- a/apps/x/packages/core/src/todo/agent.ts
+++ b/apps/x/packages/core/src/todo/agent.ts
@@ -14,7 +14,7 @@ Each delegated item is one conversation (a session). The first message frames th
 
 # Message Anatomy
 
-The first message carries the item's exact text; use that same text in every \`todo-report\` call for this conversation. When the item is a sub-item of a larger to-do, the message also carries **Part of:** with the parent's text — pass it as \`parent\` in every \`todo-report\` call, and scope your work to this one step (the other steps are their own conversations). Start by reading \`todo.md\` with \`file-readText\` — the surrounding list often carries context this item's phrasing assumes. An optional **Context from the user:** block carries guidance that arrived with the delegation.
+The first message carries the item's exact text; use that same text in every \`todo-report\` call for this conversation. When the item is a sub-item of a larger to-do, the message also carries **Part of:** with the parent's text — pass it as \`parent\` in every \`todo-report\` call, and scope your work to this one step (the other steps are their own conversations). When the item is a parent with sub-items, the message carries **Steps:** — those steps ARE this delegation: work through the unchecked ones in order, report each finished step with its own \`todo-report\` call (item = the step's exact text, parent = the item's text) so its box checks as you go, then close with one final \`todo-report\` on the item itself. Start by reading \`todo.md\` with \`file-readText\` — the surrounding list often carries context this item's phrasing assumes. An optional **Context from the user:** block carries guidance that arrived with the delegation.
 
 # Follow-up Messages
 

--- a/apps/x/packages/core/src/todo/conversation.ts
+++ b/apps/x/packages/core/src/todo/conversation.ts
@@ -43,6 +43,12 @@ function userBubbleText(raw: string): string | null {
     return context || null;
 }
 
+// Voice-mode replies wrap speakable sentences in <voice>…</voice> — player
+// markup, never prose. Keep the words, drop the tags.
+function stripVoiceTags(text: string): string {
+    return text.replace(/<\/?voice>/g, '').trim();
+}
+
 function reportLinks(input: unknown): TodoLink[] {
     if (!input || typeof input !== 'object') return [];
     const links = (input as { links?: unknown }).links;
@@ -92,9 +98,9 @@ export async function deriveConversation(
             const terminal = state.terminal;
             if (!terminal) continue; // in flight — the spinner covers it
             if (terminal.type === 'turn_completed') {
-                const text = assistantText(terminal.output);
+                const text = stripVoiceTags(assistantText(terminal.output) ?? '');
                 if (text || links.length > 0) {
-                    bubbles.push({ role: 'rowboat', text: text ?? '', links });
+                    bubbles.push({ role: 'rowboat', text, links });
                 }
             } else if (terminal.type === 'turn_failed') {
                 // First line only — provider errors can be multi-line JSON.

--- a/apps/x/packages/core/src/todo/fileops.ts
+++ b/apps/x/packages/core/src/todo/fileops.ts
@@ -360,13 +360,21 @@ export async function attachReceipt(
         }
         const have = new Set(found.item.receipts.map(receiptId));
         if (!have.has(receiptId(receipt))) found.item.receipts.push(receipt);
-        if (opts?.check) found.item.checked = true;
+        // A parent's done means the whole block is done — its steps included.
+        if (opts?.check) {
+            found.item.checked = true;
+            if (!found.parent) for (const child of found.item.children) child.checked = true;
+        }
         await writeRaw(serializeTodoFile(list));
         return true;
     });
 }
 
-/** Set an item's checkbox. Returns false when the line no longer exists. */
+/** Set an item's checkbox. Deliberately touches ONLY this line — the
+ * parent↔steps cascade lives in the UI toggle and in attachReceipt's
+ * parent-done check, so a comment reopening a done parent never silently
+ * reopens its finished steps. Returns false when the line no longer
+ * exists. */
 export async function setChecked(key: string, checked: boolean): Promise<boolean> {
     return withTodoLock(async () => {
         const list = parseTodoFile(await readRaw());

--- a/apps/x/packages/core/src/todo/planner-task.ts
+++ b/apps/x/packages/core/src/todo/planner-task.ts
@@ -27,14 +27,17 @@ Process, in order:
 3. Read todo.md and this month's todo/archive file. Never duplicate an existing or recently archived item. If an existing item already covers a matter, do nothing about it.
 4. Hunt for candidates ONLY in these sources, ranked, using the last ~3 days of synced data (gmail_sync/, calendar_sync/, granola_sync/, fireflies_sync/ — read specific recent files; keep any grep narrow):
    1) Commitments the user made ("I'll send X by Friday" in sent mail or meeting transcripts) — the gold vein.
-   2) Explicit deadlines approaching.
-   3) Important email threads aging without the user's reply for 2+ days.
-   4) Waiting-on-others gone quiet for 3+ days (propose a chase).
+   2) Action items given to the user in recent meeting notes (granola_sync/, fireflies_sync/ — transcripts and their action-item sections).
+   3) Explicit deadlines approaching.
+   4) Important email threads aging without the user's reply for 2+ days.
+   5) Waiting-on-others gone quiet for 3+ days (propose a chase).
+   6) Prep that a significant upcoming meeting plainly needs (today or tomorrow on calendar_sync/ — an agenda to write, attendees to research, material to review). Only when the meeting clearly warrants it; never propose merely attending.
 5. THE EMAIL GATE: every gmail_sync/*.md file carries an \`importance:\` line in its frontmatter, stamped by the app's classifier (which learns from the user's own corrections). Only threads stamped \`importance: important\` may produce candidates — find them with a narrow grep for "importance: important". Threads stamped \`importance: other\` and unstamped files are newsletters, notifications, and noise by definition: never read them for candidates, no matter how actionable a subject line looks.
-6. NEVER propose: routine email replies (the Email surface already pre-drafts those), meetings (the calendar shows them), anything an existing background agent already handles, newsletters or automated notifications, or restatements of information with no action.
-7. Cap: at most 3 proposals. One or two great items beat three decent ones. ZERO is a good outcome — if nothing clears the bar, end quietly with a "nothing needed" summary. The test for every candidate: does putting this on the list change what the user does today?
-8. Phrase each item the way the user would write it — short, concrete, starting with a verb. Include @rowboat in the text ONLY to offer internal prep you could do yourself (research, outline, compile, summarize — never anything outward-facing); it waits for the user's go either way.
-9. Submit via todo-propose — your only pen. Proposals land in a suggestion tray on the home surface where the user accepts or declines each one; nothing touches the list or runs without their accept. Never use todo-add, never edit todo.md directly, never start runs.`;
+6. THE ALREADY-HANDLED GATE: a thread file lists its messages oldest-first as "### From:" blocks — before proposing ANYTHING email-based, check the LAST one. If the most recent message is from the user themself, they already replied: never propose replying to, chasing, or following up on that thread. The same test applies everywhere — a commitment the user's later mail or notes show as delivered, or a meeting action item already done, is finished business, not a candidate.
+7. NEVER propose: routine email replies (the Email surface already pre-drafts those), attending meetings (the calendar shows them — prep for one is fair game under 4.6), anything an existing background agent already handles, newsletters or automated notifications, or restatements of information with no action.
+8. Cap: at most 3 proposals. One or two great items beat three decent ones. ZERO is a good outcome — if nothing clears the bar, end quietly with a "nothing needed" summary. The test for every candidate: does putting this on the list change what the user does today?
+9. Phrase each item the way the user would write it — short, concrete, starting with a verb. Include @rowboat in the text ONLY to offer internal prep you could do yourself (research, outline, compile, summarize — never anything outward-facing); it waits for the user's go either way.
+10. Submit via todo-propose — your only pen. Proposals land in a suggestion tray on the home surface where the user accepts or declines each one; nothing touches the list or runs without their accept. Never use todo-add, never edit todo.md directly, never start runs.`;
 
 // Prior seeded doctrines, verbatim. A task whose instructions exactly match
 // one of these was never edited by the user, so boot upgrades it to the
@@ -55,11 +58,31 @@ Process, in order:
 6. Cap: at most 3 proposals. One or two great items beat three decent ones. ZERO is a good outcome — if nothing clears the bar, end quietly with a "nothing needed" summary. The test for every candidate: does putting this on the list change what the user does today?
 7. Phrase each item the way the user would write it — short, concrete, starting with a verb. Include @rowboat in the text ONLY to offer internal prep you could do yourself (research, outline, compile, summarize — never anything outward-facing); it waits for the user's go either way.`;
 
+// v3: added the email gate; predates meeting awareness + the already-handled gate.
+const PLANNER_INSTRUCTIONS_V3 = `Each morning, propose a FEW high-signal to-do items for the user's day — or none. This is ACTION mode: your side-effect is the todo-propose tool; journal one line about what you proposed (or that nothing was needed).
+
+Process, in order:
+
+1. Read ${PREFS_REL_PATH}. "Your rules" outrank "Learned"; both outrank the defaults below.
+2. Read ${FEEDBACK_REL_PATH} — recent outcomes are examples of the user's taste: 'dismissed'/'taught' items were unwanted (never propose anything similar); 'ran'/'kept' items were valued (more like those).
+3. Read todo.md and this month's todo/archive file. Never duplicate an existing or recently archived item. If an existing item already covers a matter, do nothing about it.
+4. Hunt for candidates ONLY in these sources, ranked, using the last ~3 days of synced data (gmail_sync/, calendar_sync/, granola_sync/, fireflies_sync/ — read specific recent files; keep any grep narrow):
+   1) Commitments the user made ("I'll send X by Friday" in sent mail or meeting transcripts) — the gold vein.
+   2) Explicit deadlines approaching.
+   3) Important email threads aging without the user's reply for 2+ days.
+   4) Waiting-on-others gone quiet for 3+ days (propose a chase).
+5. THE EMAIL GATE: every gmail_sync/*.md file carries an \`importance:\` line in its frontmatter, stamped by the app's classifier (which learns from the user's own corrections). Only threads stamped \`importance: important\` may produce candidates — find them with a narrow grep for "importance: important". Threads stamped \`importance: other\` and unstamped files are newsletters, notifications, and noise by definition: never read them for candidates, no matter how actionable a subject line looks.
+6. NEVER propose: routine email replies (the Email surface already pre-drafts those), meetings (the calendar shows them), anything an existing background agent already handles, newsletters or automated notifications, or restatements of information with no action.
+7. Cap: at most 3 proposals. One or two great items beat three decent ones. ZERO is a good outcome — if nothing clears the bar, end quietly with a "nothing needed" summary. The test for every candidate: does putting this on the list change what the user does today?
+8. Phrase each item the way the user would write it — short, concrete, starting with a verb. Include @rowboat in the text ONLY to offer internal prep you could do yourself (research, outline, compile, summarize — never anything outward-facing); it waits for the user's go either way.
+9. Submit via todo-propose — your only pen. Proposals land in a suggestion tray on the home surface where the user accepts or declines each one; nothing touches the list or runs without their accept. Never use todo-add, never edit todo.md directly, never start runs.`;
+
 const PLANNER_INSTRUCTIONS_PRIOR: string[] = [
     `${PLANNER_PRIOR_COMMON}
 8. Report via todo-propose — your only pen on the list. Never use todo-add, never edit todo.md directly, never start runs.`,
     `${PLANNER_PRIOR_COMMON}
 8. Submit via todo-propose — your only pen. Proposals land in a suggestion tray on the home surface where the user accepts or declines each one; nothing touches the list or runs without their accept. Never use todo-add, never edit todo.md directly, never start runs.`,
+    PLANNER_INSTRUCTIONS_V3,
 ];
 
 // Frequency presets the Home surface offers — each maps to daily windows.

--- a/apps/x/packages/core/src/todo/runner.ts
+++ b/apps/x/packages/core/src/todo/runner.ts
@@ -42,18 +42,29 @@ function errorLine(msg: string, n = 200): string {
     return truncate(msg.split('\n')[0], n);
 }
 
-function buildFirstMessage(text: string, context?: string, parentText?: string): string {
+function buildFirstMessage(
+    text: string,
+    context?: string,
+    parentText?: string,
+    children?: { text: string; checked: boolean }[],
+): string {
     const now = new Date();
     const localNow = now.toLocaleString('en-US', { dateStyle: 'full', timeStyle: 'long' });
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     const partOf = parentText ? `\n**Part of:** ${parentText} — this item is one step of that larger to-do; scope your work to THIS step only.` : '';
+    // A parent item owns its steps: the run works through them, checking
+    // each off via todo-report, then closes out the parent itself.
+    const openSteps = (children ?? []).filter((c) => !c.checked);
+    const steps = openSteps.length > 0
+        ? `\n**Steps:**\n${(children ?? []).map((c) => `- [${c.checked ? 'x' : ' '}] ${c.text}`).join('\n')}\nThese sub-items are part of this delegation. Work through the unchecked ones in order; steps already checked are done — skip them. Report EACH step you finish with its own \`todo-report\` call (item = the step's exact text, parent = the item text above) so its box gets checked as you go, then finish with one more \`todo-report\` for the item itself with the overall outcome. The trust rules apply per step: an outward-facing step stops at \`ready\`, and then the item overall is \`ready\`, not \`done\`.`
+        : '';
     const report = parentText
         ? `report the outcome with \`todo-report\` (item text exactly as above, parent exactly as in **Part of**)`
         : `report the outcome with \`todo-report\` (item text exactly as above)`;
     const base = `Work on this item from the user's to-do list at \`${TODO_REL_PATH}\`:
 
-**Item:** ${text}${partOf}
+**Item:** ${text}${partOf}${steps}
 **Time:** ${localNow} (${tz})
 
 Start by calling \`file-readText\` on \`${TODO_REL_PATH}\` — the surrounding list often carries context this item's phrasing assumes. Then do the work per your instructions, and ${report}.`;
@@ -159,6 +170,8 @@ function watchSettles(bus: ITurnEventBus): SettleWatcher {
 const runningItems = new Set<string>();
 /** Suspended ask-human questions awaiting an answer, by item key. */
 const pendingAsks = new Map<string, { turnId: string; toolCallId: string }>();
+/** The live turn per running key — what a stop request aborts. */
+const runningTurns = new Map<string, string>();
 
 export function isItemRunning(key: string): boolean {
     return runningItems.has(normalizeKey(key));
@@ -166,6 +179,20 @@ export function isItemRunning(key: string): boolean {
 
 export function runningItemKeys(): string[] {
     return [...runningItems];
+}
+
+/**
+ * Stop the live run on an item (or a `chat:<sessionId>` thread) — the
+ * mistaken-assign escape hatch. The cancelled turn settles normally
+ * ('Stopped'), which clears the spinner and frees the item.
+ */
+export async function stopTodoRun(key: string): Promise<boolean> {
+    const norm = key.startsWith('chat:') ? key : normalizeKey(key);
+    const turnId = runningTurns.get(norm);
+    if (!turnId) return false;
+    const { sessions } = await resolveDeps();
+    await sessions.stopTurn(turnId, 'Stopped by the user from the to-do list');
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -313,6 +340,7 @@ async function driveTurn(
         }
 
         log.log(`turn=${sent.turnId} session=${sessionId} item="${truncate(itemText, 80)}"`);
+        runningTurns.set(norm, sent.turnId);
         todoBus.publish({ type: 'run_start', key: norm });
         // A manual-permission run suspends until the user approves from the
         // item's chat — surface it once, then KEEP WAITING so the completion
@@ -340,6 +368,7 @@ async function driveTurn(
             }
         }
     } finally {
+        runningTurns.delete(norm);
         watcher.dispose();
     }
 }
@@ -381,7 +410,7 @@ export async function runTodoItem(
         const { sessions } = await resolveDeps();
         const title = parent ? `${item.text} · ${parent.text}` : item.text;
         const { sessionId } = await ensureSession(sessions, item.key, title);
-        return await driveTurn(item.key, item.text, item.receipts.length, sessionId, buildFirstMessage(item.text, context, parent?.text), 'manual', opts?.model, opts?.autoPermission ?? true);
+        return await driveTurn(item.key, item.text, item.receipts.length, sessionId, buildFirstMessage(item.text, context, parent?.text, item.children), 'manual', opts?.model, opts?.autoPermission ?? true);
     } finally {
         runningItems.delete(norm);
     }
@@ -444,6 +473,7 @@ async function driveChatTurn(
             return { sessionId, turnId: null, error: msg };
         }
 
+        runningTurns.set(key, sent.turnId);
         todoBus.publish({ type: 'run_start', key });
         // A manual-permission turn suspends until the user approves from the
         // chat — surface it once, then keep waiting so the thread still shows
@@ -474,6 +504,7 @@ async function driveChatTurn(
             return { sessionId, turnId: sent.turnId };
         }
     } finally {
+        runningTurns.delete(key);
         watcher.dispose();
         runningItems.delete(key);
     }
@@ -557,7 +588,7 @@ export async function commentOnTodoItem(
 
         const title = parent ? `${item.text} · ${parent.text}` : item.text;
         const { sessionId, isNew } = await ensureSession(sessions, item.key, title);
-        const text = isNew ? buildFirstMessage(item.text, message, parent?.text) : message;
+        const text = isNew ? buildFirstMessage(item.text, message, parent?.text, item.children) : message;
         return await driveTurn(item.key, item.text, item.receipts.length, sessionId, text, 'comment', opts?.model, opts?.autoPermission ?? true);
     } finally {
         runningItems.delete(norm);

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2527,6 +2527,18 @@ const ipcSchemas = {
       error: z.string().optional(),
     }),
   },
+  // Stop the live run on one item (or `chat:<sessionId>` thread) — the
+  // mistaken-assign escape hatch. The cancelled turn settles as 'Stopped'
+  // on todo:events, which clears the spinner.
+  'todo:stopRun': {
+    req: z.object({
+      key: z.string(),
+    }),
+    res: z.object({
+      success: z.boolean(),
+      error: z.string().optional(),
+    }),
+  },
   // Home-stream chat threads: a plain message from the home composer starts
   // a copilot session; replies continue it. Events ride todo:events keyed
   // `chat:<sessionId>`.


### PR DESCRIPTION
Nine fixes to the to-do Home surface (#812 follow-up), straight from a user-testing pass.

## Suggestions (planner)
- **Already-handled gate** — before proposing anything email-based, the planner checks the thread file's last `### From:` block; if the most recent message is from the user, the thread is answered — no reply/chase/follow-up proposals. The same test covers delivered commitments and finished meeting action items.
- **Meeting awareness** — two new candidate sources: action items assigned to the user in recent meeting notes (`granola_sync/`, `fireflies_sync/`), and prep a significant upcoming meeting plainly needs. "Never propose meetings" is now scoped to *attending* them.
- The replaced doctrine is kept verbatim in the prior-versions list (byte-verified), so unedited seeded planners upgrade on next boot; user-edited instructions are never touched, and the active/paused state is preserved.

## Threads & reading
- **Opening marks read** — per-session read marks (localStorage, bounded to 300): expanding a thread, expanding an item row, or opening either in the sidebar clears its unread dot immediately. The window-blur baseline still catches everything else. Read threads also stop claiming priority stream slots.
- **`<voice>` tags stripped** from Home conversation bubbles and preview lines — voice-mode sessions now read as prose.
- **Hover trays** sit inside their own row's band instead of straddling the previous row.

## The list
- **Sub-items compose like bullets** — Enter lands a step and keeps the composer open for the next one (Enter on empty or Escape ends it); Enter while editing an existing step opens the next step's composer.
- **Parent runs carry their steps** — assigning a parent item sends a **Steps:** block; the agent works unchecked sub-items in order, `todo-report`s each so its box checks as it goes, then closes out the parent. Trust rules apply per step (an outward-facing step caps the whole item at `ready`).
- **Stop chip** — every running row (top-level and sub-item) shows a `stop` chip that aborts the live turn via a new `todo:stopRun` IPC; the run settles as "Stopped". The mistaken-assign escape hatch.
- **Parent checkbox cascades** — checking a parent checks all steps, unchecking reopens them (UI), and an agent reporting the parent `done` checks remaining steps. Comment-reopen deliberately does **not** cascade, so refining a done parent never silently reopens finished steps for redo.

## Verification
- `npm run deps`, `npm run typecheck`, `npm run lint` all clean
- Full suites: core 580/580, shared 107/107, renderer 133/133

🤖 Generated with [Claude Code](https://claude.com/claude-code)