### PR TITLE
fix(x): treat owner identity as an email set

### DIFF
--- a/apps/x/packages/core/src/config/user_config.test.ts
+++ b/apps/x/packages/core/src/config/user_config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// WorkDir is resolved at config module load — set env before any import.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rowboat-user-config-test-'));
+process.env.ROWBOAT_WORKDIR = tmpDir;
+
+const {
+    normalizeUserConfig,
+    unionEmails,
+    loadUserConfig,
+    saveUserConfig,
+    updateUserEmail,
+    getOwnerEmails,
+    isOwnerEmail,
+} = await import('./user_config.js');
+
+const configPath = path.join(tmpDir, 'config', 'user.json');
+
+function writeRaw(obj: unknown) {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(obj, null, 2));
+}
+
+describe('unionEmails / normalizeUserConfig', () => {
+    it('dedupes and lowercases', () => {
+        expect(unionEmails(['A@X.com', 'a@x.com'], 'b@y.com')).toEqual(['a@x.com', 'b@y.com']);
+    });
+
+    it('migrates legacy { email } only into emails set', () => {
+        const n = normalizeUserConfig({ email: 'A@X.com' });
+        expect(n).toEqual({
+            email: 'a@x.com',
+            emails: ['a@x.com'],
+            domain: 'x.com',
+        });
+    });
+
+    it('unions emails + email fields', () => {
+        const n = normalizeUserConfig({
+            email: 'primary@acme.com',
+            emails: ['alias@acme.com', 'PRIMARY@acme.com'],
+            name: 'Alex',
+        });
+        expect(n?.email).toBe('primary@acme.com');
+        expect(n?.emails).toEqual(['alias@acme.com', 'primary@acme.com']);
+        expect(n?.name).toBe('Alex');
+    });
+
+    it('accepts emails-only config', () => {
+        const n = normalizeUserConfig({ emails: ['one@x.com', 'two@y.com'] });
+        expect(n?.email).toBe('one@x.com');
+        expect(n?.emails).toEqual(['one@x.com', 'two@y.com']);
+    });
+
+    it('returns null when no identity present', () => {
+        expect(normalizeUserConfig({})).toBeNull();
+        expect(normalizeUserConfig({ name: 'No Email' })).toBeNull();
+    });
+});
+
+describe('load / save / updateUserEmail', () => {
+    beforeEach(() => {
+        if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+    });
+
+    afterEach(() => {
+        if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+    });
+
+    it('loads legacy single-email file', () => {
+        writeRaw({ email: 'legacy@acme.com' });
+        const u = loadUserConfig();
+        expect(u?.email).toBe('legacy@acme.com');
+        expect(u?.emails).toEqual(['legacy@acme.com']);
+    });
+
+    it('updateUserEmail creates config when missing', () => {
+        updateUserEmail('new@acme.com');
+        const u = loadUserConfig();
+        expect(u?.email).toBe('new@acme.com');
+        expect(u?.emails).toEqual(['new@acme.com']);
+        const disk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        expect(disk.emails).toEqual(['new@acme.com']);
+        expect(disk.email).toBe('new@acme.com');
+    });
+
+    it('updateUserEmail adds second address without dropping primary', () => {
+        writeRaw({ email: 'a@acme.com', emails: ['a@acme.com'] });
+        updateUserEmail('b@acme.com');
+        const u = loadUserConfig();
+        expect(u?.email).toBe('a@acme.com');
+        expect(u?.emails).toEqual(['a@acme.com', 'b@acme.com']);
+    });
+
+    it('saveUserConfig always writes both email and emails', () => {
+        saveUserConfig({ email: 'solo@x.com', emails: ['solo@x.com'] });
+        const disk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        expect(disk.email).toBe('solo@x.com');
+        expect(disk.emails).toEqual(['solo@x.com']);
+    });
+
+    it('getOwnerEmails / isOwnerEmail match the set', () => {
+        writeRaw({
+            email: 'a@acme.com',
+            emails: ['a@acme.com', 'b@custom.com'],
+        });
+        expect(getOwnerEmails()).toEqual(['a@acme.com', 'b@custom.com']);
+        expect(isOwnerEmail('Alice <a@acme.com>')).toBe(true);
+        expect(isOwnerEmail('Bob <b@custom.com>')).toBe(true);
+        expect(isOwnerEmail('Eve <eve@other.com>')).toBe(false);
+    });
+});

--- a/apps/x/packages/core/src/config/user_config.ts
+++ b/apps/x/packages/core/src/config/user_config.ts
@@ -5,20 +5,85 @@ import { WorkDir } from './config.js';
 
 const USER_CONFIG_PATH = path.join(WorkDir, 'config', 'user.json');
 
