### PR TITLE
feat(x): auto-delete old chats and task transcripts (storage retention)

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -85,6 +85,8 @@ import { syncSlackKnowledgeSources, triggerSync as triggerSlackKnowledgeSync, ge
 import { isOnboardingComplete, markOnboardingComplete } from '@x/core/dist/config/note_creation_config.js';
 import { loadNotificationSettings, saveNotificationSettings } from '@x/core/dist/config/notification_config.js';
 import { loadTurnLimitsSettings, saveTurnLimitsSettings } from '@x/core/dist/config/turn_limits.js';
+import { loadRetentionSettings, saveRetentionSettings } from '@x/core/dist/config/retention.js';
+import { runRetentionSweep } from '@x/core/dist/runtime/sessions/retention.js';
 import { saveAppSettings } from '@x/core/dist/config/app_settings.js';
 import { isLoginItemEnabled, setLoginItemEnabled } from './login_item.js';
 import { setSelfCaptureActive } from '@x/core/dist/meetings/detector.js';
@@ -834,6 +836,37 @@ const sessionsIndexReady = new Promise<void>((resolve) => {
 });
 export function markSessionsIndexReady(): void {
   resolveSessionsIndexReady();
+}
+
+// Daily storage-retention sweep (auto-delete old chats & task transcripts).
+// Started from main.ts once the session index is ready; the initial run is
+// delayed so it never competes with startup. The first launch with retention
+// enabled only arms the one-time notice (retention:consumeFirstRunNotice) —
+// sweeping begins on the next launch, after the user has seen it.
+let retentionSweepStarted = false;
+export function startRetentionSweep(): void {
+  if (retentionSweepStarted) return;
+  retentionSweepStarted = true;
+  const sweep = async () => {
+    try {
+      const settings = await loadRetentionSettings();
+      if (!settings.enabled || !settings.noticeShown) return;
+      const result = await runRetentionSweep({
+        sessions: container.resolve<ISessions>('sessions'),
+        turnsRootDir: container.resolve<string>('turnsRootDir'),
+        settings,
+      });
+      if (result.deletedSessions > 0 || result.deletedTurnFiles > 0) {
+        console.log(
+          `[Retention] sweep: deleted ${result.deletedSessions} session(s), ${result.deletedTurnFiles} turn file(s)`,
+        );
+      }
+    } catch (error) {
+      console.error('[Retention] sweep failed:', error);
+    }
+  };
+  setTimeout(() => { void sweep(); }, 90_000);
+  setInterval(() => { void sweep(); }, 24 * 60 * 60 * 1000);
 }
 
 let servicesWatcher: (() => void) | null = null;
@@ -2892,6 +2925,21 @@ export function setupIpcHandlers() {
     'turnLimits:setSettings': async (_event, args) => {
       await saveTurnLimitsSettings(args);
       return { success: true };
+    },
+    'retention:getSettings': async () => {
+      return await loadRetentionSettings();
+    },
+    'retention:setSettings': async (_event, args) => {
+      await saveRetentionSettings(args);
+      return { success: true };
+    },
+    'retention:consumeFirstRunNotice': async () => {
+      const settings = await loadRetentionSettings();
+      if (settings.enabled && !settings.noticeShown) {
+        await saveRetentionSettings({ noticeShown: true });
+        return { show: true, chatDays: settings.chatDays };
+      }
+      return { show: false, chatDays: settings.chatDays };
     },
     // Embedded browser handlers (WebContentsView + navigation)
     ...browserIpcHandlers,

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import os from "node:os";
 import {
   setupIpcHandlers,
-  startRunsWatcher, startSessionsWatcher, startTurnEventsWatcher, markSessionsIndexReady,
+  startRunsWatcher, startSessionsWatcher, startTurnEventsWatcher, markSessionsIndexReady, startRetentionSweep,
   startCodeRunFeedWatcher,
   startChannelsWatcher,
   startCodeSessionStatusWatcher,
@@ -662,6 +662,8 @@ app.whenReady().then(async () => {
     markSessionsIndexReady();
   }
   startSessionsWatcher();
+  // Daily auto-delete of old chats & task transcripts (delayed first run).
+  startRetentionSweep();
   // Turn event spine: durable events of every turn (session, headless,
   // sub-agent) → renderer, for turnId-keyed live views.
   startTurnEventsWatcher();

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/components/ui/sidebar"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
+import { SettingsDialog } from "@/components/settings-dialog"
 import { Button } from "@/components/ui/button"
 import { Toaster } from "@/components/ui/sonner"
 import { UpdateCard } from "@/components/update-card"
@@ -5579,18 +5580,14 @@ function App() {
     })
   }, [])
 
-  // One-time storage-retention notice: shown on the first launch with
+  // One-time storage-retention notice: a modal on the first launch with
   // retention enabled; the actual sweep starts on the NEXT launch so months
   // of history are never deleted before the user has seen this.
+  const [retentionNotice, setRetentionNotice] = useState<{ chatDays: number | null } | null>(null)
+  const [retentionSettingsOpen, setRetentionSettingsOpen] = useState(false)
   useEffect(() => {
     void window.ipc.invoke('retention:consumeFirstRunNotice', null).then(({ show, chatDays }) => {
-      if (!show) return
-      toast('Old chats are now cleaned up automatically', {
-        description: chatDays === null
-          ? 'Old background-task transcripts are deleted to save disk space. Notes and files created by agents are never touched. Adjust this in Settings → Advanced.'
-          : `Chats inactive for ${chatDays}+ days and old background-task transcripts are deleted to save disk space. Notes and files created by agents are never touched. Turn this off in Settings → Advanced.`,
-        duration: 15000,
-      })
+      if (show) setRetentionNotice({ chatDays })
     }).catch(() => { /* settings unavailable — try again next launch */ })
   }, [])
 
@@ -7883,6 +7880,37 @@ function App() {
         open={billingErrorOpen}
         match={billingErrorMatch}
         onOpenChange={setBillingErrorOpen}
+      />
+      {/* One-time storage-retention notice (see retention:consumeFirstRunNotice). */}
+      <Dialog open={retentionNotice !== null} onOpenChange={(open) => { if (!open) setRetentionNotice(null) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Old chats are cleaned up automatically</DialogTitle>
+            <DialogDescription className="pt-1 leading-relaxed">
+              {retentionNotice?.chatDays != null
+                ? `To save disk space, Rowboat now deletes chats that have been inactive for ${retentionNotice.chatDays}+ days, along with old background-task transcripts.`
+                : 'To save disk space, Rowboat now deletes old background-task transcripts.'}
+              {' '}Notes and files created by agents are never touched. Cleanup starts from the next launch, and you can change or turn this off anytime.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRetentionNotice(null)
+                setRetentionSettingsOpen(true)
+              }}
+            >
+              Open Settings
+            </Button>
+            <Button onClick={() => setRetentionNotice(null)}>Got it</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <SettingsDialog
+        open={retentionSettingsOpen}
+        onOpenChange={setRetentionSettingsOpen}
+        defaultTab="advanced"
       />
       <OnboardingModal
         open={showOnboarding}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -5579,6 +5579,21 @@ function App() {
     })
   }, [])
 
