### PR TITLE
feat(meetings): label Zoom speakers from Accessibility

### DIFF
--- a/apps/x/apps/main/bundle.mjs
+++ b/apps/x/apps/main/bundle.mjs
@@ -11,7 +11,7 @@
 
 import * as esbuild from 'esbuild';
 import { readFile } from 'node:fs/promises';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -56,6 +56,34 @@ await esbuild.build({
 // binaries). The macOS spawn-helper must be executable — pnpm extraction drops
 // the bit, and a non-executable helper makes every PTY spawn fail.
 const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Finder/CI shells occasionally expose a Command Line Tools compiler whose
+// default SDK symlink points at an incompatible newer SDK. Try the default
+// first, then each installed CLT SDK, while keeping the module cache inside
+// the build tree instead of relying on a writable home-directory cache.
+function compileSwiftHelper(source, output) {
+  const moduleCache = path.join(here, '.package', 'swift-module-cache');
+  fs.mkdirSync(moduleCache, { recursive: true });
+  const sdkRoot = '/Library/Developer/CommandLineTools/SDKs';
+  const sdkCandidates = fs.existsSync(sdkRoot)
+    ? fs.readdirSync(sdkRoot)
+      .filter(name => /^MacOSX[0-9.]*\.sdk$/.test(name))
+      .map(name => path.join(sdkRoot, name))
+    : [];
+  let lastError;
+  for (const sdk of [null, ...sdkCandidates]) {
+    const args = ['-O', '-module-cache-path', moduleCache];
+    if (sdk) args.push('-sdk', sdk);
+    args.push(source, '-o', output);
+    try {
+      execFileSync('swiftc', args, { stdio: 'pipe' });
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error('swiftc failed without an error');
+}
 const ptySrc = fs.realpathSync(path.join(here, 'node_modules', 'node-pty'));
 const ptyDest = path.join(here, '.package', 'node_modules', 'node-pty');
 fs.rmSync(ptyDest, { recursive: true, force: true });
@@ -151,12 +179,37 @@ if (process.platform === 'darwin') {
     console.log('✅ mic-monitor helper up to date');
   } else {
     try {
-      execSync(`swiftc -O "${swiftSrc}" -o "${helperOut}"`, { stdio: 'inherit' });
+      compileSwiftHelper(swiftSrc, helperOut);
       console.log('✅ mic-monitor helper compiled');
     } catch {
       console.warn('⚠️  mic-monitor helper not built (swiftc unavailable?) — meeting detection disabled');
     }
   }
+}
+
+// Compile the bounded Zoom Accessibility helper on macOS. Like mic-monitor,
+// this is best-effort: meeting capture continues with generic diarization if
+// the helper cannot be built or Accessibility is not granted.
+if (process.platform === 'darwin') {
+  const swiftSrc = path.join(here, 'native', 'zoom-accessibility.swift');
+  const helperOut = path.join(here, '.package', 'dist', 'zoom-accessibility');
+  const licenseSrc = path.join(here, 'native', 'zoom-accessibility-LICENSE.txt');
+  const licenseOut = path.join(here, '.package', 'dist', 'zoom-accessibility-LICENSE.txt');
+  const upToDate = fs.existsSync(helperOut) &&
+    fs.statSync(helperOut).mtimeMs >= fs.statSync(swiftSrc).mtimeMs;
+  if (upToDate) {
+    console.log('✅ zoom-accessibility helper up to date');
+  } else {
+    try {
+      compileSwiftHelper(swiftSrc, helperOut);
+      execFileSync(helperOut, ['--self-test'], { stdio: 'inherit' });
+      console.log('✅ zoom-accessibility helper compiled and self-tested');
+    } catch {
+      fs.rmSync(helperOut, { force: true });
+      console.warn('⚠️  zoom-accessibility helper not built — Zoom names stay on diarization labels');
+    }
+  }
+  fs.copyFileSync(licenseSrc, licenseOut);
 }
 
 // Bundle the vendored agent-slack CLI into a single self-contained script next

--- a/apps/x/apps/main/forge.config.cjs
+++ b/apps/x/apps/main/forge.config.cjs
@@ -230,6 +230,7 @@ module.exports = {
         ],
         extendInfo: {
             NSAudioCaptureUsageDescription: 'Rowboat needs access to system audio to transcribe meetings from other apps (Zoom, Meet, etc.)',
+            NSAccessibilityUsageDescription: 'Rowboat uses Accessibility during Zoom meetings to label active speakers and detect when the meeting window closes.',
             NSCameraUsageDescription: 'Rowboat uses your camera in video chat mode so the assistant can see you and give feedback (e.g. pitch practice).',
         },
         // Signs the packaged app's executables (rowboat.exe etc.); the Squirrel

--- a/apps/x/apps/main/native/zoom-accessibility-LICENSE.txt
+++ b/apps/x/apps/main/native/zoom-accessibility-LICENSE.txt
@@ -1,0 +1,26 @@
+This helper adapts bounded traversal and Zoom label parsing from:
+https://github.com/fastrepl/anarlog/tree/609ee772801f29292e4edee453f269089ebf0e8b
+
+The following upstream license is retained for the adapted portions.
+
+MIT License
+
+Copyright (c) 2023-present Fastrepl, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/x/apps/main/native/zoom-accessibility.swift
+++ b/apps/x/apps/main/native/zoom-accessibility.swift
@@ -1,0 +1,443 @@
+// zoom-accessibility: bounded, read-only Zoom Accessibility evidence.
+//
+// The helper emits newline-delimited JSON and never emits raw AX nodes, window
+// titles, arbitrary labels, screenshots, transcript text, or process paths.
+// It exits when the parent closes stdin, so it cannot outlive Rowboat.
+//
+// Protocol:
+//   {"type":"permission","trusted":true,"observedAtMs":...}
+//   {"type":"surface","state":"active|missing|unknown","observedAtMs":...}
+//   {"type":"speaker","displayName":"...","isSelf":false,
+//    "isActive":true,"isMuted":null,"confidence":0.98,
+//    "signals":["explicit-talking-label"],"observedAtMs":...}
+//
+// The bounded traversal and explicit-label parsing are adapted from Anarlog's
+// MIT-licensed meeting_ax module at revision
+// 609ee772801f29292e4edee453f269089ebf0e8b. See
+// zoom-accessibility-LICENSE.txt and docs/zoom-accessibility-evidence.md.
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+private let zoomBundleIdentifier = "us.zoom.xos"
+private let maximumWindows = 8
+private let maximumDepth = 18
+private let maximumNodes = 1_800
+private let maximumChildrenPerNode = 128
+private let inspectionBudgetSeconds = 0.60
+private let pollIntervalSeconds = 0.75
+
+private enum SurfaceState: String, Encodable {
+    case active
+    case missing
+    case unknown
+}
+
+private struct PermissionEvent: Encodable {
+    let type = "permission"
+    let trusted: Bool
+    let observedAtMs: UInt64
+}
+
+private struct SurfaceEvent: Encodable {
+    let type = "surface"
+    let state: SurfaceState
+    let observedAtMs: UInt64
+}
+
+private struct SpeakerEvent: Encodable, Equatable {
+    let type = "speaker"
+    let displayName: String
+    let isSelf: Bool?
+    let isActive: Bool
+    let isMuted: Bool?
+    let confidence: Double
+    let signals: [String]
+    let observedAtMs: UInt64
+
+    static func == (lhs: SpeakerEvent, rhs: SpeakerEvent) -> Bool {
+        lhs.displayName.caseInsensitiveCompare(rhs.displayName) == .orderedSame
+            && lhs.isSelf == rhs.isSelf
+            && lhs.isActive == rhs.isActive
+            && lhs.isMuted == rhs.isMuted
+    }
+}
+
+private struct Inspection {
+    let surface: SurfaceState
+    let speakers: [SpeakerEvent]
+}
+
+private struct AxNode {
+    let role: String?
+    let labels: [String]
+}
+
+private struct TraversalBudget {
+    let deadline: DispatchTime
+    var visited: Set<CFHashCode> = []
+    var count = 0
+
+    mutating func canVisit(_ element: AXUIElement, depth: Int) -> Bool {
+        guard depth <= maximumDepth,
+              count < maximumNodes,
+              DispatchTime.now() < deadline else {
+            return false
+        }
+        let identity = CFHash(element)
+        guard visited.insert(identity).inserted else { return false }
+        count += 1
+        return true
+    }
+}
+
+private func nowMilliseconds() -> UInt64 {
+    UInt64(Date().timeIntervalSince1970 * 1_000)
+}
+
+private func emit<T: Encodable>(_ event: T) {
+    let encoder = JSONEncoder()
+    guard let data = try? encoder.encode(event),
+          let line = String(data: data, encoding: .utf8) else {
+        return
+    }
+    print(line)
+    fflush(stdout)
+}
+
+private func copyString(_ element: AXUIElement, _ attribute: String) -> String? {
+    var raw: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &raw) == .success,
+          let value = raw as? String else {
+        return nil
+    }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : String(trimmed.prefix(512))
+}
+
+private func copyChildren(_ element: AXUIElement) -> [AXUIElement] {
+    var values: CFArray?
+    guard AXUIElementCopyAttributeValues(
+        element,
+        kAXChildrenAttribute as CFString,
+        0,
+        maximumChildrenPerNode,
+        &values
+    ) == .success,
+    let values else {
+        return []
+    }
+    return (values as NSArray).compactMap { $0 as! AXUIElement? }
+}
+
+private func copyWindows(_ application: AXUIElement) -> [AXUIElement] {
+    var values: CFArray?
+    guard AXUIElementCopyAttributeValues(
+        application,
+        kAXWindowsAttribute as CFString,
+        0,
+        maximumWindows,
+        &values
+    ) == .success,
+    let values else {
+        return []
+    }
+    return (values as NSArray).compactMap { $0 as! AXUIElement? }
+}
+
+private func isTextInputRole(_ role: String?) -> Bool {
+    role == kAXTextFieldRole || role == kAXTextAreaRole || role == "AXSecureTextField"
+}
+
+private func labels(for element: AXUIElement, role: String?) -> [String] {
+    var result: [String] = []
+    for attribute in [kAXTitleAttribute, kAXDescriptionAttribute, kAXHelpAttribute] {
+        if let value = copyString(element, attribute) { result.append(value) }
+    }
+    // Static text and controls often expose their accessibility label through
+    // AXValue. Never read it from editable or secure controls.
+    if !isTextInputRole(role),
+       role == kAXStaticTextRole || role == kAXButtonRole || role == kAXCheckBoxRole,
+       let value = copyString(element, kAXValueAttribute) {
+        result.append(value)
+    }
+    var seen: Set<String> = []
+    return result.filter { seen.insert($0.lowercased()).inserted }
+}
+
+private func collectNodes(
+    from element: AXUIElement,
+    depth: Int,
+    budget: inout TraversalBudget,
+    into nodes: inout [AxNode]
+) {
+    guard budget.canVisit(element, depth: depth) else { return }
+    let role = copyString(element, kAXRoleAttribute)
+    nodes.append(AxNode(role: role, labels: labels(for: element, role: role)))
+    for child in copyChildren(element) {
+        collectNodes(from: child, depth: depth + 1, budget: &budget, into: &nodes)
+    }
+}
+
+private func normalized(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "\u{00a0}", with: " ")
+        .split(whereSeparator: { $0.isWhitespace })
+        .joined(separator: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private let genericNames: Set<String> = [
+    "active speaker", "audio", "camera", "chat", "host", "meeting", "more",
+    "mute", "participant", "participants", "screen", "speaker", "talking",
+    "unmute", "video", "you", "zoom"
+]
+
+private func plausibleParticipantName(_ candidate: String) -> String? {
+    let name = normalized(candidate)
+        .trimmingCharacters(in: CharacterSet(charactersIn: "-–—:,. "))
+    guard name.count >= 2,
+          name.count <= 100,
+          !genericNames.contains(name.lowercased()),
+          name.rangeOfCharacter(from: .letters) != nil,
+          !name.contains("http"),
+          !name.contains("@") else {
+        return nil
+    }
+    return name
+}
+
+private func removingSelfMarker(_ raw: String) -> (name: String, marked: Bool) {
+    var value = normalized(raw)
+    let patterns = [" (Me)", " (me)", " (You)", " (you)", ", Me", ", me", ", You", ", you"]
+    for pattern in patterns where value.hasSuffix(pattern) {
+        value.removeLast(pattern.count)
+        return (value, true)
+    }
+    return (value, false)
+}
+
+private func parseTalkingLabel(_ label: String) -> (name: String, isSelf: Bool)? {
+    let text = normalized(label)
+    let lower = text.lowercased()
+    let rawName: String
+
+    if lower.hasPrefix("talking:") {
+        rawName = String(text.dropFirst("talking:".count))
+    } else if lower.hasPrefix("speaking:") {
+        rawName = String(text.dropFirst("speaking:".count))
+    } else if let range = lower.range(of: " is talking"), range.upperBound == lower.endIndex {
+        rawName = String(text[..<range.lowerBound])
+    } else if let range = lower.range(of: " is speaking"), range.upperBound == lower.endIndex {
+        rawName = String(text[..<range.lowerBound])
+    } else if let range = lower.range(of: ", talking"), range.upperBound == lower.endIndex {
+        rawName = String(text[..<range.lowerBound])
+    } else if let range = lower.range(of: ", speaking"), range.upperBound == lower.endIndex {
+        rawName = String(text[..<range.lowerBound])
+    } else {
+        return nil
+    }
+
+    let marked = removingSelfMarker(rawName)
+    guard let name = plausibleParticipantName(marked.name) else { return nil }
+    return (name, marked.marked)
+}
+
+private func parseParticipantSelfName(_ label: String) -> String? {
+    let text = normalized(label)
+    let lower = text.lowercased()
+    let markers = [" (me)", " (you)", ", me", ", you"]
+    guard let markerRange = markers.compactMap({ lower.range(of: $0) }).min(by: {
+        $0.lowerBound < $1.lowerBound
+    }) else {
+        return nil
+    }
+    return plausibleParticipantName(String(text[..<markerRange.lowerBound]))
+}
+
+private enum TileAudioState {
+    case muted
+    case unmuted
+}
+
+private struct VideoTile {
+    let name: String
+    let isSelf: Bool
+    let audio: TileAudioState
+}
+
+private func parseVideoTile(_ label: String) -> VideoTile? {
+    let text = normalized(label)
+    let lower = text.lowercased()
+    let audio: TileAudioState
+    if lower.contains("audio unmuted") || lower.contains("microphone unmuted") {
+        audio = .unmuted
+    } else if lower.contains("audio muted") || lower.contains("microphone muted") {
+        audio = .muted
+    } else {
+        return nil
+    }
+    guard let first = text.split(separator: ",", maxSplits: 1).first else { return nil }
+    let marked = removingSelfMarker(String(first))
+    guard let name = plausibleParticipantName(marked.name) else { return nil }
+    return VideoTile(name: name, isSelf: marked.marked, audio: audio)
+}
+
+private func isMeetingSurface(_ nodes: [AxNode]) -> Bool {
+    let labels = nodes.flatMap(\.labels).map { $0.lowercased() }
+    let joined = labels.joined(separator: " | ")
+    let hasMeetingTitle = joined.contains("zoom meeting") || joined.contains("in a zoom meeting")
+    let hasAudioControl = joined.contains("mute my audio") || joined.contains("unmute my audio")
+    let hasLeaveControl = joined.contains("leave meeting") || joined.contains("end meeting")
+    let hasParticipantsControl = labels.contains { $0 == "participants" || $0.hasPrefix("participants,") }
+    let controls = [hasAudioControl, hasLeaveControl, hasParticipantsControl].filter { $0 }.count
+    return (hasMeetingTitle && controls >= 1) || controls >= 2
+}
+
+private func inspectZoom() -> Inspection {
+    guard AXIsProcessTrusted() else {
+        return Inspection(surface: .unknown, speakers: [])
+    }
+
+    let running = NSRunningApplication.runningApplications(withBundleIdentifier: zoomBundleIdentifier)
+        .filter { !$0.isTerminated }
+    guard !running.isEmpty else {
+        return Inspection(surface: .missing, speakers: [])
+    }
+
+    // One budget covers the complete observation, not each window. This keeps
+    // the documented 1,800-node/600-ms bound true even when Zoom has several
+    // auxiliary windows or processes.
+    var budget = TraversalBudget(
+        deadline: DispatchTime.now() + inspectionBudgetSeconds,
+        visited: [],
+        count: 0
+    )
+    var meetingNodes: [AxNode] = []
+    var sawReadableWindow = false
+    for process in running.prefix(2) {
+        guard DispatchTime.now() < budget.deadline else { break }
+        let application = AXUIElementCreateApplication(process.processIdentifier)
+        AXUIElementSetMessagingTimeout(application, Float(inspectionBudgetSeconds))
+
+        // Zoom does not consistently expose its meeting subtree until one of
+        // these application attributes is enabled. This is a best-effort
+        // interoperability hint; failure leaves the helper read-only.
+        _ = AXUIElementSetAttributeValue(application, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+        _ = AXUIElementSetAttributeValue(application, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
+
+        for window in copyWindows(application) {
+            guard DispatchTime.now() < budget.deadline, budget.count < maximumNodes else { break }
+            var nodes: [AxNode] = []
+            collectNodes(from: window, depth: 0, budget: &budget, into: &nodes)
+            guard !nodes.isEmpty else { continue }
+            sawReadableWindow = true
+            if isMeetingSurface(nodes) { meetingNodes.append(contentsOf: nodes) }
+        }
+    }
+
+    guard !meetingNodes.isEmpty else {
+        return Inspection(surface: sawReadableWindow ? .missing : .unknown, speakers: [])
+    }
+
+    let selfNames = Set(meetingNodes.flatMap(\.labels).compactMap(parseParticipantSelfName).map { $0.lowercased() })
+    let observedAt = nowMilliseconds()
+    var speakers: [SpeakerEvent] = []
+
+    for label in meetingNodes.flatMap(\.labels) {
+        guard let parsed = parseTalkingLabel(label) else { continue }
+        let matchesSelf = parsed.isSelf || selfNames.contains(parsed.name.lowercased())
+        speakers.append(SpeakerEvent(
+            displayName: parsed.name,
+            isSelf: matchesSelf ? true : (selfNames.isEmpty ? nil : false),
+            isActive: true,
+            isMuted: false,
+            confidence: parsed.isSelf ? 1.0 : 0.98,
+            signals: parsed.isSelf
+                ? ["explicit-talking-label", "explicit-self-marker"]
+                : ["explicit-talking-label"],
+            observedAtMs: observedAt
+        ))
+    }
+
+    // Current compact Zoom windows sometimes expose tile audio state but no
+    // explicit Talking label. Exactly one unmuted visible tile is useful,
+    // bounded evidence; two or more unmuted tiles deliberately remain
+    // ambiguous (including during overlap).
+    if speakers.isEmpty {
+        let tiles = meetingNodes.flatMap(\.labels).compactMap(parseVideoTile)
+        let unmuted = tiles.filter { $0.audio == .unmuted }
+        if unmuted.count == 1, let tile = unmuted.first {
+            let matchesSelf = tile.isSelf || selfNames.contains(tile.name.lowercased())
+            speakers.append(SpeakerEvent(
+                displayName: tile.name,
+                isSelf: matchesSelf ? true : (selfNames.isEmpty ? nil : false),
+                isActive: true,
+                isMuted: false,
+                confidence: tile.isSelf ? 0.90 : 0.82,
+                signals: tile.isSelf
+                    ? ["sole-unmuted-video-tile", "explicit-self-marker"]
+                    : ["sole-unmuted-video-tile"],
+                observedAtMs: observedAt
+            ))
+        }
+    }
+
+    var unique: [String: SpeakerEvent] = [:]
+    for speaker in speakers {
+        let key = "\(speaker.displayName.lowercased())|\(speaker.isSelf.map(String.init) ?? "unknown")"
+        if unique[key] == nil || speaker.confidence > unique[key]!.confidence {
+            unique[key] = speaker
+        }
+    }
+    return Inspection(surface: .active, speakers: Array(unique.values).prefix(8).map { $0 })
+}
+
+private func runSelfTest() -> Never {
+    var failures: [String] = []
+    func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        if !condition() { failures.append(message) }
+    }
+
+    expect(parseTalkingLabel("Talking: Rahul Khatri")?.name == "Rahul Khatri", "Talking prefix")
+    expect(parseTalkingLabel("Rahul Khatri is talking")?.name == "Rahul Khatri", "is talking suffix")
+    expect(parseTalkingLabel("Rahul Khatri (Me), Talking")?.isSelf == true, "explicit self marker")
+    expect(parseTalkingLabel("Mute my audio") == nil, "reject controls")
+    expect(parseParticipantSelfName("Rahul Khatri (Me), Host") == "Rahul Khatri", "participant self row")
+    expect(parseVideoTile("Akbar Singh, video on, audio unmuted")?.name == "Akbar Singh", "video tile")
+    expect(parseVideoTile("Akbar Singh, video on, audio muted")?.audio == .muted, "muted tile")
+
+    if failures.isEmpty {
+        print("zoom-accessibility self-test passed")
+        exit(0)
+    }
+    fputs("zoom-accessibility self-test failed: \(failures.joined(separator: ", "))\n", stderr)
+    exit(1)
+}
+
+if CommandLine.arguments.contains("--self-test") {
+    runSelfTest()
+}
+
+// The parent's writable stdin is our lifetime token.
+DispatchQueue.global(qos: .utility).async {
+    while readLine(strippingNewline: false) != nil {}
+    exit(0)
+}
+
+var lastTrusted: Bool?
+while true {
+    autoreleasepool {
+        let trusted = AXIsProcessTrusted()
+        let observedAt = nowMilliseconds()
+        if lastTrusted != trusted {
+            emit(PermissionEvent(trusted: trusted, observedAtMs: observedAt))
+            lastTrusted = trusted
+        }
+        let inspection = inspectZoom()
+        emit(SurfaceEvent(state: inspection.surface, observedAtMs: observedAt))
+        for speaker in inspection.speakers { emit(speaker) }
+    }
+    Thread.sleep(forTimeInterval: pollIntervalSeconds)
+}

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -91,6 +91,7 @@ import { setSelfCaptureActive } from '@x/core/dist/meetings/detector.js';
 import { notifyIfEnabled } from '@x/core/dist/application/notification/notifier.js';
 import { consumePendingToggleMeetingNotes, setTrayRecordingState } from './tray.js';
 import { closeMeetingPopup, getMeetingPopupPayload, handleMeetingPopupAction } from './meeting-popup.js';
+import { zoomAccessibilitySupervisor } from './zoom-accessibility.js';
 
 // Ambient meeting detection must ignore Rowboat's own mic use: meeting
 // capture and assistant voice/video calls both hold the mic. Either being
@@ -963,6 +964,19 @@ export function setupIpcHandlers() {
       setTrayRecordingState(args.recording);
       meetingRecordingActive = args.recording;
       updateSelfCaptureState();
+      if (args.recording) {
+        zoomAccessibilitySupervisor.start({
+          helperPath: path.join(__dirname, 'zoom-accessibility'),
+          onEvent: (event) => {
+            broadcastToWindows('meeting:zoomAccessibilityEvidence', event);
+          },
+          onMeetingEnded: () => {
+            broadcastToWindows('meeting:externalCallEnded', null);
+          },
+        });
+      } else {
+        zoomAccessibilitySupervisor.stop();
+      }
       // Recording started through another path — a lingering "Take Notes?"
       // popup is stale now.
       if (args.recording) closeMeetingPopup();
@@ -1013,6 +1027,7 @@ export function setupIpcHandlers() {
         camera: 'Privacy_Camera',
         'screen-recording': 'Privacy_ScreenCapture',
         'input-monitoring': 'Privacy_ListenEvent',
+        accessibility: 'Privacy_Accessibility',
       } as const;
       try {
         await shell.openExternal(

--- a/apps/x/apps/main/src/zoom-accessibility.ts
+++ b/apps/x/apps/main/src/zoom-accessibility.ts
@@ -1,0 +1,129 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import fs from 'node:fs';
+import type { z } from 'zod';
+import { ipc } from '@x/shared';
+
+export type ZoomAccessibilityEvent = z.infer<typeof ipc.ZoomAccessibilityEvidence>;
+
+type SupervisorOptions = {
+  helperPath: string;
+  onEvent: (event: ZoomAccessibilityEvent) => void;
+  onMeetingEnded: () => void;
+};
+
+const MISSING_POLLS_TO_END = 3;
+const MAX_LINE_LENGTH = 16 * 1024;
+
+/**
+ * Owns the optional macOS Zoom Accessibility helper for one Rowboat capture.
+ * Meeting end is emitted only after a validated active Zoom surface was seen
+ * and then disappeared for three consecutive observations.
+ */
+export class ZoomAccessibilitySupervisor {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private stdoutBuffer = '';
+  private activeSurfaceSeen = false;
+  private consecutiveMissing = 0;
+  private endEmitted = false;
+
+  start(options: SupervisorOptions): boolean {
+    this.stop();
+    if (process.platform !== 'darwin' || !fs.existsSync(options.helperPath)) {
+      return false;
+    }
+
+    this.activeSurfaceSeen = false;
+    this.consecutiveMissing = 0;
+    this.endEmitted = false;
+    this.stdoutBuffer = '';
+
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(options.helperPath, [], { stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch (error) {
+      console.warn('[ZoomAX] failed to start helper:', error);
+      return false;
+    }
+    this.child = child;
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      this.stdoutBuffer += chunk;
+      if (this.stdoutBuffer.length > MAX_LINE_LENGTH * 4) {
+        console.warn('[ZoomAX] dropping oversized helper output');
+        this.stdoutBuffer = '';
+        return;
+      }
+      let newline: number;
+      while ((newline = this.stdoutBuffer.indexOf('\n')) >= 0) {
+        const line = this.stdoutBuffer.slice(0, newline).trim();
+        this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+        if (!line || line.length > MAX_LINE_LENGTH) continue;
+        this.handleLine(line, options);
+      }
+    });
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      const message = chunk.trim();
+      if (message) console.warn('[ZoomAX helper]', message.slice(0, 2_000));
+    });
+    child.on('error', (error) => {
+      console.warn('[ZoomAX] helper error:', error);
+    });
+    child.on('exit', (code) => {
+      if (this.child === child) this.child = null;
+      if (code !== 0 && code !== null) {
+        console.warn(`[ZoomAX] helper exited with code ${code}`);
+      }
+    });
+    return true;
+  }
+
+  stop(): void {
+    const child = this.child;
+    this.child = null;
+    this.stdoutBuffer = '';
+    this.activeSurfaceSeen = false;
+    this.consecutiveMissing = 0;
+    this.endEmitted = false;
+    if (!child) return;
+    child.stdin.end();
+    const forceKill = setTimeout(() => {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }, 1_000);
+    forceKill.unref();
+    child.once('exit', () => clearTimeout(forceKill));
+  }
+
+  private handleLine(line: string, options: SupervisorOptions): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const result = ipc.ZoomAccessibilityEvidence.safeParse(parsed);
+    if (!result.success) return;
+    const event = result.data;
+    options.onEvent(event);
+
+    if (event.type !== 'surface' || this.endEmitted) return;
+    if (event.state === 'active') {
+      this.activeSurfaceSeen = true;
+      this.consecutiveMissing = 0;
+      return;
+    }
+    if (event.state === 'unknown') {
+      // Permission and transient AX failures never prove that a call ended.
+      this.consecutiveMissing = 0;
+      return;
+    }
+    if (!this.activeSurfaceSeen) return;
+    this.consecutiveMissing += 1;
+    if (this.consecutiveMissing >= MISSING_POLLS_TO_END) {
+      this.endEmitted = true;
+      options.onMeetingEnded();
+    }
+  }
+}
+
+export const zoomAccessibilitySupervisor = new ZoomAccessibilitySupervisor();

--- a/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
+++ b/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
@@ -1,9 +1,14 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { buildDeepgramListenUrl } from '@/lib/deepgram-listen-url';
 import { finalizeDeepgramStream } from '@/lib/deepgram-finalize';
 import { useRowboatAccount } from '@/hooks/useRowboatAccount';
 import { fetchRowboatConfig } from '@/hooks/use-rowboat-config';
+import {
+    appendZoomSpeakerEvidence,
+    resolveZoomSpeakerForInterval,
+    type ZoomSpeakerEvent,
+} from '@/lib/zoom-speaker-evidence';
 
 export type MeetingTranscriptionState = 'idle' | 'connecting' | 'recording' | 'stopping';
 
@@ -173,6 +178,32 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
     onAutoStopRef.current = onAutoStop;
     const dateRef = useRef<string>('');
     const calendarEventRef = useRef<CalendarEventMeta | undefined>(undefined);
+    const captureStartedAtMsRef = useRef<number>(0);
+    const zoomSpeakerTimelineRef = useRef<ZoomSpeakerEvent[]>([]);
+    const accessibilityWarningShownRef = useRef(false);
+
+    useEffect(() => window.ipc.on('meeting:zoomAccessibilityEvidence', (event) => {
+        if (event.type === 'speaker') {
+            zoomSpeakerTimelineRef.current = appendZoomSpeakerEvidence(
+                zoomSpeakerTimelineRef.current,
+                event,
+            );
+            return;
+        }
+        if (event.type === 'permission' && !event.trusted && !accessibilityWarningShownRef.current) {
+            accessibilityWarningShownRef.current = true;
+            toast.info('Enable Accessibility for Zoom speaker names', {
+                description: 'Recording still works, but names will use generic speaker labels until Rowboat is allowed in System Settings.',
+                duration: 10_000,
+                action: {
+                    label: 'Open Settings',
+                    onClick: () => {
+                        void window.ipc.invoke('app:openPrivacySettings', { section: 'accessibility' });
+                    },
+                },
+            });
+        }
+    }), []);
 
     const writeTranscriptToFile = useCallback(async () => {
         if (!notePathRef.current) return;
@@ -350,6 +381,8 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
         // Set up WS message handler
         transcriptRef.current = [];
         interimRef.current = new Map();
+        zoomSpeakerTimelineRef.current = [];
+        accessibilityWarningShownRef.current = false;
         ws.onmessage = (event) => {
             const data = JSON.parse(event.data);
             if (!data.channel?.alternatives?.[0]) return;
@@ -367,7 +400,22 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                 // Use Deepgram diarization speaker ID for system audio channel
                 const words = data.channel.alternatives[0].words;
                 const speakerId = words?.[0]?.speaker;
-                speaker = speakerId != null ? `Speaker ${speakerId}` : 'System audio';
+                const fallback = speakerId != null ? `Speaker ${speakerId}` : 'System audio';
+                const now = Date.now();
+                const relativeStartSeconds = typeof data.start === 'number' ? data.start : null;
+                const durationSeconds = typeof data.duration === 'number' ? data.duration : null;
+                const intervalStartMs = relativeStartSeconds !== null && captureStartedAtMsRef.current > 0
+                    ? captureStartedAtMsRef.current + relativeStartSeconds * 1_000
+                    : now - 2_500;
+                const intervalEndMs = durationSeconds !== null
+                    ? intervalStartMs + durationSeconds * 1_000
+                    : now;
+                speaker = resolveZoomSpeakerForInterval(
+                    zoomSpeakerTimelineRef.current,
+                    intervalStartMs,
+                    intervalEndMs,
+                    fallback,
+                );
             }
 
             if (data.is_final) {
@@ -462,6 +510,7 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
 
         const processor = audioCtx.createScriptProcessor(4096, 2, 2);
         processorRef.current = processor;
+        captureStartedAtMsRef.current = Date.now();
 
         processor.onaudioprocess = (e) => {
             if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;

--- a/apps/x/apps/renderer/src/lib/zoom-speaker-evidence.test.ts
+++ b/apps/x/apps/renderer/src/lib/zoom-speaker-evidence.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendZoomSpeakerEvidence,
+  resolveZoomSpeakerForInterval,
+  type ZoomSpeakerEvent,
+} from './zoom-speaker-evidence';
+
+function speaker(overrides: Partial<ZoomSpeakerEvent> = {}): ZoomSpeakerEvent {
+  return {
+    type: 'speaker',
+    displayName: 'Akbar Singh',
+    isSelf: false,
+    isActive: true,
+    isMuted: false,
+    confidence: 0.98,
+    signals: ['explicit-talking-label'],
+    observedAtMs: 10_000,
+    ...overrides,
+  };
+}
+
+describe('Zoom speaker evidence', () => {
+  it('uses aligned active-speaker evidence for system audio', () => {
+    expect(resolveZoomSpeakerForInterval([speaker()], 9_500, 10_500, 'Speaker 0'))
+      .toBe('Akbar Singh');
+  });
+
+  it('never assigns a self observation to system audio', () => {
+    expect(resolveZoomSpeakerForInterval([speaker({ isSelf: true })], 9_500, 10_500, 'Speaker 0'))
+      .toBe('Speaker 0');
+  });
+
+  it('fails closed when two people overlap without a dominant signal', () => {
+    const timeline = [
+      speaker({ displayName: 'Akbar Singh', observedAtMs: 10_000 }),
+      speaker({ displayName: 'Parminder Kaur', observedAtMs: 10_050 }),
+    ];
+    expect(resolveZoomSpeakerForInterval(timeline, 9_500, 10_500, 'Speaker 0'))
+      .toBe('Speaker 0');
+  });
+
+  it('ignores stale observations', () => {
+    expect(resolveZoomSpeakerForInterval([speaker({ observedAtMs: 1_000 })], 9_500, 10_500, 'Speaker 0'))
+      .toBe('Speaker 0');
+  });
+
+  it('keeps the evidence timeline bounded', () => {
+    let timeline: ZoomSpeakerEvent[] = [];
+    for (let index = 0; index < 120; index += 1) {
+      timeline = appendZoomSpeakerEvidence(timeline, speaker({ observedAtMs: index }));
+    }
+    expect(timeline).toHaveLength(96);
+    expect(timeline[0].observedAtMs).toBe(24);
+  });
+});

--- a/apps/x/apps/renderer/src/lib/zoom-speaker-evidence.ts
+++ b/apps/x/apps/renderer/src/lib/zoom-speaker-evidence.ts
@@ -1,0 +1,53 @@
+import type { IPCChannels } from '@x/shared/dist/ipc';
+
+export type ZoomAccessibilityEvent = IPCChannels['meeting:zoomAccessibilityEvidence']['req'];
+export type ZoomSpeakerEvent = Extract<ZoomAccessibilityEvent, { type: 'speaker' }>;
+
+const MAX_TIMELINE_EVENTS = 96;
+const BEFORE_INTERVAL_TOLERANCE_MS = 1_500;
+const AFTER_INTERVAL_TOLERANCE_MS = 2_500;
+const MINIMUM_DOMINANCE_RATIO = 1.35;
+
+export function appendZoomSpeakerEvidence(
+  timeline: ZoomSpeakerEvent[],
+  event: ZoomSpeakerEvent,
+): ZoomSpeakerEvent[] {
+  const next = [...timeline, event];
+  return next.length > MAX_TIMELINE_EVENTS
+    ? next.slice(next.length - MAX_TIMELINE_EVENTS)
+    : next;
+}
+
+/**
+ * Resolve one system-audio transcript interval to a Zoom display name. Raw
+ * roster names and self markers are insufficient: only explicit active
+ * speaker evidence (or the helper's sole-unmuted fallback) is accepted.
+ * Overlap or weak/conflicting evidence deliberately preserves diarization.
+ */
+export function resolveZoomSpeakerForInterval(
+  timeline: readonly ZoomSpeakerEvent[],
+  intervalStartMs: number,
+  intervalEndMs: number,
+  fallback: string,
+): string {
+  const scores = new Map<string, { displayName: string; score: number }>();
+  for (const event of timeline) {
+    if (!event.isActive || event.isSelf === true) continue;
+    if (event.observedAtMs < intervalStartMs - BEFORE_INTERVAL_TOLERANCE_MS) continue;
+    if (event.observedAtMs > intervalEndMs + AFTER_INTERVAL_TOLERANCE_MS) continue;
+    const key = event.displayName.trim().toLocaleLowerCase();
+    if (!key) continue;
+    const previous = scores.get(key);
+    scores.set(key, {
+      displayName: event.displayName.trim(),
+      score: (previous?.score ?? 0) + event.confidence,
+    });
+  }
+
+  const ranked = [...scores.values()].sort((left, right) => right.score - left.score);
+  if (ranked.length === 0) return fallback;
+  if (ranked.length > 1 && ranked[0].score < ranked[1].score * MINIMUM_DOMINANCE_RATIO) {
+    return fallback;
+  }
+  return ranked[0].displayName;
+}

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -95,6 +95,34 @@ const SlackErrorKindSchema = z.enum([
   'not_authed', 'rate_limited', 'network', 'bad_channel', 'unknown',
 ]);
 
+/**
+ * Privacy-bounded evidence from the macOS Zoom Accessibility helper. The
+ * helper never forwards raw AX nodes, window titles, arbitrary labels, or
+ * transcript text across IPC.
+ */
+export const ZoomAccessibilityEvidence = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('permission'),
+    trusted: z.boolean(),
+    observedAtMs: z.number().int().nonnegative(),
+  }),
+  z.object({
+    type: z.literal('surface'),
+    state: z.enum(['active', 'missing', 'unknown']),
+    observedAtMs: z.number().int().nonnegative(),
+  }),
+  z.object({
+    type: z.literal('speaker'),
+    displayName: z.string().min(1).max(100),
+    isSelf: z.boolean().nullable(),
+    isActive: z.boolean(),
+    isMuted: z.boolean().nullable(),
+    confidence: z.number().min(0).max(1),
+    signals: z.array(z.string().max(64)).max(8),
+    observedAtMs: z.number().int().nonnegative(),
+  }),
+]);
+
 const KnowledgeSourceConfigSchema = z.object({
   id: z.string(),
   provider: z.enum(['gmail', 'meeting', 'voice_memo', 'slack', 'github', 'linear']),
@@ -1076,6 +1104,12 @@ const ipcSchemas = {
     req: z.null(),
     res: z.null(),
   },
+  // Main → renderer: bounded Zoom active-speaker and meeting-surface evidence
+  // from the optional macOS Accessibility helper.
+  'meeting:zoomAccessibilityEvidence': {
+    req: ZoomAccessibilityEvidence,
+    res: z.null(),
+  },
   // Renderer → main: assistant voice/video call holds the mic — suppresses
   // ambient meeting detection (it would otherwise see our own capture) and
   // runs the global push-to-talk key hook for the duration of the call.
@@ -1123,7 +1157,7 @@ const ipcSchemas = {
   // Deep-link to a macOS Privacy & Security pane (permission dialogs).
   'app:openPrivacySettings': {
     req: z.object({
-      section: z.enum(['microphone', 'camera', 'screen-recording', 'input-monitoring']),
+      section: z.enum(['microphone', 'camera', 'screen-recording', 'input-monitoring', 'accessibility']),
     }),
     res: z.object({ success: z.boolean() }),
   },

--- a/docs/zoom-accessibility-evidence.md
+++ b/docs/zoom-accessibility-evidence.md
@@ -1,0 +1,98 @@
+# Zoom speaker evidence on macOS
+
+Rowboat's existing meeting recorder captures two independent audio channels:
+the local microphone and system audio. Deepgram diarization can separate
+voices on system audio, but it cannot know the display names shown by Zoom.
+
+This integration adds an optional, macOS-only Accessibility helper that emits
+bounded Zoom evidence while Rowboat is already recording. It does not replace
+capture or transcription.
+
+## User-visible behavior
+
+- The microphone remains **You**.
+- A system-audio segment uses a Zoom display name only when active-speaker
+  evidence overlaps that audio interval.
+- Missing, stale, self, or conflicting evidence preserves Deepgram's generic
+  `Speaker N` label.
+- If two participants speak at once and neither signal dominates, Rowboat
+  keeps the generic diarization label instead of guessing.
+- After a validated Zoom meeting surface disappears for three consecutive
+  polls, Rowboat follows its existing stop-and-generate-notes flow.
+- Without Accessibility permission, recording continues normally with generic
+  speaker labels. Rowboat does not raise a surprise operating-system prompt;
+  the in-app notice offers an explicit **Open Settings** action instead.
+
+## Privacy and bounds
+
+`zoom-accessibility.swift`:
+
+- scopes inspection to the native `us.zoom.xos` process;
+- considers at most 8 windows per Zoom process and visits at most 1,800 nodes total, 18 levels, and 128
+  children per node;
+- uses one 600 ms inspection budget for the complete observation;
+- never reads editable or secure-field values;
+- never emits raw AX nodes, window titles, arbitrary labels, screenshots,
+  transcript text, process paths, or participant rosters;
+- emits only permission state, meeting-surface state, and normalized active
+  speaker evidence; and
+- exits when Electron closes its stdin lifetime pipe.
+
+The traversal and explicit-label parsing are adapted from Anarlog's MIT-licensed `meeting_ax`
+implementation at revision
+[`609ee772`](https://github.com/fastrepl/anarlog/tree/609ee772801f29292e4edee453f269089ebf0e8b).
+Its copyright, source revision, and license are included next to the packaged helper. The local changes
+replace Anarlog's application model with a single-purpose newline-delimited protocol, narrower output,
+parent-lifetime supervision, and Rowboat-specific attribution.
+
+The helper is read-only with respect to meeting/user content. It does set Zoom's non-content
+`AXManualAccessibility` and `AXEnhancedUserInterface` compatibility flags because Zoom otherwise omits parts
+of its semantic Accessibility tree in some layouts.
+
+## Build and verification
+
+The normal main-process bundle builds the helper with `swiftc`, runs its parser
+self-test, and stages the helper plus license beside `main.cjs`. Compilation is
+best-effort so a missing toolchain does not break meeting capture.
+
+Automated checks:
+
+```sh
+cd apps/x/packages/shared && npm run build
+cd ../../apps/renderer && npm test -- --run src/lib/zoom-speaker-evidence.test.ts
+cd ../main && npm run build
+```
+
+Before treating the feature as physically qualified, test a signed packaged
+build with Accessibility granted against a real native Zoom meeting:
+
+1. local-only speech;
+2. remote-only speech;
+3. simultaneous speech;
+4. mute and unmute;
+5. minimized meeting window;
+6. screen sharing;
+7. two participants with the same display name;
+8. permission revoke and re-grant; and
+9. meeting end while Zoom remains open.
+
+Do not treat unit tests or the helper's parser self-test as physical Zoom or
+macOS TCC coverage.
+
+## Extension path for other platforms
+
+This pull request intentionally supports only native Zoom on macOS. The typed evidence event is the reusable
+boundary; a future adapter must meet the same privacy, timing, self-marker, ambiguity, and fail-open rules
+before its names are trusted.
+
+- **Google Meet in Chrome:** measure the bounded macOS Accessibility tree first. If it cannot expose reliable
+  tab-scoped active-speaker transitions, use a minimal Chrome extension plus a separately packaged
+  [Native Messaging host](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging).
+  The extension should emit meeting metadata/evidence only; audio capture remains outside the extension.
+- **Microsoft Teams on macOS:** implement and physically qualify a separate bundle-scoped Accessibility
+  parser. Zoom labels or heuristics must not be reused without fixtures from Teams.
+- **Windows:** implement the same event schema over
+  [UI Automation](https://learn.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32) and qualify it
+  on Windows. A cross-compile or shared resolver test is not a Windows support claim.
+
+Unsupported adapters keep Rowboat's current generic diarization labels; they never block recording.


### PR DESCRIPTION
## Problem

Rowboat captures the local microphone and system audio separately, but diarization cannot map system-audio clusters to the participant display names shown by native Zoom. Meeting end also needs a stronger signal than a quiet audio track.

## What this adds

- An optional macOS Swift Accessibility helper scoped to native Zoom (`us.zoom.xos`).
- A typed, privacy-bounded event contract for permission, meeting-surface, and active-speaker evidence.
- Conservative alignment of system-audio transcript intervals to Zoom display names.
- A three-poll disappearance gate, enabled only after a validated meeting surface was observed, before emitting Rowboat's existing external-call-ended event.
- Best-effort packaging plus parser and attribution tests.
- Explicit **Open Settings** permission UX; starting notes does not raise a surprise macOS Accessibility prompt.

The microphone remains **You**. Missing, stale, self, overlapping, or conflicting evidence keeps the existing generic `Speaker N` label instead of guessing. Capture and transcription remain usable when Accessibility or the optional helper is unavailable.

## Privacy, provenance, and bounds

The helper inspects at most two native Zoom processes, eight windows per process, 1,800 AX nodes total, 18 levels, 128 children per node, and one 600 ms budget per observation. It does not read editable/secure-field values or emit raw AX nodes, arbitrary labels, window titles, screenshots, transcript text, process paths, or participant rosters. It exits when Electron closes its stdin lifetime pipe.

Traversal and explicit-label parsing are adapted from Anarlog's MIT-licensed `meeting_ax` at revision [`609ee772801f29292e4edee453f269089ebf0e8b`](https://github.com/fastrepl/anarlog/tree/609ee772801f29292e4edee453f269089ebf0e8b). The exact revision, retained copyright/license, and Rowboat-specific changes are documented beside the helper.

## Scope and composition

This PR supports **native Zoom on macOS only**. The documentation gives concrete extension paths for Chrome/Meet via a metadata-only extension/native host when AX is insufficient, Teams via its own bundle-scoped AX parser, and Windows via UI Automation. Unsupported platforms keep generic diarization and never block recording.

The evidence resolver is independent of the transcription vendor. #835 now exposes provider-neutral stable-audio intervals; the two PRs have been exercised together on a combined integration branch without creating a source dependency between them.

## Verification

Passed on the PR head:

- workspace TypeScript check
- workspace ESLint
- shared/core/preload dependency builds
- main-process bundle, including helper compile and self-test
- focused Zoom attribution tests: 5/5
- standalone native helper compile and parser self-test
- `git diff --check`

The broader core suite passed 585/586 tests; the unchanged ChatGPT token-revocation test timed out while attempting its network path in the restricted test environment. This branch has no core-package diff.

## Remaining qualification

This PR is ready for code review, but unit/parser/build checks are not physical Zoom or macOS TCC evidence. A signed packaged build still needs the documented matrix: local-only speech, remote-only speech, overlap, mute/unmute, minimization, screen sharing, identical display names, permission revoke/re-grant, and meeting end while Zoom remains open.
