### PR TITLE
feat(x): import Wispr Flow meetings via MCP

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -23,6 +23,7 @@ import { initUpdater } from "./updater.js";
 import { init as initGmailSync } from "@x/core/dist/knowledge/sync_gmail.js";
 import { init as initCalendarSync } from "@x/core/dist/knowledge/sync_calendar.js";
 import { init as initFirefliesSync } from "@x/core/dist/knowledge/sync_fireflies.js";
+import { init as initWisprFlowSync } from "@x/core/dist/knowledge/wispr-flow/sync.js";
 import { init as initGranolaSync } from "@x/core/dist/knowledge/granola/sync.js";
 import { init as initGraphBuilder } from "@x/core/dist/knowledge/build_graph.js";
 import { init as initNoteTagging } from "@x/core/dist/knowledge/tag_notes.js";
@@ -722,6 +723,9 @@ app.whenReady().then(async () => {
 
   // start fireflies sync
   initFirefliesSync();
+
+  // Import finalized Wispr Notetaker meetings through its OAuth-protected MCP.
+  initWisprFlowSync();
 
   // start granola sync
   initGranolaSync();

--- a/apps/x/apps/main/src/oauth-handler.ts
+++ b/apps/x/apps/main/src/oauth-handler.ts
@@ -11,6 +11,7 @@ import { IClientRegistrationRepo } from '@x/core/dist/auth/client-repo.js';
 import { triggerSync as triggerGmailSync } from '@x/core/dist/knowledge/sync_gmail.js';
 import { triggerSync as triggerCalendarSync } from '@x/core/dist/knowledge/sync_calendar.js';
 import { triggerSync as triggerFirefliesSync } from '@x/core/dist/knowledge/sync_fireflies.js';
+import { triggerSync as triggerWisprFlowSync } from '@x/core/dist/knowledge/wispr-flow/sync.js';
 import { emitOAuthEvent } from './ipc.js';
 import { getBillingInfo } from '@x/core/dist/billing/billing.js';
 import { capture as analyticsCapture, identify as analyticsIdentify, reset as analyticsReset } from '@x/core/dist/analytics/posthog.js';
@@ -66,6 +67,7 @@ const activeFlows = new Map<string, {
   codeVerifier: string;
   provider: string;
   config: Configuration;
+  resource?: string;
 }>();
 
 // Module-level state for tracking the active OAuth flow
@@ -173,7 +175,9 @@ async function getProviderConfiguration(
       const { config: oauthConfig, registration } = await oauthClient.registerClient(
         config.discovery.issuer,
         [redirectUri],
-        scopes
+        scopes,
+        'RowboatX Desktop App',
+        config.client.registrationEndpoint,
       );
 
       // Parse port from redirectUri (e.g. "http://localhost:8081/...") and save
@@ -313,7 +317,8 @@ export async function connectProvider(provider: string, credentials?: { clientId
             flow.config,
             callbackUrl,
             flow.codeVerifier,
-            state
+            state,
+            flow.resource,
           );
 
           // Save tokens and credentials. For Google, BYOK is the only path
@@ -334,6 +339,8 @@ export async function connectProvider(provider: string, credentials?: { clientId
             triggerCalendarSync();
           } else if (provider === 'fireflies-ai') {
             triggerFirefliesSync();
+          } else if (provider === 'wispr-flow') {
+            triggerWisprFlowSync();
           }
 
           // For Rowboat sign-in, ensure user + Stripe customer exist before
@@ -421,13 +428,19 @@ export async function connectProvider(provider: string, credentials?: { clientId
       state = oauthClient.generateState();
 
       const scopes = providerConfig.scopes || [];
-      activeFlows.set(state, { codeVerifier, provider, config });
+      activeFlows.set(state, {
+        codeVerifier,
+        provider,
+        config,
+        resource: providerConfig.resource,
+      });
 
       const authUrl = oauthClient.buildAuthorizationUrl(config, {
         redirect_uri: redirectUri,
         scope: scopes.join(' '),
         code_challenge: codeChallenge,
         state,
+        ...(providerConfig.resource ? { resource: providerConfig.resource } : {}),
         // Google only returns a refresh_token when offline access is requested,
         // and only re-issues one when re-consent is forced. Without these, a
         // BYOK token expires after ~1h with no way to refresh (it goes stale and
@@ -655,7 +668,13 @@ export async function getAccessToken(provider: string): Promise<string | null> {
 
         // Refresh token, preserving existing scopes
         const existingScopes = tokens.scopes;
-        const refreshedTokens = await oauthClient.refreshTokens(config, tokens.refresh_token, existingScopes);
+        const providerConfig = await getProviderConfig(provider);
+        const refreshedTokens = await oauthClient.refreshTokens(
+          config,
+          tokens.refresh_token,
+          existingScopes,
+          providerConfig.resource,
+        );
         await oauthRepo.upsert(provider, { tokens: refreshedTokens });
         tokens = refreshedTokens;
       } catch (error) {

--- a/apps/x/apps/renderer/src/components/connectors-popover.tsx
+++ b/apps/x/apps/renderer/src/components/connectors-popover.tsx
@@ -135,6 +135,10 @@ export function ConnectorsPopover({ children, tooltip, open: openProp, onOpenCha
       const firefliesState = c.providerStates['fireflies-ai']
       if (!firefliesState?.isConnected || c.providerStatus['fireflies-ai']?.error) return true
     }
+    if (c.providers.includes('wispr-flow')) {
+      const wisprState = c.providerStates['wispr-flow']
+      if (!wisprState?.isConnected || c.providerStatus['wispr-flow']?.error) return true
+    }
     return false
   })()
 
@@ -344,6 +348,7 @@ export function ConnectorsPopover({ children, tooltip, open: openProp, onOpenCha
 
                   {/* Fireflies */}
                   {c.providers.includes('fireflies-ai') && renderOAuthProvider('fireflies-ai', 'Fireflies', <Mic className="size-4" />, 'AI meeting transcripts')}
+                  {c.providers.includes('wispr-flow') && renderOAuthProvider('wispr-flow', 'Wispr Flow', <Mic className="size-4" />, 'Import finalized Notetaker meetings')}
 
                   <Separator className="my-2" />
                 </>

--- a/apps/x/apps/renderer/src/components/onboarding/steps/completion-step.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/steps/completion-step.tsx
@@ -103,6 +103,17 @@ export function CompletionStep({ state }: CompletionStepProps) {
                 <span>Fireflies (Meeting transcripts)</span>
               </motion.div>
             )}
+            {connectedProviders.includes('wispr-flow') && (
+              <motion.div
+                initial={{ opacity: 0, x: -8 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.57 }}
+                className="flex items-center gap-2 text-sm text-muted-foreground"
+              >
+                <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
+                <span>Wispr Flow (Notetaker meetings)</span>
+              </motion.div>
+            )}
           </div>
         </motion.div>
       )}

--- a/apps/x/apps/renderer/src/components/onboarding/steps/connect-accounts-step.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/steps/connect-accounts-step.tsx
@@ -1,4 +1,4 @@
-import { Loader2, CheckCircle2, ArrowLeft, Calendar, FileText } from "lucide-react"
+import { Loader2, CheckCircle2, ArrowLeft, Calendar, FileText, Mic } from "lucide-react"
 import { motion } from "motion/react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -186,6 +186,18 @@ export function ConnectAccountsStep({ state }: ConnectAccountsStepProps) {
                 iconColor="text-amber-500"
                 providerState={providerStates['fireflies-ai']}
                 onConnect={() => handleConnect('fireflies-ai')}
+                index={cardIndex++}
+              />
+            )}
+            {providers.includes('wispr-flow') && (
+              <ProviderCard
+                name="Wispr Flow"
+                description="Import finalized Notetaker meetings."
+                icon={<Mic className="size-5" />}
+                iconBg="bg-violet-500/10"
+                iconColor="text-violet-500"
+                providerState={providerStates['wispr-flow']}
+                onConnect={() => handleConnect('wispr-flow')}
                 index={cardIndex++}
               />
             )}

--- a/apps/x/apps/renderer/src/components/settings/connected-accounts-settings.tsx
+++ b/apps/x/apps/renderer/src/components/settings/connected-accounts-settings.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Loader2, Calendar } from "lucide-react"
+import { Loader2, Calendar, Mic } from "lucide-react"
 import { FirefliesIcon, GoogleIcon, SlackIcon } from "@/components/onboarding/provider-icons"
 import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
@@ -236,7 +236,7 @@ export function ConnectedAccountsSettings({ dialogOpen }: ConnectedAccountsSetti
         )}
 
         {/* Meeting Notes Section */}
-        {c.providers.includes('fireflies-ai') && (
+        {(c.providers.includes('fireflies-ai') || c.providers.includes('wispr-flow')) && (
           <>
             <div className="px-3 pt-1 pb-0.5">
               <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
@@ -245,7 +245,8 @@ export function ConnectedAccountsSettings({ dialogOpen }: ConnectedAccountsSetti
             </div>
 
             {/* Fireflies */}
-            {renderOAuthProvider('fireflies-ai', 'Fireflies', <FirefliesIcon className="size-5" />, 'AI meeting transcripts')}
+            {c.providers.includes('fireflies-ai') && renderOAuthProvider('fireflies-ai', 'Fireflies', <FirefliesIcon className="size-5" />, 'AI meeting transcripts')}
+            {c.providers.includes('wispr-flow') && renderOAuthProvider('wispr-flow', 'Wispr Flow', <Mic className="size-5" />, 'Import finalized Notetaker meetings')}
           </>
         )}
 

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -155,6 +155,7 @@ const SERVICE_LABELS: Record<string, string> = {
   gmail: "Syncing Gmail",
   calendar: "Syncing Calendar",
   fireflies: "Syncing Fireflies",
+  wispr_flow: "Syncing Wispr Flow",
   granola: "Syncing Granola",
   graph: "Updating knowledge",
   voice_memo: "Processing voice memo",

--- a/apps/x/apps/renderer/src/hooks/useConnectors.ts
+++ b/apps/x/apps/renderer/src/hooks/useConnectors.ts
@@ -12,6 +12,12 @@ export interface ProviderStatus {
   error?: string
 }
 
+function providerDisplayName(provider: string): string {
+  if (provider === 'fireflies-ai') return 'Fireflies'
+  if (provider === 'wispr-flow') return 'Wispr Flow'
+  return provider.charAt(0).toUpperCase() + provider.slice(1)
+}
+
 type KnowledgeSourceConfig = {
   id: string
   provider: 'gmail' | 'meeting' | 'voice_memo' | 'slack' | 'github' | 'linear'
@@ -638,7 +644,7 @@ export function useConnectors(active: boolean) {
         if (provider === 'google') {
           clearGoogleCredentials()
         }
-        const displayName = provider === 'fireflies-ai' ? 'Fireflies' : provider.charAt(0).toUpperCase() + provider.slice(1)
+        const displayName = providerDisplayName(provider)
         toast.success(provider === 'rowboat' ? 'Logged out of Rowboat' : `Disconnected from ${displayName}`)
         setProviderStates(prev => ({
           ...prev,
@@ -739,10 +745,10 @@ export function useConnectors(active: boolean) {
       }))
 
       if (success) {
-        const displayName = provider === 'fireflies-ai' ? 'Fireflies' : provider.charAt(0).toUpperCase() + provider.slice(1)
+        const displayName = providerDisplayName(provider)
         if (provider === 'rowboat') {
           toast.success('Logged in to Rowboat')
-        } else if (provider === 'google' || provider === 'fireflies-ai') {
+        } else if (provider === 'google' || provider === 'fireflies-ai' || provider === 'wispr-flow') {
           toast.success(`Connected to ${displayName}`, {
             description: 'Syncing your data in the background. This may take a few minutes before changes appear.',
             duration: 8000,

--- a/apps/x/packages/core/src/auth/oauth-client.test.ts
+++ b/apps/x/packages/core/src/auth/oauth-client.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerClientAtEndpoint, resourceParameters } from './oauth-client.js';
+import { getProviderConfig } from './providers.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('explicit OAuth dynamic client registration', () => {
+  it('posts the RFC 7591 public PKCE registration and parses the response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      client_id: 'wispr-client-123',
+      client_id_issued_at: 1_786_000_000,
+    }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(registerClientAtEndpoint(
+      'https://mcp-auth.wisprflow.com/oauth2/register',
+      {
+        redirect_uris: ['http://127.0.0.1:19876/oauth/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        client_name: 'RowboatX Desktop App',
+        scope: 'openid email profile offline_access',
+      },
+    )).resolves.toMatchObject({ client_id: 'wispr-client-123' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://mcp-auth.wisprflow.com/oauth2/register');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toEqual({
+      redirect_uris: ['http://127.0.0.1:19876/oauth/callback'],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      client_name: 'RowboatX Desktop App',
+      scope: 'openid email profile offline_access',
+    });
+  });
+
+  it('returns a bounded provider error without accepting a failed registration', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('x'.repeat(1_200), {
+      status: 400,
+    })));
+
+    await expect(registerClientAtEndpoint(
+      'https://mcp-auth.wisprflow.com/oauth2/register',
+      { redirect_uris: ['http://127.0.0.1:19876/oauth/callback'] },
+    )).rejects.toThrow(/^Dynamic client registration failed \(400\): x{1000}$/);
+  });
+});
+
+describe('OAuth protected-resource binding', () => {
+  it('binds the Wispr authorization and token requests to the protected MCP resource', async () => {
+    const provider = await getProviderConfig('wispr-flow');
+    expect(provider.resource).toBe('https://api.wisprflow.ai/connect/mcp');
+    expect(resourceParameters(provider.resource)).toEqual({
+      resource: 'https://api.wisprflow.ai/connect/mcp',
+    });
+  });
+
+  it('does not add a resource parameter for ordinary providers', () => {
+    expect(resourceParameters()).toBeUndefined();
+  });
+});

--- a/apps/x/packages/core/src/auth/oauth-client.ts
+++ b/apps/x/packages/core/src/auth/oauth-client.ts
@@ -1,10 +1,18 @@
 import * as client from 'openid-client';
-import { OAuthTokens, ClientRegistrationResponse } from './types.js';
+import {
+  OAuthTokens,
+  ClientRegistrationRequest,
+  ClientRegistrationResponse,
+} from './types.js';
 
 /**
  * Cached configurations per provider (issuer:clientId -> Configuration)
  */
 const configCache = new Map<string, client.Configuration>();
+
+function configurationCacheKey(issuerUrl: string, clientId: string, hasSecret = false): string {
+  return `${issuerUrl}:${clientId}:${hasSecret ? 'secret' : 'none'}`;
+}
 
 /**
  * Helper to convert openid-client token response to our OAuthTokens type
@@ -40,7 +48,7 @@ export async function discoverConfiguration(
   clientId: string,
   clientSecret?: string
 ): Promise<client.Configuration> {
-  const cacheKey = `${issuerUrl}:${clientId}:${clientSecret ? 'secret' : 'none'}`;
+  const cacheKey = configurationCacheKey(issuerUrl, clientId, Boolean(clientSecret));
 
   const cached = configCache.get(cacheKey);
   if (cached) {
@@ -94,6 +102,33 @@ export function createStaticConfiguration(
 }
 
 /**
+ * Register a public PKCE client against an explicit RFC 7591 endpoint.
+ *
+ * Some providers expose registration_endpoint only in RFC 8414 authorization
+ * server metadata, not in OpenID discovery. Keeping the POST isolated also
+ * makes the trust boundary and request shape independently testable.
+ */
+export async function registerClientAtEndpoint(
+  registrationEndpoint: string,
+  request: ClientRegistrationRequest,
+): Promise<ClientRegistrationResponse> {
+  const response = await fetch(registrationEndpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(request),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 1_000);
+    throw new Error(`Dynamic client registration failed (${response.status}): ${detail}`);
+  }
+  return ClientRegistrationResponse.parse(await response.json());
+}
+
+/**
  * Register client via Dynamic Client Registration (RFC 7591)
  * Returns both the Configuration and the registration response (for persistence)
  */
@@ -101,9 +136,34 @@ export async function registerClient(
   issuerUrl: string,
   redirectUris: string[],
   scopes: string[],
-  clientName: string = 'RowboatX Desktop App'
+  clientName: string = 'RowboatX Desktop App',
+  registrationEndpoint?: string,
 ): Promise<{ config: client.Configuration; registration: ClientRegistrationResponse }> {
   console.log(`[OAuth] Registering client via DCR at ${issuerUrl}...`);
+
+  // Some OAuth servers publish Dynamic Client Registration only in their
+  // RFC 8414 authorization-server document, while their OpenID discovery
+  // document omits registration_endpoint. openid-client's convenience DCR
+  // helper uses OpenID discovery and therefore cannot register those valid
+  // providers. When the provider advertises an explicit endpoint, perform the
+  // standard RFC 7591 POST and then use ordinary discovery for auth/token URLs.
+  if (registrationEndpoint) {
+    const registration = await registerClientAtEndpoint(registrationEndpoint, {
+      redirect_uris: redirectUris,
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      client_name: clientName,
+      scope: scopes.join(' '),
+    });
+    // This is a public desktop PKCE client. Ignore any unexpected secret in a
+    // registration response rather than changing the token auth method.
+    const config = await discoverConfiguration(issuerUrl, registration.client_id);
+    const cacheKey = configurationCacheKey(issuerUrl, registration.client_id);
+    configCache.set(cacheKey, config);
+    return { config, registration };
+  }
+
   const config = await client.dynamicClientRegistration(
     new URL(issuerUrl),
     {
@@ -132,7 +192,7 @@ export async function registerClient(
   });
 
   // Cache the configuration
-  const cacheKey = `${issuerUrl}:${metadata.client_id}`;
+  const cacheKey = configurationCacheKey(issuerUrl, metadata.client_id);
   configCache.set(cacheKey, config);
 
   return { config, registration };
@@ -167,6 +227,11 @@ export function buildAuthorizationUrl(
   });
 }
 
+/** Return RFC 8707 token-endpoint parameters for a protected resource. */
+export function resourceParameters(resource?: string): Record<string, string> | undefined {
+  return resource ? { resource } : undefined;
+}
+
 /**
  * Exchange authorization code for tokens
  */
@@ -174,14 +239,15 @@ export async function exchangeCodeForTokens(
   config: client.Configuration,
   callbackUrl: URL,
   codeVerifier: string,
-  expectedState: string
+  expectedState: string,
+  resource?: string,
 ): Promise<OAuthTokens> {
   console.log(`[OAuth] Exchanging authorization code for tokens...`);
 
   const response = await client.authorizationCodeGrant(config, callbackUrl, {
     pkceCodeVerifier: codeVerifier,
     expectedState,
-  });
+  }, resourceParameters(resource));
 
   console.log(`[OAuth] Token exchange successful`);
   return toOAuthTokens(response);
@@ -194,11 +260,16 @@ export async function exchangeCodeForTokens(
 export async function refreshTokens(
   config: client.Configuration,
   refreshToken: string,
-  existingScopes?: string[]
+  existingScopes?: string[],
+  resource?: string,
 ): Promise<OAuthTokens> {
   console.log(`[OAuth] Refreshing access token...`);
 
-  const response = await client.refreshTokenGrant(config, refreshToken);
+  const response = await client.refreshTokenGrant(
+    config,
+    refreshToken,
+    resourceParameters(resource),
+  );
 
   const tokens = toOAuthTokens(response);
 
@@ -232,7 +303,8 @@ export function isTokenExpired(tokens: OAuthTokens): boolean {
  */
 export function clearConfigCache(issuerUrl?: string, clientId?: string): void {
   if (issuerUrl && clientId) {
-    configCache.delete(`${issuerUrl}:${clientId}`);
+    configCache.delete(configurationCacheKey(issuerUrl, clientId));
+    configCache.delete(configurationCacheKey(issuerUrl, clientId, true));
     console.log(`[OAuth] Cleared configuration cache for ${issuerUrl}`);
   } else {
     configCache.clear();
@@ -244,9 +316,9 @@ export function clearConfigCache(issuerUrl?: string, clientId?: string): void {
  * Get cached configuration if available
  */
 export function getCachedConfiguration(issuerUrl: string, clientId: string): client.Configuration | undefined {
-  return configCache.get(`${issuerUrl}:${clientId}`);
+  return configCache.get(configurationCacheKey(issuerUrl, clientId))
+    ?? configCache.get(configurationCacheKey(issuerUrl, clientId, true));
 }
 
 // Re-export Configuration type for external use
 export type { Configuration } from 'openid-client';
-

--- a/apps/x/packages/core/src/auth/providers.ts
+++ b/apps/x/packages/core/src/auth/providers.ts
@@ -42,6 +42,9 @@ const ProviderConfigSchema = z.record(
     discovery: DiscoverySchema,
     client: ClientSchema,
     scopes: z.array(z.string()).optional(),
+    // RFC 8707 resource indicator. MCP servers use this to issue an access
+    // token whose audience is the protected resource rather than the issuer.
+    resource: z.url().optional(),
   })
 );
 
@@ -95,6 +98,23 @@ const providerConfigs: ProviderConfig = {
       'profile',
       'email',
     ]
+  },
+  'wispr-flow': {
+    discovery: {
+      mode: 'issuer',
+      issuer: 'https://mcp-auth.wisprflow.com',
+    },
+    client: {
+      mode: 'dcr',
+      registrationEndpoint: 'https://mcp-auth.wisprflow.com/oauth2/register',
+    },
+    scopes: [
+      'openid',
+      'email',
+      'profile',
+      'offline_access',
+    ],
+    resource: 'https://api.wisprflow.ai/connect/mcp',
   }
 };
 

--- a/apps/x/packages/core/src/knowledge/live-note/agent.ts
+++ b/apps/x/packages/core/src/knowledge/live-note/agent.ts
@@ -121,7 +121,7 @@ The user's knowledge graph is plain markdown in \`${WorkDir}/knowledge/\`, organ
 - **Projects/** — initiatives
 - **Topics/** — recurring themes
 
-Synced external data often sits alongside under \`gmail_sync/\`, \`calendar_sync/\`, \`granola_sync/\`, \`fireflies_sync/\` — consult these when the objective references emails, meetings, or calendar events.
+Synced external data sits under \`gmail_sync/\`, \`calendar_sync/\`, and \`knowledge/Meetings/\` (including Granola, Fireflies, Rowboat, and Wispr Flow) — consult these when the objective references emails, meetings, or calendar events.
 
 **CRITICAL:** Always include the folder prefix in paths. Never pass an empty path or the workspace root.
 - \`file-grep({ pattern: "Acme", searchPath: "knowledge/" })\`

--- a/apps/x/packages/core/src/knowledge/note_creation.ts
+++ b/apps/x/packages/core/src/knowledge/note_creation.ts
@@ -213,7 +213,7 @@ file-readText({ path: "{source_file}" })
 - Has \`Attendees:\` field
 - Has \`Meeting:\` title
 - Transcript format with speaker labels
-- Source file path is under \`knowledge/Meetings/\` (e.g. \`knowledge/Meetings/granola/...\` or \`knowledge/Meetings/fireflies/...\`)
+- Source file path is under \`knowledge/Meetings/\` (e.g. \`knowledge/Meetings/granola/...\`, \`knowledge/Meetings/fireflies/...\`, or \`knowledge/Meetings/wispr-flow/...\`)
 
 **Email indicators:**
 - Has \`From:\` and \`To:\` fields

--- a/apps/x/packages/core/src/knowledge/note_tagging_agent.ts
+++ b/apps/x/packages/core/src/knowledge/note_tagging_agent.ts
@@ -98,7 +98,7 @@ Extract all \`**Key:** value\` fields from the \`## Info\` (or \`## About\`) sec
 - **Topics** (from \`## About\`): keywords, aliases, first_mentioned, last_update
 - **Meetings**: Extract from the note content and file path:
   - \`date\`: meeting date (from the file path \`Meetings/{source}/YYYY/MM/DD/\` or from \`created_at\`/\`Date:\` in content)
-  - \`source\`: \`granola\` or \`fireflies\` (from the file path)
+  - \`source\`: \`granola\`, \`fireflies\`, \`wispr-flow\`, or \`rowboat\` (from the file path)
   - \`attendees\`: list of attendee names (from \`Attendees:\` field or participant list)
   - \`title\`: meeting title
   - \`topic\`: relevant topic tags based on meeting content

--- a/apps/x/packages/core/src/knowledge/sources/repo.ts
+++ b/apps/x/packages/core/src/knowledge/sources/repo.ts
@@ -35,6 +35,14 @@ const BUILTIN_SOURCES: KnowledgeSourceConfig[] = [
         scopes: [],
     },
     {
+        id: 'wispr-flow-meetings',
+        provider: 'meeting',
+        enabled: true,
+        artifactDir: path.join('knowledge', 'Meetings', 'wispr-flow'),
+        syncMode: 'file',
+        scopes: [],
+    },
+    {
         id: 'rowboat-meetings',
         provider: 'meeting',
         enabled: true,

--- a/apps/x/packages/core/src/knowledge/wispr-flow/client-factory.test.ts
+++ b/apps/x/packages/core/src/knowledge/wispr-flow/client-factory.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import container from '../../di/container.js';
+import { WisprFlowClientFactory } from './client-factory.js';
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await WisprFlowClientFactory.clearCache();
+});
+
+describe('WisprFlowClientFactory credentials', () => {
+  it.each([undefined, null])('treats %s tokens as disconnected', async (tokens) => {
+    vi.spyOn(container, 'resolve').mockReturnValue({
+      read: vi.fn().mockResolvedValue({ tokens }),
+    } as never);
+    await expect(WisprFlowClientFactory.hasCredentials()).resolves.toBe(false);
+  });
+
+  it('recognizes a stored OAuth token', async () => {
+    vi.spyOn(container, 'resolve').mockReturnValue({
+      read: vi.fn().mockResolvedValue({ tokens: { access_token: 'test-token' } }),
+    } as never);
+    await expect(WisprFlowClientFactory.hasCredentials()).resolves.toBe(true);
+  });
+});

--- a/apps/x/packages/core/src/knowledge/wispr-flow/client-factory.ts
+++ b/apps/x/packages/core/src/knowledge/wispr-flow/client-factory.ts
@@ -1,0 +1,122 @@
+import { Client } from '@modelcontextprotocol/sdk/client';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import container from '../../di/container.js';
+import type { IOAuthRepo } from '../../auth/repo.js';
+import type { IClientRegistrationRepo } from '../../auth/client-repo.js';
+import { getProviderConfig } from '../../auth/providers.js';
+import * as oauthClient from '../../auth/oauth-client.js';
+import type { Configuration } from '../../auth/oauth-client.js';
+import type { OAuthTokens } from '../../auth/types.js';
+
+const PROVIDER_NAME = 'wispr-flow';
+const MCP_URL = 'https://api.wisprflow.ai/connect/mcp';
+
+type ClientCache = {
+  config: Configuration | null;
+  client: Client | null;
+  tokens: OAuthTokens | null;
+};
+
+/**
+ * Authenticated client for Wispr Flow's OAuth-protected MCP connector. Tokens
+ * and DCR registrations use Rowboat's existing OAuth repositories; this
+ * client never reads Wispr's desktop session, Keychain, or private local data.
+ */
+export class WisprFlowClientFactory {
+  private static cache: ClientCache = { config: null, client: null, tokens: null };
+
+  static async hasCredentials(): Promise<boolean> {
+    const repo = container.resolve<IOAuthRepo>('oauthRepo');
+    const { tokens } = await repo.read(PROVIDER_NAME);
+    if (!tokens && this.cache.client) await this.clearCache();
+    return Boolean(tokens);
+  }
+
+  static async getClient(): Promise<Client | null> {
+    const repo = container.resolve<IOAuthRepo>('oauthRepo');
+    const connection = await repo.read(PROVIDER_NAME);
+    const tokens = connection.tokens;
+    if (!tokens) {
+      await this.clearCache();
+      return null;
+    }
+
+    const config = await this.getConfiguration();
+    if (oauthClient.isTokenExpired(tokens)) {
+      if (!tokens.refresh_token) {
+        await repo.upsert(PROVIDER_NAME, {
+          error: 'Wispr Flow access expired. Please reconnect.',
+        });
+        await this.clearCache();
+        return null;
+      }
+      try {
+        const refreshed = await oauthClient.refreshTokens(
+          config,
+          tokens.refresh_token,
+          tokens.scopes,
+          MCP_URL,
+        );
+        await repo.upsert(PROVIDER_NAME, { tokens: refreshed, error: null });
+        await this.replaceClient(refreshed);
+        return this.cache.client;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Wispr Flow token refresh failed';
+        await repo.upsert(PROVIDER_NAME, { error: message });
+        await this.clearCache();
+        return null;
+      }
+    }
+
+    if (this.cache.client && this.cache.tokens?.access_token === tokens.access_token) {
+      return this.cache.client;
+    }
+    await this.replaceClient(tokens);
+    return this.cache.client;
+  }
+
+  static async clearCache(): Promise<void> {
+    if (this.cache.client) {
+      await this.cache.client.close().catch(() => undefined);
+    }
+    this.cache = { config: null, client: null, tokens: null };
+  }
+
+  private static async getConfiguration(): Promise<Configuration> {
+    if (this.cache.config) return this.cache.config;
+    const provider = await getProviderConfig(PROVIDER_NAME);
+    if (provider.discovery.mode !== 'issuer' || provider.client.mode !== 'dcr') {
+      throw new Error('Wispr Flow OAuth must use issuer discovery and DCR');
+    }
+    const registrations = container.resolve<IClientRegistrationRepo>('clientRegistrationRepo');
+    const registration = await registrations.getClientRegistration(PROVIDER_NAME);
+    if (!registration) {
+      throw new Error('Wispr Flow is not registered. Connect it in Rowboat Settings first.');
+    }
+    this.cache.config = await oauthClient.discoverConfiguration(
+      provider.discovery.issuer,
+      registration.client_id,
+    );
+    return this.cache.config;
+  }
+
+  private static async replaceClient(tokens: OAuthTokens): Promise<void> {
+    if (this.cache.client) {
+      await this.cache.client.close().catch(() => undefined);
+    }
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+      requestInit: {
+        headers: { Authorization: `Bearer ${tokens.access_token}` },
+      },
+    });
+    const client = new Client({ name: 'rowboat-wispr-flow', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+    } catch (error) {
+      await client.close().catch(() => undefined);
+      throw error;
+    }
+    this.cache.tokens = tokens;
+    this.cache.client = client;
+  }
+}

--- a/apps/x/packages/core/src/knowledge/wispr-flow/sync.test.ts
+++ b/apps/x/packages/core/src/knowledge/wispr-flow/sync.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chooseWisprTools,
+  detailArguments,
+  listArguments,
+  mergeMeetingArtifact,
+  mergeNormalizedWisprMeeting,
+  meetingToMarkdown,
+  normalizeWisprMeeting,
+} from './sync.js';
+
+describe('Wispr Flow meeting sync', () => {
+  it('normalizes finalized Notetaker artifacts and groups transcript turns', () => {
+    const meeting = normalizeWisprMeeting({
+      id: 'meeting-1',
+      title: 'Product review',
+      status: 'completed',
+      startedAt: '2026-08-06T10:00:00Z',
+      myThoughts: 'Remember the launch constraint.',
+      summary: 'The team chose option B.',
+      participants: [{ displayName: 'Rahul' }, { name: 'Akbar' }],
+      transcript: {
+        segments: [
+          { speakerName: 'Rahul', text: 'First sentence.' },
+          { speakerName: 'Rahul', text: 'Second sentence.' },
+          { speakerName: 'Akbar', text: 'Reply.' },
+        ],
+      },
+    });
+    expect(meeting).not.toBeNull();
+    expect(meeting?.finalized).toBe(true);
+    expect(meeting?.participants).toEqual(['Rahul', 'Akbar']);
+    expect(meeting?.transcript).toContain('**Rahul:** First sentence. Second sentence.');
+  });
+
+  it('normalizes Wispr MCP post-call fields without requiring a transcript', () => {
+    const meeting = normalizeWisprMeeting({
+      id: 'wispr-meeting-1',
+      title: 'Zoom meeting',
+      content: 'Remember the personal follow-up.',
+      summary: 'Rahul and Akbar agreed on the launch.',
+      finalized: true,
+      has_transcript: false,
+      attendees: [{ name: 'Rahul' }, { email: 'akbar@example.com' }],
+      todos: [{ text: 'Send the launch brief' }],
+      start: '2026-08-06T10:00:00Z',
+      end: '2026-08-06T10:30:00Z',
+      modified_at: '2026-08-06T10:31:00Z',
+    });
+    expect(meeting).toMatchObject({
+      thoughts: 'Remember the personal follow-up.',
+      participants: ['Rahul', 'akbar@example.com'],
+      actionItems: ['Send the launch brief'],
+      occurredAt: '2026-08-06T10:00:00.000Z',
+      endedAt: '2026-08-06T10:30:00.000Z',
+      finalized: true,
+    });
+    expect(meeting?.transcript).toBeUndefined();
+  });
+
+  it('converts Wispr speaker turns into a valid Rowboat transcript and derives named participants', () => {
+    const meeting = normalizeWisprMeeting({
+      id: 'wispr-meeting-speakers',
+      finalized: true,
+      transcript: [
+        '<<<Transcript starts here, use responsibly>>>',
+        'rajat prakash: First point.',
+        'Speaker 2: Generic diarized response.',
+        'Rahul Khatri: Follow-up point.',
+      ].join('\n'),
+    });
+    expect(meeting?.transcript).toContain('**rajat prakash:** First point.');
+    expect(meeting?.transcript).toContain('**Speaker 2:** Generic diarized response.');
+    expect(meeting?.transcript).toContain('**Rahul Khatri:** Follow-up point.');
+    expect(meeting?.participants).toEqual(['rajat prakash', 'Rahul Khatri']);
+  });
+
+  it('wraps an unlabeled Wispr transcript in a valid unknown-speaker turn', () => {
+    const meeting = normalizeWisprMeeting({
+      id: 'wispr-meeting-unlabeled',
+      finalized: true,
+      transcript: 'A transcript with no speaker boundary.',
+    });
+    expect(meeting?.transcript).toBe('**Unknown speaker:** A transcript with no speaker boundary.');
+    expect(meeting?.participants).toEqual([]);
+  });
+
+  it('does not import a transcript-only live meeting', () => {
+    const meeting = normalizeWisprMeeting({
+      id: 'meeting-live',
+      status: 'recording',
+      transcript: 'Still in progress',
+    });
+    expect(meeting?.finalized).toBe(false);
+  });
+
+  it('rejects nested non-meeting records that only have a generic id', () => {
+    expect(normalizeWisprMeeting({
+      id: 'action-1',
+      title: 'Send the brief',
+      content: 'Due tomorrow',
+    })).toBeNull();
+  });
+
+  it('merges sparse detail payloads without discarding list metadata', () => {
+    const merged = mergeNormalizedWisprMeeting({
+      id: 'meeting-1',
+      title: 'Product review',
+      occurredAt: '2026-08-06T10:00:00.000Z',
+      participants: ['Rahul'],
+      summary: 'Original summary',
+      actionItems: ['Send brief'],
+      transcript: '**Rahul:** Short.',
+      finalized: true,
+    }, {
+      id: 'meeting-1',
+      title: 'Wispr meeting',
+      occurredAt: '2026-08-06T10:01:00.000Z',
+      participants: ['Akbar'],
+      actionItems: [],
+      transcript: '**Rahul:** A longer transcript from meeting detail.',
+      finalized: false,
+    });
+    expect(merged).toMatchObject({
+      title: 'Product review',
+      participants: ['Rahul', 'Akbar'],
+      summary: 'Original summary',
+      actionItems: ['Send brief'],
+      transcript: '**Rahul:** A longer transcript from meeting detail.',
+      finalized: true,
+    });
+  });
+
+  it('selects meeting search and detail tools without hard-coding Wispr names', () => {
+    const selected = chooseWisprTools([
+      { name: 'search_notetaker_meetings', description: 'Search meeting notes' },
+      { name: 'get_notetaker_meeting', description: 'Get meeting transcript and brief' },
+      { name: 'search_dictations', description: 'Search dictation history' },
+    ]);
+    expect(selected.list.name).toBe('search_notetaker_meetings');
+    expect(selected.detail?.name).toBe('get_notetaker_meeting');
+  });
+
+  it('prefers Wispr meeting detail over similarly described calendar tools', () => {
+    const selected = chooseWisprTools([
+      { name: 'search_meetings', description: 'Search recorded meetings' },
+      { name: 'get_upcoming_meeting', description: 'Get upcoming meeting by calendar id' },
+      { name: 'get_meeting', description: 'Get recorded notes and transcript' },
+    ]);
+    expect(selected.list.name).toBe('search_meetings');
+    expect(selected.detail?.name).toBe('get_meeting');
+  });
+
+  it('uses Wispr recent-meeting semantics and requests post-call artifacts', () => {
+    const listTool = {
+      name: 'search_meetings',
+      inputSchema: { properties: { query: {}, since: {}, until: {}, limit: {} } },
+    };
+    const detailTool = {
+      name: 'get_meeting',
+      inputSchema: { properties: { meeting_id: {}, view_content: {}, view_transcript: {} } },
+    };
+    expect(listArguments(listTool)).toEqual({ limit: 50 });
+    expect(detailArguments(detailTool, 'meeting-1')).toEqual({
+      meeting_id: 'meeting-1',
+      view_content: { start_char: 0, char_limit: 40_000 },
+      view_transcript: { start_char: 0, char_limit: 40_000 },
+    });
+  });
+
+  it('writes Rowboat meeting frontmatter and knowledge sections', () => {
+    const markdown = meetingToMarkdown({
+      id: 'meeting-1',
+      title: 'Product review',
+      occurredAt: '2026-08-06T10:00:00.000Z',
+      participants: ['Rahul'],
+      thoughts: 'Personal note',
+      summary: 'Summary text',
+      actionItems: ['Send brief'],
+      transcript: '**Rahul:** Hello',
+      finalized: true,
+    });
+    expect(markdown).toContain('source: wispr-flow');
+    expect(markdown).toContain('## My thoughts');
+    expect(markdown).toContain('## Summary');
+    expect(markdown).toContain('## Action items');
+    expect(markdown).toContain('```transcript');
+  });
+
+  it('preserves durable post-call sections when a later response omits them', () => {
+    const previous = meetingToMarkdown({
+      id: 'meeting-1',
+      title: 'Original title',
+      occurredAt: '2026-08-06T10:00:00.000Z',
+      participants: ['Rahul'],
+      thoughts: 'Personal note',
+      summary: 'Summary text',
+      actionItems: ['Send brief'],
+      transcript: '**Rahul:** Durable transcript',
+      finalized: true,
+    });
+    const merged = mergeMeetingArtifact({
+      id: 'meeting-1',
+      title: 'Retitled meeting',
+      occurredAt: '2026-08-06T10:00:00.000Z',
+      participants: ['Akbar'],
+      actionItems: [],
+      finalized: true,
+    }, previous);
+    expect(merged).toMatchObject({
+      title: 'Retitled meeting',
+      participants: ['Akbar', 'Rahul'],
+      thoughts: 'Personal note',
+      summary: 'Summary text',
+      actionItems: ['Send brief'],
+      transcript: '**Rahul:** Durable transcript',
+    });
+  });
+});

--- a/apps/x/packages/core/src/knowledge/wispr-flow/sync.ts
+++ b/apps/x/packages/core/src/knowledge/wispr-flow/sync.ts
@@ -1,0 +1,714 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Client } from '@modelcontextprotocol/sdk/client';
+import { WorkDir } from '../../config/config.js';
+import { serviceLogger, type ServiceRunContext } from '../../services/service_logger.js';
+import { publishMeetingNotesReadyEvent } from '../meeting-events.js';
+import { WisprFlowClientFactory } from './client-factory.js';
+
+const SYNC_DIR = path.join(WorkDir, 'knowledge', 'Meetings', 'wispr-flow');
+const STATE_FILE = path.join(WorkDir, 'wispr_flow_sync_state.json');
+const SYNC_INTERVAL_MS = 90_000;
+const MAX_MEETINGS_PER_RUN = 8;
+
+type JsonObject = Record<string, unknown>;
+type McpTool = {
+  name: string;
+  description?: string;
+  inputSchema?: JsonObject;
+};
+
+export type NormalizedWisprMeeting = {
+  id: string;
+  title: string;
+  occurredAt: string;
+  endedAt?: string;
+  participants: string[];
+  thoughts?: string;
+  summary?: string;
+  actionItems: string[];
+  transcript?: string;
+  finalized: boolean;
+};
+
+type SyncState = {
+  version: 1;
+  baselineComplete: boolean;
+  synced: Record<string, { contentHash: string; filePath: string; importedAt: string }>;
+  ignoredBaselineIds: string[];
+};
+
+let wake: (() => void) | null = null;
+let running = false;
+
+function asObject(value: unknown): JsonObject | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonObject
+    : null;
+}
+
+function firstValue(object: JsonObject, keys: string[]): unknown {
+  for (const key of keys) {
+    if (object[key] !== undefined && object[key] !== null) return object[key];
+  }
+  return undefined;
+}
+
+function textValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  const object = asObject(value);
+  if (!object) return undefined;
+  return textValue(firstValue(object, ['markdown', 'text', 'content', 'value', 'body']));
+}
+
+function isoValue(value: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+}
+
+function participantNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const names = value.flatMap((item) => {
+    if (typeof item === 'string') return [item.trim()];
+    const object = asObject(item);
+    const name = object && textValue(firstValue(object, ['displayName', 'display_name', 'name', 'email']));
+    return name ? [name] : [];
+  }).filter(Boolean);
+  return [...new Set(names)].slice(0, 200);
+}
+
+function actionItemTexts(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const items = value.flatMap((item) => {
+    if (typeof item === 'string') return [item.trim()];
+    const object = asObject(item);
+    const text = object && textValue(firstValue(object, [
+      'text', 'title', 'description', 'content', 'task', 'todo', 'actionItem', 'action_item',
+    ]));
+    return text ? [text] : [];
+  }).filter(Boolean);
+  return [...new Set(items)].slice(0, 200);
+}
+
+type NormalizedTranscript = {
+  text?: string;
+  speakers: string[];
+};
+
+function isGenericSpeakerName(value: string): boolean {
+  return /^(?:speaker[ _-]*\d+|unknown(?: speaker)?|you|them)$/i.test(value.trim());
+}
+
+function dedupeNames(values: string[]): string[] {
+  const names = new Map<string, string>();
+  for (const value of values) {
+    const normalized = value.replace(/\s+/g, ' ').trim();
+    if (normalized && !names.has(normalized.toLocaleLowerCase())) {
+      names.set(normalized.toLocaleLowerCase(), normalized);
+    }
+  }
+  return [...names.values()].slice(0, 200);
+}
+
+/**
+ * Wispr returns its transcript as one plain-text line per turn (`Name: text`).
+ * Rowboat's legacy transcript block accepts the same turns only as
+ * `**Name:** text`. Preserve already-normalized turns, drop Wispr's sentinel
+ * banner, and provide an Unknown speaker turn for unlabeled plain text so a
+ * valid transcript can never render as an invalid block.
+ */
+function normalizeTranscriptForRowboat(value: string | undefined): NormalizedTranscript {
+  if (!value) return { speakers: [] };
+  const output: string[] = [];
+  const speakers: string[] = [];
+  let sawTurn = false;
+
+  for (const rawLine of value.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || /^<<<.*>>>$/.test(line)) continue;
+
+    const markdownTurn = line.match(/^\*\*([^*:\n]{1,120}):\*\*\s*(.*)$/);
+    if (markdownTurn) {
+      const speaker = markdownTurn[1].replace(/\s+/g, ' ').trim();
+      output.push(`**${speaker}:** ${markdownTurn[2].trim()}`);
+      speakers.push(speaker);
+      sawTurn = true;
+      continue;
+    }
+
+    const plainTurn = line.match(/^([^*:\n]{1,120}):\s+(.*)$/);
+    if (plainTurn && /\p{L}/u.test(plainTurn[1])) {
+      const speaker = plainTurn[1].replace(/\s+/g, ' ').trim();
+      output.push(`**${speaker}:** ${plainTurn[2].trim()}`);
+      speakers.push(speaker);
+      sawTurn = true;
+      continue;
+    }
+
+    if (sawTurn && output.length > 0) output[output.length - 1] += ` ${line}`;
+    else output.push(line);
+  }
+
+  const text = output.join('\n').trim();
+  if (!text) return { speakers: [] };
+  if (!sawTurn) return { text: `**Unknown speaker:** ${text}`, speakers: [] };
+  return { text, speakers: dedupeNames(speakers) };
+}
+
+function transcriptText(value: unknown): string | undefined {
+  const direct = textValue(value);
+  if (direct) return direct;
+  const object = asObject(value);
+  if (object) {
+    return transcriptText(firstValue(object, ['sentences', 'segments', 'utterances', 'entries', 'items']));
+  }
+  if (!Array.isArray(value)) return undefined;
+  const lines: string[] = [];
+  let previousSpeaker = '';
+  for (const item of value) {
+    if (typeof item === 'string') {
+      if (item.trim()) lines.push(item.trim());
+      continue;
+    }
+    const entry = asObject(item);
+    if (!entry) continue;
+    const text = textValue(firstValue(entry, ['text', 'content', 'transcript', 'utterance']));
+    if (!text) continue;
+    const speaker = textValue(firstValue(entry, [
+      'speakerName', 'speaker_name', 'displayName', 'speaker', 'participantName',
+    ]));
+    const resolvedSpeaker = speaker && speaker !== '[object Object]' ? speaker : 'Unknown speaker';
+    if (resolvedSpeaker !== previousSpeaker) {
+      if (lines.length > 0) lines.push('');
+      lines.push(`**${resolvedSpeaker}:** ${text}`);
+      previousSpeaker = resolvedSpeaker;
+    } else {
+      lines[lines.length - 1] = `${lines[lines.length - 1]} ${text}`;
+    }
+  }
+  const joined = lines.join('\n').trim();
+  return joined || undefined;
+}
+
+export function normalizeWisprMeeting(value: unknown): NormalizedWisprMeeting | null {
+  const object = asObject(value);
+  if (!object) return null;
+  const nested = asObject(firstValue(object, ['meeting', 'note', 'notetakerMeeting', 'data']));
+  const source = nested ? { ...object, ...nested } : object;
+  const explicitId = textValue(firstValue(source, [
+    'meetingId', 'meeting_id', 'noteId', 'note_id', 'uuid',
+  ]));
+  const id = explicitId ?? textValue(source.id);
+  if (!id) return null;
+
+  // MCP payloads can contain nested action items and other objects with their
+  // own generic `id`. Require meeting-shaped evidence before accepting such an
+  // object, otherwise a task can accidentally become a standalone meeting.
+  if (!explicitId && !nested) {
+    const hasStrongArtifact = firstValue(source, [
+      'transcript', 'rawTranscript', 'raw_transcript', 'summary', 'meetingSummary',
+      'meeting_summary', 'myThoughts', 'my_thoughts', 'thoughts',
+    ]) !== undefined;
+    const hasMeetingMetadata = firstValue(source, [
+      'startedAt', 'started_at', 'start', 'endedAt', 'ended_at', 'end',
+      'participants', 'attendees', 'meetingTitle', 'meeting_title', 'finalized',
+      'isFinalized', 'is_finalized', 'processingStatus',
+    ]) !== undefined;
+    if (!hasStrongArtifact && !hasMeetingMetadata) return null;
+  }
+
+  const summary = textValue(firstValue(source, [
+    'summary', 'meetingSummary', 'meeting_summary', 'brief', 'overview',
+  ]));
+  const thoughts = textValue(firstValue(source, [
+    'myThoughts', 'my_thoughts', 'thoughts', 'notes', 'userNotes', 'user_notes', 'content',
+  ]));
+  const rawTranscript = transcriptText(firstValue(source, [
+    'transcript', 'rawTranscript', 'raw_transcript', 'sentences', 'segments', 'utterances',
+  ]));
+  const normalizedTranscript = normalizeTranscriptForRowboat(rawTranscript);
+  const transcript = normalizedTranscript.text;
+  if (!transcript && !summary && !thoughts) return null;
+
+  const rawStatus = textValue(firstValue(source, ['status', 'state', 'processingStatus']))?.toLowerCase();
+  const explicitFinal = firstValue(source, ['finalized', 'isFinalized', 'is_finalized', 'complete', 'completed']);
+  const statusFinal = rawStatus
+    ? ['complete', 'completed', 'done', 'final', 'finalized', 'ready', 'processed'].includes(rawStatus)
+    : false;
+  const statusActive = rawStatus
+    ? ['active', 'capturing', 'in_progress', 'in progress', 'processing', 'recording'].includes(rawStatus)
+    : false;
+  // Wispr's summary/thoughts are post-call artifacts. If the connector omits a
+  // status flag, their presence alongside a transcript is the conservative
+  // finalization signal. Transcript-only live meetings are never imported.
+  const finalized = !statusActive && (
+    explicitFinal === true || statusFinal || Boolean(summary || thoughts)
+  );
+
+  const occurredAt = isoValue(firstValue(source, [
+    'startedAt', 'started_at', 'start', 'date', 'createdAt', 'created_at', 'meetingDate',
+  ])) ?? new Date().toISOString();
+  const endedAt = isoValue(firstValue(source, [
+    'endedAt', 'ended_at', 'end', 'completedAt', 'completed_at', 'updatedAt', 'updated_at',
+    'modifiedAt', 'modified_at',
+  ]));
+  const title = (textValue(firstValue(source, ['title', 'meetingTitle', 'meeting_title', 'name']))
+    ?? 'Wispr meeting').replace(/\s+/g, ' ').slice(0, 240);
+  const explicitParticipants = participantNames(firstValue(source, [
+    'participants', 'attendees', 'people', 'participantNames', 'participant_names',
+  ]));
+  const transcriptParticipants = normalizedTranscript.speakers.filter((name) => !isGenericSpeakerName(name));
+  const participants = dedupeNames([...explicitParticipants, ...transcriptParticipants]);
+  const actionItems = actionItemTexts(firstValue(source, [
+    'todos', 'toDos', 'actionItems', 'action_items', 'tasks',
+  ]));
+
+  return { id, title, occurredAt, ...(endedAt ? { endedAt } : {}), participants,
+    ...(thoughts ? { thoughts } : {}), ...(summary ? { summary } : {}), actionItems,
+    ...(transcript ? { transcript } : {}), finalized };
+}
+
+/** Combine list/detail representations without letting a sparse nested object erase richer data. */
+export function mergeNormalizedWisprMeeting(
+  existing: NormalizedWisprMeeting | undefined,
+  candidate: NormalizedWisprMeeting,
+): NormalizedWisprMeeting {
+  if (!existing) return candidate;
+  const transcript = !existing.transcript || (candidate.transcript?.length ?? 0) > existing.transcript.length
+    ? candidate.transcript
+    : existing.transcript;
+  return {
+    ...existing,
+    title: existing.title === 'Wispr meeting' ? candidate.title : existing.title,
+    endedAt: candidate.endedAt ?? existing.endedAt,
+    participants: dedupeNames([...existing.participants, ...candidate.participants]),
+    thoughts: candidate.thoughts ?? existing.thoughts,
+    summary: candidate.summary ?? existing.summary,
+    actionItems: candidate.actionItems.length > 0 ? candidate.actionItems : existing.actionItems,
+    ...(transcript ? { transcript } : {}),
+    finalized: existing.finalized || candidate.finalized,
+  };
+}
+
+function collectObjects(value: unknown, depth = 0): JsonObject[] {
+  if (depth > 5) return [];
+  if (Array.isArray(value)) return value.flatMap((item) => collectObjects(item, depth + 1));
+  const object = asObject(value);
+  if (!object) return [];
+  return [object, ...Object.values(object).flatMap((item) => collectObjects(item, depth + 1))];
+}
+
+function extractPayloads(result: unknown): unknown[] {
+  const root = asObject(result);
+  if (!root) return [];
+  const payloads: unknown[] = [];
+  if (root.structuredContent !== undefined) payloads.push(root.structuredContent);
+  if (Array.isArray(root.content)) {
+    for (const item of root.content) {
+      const content = asObject(item);
+      if (!content) continue;
+      if (content.type === 'text' && typeof content.text === 'string') {
+        try { payloads.push(JSON.parse(content.text)); }
+        catch { /* Plain prose is not a stable sync contract. */ }
+      }
+      const resource = asObject(content.resource);
+      if (resource && typeof resource.text === 'string') {
+        try { payloads.push(JSON.parse(resource.text)); }
+        catch { /* Ignore non-JSON embedded resources. */ }
+      }
+    }
+  }
+  return payloads;
+}
+
+function toolScore(tool: McpTool, mode: 'list' | 'detail'): number {
+  const haystack = `${tool.name} ${tool.description ?? ''}`.toLowerCase();
+  let score = 0;
+  if (/meeting|notetaker/.test(haystack)) score += 6;
+  if (/note/.test(haystack)) score += 2;
+  if (mode === 'list' && /list|search|recent|history/.test(haystack)) score += 5;
+  if (mode === 'detail' && /get|fetch|retrieve|detail|transcript/.test(haystack)) score += 5;
+  if (mode === 'list' && /get|detail/.test(haystack)) score -= 2;
+  if (mode === 'detail' && /list|search|recent/.test(haystack)) score -= 2;
+  return score;
+}
+
+export function chooseWisprTools(tools: McpTool[]): { list: McpTool; detail?: McpTool } {
+  // Wispr's MCP contract currently exposes these canonical names. Use
+  // them when present so similarly described calendar tools (for example
+  // get_upcoming_meeting) cannot win a heuristic tie.
+  const canonicalList = tools.find((tool) => tool.name === 'search_meetings');
+  const canonicalDetail = tools.find((tool) => tool.name === 'get_meeting');
+  if (canonicalList) {
+    return {
+      list: canonicalList,
+      ...(canonicalDetail ? { detail: canonicalDetail } : {}),
+    };
+  }
+
+  const rankedList = [...tools].sort((a, b) => toolScore(b, 'list') - toolScore(a, 'list'));
+  const list = rankedList[0];
+  if (!list || toolScore(list, 'list') < 6) {
+    throw new Error('Wispr MCP did not expose a recognizable Notetaker meeting search tool');
+  }
+  const detail = [...tools]
+    .filter((tool) => tool.name !== list.name)
+    .sort((a, b) => toolScore(b, 'detail') - toolScore(a, 'detail'))[0];
+  return { list, ...(detail && toolScore(detail, 'detail') >= 6 ? { detail } : {}) };
+}
+
+function schemaProperties(tool: McpTool): JsonObject {
+  return asObject(tool.inputSchema?.properties) ?? {};
+}
+
+export function listArguments(tool: McpTool): JsonObject {
+  const properties = schemaProperties(tool);
+  const args: JsonObject = {};
+  for (const key of Object.keys(properties)) {
+    const lower = key.toLowerCase();
+    if (['limit', 'pagesize', 'page_size', 'maxresults', 'max_results'].includes(lower)) args[key] = 50;
+    // Wispr's search_meetings contract lists recently modified meetings when
+    // query is omitted. Supplying a generic word such as "meeting" filters by
+    // title/content and silently hides ordinary meeting titles.
+  }
+  return args;
+}
+
+export function detailArguments(tool: McpTool, meetingId: string): JsonObject | null {
+  const properties = schemaProperties(tool);
+  for (const key of Object.keys(properties)) {
+    if (/^(id|meeting_?id|note_?id|notetaker_?id|transcript_?id)$/i.test(key)) {
+      const args: JsonObject = { [key]: meetingId };
+      if ('view_content' in properties) {
+        args.view_content = { start_char: 0, char_limit: 40_000 };
+      }
+      if ('view_transcript' in properties) {
+        args.view_transcript = { start_char: 0, char_limit: 40_000 };
+      }
+      return args;
+    }
+  }
+  return null;
+}
+
+function cleanFilename(value: string): string {
+  return value.replace(/[\\/*?:"<>|]/g, '_').replace(/\s+/g, ' ').trim().slice(0, 100) || 'Wispr meeting';
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function meetingToMarkdown(meeting: NormalizedWisprMeeting): string {
+  const lines = [
+    '---',
+    'type: meeting',
+    'source: wispr-flow',
+    `wispr_meeting_id: ${yamlString(meeting.id)}`,
+    `title: ${yamlString(meeting.title)}`,
+    `date: ${yamlString(meeting.occurredAt)}`,
+    ...(meeting.endedAt ? [`ended_at: ${yamlString(meeting.endedAt)}`] : []),
+    `participants: ${JSON.stringify(meeting.participants)}`,
+    '---',
+    '',
+    `# ${meeting.title}`,
+    '',
+  ];
+  if (meeting.thoughts) lines.push('## My thoughts', '', meeting.thoughts, '');
+  if (meeting.summary) lines.push('## Summary', '', meeting.summary, '');
+  if (meeting.actionItems.length > 0) {
+    lines.push('## Action items', '', ...meeting.actionItems.map((item) => `- ${item}`), '');
+  }
+  if (meeting.transcript) {
+    lines.push('## Transcript', '', '```transcript', JSON.stringify({ transcript: meeting.transcript }), '```', '');
+  } else {
+    lines.push('## Transcript', '', '_Not available from Wispr Flow for this meeting._', '');
+  }
+  return lines.join('\n');
+}
+
+const ARTIFACT_SECTION_NAMES = ['My thoughts', 'Summary', 'Action items', 'Transcript'] as const;
+
+function markdownSection(markdown: string, name: typeof ARTIFACT_SECTION_NAMES[number]): string | undefined {
+  const marker = `\n## ${name}\n`;
+  const start = markdown.indexOf(marker);
+  if (start < 0) return undefined;
+  const bodyStart = start + marker.length;
+  const nextStarts = ARTIFACT_SECTION_NAMES
+    .map((candidate) => markdown.indexOf(`\n## ${candidate}\n`, bodyStart))
+    .filter((candidate) => candidate >= 0);
+  const end = nextStarts.length > 0 ? Math.min(...nextStarts) : markdown.length;
+  return markdown.slice(bodyStart, end).trim() || undefined;
+}
+
+function existingArtifact(markdown: string): Partial<NormalizedWisprMeeting> {
+  let participants: string[] = [];
+  const participantsLine = markdown.match(/^participants:\s*(\[[^\n]*\])\s*$/m)?.[1];
+  if (participantsLine) {
+    try {
+      const parsed = JSON.parse(participantsLine) as unknown;
+      if (Array.isArray(parsed)) participants = parsed.filter((item): item is string => typeof item === 'string');
+    } catch { /* Ignore malformed legacy frontmatter. */ }
+  }
+
+  const transcriptSection = markdownSection(markdown, 'Transcript');
+  let transcript: string | undefined;
+  const transcriptPayload = transcriptSection?.match(/^```transcript\s*\n([\s\S]*?)\n```/i)?.[1];
+  if (transcriptPayload) {
+    try {
+      transcript = textValue((JSON.parse(transcriptPayload) as JsonObject).transcript);
+    } catch { /* Ignore malformed legacy transcript blocks. */ }
+  }
+
+  const actionItems = (markdownSection(markdown, 'Action items') ?? '')
+    .split('\n')
+    .map((line) => line.match(/^\s*-\s+(.+)$/)?.[1]?.trim())
+    .filter((item): item is string => Boolean(item));
+
+  const thoughts = markdownSection(markdown, 'My thoughts');
+  const summary = markdownSection(markdown, 'Summary');
+  return {
+    participants,
+    actionItems,
+    ...(thoughts ? { thoughts } : {}),
+    ...(summary ? { summary } : {}),
+    ...(transcript ? { transcript } : {}),
+  };
+}
+
+/** Preserve post-call sections when an eventually-consistent MCP response omits them. */
+export function mergeMeetingArtifact(
+  meeting: NormalizedWisprMeeting,
+  previousMarkdown: string | undefined,
+): NormalizedWisprMeeting {
+  if (!previousMarkdown) return meeting;
+  const previous = existingArtifact(previousMarkdown);
+  return {
+    ...meeting,
+    participants: dedupeNames([...meeting.participants, ...(previous.participants ?? [])]),
+    actionItems: meeting.actionItems.length > 0 ? meeting.actionItems : (previous.actionItems ?? []),
+    thoughts: meeting.thoughts ?? previous.thoughts,
+    summary: meeting.summary ?? previous.summary,
+    transcript: meeting.transcript ?? previous.transcript,
+  };
+}
+
+function defaultState(): SyncState {
+  return { version: 1, baselineComplete: false, synced: {}, ignoredBaselineIds: [] };
+}
+
+function loadState(): SyncState {
+  try {
+    if (!fs.existsSync(STATE_FILE)) return defaultState();
+    const parsed = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')) as Partial<SyncState>;
+    if (parsed.version !== 1) return defaultState();
+    return {
+      version: 1,
+      baselineComplete: parsed.baselineComplete === true,
+      synced: parsed.synced ?? {},
+      ignoredBaselineIds: Array.isArray(parsed.ignoredBaselineIds) ? parsed.ignoredBaselineIds : [],
+    };
+  } catch {
+    return defaultState();
+  }
+}
+
+function saveState(state: SyncState): void {
+  fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
+  const temporary = `${STATE_FILE}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(state, null, 2), 'utf8');
+  fs.renameSync(temporary, STATE_FILE);
+}
+
+async function fetchMeetings(client: Client): Promise<NormalizedWisprMeeting[]> {
+  const listed = await client.listTools();
+  const tools = listed.tools as McpTool[];
+  const selected = chooseWisprTools(tools);
+  const listResult = await client.callTool({ name: selected.list.name, arguments: listArguments(selected.list) });
+  const candidates = extractPayloads(listResult).flatMap((payload) => collectObjects(payload));
+  const byId = new Map<string, NormalizedWisprMeeting>();
+  for (const candidate of candidates) {
+    const normalized = normalizeWisprMeeting(candidate);
+    if (normalized) {
+      byId.set(normalized.id, mergeNormalizedWisprMeeting(byId.get(normalized.id), normalized));
+    }
+  }
+
+  if (selected.detail) {
+    // Only request details for objects already validated as meetings. Nested
+    // action-item IDs are not valid get_meeting arguments.
+    for (const id of [...byId.keys()].slice(0, MAX_MEETINGS_PER_RUN)) {
+      const args = detailArguments(selected.detail, id);
+      if (!args) break;
+      const detailResult = await client.callTool({ name: selected.detail.name, arguments: args });
+      for (const payload of extractPayloads(detailResult)) {
+        for (const object of collectObjects(payload)) {
+          const normalized = normalizeWisprMeeting(object);
+          if (normalized) {
+            byId.set(normalized.id, mergeNormalizedWisprMeeting(byId.get(normalized.id), normalized));
+          }
+        }
+      }
+    }
+  }
+  return [...byId.values()];
+}
+
+async function syncOnce(): Promise<void> {
+  if (running) return;
+  running = true;
+  let run: ServiceRunContext | null = null;
+  try {
+    const client = await WisprFlowClientFactory.getClient();
+    if (!client) return;
+    run = await serviceLogger.startRun({
+      service: 'wispr_flow',
+      message: 'Syncing Wispr Flow meetings',
+      trigger: 'timer',
+    });
+    const meetings = await fetchMeetings(client);
+    const finalized = meetings.filter((meeting) => meeting.finalized);
+    const state = loadState();
+
+    // Connecting Wispr must not silently backfill a user's full meeting
+    // history. Existing finalized IDs form a baseline; an in-progress meeting
+    // is intentionally not baselined and will import after Wispr finalizes it.
+    if (!state.baselineComplete) {
+      state.ignoredBaselineIds = finalized.map((meeting) => meeting.id).slice(-500);
+      state.baselineComplete = true;
+      saveState(state);
+      console.log(`[Wispr Flow] Baseline recorded (${state.ignoredBaselineIds.length} existing meetings)`);
+      await serviceLogger.log({
+        type: 'run_complete',
+        service: run.service,
+        runId: run.runId,
+        level: 'info',
+        message: `Wispr Flow baseline recorded: ${state.ignoredBaselineIds.length} existing meetings`,
+        durationMs: Date.now() - run.startedAt,
+        outcome: 'idle',
+        summary: { baselineMeetings: state.ignoredBaselineIds.length },
+      });
+      return;
+    }
+
+    const ignored = new Set(state.ignoredBaselineIds);
+    fs.mkdirSync(SYNC_DIR, { recursive: true });
+    let importedCount = 0;
+    let updatedCount = 0;
+    for (const meeting of finalized.slice(0, MAX_MEETINGS_PER_RUN)) {
+      if (ignored.has(meeting.id)) continue;
+      const existing = state.synced[meeting.id];
+      const existingPath = typeof existing?.filePath === 'string' ? existing.filePath : undefined;
+      const relativeExistingPath = existingPath ? path.relative(SYNC_DIR, existingPath) : undefined;
+      const safeExistingPath = relativeExistingPath
+        && relativeExistingPath !== '..'
+        && !relativeExistingPath.startsWith(`..${path.sep}`)
+        && !path.isAbsolute(relativeExistingPath)
+        ? existingPath
+        : undefined;
+      let previousMarkdown: string | undefined;
+      if (safeExistingPath && fs.existsSync(safeExistingPath)) {
+        try { previousMarkdown = fs.readFileSync(safeExistingPath, 'utf8'); }
+        catch { /* A later atomic write may recreate an unreadable/missing file. */ }
+      }
+      const durableMeeting = mergeMeetingArtifact(meeting, previousMarkdown);
+      const markdown = meetingToMarkdown(durableMeeting);
+      const contentHash = createHash('sha256').update(markdown).digest('hex');
+      if (existing?.contentHash === contentHash) continue;
+
+      const occurredAt = new Date(meeting.occurredAt);
+      const date = Number.isFinite(occurredAt.getTime()) ? occurredAt : new Date();
+      const directory = path.join(
+        SYNC_DIR,
+        String(date.getFullYear()),
+        String(date.getMonth() + 1).padStart(2, '0'),
+        String(date.getDate()).padStart(2, '0'),
+      );
+      fs.mkdirSync(directory, { recursive: true });
+      const suffix = createHash('sha256').update(meeting.id).digest('hex').slice(0, 8);
+      // Once imported, keep the same path even if Wispr later retitles the
+      // meeting. The note frontmatter and heading update in place, avoiding an
+      // orphaned duplicate under the old title.
+      const filePath = safeExistingPath
+        ?? path.join(directory, `${cleanFilename(meeting.title)}--${suffix}.md`);
+      const temporary = `${filePath}.tmp`;
+      fs.writeFileSync(temporary, markdown, 'utf8');
+      fs.renameSync(temporary, filePath);
+      state.synced[meeting.id] = { contentHash, filePath, importedAt: new Date().toISOString() };
+      saveState(state);
+
+      if (!existing) {
+        importedCount++;
+        await publishMeetingNotesReadyEvent({
+          source: 'wispr-flow',
+          title: meeting.title,
+          filePath,
+          when: meeting.endedAt ?? meeting.occurredAt,
+        });
+      } else {
+        updatedCount++;
+      }
+      console.log(`[Wispr Flow] ${existing ? 'Updated' : 'Imported'} ${meeting.title}`);
+    }
+    await serviceLogger.log({
+      type: 'run_complete',
+      service: run.service,
+      runId: run.runId,
+      level: 'info',
+      message: `Wispr Flow sync complete: ${importedCount} new, ${updatedCount} updated`,
+      durationMs: Date.now() - run.startedAt,
+      outcome: importedCount + updatedCount > 0 ? 'ok' : 'idle',
+      summary: { newNotes: importedCount, updatedNotes: updatedCount },
+    });
+  } catch (error) {
+    console.error('[Wispr Flow] Sync failed:', error);
+    if (run) {
+      await serviceLogger.log({
+        type: 'error',
+        service: run.service,
+        runId: run.runId,
+        level: 'error',
+        message: 'Wispr Flow sync error',
+        error: error instanceof Error ? error.message : String(error),
+      }).catch(() => undefined);
+      await serviceLogger.log({
+        type: 'run_complete',
+        service: run.service,
+        runId: run.runId,
+        level: 'error',
+        message: 'Wispr Flow sync failed',
+        durationMs: Date.now() - run.startedAt,
+        outcome: 'error',
+      }).catch(() => undefined);
+    }
+  } finally {
+    running = false;
+  }
+}
+
+function sleep(): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => { wake = null; resolve(); }, SYNC_INTERVAL_MS);
+    wake = () => { clearTimeout(timer); wake = null; resolve(); };
+  });
+}
+
+export function triggerSync(): void {
+  wake?.();
+}
+
+export async function init(): Promise<never> {
+  while (true) {
+    try {
+      if (await WisprFlowClientFactory.hasCredentials()) await syncOnce();
+    } catch (error) {
+      console.error('[Wispr Flow] Error in sync loop:', error);
+    }
+    await sleep();
+  }
+}

--- a/apps/x/packages/core/src/runtime/assembly/copilot/instructions.ts
+++ b/apps/x/packages/core/src/runtime/assembly/copilot/instructions.ts
@@ -226,7 +226,7 @@ Use the \`save-to-memory\` tool to note things worth remembering about the user.
 - Information you can derive from reading their notes
 
 ## Memory That Compounds
-Unlike other AI assistants that start cold every session, you have access to a live knowledge graph that updates itself from Gmail, calendar, and meeting notes (Google Meet, Granola, Fireflies). This isn't just summaries - it's structured extraction of decisions, commitments, open questions, and context, routed to long-lived notes for each person, project, and topic.
+Unlike other AI assistants that start cold every session, you have access to a live knowledge graph that updates itself from Gmail, calendar, and meeting notes (Rowboat, Granola, Fireflies, Wispr Flow). This isn't just summaries - it's structured extraction of decisions, commitments, open questions, and context, routed to long-lived notes for each person, project, and topic.
 
 When a user asks you to prep them for a call with someone, you already know every prior decision, concerns they've raised, and commitments on both sides - because memory has been accumulating across every email and call, not reconstructed on demand.
 

--- a/apps/x/packages/shared/src/service-events.ts
+++ b/apps/x/packages/shared/src/service-events.ts
@@ -5,6 +5,7 @@ export const ServiceName = z.enum([
   'gmail',
   'calendar',
   'fireflies',
+  'wispr_flow',
   'granola',
   'slack',
   'voice_memo',

--- a/docs/WISPR_FLOW_MCP_SYNC.md
+++ b/docs/WISPR_FLOW_MCP_SYNC.md
@@ -1,0 +1,76 @@
+# Wispr Flow Notetaker to Rowboat knowledge
+
+## Product boundary
+
+Wispr Flow owns the live meeting: detection, audio capture, live transcript,
+speaker UI, and its post-call processing. Rowboat does not mirror the live
+transcript and does not start a second recording automatically.
+
+Rowboat owns the durable knowledge experience after Wispr finalizes a meeting.
+The integration uses Wispr's OAuth-protected MCP connector; it never reads or
+replays Wispr desktop session tokens, Keychain entries, private APIs, or local
+application databases.
+
+## User journey
+
+1. Connect **Wispr Flow** once in Rowboat Settings. Authorization opens in the
+   browser using PKCE and dynamic client registration.
+2. Join a meeting normally. Wispr shows the live Notetaker experience. The
+   connector does not start or stop either recorder and does not change
+   Rowboat's own meeting-detection prompts.
+3. End the meeting. Wispr produces the title, My thoughts, summary, participant
+   metadata, action items, and transcript.
+4. Rowboat checks Wispr every 90 seconds. Once the artifact has a post-call
+   finalization signal, it writes an idempotent note under:
+
+   ```text
+   ~/.rowboat/knowledge/Meetings/wispr-flow/YYYY/MM/DD/<title>--<id>.md
+   ```
+
+5. The note is a normal Rowboat knowledge source. The existing graph builder,
+   note extraction, search, backlinks, meeting-note events, background tasks,
+   and agents can use it exactly like Granola, Fireflies, and native Rowboat
+   meeting notes.
+
+## Markdown contract
+
+The imported file has stable frontmatter (`type: meeting`, `source:
+wispr-flow`, external meeting ID, title, date, participants) and these content
+sections when Wispr exposes them:
+
+- `## My thoughts`
+- `## Summary`
+- `## Action items`
+- `## Transcript`
+
+Transcript utterances are grouped into speaker turns instead of creating one
+line for every partial phrase.
+
+## Sync semantics
+
+- Connecting the provider records existing finalized meetings as a baseline;
+  it does not silently backfill the user's history.
+- A meeting still in progress is not baselined. It imports after Wispr adds
+  its post-call summary/thoughts and transcript.
+- Writes are atomic and keyed by Wispr meeting ID. A later Wispr edit updates
+  the same note, even if the title changes. Sections already imported are
+  preserved when an eventually-consistent response temporarily omits them;
+  the `meeting.notes_ready` event fires only on the first import.
+- If Wispr changes its MCP tool names or response shape, sync fails visibly in
+  logs and leaves local knowledge untouched instead of guessing.
+
+## Contributor test path
+
+Install dependencies and start the normal desktop development app:
+
+```sh
+cd apps/x
+pnpm install --frozen-lockfile
+pnpm dev
+```
+
+Connect Wispr Flow in Settings, finish a new meeting, and wait up to 90 seconds.
+Verify that one note appears under `knowledge/Meetings/wispr-flow/`, that its
+transcript block expands, and that identified speaker names appear in the
+`participants` property. Existing meetings at connection time are deliberately
+recorded as a baseline rather than backfilled.


### PR DESCRIPTION
## What

Adds an OAuth-backed Wispr Flow connector to the Rowboat desktop app. After Wispr finalizes a Notetaker meeting, Rowboat imports the title, My thoughts, summary, action items, participants, and speaker-attributed transcript as a normal meeting note under `knowledge/Meetings/wispr-flow/`.

The note then participates in Rowboat's existing knowledge ingestion, tagging, graph, search, backlink, agent, and meeting-ready event flows.

## Why

Wispr already provides the live meeting experience (detection, capture, transcript, speakers, and post-call processing). Re-recording the same call in Rowboat would duplicate capture and processing. This connector keeps the boundary simple:

- Wispr owns the live and post-processing experience.
- Rowboat owns the durable knowledge artifact after the call.

The existing DCR path also assumed that `registration_endpoint` was present in OpenID discovery metadata. Wispr exposes an explicit RFC 7591 registration endpoint, so this adds a reusable, tested explicit-DCR path and RFC 8707 protected-resource binding.

## Behavior and safety

- Uses Wispr's OAuth-protected MCP connector with PKCE, dynamic client registration, refresh tokens, and the MCP resource audience.
- Never reads Wispr desktop sessions, Keychain entries, private APIs, or local application databases.
- Does not start/stop either recorder and does not change Rowboat's meeting-detection prompt.
- Records existing finalized meetings as a baseline; it does not silently backfill meeting history.
- Imports only artifacts with a conservative post-call finalization signal.
- Uses atomic, idempotent writes keyed by Wispr meeting ID.
- Preserves the same file across title changes.
- Preserves already imported sections if an eventually-consistent MCP response temporarily omits them.
- Validates meeting-shaped objects before requesting details so nested action-item IDs cannot become notes.
- Converts Wispr's `Name: text` turns to Rowboat's transcript-block contract and derives non-generic participant names.
- Fails closed on unrecognized MCP tool/response shapes.

The full contract and contributor test path are documented in `docs/WISPR_FLOW_MCP_SYNC.md`.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 75 files / 848 tests passed
- Focused Wispr/OAuth suites — 3 files / 19 tests passed
- Shared, core, preload, main-process, and renderer production builds completed
- Manual macOS end-to-end verification on the fork build:
  - completed OAuth authorization in the system browser
  - finalized a new Wispr Notetaker meeting
  - observed one Rowboat knowledge note with title, post-call notes/summary, transcript, and named participants
  - verified that the transcript block renders instead of showing “Invalid transcript block”
  - verified that subsequent Wispr updates replace the same note rather than duplicating it

The local main-process build skipped Rowboat's optional Swift mic-monitor helper because the installed Swift compiler and macOS SDK versions do not match; the Electron main bundle completed. That existing helper is unrelated to this connector and CI's package smoke test remains authoritative.

## Scope

This PR is deliberately independent of #833. It excludes native capture, Accessibility, local desktop extraction, meeting overlays, and experimental meeting-only launchers.