### PR TITLE
feat(meetings): add self-hosted transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ To connect Google services (Gmail, Calendar, and Drive), follow [Google setup](h
 ### Voice input
 To enable voice input and voice notes (optional), add a Deepgram API key in `~/.rowboat/config/deepgram.json`
 
+Meeting transcription can instead use an explicitly configured local or remote worker. See
+[Self-hosted meeting transcription](docs/self-hosted-meeting-transcription.md) for its strict routing,
+secret handling, protocol, and qualification boundary.
+
 ### Voice output
 
 To enable voice output (optional), add an ElevenLabs API key in `~/.rowboat/config/elevenlabs.json`

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -91,12 +91,14 @@ import { setSelfCaptureActive } from '@x/core/dist/meetings/detector.js';
 import { notifyIfEnabled } from '@x/core/dist/application/notification/notifier.js';
 import { consumePendingToggleMeetingNotes, setTrayRecordingState } from './tray.js';
 import { closeMeetingPopup, getMeetingPopupPayload, handleMeetingPopupAction } from './meeting-popup.js';
+import { selfHostedMeetingTranscription } from './self-hosted-meeting-transcription.js';
 
 // Ambient meeting detection must ignore Rowboat's own mic use: meeting
 // capture and assistant voice/video calls both hold the mic. Either being
 // active suppresses "Meeting detected" prompts.
 let meetingRecordingActive = false;
 let voiceCallActive = false;
+const selfHostedCleanupSenders = new WeakSet<object>();
 function updateSelfCaptureState() {
   setSelfCaptureActive(meetingRecordingActive || voiceCallActive);
 }
@@ -2413,6 +2415,39 @@ export function setupIpcHandlers() {
         void maybeActivateCredit('first_meeting_note');
       }
       return { notes };
+    },
+    'meeting:selfHostedTranscriptionStatus': async () => {
+      return selfHostedMeetingTranscription.status();
+    },
+    'meeting:selfHostedTranscriptionBegin': async (event) => {
+      const sender = event.sender;
+      const ownerId = sender.id;
+      if (!selfHostedCleanupSenders.has(sender)) {
+        selfHostedCleanupSenders.add(sender);
+        sender.once('destroyed', () => {
+          void selfHostedMeetingTranscription.resetOwner(ownerId);
+        });
+      }
+      const result = await selfHostedMeetingTranscription.begin(ownerId);
+      if (sender.isDestroyed()) {
+        await selfHostedMeetingTranscription.resetOwner(ownerId);
+        throw new Error('Meeting transcription window closed while the worker was starting');
+      }
+      return result;
+    },
+    'meeting:selfHostedTranscriptionFeed': async (event, args) => {
+      return selfHostedMeetingTranscription.feed(
+        event.sender.id,
+        args.connectionId,
+        args.pcmBase64,
+      );
+    },
+    'meeting:selfHostedTranscriptionFinalize': async (event, args) => {
+      return selfHostedMeetingTranscription.finalize(event.sender.id, args.connectionId);
+    },
+    'meeting:selfHostedTranscriptionReset': async (event, args) => {
+      await selfHostedMeetingTranscription.reset(event.sender.id, args.connectionId);
+      return { success: true as const };
     },
     'meeting-prep:resolve': async (_event, args) => {
       const result = await resolveMeetingPrep(args.attendees);

--- a/apps/x/apps/main/src/self-hosted-meeting-transcription.ts
+++ b/apps/x/apps/main/src/self-hosted-meeting-transcription.ts
@@ -1,0 +1,412 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { WorkDir } from '@x/core/dist/config/config.js';
+import {
+  SELF_HOSTED_TRANSCRIPTION_PROTOCOL,
+  normalizeSelfHostedTranscriptionUrl,
+  validateSelfHostedTranscriptionLanguage,
+  validateSelfHostedTranscriptionToken,
+} from '@x/shared/dist/self-hosted-transcription.js';
+
+const CONFIG_FILENAME = 'meeting-transcription.json';
+const ENV_URL = 'ROWBOAT_MEETING_STT_URL';
+const ENV_TOKEN = 'ROWBOAT_MEETING_STT_TOKEN';
+const MAX_CONNECTIONS = 4;
+const MAX_PCM_BYTES = 256 * 1024;
+const MAX_RESPONSE_BYTES = 512 * 1024;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export type SelfHostedTranscriptUpdate = {
+  channelIndex: 0 | 1;
+  full: string;
+  committed: string;
+  tentative: string;
+  final: boolean;
+  revision: number;
+  inputMs: number;
+  bufferedMs: number;
+};
+
+type ProviderConfig = {
+  baseUrl: string;
+  token: string;
+  language: string;
+};
+
+type Session = {
+  id: string;
+  ownerId: number;
+  config: ProviderConfig;
+  microphoneSession: string;
+  systemSession: string;
+  tail: Promise<void>;
+  closed: boolean;
+};
+
+type ConfigFile = {
+  provider?: unknown;
+  protocol?: unknown;
+  baseUrl?: unknown;
+  tokenFile?: unknown;
+  language?: unknown;
+};
+
+export type SelfHostedProviderStatus = {
+  configured: boolean;
+  valid: boolean;
+  protocol?: typeof SELF_HOSTED_TRANSCRIPTION_PROTOCOL;
+  endpoint?: string;
+  error?: string;
+};
+
+function safeError(error: unknown): string {
+  return error instanceof Error ? error.message : 'Self-hosted transcription failed';
+}
+
+async function readTokenFile(rawPath: unknown): Promise<string> {
+  if (typeof rawPath !== 'string' || !path.isAbsolute(rawPath)) {
+    throw new Error('Self-hosted transcription tokenFile must be an absolute path');
+  }
+  const stat = await fs.lstat(rawPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error('Self-hosted transcription tokenFile must be a regular non-symlink file');
+  }
+  if (process.platform !== 'win32' && (stat.mode & 0o077) !== 0) {
+    throw new Error('Self-hosted transcription tokenFile must not be accessible by group or other users');
+  }
+  if (stat.size < 32 || stat.size > 1_024) {
+    throw new Error('Self-hosted transcription tokenFile has an invalid size');
+  }
+  return validateSelfHostedTranscriptionToken(await fs.readFile(rawPath, 'utf8'));
+}
+
+async function readConfigFile(): Promise<{ configured: boolean; value?: ConfigFile }> {
+  const configPath = path.join(WorkDir, 'config', CONFIG_FILENAME);
+  try {
+    const raw = await fs.readFile(configPath, 'utf8');
+    if (raw.length > 16 * 1024) throw new Error('Self-hosted transcription config is too large');
+    const value: unknown = JSON.parse(raw);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('Self-hosted transcription config must be a JSON object');
+    }
+    const config = value as ConfigFile;
+    if (config.provider !== 'self-hosted') return { configured: false };
+    return { configured: true, value: config };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { configured: false };
+    throw error;
+  }
+}
+
+async function resolveConfig(): Promise<{ configured: boolean; config?: ProviderConfig }> {
+  const envUrl = process.env[ENV_URL]?.trim();
+  const envToken = process.env[ENV_TOKEN]?.trim();
+  const file = await readConfigFile();
+  const configured = Boolean(envUrl || envToken || file.configured);
+  if (!configured) return { configured: false };
+
+  const value = file.value ?? {};
+  if (value.protocol !== undefined && value.protocol !== SELF_HOSTED_TRANSCRIPTION_PROTOCOL) {
+    throw new Error(`Unsupported self-hosted transcription protocol; expected ${SELF_HOSTED_TRANSCRIPTION_PROTOCOL}`);
+  }
+  const rawUrl = envUrl ?? (typeof value.baseUrl === 'string' ? value.baseUrl : '');
+  if (!rawUrl) throw new Error(`Set ${ENV_URL} or baseUrl in ${CONFIG_FILENAME}`);
+
+  let token: string;
+  if (envToken) {
+    token = validateSelfHostedTranscriptionToken(envToken);
+  } else {
+    token = await readTokenFile(value.tokenFile);
+  }
+
+  return {
+    configured: true,
+    config: {
+      baseUrl: normalizeSelfHostedTranscriptionUrl(rawUrl),
+      token,
+      language: validateSelfHostedTranscriptionLanguage(value.language),
+    },
+  };
+}
+
+function endpoint(baseUrl: string, route: string, session?: string, language?: string): string {
+  const url = new URL(`${baseUrl}/${route}`);
+  if (session) url.searchParams.set('session', session);
+  if (language) url.searchParams.set('language', language);
+  return url.toString();
+}
+
+async function request(
+  config: ProviderConfig,
+  route: string,
+  options: { method?: 'GET' | 'POST'; session?: string; language?: string; body?: Buffer } = {},
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  timeout.unref();
+  try {
+    const response = await fetch(endpoint(
+      config.baseUrl,
+      route,
+      options.session,
+      options.language,
+    ), {
+      method: options.method ?? 'POST',
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        ...(options.body ? { 'Content-Type': 'application/octet-stream' } : {}),
+      },
+      body: options.body ? Uint8Array.from(options.body) : undefined,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    if (text.length > MAX_RESPONSE_BYTES) {
+      throw new Error('Self-hosted transcription response exceeded the size limit');
+    }
+    if (!response.ok) {
+      throw new Error(`Self-hosted transcription ${route} failed with HTTP ${response.status}`);
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`Self-hosted transcription ${route} returned invalid JSON`);
+    }
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error(`Self-hosted transcription ${route} timed out`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function finiteNonNegative(value: unknown, field: string, integer = false): number {
+  if (
+    typeof value !== 'number'
+    || !Number.isFinite(value)
+    || value < 0
+    || (integer && !Number.isInteger(value))
+  ) {
+    throw new Error(`Self-hosted transcription response has invalid ${field}`);
+  }
+  return value;
+}
+
+function boundedText(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length > 250_000) {
+    throw new Error(`Self-hosted transcription response has invalid ${field}`);
+  }
+  return value;
+}
+
+function parseSnapshot(value: unknown, channelIndex: 0 | 1): SelfHostedTranscriptUpdate {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Self-hosted transcription returned an invalid snapshot');
+  }
+  const snapshot = value as Record<string, unknown>;
+  if (typeof snapshot.final !== 'boolean') {
+    throw new Error('Self-hosted transcription response has invalid final state');
+  }
+  return {
+    channelIndex,
+    full: boundedText(snapshot.full, 'full text'),
+    committed: boundedText(snapshot.committed, 'committed text'),
+    tentative: boundedText(snapshot.tentative, 'tentative text'),
+    final: snapshot.final,
+    revision: finiteNonNegative(snapshot.revision, 'revision', true),
+    inputMs: finiteNonNegative(snapshot.inputMs, 'inputMs'),
+    bufferedMs: finiteNonNegative(snapshot.bufferedMs, 'bufferedMs'),
+  };
+}
+
+function decodeStereoPcm(base64: string): { microphone: Buffer; system: Buffer } {
+  if (
+    !base64
+    || base64.length > Math.ceil(MAX_PCM_BYTES * 4 / 3) + 4
+    || base64.length % 4 !== 0
+    || !/^[A-Za-z0-9+/]*={0,2}$/.test(base64)
+  ) {
+    throw new Error('Self-hosted transcription PCM payload is invalid');
+  }
+  const stereo = Buffer.from(base64, 'base64');
+  if (stereo.length === 0 || stereo.length > MAX_PCM_BYTES || stereo.length % 4 !== 0) {
+    throw new Error('Self-hosted transcription requires interleaved stereo s16 PCM');
+  }
+  const frames = stereo.length / 4;
+  const microphone = Buffer.allocUnsafe(frames * 2);
+  const system = Buffer.allocUnsafe(frames * 2);
+  for (let frame = 0; frame < frames; frame += 1) {
+    const source = frame * 4;
+    const destination = frame * 2;
+    microphone[destination] = stereo[source];
+    microphone[destination + 1] = stereo[source + 1];
+    system[destination] = stereo[source + 2];
+    system[destination + 1] = stereo[source + 3];
+  }
+  return { microphone, system };
+}
+
+async function bestEffortReset(session: Session): Promise<void> {
+  await Promise.allSettled([
+    request(session.config, 'stream/reset', { session: session.microphoneSession }),
+    request(session.config, 'stream/reset', { session: session.systemSession }),
+  ]);
+}
+
+export class SelfHostedMeetingTranscription {
+  private sessions = new Map<string, Session>();
+  private ownersStarting = new Set<number>();
+
+  async status(): Promise<SelfHostedProviderStatus> {
+    try {
+      const resolved = await resolveConfig();
+      if (!resolved.config) return { configured: false, valid: true };
+      return {
+        configured: true,
+        valid: true,
+        protocol: SELF_HOSTED_TRANSCRIPTION_PROTOCOL,
+        endpoint: new URL(resolved.config.baseUrl).host,
+      };
+    } catch (error) {
+      return { configured: true, valid: false, error: safeError(error) };
+    }
+  }
+
+  async begin(ownerId: number): Promise<{ connectionId: string }> {
+    if (this.ownersStarting.has(ownerId)) {
+      throw new Error('Self-hosted transcription is already starting');
+    }
+    this.ownersStarting.add(ownerId);
+    try {
+      const resolved = await resolveConfig();
+      if (!resolved.config) throw new Error('Self-hosted transcription is not configured');
+      const config = resolved.config;
+      await this.resetOwner(ownerId);
+      if (this.sessions.size >= MAX_CONNECTIONS) {
+        throw new Error('Self-hosted transcription connection capacity reached');
+      }
+
+      const health = await request(config, 'health', { method: 'GET' });
+      if (!health || typeof health !== 'object' || (health as { ok?: unknown }).ok !== true) {
+        throw new Error('Self-hosted transcription health check failed');
+      }
+      const maxStreams = (health as { maxStreams?: unknown }).maxStreams;
+      if (typeof maxStreams !== 'number' || !Number.isInteger(maxStreams) || maxStreams < 2) {
+        throw new Error('Self-hosted transcription worker must allow at least two streams');
+      }
+
+      const id = randomUUID();
+      const suffix = id.replaceAll('-', '').slice(0, 24);
+      const session: Session = {
+        id,
+        ownerId,
+        config,
+        microphoneSession: `rowboat-${suffix}-mic`,
+        systemSession: `rowboat-${suffix}-system`,
+        tail: Promise.resolve(),
+        closed: false,
+      };
+      try {
+        await Promise.all([
+          request(config, 'stream/begin', {
+            session: session.microphoneSession,
+            language: config.language,
+          }),
+          request(config, 'stream/begin', {
+            session: session.systemSession,
+            language: config.language,
+          }),
+        ]);
+      } catch (error) {
+        await bestEffortReset(session);
+        throw error;
+      }
+      this.sessions.set(id, session);
+      return { connectionId: id };
+    } finally {
+      this.ownersStarting.delete(ownerId);
+    }
+  }
+
+  async feed(
+    ownerId: number,
+    connectionId: string,
+    pcmBase64: string,
+  ): Promise<{ updates: SelfHostedTranscriptUpdate[] }> {
+    const session = this.ownedSession(ownerId, connectionId);
+    if (session.closed) throw new Error('Self-hosted transcription session is closed');
+    const pcm = decodeStereoPcm(pcmBase64);
+
+    const task = session.tail.then(async () => {
+      if (session.closed) throw new Error('Self-hosted transcription session is closed');
+      const [microphone, system] = await Promise.all([
+        request(session.config, 'stream/feed', {
+          session: session.microphoneSession,
+          body: pcm.microphone,
+        }),
+        request(session.config, 'stream/feed', {
+          session: session.systemSession,
+          body: pcm.system,
+        }),
+      ]);
+      return {
+        updates: [
+          parseSnapshot(microphone, 0),
+          parseSnapshot(system, 1),
+        ],
+      };
+    });
+    session.tail = task.then(() => undefined, () => undefined);
+    return task;
+  }
+
+  async finalize(
+    ownerId: number,
+    connectionId: string,
+  ): Promise<{ updates: SelfHostedTranscriptUpdate[] }> {
+    const session = this.ownedSession(ownerId, connectionId);
+    session.closed = true;
+    await session.tail;
+    try {
+      const [microphone, system] = await Promise.all([
+        request(session.config, 'stream/finalize', { session: session.microphoneSession }),
+        request(session.config, 'stream/finalize', { session: session.systemSession }),
+      ]);
+      return {
+        updates: [
+          parseSnapshot(microphone, 0),
+          parseSnapshot(system, 1),
+        ],
+      };
+    } finally {
+      this.sessions.delete(connectionId);
+      await bestEffortReset(session);
+    }
+  }
+
+  async reset(ownerId: number, connectionId: string): Promise<void> {
+    const session = this.sessions.get(connectionId);
+    if (!session || session.ownerId !== ownerId) return;
+    session.closed = true;
+    await session.tail;
+    this.sessions.delete(connectionId);
+    await bestEffortReset(session);
+  }
+
+  async resetOwner(ownerId: number): Promise<void> {
+    const owned = [...this.sessions.values()].filter((session) => session.ownerId === ownerId);
+    await Promise.all(owned.map((session) => this.reset(ownerId, session.id)));
+  }
+
+  private ownedSession(ownerId: number, connectionId: string): Session {
+    const session = this.sessions.get(connectionId);
+    if (!session || session.ownerId !== ownerId) {
+      throw new Error('Self-hosted transcription session is unavailable');
+    }
+    return session;
+  }
+}
+
+export const selfHostedMeetingTranscription = new SelfHostedMeetingTranscription();

--- a/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
+++ b/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
@@ -4,6 +4,11 @@ import { buildDeepgramListenUrl } from '@/lib/deepgram-listen-url';
 import { finalizeDeepgramStream } from '@/lib/deepgram-finalize';
 import { useRowboatAccount } from '@/hooks/useRowboatAccount';
 import { fetchRowboatConfig } from '@/hooks/use-rowboat-config';
+import {
+    SelfHostedMeetingTranscriber,
+    createIpcSelfHostedMeetingTransport,
+    type CanonicalTranscriptUpdate,
+} from '@/lib/self-hosted-meeting-transcriber';
 
 export type MeetingTranscriptionState = 'idle' | 'connecting' | 'recording' | 'stopping';
 
@@ -88,6 +93,8 @@ interface TranscriptEntry {
     text: string;
 }
 
+type MeetingTranscriptionProvider = 'rowboat-managed' | 'deepgram' | 'self-hosted';
+
 export interface CalendarEventMeta {
     summary?: string
     start?: { dateTime?: string; date?: string }
@@ -98,7 +105,12 @@ export interface CalendarEventMeta {
     source?: string
 }
 
-function formatTranscript(entries: TranscriptEntry[], date: string, calendarEvent?: CalendarEventMeta): string {
+function formatTranscript(
+    entries: TranscriptEntry[],
+    date: string,
+    calendarEvent?: CalendarEventMeta,
+    transcriptionProvider?: MeetingTranscriptionProvider,
+): string {
     const noteTitle = calendarEvent?.summary || 'Meeting Notes';
     const lines = [
         '---',
@@ -107,6 +119,7 @@ function formatTranscript(entries: TranscriptEntry[], date: string, calendarEven
         `title: ${noteTitle}`,
         `date: "${date}"`,
     ];
+    if (transcriptionProvider) lines.push(`transcription_provider: ${transcriptionProvider}`);
     if (calendarEvent) {
         // Serialize as a JSON string on one line — the frontmatter system
         // only supports flat key: value pairs, not nested YAML objects.
@@ -150,6 +163,7 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
     const { refresh: refreshRowboatAccount } = useRowboatAccount();
     const [state, setState] = useState<MeetingTranscriptionState>('idle');
     const wsRef = useRef<WebSocket | null>(null);
+    const selfHostedRef = useRef<SelfHostedMeetingTranscriber | null>(null);
     const micStreamRef = useRef<MediaStream | null>(null);
     const systemStreamRef = useRef<MediaStream | null>(null);
     const processorRef = useRef<ScriptProcessorNode | null>(null);
@@ -173,6 +187,7 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
     onAutoStopRef.current = onAutoStop;
     const dateRef = useRef<string>('');
     const calendarEventRef = useRef<CalendarEventMeta | undefined>(undefined);
+    const transcriptionProviderRef = useRef<MeetingTranscriptionProvider | undefined>(undefined);
 
     const writeTranscriptToFile = useCallback(async () => {
         if (!notePathRef.current) return;
@@ -186,7 +201,12 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
             }
         }
         if (entries.length === 0) return;
-        const content = formatTranscript(entries, dateRef.current, calendarEventRef.current);
+        const content = formatTranscript(
+            entries,
+            dateRef.current,
+            calendarEventRef.current,
+            transcriptionProviderRef.current,
+        );
         try {
             await window.ipc.invoke('workspace:writeFile', {
                 path: notePathRef.current,
@@ -247,18 +267,70 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
             wsRef.current.close();
             wsRef.current = null;
         }
+        if (selfHostedRef.current) {
+            void selfHostedRef.current.cancel();
+            selfHostedRef.current = null;
+        }
     }, [stopInputCapture]);
 
     const start = useCallback(async (calendarEvent?: CalendarEventMeta): Promise<string | null> => {
         if (state !== 'idle') return null;
         setState('connecting');
 
+        const applyTranscript = ({
+            channelIndex,
+            text,
+            isFinal,
+        }: CanonicalTranscriptUpdate) => {
+            const speaker = channelIndex === 0 ? 'You' : 'System audio';
+            if (isFinal) {
+                interimRef.current.delete(channelIndex);
+                if (!text) return;
+                const entries = transcriptRef.current;
+                if (entries.length > 0 && entries[entries.length - 1].speaker === speaker) {
+                    const separator = /^[\s,.;:!?)]/.test(text) ? '' : ' ';
+                    entries[entries.length - 1].text += separator + text;
+                } else {
+                    entries.push({ speaker, text: text.trim() });
+                }
+            } else if (text) {
+                interimRef.current.set(channelIndex, { speaker, text });
+            } else {
+                interimRef.current.delete(channelIndex);
+            }
+            scheduleDebouncedWrite();
+        };
+
         // Run independent setup steps in parallel for faster startup
-        const [headphoneResult, wsResult, micResult, systemResult] = await Promise.allSettled([
+        const [headphoneResult, providerResult, micResult, systemResult] = await Promise.allSettled([
             // 1. Detect headphones vs speakers
             detectHeadphones(),
-            // 2. Set up Deepgram WebSocket (account refresh + connect + wait for open)
+            // 2. Resolve the explicitly configured provider. A self-hosted
+            // worker is strict: invalid/unavailable configuration fails the
+            // start instead of silently sending audio to another provider.
             (async () => {
+                const selfHosted = await window.ipc.invoke('meeting:selfHostedTranscriptionStatus', null);
+                if (selfHosted.configured) {
+                    if (!selfHosted.valid) {
+                        throw new Error(selfHosted.error || 'Self-hosted transcription configuration is invalid');
+                    }
+                    const client = new SelfHostedMeetingTranscriber(
+                        createIpcSelfHostedMeetingTransport(),
+                        applyTranscript,
+                        (error) => {
+                            console.error('[meeting] Self-hosted transcription failed:', error);
+                            toast.error('Self-hosted transcription needs attention', {
+                                description: error.message,
+                                duration: 10_000,
+                            });
+                            onAutoStopRef.current?.();
+                        },
+                    );
+                    await client.start();
+                    console.log(`[meeting] Using self-hosted transcription (${selfHosted.endpoint ?? 'private worker'})`);
+                    return { kind: 'self-hosted' as const, client, provider: 'self-hosted' as const };
+                }
+
                 // Token from account refresh; websocket URL from the
                 // sign-in-independent bootstrap config store.
                 const [account, rowboatConfig] = await Promise.all([
@@ -266,6 +338,7 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                     fetchRowboatConfig(),
                 ]);
                 let ws: WebSocket;
+                let provider: 'rowboat-managed' | 'deepgram';
                 if (
                     account?.signedIn &&
                     account.accessToken &&
@@ -274,6 +347,7 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                     const listenUrl = buildDeepgramListenUrl(rowboatConfig.websocketApiUrl, DEEPGRAM_PARAMS);
                     console.log('[meeting] Using Rowboat WebSocket');
                     ws = new WebSocket(listenUrl, ['bearer', account.accessToken]);
+                    provider = 'rowboat-managed';
                 } else {
                     const config = await window.ipc.invoke('voice:getConfig', null);
                     if (!config?.deepgram) {
@@ -281,6 +355,7 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                     }
                     console.log('[meeting] Using Deepgram API key');
                     ws = new WebSocket(DEEPGRAM_LISTEN_URL, ['token', config.deepgram.apiKey]);
+                    provider = 'deepgram';
                 }
                 const ok = await new Promise<boolean>((resolve) => {
                     ws.onopen = () => resolve(true);
@@ -289,7 +364,11 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                 });
                 if (!ok) throw new Error('WebSocket failed to connect');
                 console.log('[meeting] WebSocket connected');
-                return ws;
+                return {
+                    kind: 'deepgram' as const,
+                    ws,
+                    provider,
+                };
             })(),
             // 3. Get mic stream
             navigator.mediaDevices.getUserMedia({
@@ -316,12 +395,20 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
         ]);
 
         // Check for failures — clean up any successful resources if something failed
-        const failed = wsResult.status === 'rejected'
+        const failed = providerResult.status === 'rejected'
             || micResult.status === 'rejected'
             || systemResult.status === 'rejected';
 
         if (failed) {
-            if (wsResult.status === 'rejected') console.error('[meeting] WebSocket setup failed:', wsResult.reason);
+            if (providerResult.status === 'rejected') {
+                console.error('[meeting] Transcription provider setup failed:', providerResult.reason);
+                toast.error('Could not start meeting transcription', {
+                    description: providerResult.reason instanceof Error
+                        ? providerResult.reason.message
+                        : 'The configured transcription provider is unavailable.',
+                    duration: 10_000,
+                });
+            }
             if (micResult.status === 'rejected') console.error('[meeting] Microphone access denied:', micResult.reason);
             if (systemResult.status === 'rejected') {
                 console.error('[meeting] System audio access denied:', systemResult.reason);
@@ -333,7 +420,10 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                 }
             }
             // Clean up any resources that did succeed
-            if (wsResult.status === 'fulfilled') { wsResult.value.close(); }
+            if (providerResult.status === 'fulfilled') {
+                if (providerResult.value.kind === 'deepgram') providerResult.value.ws.close();
+                else await providerResult.value.client.cancel();
+            }
             if (micResult.status === 'fulfilled') { micResult.value.getTracks().forEach(t => t.stop()); }
             if (systemResult.status === 'fulfilled') { systemResult.value.getTracks().forEach(t => t.stop()); }
             cleanup();
@@ -344,50 +434,46 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
         const usingHeadphones = headphoneResult.status === 'fulfilled' ? headphoneResult.value : false;
         console.log(`[meeting] Audio output mode: ${usingHeadphones ? 'headphones' : 'speakers'}`);
 
-        const ws = wsResult.value;
-        wsRef.current = ws;
-
-        // Set up WS message handler
         transcriptRef.current = [];
         interimRef.current = new Map();
-        ws.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            if (!data.channel?.alternatives?.[0]) return;
-            const transcript = data.channel.alternatives[0].transcript;
-            if (!transcript) return;
+        transcriptionProviderRef.current = providerResult.value.provider;
+        if (providerResult.value.kind === 'deepgram') {
+            const ws = providerResult.value.ws;
+            wsRef.current = ws;
+            ws.onmessage = (event) => {
+                const data = JSON.parse(event.data);
+                if (!data.channel?.alternatives?.[0]) return;
+                const transcript = data.channel.alternatives[0].transcript;
+                if (!transcript) return;
 
-            const channelIndex = data.channel_index?.[0] ?? 0;
-            const isMic = channelIndex === 0;
-
-            // Channel 0 = mic = "You", Channel 1 = system audio with diarization
-            let speaker: string;
-            if (isMic) {
-                speaker = 'You';
-            } else {
-                // Use Deepgram diarization speaker ID for system audio channel
+                const channelIndex = (data.channel_index?.[0] ?? 0) as 0 | 1;
                 const words = data.channel.alternatives[0].words;
                 const speakerId = words?.[0]?.speaker;
-                speaker = speakerId != null ? `Speaker ${speakerId}` : 'System audio';
-            }
+                const speaker = channelIndex === 0
+                    ? 'You'
+                    : speakerId != null ? `Speaker ${speakerId}` : 'System audio';
 
-            if (data.is_final) {
-                interimRef.current.delete(channelIndex);
-                const entries = transcriptRef.current;
-                if (entries.length > 0 && entries[entries.length - 1].speaker === speaker) {
-                    entries[entries.length - 1].text += ' ' + transcript;
+                if (data.is_final) {
+                    interimRef.current.delete(channelIndex);
+                    const entries = transcriptRef.current;
+                    if (entries.length > 0 && entries[entries.length - 1].speaker === speaker) {
+                        entries[entries.length - 1].text += ' ' + transcript;
+                    } else {
+                        entries.push({ speaker, text: transcript });
+                    }
                 } else {
-                    entries.push({ speaker, text: transcript });
+                    interimRef.current.set(channelIndex, { speaker, text: transcript });
                 }
-            } else {
-                interimRef.current.set(channelIndex, { speaker, text: transcript });
-            }
-            scheduleDebouncedWrite();
-        };
+                scheduleDebouncedWrite();
+            };
 
-        ws.onclose = () => {
-            console.log('[meeting] WebSocket closed');
-            wsRef.current = null;
-        };
+            ws.onclose = () => {
+                console.log('[meeting] WebSocket closed');
+                wsRef.current = null;
+            };
+        } else {
+            selfHostedRef.current = providerResult.value.client;
+        }
 
         const micStream = micResult.value;
         micStreamRef.current = micStream;
@@ -464,7 +550,9 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
         processorRef.current = processor;
 
         processor.onaudioprocess = (e) => {
-            if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
+            const deepgram = wsRef.current?.readyState === WebSocket.OPEN ? wsRef.current : null;
+            const selfHosted = selfHostedRef.current;
+            if (!deepgram && !selfHosted) return;
 
             const micRaw = e.inputBuffer.getChannelData(0);
             const sysRaw = e.inputBuffer.getChannelData(1);
@@ -506,7 +594,8 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
                 int16[i * 2] = s0 < 0 ? s0 * 0x8000 : s0 * 0x7fff;
                 int16[i * 2 + 1] = s1 < 0 ? s1 * 0x8000 : s1 * 0x7fff;
             }
-            wsRef.current.send(int16.buffer);
+            if (selfHosted) selfHosted.send(int16);
+            else deepgram?.send(int16.buffer);
         };
 
         merger.connect(processor);
@@ -539,7 +628,12 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
         const calEndMs = calendarEvent?.end?.dateTime ? Date.parse(calendarEvent.end.dateTime) : NaN;
         calendarEndMsRef.current = Number.isFinite(calEndMs) ? calEndMs : null;
 
-        const initialContent = formatTranscript([], dateStr, calendarEvent);
+        const initialContent = formatTranscript(
+            [],
+            dateStr,
+            calendarEvent,
+            transcriptionProviderRef.current,
+        );
         await window.ipc.invoke('workspace:writeFile', {
             path: notePath,
             data: initialContent,
@@ -594,7 +688,18 @@ export function useMeetingTranscription(onAutoStop?: () => void) {
         setState('stopping');
 
         stopInputCapture();
-        await finalizeDeepgramStream(wsRef.current, 2200);
+        if (selfHostedRef.current) {
+            const client = selfHostedRef.current;
+            selfHostedRef.current = null;
+            try {
+                await client.finish();
+            } catch (error) {
+                console.error('[meeting] Failed to finalize self-hosted transcription:', error);
+                await client.cancel();
+            }
+        } else {
+            await finalizeDeepgramStream(wsRef.current, 2200);
+        }
         cleanup();
         await writeTranscriptToFile();
         interimRef.current = new Map();

--- a/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.test.ts
+++ b/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SelfHostedMeetingTranscriber,
+  SelfHostedSnapshotAssembler,
+  type SelfHostedMeetingTransport,
+  type SelfHostedTranscriptSnapshot,
+} from './self-hosted-meeting-transcriber';
+
+function snapshot(
+  channelIndex: 0 | 1,
+  overrides: Partial<SelfHostedTranscriptSnapshot> = {},
+): SelfHostedTranscriptSnapshot {
+  return {
+    channelIndex,
+    full: '',
+    committed: '',
+    tentative: '',
+    final: false,
+    revision: 0,
+    inputMs: 0,
+    bufferedMs: 0,
+    ...overrides,
+  };
+}
+
+function emptyResponse() {
+  return { updates: [snapshot(0), snapshot(1)] as [SelfHostedTranscriptSnapshot, SelfHostedTranscriptSnapshot] };
+}
+
+describe('SelfHostedSnapshotAssembler', () => {
+  it('emits only new stable text and keeps tentative text replaceable', () => {
+    const assembler = new SelfHostedSnapshotAssembler();
+    expect(assembler.apply(snapshot(0, {
+      full: 'hello wor',
+      committed: 'hello',
+      tentative: 'wor',
+      revision: 1,
+    }))).toEqual([
+      { channelIndex: 0, text: 'hello', isFinal: true },
+      { channelIndex: 0, text: 'wor', isFinal: false },
+    ]);
+    expect(assembler.apply(snapshot(0, {
+      full: 'hello world',
+      committed: 'hello world',
+      tentative: '',
+      revision: 2,
+    }))).toEqual([
+      { channelIndex: 0, text: ' world', isFinal: true },
+      { channelIndex: 0, text: '', isFinal: false },
+    ]);
+  });
+
+  it('keeps microphone and system channel revisions independent', () => {
+    const assembler = new SelfHostedSnapshotAssembler();
+    expect(assembler.apply(snapshot(1, {
+      committed: 'remote',
+      revision: 4,
+    }))[0]).toEqual({ channelIndex: 1, text: 'remote', isFinal: true });
+    expect(assembler.apply(snapshot(0, {
+      committed: 'local',
+      revision: 1,
+    }))[0]).toEqual({ channelIndex: 0, text: 'local', isFinal: true });
+  });
+
+  it('preserves punctuation attachment in committed deltas', () => {
+    const assembler = new SelfHostedSnapshotAssembler();
+    assembler.apply(snapshot(0, { committed: 'hello', revision: 1 }));
+    expect(assembler.apply(snapshot(0, { committed: 'hello, world', revision: 2 }))[0])
+      .toEqual({ channelIndex: 0, text: ', world', isFinal: true });
+  });
+
+  it('rejects revision rollback and committed-text mutation', () => {
+    const assembler = new SelfHostedSnapshotAssembler();
+    assembler.apply(snapshot(0, { committed: 'stable', revision: 2 }));
+    expect(() => assembler.apply(snapshot(0, { committed: 'stable', revision: 1 })))
+      .toThrow(/revision moved backwards/);
+    expect(() => assembler.apply(snapshot(0, { committed: 'changed', revision: 3 })))
+      .toThrow(/changed already committed text/);
+  });
+});
+
+describe('SelfHostedMeetingTranscriber', () => {
+  it('serializes feed requests so a slow worker cannot reorder audio', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const feed = vi.fn(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return emptyResponse();
+    });
+    const transport: SelfHostedMeetingTransport = {
+      begin: async () => ({ connectionId: '11111111-1111-4111-8111-111111111111' }),
+      feed,
+      finalize: async () => emptyResponse(),
+      reset: async () => undefined,
+    };
+    const client = new SelfHostedMeetingTranscriber(transport, () => undefined, () => undefined);
+    await client.start();
+    client.send(new Int16Array(64));
+    client.send(new Int16Array(64));
+    await client.finish();
+
+    expect(feed).toHaveBeenCalledTimes(2);
+    expect(maximumActive).toBe(1);
+  });
+
+  it('fails visibly instead of growing an unbounded audio queue', async () => {
+    const fatal = vi.fn();
+    const reset = vi.fn(async () => undefined);
+    const transport: SelfHostedMeetingTransport = {
+      begin: async () => ({ connectionId: '11111111-1111-4111-8111-111111111111' }),
+      feed: async () => emptyResponse(),
+      finalize: async () => emptyResponse(),
+      reset,
+    };
+    const client = new SelfHostedMeetingTranscriber(transport, () => undefined, fatal);
+    await client.start();
+    client.send(new Int16Array(200_000));
+
+    expect(fatal).toHaveBeenCalledOnce();
+    expect(fatal.mock.calls[0][0].message).toMatch(/five seconds behind/);
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.test.ts
+++ b/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.test.ts
@@ -69,6 +69,34 @@ describe('SelfHostedSnapshotAssembler', () => {
       .toEqual({ channelIndex: 0, text: ', world', isFinal: true });
   });
 
+  it('exposes stable audio intervals for independent speaker evidence', () => {
+    const assembler = new SelfHostedSnapshotAssembler();
+    expect(assembler.apply(snapshot(1, {
+      committed: 'first',
+      inputMs: 3_200,
+      bufferedMs: 600,
+      revision: 1,
+    }))[0]).toEqual({
+      channelIndex: 1,
+      text: 'first',
+      isFinal: true,
+      stableStartMs: 0,
+      stableEndMs: 2_600,
+    });
+    expect(assembler.apply(snapshot(1, {
+      committed: 'first second',
+      inputMs: 4_800,
+      bufferedMs: 400,
+      revision: 2,
+    }))[0]).toEqual({
+      channelIndex: 1,
+      text: ' second',
+      isFinal: true,
+      stableStartMs: 2_600,
+      stableEndMs: 4_400,
+    });
+  });
+
   it('rejects revision rollback and committed-text mutation', () => {
     const assembler = new SelfHostedSnapshotAssembler();
     assembler.apply(snapshot(0, { committed: 'stable', revision: 2 }));

--- a/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.ts
+++ b/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.ts
@@ -1,0 +1,163 @@
+import type { IPCChannels } from '@x/shared/dist/ipc';
+
+type FeedResponse = IPCChannels['meeting:selfHostedTranscriptionFeed']['res'];
+export type SelfHostedTranscriptSnapshot = FeedResponse['updates'][number];
+
+export type CanonicalTranscriptUpdate = {
+  channelIndex: 0 | 1;
+  text: string;
+  isFinal: boolean;
+};
+
+export interface SelfHostedMeetingTransport {
+  begin(): Promise<{ connectionId: string }>;
+  feed(connectionId: string, pcmBase64: string): Promise<FeedResponse>;
+  finalize(connectionId: string): Promise<FeedResponse>;
+  reset(connectionId: string): Promise<void>;
+}
+
+const MAX_QUEUED_PCM_BYTES = 5 * 16_000 * 2 * 2;
+
+function pcmToBase64(pcm: Int16Array): string {
+  const bytes = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary);
+}
+
+export class SelfHostedSnapshotAssembler {
+  private committed: [string, string] = ['', ''];
+  private revisions: [number, number] = [-1, -1];
+
+  apply(snapshot: SelfHostedTranscriptSnapshot): CanonicalTranscriptUpdate[] {
+    const channel = snapshot.channelIndex;
+    if (snapshot.revision < this.revisions[channel]) {
+      throw new Error('Self-hosted transcription revision moved backwards');
+    }
+    this.revisions[channel] = snapshot.revision;
+
+    const previous = this.committed[channel];
+    if (!snapshot.committed.startsWith(previous)) {
+      throw new Error('Self-hosted transcription changed already committed text');
+    }
+    const updates: CanonicalTranscriptUpdate[] = [];
+    const committedDelta = snapshot.committed.slice(previous.length);
+    if (committedDelta.trim()) {
+      updates.push({ channelIndex: channel, text: committedDelta, isFinal: true });
+    }
+    this.committed[channel] = snapshot.committed;
+
+    const tentative = snapshot.tentative.trim();
+    updates.push({ channelIndex: channel, text: tentative, isFinal: false });
+    return updates;
+  }
+}
+
+export class SelfHostedMeetingTranscriber {
+  private connectionId: string | null = null;
+  private accepting = true;
+  private failed: Error | null = null;
+  private queuedBytes = 0;
+  private tail: Promise<void> = Promise.resolve();
+  private readonly assembler = new SelfHostedSnapshotAssembler();
+  private readonly transport: SelfHostedMeetingTransport;
+  private readonly onTranscript: (update: CanonicalTranscriptUpdate) => void;
+  private readonly onFatal: (error: Error) => void;
+
+  constructor(
+    transport: SelfHostedMeetingTransport,
+    onTranscript: (update: CanonicalTranscriptUpdate) => void,
+    onFatal: (error: Error) => void,
+  ) {
+    this.transport = transport;
+    this.onTranscript = onTranscript;
+    this.onFatal = onFatal;
+  }
+
+  async start(): Promise<void> {
+    if (this.connectionId) throw new Error('Self-hosted transcription is already started');
+    this.connectionId = (await this.transport.begin()).connectionId;
+  }
+
+  send(pcm: Int16Array): void {
+    if (!this.accepting || this.failed || !this.connectionId) return;
+    const byteLength = pcm.byteLength;
+    if (this.queuedBytes + byteLength > MAX_QUEUED_PCM_BYTES) {
+      this.fail(new Error('Self-hosted transcription fell more than five seconds behind'));
+      return;
+    }
+    const encoded = pcmToBase64(pcm);
+    const connectionId = this.connectionId;
+    this.queuedBytes += byteLength;
+    const operation = this.tail.then(async () => {
+      if (this.failed) return;
+      const response = await this.transport.feed(connectionId, encoded);
+      this.apply(response);
+    });
+    this.tail = operation
+      .catch((error: unknown) => this.fail(error))
+      .finally(() => {
+        this.queuedBytes -= byteLength;
+      });
+  }
+
+  async finish(): Promise<void> {
+    this.accepting = false;
+    await this.tail;
+    if (this.failed) throw this.failed;
+    const connectionId = this.connectionId;
+    if (!connectionId) return;
+    try {
+      this.apply(await this.transport.finalize(connectionId));
+    } finally {
+      this.connectionId = null;
+    }
+  }
+
+  async cancel(): Promise<void> {
+    this.accepting = false;
+    const connectionId = this.connectionId;
+    this.connectionId = null;
+    if (!connectionId) return;
+    await this.transport.reset(connectionId).catch(() => undefined);
+  }
+
+  private apply(response: FeedResponse): void {
+    for (const snapshot of response.updates) {
+      for (const update of this.assembler.apply(snapshot)) {
+        this.onTranscript(update);
+      }
+    }
+  }
+
+  private fail(error: unknown): void {
+    if (this.failed) return;
+    this.failed = error instanceof Error ? error : new Error('Self-hosted transcription failed');
+    this.accepting = false;
+    const connectionId = this.connectionId;
+    this.connectionId = null;
+    if (connectionId) {
+      void this.transport.reset(connectionId).catch(() => undefined);
+    }
+    this.onFatal(this.failed);
+  }
+}
+
+export function createIpcSelfHostedMeetingTransport(): SelfHostedMeetingTransport {
+  return {
+    begin: () => window.ipc.invoke('meeting:selfHostedTranscriptionBegin', null),
+    feed: (connectionId, pcmBase64) => window.ipc.invoke(
+      'meeting:selfHostedTranscriptionFeed',
+      { connectionId, pcmBase64 },
+    ),
+    finalize: (connectionId) => window.ipc.invoke(
+      'meeting:selfHostedTranscriptionFinalize',
+      { connectionId },
+    ),
+    reset: async (connectionId) => {
+      await window.ipc.invoke('meeting:selfHostedTranscriptionReset', { connectionId });
+    },
+  };
+}

--- a/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.ts
+++ b/apps/x/apps/renderer/src/lib/self-hosted-meeting-transcriber.ts
@@ -7,6 +7,8 @@ export type CanonicalTranscriptUpdate = {
   channelIndex: 0 | 1;
   text: string;
   isFinal: boolean;
+  stableStartMs?: number;
+  stableEndMs?: number;
 };
 
 export interface SelfHostedMeetingTransport {
@@ -30,6 +32,7 @@ function pcmToBase64(pcm: Int16Array): string {
 export class SelfHostedSnapshotAssembler {
   private committed: [string, string] = ['', ''];
   private revisions: [number, number] = [-1, -1];
+  private stableAudioMs: [number, number] = [0, 0];
 
   apply(snapshot: SelfHostedTranscriptSnapshot): CanonicalTranscriptUpdate[] {
     const channel = snapshot.channelIndex;
@@ -44,10 +47,24 @@ export class SelfHostedSnapshotAssembler {
     }
     const updates: CanonicalTranscriptUpdate[] = [];
     const committedDelta = snapshot.committed.slice(previous.length);
+    const previousStableAudioMs = this.stableAudioMs[channel];
+    const stableAudioMs = Math.max(
+      previousStableAudioMs,
+      snapshot.inputMs - snapshot.bufferedMs,
+    );
     if (committedDelta.trim()) {
-      updates.push({ channelIndex: channel, text: committedDelta, isFinal: true });
+      updates.push({
+        channelIndex: channel,
+        text: committedDelta,
+        isFinal: true,
+        ...(stableAudioMs > previousStableAudioMs ? {
+          stableStartMs: previousStableAudioMs,
+          stableEndMs: stableAudioMs,
+        } : {}),
+      });
     }
     this.committed[channel] = snapshot.committed;
+    this.stableAudioMs[channel] = stableAudioMs;
 
     const tentative = snapshot.tentative.trim();
     updates.push({ channelIndex: channel, text: tentative, isFinal: false });

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -30,6 +30,7 @@ import { NotificationSettingsSchema } from './notification-settings.js';
 import { TurnLimitsSettingsSchema } from './turn-limits.js';
 import { CodeProject, CodeSession, CodeSessionMode, CodeSessionStatus, GitRepoInfo, GitStatusFile, CodeAgentModelOptions } from './code-sessions.js';
 import { ChannelsConfig, ChannelsStatus } from './channels.js';
+import { SELF_HOSTED_TRANSCRIPTION_PROTOCOL } from './self-hosted-transcription.js';
 
 // ============================================================================
 // Runtime Validation Schemas (Single Source of Truth)
@@ -121,6 +122,17 @@ const UpdaterStatusSchema = z.object({
   releaseNotes: z.string().optional(),
   error: z.string().optional(),
   lastCheckedAt: z.number().optional(),
+});
+
+const SelfHostedTranscriptUpdateSchema = z.object({
+  channelIndex: z.union([z.literal(0), z.literal(1)]),
+  full: z.string(),
+  committed: z.string(),
+  tentative: z.string(),
+  final: z.boolean(),
+  revision: z.number().nonnegative(),
+  inputMs: z.number().nonnegative(),
+  bufferedMs: z.number().nonnegative(),
 });
 
 const ipcSchemas = {
@@ -2436,6 +2448,42 @@ const ipcSchemas = {
     res: z.object({
       notes: z.string(),
     }),
+  },
+  // Optional self-hosted meeting transcription. Main owns the bearer token,
+  // validates the destination, and serializes each connection's audio. The
+  // renderer sees only a connection ID and bounded transcript snapshots.
+  'meeting:selfHostedTranscriptionStatus': {
+    req: z.null(),
+    res: z.object({
+      configured: z.boolean(),
+      valid: z.boolean(),
+      protocol: z.literal(SELF_HOSTED_TRANSCRIPTION_PROTOCOL).optional(),
+      endpoint: z.string().optional(),
+      error: z.string().optional(),
+    }),
+  },
+  'meeting:selfHostedTranscriptionBegin': {
+    req: z.null(),
+    res: z.object({ connectionId: z.string().uuid() }),
+  },
+  'meeting:selfHostedTranscriptionFeed': {
+    req: z.object({
+      connectionId: z.string().uuid(),
+      pcmBase64: z.string().max(350_000),
+    }),
+    res: z.object({
+      updates: z.array(SelfHostedTranscriptUpdateSchema).length(2),
+    }),
+  },
+  'meeting:selfHostedTranscriptionFinalize': {
+    req: z.object({ connectionId: z.string().uuid() }),
+    res: z.object({
+      updates: z.array(SelfHostedTranscriptUpdateSchema).length(2),
+    }),
+  },
+  'meeting:selfHostedTranscriptionReset': {
+    req: z.object({ connectionId: z.string().uuid() }),
+    res: z.object({ success: z.literal(true) }),
   },
   // Resolve a meeting's attendees against the knowledge base — returns each
   // attendee's existing person note (or null). Deterministic, no LLM; powers

--- a/apps/x/packages/shared/src/self-hosted-transcription.test.ts
+++ b/apps/x/packages/shared/src/self-hosted-transcription.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeSelfHostedTranscriptionUrl,
+  validateSelfHostedTranscriptionLanguage,
+  validateSelfHostedTranscriptionToken,
+} from './self-hosted-transcription.js';
+
+describe('self-hosted transcription configuration', () => {
+  it.each([
+    ['http://127.0.0.1:18091/', 'http://127.0.0.1:18091'],
+    ['http://localhost:8091', 'http://localhost:8091'],
+    ['http://[::1]:8091', 'http://[::1]:8091'],
+    ['https://speech.example.com/api///', 'https://speech.example.com/api'],
+    ['https://speech.example.com/api', 'https://speech.example.com/api'],
+  ])('accepts qualified local and remote URLs', (input, expected) => {
+    expect(normalizeSelfHostedTranscriptionUrl(input)).toBe(expected);
+  });
+
+  it.each([
+    'http://speech.example.com',
+    'ws://127.0.0.1:8091',
+    'https://user:secret@speech.example.com',
+    'https://speech.example.com?token=secret',
+    'https://speech.example.com/#fragment',
+  ])('rejects insecure or credential-bearing URLs', (input) => {
+    expect(() => normalizeSelfHostedTranscriptionUrl(input)).toThrow();
+  });
+
+  it('requires a bounded whitespace-free bearer token', () => {
+    expect(validateSelfHostedTranscriptionToken('x'.repeat(32))).toBe('x'.repeat(32));
+    expect(() => validateSelfHostedTranscriptionToken('short')).toThrow();
+    expect(() => validateSelfHostedTranscriptionToken(`${'x'.repeat(32)} space`)).toThrow();
+  });
+
+  it('accepts bounded language tags and defaults to English', () => {
+    expect(validateSelfHostedTranscriptionLanguage(undefined)).toBe('en');
+    expect(validateSelfHostedTranscriptionLanguage('auto')).toBe('auto');
+    expect(validateSelfHostedTranscriptionLanguage('en-IN')).toBe('en-IN');
+    expect(() => validateSelfHostedTranscriptionLanguage('../../en')).toThrow();
+  });
+});

--- a/apps/x/packages/shared/src/self-hosted-transcription.ts
+++ b/apps/x/packages/shared/src/self-hosted-transcription.ts
@@ -1,0 +1,37 @@
+export const SELF_HOSTED_TRANSCRIPTION_PROTOCOL = 'transcribe-stream-v1' as const;
+
+export function normalizeSelfHostedTranscriptionUrl(raw: string): string {
+  const value = raw.trim().replace(/\/+$/, '');
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Self-hosted transcription URL is invalid');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Self-hosted transcription URL cannot contain credentials, query parameters, or fragments');
+  }
+  const loopback = url.hostname === '127.0.0.1'
+    || url.hostname === 'localhost'
+    || url.hostname === '[::1]';
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+    throw new Error('Self-hosted transcription requires HTTPS or an HTTP loopback URL');
+  }
+  return value;
+}
+
+export function validateSelfHostedTranscriptionToken(raw: string): string {
+  const token = raw.trim();
+  if (token.length < 32 || token.length > 512 || /\s/.test(token)) {
+    throw new Error('Self-hosted transcription token must be 32-512 non-whitespace characters');
+  }
+  return token;
+}
+
+export function validateSelfHostedTranscriptionLanguage(raw: unknown): string {
+  if (raw === undefined) return 'en';
+  if (typeof raw !== 'string' || !/^(auto|[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})?)$/.test(raw)) {
+    throw new Error('Self-hosted transcription language is invalid');
+  }
+  return raw;
+}

--- a/docs/self-hosted-meeting-transcription.md
+++ b/docs/self-hosted-meeting-transcription.md
@@ -80,6 +80,10 @@ serializes each connection's feed requests, and resets sessions on stop or rende
 only a random connection ID and bounded snapshots. Generated meeting Markdown records
 `transcription_provider: self-hosted` in frontmatter so later processing retains provenance.
 
+Committed updates also retain their monotonic stable-audio interval from `inputMs - bufferedMs`. This lets an
+independent, privacy-bounded evidence source align participant names without coupling this provider adapter to
+Zoom, Accessibility, or any one meeting platform.
+
 A compatible reference worker and provider-neutral Docker deployment are available in
 [Meeting Assistant's self-hosted STT directory](https://github.com/Rahulk644/Meeting-Assitant/tree/main/deploy/self-hosted-stt).
 That project records one-vCPU/4-GB measurements as a reference, not a Hostinger dependency.

--- a/docs/self-hosted-meeting-transcription.md
+++ b/docs/self-hosted-meeting-transcription.md
@@ -1,0 +1,116 @@
+# Self-hosted meeting transcription
+
+Rowboat can keep its existing capture, live note, summary, and knowledge workflow while sending the two
+meeting-audio channels to a transcription worker that you operate. The worker may run on the same machine,
+on a private network, or on any VPS/cloud provider. No hosting company is part of the protocol.
+
+This is an advanced, explicit override. When it is configured, Rowboat does **not** silently fall back to its
+managed/Deepgram path if the worker is invalid, unreachable, too slow, or incompatible. Meeting start fails
+visibly so audio is never sent to an unintended provider.
+
+## Configure
+
+Create `config/meeting-transcription.json` inside the Rowboat work directory. This is
+`~/.rowboat/config/meeting-transcription.json` by default, or the equivalent path under
+`ROWBOAT_WORKDIR` when that environment variable is set:
+
+```json
+{
+  "provider": "self-hosted",
+  "protocol": "transcribe-stream-v1",
+  "baseUrl": "http://127.0.0.1:18091",
+  "tokenFile": "/absolute/path/to/rowboat-meeting-stt.token",
+  "language": "en"
+}
+```
+
+The token file must:
+
+- be an absolute path;
+- be a regular file, not a symlink;
+- contain 32-512 non-whitespace characters; and
+- on macOS/Linux, have no group/other permission bits (for example, mode `0600`).
+
+For ephemeral development or a service manager, these environment variables override the URL/token without
+putting a secret in the workspace:
+
+```sh
+ROWBOAT_MEETING_STT_URL=http://127.0.0.1:18091
+ROWBOAT_MEETING_STT_TOKEN='a-random-secret-of-at-least-32-characters'
+```
+
+Plain HTTP is accepted only for `localhost`, `127.0.0.1`, or `[::1]`. That covers a same-machine worker
+and a restricted SSH/VPN tunnel. A remote address must use trusted HTTPS. URLs containing credentials, query
+parameters, or fragments are rejected.
+
+`language` accepts `auto` or a bounded language tag such as `en`, `hi`, or `en-IN`. The default is `en`.
+
+## Protocol: `transcribe-stream-v1`
+
+The current adapter is deliberately small and versioned. It is not advertised as an OpenAI, Deepgram,
+WhisperLive, or universal speech protocol.
+
+Every request except `/livez` carries `Authorization: Bearer <token>`.
+
+| Route | Contract |
+|---|---|
+| `GET /health` | JSON `{"ok":true,"maxStreams":2}` or greater |
+| `POST /stream/begin?session=...&language=en` | Create one named mono 16 kHz stream |
+| `POST /stream/feed?session=...` | Little-endian mono signed-16 PCM; return a bounded snapshot |
+| `POST /stream/finalize?session=...` | Flush and return the final snapshot |
+| `POST /stream/reset?session=...` | Release the named stream |
+
+A snapshot contains:
+
+```json
+{
+  "full": "complete current hypothesis",
+  "committed": "stable prefix that will never be revised",
+  "tentative": "replaceable suffix",
+  "final": false,
+  "revision": 4,
+  "inputMs": 2240,
+  "bufferedMs": 560
+}
+```
+
+Rowboat opens two named sessions—microphone and system audio—while the model may remain loaded once in the
+worker. Main owns the endpoint and token, splits stereo PCM into the two mono feeds, validates all responses,
+serializes each connection's feed requests, and resets sessions on stop or renderer exit. The renderer sees
+only a random connection ID and bounded snapshots. Generated meeting Markdown records
+`transcription_provider: self-hosted` in frontmatter so later processing retains provenance.
+
+A compatible reference worker and provider-neutral Docker deployment are available in
+[Meeting Assistant's self-hosted STT directory](https://github.com/Rahulk644/Meeting-Assitant/tree/main/deploy/self-hosted-stt).
+That project records one-vCPU/4-GB measurements as a reference, not a Hostinger dependency.
+
+## Current limits
+
+- The worker must implement genuine streaming and stable committed prefixes. A batch-only Whisper/OpenAI
+  endpoint needs a separate adapter rather than repeated fake streaming calls.
+- This protocol preserves microphone versus system-audio separation but does not add remote diarization.
+  System-audio text remains **System audio** until independent speaker evidence or a diarization adapter names
+  it.
+- Simultaneous local/remote speech stays on separate channels, but this v1 snapshot lacks word timestamps for
+  perfect cross-channel interleaving.
+- A five-second client queue is the hard backpressure bound. Exceeding it stops the transcription path
+  visibly instead of consuming unbounded memory or silently dropping old audio.
+- There is no settings UI in this PR. The file/environment boundary keeps the first contribution small and
+  reviewable; a future UI should use OS-backed secret storage and preserve the same validation/fail-closed
+  behavior.
+
+## Qualification
+
+Before claiming a worker configuration is meeting-ready, test the exact Rowboat artifact and worker revision
+with:
+
+1. local-only speech from the start;
+2. remote-only speech;
+3. simultaneous local/remote speech;
+4. a 30-45 minute call;
+5. worker restart and network/tunnel loss;
+6. mute/unmute and audio-device switching; and
+7. Rowboat/renderer exit while both sessions are active.
+
+Record timings, queue lag, memory, and error states without committing audio, transcripts, tokens, names, or
+meeting metadata.


### PR DESCRIPTION
## What this changes

Adds an explicit, provider-neutral self-hosted meeting-transcription path while preserving Rowboat's existing capture, live-note, summary, and knowledge workflows.

The worker may run on the same machine, behind a loopback tunnel, or on any remote host with trusted HTTPS. There is no Hostinger-specific code.

## Design and trust boundary

- Defines a small versioned `transcribe-stream-v1` HTTP protocol rather than pretending every Whisper server is API-compatible.
- Keeps the endpoint and bearer token in Electron main; the renderer receives only a random connection ID and validated transcript snapshots.
- Accepts plain HTTP only on loopback. Remote endpoints require HTTPS, and credential-bearing URLs are rejected.
- Opens separate microphone and system-audio sessions so one worker can keep one model loaded while serving both streams.
- Serializes audio delivery, caps queued PCM at five seconds, bounds responses, and resets worker sessions on failure or renderer exit.
- Exposes monotonic stable-audio intervals on committed updates so an independent evidence source can align names without coupling this adapter to Zoom, Accessibility, or any meeting platform.
- Fails closed: when self-hosting is explicitly configured, Rowboat does not silently fall back to its managed/Deepgram path.
- Records `transcription_provider` in meeting-note frontmatter.

Configuration, protocol details, deployment shapes, and qualification criteria are documented in `docs/self-hosted-meeting-transcription.md`.

## Honest scope

This adapter preserves local-vs-system channel separation. It does **not** claim remote speaker diarization or participant naming; system audio remains `System audio` until an independent evidence source labels it. Perfect cross-channel ordering also needs word timestamps in a later protocol revision.

This is intentionally separate from #833, which supplies bounded Zoom Accessibility evidence for participant names. The stable interval contract has been exercised on a combined branch with #833 while both PRs remain independently reviewable.

## Verification

- `npm run typecheck` — passed
- `npm run lint` — passed
- shared tests — 118/118 passed
- renderer tests — 142/142 passed on the feature commit
- focused protocol/client tests — 18/18 passed on the feature commit
- focused stable-interval assembler tests — 7/7 passed on the current head
- Electron main TypeScript check — passed
- Electron main bundle — passed
- authenticated loopback mock-worker smoke test — passed (health, begin, stereo split, feed, finalize, reset)
- `git diff --check` — passed

The bundle's optional, unrelated macOS mic-monitor Swift build warned locally because the selected Swift compiler and Command Line Tools SDK versions differ; the Electron main bundle completed successfully.

## Remaining qualification

This PR is ready for code review, but it does not claim physical meeting qualification. That still requires the documented matrix against a real compatible worker: local-only, remote-only, overlap, long call, worker/network failure, mute/unmute, device switching, and renderer exit. No audio, transcripts, names, tokens, or meeting metadata are included in this PR.
