### PR TITLE
fix(x): delete turn files (incl. sub-agent children) when a chat is deleted

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -4562,6 +4562,22 @@ function App() {
     setIsMeetingsOpen(false); setIsLiveNotesOpen(false); setIsBgTasksOpen(false); setIsEmailOpen(false); setIsWorkspaceOpen(false); setIsKnowledgeViewOpen(false); setIsChatHistoryOpen(false); setIsHomeOpen(false); setIsAppsOpen(false)
   }, [dismissBrowserOverlay, handleNewChat, selectedPath, isGraphOpen, isSuggestedTopicsOpen, isMeetingsOpen, isLiveNotesOpen, isBgTasksOpen, isAppsOpen, isEmailOpen, isWorkspaceOpen, isKnowledgeViewOpen, isChatHistoryOpen, isHomeOpen])
 
+  // A chat was deleted (sessions:delete succeeded): drop it from the recents
+  // list and — because closeChatTab no-ops on the last tab in the single-chat
+  // model — reset the chat surface to a fresh conversation when the deleted
+  // chat is the one currently bound, so a dead transcript never stays on
+  // screen.
+  const handleRunDeleted = useCallback((rid: string) => {
+    setRuns((prev) => prev.filter((r) => r.id !== rid))
+    const openTab = chatTabs.find((t) => t.runId === rid)
+    if (!openTab) return
+    if (chatTabs.length > 1) {
+      closeChatTab(openTab.id)
+    } else {
+      handleNewChatTab()
+    }
+  }, [chatTabs, closeChatTab, handleNewChatTab])
+
   // Sidebar variant: reset the chat in place without leaving file/graph context.
   // A caller with a selection already chosen for the fresh chat (the Home
   // composer handoff) passes it here so the map entry exists BEFORE the
@@ -6949,11 +6965,7 @@ function App() {
               }}
               onDeleteRun={(rid) => {
                 void window.ipc.invoke('sessions:delete', { sessionId: rid })
-                  .then(() => {
-                    setRuns((prev) => prev.filter((r) => r.id !== rid))
-                    const openTab = chatTabs.find((t) => t.runId === rid)
-                    if (openTab) closeChatTab(openTab.id)
-                  })
+                  .then(() => handleRunDeleted(rid))
                   .catch((err) => console.error('Failed to delete chat:', err))
               }}
               onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
