### PR TITLE
feat(x): Files panel for chats, in-app PDF viewing, file card redesign

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -73,6 +73,8 @@ import { LiveNoteSidebar } from '@/components/live-note-sidebar'
 import { BackgroundTaskDetail } from '@/components/background-task-detail'
 import { BrowserPane } from '@/components/browser-pane/BrowserPane'
 import { VersionHistoryPanel } from '@/components/version-history-panel'
+import { ChatFilesPanel } from '@/components/chat-files-panel'
+import { collectSessionFiles } from '@/lib/session-files'
 import { FileCardProvider } from '@/contexts/file-card-context'
 import { TabBar, type ChatTab, type FileTab } from '@/components/tab-bar'
 import { CaffeinateIndicator } from '@/components/caffeinate-indicator'
@@ -5288,6 +5290,12 @@ function App() {
       if (isBrowserOpen) {
         dismissBrowserOverlay()
       }
+      // Re-navigating to the already-open view while the chat pane is
+      // maximized over it should reveal it (e.g. clicking "Open" on a PDF
+      // that is already the current file) — mirror applyViewState.
+      if (isRightPaneMaximized) {
+        setIsRightPaneMaximized(false)
+      }
       return
     }
 
@@ -5298,7 +5306,7 @@ function App() {
     }
     setHistory(nextHistory)
     await applyViewState(nextView)
-  }, [appendUnique, applyViewState, cancelRecordingIfActive, currentViewState, setHistory, isBrowserOpen, dismissBrowserOverlay])
+  }, [appendUnique, applyViewState, cancelRecordingIfActive, currentViewState, setHistory, isBrowserOpen, dismissBrowserOverlay, isRightPaneMaximized])
 
   // Move the maximized/full-screen chat into the right side pane: restore the
   // view we expanded from (or fall back to Home) and dock the chat on the right.
@@ -6690,6 +6698,13 @@ function App() {
     permissionResponses,
     autoPermissionDecisions,
   ])
