### PR TITLE
feat(x): render model reasoning in the chat UI

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7559,6 +7559,7 @@ function App() {
                 onOpenFullScreen={toggleRightPaneMaximize}
                 conversation={activeChatTabState.conversation}
                 currentAssistantMessage={activeChatTabState.currentAssistantMessage}
+                currentReasoning={activeChatTabState.currentReasoning}
                 sessionUsage={activeChatTabState.sessionUsage}
                 chatTabStates={chatTabStatesForRender}
                 viewportAnchors={chatViewportAnchorByTab}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -15,6 +15,7 @@ import {
   type FileMention,
 } from '@/components/ai-elements/prompt-input'
 import { AskHumanRequest } from '@/components/ai-elements/ask-human-request'
+import { ReasoningRow } from '@/components/reasoning-row'
 import { TurnActivityIndicator } from '@/components/turn-activity-indicator'
 import { TurnConversation } from '@/components/turn-conversation'
 import { streamdownComponents } from '@/lib/markdown-render'
@@ -145,6 +146,17 @@ export function ChatSessionPane({
                 />
               ))}
 
+              {/* In-flight model call's thought stream: open with a
+                  "Thinking..." shimmer while reasoning streams, auto-collapses
+                  once the model moves on to its answer. Replaced by the
+                  durable (collapsed) reasoning item when the call completes. */}
+              {tabState.currentReasoning && (
+                <ReasoningRow
+                  content={tabState.currentReasoning}
+                  isStreaming={isActive && activeIsReasoning}
+                />
+              )}
+
               {tabState.currentAssistantMessage && (
                 <Message from="assistant">
                   <MessageContent>
@@ -153,7 +165,11 @@ export function ChatSessionPane({
                 </Message>
               )}
 
-              {isActive && activeIsProcessing && (
+              {/* The reasoning block above already shows its own "Thinking..."
+                  shimmer while thought text is streaming — only fall back to
+                  the bare indicator when there is nothing to show (working, or
+                  reasoning with no visible text, e.g. encrypted-only). */}
+              {isActive && activeIsProcessing && !(activeIsReasoning && tabState.currentReasoning) && (
                 <Message from="assistant">
                   <MessageContent>
                     <TurnActivityIndicator isReasoning={activeIsReasoning} />

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -67,6 +67,7 @@ interface ChatSidebarProps {
   onOpenFullScreen?: () => void
   conversation: ConversationItem[]
   currentAssistantMessage: string
+  currentReasoning?: string
   sessionUsage?: TokenUsage
   chatTabStates?: Record<string, ChatTabViewState>
   viewportAnchors?: Record<string, ChatViewportAnchorState>
@@ -142,6 +143,7 @@ export function ChatSidebar({
   onOpenFullScreen,
   conversation,
   currentAssistantMessage,
+  currentReasoning = '',
   sessionUsage = {},
   chatTabStates = {},
   viewportAnchors = {},
@@ -290,6 +292,7 @@ export function ChatSidebar({
     runId: runId ?? null,
     conversation,
     currentAssistantMessage,
+    currentReasoning,
     sessionUsage,
     pendingAskHumanRequests,
     allPermissionRequests,
@@ -299,6 +302,7 @@ export function ChatSidebar({
     runId,
     conversation,
     currentAssistantMessage,
+    currentReasoning,
     sessionUsage,
     pendingAskHumanRequests,
     allPermissionRequests,

--- a/apps/x/apps/renderer/src/components/reasoning-row.tsx
+++ b/apps/x/apps/renderer/src/components/reasoning-row.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import { ChevronDownIcon, LoaderIcon } from 'lucide-react'
+import { Streamdown } from 'streamdown'
+import { Collapsible, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Shimmer } from '@/components/ai-elements/shimmer'
+import {
+  ToolContent,
+  quietRowContainerClass,
+  quietRowGlyphSlotClass,
+  quietRowTriggerClass,
+} from '@/components/ai-elements/tool'
+import { cn } from '@/lib/utils'
+
+// The model's thought process as a quiet row — same 13px line, lead glyph
+// slot, and collapse mechanics as the tool rows (spinner while streaming,
+// chevron once settled, expanded text hanging off the hairline rule). A
+// streaming row opens itself and collapses when the model moves on to its
+// answer; settled rows load collapsed.
+export function ReasoningRow({
+  content,
+  isStreaming = false,
+  className,
+}: {
+  content: string
+  isStreaming?: boolean
+  className?: string
+}) {
+  const [open, setOpen] = React.useState(isStreaming)
+  // Only the live row knows how long the model actually thought; durable
+  // rows mount settled and fall back to the vague label.
+  const [duration, setDuration] = React.useState<number | undefined>(undefined)
+  const startedAt = React.useRef<number | null>(isStreaming ? Date.now() : null)
+  const wasStreaming = React.useRef(isStreaming)
+  React.useEffect(() => {
+    if (!wasStreaming.current && isStreaming) {
+      startedAt.current = Date.now()
+      setOpen(true)
+    } else if (wasStreaming.current && !isStreaming) {
+      if (startedAt.current !== null) {
+        setDuration(Math.max(1, Math.round((Date.now() - startedAt.current) / 1000)))
+        startedAt.current = null
+      }
+      setOpen(false)
+    }
+    wasStreaming.current = isStreaming
+  }, [isStreaming])
+
+  const label =
+    duration === undefined
+      ? 'Thought for a few seconds'
+      : `Thought for ${duration} second${duration !== 1 ? 's' : ''}`
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className={cn(quietRowContainerClass, className)}>
+      <CollapsibleTrigger className={quietRowTriggerClass}>
+        <span className={quietRowGlyphSlotClass}>
+          {isStreaming ? (
+            <LoaderIcon className="size-3 animate-spin text-muted-foreground" />
+          ) : (
+            <ChevronDownIcon className="size-3 text-muted-foreground/50 transition-transform group-data-[state=open]/row:rotate-180" />
+          )}
+        </span>
+        {isStreaming ? (
+          <Shimmer as="span" duration={1} className="shrink-0 font-medium">
+            Thinking...
+          </Shimmer>
+        ) : (
+          <span className="shrink-0 font-medium text-muted-foreground">{label}</span>
+        )}
+      </CollapsibleTrigger>
+      <ToolContent>
+        <div className="text-sm text-muted-foreground">
+          <Streamdown>{content}</Streamdown>
+        </div>
+      </ToolContent>
+    </Collapsible>
+  )
+}

--- a/apps/x/apps/renderer/src/components/turn-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.tsx
@@ -7,6 +7,7 @@ import {
   MessageResponse,
 } from '@/components/ai-elements/message'
 import { Tool, ToolContent, ToolGroupComponent, ToolHeader, ToolIODetails } from '@/components/ai-elements/tool'
+import { ReasoningRow } from '@/components/reasoning-row'
 import { PermissionRequest } from '@/components/ai-elements/permission-request'
 import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission-decision'
 import { WebSearchResult } from '@/components/ai-elements/web-search-result'
@@ -33,6 +34,7 @@ import {
   groupConversationItems,
   isChatMessage,
   isErrorMessage,
+  isReasoningMessage,
   isToolCall,
   isToolGroup,
   isTurnUsageMessage,
@@ -200,6 +202,12 @@ export function TurnConversation({
           </MessageContent>
         </Message>
       )
+    }
+
+    if (isReasoningMessage(item)) {
+      // Settled thoughts start collapsed; the live streaming row in
+      // ChatSessionPane is what shows reasoning expanded while it happens.
+      return <ReasoningRow key={item.id} content={item.content} />
     }
 
     if (isToolCall(item)) {

--- a/apps/x/apps/renderer/src/lib/chat-conversation.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.ts
@@ -53,6 +53,16 @@ export interface ErrorMessage {
   timestamp: number
 }
 
+// The model's thought process for one model call, shown as a collapsible
+// block above the text/tools it produced. Providers that only emit
+// encrypted reasoning yield no item (there is no text to show).
+export interface ReasoningMessage {
+  id: string
+  kind: 'reasoning'
+  content: string
+  timestamp: number
+}
+
 export type ReasoningEffortLevel = 'low' | 'medium' | 'high'
 
 // User-facing names for the canonical effort ladder ("auto" = absent).
@@ -72,13 +82,17 @@ export interface TurnUsageMessage {
   timestamp: number
 }
 
-export type ConversationItem = ChatMessage | ToolCall | ErrorMessage | TurnUsageMessage
+export type ConversationItem = ChatMessage | ToolCall | ErrorMessage | ReasoningMessage | TurnUsageMessage
 export type PermissionResponse = 'approve' | 'deny'
 
 export type ChatTabViewState = {
   runId: string | null
   conversation: ConversationItem[]
   currentAssistantMessage: string
+  // Reasoning text streaming for the in-flight model call; superseded by the
+  // durable reasoning item once the call completes. Optional because the
+  // legacy pre-load fallback path never carries it.
+  currentReasoning?: string
   sessionUsage: TokenUsage
   pendingAskHumanRequests: Map<string, z.infer<typeof AskHumanRequestEvent>>
   allPermissionRequests: Map<string, z.infer<typeof ToolPermissionRequestEvent>>
@@ -95,6 +109,7 @@ export const createEmptyChatTabViewState = (): ChatTabViewState => ({
   runId: null,
   conversation: [],
   currentAssistantMessage: '',
+  currentReasoning: '',
   sessionUsage: {},
   pendingAskHumanRequests: new Map(),
   allPermissionRequests: new Map(),
@@ -108,6 +123,8 @@ export const isChatMessage = (item: ConversationItem): item is ChatMessage => 'r
 export const isToolCall = (item: ConversationItem): item is ToolCall => 'name' in item
 export const isErrorMessage = (item: ConversationItem): item is ErrorMessage =>
   'kind' in item && item.kind === 'error'
+export const isReasoningMessage = (item: ConversationItem): item is ReasoningMessage =>
+  'kind' in item && item.kind === 'reasoning'
 export const isTurnUsageMessage = (item: ConversationItem): item is TurnUsageMessage =>
   'kind' in item && item.kind === 'turn-usage'
 

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { reduceTurn } from '@x/shared/src/turns.js'
-import { isChatMessage, isErrorMessage, isToolCall, isTurnUsageMessage } from '@/lib/chat-conversation'
+import { isChatMessage, isErrorMessage, isReasoningMessage, isToolCall, isTurnUsageMessage } from '@/lib/chat-conversation'
 import {
   applyOverlay,
   buildSessionChatState,
@@ -380,6 +380,84 @@ describe('buildTurnConversation', () => {
     expect(buildTurnConversation(bare).filter(isToolCall)[0].subAgent).toBeUndefined()
   })
 
+  it('emits each model call\'s reasoning as an item before its text and tools', () => {
+    const state = reduceTurn([
+      created(T1, S1, user('q')),
+      requested(T1, 0),
+      completed(T1, 0, {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'planning the tool call' },
+          toolCallPart('tc1', 'echo'),
+        ],
+      }),
+      invocation(T1, 'tc1', 'echo'),
+      toolResult(T1, 'tc1', 'echo'),
+      requested(T1, 1, ['assistant:0', 'toolResult:tc1']),
+      completed(T1, 1, {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'shaping the answer' },
+          { type: 'text', text: 'answer' },
+        ],
+      }),
+      turnCompleted(T1, 'answer'),
+    ])
+    const items = buildTurnConversation(state)
+    expect(
+      items.map((i) =>
+        isReasoningMessage(i)
+          ? `reasoning:${i.content}`
+          : isToolCall(i)
+            ? `tool:${i.name}`
+            : isChatMessage(i)
+              ? i.role
+              : 'x',
+      ),
+    ).toEqual([
+      'user',
+      'reasoning:planning the tool call',
+      'tool:echo',
+      'reasoning:shaping the answer',
+      'assistant',
+    ])
+  })
+
+  it('joins multiple reasoning parts and drops encrypted-only (empty) ones', () => {
+    const state = reduceTurn([
+      created(T1, S1, user('q')),
+      requested(T1, 0),
+      completed(T1, 0, {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'part one' },
+          { type: 'reasoning', text: '' },
+          { type: 'reasoning', text: 'part two' },
+          { type: 'text', text: 'answer' },
+        ],
+      }),
+      turnCompleted(T1, 'answer'),
+    ])
+    const reasoning = buildTurnConversation(state).filter(isReasoningMessage)
+    expect(reasoning).toHaveLength(1)
+    expect(reasoning[0].content).toBe('part one\n\npart two')
+
+    // A call whose reasoning is entirely encrypted (no text) yields no item.
+    const encryptedOnly = reduceTurn([
+      created(T1, S1, user('q')),
+      requested(T1, 0),
+      completed(T1, 0, {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: '' },
+          { type: 'text', text: 'answer' },
+        ],
+      }),
+      turnCompleted(T1, 'answer'),
+    ])
+    expect(buildTurnConversation(encryptedOnly).filter(isReasoningMessage)).toHaveLength(0)
+  })
+
   it('renders user attachments and a failed turn as an error item', () => {
     const input = {
       role: 'user' as const,
@@ -625,6 +703,17 @@ describe('buildSessionChatState', () => {
     const state = buildSessionChatState([turn], { ...emptyOverlay(), text: 'typing…' })
     expect(state.currentAssistantMessage).toBe('typing…')
     expect(state.isReasoning).toBe(false)
+  })
+
+  it('surfaces streaming reasoning as currentReasoning', () => {
+    const turn = reduceTurn([
+      created(T1, S1),
+      requested(T1, 0),
+      modelStep(T1, 0, { type: 'reasoning_start' }),
+    ])
+    const state = buildSessionChatState([turn], { ...emptyOverlay(), reasoning: 'hmm…' })
+    expect(state.currentReasoning).toBe('hmm…')
+    expect(state.isReasoning).toBe(true)
   })
 })
 

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
@@ -21,6 +21,7 @@ import type {
   ErrorMessage,
   MessageAttachment,
   PermissionResponse,
+  ReasoningMessage,
   TokenUsage,
   ToolCall,
 } from '@/lib/chat-conversation'
@@ -295,6 +296,22 @@ export function buildTurnConversation(state: TurnState): ConversationItem[] {
   for (const call of state.modelCalls) {
     if (call.response === undefined) continue
     const content = call.response.content
+    // The model's thought process precedes what it produced. Encrypted-only
+    // reasoning has no text and yields no item.
+    const reasoning = Array.isArray(content)
+      ? content
+          .map((part) => (part.type === 'reasoning' ? part.text : ''))
+          .filter((text) => text.trim())
+          .join('\n\n')
+      : ''
+    if (reasoning) {
+      items.push({
+        id: `${turnId}:r${call.index}`,
+        kind: 'reasoning',
+        content: reasoning,
+        timestamp: ts(),
+      } satisfies ReasoningMessage)
+    }
     // Voice tags are model-facing markup, never shown (parity with the
     // legacy path's display-time strip).
     const text = stripVoiceTags(
@@ -371,6 +388,10 @@ type PermMeta = z.infer<typeof ToolPermissionMetadata>
 export type SessionChatState = {
   conversation: ConversationItem[]
   currentAssistantMessage: string
+  // Reasoning text streaming for the in-flight model call; the durable
+  // reasoning item supersedes it when the call completes (same lifecycle as
+  // currentAssistantMessage).
+  currentReasoning: string
   sessionUsage: TokenUsage
   // See LiveOverlay.voiceSegments.
   voiceSegments: string[]
@@ -520,6 +541,7 @@ export function buildSessionChatState(
       : null,
     conversation,
     currentAssistantMessage: stripVoiceTags(overlay.text),
+    currentReasoning: overlay.reasoning,
     sessionUsage,
     voiceSegments: overlay.voiceSegments,
     pendingAskHumanRequests,


### PR DESCRIPTION
## What

Reasoning/thought events were fully captured by the turn runtime (durable `reasoning` parts on `model_call_completed`, live `reasoning_delta`s accumulated in the stream overlay) but the view layer dropped both — the only visible trace was the bare "Thinking..." shimmer. This PR renders them.

## How it shows

- **While the model thinks**: a quiet row with a spinner and shimmering "Thinking..." label, expanded, with the thought text streaming in live. It auto-collapses the moment the model moves on to its answer.
- **Settled**: a collapsed "Thought for N seconds" row styled exactly like tool-call rows (13px line, lead chevron, muted text, hairline-rule expansion) — click to expand the full thought text as markdown.
- One row per model call, interleaved in place with the tool calls/text that bout produced.
- Providers that emit only encrypted reasoning (no text) get no row; the plain shimmer indicator remains the fallback there.

## Changes

- `lib/chat-conversation.ts` — new `ReasoningMessage` conversation item + `currentReasoning` on the tab view state
- `lib/session-chat/turn-view.ts` — `buildTurnConversation` emits reasoning items per model call; `buildSessionChatState` exposes the live overlay buffer
- `components/reasoning-row.tsx` — new shared row composing the quiet-row primitives from `ai-elements/tool.tsx`
- `components/turn-conversation.tsx` — renders settled reasoning items; since this is the shared renderer, reasoning appears on every transcript surface (full-screen chat, side pane, subagent cards, bg-task runs history, live-note runs)
- `components/chat-session.tsx` — live streaming row; the `TurnActivityIndicator` "Thinking..." shimmer now only shows when there is no reasoning text to display
- `chat-sidebar.tsx` / `App.tsx` — prop plumbing for the side pane

## Notes

- Durable rows read "Thought for a few seconds" — step events in reduced turn state carry no timestamps, so exact duration is only known for the live row (which times itself). Threading timestamps through the shared reducer is a possible follow-up.
- Reopening a session mid-turn won't show the in-flight call's reasoning until it completes (the live buffer is per-window).

## Testing

- 3 new unit tests (per-call item placement, part joining/encrypted-only skip, live `currentReasoning`); full renderer suite 136/136 green, typecheck + lint clean.
- Manually verified against a real Gemini session with reasoning events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)