### PR TITLE
fix(todo): make sticky-dismissed suggestions immune to feedback-log truncation

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -2632,7 +2632,7 @@ export function setupIpcHandlers() {
         // and it is a positive taste signal. Delegated text still waits for
         // the user's explicit go — accepting is not running.
         await addTodoItem(taken, { proposed: true });
-        void recordPlannerSignal('kept', taken).catch(() => {});
+        await recordPlannerSignal('kept', taken).catch(() => {});
         todoBus.publish({ type: 'list_changed' });
         return { success: true };
       } catch (err) {
@@ -2643,7 +2643,7 @@ export function setupIpcHandlers() {
       try {
         const taken = await takeTodoSuggestion(args.text);
         if (!taken) return { success: false, error: 'Suggestion no longer exists' };
-        void recordPlannerSignal('dismissed', taken).catch(() => {});
+        await recordPlannerSignal('dismissed', taken).catch(() => {});
         todoBus.publish({ type: 'list_changed' });
         return { success: true };
       } catch (err) {
@@ -2761,7 +2761,7 @@ export function setupIpcHandlers() {
         const found = await findTodoItem(args.key).catch(() => null);
         const ok = await dismissTodoItem(args.key);
         if (ok && found?.item.proposed) {
-          void recordPlannerSignal('dismissed', found.item.text).catch(() => {});
+          await recordPlannerSignal('dismissed', found.item.text).catch(() => {});
         }
         todoBus.publish({ type: 'list_changed' });
         return ok ? { success: true, wasProposed: !!found?.item.proposed } : { success: false, error: 'Item not found' };
@@ -2772,7 +2772,7 @@ export function setupIpcHandlers() {
     'todo:teach': async (_event, args) => {
       try {
         await addPlannerRule(`Don't suggest items like: "${args.text}"`);
-        void recordPlannerSignal('taught', args.text).catch(() => {});
+        await recordPlannerSignal('taught', args.text).catch(() => {});
         return { success: true };
       } catch (err) {
         return { success: false, error: err instanceof Error ? err.message : String(err) };

--- a/apps/x/packages/core/src/todo/planner-memory.test.ts
+++ b/apps/x/packages/core/src/todo/planner-memory.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeKey } from "./fileops.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "rowboat-planner-memory-test-"));
+    process.env.ROWBOAT_WORKDIR = tmpDir;
+    vi.resetModules();
+    // config.js kicks off async filesystem/git initialization at import time.
+    // Keep these tests focused on planner-memory's files.
+    vi.doMock("../knowledge/version_history.js", () => ({
+        commitAll: vi.fn(async () => undefined),
+        initRepo: vi.fn(async () => undefined),
+    }));
+    vi.doMock("../knowledge/deprecate_today_note.js", () => ({
+        deprecateTodayNote: vi.fn(async () => undefined),
+    }));
+});
+
+afterEach(async () => {
+    delete process.env.ROWBOAT_WORKDIR;
+    vi.doUnmock("../knowledge/version_history.js");
+    vi.doUnmock("../knowledge/deprecate_today_note.js");
+    vi.resetModules();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function loadPlannerMemory() {
+    return import("./planner-memory.js");
+}
+
+describe("planner memory sticky dismissals", () => {
+    it("keeps dismissed keys sticky after the bounded feedback ledger rolls over", async () => {
+        const { recordPlannerSignal, stickyDismissedKeys } = await loadPlannerMemory();
+        const dismissed = "Resurface quarterly pricing research";
+
+        await recordPlannerSignal("dismissed", dismissed);
+        expect(await stickyDismissedKeys()).toContain(normalizeKey(dismissed));
+
+        for (let i = 0; i < 260; i++) {
+            const text = `Unrelated planner item ${i}`;
+            await recordPlannerSignal(i % 2 === 0 ? "proposed" : "ran", text);
+        }
+
+        expect(await stickyDismissedKeys()).toContain(normalizeKey(dismissed));
+    });
+
+    it("treats taught signals as sticky dismissals", async () => {
+        const { recordPlannerSignal, stickyDismissedKeys } = await loadPlannerMemory();
+        const taught = "Suggest a weekly vanity metrics review";
+
+        await recordPlannerSignal("taught", taught);
+
+        expect(await stickyDismissedKeys()).toEqual(new Set([normalizeKey(taught)]));
+    });
+
+    it("removes a sticky dismissal after a later ran or kept signal for the same key", async () => {
+        const { recordPlannerSignal, stickyDismissedKeys } = await loadPlannerMemory();
+        const ran = "Draft investor update";
+        const kept = "Review onboarding funnel";
+
+        await recordPlannerSignal("dismissed", ran);
+        await recordPlannerSignal("taught", kept);
+        expect(await stickyDismissedKeys()).toEqual(new Set([
+            normalizeKey(ran),
+            normalizeKey(kept),
+        ]));
+
+        await recordPlannerSignal("ran", ran);
+        expect(await stickyDismissedKeys()).toEqual(new Set([normalizeKey(kept)]));
+
+        await recordPlannerSignal("kept", kept);
+        expect(await stickyDismissedKeys()).toEqual(new Set());
+    });
+});

--- a/apps/x/packages/core/src/todo/planner-memory.ts
+++ b/apps/x/packages/core/src/todo/planner-memory.ts
@@ -16,14 +16,17 @@ const log = new PrefixLogger('Todo:PlannerMemory');
 //   hand; the machine NEVER edits it) outranks "## Learned" (distilled from
 //   signals; regenerated; delete a line and it stays gone until re-earned).
 // - `todo/planner_feedback.json` — the raw signal ledger (losable): what was
-//   proposed and what the user did with it. Sticky verdicts and few-shot
-//   examples derive from here.
+//   proposed and what the user did with it. Few-shot examples derive from here.
+// - `todo/sticky_dismissed.json` — uncapped negative verdicts. The recent
+//   ledger may roll over; sticky dismissals must not.
 // ---------------------------------------------------------------------------
 
 const PREFS_PATH = path.join(WorkDir, 'todo', 'preferences.md');
 export const PREFS_REL_PATH = 'todo/preferences.md';
 const FEEDBACK_PATH = path.join(WorkDir, 'todo', 'planner_feedback.json');
 export const FEEDBACK_REL_PATH = 'todo/planner_feedback.json';
+const STICKY_PATH = path.join(WorkDir, 'todo', 'sticky_dismissed.json');
+export const STICKY_REL_PATH = 'todo/sticky_dismissed.json';
 
 const MAX_SIGNALS = 200;
 
@@ -56,6 +59,16 @@ interface PlannerFeedback {
     signals: PlannerSignal[];
 }
 
+type StickyKind = Extract<PlannerSignalKind, 'dismissed' | 'taught'>;
+
+interface StickyDismissedEntry {
+    itemText: string;
+    kind: StickyKind;
+    at: string;
+}
+
+type StickyDismissedStore = Record<string, StickyDismissedEntry>;
+
 async function readFeedback(): Promise<PlannerFeedback> {
     try {
         const parsed: unknown = JSON.parse(await fs.readFile(FEEDBACK_PATH, 'utf-8'));
@@ -68,10 +81,42 @@ async function readFeedback(): Promise<PlannerFeedback> {
     return { signals: [] };
 }
 
+async function readStickyDismissed(): Promise<StickyDismissedStore> {
+    try {
+        const parsed: unknown = JSON.parse(await fs.readFile(STICKY_PATH, 'utf-8'));
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            const out: StickyDismissedStore = {};
+            for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+                if (!key || !value || typeof value !== 'object') continue;
+                const entry = value as Partial<StickyDismissedEntry>;
+                if (
+                    typeof entry.itemText === 'string'
+                    && (entry.kind === 'dismissed' || entry.kind === 'taught')
+                    && typeof entry.at === 'string'
+                ) {
+                    out[key] = { itemText: entry.itemText, kind: entry.kind, at: entry.at };
+                }
+            }
+            return out;
+        }
+    } catch {
+        // missing/corrupt — fresh sticky store
+    }
+    return {};
+}
+
+async function writeStickyDismissed(store: StickyDismissedStore): Promise<void> {
+    const dir = path.dirname(STICKY_PATH);
+    if (!fsSync.existsSync(dir)) fsSync.mkdirSync(dir, { recursive: true });
+    await fs.writeFile(STICKY_PATH, JSON.stringify(store, null, 2), 'utf-8');
+}
+
 export async function recordPlannerSignal(kind: PlannerSignalKind, itemText: string): Promise<void> {
+    const key = normalizeKey(itemText);
+    const at = new Date().toISOString();
     await withFileLock(FEEDBACK_PATH, async () => {
         const feedback = await readFeedback();
-        feedback.signals.push({ kind, itemText, key: normalizeKey(itemText), at: new Date().toISOString() });
+        feedback.signals.push({ kind, itemText, key, at });
         if (feedback.signals.length > MAX_SIGNALS) {
             feedback.signals = feedback.signals.slice(-MAX_SIGNALS);
         }
@@ -79,20 +124,24 @@ export async function recordPlannerSignal(kind: PlannerSignalKind, itemText: str
         if (!fsSync.existsSync(dir)) fsSync.mkdirSync(dir, { recursive: true });
         await fs.writeFile(FEEDBACK_PATH, JSON.stringify(feedback, null, 2), 'utf-8');
     });
+    if (kind === 'dismissed' || kind === 'taught' || kind === 'ran' || kind === 'kept') {
+        await withFileLock(STICKY_PATH, async () => {
+            const sticky = await readStickyDismissed();
+            if (kind === 'dismissed' || kind === 'taught') {
+                sticky[key] = { itemText, kind, at };
+            } else {
+                delete sticky[key];
+            }
+            await writeStickyDismissed(sticky);
+        });
+    }
     log.log(`signal: ${kind} — "${itemText.slice(0, 60)}"`);
 }
 
 /** Sticky negative verdicts: keys the user dismissed and never later ran.
  * The propose tool refuses to re-propose these. */
 export async function stickyDismissedKeys(): Promise<Set<string>> {
-    const { signals } = await readFeedback();
-    const verdict = new Map<string, PlannerSignalKind>();
-    for (const s of signals) verdict.set(s.key, s.kind);
-    const out = new Set<string>();
-    for (const [key, kind] of verdict) {
-        if (kind === 'dismissed' || kind === 'taught') out.add(key);
-    }
-    return out;
+    return new Set(Object.keys(await readStickyDismissed()));
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/x/packages/core/src/todo/runner.ts
+++ b/apps/x/packages/core/src/todo/runner.ts
@@ -405,7 +405,7 @@ export async function runTodoItem(
         if (item.proposed && item.receipts.length === 0) {
             // The user gave a planner proposal its go — a positive signal.
             const { recordPlannerSignal } = await import('./planner-memory.js');
-            void recordPlannerSignal('ran', item.text).catch(() => {});
+            await recordPlannerSignal('ran', item.text).catch(() => {});
         }
         const { sessions } = await resolveDeps();
         const title = parent ? `${item.text} · ${parent.text}` : item.text;


### PR DESCRIPTION
## Summary

Fixes a bug where the Home suggestion tray could re-show a suggestion the user had already declined. The sticky-dismissed verdict was previously derived from the bounded 200-entry planner feedback ledger, so enough unrelated signals could truncate the original dismissal and allow the suggestion to be proposed again.

This change adds a new uncapped `todo/sticky_dismissed.json` store separate from the bounded feedback ledger. Dismissed and taught signals upsert into that sticky store, while later ran or kept signals remove the key to preserve the existing override semantics. The bounded ledger remains in place for recent outcome examples.

It also awaits planner signal persistence at the accept, decline, dismiss, teach, and run call sites while still swallowing signal-recording failures, closing the race where a planner run could read sticky dismissals before a just-recorded user action had reached disk.

Fixes #830

## Testing

- Added unit tests in `apps/x/packages/core/src/todo/planner-memory.test.ts` covering sticky dismissal persistence past feedback-log truncation, taught signals, and ran/kept overrides.
- `npm test -- src/todo/fileops.test.ts src/todo/planner-memory.test.ts`: 2 files passed, 11 tests passed.
- `npm test` in `apps/x/packages/core`: 54 files passed, 583 tests passed.
- `npm run typecheck` in `apps/x/packages/core`: passed.
- `npm run build` in `apps/x/packages/core`: passed.
- `npm run build` in `apps/x/apps/main`: passed.