+  // One-time storage-retention notice: shown on the first launch with
+  // retention enabled; the actual sweep starts on the NEXT launch so months
+  // of history are never deleted before the user has seen this.
+  useEffect(() => {
+    void window.ipc.invoke('retention:consumeFirstRunNotice', null).then(({ show, chatDays }) => {
+      if (!show) return
+      toast('Old chats are now cleaned up automatically', {
+        description: chatDays === null
+          ? 'Old background-task transcripts are deleted to save disk space. Notes and files created by agents are never touched. Adjust this in Settings → Advanced.'
+          : `Chats inactive for ${chatDays}+ days and old background-task transcripts are deleted to save disk space. Notes and files created by agents are never touched. Turn this off in Settings → Advanced.`,
+        duration: 15000,
+      })
+    }).catch(() => { /* settings unavailable — try again next launch */ })
+  }, [])
+
   // Report the UI theme to the apps server (spec §7.1): apps read it from
   // GET /_rowboat/app and get live changes via the SSE theme event.
   useEffect(() => {

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -1604,7 +1604,7 @@ function AdvancedSettings({ dialogOpen }: { dialogOpen: boolean }) {
   // Storage retention (auto-delete old chats & task transcripts).
   // chatDays null = never delete chats (transcript cleanup still runs).
   const [retentionEnabled, setRetentionEnabled] = useState(true)
-  const [retentionChatDays, setRetentionChatDays] = useState<number | null>(30)
+  const [retentionChatDays, setRetentionChatDays] = useState<number | null>(60)
 
   useEffect(() => {
     if (!dialogOpen) return

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -1601,6 +1601,10 @@ function AdvancedSettings({ dialogOpen }: { dialogOpen: boolean }) {
   const [globalLimit, setGlobalLimit] = useState("")
   const [chatLimit, setChatLimit] = useState("")
   const [loaded, setLoaded] = useState(false)
+  // Storage retention (auto-delete old chats & task transcripts).
+  // chatDays null = never delete chats (transcript cleanup still runs).
+  const [retentionEnabled, setRetentionEnabled] = useState(true)
+  const [retentionChatDays, setRetentionChatDays] = useState<number | null>(30)
 
   useEffect(() => {
     if (!dialogOpen) return
@@ -1621,8 +1625,25 @@ function AdvancedSettings({ dialogOpen }: { dialogOpen: boolean }) {
       .catch(() => {
         if (!cancelled) toast.error("Failed to load advanced settings")
       })
+    window.ipc.invoke("retention:getSettings", null)
+      .then((settings) => {
+        if (cancelled) return
+        setRetentionEnabled(settings.enabled)
+        setRetentionChatDays(settings.chatDays)
+      })
+      .catch(() => {
+        if (!cancelled) toast.error("Failed to load auto-delete settings")
+      })
     return () => { cancelled = true }
   }, [dialogOpen])
+
+  const saveRetention = useCallback(async (patch: { enabled?: boolean; chatDays?: number | null }) => {
+    try {
+      await window.ipc.invoke("retention:setSettings", patch)
+    } catch {
+      toast.error("Failed to save auto-delete settings")
+    }
+  }, [])
 
   // Saves silently on success (a toast per stepper click would be noisy,
   // matching the notification toggles); errors still surface.
@@ -1727,6 +1748,56 @@ function AdvancedSettings({ dialogOpen }: { dialogOpen: boolean }) {
             />
           </div>
         </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="rounded-md border px-3 py-3 flex items-center gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium">Auto-delete old chats &amp; task history</div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              Deletes chats inactive for longer than the period below, and background run
+              transcripts (note creation, background tasks, knowledge sync) older than 14 days.
+              Notes and files created by agents are never touched.
+            </div>
+          </div>
+          <Switch
+            checked={retentionEnabled}
+            onCheckedChange={(checked) => {
+              setRetentionEnabled(checked)
+              void saveRetention({ enabled: checked })
+            }}
+            aria-label="Auto-delete old chats and task history"
+          />
+        </div>
+
+        {retentionEnabled && (
+          <div className="rounded-md border px-3 py-3 flex items-center gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium">Delete chats after</div>
+              <div className="text-xs text-muted-foreground mt-0.5">
+                Measured from the chat&apos;s last activity, not when it was created.
+              </div>
+            </div>
+            <Select
+              value={retentionChatDays === null ? "never" : String(retentionChatDays)}
+              onValueChange={(value) => {
+                const days = value === "never" ? null : Number(value)
+                setRetentionChatDays(days)
+                void saveRetention({ chatDays: days })
+              }}
+            >
+              <SelectTrigger className="w-32 shrink-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="30">30 days</SelectItem>
+                <SelectItem value="60">60 days</SelectItem>
+                <SelectItem value="90">90 days</SelectItem>
+                <SelectItem value="never">Never</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/x/packages/core/src/config/retention.ts
+++ b/apps/x/packages/core/src/config/retention.ts
@@ -1,0 +1,43 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {
+    RetentionSettingsSchema,
+    DEFAULT_RETENTION_SETTINGS,
+    type RetentionSettings,
+} from '@x/shared/dist/retention.js';
+import { WorkDir } from './config.js';
+
+const RETENTION_CONFIG_PATH = path.join(WorkDir, 'config', 'retention.json');
+
+/**
+ * Load the storage-retention settings, falling back to the defaults
+ * (enabled, 30-day chats, 14-day task transcripts, notice not yet shown)
+ * when the file is absent or malformed.
+ */
+export async function loadRetentionSettings(): Promise<RetentionSettings> {
+    try {
+        const content = await fs.readFile(RETENTION_CONFIG_PATH, 'utf-8');
+        const parsed = JSON.parse(content);
+        return RetentionSettingsSchema.parse({
+            ...DEFAULT_RETENTION_SETTINGS,
+            ...(parsed && typeof parsed === 'object' ? parsed : {}),
+        });
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            console.error('[Retention] Error loading retention settings:', error);
+        }
+        return DEFAULT_RETENTION_SETTINGS;
+    }
+}
+
+export async function saveRetentionSettings(
+    patch: Partial<RetentionSettings>,
+): Promise<RetentionSettings> {
+    const merged = RetentionSettingsSchema.parse({
+        ...(await loadRetentionSettings()),
+        ...patch,
+    });
+    await fs.mkdir(path.dirname(RETENTION_CONFIG_PATH), { recursive: true });
+    await fs.writeFile(RETENTION_CONFIG_PATH, JSON.stringify(merged, null, 2));
+    return merged;
+}

--- a/apps/x/packages/core/src/runtime/sessions/retention.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/retention.test.ts
@@ -119,7 +119,8 @@ describe("runRetentionSweep", () => {
         const result = await runRetentionSweep({
             sessions,
             turnsRootDir: path.join(root, "turns"),
-            settings: { ...DEFAULT_RETENTION_SETTINGS, noticeShown: true },
+            // Explicit windows so the assertions don't shift with the defaults.
+            settings: { ...DEFAULT_RETENTION_SETTINGS, chatDays: 30, taskDays: 14, noticeShown: true },
             now: NOW,
         });
 

--- a/apps/x/packages/core/src/runtime/sessions/retention.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/retention.test.ts
@@ -136,6 +136,76 @@ describe("runRetentionSweep", () => {
         expect(await exists(turnFile("2026-08-02T10-00-00Z-0000006-000"))).toBe(true);
     });
 
+    it("protects an old sub-agent child turn linked from an active chat's old parent turn", async () => {
+        // Active chat (recent activity) whose first turn is old and spawned a
+        // sub-agent — both parent and child are >14d old, so only the child
+        // link discovered by reading the old parent protects the child file.
+        const sessionId = "2026-06-08T10-00-00Z-0000001-000";
+        const parentId = "2026-06-08T10-00-00Z-0000002-000";
+        const childId = "2026-06-08T10-05-00Z-0000003-000";
+        await seedSession(sessionId, parentId, "2026-06-08T10:00:00.000Z");
+        await sessionRepo.append(sessionId, [{
+            type: "title_changed",
+            sessionId,
+            ts: "2026-08-05T10:00:00.000Z",
+            title: "still in use",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any]);
+        await turnRepo.create(turnCreated(childId, null, "2026-06-08T10:05:00.000Z"));
+        await turnRepo.append(parentId, [
+            {
+                type: "model_call_requested",
+                turnId: parentId,
+                ts: "2026-06-08T10:04:00.000Z",
+                modelCallIndex: 0,
+                request: { messages: ["input"], parameters: {} },
+            },
+            {
+                type: "model_call_completed",
+                turnId: parentId,
+                ts: "2026-06-08T10:04:30.000Z",
+                modelCallIndex: 0,
+                message: {
+                    role: "assistant",
+                    content: [{ type: "tool-call", toolCallId: "tc-1", toolName: "spawn-agent", arguments: {} }],
+                },
+                finishReason: "tool-calls",
+                usage: {},
+            },
+            {
+                type: "tool_invocation_requested",
+                turnId: parentId,
+                ts: "2026-06-08T10:04:31.000Z",
+                toolCallId: "tc-1",
+                toolId: "tool.spawn-agent",
+                toolName: "spawn-agent",
+                execution: "sync",
+                input: {},
+            },
+            {
+                type: "tool_progress",
+                turnId: parentId,
+                ts: "2026-06-08T10:05:00.000Z",
+                toolCallId: "tc-1",
+                source: "sync",
+                progress: { kind: "subagent", childTurnId: childId, agentName: "subagent", task: "t" },
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any);
+
+        await sessions.initialize();
+        const result = await runRetentionSweep({
+            sessions,
+            turnsRootDir: path.join(root, "turns"),
+            settings: { ...DEFAULT_RETENTION_SETTINGS, chatDays: 90, taskDays: 14, noticeShown: true },
+            now: NOW,
+        });
+
+        expect(result).toEqual({ deletedSessions: 0, deletedTurnFiles: 0 });
+        expect(await exists(turnFile(parentId))).toBe(true);
+        expect(await exists(turnFile(childId))).toBe(true);
+    });
+
     it("chatDays null keeps all chats but still cleans old task turns", async () => {
         await seedSession(
             "2026-06-08T10-00-00Z-0000001-000",

--- a/apps/x/packages/core/src/runtime/sessions/retention.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/retention.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { DEFAULT_RETENTION_SETTINGS } from "@x/shared/dist/retention.js";
+import { SessionsImpl } from "./sessions.js";
+import { FSSessionRepo } from "./fs-repo.js";
+import { FSTurnRepo } from "../turns/fs-repo.js";
+import { runRetentionSweep } from "./retention.js";
+
+// Fixed clock: "today" for the sweep. Ids/timestamps below are relative to it.
+const NOW = Date.parse("2026-08-07T12:00:00.000Z");
+
+const MODEL = { provider: "openai", model: "gpt-fixture" };
+const AGENT = { agentId: "copilot", systemPrompt: "SYS", model: MODEL, tools: [] };
+
+const user = (text: string) => ({ role: "user", content: [{ type: "text", text }] });
+
+const turnCreated = (turnId: string, sessionId: string | null, ts: string) => ({
+    type: "turn_created",
+    schemaVersion: 1,
+    turnId,
+    ts,
+    sessionId,
+    agent: { requested: { agentId: "copilot" }, resolved: AGENT },
+    context: [],
+    input: user("hi"),
+    config: { autoPermission: false, humanAvailable: true, maxModelCalls: 20 },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}) as any;
+
+describe("runRetentionSweep", () => {
+    let root: string;
+    let sessionRepo: FSSessionRepo;
+    let turnRepo: FSTurnRepo;
+    let sessions: SessionsImpl;
+
+    const turnFile = (turnId: string) => {
+        const [y, m, d] = turnId.split("-");
+        return path.join(root, "turns", y, m, d.slice(0, 2), `${turnId}.jsonl`);
+    };
+    const exists = (p: string) => fs.access(p).then(() => true, () => false);
+
+    const seedSession = async (sessionId: string, turnId: string, ts: string) => {
+        await turnRepo.create(turnCreated(turnId, sessionId, ts));
+        await sessionRepo.create({
+            type: "session_created",
+            schemaVersion: 1,
+            sessionId,
+            ts,
+            title: "t",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        await sessionRepo.append(sessionId, [{
+            type: "turn_appended",
+            sessionId,
+            ts,
+            turnId,
+            sessionSeq: 1,
+            agentId: "copilot",
+            model: MODEL,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any]);
+    };
+
+    beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), "retention-test-"));
+        sessionRepo = new FSSessionRepo({ sessionsRootDir: path.join(root, "sessions") });
+        turnRepo = new FSTurnRepo({ turnsRootDir: path.join(root, "turns") });
+        sessions = new SessionsImpl({
+            sessionRepo,
+            // Deletion-path adapter: getTurn/deleteTurn over the FS repo, the
+            // same operations the real TurnRuntime delegates to it.
+            turnRuntime: {
+                getTurn: async (turnId: string) => ({ turnId, events: await turnRepo.read(turnId) }),
+                deleteTurn: (turnId: string) => turnRepo.withLock(turnId, () => turnRepo.delete(turnId)),
+                createTurn: async () => { throw new Error("unused"); },
+                advanceTurn: () => { throw new Error("unused"); },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            idGenerator: { next: async () => { throw new Error("unused"); } } as any,
+            clock: { now: () => new Date(NOW).toISOString() },
+            sessionBus: { publish: () => {} },
+        });
+    });
+
+    afterEach(async () => {
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    it("deletes stale chats and old unreferenced turns; keeps active chats and recent task turns", async () => {
+        // Chat inactive for ~60 days → deleted (session + turn file).
+        await seedSession(
+            "2026-06-08T10-00-00Z-0000001-000",
+            "2026-06-08T10-00-00Z-0000002-000",
+            "2026-06-08T10:00:00.000Z",
+        );
+        // Chat with an OLD turn but recent activity → kept entirely: the old
+        // turn is referenced, so the task-turn policy must not take it.
+        await seedSession(
+            "2026-06-08T10-00-00Z-0000003-000",
+            "2026-06-08T10-00-00Z-0000004-000",
+            "2026-06-08T10:00:00.000Z",
+        );
+        await sessionRepo.append("2026-06-08T10-00-00Z-0000003-000", [{
+            type: "title_changed",
+            sessionId: "2026-06-08T10-00-00Z-0000003-000",
+            ts: "2026-08-05T10:00:00.000Z",
+            title: "still in use",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any]);
+        // Headless task turn older than 14 days → deleted.
+        await turnRepo.create(turnCreated("2026-07-10T10-00-00Z-0000005-000", null, "2026-07-10T10:00:00.000Z"));
+        // Headless task turn 5 days old → kept.
+        await turnRepo.create(turnCreated("2026-08-02T10-00-00Z-0000006-000", null, "2026-08-02T10:00:00.000Z"));
+
+        await sessions.initialize();
+        const result = await runRetentionSweep({
+            sessions,
+            turnsRootDir: path.join(root, "turns"),
+            settings: { ...DEFAULT_RETENTION_SETTINGS, noticeShown: true },
+            now: NOW,
+        });
+
+        expect(result).toEqual({ deletedSessions: 1, deletedTurnFiles: 1 });
+        // Stale chat gone, session file and turn file both.
+        expect(await exists(turnFile("2026-06-08T10-00-00Z-0000002-000"))).toBe(false);
+        expect(sessions.listSessions().map((s) => s.sessionId)).toEqual([
+            "2026-06-08T10-00-00Z-0000003-000",
+        ]);
+        // Active chat's old turn survives; old headless turn gone; recent kept.
+        expect(await exists(turnFile("2026-06-08T10-00-00Z-0000004-000"))).toBe(true);
+        expect(await exists(turnFile("2026-07-10T10-00-00Z-0000005-000"))).toBe(false);
+        expect(await exists(turnFile("2026-08-02T10-00-00Z-0000006-000"))).toBe(true);
+    });
+
+    it("chatDays null keeps all chats but still cleans old task turns", async () => {
+        await seedSession(
+            "2026-06-08T10-00-00Z-0000001-000",
+            "2026-06-08T10-00-00Z-0000002-000",
+            "2026-06-08T10:00:00.000Z",
+        );
+        await turnRepo.create(turnCreated("2026-07-10T10-00-00Z-0000005-000", null, "2026-07-10T10:00:00.000Z"));
+
+        await sessions.initialize();
+        const result = await runRetentionSweep({
+            sessions,
+            turnsRootDir: path.join(root, "turns"),
+            settings: { ...DEFAULT_RETENTION_SETTINGS, chatDays: null, noticeShown: true },
+            now: NOW,
+        });
+
+        expect(result).toEqual({ deletedSessions: 0, deletedTurnFiles: 1 });
+        expect(sessions.listSessions()).toHaveLength(1);
+        expect(await exists(turnFile("2026-06-08T10-00-00Z-0000002-000"))).toBe(true);
+        expect(await exists(turnFile("2026-07-10T10-00-00Z-0000005-000"))).toBe(false);
+    });
+
+    it("does nothing when disabled", async () => {
+        await seedSession(
+            "2026-06-08T10-00-00Z-0000001-000",
+            "2026-06-08T10-00-00Z-0000002-000",
+            "2026-06-08T10:00:00.000Z",
+        );
+        await sessions.initialize();
+        const result = await runRetentionSweep({
+            sessions,
+            turnsRootDir: path.join(root, "turns"),
+            settings: { ...DEFAULT_RETENTION_SETTINGS, enabled: false, noticeShown: true },
+            now: NOW,
+        });
+        expect(result).toEqual({ deletedSessions: 0, deletedTurnFiles: 0 });
+        expect(sessions.listSessions()).toHaveLength(1);
+        expect(await exists(turnFile("2026-06-08T10-00-00Z-0000002-000"))).toBe(true);
+    });
+});

--- a/apps/x/packages/core/src/runtime/sessions/retention.ts
+++ b/apps/x/packages/core/src/runtime/sessions/retention.ts
@@ -71,8 +71,8 @@ export async function runRetentionSweep({
     }
 
     // ── 2. Old unreferenced turn files ────────────────────────────
-    const referenced = await collectReferencedTurnIds(sessions);
     const taskCutoff = now - settings.taskDays * DAY_MS;
+    const referenced = await collectReferencedTurnIds(sessions, taskCutoff);
     for (const { turnId, filePath } of await listTurnFiles(turnsRootDir)) {
         if (referenced.has(turnId)) continue;
         if (idDate(turnId) >= taskCutoff) continue;
@@ -89,7 +89,16 @@ export async function runRetentionSweep({
 
 // Every turn id reachable from a live session: the session's turn refs plus
 // the spawn-agent child chain of each (children can nest).
-async function collectReferencedTurnIds(sessions: ISessions): Promise<Set<string>> {
+//
+// Turns newer than `taskCutoff` are added to the set from their id alone —
+// their files are never read. A child turn is created during its parent's
+// run, so it is never older than the parent: a recent parent can only link
+// to recent children, none of which are deletion candidates. Only turns old
+// enough to be protecting other old files need their child links followed.
+async function collectReferencedTurnIds(
+    sessions: ISessions,
+    taskCutoff: number,
+): Promise<Set<string>> {
     const referenced = new Set<string>();
     const queue: string[] = [];
     for (const entry of sessions.listSessions()) {
@@ -104,6 +113,7 @@ async function collectReferencedTurnIds(sessions: ISessions): Promise<Set<string
         const turnId = queue.shift()!;
         if (referenced.has(turnId)) continue;
         referenced.add(turnId);
+        if (idDate(turnId) >= taskCutoff) continue;
         try {
             const turn = await sessions.getTurn(turnId);
             queue.push(...childTurnIdsOf(reduceTurn(turn.events)));

--- a/apps/x/packages/core/src/runtime/sessions/retention.ts
+++ b/apps/x/packages/core/src/runtime/sessions/retention.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { reduceTurn } from "@x/shared/dist/turns.js";
+import type { RetentionSettings } from "@x/shared/dist/retention.js";
+import type { ISessions } from "./api.js";
+import { childTurnIdsOf } from "./sessions.js";
+
+// ---------------------------------------------------------------------------
+// Storage retention sweep (session-design.md §9.4 covers deletion semantics).
+//
+// Two policies, run daily from the app layer:
+//
+// 1. Chats — sessions whose last activity (updatedAt) is older than
+//    `chatDays` are deleted through ISessions.deleteSession, which removes
+//    the session file and its whole turn chain (sub-agent children
+//    included) and aborts any live advance first — so no liveness guard is
+//    needed here (and a chat idle for 30+ days has none anyway).
+//
+// 2. Task transcripts — turn files under `turnsRootDir` older than
+//    `taskDays` that are NOT reachable from any live session (headless
+//    note-creation / background-task / knowledge-sync runs, plus orphans
+//    from pre-cleanup deletes). Reachability is computed after step 1 so a
+//    just-deleted chat's files don't linger another cycle. The outputs
+//    those runs produced (notes, knowledge files, bg-task artifacts) live
+//    outside storage/ and are never touched. UIs that reference old runs
+//    (bg-task runs history) already tolerate missing transcript files.
+//
+// Everything is best-effort: one bad file never aborts the sweep.
+// ---------------------------------------------------------------------------
+
+export interface RetentionSweepResult {
+    deletedSessions: number;
+    deletedTurnFiles: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Turn/session ids start with their creation date: 2026-08-06T09-43-36Z-….
+const idDate = (id: string): number => {
+    const ts = Date.parse(id.slice(0, 10));
+    return Number.isNaN(ts) ? Number.POSITIVE_INFINITY : ts;
+};
+
+export async function runRetentionSweep({
+    sessions,
+    turnsRootDir,
+    settings,
+    now = Date.now(),
+}: {
+    sessions: ISessions;
+    turnsRootDir: string;
+    settings: RetentionSettings;
+    now?: number;
+}): Promise<RetentionSweepResult> {
+    const result: RetentionSweepResult = { deletedSessions: 0, deletedTurnFiles: 0 };
+    if (!settings.enabled) return result;
+
+    // ── 1. Old chats (chatDays null = never delete chats) ─────────
+    if (settings.chatDays !== null) {
+        const chatCutoff = now - settings.chatDays * DAY_MS;
+        for (const entry of sessions.listSessions()) {
+            const lastActivity = Date.parse(entry.updatedAt || entry.createdAt);
+            if (Number.isNaN(lastActivity) || lastActivity >= chatCutoff) continue;
+            try {
+                await sessions.deleteSession(entry.sessionId);
+                result.deletedSessions += 1;
+            } catch (error) {
+                console.error(`[Retention] failed to delete session ${entry.sessionId}:`, error);
+            }
+        }
+    }
+
+    // ── 2. Old unreferenced turn files ────────────────────────────
+    const referenced = await collectReferencedTurnIds(sessions);
+    const taskCutoff = now - settings.taskDays * DAY_MS;
+    for (const { turnId, filePath } of await listTurnFiles(turnsRootDir)) {
+        if (referenced.has(turnId)) continue;
+        if (idDate(turnId) >= taskCutoff) continue;
+        try {
+            await fs.unlink(filePath);
+            result.deletedTurnFiles += 1;
+        } catch {
+            // Already gone or unreadable — leftovers are inert.
+        }
+    }
+
+    return result;
+}
+
+// Every turn id reachable from a live session: the session's turn refs plus
+// the spawn-agent child chain of each (children can nest).
+async function collectReferencedTurnIds(sessions: ISessions): Promise<Set<string>> {
+    const referenced = new Set<string>();
+    const queue: string[] = [];
+    for (const entry of sessions.listSessions()) {
+        try {
+            const state = await sessions.getSession(entry.sessionId);
+            queue.push(...state.turns.map((ref) => ref.turnId));
+        } catch {
+            // Corrupt session — its turns stay untouched (conservative).
+        }
+    }
+    while (queue.length > 0) {
+        const turnId = queue.shift()!;
+        if (referenced.has(turnId)) continue;
+        referenced.add(turnId);
+        try {
+            const turn = await sessions.getTurn(turnId);
+            queue.push(...childTurnIdsOf(reduceTurn(turn.events)));
+        } catch {
+            // Missing or corrupt turn — nothing further to follow.
+        }
+    }
+    return referenced;
+}
+
+// Walk the yyyy/mm/dd partition tree; anything else in there is ignored.
+async function listTurnFiles(
+    rootDir: string,
+): Promise<Array<{ turnId: string; filePath: string }>> {
+    const out: Array<{ turnId: string; filePath: string }> = [];
+    const days = async (dir: string, depth: number): Promise<string[]> => {
+        if (depth === 0) return [dir];
+        const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+        const nested = await Promise.all(
+            entries
+                .filter((e) => e.isDirectory())
+                .map((e) => days(path.join(dir, e.name), depth - 1)),
+        );
+        return nested.flat();
+    };
+    for (const dayDir of await days(rootDir, 3)) {
+        const entries = await fs.readdir(dayDir, { withFileTypes: true }).catch(() => []);
+        for (const entry of entries) {
+            if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+            out.push({
+                turnId: entry.name.slice(0, -".jsonl".length),
+                filePath: path.join(dayDir, entry.name),
+            });
+        }
+    }
+    return out;
+}

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -667,9 +667,9 @@ function defaultTitle(input: z.infer<typeof UserMessage>): string {
 
 // spawn-agent records one durable 'subagent' tool_progress entry per child
 // turn (see spawn-agent.ts) — the same parent→child link the UI uses to
-// fetch child transcripts. Extracting it here lets session deletion follow
-// the chain and remove sub-agent turn files too.
-function childTurnIdsOf(state: TurnState): string[] {
+// fetch child transcripts. Extracting it here lets session deletion (and the
+// retention sweep) follow the chain and treat sub-agent turn files correctly.
+export function childTurnIdsOf(state: TurnState): string[] {
     const ids: string[] = [];
     for (const toolCall of state.toolCalls) {
         for (const progress of toolCall.progress) {

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -28,6 +28,7 @@ import { GmailThreadSchema } from './blocks.js';
 import { PermissionDecision, ApprovalPolicy, CodingAgent, type CodeRunFeedEvent } from './code-mode.js';
 import { NotificationSettingsSchema } from './notification-settings.js';
 import { TurnLimitsSettingsSchema } from './turn-limits.js';
+import { RetentionSettingsSchema, RetentionSettingsUpdateSchema } from './retention.js';
 import { CodeProject, CodeSession, CodeSessionMode, CodeSessionStatus, GitRepoInfo, GitStatusFile, CodeAgentModelOptions } from './code-sessions.js';
 import { ChannelsConfig, ChannelsStatus } from './channels.js';
 
@@ -3153,6 +3154,27 @@ const ipcSchemas = {
     req: TurnLimitsSettingsSchema,
     res: z.object({
       success: z.literal(true),
+    }),
+  },
+  // Storage retention (auto-delete old chats & task transcripts)
+  'retention:getSettings': {
+    req: z.null(),
+    res: RetentionSettingsSchema,
+  },
+  'retention:setSettings': {
+    req: RetentionSettingsUpdateSchema,
+    res: z.object({
+      success: z.literal(true),
+    }),
+  },
+  // One-time first-run notice: returns { show: true } exactly once (when
+  // retention is enabled and the notice hasn't been shown), marking it shown.
+  // Same pull-on-boot pattern as app:consumeUpdateInfo.
+  'retention:consumeFirstRunNotice': {
+    req: z.null(),
+    res: z.object({
+      show: z.boolean(),
+      chatDays: z.number().nullable(),
     }),
   },
 } as const;

--- a/apps/x/packages/shared/src/retention.ts
+++ b/apps/x/packages/shared/src/retention.ts
@@ -43,7 +43,7 @@ export type RetentionSettingsUpdate = z.infer<typeof RetentionSettingsUpdateSche
 
 export const DEFAULT_RETENTION_SETTINGS: RetentionSettings = {
   enabled: true,
-  chatDays: 30,
+  chatDays: 60,
   taskDays: 14,
   noticeShown: false,
 };

--- a/apps/x/packages/shared/src/retention.ts
+++ b/apps/x/packages/shared/src/retention.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+/**
+ * Storage retention settings — the daily sweep that keeps
+ * `$WorkDir/storage/` from growing forever.
+ *
+ * Two policies, one switch:
+ * - Chats: sessions whose last activity is older than `chatDays` are
+ *   deleted via the session layer (session file + the full turn chain,
+ *   including sub-agent child turns).
+ * - Task transcripts: sessionless turn files (note creation, background
+ *   tasks, knowledge sync, …) older than `taskDays` are deleted unless
+ *   they are still reachable from a live session. Only the run transcripts
+ *   go — the notes/files those runs produced are never touched.
+ *
+ * `noticeShown` gates the first sweep: the first launch with retention
+ * enabled surfaces a one-time notice instead of silently deleting months
+ * of history; sweeping starts on the next launch.
+ */
+
+export const MIN_RETENTION_DAYS = 7;
+export const MAX_RETENTION_DAYS = 365;
+
+const days = z.number().int().min(MIN_RETENTION_DAYS).max(MAX_RETENTION_DAYS);
+
+export const RetentionSettingsSchema = z.object({
+  enabled: z.boolean(),
+  // null = never auto-delete chats (task-transcript cleanup still runs).
+  chatDays: days.nullable(),
+  taskDays: days,
+  noticeShown: z.boolean(),
+});
+
+export type RetentionSettings = z.infer<typeof RetentionSettingsSchema>;
+
+/** Renderer-updatable subset; `taskDays`/`noticeShown` stay runtime-managed. */
+export const RetentionSettingsUpdateSchema = z.object({
+  enabled: z.boolean().optional(),
+  chatDays: days.nullable().optional(),
+});
+
+export type RetentionSettingsUpdate = z.infer<typeof RetentionSettingsUpdateSchema>;
+
+export const DEFAULT_RETENTION_SETTINGS: RetentionSettings = {
+  enabled: true,
+  chatDays: 30,
+  taskDays: 14,
+  noticeShown: false,
+};


### PR DESCRIPTION
## Problem

`~/.rowboat/storage/` grows forever — 1.0 GB on a ~2-month install. Measured breakdown: ~90% is headless task-turn transcripts (note-creation 485 MB, background tasks 311 MB, knowledge sync 117 MB) that nothing ever deletes; chat turns older than 30 days were only 2.3 MB.

## What

A daily storage-retention sweep (default **on**) with two policies:

1. **Chats** — sessions whose *last activity* is older than `chatDays` (default 30) are deleted via `deleteSession` (session file + full turn chain incl. sub-agent children; live advances aborted first).
2. **Task transcripts** — turn files older than `taskDays` (14, internal) that are **not reachable from any live session**. Reachability follows the spawn-agent child links, so an active chat's old turns and its sub-agent transcripts are protected. This also cleans up orphans left by pre-#836 deletions. Only run transcripts go — the notes/files/outputs those runs produced live outside `storage/` and are untouched. The bg-task Runs-history UI already tolerates missing transcript files.

### Setting (Settings → Advanced)
- "Auto-delete old chats & task history" toggle (default on).
- "Delete chats after" dropdown: 30 / 60 / 90 days / **Never** (`chatDays: null` — chats kept forever, transcript cleanup still runs).
- Persisted in `config/retention.json` (same pattern as `turn_limits.json`).

### First-run safety
The first launch with retention enabled shows a one-time toast (via a pull-style `retention:consumeFirstRunNotice`, like `app:consumeUpdateInfo`) and arms the flag; **sweeping starts on the next launch**, so months of history are never deleted before the user has been told. Sweep runs 90s after the session index is ready, then every 24h.

## Tests
- `retention.test.ts` runs the sweep against real FS repos in a temp dir: stale chat deleted (session + turn files), active chat with old turns fully protected, old headless turn deleted, recent one kept; `chatDays: null` keeps chats but cleans transcripts; disabled = no-op.
- Full core suite passes (590 tests); `npm run deps && npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)