### PR TITLE
fix(x): product tour stuck on first step in dev (StrictMode double-mount)

### DIFF
--- a/apps/x/apps/renderer/src/components/product-tour.tsx
+++ b/apps/x/apps/renderer/src/components/product-tour.tsx
@@ -506,6 +506,15 @@ export function ProductTour({
     const entering = enteredStepRef.current !== stepIndex
     let cancelled = false
 
+    // settle() marks the step entered *before* the boat starts rowing, so a
+    // teardown mid-travel would leave the step flagged as already-entered.
+    // The next run then takes the "resize" branch, skips startTravel, and
+    // `arrived` never flips — no bubble, tour stuck. React StrictMode does
+    // exactly this in dev (mount → cleanup → mount), so roll the flag back.
+    const unmarkEntered = () => {
+      if (entering && enteredStepRef.current === stepIndex) enteredStepRef.current = -1
+    }
+
     if (entering && step.navigate) {
       onNavigateRef.current(step.navigate)
     }
@@ -547,6 +556,7 @@ export function ProductTour({
       return () => {
         cancelled = true
         cancelTravel()
+        unmarkEntered()
       }
     }
 
@@ -574,6 +584,7 @@ export function ProductTour({
       cancelled = true
       cancelAnimationFrame(pollRaf)
       cancelTravel()
+      unmarkEntered()
     }
   }, [stepIndex, resizeNonce, goTo, applyZoom, displayedRect, startTravel, cancelTravel, moveMascot])
 


### PR DESCRIPTION
## Problem

Running `npm run dev` and clicking **Take a tour** dims the screen and shows the water/spotlight, but the boat never rows anywhere and the speech bubble (with the Next button) never appears — the tour dead-ends on step 1 of 12. Packaged builds are unaffected.

## Root cause

The renderer mounts the app in `<StrictMode>` (`main.tsx`), and React 19 double-invokes effects in dev (mount → cleanup → mount). The tour's step effect doesn't survive that round trip:

1. **First run:** `entering = true` → `settle()` sets `enteredStepRef.current = stepIndex` *before* `startTravel()` begins the rAF travel loop.
2. **StrictMode cleanup:** `cancelled = true; cancelTravel()` kills the loop.
3. **Second run:** `enteredStepRef.current` already matches, so `entering = false` → the effect takes the resize branch ("jump, keep the bubble up"), which moves the mascot to its destination and returns — **`setArrived(true)` never fires.**

Since the bubble only renders when `arrived` is true, the tour is permanently stuck. Traced via CDP: mascot frozen at its computed destination transform, wake `strokeDashoffset` never written, zero exceptions.

## Fix

Roll the entered marker back in the effect cleanups when the run that set it was torn down before arrival:

```ts
const unmarkEntered = () => {
  if (entering && enteredStepRef.current === stepIndex) enteredStepRef.current = -1
}
```

Resize-triggered re-runs execute with `entering === false`, so the existing jump-without-re-rowing behavior is preserved.

## Verification

- Before: reproduced 100% in dev — tour mounts, no bubble, stuck on step 1 indefinitely.
- After (hard reload, dev): boat rows in from off-screen drawing its wake, bubble appears, and all 12 stops advance cleanly through **Done**, which tears the tour down fully.
- `npm run typecheck:renderer` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)