+  // Files the agent created/modified in the active chat — drives the header
+  // Files button and the right-hand panel (full-screen chat only).
+  const [chatFilesPanelOpen, setChatFilesPanelOpen] = useState(false)
+  const chatSessionFiles = React.useMemo(
+    () => collectSessionFiles(activeChatTabState.conversation),
+    [activeChatTabState.conversation],
+  )
   const emptyChatTabState = React.useMemo<ChatTabViewState>(() => createEmptyChatTabViewState(), [])
   const getChatTabStateForRender = useCallback((tabId: string): ChatTabViewState => {
     if (tabId === activeChatTabId) return activeChatTabState
@@ -6852,6 +6867,9 @@ function App() {
                     sessionUsage={activeChatTabState.sessionUsage}
                     onSelectRun={(rid) => void navigateToView({ type: 'chat', runId: rid })}
                     onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
+                    filesCount={chatSessionFiles.length}
+                    filesPanelOpen={chatFilesPanelOpen}
+                    onToggleFilesPanel={() => setChatFilesPanelOpen(v => !v)}
                   />
                 ) : (
                   <TabBar
@@ -7418,6 +7436,7 @@ function App() {
                 </div>
               ) : (
               <FileCardProvider onOpenKnowledgeFile={(path) => { navigateToFile(path) }}>
+              <div className="flex min-h-0 flex-1">
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="relative min-h-0 flex-1">
                   {chatTabs.map((tab) => {
@@ -7512,6 +7531,13 @@ function App() {
                     })}
                   </div>
                 </div>
+              </div>
+              {chatFilesPanelOpen && (
+                <ChatFilesPanel
+                  files={chatSessionFiles}
+                  onClose={() => setChatFilesPanelOpen(false)}
+                />
+              )}
               </div>
               </FileCardProvider>
               )}
@@ -7612,6 +7638,9 @@ function App() {
                 isToolOpenForTab={isToolOpenForTab}
                 onToolOpenChangeForTab={setToolOpenForTab}
                 onOpenKnowledgeFile={(path) => { navigateToFile(path) }}
+                sessionFiles={chatSessionFiles}
+                filesPanelOpen={chatFilesPanelOpen}
+                onToggleFilesPanel={() => setChatFilesPanelOpen(v => !v)}
                 onActivate={() => setActiveShortcutPane('right')}
                 collapsedLeftPaddingPx={collapsedLeftPaddingPx}
                 isRecording={isRecording}

--- a/apps/x/apps/renderer/src/components/ai-elements/file-path-card.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/file-path-card.tsx
@@ -1,14 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { BookOpen, FileIcon, FileText, Image, Music, Pause, Play, Video } from 'lucide-react'
+import { FolderOpen, Pause, Play } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useFileCard } from '@/contexts/file-card-context'
 import { useSidebarSection } from '@/contexts/sidebar-context'
 import { wikiLabel } from '@/lib/wiki-links'
+import { cn } from '@/lib/utils'
 
 const AUDIO_EXTENSIONS = new Set(['.wav', '.mp3', '.m4a', '.ogg', '.flac', '.aac'])
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.ico'])
 const VIDEO_EXTENSIONS = new Set(['.mp4', '.mov', '.avi', '.mkv', '.webm'])
-const DOCUMENT_EXTENSIONS = new Set(['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.txt', '.rtf', '.csv'])
+const DOCUMENT_EXTENSIONS = new Set(['.pdf', '.doc', '.docx', '.txt', '.rtf'])
+const SPREADSHEET_EXTENSIONS = new Set(['.csv', '.tsv', '.xls', '.xlsx'])
+const ARCHIVE_EXTENSIONS = new Set(['.zip', '.rar', '.7z', '.tar', '.gz'])
+const CODE_EXTENSIONS = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.json', '.yaml', '.yml', '.toml', '.xml',
+  '.py', '.rb', '.go', '.rs', '.java', '.c', '.cpp', '.sh', '.sql', '.html', '.css',
+])
 
 function getExtension(filePath: string): string {
   const dot = filePath.lastIndexOf('.')
@@ -21,20 +28,55 @@ function getFileNameWithoutExt(filePath: string): string {
   return dot > 0 ? name.slice(0, dot) : name
 }
 
-function getFileCategory(ext: string): { label: string; icon: typeof FileIcon } {
-  if (AUDIO_EXTENSIONS.has(ext)) return { label: 'Audio', icon: Music }
-  if (IMAGE_EXTENSIONS.has(ext)) return { label: 'Image', icon: Image }
-  if (VIDEO_EXTENSIONS.has(ext)) return { label: 'Video', icon: Video }
-  if (DOCUMENT_EXTENSIONS.has(ext)) return { label: 'Document', icon: FileText }
-  if (ext === '.md') return { label: 'Markdown', icon: FileText }
-  return { label: 'File', icon: FileIcon }
+function getCategoryLabel(ext: string): string {
+  if (AUDIO_EXTENSIONS.has(ext)) return 'Audio'
+  if (IMAGE_EXTENSIONS.has(ext)) return 'Image'
+  if (VIDEO_EXTENSIONS.has(ext)) return 'Video'
+  if (DOCUMENT_EXTENSIONS.has(ext)) return 'Document'
+  if (SPREADSHEET_EXTENSIONS.has(ext)) return 'Spreadsheet'
+  if (ARCHIVE_EXTENSIONS.has(ext)) return 'Archive'
+  if (ext === '.md') return 'Markdown'
+  if (CODE_EXTENSIONS.has(ext)) return 'Code'
+  return 'File'
 }
 
 function getExtLabel(ext: string): string {
   return ext ? ext.slice(1).toUpperCase() : ''
 }
 
-// Shared card shell used by all variants
+/** Accent color for the extension label on the page glyph, by file type. */
+function extAccentClass(ext: string): string {
+  if (ext === '.pdf') return 'text-red-600 dark:text-red-400'
+  if (SPREADSHEET_EXTENSIONS.has(ext)) return 'text-emerald-600 dark:text-emerald-400'
+  if (AUDIO_EXTENSIONS.has(ext)) return 'text-fuchsia-600 dark:text-fuchsia-400'
+  if (VIDEO_EXTENSIONS.has(ext)) return 'text-violet-600 dark:text-violet-400'
+  if (ARCHIVE_EXTENSIONS.has(ext)) return 'text-amber-600 dark:text-amber-400'
+  if (DOCUMENT_EXTENSIONS.has(ext)) return 'text-blue-600 dark:text-blue-400'
+  return 'text-muted-foreground'
+}
+
+/**
+ * A small document-page glyph with a folded corner. Shows the file's
+ * extension (colored by type) — or arbitrary content (audio play button).
+ */
+function PageGlyph({ ext, children }: { ext?: string; children?: React.ReactNode }) {
+  return (
+    <div className="relative flex h-11 w-9 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-background shadow-xs dark:bg-muted/60">
+      <div
+        className="absolute -right-px -top-px size-3 rounded-bl-md border-b border-l border-border bg-muted"
+        aria-hidden
+      />
+      {children ?? (
+        <span className={cn('text-[8.5px] font-bold tracking-wider', ext ? extAccentClass(ext) : 'text-muted-foreground')}>
+          {ext ? getExtLabel(ext) : 'FILE'}
+        </span>
+      )}
+    </div>
+  )
+}
+
+// Shared card shell used by all variants: page glyph, two-line text block,
+// always-visible Open plus a hover-revealed reveal-in-Finder action.
 function CardShell({
   icon,
   title,
@@ -54,16 +96,39 @@ function CardShell({
       tabIndex={onClick ? 0 : undefined}
       onClick={onClick}
       onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
-      className="flex items-center gap-3 rounded-xl border border-border bg-card p-3 pr-4 text-left transition-colors hover:bg-accent/50 cursor-pointer w-full my-2"
+      title={title}
+      className="group my-2 flex w-full cursor-pointer items-center gap-3.5 rounded-xl border border-border/60 bg-card py-3 pl-3.5 pr-3 text-left transition-all hover:border-border hover:bg-accent/40 hover:shadow-sm"
     >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
-        {icon}
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="truncate text-sm font-medium">{title}</div>
-        <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
+      {icon}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[13px] font-medium leading-tight text-foreground">{title}</div>
+        <div className="truncate pt-0.5 text-[11.5px] leading-tight text-muted-foreground">{subtitle}</div>
       </div>
       {action}
+    </div>
+  )
+}
+
+function OpenAction({ filePath, showReveal }: { filePath: string; showReveal?: boolean }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {showReveal && (
+        <button
+          type="button"
+          title="Reveal in Finder"
+          aria-label="Reveal in Finder"
+          onClick={(e) => {
+            e.stopPropagation()
+            void window.ipc.invoke('shell:showItemInFolder', { path: filePath })
+          }}
+          className="flex size-8 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100"
+        >
+          <FolderOpen className="size-4" />
+        </button>
+      )}
+      <Button variant="outline" size="sm" className="pointer-events-none h-8 shrink-0 rounded-lg text-xs">
+        Open
+      </Button>
     </div>
   )
 }
@@ -79,15 +144,11 @@ function KnowledgeFileCard({ filePath }: { filePath: string }) {
 
   return (
     <CardShell
-      icon={<BookOpen className="h-5 w-5 text-muted-foreground" />}
+      icon={<PageGlyph ext={ext} />}
       title={label}
-      subtitle={extLabel ? `Knowledge \u00b7 ${extLabel}` : 'Knowledge'}
+      subtitle={extLabel ? `Knowledge · ${extLabel}` : 'Knowledge'}
       onClick={() => { setActiveSection('knowledge'); onOpenKnowledgeFile(filePath) }}
-      action={
-        <Button variant="outline" size="sm" className="shrink-0 text-xs h-8 rounded-lg pointer-events-none">
-          Open
-        </Button>
-      }
+      action={<OpenAction filePath={filePath} />}
     />
   )
 }
@@ -145,25 +206,21 @@ function AudioFileCard({ filePath }: { filePath: string }) {
   return (
     <CardShell
       icon={
-        <button
-          onClick={handlePlayPause}
-          disabled={isLoading}
-          className="flex h-full w-full items-center justify-center"
-        >
-          {isPlaying
-            ? <Pause className="h-5 w-5 text-muted-foreground" />
-            : <Play className="h-5 w-5 text-muted-foreground" />
-          }
-        </button>
+        <PageGlyph ext={ext}>
+          <button
+            onClick={handlePlayPause}
+            disabled={isLoading}
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+            className="flex h-full w-full items-center justify-center text-foreground"
+          >
+            {isPlaying ? <Pause className="size-4" /> : <Play className="size-4" />}
+          </button>
+        </PageGlyph>
       }
       title={getFileNameWithoutExt(filePath)}
-      subtitle={`Audio \u00b7 ${extLabel}`}
+      subtitle={`Audio · ${extLabel}`}
       onClick={handleOpen}
-      action={
-        <Button variant="outline" size="sm" className="shrink-0 text-xs h-8 rounded-lg pointer-events-none">
-          Open
-        </Button>
-      }
+      action={<OpenAction filePath={filePath} showReveal />}
     />
   )
 }
@@ -174,8 +231,12 @@ function SystemFileCard({ filePath }: { filePath: string }) {
   const ext = getExtension(filePath)
   const isImage = IMAGE_EXTENSIONS.has(ext)
   const [thumbnail, setThumbnail] = useState<string | null>(null)
-  const { label: categoryLabel, icon: CategoryIcon } = getFileCategory(ext)
+  const categoryLabel = getCategoryLabel(ext)
   const extLabel = getExtLabel(ext)
+  // PDFs open in Rowboat's own viewer (a file tab with the chat alongside);
+  // everything else still hands off to the OS.
+  const { onOpenKnowledgeFile: openInApp } = useFileCard()
+  const isPdf = ext === '.pdf'
 
   useEffect(() => {
     if (!isImage) return
@@ -191,6 +252,10 @@ function SystemFileCard({ filePath }: { filePath: string }) {
   }, [filePath, isImage])
 
   const handleOpen = async () => {
+    if (isPdf) {
+      openInApp(filePath)
+      return
+    }
     await window.ipc.invoke('shell:openPath', { path: filePath })
   }
 
@@ -198,17 +263,13 @@ function SystemFileCard({ filePath }: { filePath: string }) {
     <CardShell
       icon={
         thumbnail
-          ? <img src={thumbnail} alt="" className="h-10 w-10 rounded-lg object-cover" />
-          : <CategoryIcon className="h-5 w-5 text-muted-foreground" />
+          ? <img src={thumbnail} alt="" className="h-11 w-11 shrink-0 rounded-md border border-border object-cover" />
+          : <PageGlyph ext={ext} />
       }
       title={getFileNameWithoutExt(filePath)}
-      subtitle={extLabel ? `${categoryLabel} \u00b7 ${extLabel}` : categoryLabel}
+      subtitle={extLabel ? `${categoryLabel} · ${extLabel}` : categoryLabel}
       onClick={handleOpen}
-      action={
-        <Button variant="outline" size="sm" className="shrink-0 text-xs h-8 rounded-lg pointer-events-none">
-          Open
-        </Button>
-      }
+      action={<OpenAction filePath={filePath} showReveal />}
     />
   )
 }

--- a/apps/x/apps/renderer/src/components/chat-files-panel.tsx
+++ b/apps/x/apps/renderer/src/components/chat-files-panel.tsx
@@ -1,0 +1,52 @@
+import { X } from 'lucide-react'
+import { FilePathCard } from '@/components/ai-elements/file-path-card'
+import type { SessionFileEntry } from '@/lib/session-files'
+import { cn } from '@/lib/utils'
+
+/**
+ * Right-hand panel listing every file the agent created or modified in the
+ * current chat (derived via `collectSessionFiles`). Each row is a
+ * `FilePathCard`, so knowledge files open in the editor and system files open
+ * with the OS — same behavior as the inline cards in the conversation.
+ * Must render inside `FileCardProvider`.
+ */
+export function ChatFilesPanel({
+    files,
+    onClose,
+    className,
+}: {
+    files: SessionFileEntry[]
+    onClose: () => void
+    /** Override the default fixed-width right-panel layout (e.g. w-full overlay in the side-pane chat). */
+    className?: string
+}) {
+    return (
+        <div className={cn('flex w-[320px] shrink-0 flex-col border-l border-border bg-background', className)}>
+            <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
+                <span className="text-sm font-medium text-foreground">
+                    Files
+                    {files.length > 0 && (
+                        <span className="ml-1.5 text-xs font-normal text-muted-foreground">{files.length}</span>
+                    )}
+                </span>
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    aria-label="Close files panel"
+                >
+                    <X className="h-4 w-4" />
+                </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto px-3 py-1">
+                {files.length === 0 ? (
+                    <p className="px-2 py-10 text-center text-xs leading-relaxed text-muted-foreground">
+                        No files in this chat yet. Documents and files the agent creates will show up here.
+                    </p>
+                ) : (
+                    files.map(file => <FilePathCard key={file.path} filePath={file.path} />)
+                )}
+            </div>
+        </div>
+    )
+}

--- a/apps/x/apps/renderer/src/components/chat-header.tsx
+++ b/apps/x/apps/renderer/src/components/chat-header.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { ArrowUpRight, Bug, ChevronDown, MessageSquare, MoreHorizontal, Plus } from 'lucide-react'
+import { ArrowUpRight, Bug, ChevronDown, Files, MessageSquare, MoreHorizontal, Plus } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
@@ -32,6 +32,13 @@ export interface ChatHeaderProps {
   sessionUsage?: TokenUsage
   onSelectRun?: (runId: string) => void
   onOpenChatHistory?: () => void
+  /**
+   * Files panel wiring. The button renders when a toggle handler is provided
+   * and the chat has produced at least one file.
+   */
+  filesCount?: number
+  filesPanelOpen?: boolean
+  onToggleFilesPanel?: () => void
 }
 
 /**
@@ -49,6 +56,9 @@ export function ChatHeader({
   sessionUsage,
   onSelectRun,
   onOpenChatHistory,
+  filesCount = 0,
+  filesPanelOpen = false,
+  onToggleFilesPanel,
 }: ChatHeaderProps) {
   const hasHistory = recentRuns.length > 0 || Boolean(onOpenChatHistory)
   const showUsage = hasTokenUsage(sessionUsage)
@@ -135,6 +145,30 @@ export function ChatHeader({
           className="titlebar-no-drag my-1 shrink-0"
           align="end"
         />
+      )}
+      {onToggleFilesPanel && filesCount > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleFilesPanel}
+              className={cn(
+                'titlebar-no-drag relative my-1 h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground',
+                filesPanelOpen && 'bg-accent text-foreground',
+              )}
+              aria-label={filesPanelOpen ? 'Hide files panel' : 'Show files created in this chat'}
+            >
+              <Files className="size-4.5" />
+              {filesCount > 0 && (
+                <span className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 text-[9px] font-semibold leading-none text-primary-foreground">
+                  {filesCount > 9 ? '9+' : filesCount}
+                </span>
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Files created in this chat</TooltipContent>
+        </Tooltip>
       )}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -5,6 +5,8 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ChatHeader } from '@/components/chat-header'
+import { ChatFilesPanel } from '@/components/chat-files-panel'
+import type { SessionFileEntry } from '@/lib/session-files'
 import { type PromptInputMessage, type FileMention } from '@/components/ai-elements/prompt-input'
 import { FileCardProvider } from '@/contexts/file-card-context'
 import { type ChatTab } from '@/components/tab-bar'
@@ -108,6 +110,10 @@ interface ChatSidebarProps {
   isToolOpenForTab?: (tabId: string, toolId: string) => boolean
   onToolOpenChangeForTab?: (tabId: string, toolId: string, open: boolean) => void
   onOpenKnowledgeFile?: (path: string) => void
+  /** Files-created-in-chat panel wiring (shared state with the full-screen chat). */
+  sessionFiles?: SessionFileEntry[]
+  filesPanelOpen?: boolean
+  onToggleFilesPanel?: () => void
   onActivate?: () => void
   collapsedLeftPaddingPx?: number
   // Voice / TTS props
@@ -178,6 +184,9 @@ export function ChatSidebar({
   isToolOpenForTab,
   onToolOpenChangeForTab,
   onOpenKnowledgeFile,
+  sessionFiles,
+  filesPanelOpen,
+  onToggleFilesPanel,
   onActivate,
   collapsedLeftPaddingPx = 196,
   isRecording,
@@ -394,6 +403,9 @@ export function ChatSidebar({
                 sessionUsage={activeTabState.sessionUsage}
                 onSelectRun={onSelectRun}
                 onOpenChatHistory={onOpenChatHistory}
+                filesCount={sessionFiles?.length ?? 0}
+                filesPanelOpen={filesPanelOpen}
+                onToggleFilesPanel={onToggleFilesPanel}
               />
             )}
             {onOpenFullScreen && (
@@ -417,7 +429,7 @@ export function ChatSidebar({
           </header>
 
           <FileCardProvider onOpenKnowledgeFile={onOpenKnowledgeFile ?? (() => {})}>
-            <div className="flex min-h-0 flex-1 flex-col">
+            <div className="relative flex min-h-0 flex-1 flex-col">
               {/* Pane padding lives here, on the container — the shared chat pane renders identically on every surface. */}
               <div className="relative min-h-0 flex-1 px-3">
                 {chatTabs.map((tab) => {
@@ -496,6 +508,18 @@ export function ChatSidebar({
                   })}
                 </div>
               </div>
+
+              {/* Files panel — overlays the conversation; the pane is too
+                  narrow for a side-by-side split like the full-screen chat. */}
+              {filesPanelOpen && onToggleFilesPanel && (
+                <div className="absolute inset-0 z-20 bg-background">
+                  <ChatFilesPanel
+                    files={sessionFiles ?? []}
+                    onClose={onToggleFilesPanel}
+                    className="h-full w-full border-l-0"
+                  />
+                </div>
+              )}
             </div>
           </FileCardProvider>
         </>

--- a/apps/x/apps/renderer/src/components/pdf-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/pdf-file-viewer.tsx
@@ -7,14 +7,44 @@ interface PdfFileViewerProps {
 
 type State = 'loading' | 'ready' | 'error'
 
+// Workspace-relative paths stream through the app://workspace protocol.
+// Absolute / ~ paths (e.g. a PDF the agent saved to the Desktop) are outside
+// the protocol's boundary guard, so they load through shell:readFileBase64
+// into a blob URL instead — capped at 10MB by that IPC, with the error state's
+// "Open in system" button as the fallback for anything bigger.
+const isOutsideWorkspace = (path: string): boolean =>
+  path.startsWith('/') || path.startsWith('~')
+
 export function PdfFileViewer({ path }: PdfFileViewerProps) {
   const [state, setState] = useState<State>('loading')
+  const [blobSrc, setBlobSrc] = useState<string | null>(null)
+  const external = isOutsideWorkspace(path)
 
   useEffect(() => {
     setState('loading')
-  }, [path])
+    setBlobSrc(null)
+    if (!external) return
+    let cancelled = false
+    let url: string | null = null
+    window.ipc.invoke('shell:readFileBase64', { path })
+      .then(({ data }) => {
+        if (cancelled) return
+        const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0))
+        url = URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' }))
+        setBlobSrc(url)
+      })
+      .catch(() => {
+        if (!cancelled) setState('error')
+      })
+    return () => {
+      cancelled = true
+      if (url) URL.revokeObjectURL(url)
+    }
+  }, [path, external])
 
-  const src = `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`
+  const src = external
+    ? blobSrc
+    : `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`
 
   if (state === 'error') {
     return (
@@ -37,14 +67,16 @@ export function PdfFileViewer({ path }: PdfFileViewerProps) {
 
   return (
     <div className="relative h-full w-full">
-      <iframe
-        key={path}
-        src={src}
-        className="h-full w-full border-0 bg-white"
-        title="PDF preview"
-        onLoad={() => setState('ready')}
-        onError={() => setState('error')}
-      />
+      {src && (
+        <iframe
+          key={path}
+          src={src}
+          className="h-full w-full border-0 bg-white"
+          title="PDF preview"
+          onLoad={() => setState('ready')}
+          onError={() => setState('error')}
+        />
+      )}
       {state === 'loading' && (
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background text-muted-foreground">
           <Loader2Icon className="size-6 animate-spin" />

--- a/apps/x/apps/renderer/src/lib/session-files.ts
+++ b/apps/x/apps/renderer/src/lib/session-files.ts
@@ -1,0 +1,119 @@
+import type { ConversationItem } from '@/lib/chat-conversation'
+import { isChatMessage, isToolCall, normalizeToolInput } from '@/lib/chat-conversation'
+
+// ---------------------------------------------------------------------------
+// Files created in a chat
+//
+// Pure derivation over the session's conversation items (which span every
+// turn of the session), from two sources:
+//
+//   1. Completed file-writing tool calls (file-writeText etc.). Renames
+//      follow the file, removes drop it, so the list reflects where files
+//      ended up — not every intermediate step.
+//   2. ```filepath fences in assistant messages — the same fences that
+//      render as inline FilePathCards. This is how files produced outside
+//      the file-* tools (shell-generated PDFs, exports) surface.
+//
+// Powers the "Files" panel in the chat header.
+// ---------------------------------------------------------------------------
+
+export interface SessionFileEntry {
+    /** Workspace-relative or absolute path, exactly as the tool received it. */
+    path: string
+    /** How the file entered the chat: written whole vs. edited in place. */
+    action: 'created' | 'edited'
+    /** Timestamp of the most recent completed tool call that touched it. */
+    timestamp: number
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+    value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+
+const asString = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.trim() ? value.trim() : undefined
+
+// Scratch files (the presentations skill's tmp/convert.js etc.) are build
+// intermediates, not deliverables — keep them out of the panel.
+const isScratchPath = (p: string): boolean =>
+    p.startsWith('tmp/') || p.startsWith('./tmp/')
+
+// Matches the ```filepath fences that markdown-code-override renders as
+// inline FilePathCards. A fence may carry several paths, one per line.
+const FILEPATH_FENCE = /```filepath\s*\n([\s\S]*?)```/g
+
+export function collectSessionFiles(items: ConversationItem[]): SessionFileEntry[] {
+    const entries = new Map<string, SessionFileEntry>()
+
+    const touch = (rawPath: unknown, action: SessionFileEntry['action'], timestamp: number) => {
+        const path = asString(rawPath)
+        if (!path || isScratchPath(path)) return
+        const existing = entries.get(path)
+        // First touch decides the action label; later touches only refresh
+        // the timestamp (a created-then-edited file is still "created" here).
+        if (existing) existing.timestamp = timestamp
+        else entries.set(path, { path, action, timestamp })
+    }
+
+    for (const item of items) {
+        if (isChatMessage(item)) {
+            if (item.role !== 'assistant') continue
+            for (const match of item.content.matchAll(FILEPATH_FENCE)) {
+                for (const line of match[1].split('\n')) {
+                    touch(line, 'created', item.timestamp)
+                }
+            }
+            continue
+        }
+        if (!isToolCall(item) || item.status !== 'completed') continue
+        const input = asRecord(normalizeToolInput(item.input))
+        const result = asRecord(item.result)
+        const ts = item.timestamp
+
+        switch (item.name) {
+            case 'file-writeText':
+                touch(input?.path, 'created', ts)
+                break
+            case 'file-editText':
+                touch(input?.path, 'edited', ts)
+                break
+            case 'file-copy':
+                touch(input?.to, 'created', ts)
+                break
+            case 'file-rename': {
+                // Only follow files this chat already produced — renaming a
+                // pre-existing file doesn't make it a chat artifact.
+                const from = asString(input?.from)
+                const to = asString(input?.to)
+                const tracked = from ? entries.get(from) : undefined
+                if (tracked && from) {
+                    entries.delete(from)
+                    if (to && !isScratchPath(to)) {
+                        entries.set(to, { ...tracked, path: to, timestamp: ts })
+                    }
+                }
+                break
+            }
+            case 'file-remove': {
+                const path = asString(input?.path)
+                if (path) entries.delete(path)
+                break
+            }
+            case 'code_agent_run': {
+                // Coding runs report repo-relative paths; anchor them to the
+                // run's cwd so the cards can open them. Without a cwd in the
+                // args there's nothing reliable to anchor to — skip those.
+                const changed = Array.isArray(result?.changedFiles) ? result.changedFiles : []
+                const cwd = asString(input?.cwd)?.replace(/\/+$/, '')
+                for (const file of changed) {
+                    const rel = asString(file)
+                    if (!rel) continue
+                    if (rel.startsWith('/') || rel.startsWith('~')) touch(rel, 'edited', ts)
+                    else if (cwd) touch(`${cwd}/${rel}`, 'edited', ts)
+                }
+                break
+            }
+        }
+    }
+
+    return [...entries.values()]
+}


### PR DESCRIPTION
## What

Claude-style "Files" experience for chats: see every file/doc the agent created in the current chat at a glance, open PDFs inside Rowboat, and cleaner file cards.

### Files panel
- **`lib/session-files.ts`** — pure derivation of the chat's files from two sources: completed file-writing tool calls (`file-writeText` / `editText` / `copy` / `rename` follows the file / `remove` drops it / `code_agent_run` changedFiles anchored to cwd), and ` ```filepath ` fences in assistant messages (the same fences that render inline cards — this is how shell-generated files like PDFs surface). Deduped by path; `tmp/` scratch files filtered.
- **`components/chat-files-panel.tsx`** — right-hand panel (mirrors version-history-panel's shell) listing each file as a `FilePathCard`.
- **Header button** — a Files icon with a count badge appears in the chat header once the chat has ≥1 file. Wired in both the full-screen chat (side-by-side panel) and the side-pane chat (full-pane overlay — the pane is too narrow for a split). Shared open/close state.

### In-app PDF viewing
- Clicking Open on a PDF card routes to the existing file-view flow (file tab + `PdfFileViewer`, chat docks to the side pane) instead of the OS viewer.
- `PdfFileViewer` now also handles absolute/`~` paths (e.g. agent-saved Desktop PDFs) by loading through `shell:readFileBase64` into a blob URL — the `app://workspace` protocol is boundary-guarded and can't serve them. Files over the 10MB IPC cap fall back to the existing "Open in system" state.
- Fixed a `navigateToView` no-op: re-navigating to the already-open file from a maximized chat pane now un-maximizes so the file becomes visible.

### File card redesign
- `FilePathCard` gets a document-page glyph (folded corner, extension label color-accented by type) instead of generic lucide icons, tighter typography, hover polish, and a hover-revealed "Reveal in Finder" action. Full-width as before.

## Notes
- Renderer-only; no IPC or schema changes. `npm run typecheck` passes.
- Known gap: files written by sub-agents (`spawn-agent` child turns) aren't in the parent conversation, so they don't appear in the panel yet — needs per-child-turn transcript fetches as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)