@@ -7358,6 +7370,7 @@ function App() {
                     onDeleteRun={async (rid) => {
                       try {
                         await window.ipc.invoke('sessions:delete', { sessionId: rid })
+                        handleRunDeleted(rid)
                         await loadRuns()
                       } catch (err) {
                         console.error('Failed to delete run:', err)

--- a/apps/x/packages/core/docs/session-design.md
+++ b/apps/x/packages/core/docs/session-design.md
@@ -96,8 +96,8 @@ interface ISessionRepo {
 - `create` fails if the file exists.
 - `listSessionIds` enumerates the partition directories for the startup
   scan.
-- `delete` removes the session file only. Turn files referenced by the
-  session are left in place as harmless orphans (see section 9, deletion).
+- `delete` removes the session file only. Deleting the referenced turn
+  files is the session layer's job (see section 9.4, deletion).
 - `withLock` is in-process per-session exclusion, mirroring the turn repo.
 
 ## 5. Event schemas
@@ -354,9 +354,15 @@ runtime's job; the session layer passes its errors through.
 
 ### 9.4 Deletion
 
-`deleteSession` removes the session file and the index entry, and publishes
-`session-index-changed`. Referenced turn files are retained as orphans:
-turns are only discoverable by reference, so orphaned files are inert.
+`deleteSession` aborts any live advances for the session (mirroring
+`stopTurn`), then removes the session file, the index entry, and every turn
+file the session references — following spawn-agent's durable `subagent`
+tool_progress links so sub-agent child turn files are removed too — and
+publishes `session-index-changed`. The session file goes first: turns are
+only discoverable by reference, so a crash mid-cleanup leaves unreferenced
+turn files behind — the same inert orphans the v1 design retained on every
+delete. Turn-file removal is best-effort (`ITurnRepo.delete` is idempotent;
+missing files are not errors) and never blocks the session delete itself.
 Deleting an entity's file is not a violation of append-only discipline,
 which governs mutation of live logs, not their removal.
 

--- a/apps/x/packages/core/src/runtime/assembly/headless.test.ts
+++ b/apps/x/packages/core/src/runtime/assembly/headless.test.ts
@@ -158,6 +158,8 @@ class FakeRuntime implements ITurnRuntime {
     async getTurn() {
         return { turnId: TURN_ID, events: this.log };
     }
+
+    async deleteTurn(): Promise<void> {}
 }
 
 const completedOutcome: TurnOutcome = {

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -261,6 +261,10 @@ class FakeTurnRuntime implements ITurnRuntime {
         return { turnId, events: structuredClone(log) };
     }
 
+    async deleteTurn(turnId: string): Promise<void> {
+        this.logs.delete(turnId);
+    }
+
     setLog(turnId: string, events: TEvent[]): void {
         this.logs.set(turnId, events);
     }
@@ -812,7 +816,7 @@ describe("event forwarding and index maintenance (13.6, 13.7)", () => {
         });
     });
 
-    it("deleteSession removes the file and entry; turn files stay; late settles don't resurrect", async () => {
+    it("deleteSession removes the file, entry, and turn files; live advances abort first", async () => {
         const { sessions, repo, fake, bus } = makeSessions();
         fake.script = () => ({ untilAbort: true });
         const sessionId = await sessions.createSession();
@@ -820,6 +824,8 @@ describe("event forwarding and index maintenance (13.6, 13.7)", () => {
             agent: { agentId: "copilot" },
         });
 
+        // The advance is still live (untilAbort): deleteSession aborts it,
+        // waits for it to settle, then removes both files.
         await sessions.deleteSession(sessionId);
         await expect(
             (repo as InMemorySessionRepo).read(sessionId),
@@ -830,13 +836,91 @@ describe("event forwarding and index maintenance (13.6, 13.7)", () => {
             sessionId,
             entry: null,
         });
-        // Turn file untouched (orphaned, inert).
-        expect(fake.logs.has(turnId)).toBe(true);
+        // Turn file deleted along with the session.
+        expect(fake.logs.has(turnId)).toBe(false);
 
-        // The still-running advance settles after deletion: no resurrection.
-        await sessions.stopTurn(turnId);
         await flush();
         expect(sessions.listSessions()).toEqual([]);
+    });
+
+    it("deleteSession follows sub-agent child links and deletes child turn files", async () => {
+        const { sessions, fake } = makeSessions();
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("go"), {
+            agent: { agentId: "copilot" },
+        });
+        await flush();
+
+        // Seed a child turn plus the durable 'subagent' tool_progress trail
+        // spawn-agent records on the parent (model call → invocation →
+        // progress, so the reducer accepts the log).
+        const childTurnId = "2026-07-02T10-00-00Z-9999999-000";
+        fake.setLog(childTurnId, [
+            createdEvent(childTurnId, {
+                agent: { agentId: "subagent" },
+                sessionId: null,
+                context: [],
+                input: user("child task"),
+                config: { humanAvailable: false },
+            }),
+        ]);
+        const parentLog = fake.logs.get(turnId)!;
+        fake.setLog(turnId, [
+            ...parentLog,
+            {
+                type: "model_call_requested",
+                turnId,
+                ts: TS,
+                modelCallIndex: 0,
+                request: { messages: ["input"], parameters: {} },
+            },
+            {
+                type: "model_call_completed",
+                turnId,
+                ts: TS,
+                modelCallIndex: 0,
+                message: {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "tool-call",
+                            toolCallId: "tc-1",
+                            toolName: "spawn-agent",
+                            arguments: {},
+                        },
+                    ],
+                },
+                finishReason: "tool-calls",
+                usage: {},
+            },
+            {
+                type: "tool_invocation_requested",
+                turnId,
+                ts: TS,
+                toolCallId: "tc-1",
+                toolId: "tool.spawn-agent",
+                toolName: "spawn-agent",
+                execution: "sync",
+                input: {},
+            },
+            {
+                type: "tool_progress",
+                turnId,
+                ts: TS,
+                toolCallId: "tc-1",
+                source: "sync",
+                progress: {
+                    kind: "subagent",
+                    childTurnId,
+                    agentName: "subagent",
+                    task: "child task",
+                },
+            },
+        ] as TEvent[]);
+
+        await sessions.deleteSession(sessionId);
+        expect(fake.logs.has(turnId)).toBe(false);
+        expect(fake.logs.has(childTurnId)).toBe(false);
     });
 });
 

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -387,14 +387,67 @@ export class SessionsImpl implements ISessions {
         });
     }
 