-export const UserConfig = z.object({
+/**
+ * On-disk shape. `email` remains the primary/display address for back-compat.
+ * `emails` is the full owner identity set (self-exclusion, reply gate, classify).
+ * After load, both are always populated when a config exists.
+ */
+const RawUserConfig = z.object({
     name: z.string().optional(),
-    email: z.string().email(),
+    email: z.string().email().optional(),
+    emails: z.array(z.string().email()).optional(),
     domain: z.string().optional(),
 });
 
-export type UserConfig = z.infer<typeof UserConfig>;
+export type UserConfig = {
+    name?: string;
+    /** Primary / display address (legacy singular field; always set when config exists). */
+    email: string;
+    /** Full owner identity set (lowercased, unique). Includes `email`. */
+    emails: string[];
+    domain?: string;
+};
+
+export function normalizeEmail(addr: string): string {
+    return addr.trim().toLowerCase();
+}
+
+/** Union and dedupe email addresses (lowercased). Order: first-seen wins. */
+export function unionEmails(...groups: Array<string | null | undefined | readonly string[]>): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const g of groups) {
+        if (g == null) continue;
+        const list = typeof g === 'string' ? [g] : g;
+        for (const raw of list) {
+            if (!raw || typeof raw !== 'string') continue;
+            const e = normalizeEmail(raw);
+            if (!e || seen.has(e)) continue;
+            // Basic shape check — skip garbage without throwing mid-union
+            if (!e.includes('@')) continue;
+            seen.add(e);
+            out.push(e);
+        }
+    }
+    return out;
+}
+
+/**
+ * Normalize a raw on-disk object into UserConfig.
+ * Returns null if no usable email identity is present.
+ */
+export function normalizeUserConfig(raw: unknown): UserConfig | null {
+    const parsed = RawUserConfig.safeParse(raw);
+    if (!parsed.success) return null;
+    const data = parsed.data;
+    const emails = unionEmails(data.emails, data.email);
+    if (emails.length === 0) return null;
+
+    // Primary: legacy `email` if present and in set, else first of set
+    const primaryCandidate = data.email ? normalizeEmail(data.email) : emails[0];
+    const primary = emails.includes(primaryCandidate) ? primaryCandidate : emails[0];
+
+    const domain =
+        data.domain?.toLowerCase()
+        ?? (primary.includes('@') ? primary.split('@')[1] : undefined);
+
+    const result: UserConfig = {
+        email: primary,
+        emails,
+    };
+    if (data.name !== undefined) result.name = data.name;
+    if (domain) result.domain = domain;
+    return result;
+}
 
 export function loadUserConfig(): UserConfig | null {
     try {
         if (fs.existsSync(USER_CONFIG_PATH)) {
             const content = fs.readFileSync(USER_CONFIG_PATH, 'utf-8');
             const parsed = JSON.parse(content);
-            return UserConfig.parse(parsed);
+            return normalizeUserConfig(parsed);
         }
     } catch (error) {
         console.error('[UserConfig] Error loading user config:', error);
@@ -26,19 +91,59 @@ export function loadUserConfig(): UserConfig | null {
     return null;
 }
 
+/** Owner email set for self-exclusion / reply gate / classify matching. */
+export function getOwnerEmails(): string[] {
+    return loadUserConfig()?.emails ?? [];
+}
+
+/**
+ * True if `headerOrAddr` (e.g. a From: header) contains any owner email.
+ * Optional `emails` override for tests / call-site identity sets.
+ */
+export function isOwnerEmail(headerOrAddr: string, emails?: readonly string[]): boolean {
+    const set = emails ?? getOwnerEmails();
+    if (set.length === 0 || !headerOrAddr) return false;
+    const hay = headerOrAddr.toLowerCase();
+    return set.some((e) => hay.includes(e));
+}
+
 export function saveUserConfig(config: UserConfig): void {
     const dir = path.dirname(USER_CONFIG_PATH);
     if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
     }
-    const validated = UserConfig.parse(config);
-    fs.writeFileSync(USER_CONFIG_PATH, JSON.stringify(validated, null, 2));
+    const normalized = normalizeUserConfig(config);
+    if (!normalized) {
+        throw new Error('[UserConfig] Cannot save: no valid email identity');
+    }
+    // Persist both singular + set for back-compat readers
+    const disk = {
+        ...(normalized.name !== undefined ? { name: normalized.name } : {}),
+        email: normalized.email,
+        emails: normalized.emails,
+        ...(normalized.domain !== undefined ? { domain: normalized.domain } : {}),
+    };
+    fs.writeFileSync(USER_CONFIG_PATH, JSON.stringify(disk, null, 2));
 }
 
+/**
+ * Add `email` to the owner set. If no primary yet, it becomes primary.
+ * Existing primary is preserved when already set (unless it was empty).
+ */
 export function updateUserEmail(email: string): void {
     const existing = loadUserConfig();
-    const config = existing
-        ? { ...existing, email }
-        : { email };
-    saveUserConfig(config);
+    const next = normalizeEmail(email);
+    if (!next.includes('@')) {
+        throw new Error(`[UserConfig] Invalid email: ${email}`);
+    }
+    if (!existing) {
+        saveUserConfig({ email: next, emails: [next] });
+        return;
+    }
+    const emails = unionEmails(existing.emails, next);
+    saveUserConfig({
+        ...existing,
+        email: existing.email || next,
+        emails,
+    });
 }

--- a/apps/x/packages/core/src/knowledge/build_graph.test.ts
+++ b/apps/x/packages/core/src/knowledge/build_graph.test.ts
@@ -1,8 +1,34 @@
-import { describe, expect, it } from "vitest";
-import { emailAdmission } from "./build_graph.js";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// WorkDir is read at module load — must set before importing build_graph / user_config.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rowboat-build-graph-test-"));
+process.env.ROWBOAT_WORKDIR = tmpDir;
+
+const {
+    emailAdmission,
+    emailReplyGateBanner,
+    buildOwnerBlock,
+    ownerCompanyDomains,
+} = await import("./build_graph.js");
+const { saveUserConfig } = await import("../config/user_config.js");
 
 const email = (frontmatter: string | null, body = "# Subject\n\n**Thread ID:** t1\n") =>
     frontmatter === null ? body : `---\n${frontmatter}\n---\n\n${body}`;
+
+const gmailPath = path.join(tmpDir, "gmail_sync", "thread.md");
+
+function threadBody(...fromLines: string[]) {
+    return [
+        "# Subject",
+        "",
+        "**Thread ID:** t1",
+        "",
+        ...fromLines.flatMap((f) => [`### From: ${f}`, "**Date:** Mon, 1 Jan 2026", "", "Body", "", "---", ""]),
+    ].join("\n");
+}
 
 describe("emailAdmission", () => {
     it("holds files with no frontmatter until the classifier stamps a verdict", () => {
@@ -48,5 +74,101 @@ describe("emailAdmission", () => {
 
     it("does not mistake a message-body '---' separator for frontmatter", () => {
         expect(emailAdmission("# Subject\n\n---\n\nknowledge: skip\n")).toBe("wait");
+    });
+});
+
+describe("ownerCompanyDomains", () => {
+    it("excludes free-mail domains", () => {
+        expect(ownerCompanyDomains(["a@gmail.com", "b@acme.com"])).toEqual(["acme.com"]);
+    });
+
+    it("includes explicit domain when not free-mail", () => {
+        expect(ownerCompanyDomains(["a@gmail.com"], "acme.com")).toEqual(["acme.com"]);
+    });
+});
+
+describe("emailReplyGateBanner + buildOwnerBlock (identity set)", () => {
+    const configPath = path.join(tmpDir, "config", "user.json");
+
+    beforeEach(() => {
+        fs.mkdirSync(path.dirname(gmailPath), { recursive: true });
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+    });
+
+    afterEach(() => {
+        if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+    });
+
+    it("returns null when no user identity is configured", () => {
+        expect(emailReplyGateBanner(gmailPath, threadBody("Other <o@x.com>"))).toBeNull();
+    });
+
+    it("marks purely inbound as NOT replied (single email)", () => {
+        saveUserConfig({ email: "me@acme.com", emails: ["me@acme.com"], domain: "acme.com" });
+        const banner = emailReplyGateBanner(gmailPath, threadBody("Other <o@x.com>"));
+        expect(banner).toContain("has NOT sent");
+    });
+
+    it("marks replied when From matches primary owner email", () => {
+        saveUserConfig({ email: "me@acme.com", emails: ["me@acme.com"], domain: "acme.com" });
+        const banner = emailReplyGateBanner(gmailPath, threadBody("Other <o@x.com>", "Me <me@acme.com>"));
+        expect(banner).toContain("HAS sent");
+    });
+
+    it("marks replied when From matches secondary owner email only", () => {
+        saveUserConfig({
+            email: "me@acme.com",
+            emails: ["me@acme.com", "alias@custom.com"],
+            domain: "acme.com",
+        });
+        const banner = emailReplyGateBanner(
+            gmailPath,
+            threadBody("Other <o@x.com>", "Me <alias@custom.com>"),
+        );
+        expect(banner).toContain("HAS sent");
+    });
+
+    it("does not treat free-mail same-domain as teammate reply", () => {
+        saveUserConfig({ email: "me@gmail.com", emails: ["me@gmail.com"] });
+        const banner = emailReplyGateBanner(gmailPath, threadBody("Stranger <stranger@gmail.com>"));
+        expect(banner).toContain("has NOT sent");
+    });
+
+    it("treats company-domain teammate From as replied", () => {
+        saveUserConfig({ email: "me@acme.com", emails: ["me@acme.com"], domain: "acme.com" });
+        const banner = emailReplyGateBanner(gmailPath, threadBody("Teammate <peer@acme.com>"));
+        expect(banner).toContain("HAS sent");
+    });
+
+    it("ignores Google Groups rewrite From lines", () => {
+        saveUserConfig({ email: "me@acme.com", emails: ["me@acme.com"], domain: "acme.com" });
+        const banner = emailReplyGateBanner(
+            gmailPath,
+            threadBody("'Jane Doe' via Founders <founders@acme.com>"),
+        );
+        expect(banner).toContain("has NOT sent");
+    });
+
+    it("buildOwnerBlock lists multiple emails", () => {
+        saveUserConfig({
+            name: "Alex",
+            email: "a@acme.com",
+            emails: ["a@acme.com", "b@custom.com"],
+            domain: "acme.com",
+        });
+        const block = buildOwnerBlock();
+        expect(block).toContain("a@acme.com");
+        expect(block).toContain("b@custom.com");
+        expect(block).toContain("Alex");
+        expect(block).toContain("company domain");
+    });
+
+    it("buildOwnerBlock single email keeps singular shape", () => {
+        saveUserConfig({ email: "solo@acme.com", emails: ["solo@acme.com"], domain: "acme.com" });
+        const block = buildOwnerBlock();
+        expect(block).toMatch(/\*\*Email:\*\* solo@acme\.com\n/);
+        // Multi-email form joins with ", " — single address must not use that join.
+        expect(block).not.toMatch(/\*\*Email:\*\* .+, .+/);
     });
 });

--- a/apps/x/packages/core/src/knowledge/build_graph.ts
+++ b/apps/x/packages/core/src/knowledge/build_graph.ts
@@ -20,7 +20,7 @@ import { getTagDefinitions } from './tag_system.js';
 import { knowledgeSourcesRepo } from './sources/repo.js';
 import { syncSlackKnowledgeSources } from './sources/sync_slack.js';
 import type { KnowledgeSourceConfig } from './sources/types.js';
-import { loadUserConfig } from '../config/user_config.js';
+import { getOwnerEmails, loadUserConfig } from '../config/user_config.js';
 
 /**
  * Build obsidian-style knowledge graph by running topic extraction
@@ -268,12 +268,30 @@ const FREE_MAIL_DOMAINS = new Set([
  * gate, first-person perspective, outbound-email handling) depends on the
  * agent knowing exactly who the user is — never make it guess from headers.
  */
+/** Company domains from owner emails (excludes free-mail). Used by reply gate + owner block. */
+export function ownerCompanyDomains(emails: readonly string[], explicitDomain?: string): string[] {
+    const domains = new Set<string>();
+    if (explicitDomain) {
+        const d = explicitDomain.toLowerCase();
+        if (d && !FREE_MAIL_DOMAINS.has(d)) domains.add(d);
+    }
+    for (const e of emails) {
+        const at = e.lastIndexOf('@');
+        if (at < 0) continue;
+        const d = e.slice(at + 1).toLowerCase();
+        if (d && !FREE_MAIL_DOMAINS.has(d)) domains.add(d);
+    }
+    return [...domains];
+}
+
 export function buildOwnerBlock(): string {
     const user = loadUserConfig();
-    const email = user?.email ?? '';
-    const domainFromEmail = email.includes('@') ? email.split('@')[1].toLowerCase() : '';
-    const domain = (user?.domain ?? domainFromEmail).toLowerCase();
-    const isFreeMail = FREE_MAIL_DOMAINS.has(domain);
+    const emails = user?.emails ?? (user?.email ? [user.email.toLowerCase()] : []);
+    const primary = user?.email ?? emails[0] ?? '';
+    const companyDomains = ownerCompanyDomains(emails, user?.domain);
+    // Display domain: explicit config domain, else primary's domain (may be free-mail).
+    const domainFromEmail = primary.includes('@') ? primary.split('@')[1].toLowerCase() : '';
+    const displayDomain = (user?.domain ?? domainFromEmail).toLowerCase();
 
     // Optional profile lines from Agent Notes/user.md (e.g. role, company) —
     // gives the agent context like "the owner runs Rowboat" so it correctly
@@ -295,10 +313,23 @@ export function buildOwnerBlock(): string {
         // profile lines are best-effort
     }
 
+    const emailLine = emails.length <= 1
+        ? (primary || '(not set)')
+        : emails.join(', ');
+
+    let domainNote: string;
+    if (!displayDomain && companyDomains.length === 0) {
+        domainNote = '(not set)';
+    } else if (companyDomains.length > 0) {
+        domainNote = `${companyDomains.join(', ')} (company domain${companyDomains.length > 1 ? 's' : ''} — same-domain senders are the owner's teammates)`;
+    } else {
+        domainNote = `${displayDomain} (personal free-mail domain — do NOT treat same-domain senders as the owner's colleagues)`;
+    }
+
     let block = `# Owner Of This Memory (authoritative — do not infer identity from email headers)\n\n`;
     block += `- **Name:** ${user?.name || '(not set — resolve from the email address below when needed)'}\n`;
-    block += `- **Email:** ${email || '(not set)'}\n`;
-    block += `- **Email domain:** ${domain || '(not set)'}${isFreeMail ? ' (personal free-mail domain — do NOT treat same-domain senders as the owner\'s colleagues)' : ' (company domain — same-domain senders are the owner\'s teammates)'}\n`;
+    block += `- **Email:** ${emailLine}\n`;
+    block += `- **Email domain:** ${domainNote}\n`;
     if (profileLines) {
         block += `- **Profile:**\n${profileLines.split('\n').map(l => `  ${l}`).join('\n')}\n`;
     }
@@ -320,11 +351,10 @@ export function emailReplyGateBanner(filePath: string, content: string): string 
     // Only email sources have the ### From: thread structure.
     if (!filePath.split(path.sep).includes('gmail_sync')) return null;
     const user = loadUserConfig();
-    if (!user?.email) return null;
-    const email = user.email.toLowerCase();
-    const domainRaw = (user.domain ?? email.split('@')[1] ?? '').toLowerCase();
-    // On a free-mail domain, same-domain senders are strangers, not teammates.
-    const teamDomain = domainRaw && !FREE_MAIL_DOMAINS.has(domainRaw) ? '@' + domainRaw : null;
+    const emails = user?.emails ?? getOwnerEmails();
+    if (emails.length === 0) return null;
+    // Company domains only — free-mail same-domain senders are strangers, not teammates.
+    const teamDomains = ownerCompanyDomains(emails, user?.domain).map((d) => '@' + d);
     const froms = [...content.matchAll(/^### From: (.+)$/gm)].map(m => m[1].toLowerCase());
     if (froms.length === 0) return null;
     // Google Groups rewrites external senders to look like the list address:
@@ -334,7 +364,10 @@ export function emailReplyGateBanner(filePath: string, content: string): string 
     // are also disqualified by the rewrite marker (the group addr differs).
     const isGroupRewrite = (f: string) => /\bvia\b[^<]*</.test(f);
     const replied = froms.some(f =>
-        !isGroupRewrite(f) && (f.includes(email) || (teamDomain !== null && f.includes(teamDomain)))
+        !isGroupRewrite(f) && (
+            emails.some((e) => f.includes(e))
+            || teamDomains.some((td) => f.includes(td))
+        )
     );
     return replied
         ? `> **REPLY-GATE (computed by the system, authoritative): the user HAS sent a message in this thread.** New People/Organization notes are allowed IF the user's reply shows real engagement AND the other gates pass. A decline, brush-off, or unsubscribe-style reply ("not interested", "please remove me", a bare "no thanks") is NOT engagement — treat those threads like purely inbound ones.`
@@ -398,11 +431,18 @@ async function createNotesFromBatch(
     // heavily, and the identity rules are the ones that corrupt the graph
     // when missed. Repeat the critical three right before generation.
     const user = loadUserConfig();
-    if (user?.email) {
-        const ownerLabel = user.name ? `${user.name} <${user.email}>` : user.email;
+    const ownerEmails = user?.emails ?? (user?.email ? [user.email] : []);
+    if (ownerEmails.length > 0) {
+        const primary = user?.email ?? ownerEmails[0];
+        const ownerLabel = user?.name
+            ? `${user.name} <${primary}>`
+            : primary;
+        const fromList = ownerEmails.length === 1
+            ? ownerEmails[0]
+            : `any of ${ownerEmails.join(', ')}`;
         message += `**FINAL REMINDER — the owner of this memory is ${ownerLabel}.** `;
         message += `(1) Never create or update a People note for them; in prose they are "I", never their name. `;
-        message += `(2) Emails FROM ${user.email} are the owner's own actions ("I emailed…"), not an external contact. `;
+        message += `(2) Emails FROM ${fromList} are the owner's own actions ("I emailed…"), not an external contact. `;
         message += `(3) No placeholder text ("Unknown"/"-") and no links between entities that didn't co-occur in one source file.\n`;
     }
 

--- a/apps/x/packages/core/src/knowledge/classify_thread.test.ts
+++ b/apps/x/packages/core/src/knowledge/classify_thread.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { GmailThreadSnapshot } from './sync_gmail.js';
+import {
+    headerMatchesOwner,
+    resolveOwnerIdentityEmails,
+    userSentLatest,
+} from './classify_thread.js';
+
+function snap(messages: Array<{ from?: string }>): GmailThreadSnapshot {
+    return {
+        threadId: 't1',
+        threadUrl: 'https://mail.google.com/mail/#inbox/t1',
+        importance: 'other',
+        messages: messages.map((m) => ({
+            id: 'm',
+            from: m.from ?? '',
+            body: 'hi',
+        })),
+    };
+}
+
+describe('headerMatchesOwner', () => {
+    it('matches any owner email in a From header', () => {
+        const owners = ['a@acme.com', 'b@custom.com'];
+        expect(headerMatchesOwner('Alice <a@acme.com>', owners)).toBe(true);
+        expect(headerMatchesOwner('Bob <b@custom.com>', owners)).toBe(true);
+        expect(headerMatchesOwner('Eve <eve@x.com>', owners)).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+        expect(headerMatchesOwner('Alice <A@ACME.COM>', ['a@acme.com'])).toBe(true);
+    });
+});
+
+describe('userSentLatest', () => {
+    it('returns true when latest From is the owner', () => {
+        const s = snap([
+            { from: 'Other <o@x.com>' },
+            { from: 'Me <me@acme.com>' },
+        ]);
+        expect(userSentLatest(s, ['me@acme.com'])).toBe(true);
+    });
+
+    it('returns true when latest From is a secondary owner alias', () => {
+        const s = snap([
+            { from: 'Other <o@x.com>' },
+            { from: 'Me <alias@custom.com>' },
+        ]);
+        expect(userSentLatest(s, ['me@acme.com', 'alias@custom.com'])).toBe(true);
+    });
+
+    it('returns false when latest is external', () => {
+        const s = snap([
+            { from: 'Me <me@acme.com>' },
+            { from: 'Other <o@x.com>' },
+        ]);
+        expect(userSentLatest(s, ['me@acme.com'])).toBe(false);
+    });
+
+    it('returns false with empty owner set', () => {
+        const s = snap([{ from: 'Me <me@acme.com>' }]);
+        expect(userSentLatest(s, [])).toBe(false);
+    });
+});
+
+describe('resolveOwnerIdentityEmails', () => {
+    it('includes connected email even when user.json is empty', () => {
+        // No workdir config guaranteed — connected alone should still work.
+        const emails = resolveOwnerIdentityEmails('connected@acme.com');
+        expect(emails).toContain('connected@acme.com');
+    });
+
+    it('dedupes connected against itself', () => {
+        const emails = resolveOwnerIdentityEmails('Connected@Acme.com');
+        expect(emails.filter((e) => e === 'connected@acme.com')).toHaveLength(1);
+    });
+});

--- a/apps/x/packages/core/src/knowledge/classify_thread.ts
+++ b/apps/x/packages/core/src/knowledge/classify_thread.ts
@@ -18,6 +18,7 @@ import { formatImportanceFeedbackForPrompt, maybeDistillImportanceRules } from '
 import { formatCategoryFeedbackForPrompt } from './email_category_feedback.js';
 import { formatEmailInstructionsForPrompt } from './email_instructions.js';
 import { getEmailLabels, type EmailLabelDef } from './email_labels.js';
+import { getOwnerEmails, unionEmails } from '../config/user_config.js';
 
 const STYLE_GUIDE_PATH = path.join(WorkDir, 'knowledge', 'Agent Notes', 'style', 'email.md');
 const CALENDAR_DIR = path.join(WorkDir, 'calendar_sync');
@@ -87,21 +88,42 @@ function formatCalendar(events: CalendarSlice[]): string {
     }).join('\n');
 }
 
-let cachedUserEmail: string | null = null;
+/**
+ * Per-client cache — never process-global. A second OAuth client (or a reconnect
+ * that yields a new client instance) must not inherit the first account's email.
+ */
+const emailByClient = new WeakMap<OAuth2Client, string>();
 
 export async function getUserEmail(auth: OAuth2Client): Promise<string | null> {
-    if (cachedUserEmail) return cachedUserEmail;
+    const hit = emailByClient.get(auth);
+    if (hit) return hit;
     try {
         const gmailClient = google.gmail({ version: 'v1', auth });
         const res = await gmailClient.users.getProfile({ userId: 'me' });
         if (res.data.emailAddress) {
-            cachedUserEmail = res.data.emailAddress.toLowerCase();
-            return cachedUserEmail;
+            const email = res.data.emailAddress.toLowerCase();
+            emailByClient.set(auth, email);
+            return email;
         }
     } catch (err) {
         console.warn('[Email classifier] getProfile failed:', err);
     }
     return null;
+}
+
+/**
+ * Identity set for matching (self / "user wrote"): connected Gmail address
+ * unioned with config/user.json emails. Single-account users still get size 1.
+ */
+export function resolveOwnerIdentityEmails(connectedEmail: string | null | undefined): string[] {
+    return unionEmails(getOwnerEmails(), connectedEmail);
+}
+
+/** True if a From-style header contains any of the owner emails. */
+export function headerMatchesOwner(header: string, ownerEmails: readonly string[]): boolean {
+    if (!header || ownerEmails.length === 0) return false;
+    const hay = header.toLowerCase();
+    return ownerEmails.some((e) => e && hay.includes(e));
 }
 
 /**
@@ -208,25 +230,29 @@ Omit the draft when:
 
 Be decisive — pick exactly one importance label. Do not hedge.`;
 
-function userSentLatest(snapshot: GmailThreadSnapshot, userEmail: string | null): boolean {
-    if (!userEmail) return false;
+/** Exported for unit tests. Latest message is from any owner address. */
+export function userSentLatest(snapshot: GmailThreadSnapshot, ownerEmails: readonly string[]): boolean {
+    if (ownerEmails.length === 0) return false;
     const latest = snapshot.messages[snapshot.messages.length - 1];
     if (!latest) return false;
-    const needle = userEmail.toLowerCase();
-    return (latest.from || '').toLowerCase().includes(needle);
+    return headerMatchesOwner(latest.from || '', ownerEmails);
 }
 
 function buildPrompt(
     snapshot: GmailThreadSnapshot,
-    userEmail: string | null,
+    ownerEmails: readonly string[],
     styleGuide: string | null,
     calendar: CalendarSlice[],
 ): string {
     const lines: string[] = [];
 
-    if (userEmail) {
+    if (ownerEmails.length === 1) {
         lines.push(`# Your identity`);
-        lines.push(`The user's own email is ${userEmail}. You write as this person when drafting replies.`);
+        lines.push(`The user's own email is ${ownerEmails[0]}. You write as this person when drafting replies.`);
+        lines.push('');
+    } else if (ownerEmails.length > 1) {
+        lines.push(`# Your identity`);
+        lines.push(`The user's own emails are ${ownerEmails.join(', ')}. You write as this person when drafting replies.`);
         lines.push('');
     }
 
@@ -272,7 +298,11 @@ export async function classifyThread(
     userEmail: string | null,
     options: ClassifyOptions = {},
 ): Promise<Classification> {
-    if (userSentLatest(snapshot, userEmail)) {
+    // Match against the full owner set (connected + user.json emails), not a
+    // single string — secondary aliases must not be treated as external senders.
+    const ownerEmails = resolveOwnerIdentityEmails(userEmail);
+
+    if (userSentLatest(snapshot, ownerEmails)) {
         // Force-important only for real conversations the user replied in.
         // Threads where the user is the ONLY sender (outbound campaigns,
         // first-touch outreach, self-test sends) are not inbox-important —
@@ -282,9 +312,8 @@ export async function classifyThread(
         // Either way the user wrote the latest message themselves, so the
         // knowledge pipeline always extracts: their own words carry their
         // commitments, decisions, and relationships.
-        const needle = (userEmail ?? '').toLowerCase();
-        const othersParticipated = needle
-            ? snapshot.messages.some((m) => m.from && !m.from.toLowerCase().includes(needle))
+        const othersParticipated = ownerEmails.length > 0
+            ? snapshot.messages.some((m) => m.from && !headerMatchesOwner(m.from, ownerEmails))
             : false;
         if (othersParticipated) {
             return { importance: 'important', category: 'correspondence', knowledge: 'extract' };
@@ -334,7 +363,7 @@ export async function classifyThread(
         const result = await withUseCase({ useCase: 'knowledge_sync', subUseCase: 'email_classifier' }, () => generateObjectSafe({
             model,
             system: systemPrompt,
-            prompt: buildPrompt(snapshot, userEmail, styleGuide, calendar),
+            prompt: buildPrompt(snapshot, ownerEmails, styleGuide, calendar),
             schema: buildClassificationSchema(labels.map((l) => l.id)),
             retry: true,
             generateOptions: reasoning,
@@ -357,8 +386,8 @@ export async function classifyThread(
         // wrote in this thread, the knowledge pipeline must see it — their own
         // messages carry commitments and decisions regardless of how the LLM
         // categorized the thread.
-        const needle = (userEmail ?? '').toLowerCase();
-        if (needle && snapshot.messages.some((m) => (m.from || '').toLowerCase().includes(needle))) {
+        if (ownerEmails.length > 0
+            && snapshot.messages.some((m) => headerMatchesOwner(m.from || '', ownerEmails))) {
             out.knowledge = 'extract';
         }
         if (result.object.importance === 'important') {

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -2055,25 +2055,30 @@ export async function getAccountEmail(): Promise<string | null> {
     return getUserEmail(auth);
 }
 
-let cachedAccountName: string | null | undefined;
+/**
+ * Per-client display-name cache. Must not be process-global: reconnecting a
+ * different Google account (new OAuth2Client) must not inherit the prior name.
+ * `null` is a valid cached miss (no SENT mail); WeakMap.has distinguishes cold.
+ */
+const accountNameByClient = new WeakMap<object, string | null>();
 
 /**
  * The connected account's display name, parsed from the `From` header of a
- * recent SENT message (which is the user themselves). Cached for the process
- * lifetime. Uses only the existing gmail.modify scope — no profile/userinfo
- * scope, so it never triggers a re-consent. Used by the composer to sign off
- * AI-generated emails with the real name.
+ * recent SENT message (which is the user themselves). Cached per OAuth client.
+ * Uses only the existing gmail.modify scope — no profile/userinfo scope, so it
+ * never triggers a re-consent. Used by the composer to sign off AI-generated
+ * emails with the real name.
  */
 export async function getAccountName(): Promise<string | null> {
-    if (cachedAccountName !== undefined) return cachedAccountName;
     try {
         const auth = await GoogleClientFactory.getClient();
         if (!auth) return null;
+        if (accountNameByClient.has(auth)) return accountNameByClient.get(auth) ?? null;
         const gmailClient = google.gmail({ version: 'v1', auth });
         const list = await gmailClient.users.messages.list({ userId: 'me', labelIds: ['SENT'], maxResults: 1 });
         const id = list.data.messages?.[0]?.id;
         if (!id) {
-            cachedAccountName = null;
+            accountNameByClient.set(auth, null);
             return null;
         }
         const msg = await gmailClient.users.messages.get({
@@ -2085,7 +2090,7 @@ export async function getAccountName(): Promise<string | null> {
         const from = msg.data.payload?.headers?.find((h) => h.name?.toLowerCase() === 'from')?.value || '';
         // Pull the display name out of `"Name" <email>` / `Name <email>`.
         const name = from.match(/^\s*"?([^"<]+?)"?\s*</)?.[1]?.trim() || null;
-        cachedAccountName = name;
+        accountNameByClient.set(auth, name);
         return name;
     } catch (err) {
         console.warn('[Gmail] getAccountName failed:', err);


### PR DESCRIPTION
## Summary

Groundwork for multi-account / multi-inbox email ([#823](https://github.com/rowboatlabs/rowboat/issues/823)).

Single-account users see **zero behavior change**. This only fixes identity assumptions that would break if a second mailbox is ever connected:

- **`config/user.json`**: add `emails: string[]` (full owner set); keep `email` as primary. Legacy `{ email }` normalizes in-memory; saves write both fields.
- **`classify_thread`**: replace process-global `cachedUserEmail` with a **per-`OAuth2Client` WeakMap**; match “user wrote in thread” against the full owner set (connected ∪ `user.json` emails).
- **`build_graph`**: Owner block + Email Reply Gate + final reminder use the email set; company domains exclude free-mail.
- **`sync_gmail.getAccountName`**: per-client cache (same bug class as the email singleton).

**Out of scope (follow-ups):** multi-token OAuth, account registry, IMAP, concurrent Gmail sync, path namespacing.

Related intent: [#823 comment](https://github.com/rowboatlabs/rowboat/issues/823#issuecomment-5256380023). This is staged **PR-1** of a small sequence (identity → registry → IMAP → multi-Gmail).

## Test plan

- [x] `vitest` for `user_config`, `classify_thread`, `build_graph` (new/extended)
- [x] Existing `sync_gmail` / `classification_stamp` tests still pass
- [x] `npm run typecheck:core` clean
- [ ] Manual: single Gmail install — classify + graph owner block look the same as before
- [ ] Optional: hand-edit `user.json` with two `emails` → reply gate matches secondary From