### PR TITLE
fix: bump Dockerfile base images to node:22-alpine (#811)

### DIFF
--- a/apps/experimental/chat_widget/Dockerfile
+++ b/apps/experimental/chat_widget/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/apps/rowboat/scripts.Dockerfile
+++ b/apps/rowboat/scripts.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
Fixes #811. Updated Node base image from node:18-alpine to node:22-alpine in both Dockerfiles as requested.