-    // §9.4: removes the session file and index entry only. Referenced turn
-    // files stay behind as inert orphans.
+    // §9.4: removes the session file, the index entry, and every turn file
+    // the session references (following sub-agent child-turn links). Live
+    // advances are aborted first so nothing appends to a deleted file.
+    // Session-file-first ordering: a crash mid-cleanup leaves unreferenced
+    // turn files behind — the same inert orphans the pre-cleanup design
+    // produced, invisible and harmless.
     async deleteSession(sessionId: string): Promise<void> {
+        // Abort every live advance this process is driving for the session
+        // and wait for them to settle (mirrors stopTurn's abort path).
+        const advances = [...this.active.values()]
+            .flatMap((set) => [...set])
+            .filter((advance) => advance.sessionId === sessionId);
+        for (const advance of advances) {
+            advance.controller.abort();
+        }
+        await Promise.all(
+            advances.map((a) => a.execution.outcome.catch(() => undefined)),
+        );
+
         await this.sessionRepo.withLock(sessionId, async () => {
+            // Collect the reference chain before the session file disappears —
+            // turns are only discoverable through it. A corrupt session file
+            // still gets deleted; its turns stay orphaned as before.
+            let turnIds: string[] = [];
+            try {
+                const state = reduceSession(await this.sessionRepo.read(sessionId));
+                turnIds = state.turns.map((ref) => ref.turnId);
+            } catch {
+                // Unreadable session — nothing to traverse.
+            }
             await this.sessionRepo.delete(sessionId);
             this.index.remove(sessionId);
             this.sessionBus.publish({ kind: "index-changed", sessionId, entry: null });
+            await this.deleteTurnFiles(turnIds);
         });
+    }
+
+    // Best-effort removal of a session's turn files, following spawn-agent
+    // child links breadth-first so sub-agent transcripts go too. Individual
+    // failures are swallowed: a leftover file is an inert orphan, not a fault.
+    private async deleteTurnFiles(rootTurnIds: string[]): Promise<void> {
+        const seen = new Set<string>();
+        const queue = [...rootTurnIds];
+        while (queue.length > 0) {
+            const turnId = queue.shift()!;
+            if (seen.has(turnId)) {
+                continue;
+            }
+            seen.add(turnId);
+            try {
+                const turn = await this.turnRuntime.getTurn(turnId);
+                queue.push(...childTurnIdsOf(reduceTurn(turn.events)));
+            } catch {
+                // Missing or corrupt turn — still attempt the delete below.
+            }
+            try {
+                await this.turnRuntime.deleteTurn(turnId);
+            } catch {
+                // Leftovers are inert orphans.
+            }
+        }
     }
 
     // ------------------------------------------------------------------
@@ -610,4 +663,28 @@ function defaultTitle(input: z.infer<typeof UserMessage>): string {
         return "New session";
     }
     return collapsed.length > 80 ? `${collapsed.slice(0, 79)}…` : collapsed;
+}
+
+// spawn-agent records one durable 'subagent' tool_progress entry per child
+// turn (see spawn-agent.ts) — the same parent→child link the UI uses to
+// fetch child transcripts. Extracting it here lets session deletion follow
+// the chain and remove sub-agent turn files too.
+function childTurnIdsOf(state: TurnState): string[] {
+    const ids: string[] = [];
+    for (const toolCall of state.toolCalls) {
+        for (const progress of toolCall.progress) {
+            const entry = progress.progress;
+            if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+                continue;
+            }
+            const { kind, childTurnId } = entry as {
+                kind?: unknown;
+                childTurnId?: unknown;
+            };
+            if (kind === "subagent" && typeof childTurnId === "string") {
+                ids.push(childTurnId);
+            }
+        }
+    }
+    return ids;
 }

--- a/apps/x/packages/core/src/runtime/turns/api.ts
+++ b/apps/x/packages/core/src/runtime/turns/api.ts
@@ -95,6 +95,10 @@ export interface ITurnRuntime {
         options?: { signal?: AbortSignal },
     ): TurnExecution;
     getTurn(turnId: string): Promise<Turn>;
+    // Removes the turn's file. Idempotent — a missing turn is not an error.
+    // Callers own lifecycle safety: never delete a turn that may still be
+    // advancing (session deletion stops live advances first).
+    deleteTurn(turnId: string): Promise<void>;
 }
 
 // An external input that does not match the turn's current durable pending

--- a/apps/x/packages/core/src/runtime/turns/fs-repo.ts
+++ b/apps/x/packages/core/src/runtime/turns/fs-repo.ts
@@ -122,6 +122,18 @@ export class FSTurnRepo implements ITurnRepo {
         await fs.appendFile(file, payload);
     }
 
