### PR TITLE
fix(x): strip provider continuation metadata on mid-session model switch

### DIFF
--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -390,7 +390,10 @@ Materialization is performed by an injected resolver:
 
 ```ts
 interface IContextResolver {
-  resolve(context: TurnContext): Promise<ConversationMessage[]>;
+  resolve(
+    context: TurnContext,
+    currentModel: ModelDescriptor,
+  ): Promise<ConversationMessage[]>;
 }
 ```
 
@@ -407,6 +410,36 @@ Rules:
 - A reference to a missing or corrupt turn file is an infrastructure error.
   It rejects the execution and does not append `turn_failed`.
 - The reducer treats `context` as opaque data and never resolves references.
+
+Provider continuation metadata (`providerOptions` on assistant messages and
+their parts — Anthropic thinking signatures, OpenAI encrypted reasoning,
+Gemini thoughtSignatures, OpenRouter reasoning_details) is sealed to the
+exact endpoint that minted it; replaying it after a mid-session model
+switch is rejected by providers (e.g. OpenRouter 404 "encrypted payloads
+can only be replayed to the endpoint that created them"). `currentModel` is
+the model the materialized context is about to be sent to, and gates
+replay per walked segment:
+
+- A segment replays verbatim — metadata included — only when its producing
+  turn's `agent.resolved.model` equals `currentModel` (strict
+  provider-instance + model-id equality) AND that turn completed cleanly.
+  Same-model continuations rely on this fidelity (and it keeps provider
+  prefix caches byte-stable).
+- Every other segment — a different producing model, a failed or cancelled
+  producing turn, and always the inline base (its origin is unrecorded;
+  migrated runs may carry foreign metadata) — passes through
+  `stripProviderContinuation` (shared/turns.ts): message- and part-level
+  `providerOptions` are dropped, reasoning parts with visible text are
+  demoted to plain text parts (the continuation model keeps the
+  information, loses the opaque blobs), and signature-only reasoning parts
+  are dropped.
+
+Within-turn replay (`assistant:N` request refs, §8.3) never passes through
+the resolver, so signatures between tool calls of the in-progress loop —
+the one place providers hard-require them — are preserved by construction.
+Stripping is deterministic per message and happens at materialization only;
+durable turn files keep full fidelity, so switching back to the original
+model restores verbatim replay of its segments.
 
 The app wires the resolver through a decorator (`context-elision.ts`) that
 applies transmit-time elision to the materialized prefix: tool results from