+    async delete(turnId: string): Promise<void> {
+        const file = this.filePath(turnId);
+        try {
+            await fs.unlink(file);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                return;
+            }
+            throw error;
+        }
+    }
+
     async withLock<T>(turnId: string, fn: () => Promise<T>): Promise<T> {
         return this.mutex.run(turnId, fn);
     }

--- a/apps/x/packages/core/src/runtime/turns/in-memory-turn-repo.ts
+++ b/apps/x/packages/core/src/runtime/turns/in-memory-turn-repo.ts
@@ -44,6 +44,10 @@ export class InMemoryTurnRepo implements ITurnRepo {
         }
     }
 
+    async delete(turnId: string): Promise<void> {
+        this.files.delete(turnId);
+    }
+
     async withLock<T>(turnId: string, fn: () => Promise<T>): Promise<T> {
         return this.mutex.run(turnId, fn);
     }

--- a/apps/x/packages/core/src/runtime/turns/repo.ts
+++ b/apps/x/packages/core/src/runtime/turns/repo.ts
@@ -1,8 +1,8 @@
 import type { z } from "zod";
 import type { TurnCreated, TurnEvent } from "@x/shared/dist/turns.js";
 
-// Loop-facing repository contract. Listing, deletion, session lookup, and
-// presentation metadata are deliberately not part of it.
+// Loop-facing repository contract. Listing, session lookup, and presentation
+// metadata are deliberately not part of it.
 export interface ITurnRepo {
     // Fails if the turn already exists.
     create(event: z.infer<typeof TurnCreated>): Promise<void>;
@@ -10,6 +10,9 @@ export interface ITurnRepo {
     read(turnId: string): Promise<Array<z.infer<typeof TurnEvent>>>;
     // Validates events before writing.
     append(turnId: string, events: Array<z.infer<typeof TurnEvent>>): Promise<void>;
+    // Removes the turn file. A missing file is not an error — deletion is
+    // idempotent so session cleanup can retry safely (see session-design §9.4).
+    delete(turnId: string): Promise<void>;
     // In-process per-turn exclusion.
     withLock<T>(turnId: string, fn: () => Promise<T>): Promise<T>;
 }

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -191,6 +191,12 @@ export class TurnRuntime implements ITurnRuntime {
         return { turnId, events };
     }
 
+    async deleteTurn(turnId: string): Promise<void> {
+        // The lock serializes with any in-flight append; the caller must have
+        // stopped live advances so no new appends start after this.
+        await this.turnRepo.withLock(turnId, () => this.turnRepo.delete(turnId));
+    }
+
     advanceTurn(
         turnId: string,
         input?: TurnExternalInput,


### PR DESCRIPTION
## Problem

Deleting a chat only removed the session file under `~/.rowboat/storage/sessions/` and its index entry. The turn files under `~/.rowboat/storage/turns/` — the actual conversation transcripts — were deliberately left behind as "inert orphans" (session-design.md §9.4, v1 decision: "V1 does not garbage-collect orphans"). Every deleted chat leaked its full transcript history to disk forever, including sub-agent child-turn transcripts.

## Fix

`SessionsImpl.deleteSession` now:

1. **Aborts live advances** for the session first (mirrors `stopTurn`'s abort path) so nothing appends to a file about to be deleted.
2. Reads the session's turn references **before** deleting the session file (turns are only discoverable through it).
3. Deletes the session file + index entry and publishes `session-index-changed` (unchanged).
4. **Deletes every referenced turn file**, traversing spawn-agent's durable `subagent` tool_progress links breadth-first so sub-agent child-turn files are removed too. Best-effort per file — a failure just leaves the pre-existing inert-orphan behavior.

Ordering is session-file-first, so a crash mid-cleanup degrades to exactly the old behavior (unreferenced, invisible orphans), never a half-broken session.

### Plumbing
- `ITurnRepo.delete(turnId)` — new; idempotent (missing file is not an error). Implemented in `FSTurnRepo` (unlink, ENOENT-tolerant) and `InMemoryTurnRepo`.
- `ITurnRuntime.deleteTurn(turnId)` — new; takes the per-turn lock so it serializes with in-flight appends.
- session-design.md §4/§9.4 updated to describe the new deletion contract.

## Tests

- Updated the existing deleteSession test (previously pinned "turn files stay") to assert the turn file is deleted and that a live (`untilAbort`) advance is aborted first.
- New test: sub-agent child links are followed — parent and child turn files both deleted (seeds the full model-call → invocation → `subagent` tool_progress trail so the reducer accepts the log).
- Full core suite: 53 files / 587 tests pass; `npm run deps && npm run typecheck` clean.