--- a/apps/x/packages/core/src/runtime/turns/compose-model-request.ts
+++ b/apps/x/packages/core/src/runtime/turns/compose-model-request.ts
@@ -64,7 +64,10 @@ export async function materializeModelRequest(
     contextResolver: IContextResolver,
     encode: (messages: Array<z.infer<typeof ConversationMessage>>) => JsonValue[],
 ): Promise<ComposedModelRequest> {
-    const prefix = await contextResolver.resolve(state.definition.context);
+    const prefix = await contextResolver.resolve(
+        state.definition.context,
+        state.definition.agent.resolved.model,
+    );
     const agent = await contextResolver.resolveAgent(
         state.definition.agent.resolved,
     );

--- a/apps/x/packages/core/src/runtime/turns/context-elision.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/context-elision.test.ts
@@ -170,6 +170,8 @@ function frame(source: "camera" | "screen") {
 }
 
 const T1 = "2026-07-02T10-00-00Z-0000001-000";
+// Matches the fixture turn logs' model, so resolution replays verbatim.
+const FIXTURE_MODEL = { provider: "fake", model: "m" };
 
 describe("elideHistoricToolResults", () => {
     it("replaces tool results above the threshold with a placeholder", () => {
@@ -335,7 +337,7 @@ describe("createContextResolver", () => {
         const resolved = await createContextResolver({
             turnRepo: repo,
             loadPolicy: () => DEFAULT_ELISION_POLICY,
-        }).resolve({ previousTurnId: T1 });
+        }).resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toContain("elided");
         expect(tool?.content.length).toBeLessThan(1000);
@@ -356,7 +358,7 @@ describe("ElidingContextResolver", () => {
         const resolved = await resolver(repo, {
             ...POLICY_OFF,
             toolResults: true,
-        }).resolve({ previousTurnId: T1 });
+        }).resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toContain("elided");
         // The rest of the transcript is intact.
@@ -372,9 +374,7 @@ describe("ElidingContextResolver", () => {
         const repo = new InMemoryTurnRepo();
         const output = "x".repeat(200);
         repo.seed(toolTurnLog(T1, [], output));
-        const resolved = await resolver(repo, POLICY_OFF).resolve({
-            previousTurnId: T1,
-        });
+        const resolved = await resolver(repo, POLICY_OFF).resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toBe(output);
     });
@@ -385,7 +385,7 @@ describe("ElidingContextResolver", () => {
         const resolved = await resolver(repo, {
             ...POLICY_OFF,
             toolResults: true,
-        }).resolve({ previousTurnId: T1 });
+        }).resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         const tool = resolved.find((m) => m.role === "tool");
         expect(tool?.content).toBe("small");
     });
@@ -410,7 +410,7 @@ describe("ElidingContextResolver", () => {
         const resolved = await resolver(repo, {
             ...POLICY_OFF,
             images: true,
-        }).resolve({ previousTurnId: T1 });
+        }).resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         const input = resolved[0];
         if (input.role !== "user" || typeof input.content === "string") {
             throw new Error("expected user message with parts");
@@ -430,7 +430,7 @@ describe("ElidingContextResolver", () => {
         const resolved = await resolver(repo, {
             ...POLICY_OFF,
             middlePaneContent: true,
-        }).resolve({ previousTurnId: T1 });
+        }).resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         const input = resolved[0];
         if (input.role !== "user") throw new Error("expected user message");
         const middlePane = input.userMessageContext?.middlePane;
@@ -458,7 +458,7 @@ describe("ElidingContextResolver", () => {
         const resolved = await resolver(repo, {
             ...POLICY_OFF,
             toolResults: true,
-        }).resolve({ previousTurnId: T2 });
+        }).resolve({ previousTurnId: T2 }, FIXTURE_MODEL);
         const tools = resolved.filter((m) => m.role === "tool");
         expect(tools).toHaveLength(2);
         for (const tool of tools) {
@@ -478,8 +478,8 @@ describe("ElidingContextResolver", () => {
                 return { ...POLICY_OFF, toolResults: loads > 1 };
             },
         });
-        const first = await eliding.resolve({ previousTurnId: T1 });
-        const second = await eliding.resolve({ previousTurnId: T1 });
+        const first = await eliding.resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
+        const second = await eliding.resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         expect(loads).toBe(2);
         expect(first.find((m) => m.role === "tool")?.content).toBe(output);
         expect(second.find((m) => m.role === "tool")?.content).toContain("elided");

--- a/apps/x/packages/core/src/runtime/turns/context-elision.ts
+++ b/apps/x/packages/core/src/runtime/turns/context-elision.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { z } from "zod";
 import type {
     ConversationMessage,
+    ModelDescriptor,
     ResolvedAgent,
     ResolvedAgentSnapshot,
     TurnContext,
@@ -203,8 +204,9 @@ export class ElidingContextResolver implements IContextResolver {
 
     async resolve(
         context: z.infer<typeof TurnContext>,
+        currentModel: z.infer<typeof ModelDescriptor>,
     ): Promise<Array<z.infer<typeof ConversationMessage>>> {
-        let prefix = await this.inner.resolve(context);
+        let prefix = await this.inner.resolve(context, currentModel);
         const policy = this.loadPolicy();
         if (policy.toolResults) {
             prefix = elideHistoricToolResults(

--- a/apps/x/packages/core/src/runtime/turns/context-resolver.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/context-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { z } from "zod";
 import {
+    type ConversationMessage,
     MODEL_CALL_LIMIT_ERROR_CODE,
     type TurnContext,
     TurnCorruptionError,
@@ -25,8 +26,13 @@ function completedTurnLog(
     context: z.infer<typeof TurnContext>,
     inputText: string,
     responseText: string,
+    overrides?: {
+        model?: { provider: string; model: string };
+        response?: z.infer<typeof ConversationMessage> & { role: "assistant" };
+    },
 ): TEvent[] {
     const ts = "2026-07-02T10:00:00Z";
+    const response = overrides?.response ?? assistant(responseText);
     return [
         {
             type: "turn_created",
@@ -39,7 +45,7 @@ function completedTurnLog(
                 resolved: {
                     agentId: "copilot",
                     systemPrompt: "SYS",
-                    model: { provider: "fake", model: "m" },
+                    model: overrides?.model ?? { provider: "fake", model: "m" },
                     tools: [],
                 },
             },
@@ -70,7 +76,7 @@ function completedTurnLog(
             turnId,
             ts,
             modelCallIndex: 0,
-            message: assistant(responseText),
+            message: response,
             finishReason: "stop",
             usage: {},
         },
@@ -78,7 +84,7 @@ function completedTurnLog(
             type: "turn_completed",
             turnId,
             ts,
-            output: assistant(responseText),
+            output: response,
             finishReason: "stop",
             usage: {},
         },
@@ -105,6 +111,7 @@ function limitFailedTurnLog(turnId: string): TEvent[] {
                 toolCallId: "tc1",
                 toolName: "echo",
                 arguments: {},
+                providerOptions: { google: { thoughtSignature: "sig" } },
             },
         ],
     };
@@ -181,23 +188,26 @@ function limitFailedTurnLog(turnId: string): TEvent[] {
     ];
 }
 
+// Matches the fixture turn logs' model, so resolution replays verbatim.
+const FIXTURE_MODEL = { provider: "fake", model: "m" };
+
 const T1 = "2026-07-02T10-00-00Z-0000001-000";
 const T2 = "2026-07-02T10-00-00Z-0000002-000";
 const T3 = "2026-07-02T10-00-00Z-0000003-000";
 
 describe("TurnRepoContextResolver", () => {
-    it("passes inline context through unchanged", async () => {
+    it("passes plain inline context through unchanged", async () => {
         const repo = new InMemoryTurnRepo();
         const resolver = new TurnRepoContextResolver({ turnRepo: repo });
         const inline = [user("a"), assistant("b")];
-        expect(await resolver.resolve(inline)).toEqual(inline);
+        expect(await resolver.resolve(inline, FIXTURE_MODEL)).toEqual(inline);
     });
 
     it("resolves a single reference to the referenced turn's transcript", async () => {
         const repo = new InMemoryTurnRepo();
         repo.seed(completedTurnLog(T1, [], "first question", "first answer"));
         const resolver = new TurnRepoContextResolver({ turnRepo: repo });
-        expect(await resolver.resolve({ previousTurnId: T1 })).toEqual([
+        expect(await resolver.resolve({ previousTurnId: T1 }, FIXTURE_MODEL)).toEqual([
             user("first question"),
             assistant("first answer"),
         ]);
@@ -209,7 +219,7 @@ describe("TurnRepoContextResolver", () => {
         repo.seed(completedTurnLog(T2, { previousTurnId: T1 }, "q2", "a2"));
         repo.seed(completedTurnLog(T3, { previousTurnId: T2 }, "q3", "a3"));
         const resolver = new TurnRepoContextResolver({ turnRepo: repo });
-        expect(await resolver.resolve({ previousTurnId: T3 })).toEqual([
+        expect(await resolver.resolve({ previousTurnId: T3 }, FIXTURE_MODEL)).toEqual([
             user("preamble"),
             user("q1"),
             assistant("a1"),
@@ -224,7 +234,7 @@ describe("TurnRepoContextResolver", () => {
         const repo = new InMemoryTurnRepo();
         repo.seed(limitFailedTurnLog(T1));
         const resolver = new TurnRepoContextResolver({ turnRepo: repo });
-        const resolved = await resolver.resolve({ previousTurnId: T1 });
+        const resolved = await resolver.resolve({ previousTurnId: T1 }, FIXTURE_MODEL);
         expect(resolved.map((m) => m.role)).toEqual(["user", "assistant", "tool"]);
         expect(resolved[2]).toMatchObject({
             role: "tool",
@@ -237,7 +247,7 @@ describe("TurnRepoContextResolver", () => {
         const repo = new InMemoryTurnRepo();
         const resolver = new TurnRepoContextResolver({ turnRepo: repo });
         await expect(
-            resolver.resolve({ previousTurnId: T1 }),
+            resolver.resolve({ previousTurnId: T1 }, FIXTURE_MODEL),
         ).rejects.toThrowError(/turn not found/);
     });
 
@@ -324,7 +334,172 @@ describe("TurnRepoContextResolver", () => {
         repo.seed(completedTurnLog(T2, { previousTurnId: T1 }, "q2", "a2"));
         const resolver = new TurnRepoContextResolver({ turnRepo: repo });
         await expect(
-            resolver.resolve({ previousTurnId: T1 }),
+            resolver.resolve({ previousTurnId: T1 }, FIXTURE_MODEL),
         ).rejects.toThrowError(TurnCorruptionError);
+    });
+});
+
+const OTHER_MODEL = { provider: "openrouter", model: "gpt-5.6-luna" };
+
+// An assistant response carrying every kind of provider round-trip state:
+// message-level options (OpenRouter reasoning_details), signed reasoning,
+// signature-only reasoning (redacted/encrypted with no visible text), and
+// a signed text part.
+function sealedResponse(): z.infer<typeof ConversationMessage> & {
+    role: "assistant";
+} {
+    return {
+        role: "assistant",
+        content: [
+            {
+                type: "reasoning",
+                text: "",
+                providerOptions: { openrouter: { blob: "sealed-encrypted" } },
+            },
+            {
+                type: "reasoning",
+                text: "visible thought",
+                providerOptions: { openrouter: { sig: "s1" } },
+            },
+            {
+                type: "text",
+                text: "answer",
+                providerOptions: { openrouter: { sig: "s2" } },
+            },
+        ],
+        providerOptions: { openrouter: { reasoning_details: [{ sig: "r1" }] } },
+    };
+}
+
+describe("provider continuation replay", () => {
+    it("replays same-model completed turns verbatim, metadata included", async () => {
+        const repo = new InMemoryTurnRepo();
+        repo.seed(
+            completedTurnLog(T1, [], "q1", "", { response: sealedResponse() }),
+        );
+        const resolver = new TurnRepoContextResolver({ turnRepo: repo });
+        const resolved = await resolver.resolve(
+            { previousTurnId: T1 },
+            FIXTURE_MODEL,
+        );
+        expect(resolved).toEqual([user("q1"), sealedResponse()]);
+    });
+
+    it("strips metadata and demotes reasoning for segments from a different model", async () => {
+        const repo = new InMemoryTurnRepo();
+        repo.seed(
+            completedTurnLog(T1, [], "q1", "", {
+                model: OTHER_MODEL,
+                response: sealedResponse(),
+            }),
+        );
+        const resolver = new TurnRepoContextResolver({ turnRepo: repo });
+        const resolved = await resolver.resolve(
+            { previousTurnId: T1 },
+            FIXTURE_MODEL,
+        );
+        expect(resolved).toEqual([
+            user("q1"),
+            {
+                role: "assistant",
+                content: [
+                    // Signature-only reasoning dropped; signed reasoning
+                    // demoted to plain text; all providerOptions gone.
+                    { type: "text", text: "visible thought" },
+                    { type: "text", text: "answer" },
+                ],
+            },
+        ]);
+    });
+
+    it("strips metadata from failed turns even for the same model", async () => {
+        const repo = new InMemoryTurnRepo();
+        repo.seed(limitFailedTurnLog(T1)); // fixture model, status "failed"
+        const resolver = new TurnRepoContextResolver({ turnRepo: repo });
+        const resolved = await resolver.resolve(
+            { previousTurnId: T1 },
+            FIXTURE_MODEL,
+        );
+        const call = resolved[1];
+        if (call.role !== "assistant" || typeof call.content === "string") {
+            throw new Error("expected assistant message with parts");
+        }
+        expect(call.content[0]).toEqual({
+            type: "tool-call",
+            toolCallId: "tc1",
+            toolName: "echo",
+            arguments: {},
+        });
+    });
+
+    it("strips only the foreign segments of a mixed-model chain", async () => {
+        const repo = new InMemoryTurnRepo();
+        repo.seed(
+            completedTurnLog(T1, [], "q1", "", { response: sealedResponse() }),
+        );
+        repo.seed(
+            completedTurnLog(T2, { previousTurnId: T1 }, "q2", "", {
+                model: OTHER_MODEL,
+                response: sealedResponse(),
+            }),
+        );
+        const resolver = new TurnRepoContextResolver({ turnRepo: repo });
+        const resolved = await resolver.resolve(
+            { previousTurnId: T2 },
+            FIXTURE_MODEL,
+        );
+        expect(resolved).toEqual([
+            user("q1"),
+            sealedResponse(), // same model as current: verbatim
+            user("q2"),
+            {
+                role: "assistant",
+                content: [
+                    { type: "text", text: "visible thought" },
+                    { type: "text", text: "answer" },
+                ],
+            },
+        ]);
+    });
+
+    it("always strips the inline base, whose origin is unrecorded", async () => {
+        const repo = new InMemoryTurnRepo();
+        const resolver = new TurnRepoContextResolver({ turnRepo: repo });
+        const resolved = await resolver.resolve(
+            [user("migrated q"), sealedResponse()],
+            FIXTURE_MODEL,
+        );
+        expect(resolved).toEqual([
+            user("migrated q"),
+            {
+                role: "assistant",
+                content: [
+                    { type: "text", text: "visible thought" },
+                    { type: "text", text: "answer" },
+                ],
+            },
+        ]);
+    });
+
+    it("degrades a metadata-only assistant message to empty string content", async () => {
+        const repo = new InMemoryTurnRepo();
+        const resolver = new TurnRepoContextResolver({ turnRepo: repo });
+        const resolved = await resolver.resolve(
+            [
+                user("q"),
+                {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "reasoning",
+                            text: "",
+                            providerOptions: { openrouter: { blob: "sealed" } },
+                        },
+                    ],
+                },
+            ],
+            FIXTURE_MODEL,
+        );
+        expect(resolved[1]).toEqual({ role: "assistant", content: "" });
     });
 });

--- a/apps/x/packages/core/src/runtime/turns/context-resolver.ts
+++ b/apps/x/packages/core/src/runtime/turns/context-resolver.ts
@@ -1,12 +1,15 @@
 import type { z } from "zod";
 import {
     type ConversationMessage,
+    type ModelDescriptor,
     type ResolvedAgent,
     type ResolvedAgentSnapshot,
     type TurnContext,
     TurnCorruptionError,
+    deriveTurnStatus,
     isInheritedSnapshot,
     reduceTurn,
+    stripProviderContinuation,
     turnTranscript,
 } from "@x/shared/dist/turns.js";
 import type { ITurnRepo } from "./repo.js";
@@ -16,9 +19,21 @@ import type { ITurnRepo } from "./repo.js";
 // transcript by walking the chain down to its inline base. Resolution always
 // reads durable state, so normal execution and crash recovery share one
 // path. A missing or corrupt referenced turn is an infrastructure error.
+//
+// currentModel is the model the materialized context is about to be sent
+// to. Segments produced by that exact model in a cleanly completed turn
+// replay verbatim — provider round-trip metadata (thinking signatures,
+// encrypted reasoning) included, which same-model continuations rely on.
+// Everything else (a mid-session model switch, a failed or cancelled
+// producing turn, the inline base whose origin is unrecorded) passes
+// through stripProviderContinuation: the opaque payloads are sealed to the
+// minting endpoint and poison requests to any other. Stripping happens at
+// materialization only — durable turn files keep full fidelity, so
+// switching back to the original model restores verbatim replay.
 export interface IContextResolver {
     resolve(
         context: z.infer<typeof TurnContext>,
+        currentModel: z.infer<typeof ModelDescriptor>,
     ): Promise<Array<z.infer<typeof ConversationMessage>>>;
     // Materializes an inherited agent snapshot by walking inheritedFrom to
     // the nearest concrete snapshot (same discipline as context references:
@@ -41,6 +56,7 @@ export class TurnRepoContextResolver implements IContextResolver {
 
     async resolve(
         context: z.infer<typeof TurnContext>,
+        currentModel: z.infer<typeof ModelDescriptor>,
     ): Promise<Array<z.infer<typeof ConversationMessage>>> {
         // Walk the reference chain back to the inline base, then concatenate
         // transcripts oldest-first. Iterative to bound stack depth; a visited
@@ -58,10 +74,25 @@ export class TurnRepoContextResolver implements IContextResolver {
             visited.add(turnId);
             const events = await this.turnRepo.read(turnId);
             const state = reduceTurn(events);
-            segments.push(turnTranscript(state));
+            // Provider continuation metadata replays only for segments this
+            // exact model produced in a cleanly completed turn (see the
+            // interface note). The model comparison is deliberately strict
+            // on the provider-instance id: a false-positive strip degrades
+            // gracefully, a false-negative keeps the poisoned replay.
+            const producedBy = state.definition.agent.resolved.model;
+            const replayable =
+                producedBy.provider === currentModel.provider &&
+                producedBy.model === currentModel.model &&
+                deriveTurnStatus(state) === "completed";
+            const transcript = turnTranscript(state);
+            segments.push(
+                replayable ? transcript : stripProviderContinuation(transcript),
+            );
             current = state.definition.context;
         }
-        segments.push(current);
+        // The inline base records no producing model, so it takes the
+        // conservative path (migrated runs may carry foreign metadata).
+        segments.push(stripProviderContinuation(current));
         segments.reverse();
         return segments.flat();
     }

--- a/apps/x/packages/core/src/runtime/turns/inspect-cli.ts
+++ b/apps/x/packages/core/src/runtime/turns/inspect-cli.ts
@@ -74,7 +74,10 @@ async function inspectTurn(
     full: boolean,
 ): Promise<void> {
     const state = reduceTurn(events);
-    const prefix = await resolver.resolve(state.definition.context);
+    const prefix = await resolver.resolve(
+        state.definition.context,
+        state.definition.agent.resolved.model,
+    );
     const agent = await resolver.resolveAgent(state.definition.agent.resolved);
 
     const inherited =

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -249,8 +249,12 @@ export class TurnRuntime implements ITurnRuntime {
             useCase: "copilot_chat",
         };
         const materialize = async (): Promise<MaterializedEnv> => {
+            // The snapshot's model is concrete on both snapshot variants, so
+            // the context resolver can gate provider-continuation replay on
+            // it without resolving the agent first.
             const resolvedContext = await this.contextResolver.resolve(
                 definition.context,
+                definition.agent.resolved.model,
             );
             const resolvedAgent = await this.contextResolver.resolveAgent(
                 definition.agent.resolved,

--- a/apps/x/packages/shared/src/turns.ts
+++ b/apps/x/packages/shared/src/turns.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+    AssistantContentPart,
     AssistantMessage,
     ToolCallPart,
     ToolMessage,
@@ -1271,4 +1272,56 @@ export function turnTranscript(
         }
     }
     return messages;
+}
+
+// Removes provider "native continuation" state from a transcript segment:
+// the opaque round-trip metadata providers attach to assistant output
+// (Anthropic thinking signatures, OpenAI encrypted reasoning, Gemini
+// thoughtSignatures, OpenRouter reasoning_details). Those payloads are
+// sealed to the exact endpoint that minted them — replaying them after a
+// model switch is rejected outright (e.g. OpenRouter 404 "encrypted
+// payloads can only be replayed to the endpoint that created them"). The
+// context resolver applies this to segments produced by a different model
+// than the one about to run, and to segments of unknown or unclean origin.
+// Visible content survives: reasoning text is demoted to an ordinary text
+// part (the continuation model keeps the information, loses the blobs);
+// signature-only and redacted reasoning blocks carry nothing readable and
+// are dropped. Pure and deterministic per message, so stripped prefixes
+// stay byte-stable across calls (provider prefix caches keep working).
+export function stripProviderContinuation(
+    messages: Array<z.infer<typeof ConversationMessage>>,
+): Array<z.infer<typeof ConversationMessage>> {
+    return messages.map((message) => {
+        if (message.role !== "assistant") {
+            return message;
+        }
+        const bare = { ...message };
+        delete bare.providerOptions;
+        if (typeof bare.content === "string") {
+            return bare;
+        }
+        const content = bare.content.flatMap(
+            (part): Array<z.infer<typeof AssistantContentPart>> => {
+                switch (part.type) {
+                    case "text":
+                        return [{ type: "text", text: part.text }];
+                    case "reasoning":
+                        // No tags around the demoted text: the model must
+                        // not learn to mimic a reasoning wrapper format.
+                        return part.text.trim() === ""
+                            ? []
+                            : [{ type: "text", text: part.text }];
+                    case "tool-call": {
+                        const call = { ...part };
+                        delete call.providerOptions;
+                        return [call];
+                    }
+                }
+            },
+        );
+        // A message left with no parts (it held only signature-bearing
+        // blocks) degrades to the empty-string form the model bridge
+        // already emits for content-free responses.
+        return { ...bare, content: content.length > 0 ? content : "" };
+    });
 }


### PR DESCRIPTION
## Problem

Switching models mid-chat (e.g. `gpt-5.6-luna` → `sonnet-5`, or even → `5.6-terra`) wedges the session with a provider 404:

> Your request contains encrypted reasoning or compaction content that was produced under a different model. Encrypted payloads can only be replayed to the endpoint that created them. [`pinned_endpoint_slug: openai/gpt-5.6-luna-20260709|azure`]

We deliberately persist provider round-trip metadata (`providerOptions` on assistant messages/parts: Anthropic thinking signatures, OpenAI encrypted reasoning, Gemini thoughtSignatures, OpenRouter `reasoning_details`) so subsequent steps can replay it — that's what fixed #694. But those payloads are sealed to the exact endpoint that minted them, and the context resolver replayed them verbatim to whatever model the turn now runs, forever. Every subsequent turn re-materializes the same poisoned prefix, so the session never recovers.

## Fix

Gate replay per walked segment in the context resolver, which is exactly the cross-turn boundary (within-turn `assistant:N` refs never pass through it, so in-loop signature requirements — the one place providers hard-require them — are untouched by construction):

- **Verbatim replay** only when the producing turn's durable `agent.resolved.model` exactly equals the current turn's model (provider-instance + model id) **and** that turn completed cleanly. Same-model conversations stay byte-identical (provider prefix caches keep working).
- **Everything else** — different producing model, failed/cancelled producing turn, and always the inline base (origin unrecorded; migrated runs may carry foreign metadata) — passes through a new pure `stripProviderContinuation` helper: message- and part-level `providerOptions` dropped, reasoning with visible text demoted to plain text parts (the new model keeps the information, loses the opaque blobs), signature-only reasoning dropped.

Durable turn files keep full fidelity — stripping is recomputed at materialization, so switching back to the original model restores verbatim replay.

This matches how pi-agent and opencode handle the same problem (store everything, filter at request-build time, exact-match model equality, demote foreign reasoning to text, treat errored turns as metadata-unsafe); opencode documents it as a first-class invariant ("Native Continuation Metadata… includes it only for a successful exact originating provider/model match").

## Changes

- `packages/shared/src/turns.ts` — new `stripProviderContinuation` (pure, next to `turnTranscript`)
- `packages/core/src/runtime/turns/context-resolver.ts` — `resolve(context, currentModel)` gates replay per segment
- `context-elision.ts`, `runtime.ts`, `compose-model-request.ts`, `inspect-cli.ts` — thread the current model through (inspect reproduces the real wire bytes)
- `packages/core/docs/turn-runtime-design.md` §6.6 — policy documented
- Tests: verbatim same-model replay, cross-model strip/demote, failed-turn strip, mixed-model chains strip only foreign segments, inline base always strips, metadata-only message degrades to `""` content

## Testing

- `npm run deps` + `npm run typecheck` + `npm run lint` clean
- core: 53 files / 586 tests pass; shared: 107 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)