### PR TITLE
Screen pointer during share, unified Skipper companion, permissions panel

### DIFF
--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -276,6 +276,55 @@ Voice input/output prompt sections (`# Voice Input`, `# Voice Output`) are
 reused untouched — calls set `voiceInput` per utterance and force
 `voiceOutput: 'full'`.
 
+## Pointing at the shared screen
+
+During a live screen share the assistant can point at the user's REAL
+display: the `screen-pointer` builtin (attached by the `app-navigation`
+skill) takes fractional coordinates (x/y in 0–1, estimated from the latest
+screen-share frame) plus an optional tiny label, and main draws an animated
+laser-dot + ping rings there. "This dip here is the weekend" now comes with
+a finger on the chart.
+
+- Tool: `packages/core/src/runtime/tools/domains/screen-pointer.ts` —
+  actions `point` (x, y, `label?`, `durationMs?`, default auto-hide 8s) and
+  `hide`. Executes directly in main via the DI seam
+  (`IScreenPointerService`, registered in `main.ts` like browser control) —
+  no renderer round-trip, and it hard-fails with an explanation when no
+  share is live.
+- Share gate: an App.tsx effect reports `video.screenState === 'live'` over
+  `screenPointer:setShareActive` (covers call AND quick-ask shares); share
+  end tears the pointer down instantly.
+- Overlay: `apps/main/src/screen-pointer.ts` creates a transparent,
+  click-through (`setIgnoreMouseEvents`), non-focusable, screen-saver-level
+  NSPanel covering the primary display (the share always captures the
+  primary display), loading the renderer with `#screen-pointer` →
+  `components/screen-pointer-overlay.tsx`. State pushes over
+  `screen-pointer:state` (replayed on load; `nonce` restarts the ping when
+  pointing twice at one spot). The window exists only while something is
+  pointed at — hide destroys it.
+- Prompt surface: a "You can POINT at their screen" bullet in the
+  `# Video Mode` screen-sharing section (`capabilities/modes.ts`) plus a
+  "Pointing at the user's shared screen" section with a worked example in
+  the `app-navigation` skill.
+- **Clicking/typing was explored and removed** (design notes for whoever
+  revisits). A `screen-control` tool (click at frame coordinates + type
+  into the focused field) shipped briefly and worked mechanically, but was
+  pulled: aiming from 1280px-wide frames misses small targets, and the
+  model acts BLIND between actions (frames only arrive with user
+  messages), so it typed into wrong focus and reported success. The
+  missing piece is a post-action verification frame in the tool result.
+  Hard-won lessons if rebuilt: System Events `click at` returns success
+  WITHOUT clicking on modern macOS — post real CGEvents via
+  `osascript -l JavaScript` + the ObjC bridge instead (no native module,
+  Accessibility-only, no Automation consent); CGEventPost from an
+  untrusted process drops events silently, so an upfront
+  `isTrustedAccessibilityClient` self-check is the only reliable gate; and
+  TCC keys grants to the code signature, so ad-hoc builds lose the grant
+  on every rebuild (Developer ID signing fixes it). Web tasks never needed
+  it — the embedded browser (`browser-control`) acts element-precisely
+  with page state returned per action. Full implementation: this branch's
+  history (feat/screen-pointer-control, pre-removal).
+
 ## Driving the app on a call
 
 The assistant can drive the Rowboat UI itself via the extended

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -42,6 +42,7 @@ import {
   setPinnedCollapsed,
   showQuickAsk,
 } from './quick-ask.js';
+import { screenPointerService } from './screen-pointer.js';
 import { RunEvent } from '@x/shared/dist/runs.js';
 import { ServiceEvent } from '@x/shared/dist/service-events.js';
 import type { SessionBusEvent } from '@x/shared/dist/sessions.js';
@@ -992,11 +993,13 @@ export function setupIpcHandlers() {
     'app:openPrivacySettings': async (_event, args) => {
       if (process.platform === 'win32') {
         // Windows Settings deep links (ms-settings). Sections without a
-        // Windows equivalent (screen recording, input monitoring are macOS
-        // TCC concepts) report failure, as before.
+        // Windows equivalent (screen recording, input monitoring,
+        // accessibility, automation are macOS TCC concepts) report failure,
+        // as before.
         const winUris: Partial<Record<typeof args.section, string>> = {
           microphone: 'ms-settings:privacy-microphone',
           camera: 'ms-settings:privacy-webcam',
+          notifications: 'ms-settings:notifications',
         };
         const uri = winUris[args.section];
         if (!uri) return { success: false };
@@ -1008,19 +1011,91 @@ export function setupIpcHandlers() {
         }
       }
       if (process.platform !== 'darwin') return { success: false };
-      const anchors = {
-        microphone: 'Privacy_Microphone',
-        camera: 'Privacy_Camera',
-        'screen-recording': 'Privacy_ScreenCapture',
-        'input-monitoring': 'Privacy_ListenEvent',
-      } as const;
+      // Notification settings live outside the Privacy & Security pane.
+      const url = args.section === 'notifications'
+        ? 'x-apple.systempreferences:com.apple.Notifications-Settings.extension'
+        : `x-apple.systempreferences:com.apple.preference.security?${({
+            microphone: 'Privacy_Microphone',
+            camera: 'Privacy_Camera',
+            'screen-recording': 'Privacy_ScreenCapture',
+            'input-monitoring': 'Privacy_ListenEvent',
+          } as const)[args.section]}`;
       try {
-        await shell.openExternal(
-          `x-apple.systempreferences:com.apple.preference.security?${anchors[args.section]}`,
-        );
+        await shell.openExternal(url);
         return { success: true };
       } catch {
         return { success: false };
+      }
+    },
+    'permissions:getStatus': async () => {
+      const platform = process.platform === 'darwin' ? 'darwin' as const
+        : process.platform === 'win32' ? 'win32' as const : 'linux' as const;
+      type PermState = ipc.IPCChannels['permissions:getStatus']['res']['microphone'];
+      // getMediaAccessStatus exists on darwin and win32 only.
+      const media = (kind: 'microphone' | 'camera' | 'screen'): PermState => {
+        try {
+          return systemPreferences.getMediaAccessStatus(kind) as PermState;
+        } catch {
+          return 'unknown';
+        }
+      };
+      if (platform === 'linux') {
+        // No OS permission gates for any of these under X11; notifications
+        // vary by desktop and can't be read.
+        return {
+          platform,
+          microphone: 'not-required', camera: 'not-required', screenRecording: 'not-required',
+          inputMonitoring: 'not-required',
+          notifications: 'unknown',
+        };
+      }
+      if (platform === 'win32') {
+        // Desktop apps are gated by the global "let desktop apps access…"
+        // toggles (surfaced through getMediaAccessStatus); everything else
+        // needs no permission on Windows.
+        return {
+          platform,
+          microphone: media('microphone'), camera: media('camera'),
+          screenRecording: 'not-required',
+          inputMonitoring: 'not-required',
+          notifications: 'unknown',
+        };
+      }
+      // macOS. Input monitoring has no read API — infer from the key hook:
+      // events seen = definitely granted; anything else is honestly unknown
+      // (the hook only runs during calls, so absence of events proves
+      // nothing). Notifications can't be read at all.
+      const ptt = getPttStatus();
+      return {
+        platform,
+        microphone: media('microphone'),
+        camera: media('camera'),
+        screenRecording: media('screen'),
+        inputMonitoring: ptt.eventsSeen ? 'granted' : 'unknown',
+        notifications: 'unknown',
+      };
+    },
+    'permissions:request': async (_event, args) => {
+      const darwin = process.platform === 'darwin';
+      switch (args.permission) {
+        case 'microphone':
+        case 'camera': {
+          if (!darwin) return { state: 'unknown' };
+          try {
+            const granted = await systemPreferences.askForMediaAccess(args.permission);
+            return { state: granted ? 'granted' : 'denied' };
+          } catch {
+            return { state: 'unknown' };
+          }
+        }
+        case 'input-monitoring': {
+          if (!darwin) return { state: 'not-required' };
+          // Recreates the uiohook tap: fires the consent prompt if macOS
+          // never asked, and revives a tap created before a grant. The
+          // status stays unknown until real key events arrive (next call).
+          retryPttHook();
+          return { state: 'unknown' };
+        }
       }
     },
     // --- Quick-ask bar relays ---
@@ -2593,6 +2668,15 @@ export function setupIpcHandlers() {
     },
     'video:getPopoutState': async () => {
       return { state: getPopoutState() };
+    },
+    'screenPointer:setShareActive': async (_event, args) => {
+      // Gates the assistant's screen-pointer tool and tears the pointer
+      // overlay down the moment the share (call or quick-ask) ends.
+      screenPointerService.setShareActive(args.active);
+      return {};
+    },
+    'screenPointer:getState': async () => {
+      return { state: screenPointerService.getState() };
     },
     'video:popoutAction': async (_event, args) => {
       // Relay a popout control-bar action to the app window, which owns the

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1130,10 +1130,6 @@ export function setupIpcHandlers() {
       pushChatContext(args);
       return {};
     },
-    'quickAsk:setTextMode': async (_event, args) => {
-      findMainAppWindow()?.webContents.send('quick-ask:text-mode', args);
-      return {};
-    },
     'quickAsk:popOut': async () => {
       // Already pinned → expanded/focused in place; otherwise arm the
       // expanded-card landing and run the tuck flow (voice session, or the

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -993,9 +993,8 @@ export function setupIpcHandlers() {
     'app:openPrivacySettings': async (_event, args) => {
       if (process.platform === 'win32') {
         // Windows Settings deep links (ms-settings). Sections without a
-        // Windows equivalent (screen recording, input monitoring,
-        // accessibility, automation are macOS TCC concepts) report failure,
-        // as before.
+        // Windows equivalent (screen recording and input monitoring are
+        // macOS TCC concepts) report failure, as before.
         const winUris: Partial<Record<typeof args.section, string>> = {
           microphone: 'ms-settings:privacy-microphone',
           camera: 'ms-settings:privacy-webcam',

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -55,13 +55,14 @@ import started from "electron-squirrel-startup";
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { init as initChromeSync } from "@x/core/dist/knowledge/chrome-extension/server/server.js";
-import container, { registerBrowserControlService, registerNotificationService } from "@x/core/dist/di/container.js";
+import container, { registerBrowserControlService, registerNotificationService, registerScreenPointerService } from "@x/core/dist/di/container.js";
 import type { CodeModeManager } from "@x/core/dist/code-mode/acp/manager.js";
 import type { ISessions } from "@x/core/dist/runtime/sessions/index.js";
 import { browserViewManager, BROWSER_PARTITION } from "./browser/view.js";
 import { setupBrowserEventForwarding } from "./browser/ipc.js";
 import { setupBrowserExtensions } from "./browser/extensions.js";
 import { ElectronBrowserControlService } from "./browser/control-service.js";
+import { screenPointerService } from "./screen-pointer.js";
 import { ElectronNotificationService } from "./notification/electron-notification-service.js";
 import {
   DEEP_LINK_SCHEME,
@@ -523,6 +524,7 @@ app.whenReady().then(async () => {
 
   registerBrowserControlService(new ElectronBrowserControlService());
   registerNotificationService(new ElectronNotificationService(APP_LAUNCHED_AT));
+  registerScreenPointerService(screenPointerService);
 
   setupIpcHandlers();
   setupBrowserEventForwarding();

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -5,9 +5,11 @@
  * - `summoned` (global ⌥⇧Space): Spotlight-style — the real chat composer in
  *   a card at the bottom of a tall transparent frame, bottom-centered on the
  *   cursor's display. Takes focus; blur or Esc dismisses.
- * - `pinned` (a call's floating surface, the old #video-popout pill): shown
- *   for the whole duration of a screen share, top-right of the primary
- *   display. Never steals focus (showInactive), survives blur, draggable.
+ * - `pinned` (a call's floating surface, the old #video-popout pill). Voice
+ *   sessions land as the SKIPPER: mascot + text panel, one corner-anchored
+ *   draggable unit (text visible by default, foldable to just the mascot —
+ *   folding never moves the mascot). Camera calls use the pill, top-right.
+ *   Both survive blur.
  *
  * The window is created once and shown/hidden on toggle so summoning is
  * instant. It loads the renderer bundle with #quick-ask (see
@@ -48,6 +50,11 @@ const PINNED_MAX_HEIGHT = 560;
 // caption, everything else on hover.
 const TUCKED_WIDTH = 250;
 const TUCKED_HEIGHT = 250;
+// The Skipper card: the pinned text panel + mascot, one unit. Narrower than
+// the summoned frame (it hugs a corner instead of center-stage) but the same
+// tall transparent stage above the card for popovers and panel growth.
+const SKIPPER_FRAME_WIDTH = 560;
+const SKIPPER_FRAME_HEIGHT = 560;
 // Uniform downscale: the window shrinks and the page zooms by the SAME
 // factor, so every proportion of the design survives exactly — unlike
 // hand-shrinking individual sizes, which broke the alignment.
@@ -66,14 +73,42 @@ let tuckOrigin: 'bar' | 'pill' = 'pill';
 // The expanded surface currently applied to the window geometry (so a
 // device flip mid-call can morph card ⇄ pill in place).
 let appliedExpandedSurface: 'card' | 'pill' = 'pill';
-// A tuck was requested from the summoned bar: the NEXT pin starts collapsed,
-// placed near where the bar's mascot stood (bottom of the cursor's display)
-// instead of the pill's canonical top-right. Time-boxed so a tuck the app
-// declined (voice not configured, race) can't leak into an unrelated call.
-// `tuckPendingExpand` flips the landing to the EXPANDED text card instead —
-// the app's "pop this chat out" gesture, where the user was reading text.
+// A tuck was requested from the summoned bar: the NEXT pin lands as the
+// Skipper (text card + mascot, bottom-right of the cursor's display) instead
+// of the pill's canonical top-right. Time-boxed so a tuck the app declined
+// (voice not configured, race) can't leak into an unrelated call. Every
+// Skipper landing arrives text-open, so the old expand-vs-collapsed
+// distinction is gone.
 let tuckPendingAt = 0;
-let tuckPendingExpand = false;
+
+// The Skipper's anchor: the bottom-right corner of the window, i.e. where
+// the MASCOT stands. The user can drag the Skipper anywhere; collapsing and
+// expanding the text panel both keep this corner fixed, so the mascot never
+// jumps — the panel folds toward it and unfolds from it. Updated from
+// user drags (the 'move' listener); programmatic setBounds are guarded out.
+let skipperCorner: { x: number; y: number } | null = null;
+let applyingBounds = false;
+
+function setBoundsGuarded(win: BrowserWindow, bounds: Electron.Rectangle) {
+  applyingBounds = true;
+  win.setBounds(bounds);
+  // 'move' fires async after setBounds — release the guard a tick later.
+  setTimeout(() => { applyingBounds = false; }, 0);
+}
+
+function defaultSkipperCorner(display: Electron.Display): { x: number; y: number } {
+  const wa = display.workArea;
+  return { x: wa.x + wa.width - 24, y: wa.y + wa.height - 24 };
+}
+
+// Corner-anchored bounds: the window's bottom-right pinned to the corner,
+// clamped so the window stays on its display.
+function cornerBounds(corner: { x: number; y: number }, w: number, h: number): Electron.Rectangle {
+  const wa = screen.getDisplayNearestPoint(corner).workArea;
+  const x = Math.max(wa.x + 8, Math.min(corner.x - w, wa.x + wa.width - w - 8));
+  const y = Math.max(wa.y + 8, Math.min(corner.y - h, wa.y + wa.height - h - 8));
+  return { x, y, width: w, height: h };
+}
 
 // Last call state pushed by the app window — replayed when the window
 // (re)loads, so the pill never renders from a blank guess.
@@ -102,9 +137,8 @@ export function isPinnedCollapsed(): boolean {
   return pinnedCollapsed;
 }
 
-export function markTuckPending(expand = false) {
+export function markTuckPending() {
   tuckPendingAt = Date.now();
-  tuckPendingExpand = expand;
 }
 
 /**
@@ -121,7 +155,7 @@ export function popOutCompanion(): boolean {
     win.focus();
     return true;
   }
-  markTuckPending(true);
+  markTuckPending();
   return false;
 }
 
@@ -187,18 +221,24 @@ function createWindow(): BrowserWindow {
   if (process.platform === 'darwin') {
     win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
   }
-  // Spotlight behavior: clicking away dismisses the summoned bar. Call
-  // surfaces survive blur — but the expanded CARD of a voice call is big
-  // and Spotlight-like, so blur tucks it back to the mascot (the call keeps
-  // going; only the text gets out of the way). The pill just persists.
+  // Spotlight behavior: clicking away dismisses the summoned bar. Pinned
+  // surfaces (Skipper card AND pill) survive blur — the Skipper is a
+  // companion the user carries around and works next to, so losing focus
+  // must never fold its text away; tucking is an explicit gesture (the
+  // handle, Esc, or clicking the transparent stage).
   win.on('blur', () => {
     if (win.isDestroyed() || !win.isVisible()) return;
     if (mode === 'summoned') {
       mode = 'hidden';
       win.hide();
-    } else if (mode === 'pinned' && !pinnedCollapsed && appliedExpandedSurface === 'card') {
-      setPinnedCollapsed(true);
     }
+  });
+  // Wherever the user drags the Skipper, that becomes its anchor — the
+  // corner survives collapse/expand round-trips.
+  win.on('move', () => {
+    if (applyingBounds || win.isDestroyed() || mode !== 'pinned') return;
+    const b = win.getBounds();
+    skipperCorner = { x: b.x + b.width, y: b.y + b.height };
   });
   win.on('closed', () => {
     if (quickAskWin === win) quickAskWin = null;
@@ -252,7 +292,7 @@ function positionPinned(win: BrowserWindow) {
   // Top-right of the primary display, like the old popout window.
   const workArea = screen.getPrimaryDisplay().workArea;
   const width = scaled(PINNED_WIDTH);
-  win.setBounds({
+  setBoundsGuarded(win, {
     x: workArea.x + workArea.width - width - 24,
     y: workArea.y + 24,
     width,
@@ -358,26 +398,30 @@ export function setCompanionPinned(pinned: boolean) {
     let win = getQuickAskWindow();
     if (!win) win = createWindow();
     const fromTuck = Date.now() - tuckPendingAt < 5000;
-    const expandFromTuck = fromTuck && tuckPendingExpand;
     tuckPendingAt = 0;
-    tuckPendingExpand = false;
     mode = 'pinned';
     tuckOrigin = fromTuck ? 'bar' : 'pill';
-    if (expandFromTuck) {
-      // Pop-out landing: the user was READING this chat in the app — arrive
-      // on the expanded text card, focused and ready to type.
+    if (fromTuck) {
+      // The Skipper lands as ONE unit — mascot with the text panel already
+      // open (text is the default; tucking is the user's gesture, never the
+      // arrival state) — anchored at its corner (last dragged spot, else
+      // bottom-right of the cursor's display).
       pinnedCollapsed = false;
+      if (!skipperCorner) {
+        skipperCorner = defaultSkipperCorner(
+          screen.getDisplayNearestPoint(screen.getCursorScreenPoint()),
+        );
+      }
       applyExpandedSurface(win, 'card');
-    } else if (fromTuck) {
-      pinnedCollapsed = true;
-      positionTucked(win, screen.getDisplayNearestPoint(screen.getCursorScreenPoint()));
     } else {
       pinnedCollapsed = false;
       positionPinned(win);
       appliedExpandedSurface = 'pill';
     }
     pushMode(win);
-    if (expandFromTuck) {
+    if (fromTuck) {
+      // The user just summoned their companion — focus so speaking, typing,
+      // and Esc all work immediately.
       if (!win.isVisible()) win.show();
       win.focus();
     } else if (!win.isVisible()) {
@@ -400,12 +444,11 @@ export function setCompanionPinned(pinned: boolean) {
 }
 
 /**
- * Tucked-mascot ⇄ expanded presentation of the pinned role. The expanded
- * surface is whatever the user tucked FROM: the pill resizes in place
- * (preserving the window's right edge and whichever vertical edge hugs the
- * nearer screen edge); the bar-style card goes back to the bar's canonical
- * spot — bottom-center of the window's display — and takes focus, because
- * asking for the text back means the user is about to read or type.
+ * Text-panel fold/unfold of the Skipper (and the pill's tuck). Both states
+ * anchor on the SAME corner — the mascot's spot — so folding the text never
+ * moves the mascot: the panel collapses toward it and unfolds from it,
+ * wherever the user last dragged it. The pill keeps its edge-preserving
+ * resize (camera surface, different geometry).
  */
 export function setPinnedCollapsed(collapsed: boolean) {
   const win = getQuickAskWindow();
@@ -413,9 +456,7 @@ export function setPinnedCollapsed(collapsed: boolean) {
   pinnedCollapsed = collapsed;
   if (collapsed) {
     if (appliedExpandedSurface === 'card') {
-      // The wide card's edges mean nothing once it's gone — tuck to the
-      // mascot's canonical corner on this display.
-      positionTucked(win, screen.getDisplayMatching(win.getBounds()));
+      positionTucked(win);
     } else {
       const b = win.getBounds();
       const wa = screen.getDisplayMatching(b).workArea;
@@ -426,7 +467,7 @@ export function setPinnedCollapsed(collapsed: boolean) {
       let y = inTopHalf ? b.y : b.y + b.height - h;
       x = Math.max(wa.x + 8, Math.min(x, wa.x + wa.width - w - 8));
       y = Math.max(wa.y + 8, Math.min(y, wa.y + wa.height - h - 8));
-      win.setBounds({ x, y, width: w, height: h });
+      setBoundsGuarded(win, { x, y, width: w, height: h });
     }
     pushMode(win);
     return;
@@ -439,17 +480,12 @@ export function setPinnedCollapsed(collapsed: boolean) {
 function applyExpandedSurface(win: BrowserWindow, surface: 'card' | 'pill') {
   appliedExpandedSurface = surface;
   if (surface === 'card') {
-    // The bar's geometry: tall transparent frame, bottom-center of the
-    // display the window is on.
-    const wa = screen.getDisplayMatching(win.getBounds()).workArea;
-    const w = scaled(FRAME_WIDTH);
-    const h = scaled(FRAME_HEIGHT);
-    win.setBounds({
-      x: Math.round(wa.x + (wa.width - w) / 2),
-      y: Math.round(wa.y + wa.height - h - BOTTOM_MARGIN),
-      width: w,
-      height: h,
-    });
+    // Skipper geometry: corner-anchored frame — the card sits at the
+    // bottom with the mascot at its right edge, i.e. at the anchor.
+    if (!skipperCorner) {
+      skipperCorner = defaultSkipperCorner(screen.getDisplayMatching(win.getBounds()));
+    }
+    setBoundsGuarded(win, cornerBounds(skipperCorner, scaled(SKIPPER_FRAME_WIDTH), scaled(SKIPPER_FRAME_HEIGHT)));
     win.setHasShadow(false);
     return;
   }
@@ -462,22 +498,17 @@ function applyExpandedSurface(win: BrowserWindow, surface: 'card' | 'pill') {
   let y = inTopHalf ? b.y : b.y + b.height - h;
   x = Math.max(wa.x + 8, Math.min(x, wa.x + wa.width - w - 8));
   y = Math.max(wa.y + 8, Math.min(y, wa.y + wa.height - h - 8));
-  win.setBounds({ x, y, width: w, height: h });
+  setBoundsGuarded(win, { x, y, width: w, height: h });
   win.setHasShadow(false);
 }
 
-function positionTucked(win: BrowserWindow, display: Electron.Display) {
-  // The mascot's canonical corner: bottom right of the given display, near
-  // where it stood beside the card — never teleporting across screens.
-  const wa = display.workArea;
-  const w = scaled(TUCKED_WIDTH);
-  const h = scaled(TUCKED_HEIGHT);
-  win.setBounds({
-    x: wa.x + wa.width - w - 24,
-    y: wa.y + wa.height - h - 48,
-    width: w,
-    height: h,
-  });
+function positionTucked(win: BrowserWindow) {
+  // Fold to the mascot's anchor corner — wherever the Skipper was last
+  // dragged, never a canonical spot that would teleport it.
+  if (!skipperCorner) {
+    skipperCorner = defaultSkipperCorner(screen.getDisplayMatching(win.getBounds()));
+  }
+  setBoundsGuarded(win, cornerBounds(skipperCorner, scaled(TUCKED_WIDTH), scaled(TUCKED_HEIGHT)));
   win.setHasShadow(false);
 }
 
@@ -487,7 +518,7 @@ export function resizeCompanionPinned(height: number) {
   if (!win || mode !== 'pinned' || pinnedCollapsed) return;
   const clamped = scaled(Math.max(PINNED_BASE_HEIGHT, Math.min(PINNED_MAX_HEIGHT, Math.round(height))));
   const bounds = win.getBounds();
-  win.setBounds({ ...bounds, height: clamped });
+  setBoundsGuarded(win, { ...bounds, height: clamped });
 }
 
 /** Cache + forward the app window's call-state push (video:popoutState). */

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -119,6 +119,7 @@ type PopoutState = {
   micMuted: boolean;
   screenSharing: boolean;
   speakerMuted: boolean;
+  activityText: string | null;
   interimText: string | null;
   pttLocked: boolean;
   responseText: string | null;

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -327,12 +327,14 @@ function findAppWindow(): BrowserWindow | undefined {
 
 export function toggleQuickAsk(viaShortcut = true) {
   const win = getQuickAskWindow();
-  // While a call pill is up, the shortcut brings the text back — expanding
-  // a tucked mascot and focusing — instead of toggling a second surface
-  // into existence.
+  // While the Skipper is up, the shortcut TOGGLES its text panel: folded →
+  // unfold and focus (about to read or type); open → fold it away. All in
+  // main, so it works even if the window's own controls are wedged — the
+  // keyboard is the escape hatch.
   if (mode === 'pinned' && win) {
-    if (pinnedCollapsed) setPinnedCollapsed(false);
-    win.focus();
+    const expanding = pinnedCollapsed;
+    setPinnedCollapsed(!pinnedCollapsed);
+    if (expanding) win.focus();
     return;
   }
   if (win?.isVisible()) {
@@ -394,6 +396,17 @@ export function setCompanionPinned(pinned: boolean) {
   if (pinned) {
     if (mode === 'pinned') {
       tuckPendingAt = 0;
+      // Already pinned: re-assert the CURRENT presentation instead of
+      // bailing — callSurface flaps in the app (fullscreen ⇄ popout) can
+      // otherwise leave the window sized for one state while the renderer
+      // shows the other.
+      const win0 = getQuickAskWindow();
+      if (win0) {
+        if (pinnedCollapsed) positionTucked(win0);
+        else applyExpandedSurface(win0, getExpandedSurface());
+        pushMode(win0);
+        if (!win0.isVisible()) win0.showInactive();
+      }
       return;
     }
     let win = getQuickAskWindow();
@@ -453,7 +466,12 @@ export function setCompanionPinned(pinned: boolean) {
  */
 export function setPinnedCollapsed(collapsed: boolean) {
   const win = getQuickAskWindow();
-  if (!win || mode !== 'pinned' || pinnedCollapsed === collapsed) return;
+  if (!win || mode !== 'pinned') return;
+  // Deliberately NO same-state short-circuit: geometry is re-applied and
+  // mode re-pushed even when `collapsed` matches, so a renderer that
+  // drifted out of sync (or a window left at the wrong size) self-heals on
+  // the next request instead of wedging — a "no change" request is cheap
+  // and idempotent.
   pinnedCollapsed = collapsed;
   if (collapsed) {
     if (appliedExpandedSurface === 'card') {

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -118,6 +118,7 @@ type PopoutState = {
   cameraOn: boolean;
   micMuted: boolean;
   screenSharing: boolean;
+  speakerMuted: boolean;
   interimText: string | null;
   pttLocked: boolean;
   responseText: string | null;

--- a/apps/x/apps/main/src/screen-pointer.ts
+++ b/apps/x/apps/main/src/screen-pointer.ts
@@ -1,0 +1,177 @@
+/**
+ * Screen pointer: while the user shares their screen on a call, the
+ * assistant can point at a spot on the REAL display — a transparent,
+ * click-through overlay window covering the shared (primary) display renders
+ * an animated marker with an optional label (renderer hash #screen-pointer).
+ *
+ * This is the main-process implementation of core's IScreenPointerService
+ * (registered in main.ts, same DI seam as browser control): the
+ * screen-pointer builtin tool executes right here, no renderer round-trip.
+ * The renderer only reports share start/stop (screenPointer:setShareActive),
+ * which gates pointing and tears the overlay down when the share ends.
+ */
+import { DEV_SERVER_URL } from './dev-server.js';
+import { app, BrowserWindow, screen } from 'electron';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  IScreenPointerService,
+  ScreenPointerResult,
+  ScreenPointerTarget,
+} from '@x/core/dist/application/screen-pointer/service.js';
+
+const DEFAULT_DURATION_MS = 8000;
+
+type PointerState = {
+  visible: boolean;
+  x: number;
+  y: number;
+  label: string | null;
+  nonce: number;
+};
+
+export class ElectronScreenPointerService implements IScreenPointerService {
+  private overlayWin: BrowserWindow | null = null;
+  private shareActive = false;
+  private hideTimer: NodeJS.Timeout | null = null;
+  // Replayed on overlay load — window creation races the first point.
+  private lastState: PointerState | null = null;
+  private nonce = 0;
+
+  isShareActive(): boolean {
+    return this.shareActive;
+  }
+
+  /** Renderer-reported share state; ending a share tears the overlay down. */
+  setShareActive(active: boolean): void {
+    if (this.shareActive !== active) {
+      console.log(`[screen-pointer] share ${active ? 'started' : 'ended'}`);
+    }
+    this.shareActive = active;
+    if (!active) void this.hide();
+  }
+
+  /** Overlay pulls this on mount — the did-finish-load push can beat the
+   *  React listener registration (same race as video:getPopoutState). */
+  getState(): PointerState | null {
+    return this.lastState;
+  }
+
+  async point(target: ScreenPointerTarget): Promise<ScreenPointerResult> {
+    if (!this.shareActive) {
+      console.log('[screen-pointer] point rejected: no live share');
+      return { success: false, error: 'No screen share is live.' };
+    }
+    console.log(`[screen-pointer] point x=${target.x.toFixed(3)} y=${target.y.toFixed(3)}${target.label ? ` label="${target.label}"` : ''}`);
+    const state: PointerState = {
+      visible: true,
+      x: Math.min(1, Math.max(0, target.x)),
+      y: Math.min(1, Math.max(0, target.y)),
+      label: target.label?.trim() ? target.label.trim() : null,
+      nonce: ++this.nonce,
+    };
+    this.pushState(state);
+    this.ensureOverlay();
+
+    if (this.hideTimer) clearTimeout(this.hideTimer);
+    const duration = target.durationMs ?? DEFAULT_DURATION_MS;
+    this.hideTimer = setTimeout(() => void this.hide(), duration);
+    return { success: true };
+  }
+
+  async hide(): Promise<void> {
+    if (this.hideTimer) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+    this.lastState = null;
+    // Destroy rather than blank: the overlay only exists while something is
+    // being pointed at, so a stray transparent window can never linger over
+    // the user's screen.
+    if (this.overlayWin && !this.overlayWin.isDestroyed()) this.overlayWin.destroy();
+    this.overlayWin = null;
+  }
+
+  private pushState(state: PointerState): void {
+    this.lastState = state;
+    if (this.overlayWin && !this.overlayWin.isDestroyed()) {
+      this.overlayWin.webContents.send('screen-pointer:state', state);
+    }
+  }
+
+  private ensureOverlay(): void {
+    if (this.overlayWin && !this.overlayWin.isDestroyed()) return;
+
+    // Screen share always captures the primary display (no picker yet), so
+    // the overlay covers its FULL bounds — frame coordinates are fractions
+    // of the captured display, and the capture includes the menu bar.
+    const { bounds } = screen.getPrimaryDisplay();
+    const hereDir = path.dirname(fileURLToPath(import.meta.url));
+    const preloadPath = app.isPackaged
+      ? path.join(hereDir, '../preload/dist/preload.js')
+      : path.join(hereDir, '../../../preload/dist/preload.js');
+    const win = new BrowserWindow({
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      frame: false,
+      resizable: false,
+      movable: false,
+      // Same fullscreen-Space guards as the call popout (ipc.ts).
+      fullscreenable: false,
+      minimizable: false,
+      maximizable: false,
+      // NSPanel: the pointer must appear over other apps' fullscreen Spaces —
+      // the user is usually presenting something outside Rowboat.
+      ...(process.platform === 'darwin' ? { type: 'panel' as const } : {}),
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      show: false,
+      hasShadow: false,
+      transparent: true,
+      // A transparent full-screen window must never take focus or rounded
+      // corners — it's pure ink over the user's screen.
+      focusable: false,
+      roundedCorners: false,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+        preload: preloadPath,
+      },
+    });
+    // Above the call pill ('floating') — the pointer is momentary ink and
+    // must not end up under other overlay chrome.
+    win.setAlwaysOnTop(true, 'screen-saver');
+    if (process.platform === 'darwin') {
+      win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
+    }
+    // Click-through: the user keeps working underneath the pointer.
+    win.setIgnoreMouseEvents(true);
+    win.webContents.once('did-finish-load', () => {
+      if (win.isDestroyed()) return;
+      console.log('[screen-pointer] overlay loaded');
+      // Best-effort replay; the overlay also PULLS via screenPointer:getState
+      // on mount, since this push can fire before React has subscribed.
+      if (this.lastState) win.webContents.send('screen-pointer:state', this.lastState);
+      // showInactive: appearing must never steal focus from the app the
+      // user is presenting.
+      win.showInactive();
+    });
+    win.webContents.on('did-fail-load', (_e, code, desc) => {
+      console.error(`[screen-pointer] overlay failed to load: ${code} ${desc}`);
+    });
+    win.on('closed', () => {
+      if (this.overlayWin === win) this.overlayWin = null;
+    });
+    this.overlayWin = win;
+    if (app.isPackaged) {
+      void win.loadURL('app://-/index.html#screen-pointer');
+    } else {
+      void win.loadURL(`${DEV_SERVER_URL}/#screen-pointer`);
+    }
+  }
+}
+
+export const screenPointerService = new ElectronScreenPointerService();

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1073,8 +1073,8 @@ function App() {
       spokenVoiceRef.current.count += 1
       if (
         (ttsEnabledRef.current || speakTurnRef.current) &&
-        !companionTextModeRef.current &&
-        !suppressSpeechTurnRef.current
+        !suppressSpeechTurnRef.current &&
+        !speakerMutedRef.current
       ) {
         const marks = callTurnMarksRef.current
         if (marks && marks.speak === undefined) marks.speak = performance.now()
@@ -1093,8 +1093,8 @@ function App() {
     if (activeIsProcessing) return
     const turn = callTurnVoiceRef.current
     if (!turn.pending) return
-    // Text mode (the companion's expanded card): no fallback read-aloud.
-    if (companionTextModeRef.current || suppressSpeechTurnRef.current) {
+    // Typed turn or speaker muted: no fallback read-aloud.
+    if (suppressSpeechTurnRef.current || speakerMutedRef.current) {
       turn.pending = false
       return
     }
@@ -1175,12 +1175,16 @@ function App() {
   // future summon starts already sharing, until toggled off.
   const companionVoiceRef = useRef(false)
   const companionVoiceStartingRef = useRef(false)
-  // The companion's expanded CARD is TEXT MODE: replies render as text and
-  // are not spoken (pushed from the bar over quick-ask:text-mode). The
-  // per-turn ref makes the choice stick for a whole turn — a reply to a
-  // text-mode question stays silent even if the user tucks mid-stream.
-  const companionTextModeRef = useRef(false)
+  // Speech follows the QUESTION's modality, not the surface: a spoken
+  // question (PTT utterance) gets a spoken reply — even with the Skipper's
+  // text panel open — while a typed question renders silently. Stamped
+  // per-turn at submit so the choice sticks for the whole reply.
   const suppressSpeechTurnRef = useRef(false)
+  // Output mute (the Skipper's speaker pin): no reply audio while set —
+  // independent of micMuted (which pauses INPUT).
+  const [speakerMuted, setSpeakerMuted] = useState(false)
+  const speakerMutedRef = useRef(false)
+  speakerMutedRef.current = speakerMuted
   // In-call mute: a full input pause, not just audio — mic audio stops
   // reaching Deepgram AND camera/screen frame capture stops, so nothing said
   // or shown while muted ever reaches the assistant. Output is untouched
@@ -1408,6 +1412,7 @@ function App() {
     setPracticeMode(preset === 'practice')
     practiceModeRef.current = preset === 'practice'
     setMicMuted(false)
+    setSpeakerMuted(false)
     // Every preset starts in the floating pill (video included — the camera
     // preview lives in the pill) except practice, where the coaching session
     // is a deliberate face-to-face full screen.
@@ -1747,13 +1752,14 @@ function App() {
         cameraOn: video.cameraOn,
         micMuted,
         screenSharing: video.screenState === 'live',
+        speakerMuted,
         interimText: voice.interimText || null,
         pttLocked: pttStatus === 'locked',
         responseText: callResponseText,
         questionText: callQuestionText,
       })
       .catch(() => {})
-  }, [inCall, tts.state, videoCallStatus, video.cameraOn, micMuted, video.screenState, voice.interimText, pttStatus, callResponseText, callQuestionText])
+  }, [inCall, tts.state, videoCallStatus, video.cameraOn, micMuted, video.screenState, speakerMuted, voice.interimText, pttStatus, callResponseText, callQuestionText])
 
   // Screen-pointer gate: tell main whether a share is live (call OR
   // quick-ask — this window owns the capture either way). While true the
@@ -1786,6 +1792,22 @@ function App() {
           localStorage.setItem('companion-share-sticky', video.screenState !== 'live' ? '1' : '0')
         }
         void handleToggleScreenShare()
+      }
+      else if (action === 'toggle-speaker') {
+        setSpeakerMuted((muted) => {
+          const next = !muted
+          if (next) {
+            // Muting hushes NOW: silence in-flight speech and drop the
+            // queued backlog (marked as voiced so the fallback net doesn't
+            // read the reply aloud after an unmute).
+            ttsRef.current.cancel()
+            if (voiceSegmentsRef.current) {
+              spokenVoiceRef.current.count = voiceSegmentsRef.current.length
+            }
+            spokeSegmentThisTurnRef.current = true
+          }
+          return next
+        })
       }
       else if (action === 'stop-speaking') handleInterruptAssistant()
       else if (action === 'ptt-down') handlePttDown()
@@ -1943,21 +1965,8 @@ function App() {
     })
   }, [])
 
-  // Companion text mode (the expanded card): entering it hushes in-flight
-  // speech and skips the queued voice backlog; while it's on, replies are
-  // text only. Voice comes back when the card tucks away.
-  useEffect(() => {
-    return window.ipc.on('quick-ask:text-mode', ({ textMode }) => {
-      companionTextModeRef.current = textMode
-      if (textMode) {
-        ttsRef.current.cancel()
-        if (voiceSegmentsRef.current) {
-          spokenVoiceRef.current.count = voiceSegmentsRef.current.length
-        }
-        spokeSegmentThisTurnRef.current = true
-      }
-    })
-  }, [])
+  // (The old surface-based text-mode hush is gone: speech now follows each
+  // question's modality, plus the explicit speaker mute below.)
 
   // Tuck relay: the bar pushed its text into the mascot — voice-to-voice.
   // This is the voice call preset's long-promised "floating mascot pill"
@@ -3592,9 +3601,12 @@ function App() {
     // outside the bar never start talking.
     speakTurnRef.current =
       !inCallRef.current && quickAskActiveRef.current && quickAskOptionsRef.current.voiceOutput
-    // A turn submitted from the companion's expanded card is a TEXT turn:
-    // its reply renders silently, even if the user tucks mid-reply.
-    suppressSpeechTurnRef.current = inCallRef.current && companionTextModeRef.current
+    // Modality decides speech on calls: a TYPED question (composer, Skipper
+    // panel, popout input) renders its reply silently; a SPOKEN one (PTT
+    // utterance — pendingVoiceInputRef is set just before submit) is spoken
+    // even with the text panel open. Stamped per-turn so tucking or typing
+    // mid-reply never flips an in-flight answer.
+    suppressSpeechTurnRef.current = inCallRef.current && !pendingVoiceInputRef.current
 
     if (inCallRef.current || speakTurnRef.current) {
       // A new question supersedes whatever of the previous reply was still

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useCallback, useEffect, useLayoutEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
 import { workspace } from '@x/shared';
 import { RunEvent } from '@x/shared/src/runs.js';
 import type { ToolUIPart } from 'ai';
@@ -1740,6 +1740,26 @@ function App() {
     }
   }
 
+  // What's happening right now, at tool-NAME level ("Searching the web…",
+  // "Reasoning…" — never arguments): the most recent activity wins — a
+  // running tool by display name, else reasoning, else plain thinking.
+  // Feeds the summoned bar's status line AND the Skipper's chip/panel.
+  const liveActivityText = useMemo(() => {
+    if (!activeIsProcessing) return null
+    let label = activeIsReasoning ? 'Reasoning…' : 'Thinking…'
+    for (let i = liveConversation.length - 1; i >= 0; i--) {
+      const item = liveConversation[i]
+      if (isToolCall(item)) {
+        if (item.status === 'pending' || item.status === 'running') {
+          label = `${getToolDisplayName(item)}…`
+        }
+        break
+      }
+      if (isChatMessage(item)) break
+    }
+    return label
+  }, [activeIsProcessing, activeIsReasoning, liveConversation])
+
   // Keep the popout's mascot/status/devices/caption mirror of the call fresh.
   // The main process caches the latest state and replays it when the popout
   // loads.
@@ -1753,13 +1773,14 @@ function App() {
         micMuted,
         screenSharing: video.screenState === 'live',
         speakerMuted,
+        activityText: liveActivityText,
         interimText: voice.interimText || null,
         pttLocked: pttStatus === 'locked',
         responseText: callResponseText,
         questionText: callQuestionText,
       })
       .catch(() => {})
-  }, [inCall, tts.state, videoCallStatus, video.cameraOn, micMuted, video.screenState, speakerMuted, voice.interimText, pttStatus, callResponseText, callQuestionText])
+  }, [inCall, tts.state, videoCallStatus, video.cameraOn, micMuted, video.screenState, speakerMuted, liveActivityText, voice.interimText, pttStatus, callResponseText, callQuestionText])
 
   // Screen-pointer gate: tell main whether a share is live (call OR
   // quick-ask — this window owns the capture either way). While true the
@@ -2026,28 +2047,11 @@ function App() {
     // Nothing new yet (run not started / no fresh answer): pushing would
     // only flicker the bar's local "Thinking…" state away.
     if (!text && !activeIsProcessing) return
-    // What's happening right now, for the bar's blinking status line: the
-    // most recent activity wins — a running tool by name, else reasoning,
-    // else plain thinking.
-    let statusText: string | null = null
-    if (activeIsProcessing) {
-      statusText = activeIsReasoning ? 'Reasoning…' : 'Thinking…'
-      for (let i = liveConversation.length - 1; i >= 0; i--) {
-        const item = liveConversation[i]
-        if (isToolCall(item)) {
-          if (item.status === 'pending' || item.status === 'running') {
-            statusText = `${getToolDisplayName(item)}…`
-          }
-          break
-        }
-        if (isChatMessage(item)) break
-      }
-    }
     void window.ipc
-      .invoke('quickAsk:state', { processing: activeIsProcessing, responseText: text || null, statusText })
+      .invoke('quickAsk:state', { processing: activeIsProcessing, responseText: text || null, statusText: liveActivityText })
       .catch(() => {})
     if (!activeIsProcessing && text) quickAskActiveRef.current = false
-  }, [activeIsProcessing, activeIsReasoning, liveAssistantMessage, liveConversation])
+  }, [activeIsProcessing, liveActivityText, liveAssistantMessage, liveConversation])
 
   // Enter to submit voice input, Escape to cancel
   useEffect(() => {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1755,6 +1755,22 @@ function App() {
       .catch(() => {})
   }, [inCall, tts.state, videoCallStatus, video.cameraOn, micMuted, video.screenState, voice.interimText, pttStatus, callResponseText, callQuestionText])
 
+  // Screen-pointer gate: tell main whether a share is live (call OR
+  // quick-ask — this window owns the capture either way). While true the
+  // assistant's screen-pointer tool may draw on the shared display; flipping
+  // false tears the pointer overlay down instantly.
+  useEffect(() => {
+    try {
+      void window.ipc
+        .invoke('screenPointer:setShareActive', { active: video.screenState === 'live' })
+        .catch((err) => console.warn('[screen-pointer] setShareActive failed:', err))
+    } catch (err) {
+      // A stale preload (app not restarted since the channel was added)
+      // throws synchronously from schema validation — must not break the app.
+      console.warn('[screen-pointer] setShareActive failed:', err)
+    }
+  }, [video.screenState])
+
   // Execute popout control-bar actions (the popout window has no access to
   // the call's mic/camera/capture — they live here). 'expand' goes full
   // screen, which by the exclusivity rule stops any running share; the main
@@ -3704,7 +3720,11 @@ function App() {
             },
           },
         },
-        autoPermission: (permissionMode ?? 'manual') === 'auto',
+        // Default matches the composer toggle's default (auto): submissions
+        // that don't thread a mode — voice/PTT utterances, quick-ask, popout
+        // text — must not silently fall back to manual, which skipped the
+        // auto-permission classifier and carded EVERY gated tool mid-call.
+        autoPermission: (permissionMode ?? 'auto') === 'auto',
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(chatMaxModelCalls !== undefined ? { maxModelCalls: chatMaxModelCalls } : {}),
       }

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -70,6 +70,8 @@ type CallState = {
   screenSharing: boolean
   /** Output mute (the speaker pin): replies are not spoken while set. */
   speakerMuted: boolean
+  /** Tool-name-level "what's happening" while a turn runs, else null. */
+  activityText: string | null
   interimText: string | null
   /** A quick ⌘ tap locked hands-free capture (until the next tap). */
   pttLocked: boolean
@@ -86,6 +88,7 @@ const IDLE_CALL_STATE: CallState = {
   micMuted: false,
   screenSharing: false,
   speakerMuted: false,
+  activityText: null,
   interimText: null,
   pttLocked: false,
   responseText: null,
@@ -212,6 +215,9 @@ export function QuickAskBar() {
   // this window only renders it (same contract as the old popout).
   const [callState, setCallState] = useState<CallState>(IDLE_CALL_STATE)
   speakerMutedRef.current = callState.speakerMuted
+  // Flicker-held activity label shared by every surface this window renders
+  // (Skipper chip + panel, tucked chip, pill chip).
+  const heldActivity = useHeldLabel(callState.activityText)
   useEffect(() => {
     const cleanup = window.ipc.on('video:popout-state', (next) => setCallState(next))
     // Main replays the cached state on did-finish-load, but that can race
@@ -677,6 +683,7 @@ export function QuickAskBar() {
     return (
       <TuckedMascot
         state={callState}
+        activity={heldActivity}
         sendAction={sendAction}
         onExpand={() => requestCollapsed(false)}
       />
@@ -691,6 +698,7 @@ export function QuickAskBar() {
       <>
         <PinnedPill
           state={callState}
+          activity={heldActivity}
           sendAction={sendAction}
           onCollapse={() => requestCollapsed(true)}
           composer={
@@ -724,7 +732,9 @@ export function QuickAskBar() {
   const panelAsked = callCard ? callState.questionText : asked
   const panelText = callCard ? (callState.responseText ?? '') : (answer?.text ?? '')
   const panelProcessing = callCard ? callState.status === 'thinking' : processing
-  const panelStatusText = (!callCard && answer?.statusText) || 'Thinking…'
+  const panelStatusText = callCard
+    ? (heldActivity ?? 'Thinking…')
+    : (answer?.statusText || 'Thinking…')
   // One-line caption under the Skipper's mascot: the in-flight utterance
   // wins; otherwise the tail of the reply while it speaks.
   const skipperReplyTail =
@@ -1178,7 +1188,7 @@ export function QuickAskBar() {
               )}
             </div>
             <div className="flex h-6 items-center">
-              <SkipperStatusChip state={callState} />
+              <SkipperStatusChip state={callState} activity={heldActivity} />
             </div>
           </>
         )}
@@ -1198,6 +1208,31 @@ const STATUS_DISPLAY: Record<NonNullable<CallState['status']>, { label: string; 
 
 const dragRegion = { WebkitAppRegion: 'drag' } as React.CSSProperties
 const noDragRegion = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
+
+/**
+ * Anti-flicker hold for the activity label: agent turns fire tool calls in
+ * quick bursts, and mirroring them raw makes the chip strobe. Each shown
+ * label holds for a minimum beat; the newest value wins once it elapses.
+ */
+function useHeldLabel(next: string | null, holdMs = 800): string | null {
+  const [shown, setShown] = useState<string | null>(next)
+  const shownAtRef = useRef(0)
+  useEffect(() => {
+    if (next === shown) return
+    const apply = () => {
+      shownAtRef.current = Date.now()
+      setShown(next)
+    }
+    const elapsed = Date.now() - shownAtRef.current
+    if (shown === null || elapsed >= holdMs) {
+      apply()
+      return
+    }
+    const timer = setTimeout(apply, holdMs - elapsed)
+    return () => clearTimeout(timer)
+  }, [next, shown, holdMs])
+  return shown
+}
 
 /**
  * The Skipper's control pins — ONE cluster for both presentations (text
@@ -1333,8 +1368,11 @@ function SkipperPins({
  * The Skipper's status line — the same words under the mascot in both
  * presentations. While the mic gate is open it goes loud (green, mic icon):
  * paired with the listening halo, holding right ⌘ is unmistakably working.
+ * While a turn runs, the generic "Thinking…" upgrades to the current
+ * activity ("Searching the web…") when one is known — flicker-held by the
+ * caller via useHeldLabel.
  */
-function SkipperStatusChip({ state }: { state: CallState }) {
+function SkipperStatusChip({ state, activity }: { state: CallState; activity?: string | null }) {
   const statusDisplay = state.status ? STATUS_DISPLAY[state.status] : null
   const micOpen = !state.micMuted && (state.status === 'listening' || state.pttLocked)
   return (
@@ -1361,7 +1399,11 @@ function SkipperStatusChip({ state }: { state: CallState }) {
       ) : statusDisplay ? (
         <>
           <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
-          {state.status === 'idle' ? 'Hold the mic — or right ⌘' : statusDisplay.label}
+          {state.status === 'idle'
+            ? 'Hold the mic — or right ⌘'
+            : state.status === 'thinking' && activity
+              ? activity
+              : statusDisplay.label}
         </>
       ) : (
         <>
@@ -1387,11 +1429,13 @@ function SkipperStatusChip({ state }: { state: CallState }) {
  */
 function PinnedPill({
   state,
+  activity,
   sendAction,
   onCollapse,
   composer,
 }: {
   state: CallState
+  activity?: string | null
   sendAction: (action: PopoutAction) => void
   /** Tuck the pill down to just the mascot (voice-to-voice presentation). */
   onCollapse: () => void
@@ -1559,7 +1603,7 @@ function PinnedPill({
               ) : (
                 <>
                   <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
-                  {statusDisplay.label}
+                  {state.status === 'thinking' && activity ? activity : statusDisplay.label}
                 </>
               )}
             </span>
@@ -1751,10 +1795,12 @@ function PinnedPill({
  */
 function TuckedMascot({
   state,
+  activity,
   sendAction,
   onExpand,
 }: {
   state: CallState
+  activity?: string | null
   sendAction: (action: PopoutAction) => void
   onExpand: () => void
 }) {
@@ -1840,7 +1886,7 @@ function TuckedMascot({
       </div>
       {/* Pure status line — the CONTROLS are the pins. */}
       <div className="flex h-6 items-center">
-        <SkipperStatusChip state={state} />
+        <SkipperStatusChip state={state} activity={activity} />
       </div>
     </div>
   )

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -201,7 +201,10 @@ export function QuickAskBar() {
     if (next && speakerMutedRef.current) {
       void window.ipc.invoke('video:popoutAction', { action: 'toggle-speaker' }).catch(() => {})
     }
-    setCollapsed(next)
+    // No optimistic local flip: main owns collapsed state and window
+    // geometry as one unit, and answers with a quick-ask:mode push. A local
+    // flip could disagree with the window size (the squeezed-card wedge
+    // where every control looks dead) — one IPC round-trip is imperceptible.
     void window.ipc.invoke('quickAsk:setPinnedCollapsed', { collapsed: next }).catch(() => {})
   }, [])
 

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowUpRight,
   ChevronDown,
@@ -734,6 +734,23 @@ export function QuickAskBar() {
       : ''
   const skipperCaption = skipper ? (callState.interimText || skipperReplyTail) : ''
 
+  // History includes the chat's LATEST messages — but the current exchange
+  // is already rendered below the "earlier" divider, so trim it off the
+  // tail. Matched on the question text (the reliable key: a streaming reply
+  // can differ from its stored copy): drop the newest user message and
+  // everything after it iff it IS the question on display.
+  const earlierItems = useMemo(() => {
+    if (!historyData) return historyData
+    const current = (panelAsked ?? '').trim()
+    if (!current) return historyData
+    for (let i = historyData.length - 1; i >= 0; i--) {
+      if (historyData[i].role !== 'user') continue
+      if (historyData[i].content.trim() === current) return historyData.slice(0, i)
+      break
+    }
+    return historyData
+  }, [historyData, panelAsked])
+
   return (
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden">
       {/* The invisible stage: popovers open into this zone; clicking it
@@ -955,13 +972,13 @@ export function QuickAskBar() {
             {showHistory && historyData === null && (
               <div className="mb-2 animate-pulse text-xs text-neutral-400">Loading history…</div>
             )}
-            {showHistory && historyData !== null && (
+            {showHistory && earlierItems !== null && (
               <div className="mb-1">
-                {historyData.length === 0 ? (
+                {earlierItems.length === 0 ? (
                   <div className="mb-2 text-xs text-neutral-400">No earlier messages in this chat.</div>
                 ) : (
                   <div className="opacity-75">
-                    {historyData.map((m, i) =>
+                    {earlierItems.map((m, i) =>
                       m.role === 'user' ? (
                         <div key={i} className="mb-1.5 mt-3 text-sm font-medium text-neutral-500 first:mt-0">
                           {m.content}
@@ -977,7 +994,7 @@ export function QuickAskBar() {
                     )}
                   </div>
                 )}
-                {(panelAsked || panelText) && historyData.length > 0 && (
+                {(panelAsked || panelText) && earlierItems.length > 0 && (
                   <div className="my-2 flex items-center gap-2 text-[9px] uppercase tracking-wider text-neutral-400">
                     <span className="h-px flex-1 bg-black/10" />
                     earlier

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -19,6 +19,7 @@ import {
   Video,
   VideoOff,
   Volume2,
+  VolumeX,
   X,
 } from 'lucide-react'
 import { Streamdown } from 'streamdown'
@@ -67,6 +68,8 @@ type CallState = {
   /** User mute = full input pause: no mic audio AND no frame capture. */
   micMuted: boolean
   screenSharing: boolean
+  /** Output mute (the speaker pin): replies are not spoken while set. */
+  speakerMuted: boolean
   interimText: string | null
   /** A quick ⌘ tap locked hands-free capture (until the next tap). */
   pttLocked: boolean
@@ -82,6 +85,7 @@ const IDLE_CALL_STATE: CallState = {
   cameraOn: false,
   micMuted: false,
   screenSharing: false,
+  speakerMuted: false,
   interimText: null,
   pttLocked: false,
   responseText: null,
@@ -92,6 +96,7 @@ type PopoutAction =
   | 'toggle-mic'
   | 'toggle-camera'
   | 'toggle-share'
+  | 'toggle-speaker'
   | 'stop-speaking'
   | 'ptt-down'
   | 'ptt-up'
@@ -184,20 +189,26 @@ export function QuickAskBar() {
   // from a bar-originated tuck): same layout, call-aware contents.
   const callCard = pinned && !collapsed && surface === 'card'
 
+  // Mirrors callState.speakerMuted for the fold callback below (which is
+  // deliberately dependency-free).
+  const speakerMutedRef = useRef(false)
+
   const requestCollapsed = useCallback((next: boolean) => {
+    // Folding the text makes VOICE the only output channel — a muted
+    // speaker there would mean no answer arrives at all, so folding always
+    // unmutes. (The toggle itself lives on the text panel for the same
+    // reason: it's a "read instead of listen" choice.)
+    if (next && speakerMutedRef.current) {
+      void window.ipc.invoke('video:popoutAction', { action: 'toggle-speaker' }).catch(() => {})
+    }
     setCollapsed(next)
     void window.ipc.invoke('quickAsk:setPinnedCollapsed', { collapsed: next }).catch(() => {})
   }, [])
 
-  // The expanded card is TEXT MODE: tell the app so replies render silently
-  // there (and any in-flight speech hushes the moment the card opens).
-  useEffect(() => {
-    void window.ipc.invoke('quickAsk:setTextMode', { textMode: callCard }).catch(() => {})
-  }, [callCard])
-
   // Call state mirrored from the app window, which owns the call engine —
   // this window only renders it (same contract as the old popout).
   const [callState, setCallState] = useState<CallState>(IDLE_CALL_STATE)
+  speakerMutedRef.current = callState.speakerMuted
   useEffect(() => {
     const cleanup = window.ipc.on('video:popout-state', (next) => setCallState(next))
     // Main replays the cached state on did-finish-load, but that can race
@@ -705,7 +716,6 @@ export function QuickAskBar() {
   const panelText = callCard ? (callState.responseText ?? '') : (answer?.text ?? '')
   const panelProcessing = callCard ? callState.status === 'thinking' : processing
   const panelStatusText = (!callCard && answer?.statusText) || 'Thinking…'
-  const callStatusDisplay = callCard && callState.status ? STATUS_DISPLAY[callState.status] : null
 
   return (
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden">
@@ -824,103 +834,32 @@ export function QuickAskBar() {
                   : 'No history yet — this is a new chat'}
             </TooltipContent>
           </Tooltip>
+          {/* Call controls live on the MASCOT (the same pins as the folded
+              Skipper); this strip keeps chat-destination affordances plus
+              the speaker mute — a "read instead of listen" choice that only
+              exists while the text panel does (folding auto-unmutes). */}
           {callCard && (
-            <span className="mr-auto flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-neutral-500">
-              <span
-                className={`block h-1.5 w-1.5 rounded-full ${
-                  callState.micMuted
-                    ? 'bg-red-500'
-                    : callStatusDisplay
-                      ? callStatusDisplay.dotClass
-                      : 'bg-neutral-400'
-                }`}
-              />
-              {callState.micMuted
-                ? 'Muted'
-                : callState.pttLocked
-                  ? 'Hands-free — tap ⌘ to send'
-                  : (callStatusDisplay?.label ?? 'Voice call')}
-            </span>
-          )}
-          {callCard && (
-            <>
-              {(callState.status === 'speaking' || callState.status === 'thinking') && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => sendAction('stop-speaking')}
-                      aria-label="Stop the assistant"
-                      className="flex h-7 items-center gap-1 rounded-full bg-red-500/15 px-2.5 text-[11px] font-medium text-red-600 ring-1 ring-inset ring-red-500/30 transition-colors hover:bg-red-500/25"
-                    >
-                      <Square className="h-2.5 w-2.5 fill-current" />
-                      Stop
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    {callState.status === 'speaking' ? 'Stop speaking' : 'Stop responding'}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Share consent + control on the card too: expanding while
-                  sharing keeps the TEXT surface (only a live camera forces
-                  the pill), so the lit toggle is the card's share badge —
-                  it must never be possible to share with no indicator in
-                  sight. */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => sendAction('toggle-share')}
-                    aria-label={callState.screenSharing ? 'Stop sharing your screen' : 'Share your screen'}
-                    className={`flex h-7 w-7 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
-                      callState.screenSharing
-                        ? 'bg-sky-500/15 text-sky-600 ring-sky-500/30'
-                        : 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                    }`}
-                  >
-                    <MonitorUp className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {callState.screenSharing
-                    ? 'Sharing your screen — click to stop'
-                    : 'Share your screen with this session'}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => sendAction('toggle-mic')}
-                    aria-label={callState.micMuted ? 'Unmute' : 'Mute (pauses mic and frame capture)'}
-                    className={`flex h-7 w-7 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
-                      callState.micMuted
-                        ? 'bg-red-500/15 text-red-600 ring-red-500/30'
-                        : 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                    }`}
-                  >
-                    {callState.micMuted ? <MicOff className="h-3.5 w-3.5" /> : <Mic className="h-3.5 w-3.5" />}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {callState.micMuted ? 'Unmute' : 'Mute — pauses your mic'}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => sendAction('end-call')}
-                    aria-label="End call"
-                    className="flex h-7 w-7 items-center justify-center rounded-full bg-red-600 text-white ring-1 ring-inset ring-red-700/30 transition-colors hover:bg-red-500"
-                  >
-                    <PhoneOff className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">End the voice session</TooltipContent>
-              </Tooltip>
-            </>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => sendAction('toggle-speaker')}
+                  aria-label={callState.speakerMuted ? 'Unmute spoken replies' : 'Mute spoken replies'}
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
+                    callState.speakerMuted
+                      ? 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
+                      : 'bg-sky-500/15 text-sky-700 ring-sky-500/30'
+                  }`}
+                >
+                  {callState.speakerMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {callState.speakerMuted
+                  ? 'Replies are silent while the text is open — click to speak them again'
+                  : 'Spoken questions are answered aloud — click to read replies silently instead'}
+              </TooltipContent>
+            </Tooltip>
           )}
           {!callCard && (
             <>
@@ -1113,13 +1052,15 @@ export function QuickAskBar() {
           TalkingHead the product tour and call tiles render. On the call
           card it lip-syncs the spoken reply; summoned it bobs, with
           thinking bubbles while a question is processing. On the Skipper
-          (callCard) the mascot IS the drag handle — grab it to carry the
-          whole companion around; summoned it stays inert (pointer-events
-          none, clicks neither dismiss nor do anything). */}
+          (callCard) the mascot IS the control surface AND the drag handle —
+          the same pins as the folded presentation ride its hat and hull,
+          the status line sits beneath, and grabbing anywhere else on it
+          carries the whole companion around; summoned it stays inert
+          (pointer-events none, clicks neither dismiss nor do anything). */}
       <div
-        className={`relative w-[124px] shrink-0 select-none ${callCard ? 'cursor-grab' : 'pointer-events-none'}`}
+        className={`relative flex w-[132px] shrink-0 select-none flex-col items-center ${callCard ? 'cursor-grab' : 'pointer-events-none'}`}
         style={callCard ? dragRegion : undefined}
-        aria-hidden="true"
+        aria-hidden={callCard ? undefined : true}
         title={callCard ? 'Drag to move your Skipper' : undefined}
       >
         {callCard && (
@@ -1158,7 +1099,22 @@ export function QuickAskBar() {
           getLevel={callCard ? synthLevel : zeroLevel}
           size={124}
           hat={callCard ? 'cowboy' : undefined}
+          hatOverlay={
+            callCard ? (
+              <SkipperPins
+                state={callState}
+                sendAction={sendAction}
+                textPin="collapse"
+                onTextPin={() => requestCollapsed(true)}
+              />
+            ) : undefined
+          }
         />
+        {callCard && (
+          <div className="-mt-3 flex h-6 items-center">
+            <SkipperStatusChip state={callState} />
+          </div>
+        )}
       </div>
       </div>
       <SonnerToaster theme="light" />
@@ -1175,6 +1131,180 @@ const STATUS_DISPLAY: Record<NonNullable<CallState['status']>, { label: string; 
 
 const dragRegion = { WebkitAppRegion: 'drag' } as React.CSSProperties
 const noDragRegion = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
+
+/**
+ * The Skipper's control pins — ONE cluster for both presentations (text
+ * panel open or folded), riding TalkingHead's hatOverlay so they bob with
+ * the artwork. Hat = voice: the mic pin, morphing into Stop while a turn is
+ * in flight. Boat = surface: the share bow light, the text fold/unfold pin
+ * on the left edge, ✕ end on the right. The speaker mute deliberately does
+ * NOT live here — with the text folded, voice is the only output channel,
+ * so the mute is the text panel's affordance. no-drag sits on EACH button:
+ * Electron punches drag-region holes from painted bounds, and a zero-size
+ * wrapper excludes nothing.
+ */
+function SkipperPins({
+  state,
+  sendAction,
+  textPin,
+  onTextPin,
+}: {
+  state: CallState
+  sendAction: (action: PopoutAction) => void
+  /** 'expand' = bring the text back (tucked); 'collapse' = fold it away. */
+  textPin: 'expand' | 'collapse'
+  onTextPin: () => void
+}) {
+  // The mic and Stop are exclusive states of ONE control: while a turn is
+  // in flight the mic is dead anyway, so the hat's single pin morphs.
+  const busy = state.status === 'thinking' || state.status === 'speaking'
+  return (
+    <div>
+      {busy ? (
+        <button
+          type="button"
+          onClick={() => sendAction('stop-speaking')}
+          aria-label="Stop the assistant"
+          title="Stop — cut the reply short (the session keeps going)"
+          className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+          style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
+        >
+          <span className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-red-600 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110">
+            <Square className="h-2.5 w-2.5 fill-current text-white" />
+          </span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          onPointerDown={(e) => {
+            if (state.micMuted) return
+            e.currentTarget.setPointerCapture(e.pointerId)
+            sendAction('ptt-down')
+          }}
+          onPointerUp={() => {
+            if (!state.micMuted) sendAction('ptt-up')
+          }}
+          onPointerCancel={() => {
+            if (!state.micMuted) sendAction('ptt-up')
+          }}
+          aria-label="Hold to talk — tap for hands-free"
+          title="Hold to talk (tap for hands-free) — or hold the right ⌘ key"
+          className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+          style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
+        >
+          <span
+            className={`flex h-[18px] w-[18px] select-none items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
+              state.status === 'listening' || state.pttLocked ? 'bg-green-500' : 'bg-amber-400'
+            }`}
+          >
+            <Mic
+              className={`h-3 w-3 ${
+                state.status === 'listening' || state.pttLocked ? 'text-white' : 'text-[#17171B]'
+              }`}
+            />
+          </span>
+        </button>
+      )}
+      {/* The BOW LIGHT — share pin, front and center on the hull: lit sky +
+          pulsing dot = broadcasting (the lit pin IS the consent badge). The
+          choice is STICKY — future summons start already sharing until it's
+          turned off (persisted app-side). */}
+      <button
+        type="button"
+        onClick={() => sendAction('toggle-share')}
+        aria-label={state.screenSharing ? 'Stop sharing your screen' : 'Share your screen'}
+        className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+        style={{ ...noDragRegion, left: '50%', top: '73%' }}
+      >
+        <span
+          className={`relative flex h-[18px] w-[18px] items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
+            state.screenSharing ? 'bg-sky-500' : 'bg-neutral-600'
+          }`}
+        >
+          <MonitorUp className="h-3 w-3 text-white" />
+          {state.screenSharing && (
+            <span className="absolute -right-1 -top-1 block h-[7px] w-[7px] animate-pulse rounded-full bg-sky-300 ring-1 ring-[#17171B]" />
+          )}
+        </span>
+        <span className="pointer-events-none absolute left-1/2 top-full mt-0.5 -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[9px] font-medium text-white opacity-0 transition-opacity group-hover/pin:opacity-100">
+          {state.screenSharing ? 'Sharing screen — click to stop' : 'Share your screen'}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onTextPin}
+        aria-label={textPin === 'expand' ? 'Bring the text back' : 'Tuck the text away'}
+        title={textPin === 'expand' ? 'Bring the text back (⌥⇧Space works too)' : 'Tuck the text away — the session keeps going'}
+        className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+        style={{ ...noDragRegion, left: '18%', top: '68%' }}
+      >
+        <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-sky-500 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-125">
+          {textPin === 'expand' ? (
+            <ChevronsLeft className="h-2.5 w-2.5 text-white" />
+          ) : (
+            <ChevronsRight className="h-2.5 w-2.5 text-white" />
+          )}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => sendAction('end-call')}
+        aria-label="End the voice session and close"
+        title="End & close (a live session can't be hidden while it keeps listening)"
+        className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+        style={{ ...noDragRegion, left: '82%', top: '68%' }}
+      >
+        <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-neutral-700 shadow-sm ring-2 ring-[#17171B] transition-colors transition-transform group-hover/pin:scale-125 group-hover/pin:bg-red-600">
+          <X className="h-2.5 w-2.5 text-white" />
+        </span>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * The Skipper's status line — the same words under the mascot in both
+ * presentations. While the mic gate is open it goes loud (green, mic icon):
+ * paired with the listening halo, holding right ⌘ is unmistakably working.
+ */
+function SkipperStatusChip({ state }: { state: CallState }) {
+  const statusDisplay = state.status ? STATUS_DISPLAY[state.status] : null
+  const micOpen = !state.micMuted && (state.status === 'listening' || state.pttLocked)
+  return (
+    <span
+      className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium text-white shadow-md ${
+        micOpen ? 'bg-green-600 text-[11px] font-semibold' : 'bg-black/60 text-[10px]'
+      }`}
+    >
+      {state.micMuted && (state.status === 'listening' || state.status === 'idle') ? (
+        <>
+          <span className="block h-1.5 w-1.5 rounded-full bg-red-500" />
+          Muted
+        </>
+      ) : state.pttLocked ? (
+        <>
+          <Mic className="h-3 w-3 animate-pulse" />
+          Hands-free — tap ⌘ to send
+        </>
+      ) : state.status === 'listening' ? (
+        <>
+          <Mic className="h-3 w-3 animate-pulse" />
+          Listening — release to send
+        </>
+      ) : statusDisplay ? (
+        <>
+          <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
+          {state.status === 'idle' ? 'Hold the mic — or right ⌘' : statusDisplay.label}
+        </>
+      ) : (
+        <>
+          <span className="block h-1.5 w-1.5 rounded-full bg-neutral-500" />
+          Connecting…
+        </>
+      )}
+    </span>
+  )
+}
 
 /**
  * The pinned role's layout: the Meet-style floating mini-call pill (absorbed
@@ -1431,6 +1561,19 @@ function PinnedPill({
         </button>
         <button
           type="button"
+          onClick={() => sendAction('toggle-speaker')}
+          className={`flex h-6 w-6 items-center justify-center rounded-full transition-colors ${
+            state.speakerMuted
+              ? 'bg-red-600 text-white hover:bg-red-500'
+              : 'bg-neutral-700 text-white/90 hover:bg-neutral-600'
+          }`}
+          aria-label={state.speakerMuted ? 'Unmute spoken replies' : 'Mute spoken replies'}
+          title={state.speakerMuted ? 'Replies muted — click to speak them' : 'Spoken replies on — click to mute'}
+        >
+          {state.speakerMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
+        </button>
+        <button
+          type="button"
           onClick={() => sendAction('toggle-camera')}
           className={`flex h-6 w-6 items-center justify-center rounded-full transition-colors ${
             state.cameraOn
@@ -1552,11 +1695,6 @@ function TuckedMascot({
   // as the pill's mascot tile.
   const getLevel = useCallback(() => 0.45 + 0.35 * Math.sin(performance.now() / 90), [])
 
-  // The mic and Stop are exclusive states of ONE control: while a turn is
-  // in flight the mic is dead anyway, so the hat's single pin morphs
-  // mic → Stop and back.
-  const busy = state.status === 'thinking' || state.status === 'speaking'
-
   // One-line caption: the user's in-flight utterance wins; otherwise the
   // tail of the reply while it's being spoken (markdown stripped).
   const replyTail =
@@ -1568,8 +1706,6 @@ function TuckedMascot({
           .slice(-90)
       : ''
   const caption = state.interimText || replyTail
-
-  const statusDisplay = state.status ? STATUS_DISPLAY[state.status] : null
 
   // Mic gate open (holding right ⌘ / the pin, or hands-free lock): the ONE
   // state the user must never have to squint for — without visible feedback
@@ -1624,112 +1760,7 @@ function TuckedMascot({
           size={132}
           hat="cowboy"
           hatOverlay={
-            /* Hat = voice, boat = surface. ONE pin on the hat: the mic,
-               which morphs into Stop while a turn is in flight (they're
-               exclusive — the mic is dead while the assistant works) and
-               back when the turn ends. « (bring the text back) rides the
-               boat's left edge; ✕ (end & close) rides its right. no-drag
-               sits on EACH button: Electron punches drag-region holes from
-               painted bounds, and a zero-size wrapper excludes nothing. */
-            <div>
-              {busy ? (
-                <button
-                  type="button"
-                  onClick={() => sendAction('stop-speaking')}
-                  aria-label="Stop the assistant"
-                  title="Stop — cut the reply short (the session keeps going)"
-                  className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-                  style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
-                >
-                  <span className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-red-600 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110">
-                    <Square className="h-2.5 w-2.5 fill-current text-white" />
-                  </span>
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  onPointerDown={(e) => {
-                    if (state.micMuted) return
-                    e.currentTarget.setPointerCapture(e.pointerId)
-                    sendAction('ptt-down')
-                  }}
-                  onPointerUp={() => {
-                    if (!state.micMuted) sendAction('ptt-up')
-                  }}
-                  onPointerCancel={() => {
-                    if (!state.micMuted) sendAction('ptt-up')
-                  }}
-                  aria-label="Hold to talk — tap for hands-free"
-                  title="Hold to talk (tap for hands-free) — or hold the right ⌘ key"
-                  className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-                  style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
-                >
-                  <span
-                    className={`flex h-[18px] w-[18px] select-none items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
-                      state.status === 'listening' || state.pttLocked ? 'bg-green-500' : 'bg-amber-400'
-                    }`}
-                  >
-                    <Mic
-                      className={`h-3 w-3 ${
-                        state.status === 'listening' || state.pttLocked ? 'text-white' : 'text-[#17171B]'
-                      }`}
-                    />
-                  </span>
-                </button>
-              )}
-              {/* The BOW LIGHT — share pin, front and center on the hull:
-                  lit sky + pulsing dot = broadcasting (the lit pin IS the
-                  consent badge, same pattern the old bar's share toggle
-                  used — no floating banner). A quiet hover chip explains
-                  the button; the choice is STICKY — future summons start
-                  already sharing until it's turned off (persisted
-                  app-side). */}
-              <button
-                type="button"
-                onClick={() => sendAction('toggle-share')}
-                aria-label={state.screenSharing ? 'Stop sharing your screen' : 'Share your screen'}
-                className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-                style={{ ...noDragRegion, left: '50%', top: '73%' }}
-              >
-                <span
-                  className={`relative flex h-[18px] w-[18px] items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
-                    state.screenSharing ? 'bg-sky-500' : 'bg-neutral-600'
-                  }`}
-                >
-                  <MonitorUp className="h-3 w-3 text-white" />
-                  {state.screenSharing && (
-                    <span className="absolute -right-1 -top-1 block h-[7px] w-[7px] animate-pulse rounded-full bg-sky-300 ring-1 ring-[#17171B]" />
-                  )}
-                </span>
-                <span className="pointer-events-none absolute left-1/2 top-full mt-0.5 -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[9px] font-medium text-white opacity-0 transition-opacity group-hover/pin:opacity-100">
-                  {state.screenSharing ? 'Sharing screen — click to stop' : 'Share your screen'}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={onExpand}
-                aria-label="Bring the text back"
-                title="Bring the text back (⌥⇧Space works too)"
-                className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-                style={{ ...noDragRegion, left: '18%', top: '68%' }}
-              >
-                <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-sky-500 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-125">
-                  <ChevronsLeft className="h-2.5 w-2.5 text-white" />
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => sendAction('end-call')}
-                aria-label="End the voice session and close"
-                title="End & close (a live session can't be hidden while it keeps listening)"
-                className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-                style={{ ...noDragRegion, left: '82%', top: '68%' }}
-              >
-                <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-neutral-700 shadow-sm ring-2 ring-[#17171B] transition-colors transition-transform group-hover/pin:scale-125 group-hover/pin:bg-red-600">
-                  <X className="h-2.5 w-2.5 text-white" />
-                </span>
-              </button>
-            </div>
+            <SkipperPins state={state} sendAction={sendAction} textPin="expand" onTextPin={onExpand} />
           }
         />
       </div>
@@ -1740,43 +1771,9 @@ function TuckedMascot({
           <span className="truncate rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{caption}</span>
         )}
       </div>
-      {/* Pure status line — the CONTROLS are the pins (gold mic = hold to
-          talk, red = stop) and the ✕ (end & close). While the mic gate is
-          open the chip goes loud (green, mic icon): paired with the halo,
-          holding right ⌘ is unmistakably "working". */}
+      {/* Pure status line — the CONTROLS are the pins. */}
       <div className="flex h-6 items-center">
-        <span
-          className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium text-white shadow-md ${
-            micOpen ? 'bg-green-600 text-[11px] font-semibold' : 'bg-black/60 text-[10px]'
-          }`}
-        >
-          {state.micMuted && (state.status === 'listening' || state.status === 'idle') ? (
-            <>
-              <span className="block h-1.5 w-1.5 rounded-full bg-red-500" />
-              Muted
-            </>
-          ) : state.pttLocked ? (
-            <>
-              <Mic className="h-3 w-3 animate-pulse" />
-              Hands-free — tap ⌘ to send
-            </>
-          ) : state.status === 'listening' ? (
-            <>
-              <Mic className="h-3 w-3 animate-pulse" />
-              Listening — release to send
-            </>
-          ) : statusDisplay ? (
-            <>
-              <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
-              {state.status === 'idle' ? 'Hold the mic — or right ⌘' : statusDisplay.label}
-            </>
-          ) : (
-            <>
-              <span className="block h-1.5 w-1.5 rounded-full bg-neutral-500" />
-              Connecting…
-            </>
-          )}
-        </span>
+        <SkipperStatusChip state={state} />
       </div>
     </div>
   )

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1165,10 +1165,13 @@ export function QuickAskBar() {
           <>
             {/* Fixed-height caption + chip slots: present in BOTH states so
                 the head never shifts when a caption appears or the text
-                folds. */}
-            <div className="flex h-4 max-w-full items-center px-2">
+                folds. Both are single-line and CENTERED on the mascot —
+                wider than the 132px column they overflow it symmetrically
+                (the column doesn't clip), which reads as a caption under
+                the head instead of a squeezed left-ragged wrap. */}
+            <div className="flex h-4 items-center">
               {skipperCaption && (
-                <span className="truncate rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{skipperCaption}</span>
+                <span className="max-w-[176px] truncate whitespace-nowrap rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{skipperCaption}</span>
               )}
             </div>
             <div className="flex h-6 items-center">
@@ -1333,7 +1336,7 @@ function SkipperStatusChip({ state }: { state: CallState }) {
   const micOpen = !state.micMuted && (state.status === 'listening' || state.pttLocked)
   return (
     <span
-      className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium text-white shadow-md ${
+      className={`flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 font-medium text-white shadow-md ${
         micOpen ? 'bg-green-600 text-[11px] font-semibold' : 'bg-black/60 text-[10px]'
       }`}
     >

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -644,11 +644,14 @@ export function QuickAskBar() {
         void submitRecording()
       }
     }
-    document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('keyup', onKeyUp)
+    // Capture phase: right ⌘ must work even while the embedded composer (or
+    // any popover) has focus — "press ⌘ and speak" is promised in BOTH
+    // Skipper states, and bubble-phase listeners can be swallowed below.
+    document.addEventListener('keydown', onKeyDown, true)
+    document.addEventListener('keyup', onKeyUp, true)
     return () => {
-      document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('keyup', onKeyUp)
+      document.removeEventListener('keydown', onKeyDown, true)
+      document.removeEventListener('keyup', onKeyUp, true)
     }
   }, [asked, pinned, surface, collapsed, requestCollapsed, sendAction, startRecording, submitRecording, cancelRecording, reset, dismiss])
 
@@ -1109,10 +1112,39 @@ export function QuickAskBar() {
       {/* The mascot, full silhouette on the transparent stage — the same
           TalkingHead the product tour and call tiles render. On the call
           card it lip-syncs the spoken reply; summoned it bobs, with
-          thinking bubbles while a question is processing. pointer-events-
-          none: clicks on it neither dismiss nor do anything (the tuck
-          handle on the card is the gesture). */}
-      <div className="pointer-events-none w-[124px] shrink-0 select-none" aria-hidden="true">
+          thinking bubbles while a question is processing. On the Skipper
+          (callCard) the mascot IS the drag handle — grab it to carry the
+          whole companion around; summoned it stays inert (pointer-events
+          none, clicks neither dismiss nor do anything). */}
+      <div
+        className={`relative w-[124px] shrink-0 select-none ${callCard ? 'cursor-grab' : 'pointer-events-none'}`}
+        style={callCard ? dragRegion : undefined}
+        aria-hidden="true"
+        title={callCard ? 'Drag to move your Skipper' : undefined}
+      >
+        {callCard && (
+          <style>{`
+            @keyframes listen-ring {
+              0% { transform: scale(0.72); opacity: 0.9; }
+              100% { transform: scale(1.28); opacity: 0; }
+            }
+          `}</style>
+        )}
+        {/* Listening halo — same signal as the tucked mascot: rings pulse
+            around the head while the mic gate is open, so "press ⌘ and
+            speak" is visibly working even with the text panel up. */}
+        {callCard && !callState.micMuted && (callState.status === 'listening' || callState.pttLocked) && (
+          <>
+            <span
+              className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+              style={{ top: '42%', width: 96, height: 96, marginLeft: -48, marginTop: -48, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
+            />
+            <span
+              className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+              style={{ top: '42%', width: 96, height: 96, marginLeft: -48, marginTop: -48, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
+            />
+          </>
+        )}
         <TalkingHead
           ttsState={
             callCard

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1281,6 +1281,27 @@ function PinnedPill({
         </div>
         )}
         <div className="relative flex flex-1 items-center justify-center overflow-hidden rounded-lg bg-neutral-800">
+          <style>{`
+            @keyframes listen-ring {
+              0% { transform: scale(0.72); opacity: 0.9; }
+              100% { transform: scale(1.28); opacity: 0; }
+            }
+          `}</style>
+          {/* Listening halo — same signal as the tucked mascot: while the
+              mic gate is open (right ⌘ held / hands-free), green rings pulse
+              around the head. The corner chip alone is too easy to miss. */}
+          {!state.micMuted && (state.status === 'listening' || state.pttLocked) && (
+            <>
+              <span
+                className="pointer-events-none absolute left-1/2 top-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+                style={{ width: 88, height: 88, marginLeft: -44, marginTop: -44, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
+              />
+              <span
+                className="pointer-events-none absolute left-1/2 top-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+                style={{ width: 88, height: 88, marginLeft: -44, marginTop: -44, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
+              />
+            </>
+          )}
           {/* On a call = hat on (the companion's on-duty signal); thinking
               shows the thought bubbles. */}
           <TalkingHead
@@ -1518,6 +1539,11 @@ function TuckedMascot({
 
   const statusDisplay = state.status ? STATUS_DISPLAY[state.status] : null
 
+  // Mic gate open (holding right ⌘ / the pin, or hands-free lock): the ONE
+  // state the user must never have to squint for — without visible feedback
+  // there is no way to tell a working hold from a dead key hook.
+  const micOpen = !state.micMuted && (state.status === 'listening' || state.pttLocked)
+
   return (
     <div
       className="group relative flex h-screen w-screen select-none flex-col items-center justify-end overflow-hidden pb-2"
@@ -1528,6 +1554,10 @@ function TuckedMascot({
           0% { opacity: 0; transform: scale(0.5); }
           100% { opacity: 1; transform: scale(1); }
         }
+        @keyframes listen-ring {
+          0% { transform: scale(0.72); opacity: 0.9; }
+          100% { transform: scale(1.28); opacity: 0; }
+        }
       `}</style>
 
       {/* On duty = cowboy hat on; the controls are enamel pins on the hat
@@ -1537,7 +1567,22 @@ function TuckedMascot({
           hit target that grows on hover. */}
       {/* -mb pulls the caption/chip up under the boat: the SVG box has dead
           space below the ripples that read as a big gap. */}
-      <div className="-mb-4" style={{ animation: 'tucked-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}>
+      <div className="relative -mb-4" style={{ animation: 'tucked-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}>
+        {/* Listening halo: expanding green rings around the head while the
+            mic gate is open. Peripheral-vision feedback — the user is
+            usually looking at their own work, not at the chip's 10px text. */}
+        {micOpen && (
+          <>
+            <span
+              className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+              style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
+            />
+            <span
+              className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+              style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
+            />
+          </>
+        )}
         <TalkingHead
           // Thinking = thought bubbles (the calm version — rowing on every
           // turn wore thin): status 'thinking' with idle TTS maps to the
@@ -1664,9 +1709,15 @@ function TuckedMascot({
         )}
       </div>
       {/* Pure status line — the CONTROLS are the pins (gold mic = hold to
-          talk, red = stop) and the ✕ (end & close). */}
+          talk, red = stop) and the ✕ (end & close). While the mic gate is
+          open the chip goes loud (green, mic icon): paired with the halo,
+          holding right ⌘ is unmistakably "working". */}
       <div className="flex h-6 items-center">
-        <span className="flex items-center gap-1.5 rounded-full bg-black/60 px-2.5 py-1 text-[10px] font-medium text-white shadow-md">
+        <span
+          className={`flex items-center gap-1.5 rounded-full px-2.5 py-1 font-medium text-white shadow-md ${
+            micOpen ? 'bg-green-600 text-[11px] font-semibold' : 'bg-black/60 text-[10px]'
+          }`}
+        >
           {state.micMuted && (state.status === 'listening' || state.status === 'idle') ? (
             <>
               <span className="block h-1.5 w-1.5 rounded-full bg-red-500" />
@@ -1674,13 +1725,13 @@ function TuckedMascot({
             </>
           ) : state.pttLocked ? (
             <>
-              <span className="block h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
-              Hands-free — tap the mic to send
+              <Mic className="h-3 w-3 animate-pulse" />
+              Hands-free — tap ⌘ to send
             </>
           ) : state.status === 'listening' ? (
             <>
-              <span className="block h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
-              Release to send
+              <Mic className="h-3 w-3 animate-pulse" />
+              Listening — release to send
             </>
           ) : statusDisplay ? (
             <>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -666,8 +666,11 @@ export function QuickAskBar() {
     }
   }, [asked, pinned, surface, collapsed, requestCollapsed, sendAction, startRecording, submitRecording, cancelRecording, reset, dismiss])
 
-  // Pinned role, tucked: just the mascot (voice-to-voice).
-  if (pinned && collapsed) {
+  // Pinned PILL role, tucked: just the mascot (voice-to-voice). The card
+  // surface does NOT branch here — its folded state renders inside the one
+  // Skipper layout below, so the mascot never remounts (and never moves) on
+  // fold/unfold.
+  if (pinned && collapsed && surface !== 'card') {
     return (
       <TuckedMascot
         state={callState}
@@ -708,27 +711,49 @@ export function QuickAskBar() {
     )
   }
 
-  // The bar-style card — summoned (no call), or hosting a live voice call
-  // (callCard: "bring the text back" from a bar-originated tuck). Same
-  // layout; the exchange comes from the call's mirror on the call card
-  // (covers spoken turns too), from the quick-ask mirror when summoned.
+  // The bar-style card — summoned (no call), or the SKIPPER (a live voice
+  // call on the card surface, text panel open or folded). One layout: the
+  // mascot column below is the SAME mounted node in both Skipper states —
+  // fold/unfold only adds/removes the card beside it, so the mascot never
+  // moves, resizes, or replays its entry animation. The exchange comes from
+  // the call's mirror on the call card, from the quick-ask mirror summoned.
+  const skipper = pinned && surface === 'card'
   const panelAsked = callCard ? callState.questionText : asked
   const panelText = callCard ? (callState.responseText ?? '') : (answer?.text ?? '')
   const panelProcessing = callCard ? callState.status === 'thinking' : processing
   const panelStatusText = (!callCard && answer?.statusText) || 'Thinking…'
+  // One-line caption under the Skipper's mascot: the in-flight utterance
+  // wins; otherwise the tail of the reply while it speaks.
+  const skipperReplyTail =
+    skipper && (callState.ttsState !== 'idle' || callState.status === 'thinking')
+      ? (callState.responseText ?? '')
+          .replace(/[#*_`>[\]]/g, '')
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(-90)
+      : ''
+  const skipperCaption = skipper ? (callState.interimText || skipperReplyTail) : ''
 
   return (
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden">
       {/* The invisible stage: popovers open into this zone; clicking it
           dismisses the bar — or, on the call card, tucks the text back into
-          the mascot (the call keeps going). */}
-      <div className="min-h-0 flex-1" onMouseDown={callCard ? () => requestCollapsed(true) : dismiss} />
+          the mascot (the call keeps going). Folded Skipper: the stage is a
+          drag area, part of "carry it around". */}
+      <div
+        className="min-h-0 flex-1"
+        style={skipper && collapsed ? dragRegion : undefined}
+        onMouseDown={callCard ? () => requestCollapsed(true) : skipper ? undefined : dismiss}
+      />
 
       {/* Bottom row: card + the mascot riding alongside on the transparent
           stage. The row is PADDED so the card's CSS shadow fades inside the
           window instead of clipping at its rectangular edge (which read as
-          a grey rectangle around the card). */}
-      <div className="flex shrink-0 items-end gap-1 px-6 pb-5">
+          a grey rectangle around the card). The paddings are IDENTICAL in
+          both Skipper states — with the corner-anchored window, that pins
+          the mascot to the exact same screen pixels across fold/unfold. */}
+      <div className="flex shrink-0 items-end justify-end gap-1 px-6 pb-5">
+      {!(skipper && collapsed) && (
       <div className="relative min-w-0 flex-1">
       {/* Light skin (#810): near-white card, hairline dark border, dark
           text. The window's native shadow is off (it would outline the
@@ -1047,73 +1072,92 @@ export function QuickAskBar() {
         </TooltipContent>
       </Tooltip>
       </div>
+      )}
 
-      {/* The mascot, full silhouette on the transparent stage — the same
-          TalkingHead the product tour and call tiles render. On the call
-          card it lip-syncs the spoken reply; summoned it bobs, with
-          thinking bubbles while a question is processing. On the Skipper
-          (callCard) the mascot IS the control surface AND the drag handle —
-          the same pins as the folded presentation ride its hat and hull,
-          the status line sits beneath, and grabbing anywhere else on it
-          carries the whole companion around; summoned it stays inert
-          (pointer-events none, clicks neither dismiss nor do anything). */}
+      {/* The mascot column — the Skipper's CONSTANT. One mounted node for
+          both Skipper states (text open or folded): identical size, pins,
+          caption slot, and status chip, at identical offsets from the
+          window's bottom-right corner — which the corner-anchored window
+          keeps fixed on screen, so fold/unfold moves NOTHING here; only the
+          card beside it comes and goes. It is the control surface AND the
+          drag handle. Summoned (no call) it stays the inert 124px bobbing
+          silhouette. */}
       <div
-        className={`relative flex w-[132px] shrink-0 select-none flex-col items-center ${callCard ? 'cursor-grab' : 'pointer-events-none'}`}
-        style={callCard ? dragRegion : undefined}
-        aria-hidden={callCard ? undefined : true}
-        title={callCard ? 'Drag to move your Skipper' : undefined}
+        className={`relative flex w-[132px] shrink-0 select-none flex-col items-center ${skipper ? 'cursor-grab' : 'pointer-events-none'}`}
+        style={skipper ? dragRegion : undefined}
+        aria-hidden={skipper ? undefined : true}
+        title={skipper ? 'Drag to move your Skipper' : undefined}
       >
-        {callCard && (
+        {skipper && (
           <style>{`
             @keyframes listen-ring {
               0% { transform: scale(0.72); opacity: 0.9; }
               100% { transform: scale(1.28); opacity: 0; }
             }
+            @keyframes skipper-pop {
+              0% { opacity: 0; transform: scale(0.5); }
+              100% { opacity: 1; transform: scale(1); }
+            }
           `}</style>
         )}
-        {/* Listening halo — same signal as the tucked mascot: rings pulse
-            around the head while the mic gate is open, so "press ⌘ and
-            speak" is visibly working even with the text panel up. */}
-        {callCard && !callState.micMuted && (callState.status === 'listening' || callState.pttLocked) && (
-          <>
-            <span
-              className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
-              style={{ top: '42%', width: 96, height: 96, marginLeft: -48, marginTop: -48, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
-            />
-            <span
-              className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
-              style={{ top: '42%', width: 96, height: 96, marginLeft: -48, marginTop: -48, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
-            />
-          </>
-        )}
-        <TalkingHead
-          ttsState={
-            callCard
-              ? callState.status === 'thinking' && callState.ttsState === 'idle'
-                ? 'synthesizing'
-                : callState.ttsState
-              : processing
-                ? 'synthesizing'
-                : 'idle'
-          }
-          getLevel={callCard ? synthLevel : zeroLevel}
-          size={124}
-          hat={callCard ? 'cowboy' : undefined}
-          hatOverlay={
-            callCard ? (
-              <SkipperPins
-                state={callState}
-                sendAction={sendAction}
-                textPin="collapse"
-                onTextPin={() => requestCollapsed(true)}
+        <div
+          className="relative -mb-4"
+          style={skipper ? { animation: 'skipper-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' } : undefined}
+        >
+          {/* Listening halo — rings pulse around the head while the mic
+              gate is open, so "press ⌘ and speak" is visibly working in
+              both states. */}
+          {skipper && !callState.micMuted && (callState.status === 'listening' || callState.pttLocked) && (
+            <>
+              <span
+                className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+                style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
               />
-            ) : undefined
-          }
-        />
-        {callCard && (
-          <div className="-mt-3 flex h-6 items-center">
-            <SkipperStatusChip state={callState} />
-          </div>
+              <span
+                className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
+                style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
+              />
+            </>
+          )}
+          <TalkingHead
+            ttsState={
+              skipper
+                ? callState.status === 'thinking' && callState.ttsState === 'idle'
+                  ? 'synthesizing'
+                  : callState.ttsState
+                : processing
+                  ? 'synthesizing'
+                  : 'idle'
+            }
+            getLevel={skipper ? synthLevel : zeroLevel}
+            size={skipper ? 132 : 124}
+            hat={skipper ? 'cowboy' : undefined}
+            hatOverlay={
+              skipper ? (
+                <SkipperPins
+                  state={callState}
+                  sendAction={sendAction}
+                  textPin={collapsed ? 'expand' : 'collapse'}
+                  onTextPin={() => requestCollapsed(!collapsed)}
+                />
+              ) : undefined
+            }
+          />
+        </div>
+        {skipper && (
+          <>
+            {/* Fixed-height caption + chip slots: present in BOTH states so
+                the head never shifts when a caption appears or the text
+                folds. */}
+            <div className="flex h-4 max-w-full items-center px-2">
+              {skipperCaption && (
+                <span className="truncate rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{skipperCaption}</span>
+              )}
+            </div>
+            <div className="flex h-6 items-center">
+              <SkipperStatusChip state={callState} />
+            </div>
+          </>
         )}
       </div>
       </div>

--- a/apps/x/apps/renderer/src/components/screen-pointer-overlay.tsx
+++ b/apps/x/apps/renderer/src/components/screen-pointer-overlay.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Screen-pointer overlay (window hash #screen-pointer): a transparent,
+ * click-through window covering the shared display, on which the assistant's
+ * pointer is drawn — a laser-dot with ping rings and an optional label.
+ * Driven entirely by main over the screen-pointer:state push channel
+ * (replayed on load); the window exists only while something is pointed at.
+ */
+
+type PointerState = {
+  visible: boolean
+  x: number
+  y: number
+  label: string | null
+  nonce: number
+}
+
+export function ScreenPointerOverlay() {
+  const [state, setState] = useState<PointerState | null>(null)
+
+  // Transparent window: clear every background layer — any paint here is a
+  // permanent smudge over the user's real screen.
+  useEffect(() => {
+    document.documentElement.style.background = 'transparent'
+    document.body.style.background = 'transparent'
+    document.documentElement.style.overflow = 'hidden'
+    document.body.style.overflow = 'hidden'
+    const root = document.getElementById('root')
+    if (root) root.style.background = 'transparent'
+  }, [])
+
+  useEffect(() => {
+    // Subscribe FIRST, then pull: main's did-finish-load push can fire
+    // before this effect runs (the popout had the same race — a missed
+    // push here is an invisible pointer). The nonce guard keeps a stale
+    // pulled state from clobbering a fresher pushed one.
+    const off = window.ipc.on('screen-pointer:state', (s) =>
+      setState((prev) => (prev && prev.nonce > s.nonce ? prev : s)),
+    )
+    void window.ipc
+      .invoke('screenPointer:getState', null)
+      .then(({ state: s }) => {
+        if (s) setState((prev) => (prev && prev.nonce >= s.nonce ? prev : s))
+      })
+      .catch((err) => console.warn('[screen-pointer] getState failed:', err))
+    return off
+  }, [])
+
+  if (!state?.visible) return null
+
+  // Flip the label to the dot's other side near the right edge so it stays
+  // on screen; clamp isn't needed vertically (the chip is dot-centered).
+  const labelOnLeft = state.x > 0.62
+
+  return (
+    <div className="fixed inset-0 overflow-hidden pointer-events-none select-none">
+      <style>{`
+        @keyframes sp-ping {
+          0% { transform: scale(0.5); opacity: 0.9; }
+          100% { transform: scale(2.6); opacity: 0; }
+        }
+        @keyframes sp-pop {
+          0% { transform: scale(0); }
+          60% { transform: scale(1.35); }
+          100% { transform: scale(1); }
+        }
+        @keyframes sp-label-in {
+          0% { opacity: 0; transform: translateY(-50%) scale(0.9); }
+          100% { opacity: 1; transform: translateY(-50%) scale(1); }
+        }
+      `}</style>
+      {/* key={nonce}: pointing again — even at the same spot — restarts the
+          pop/ping so the user's eye is drawn there each time. */}
+      <div
+        key={state.nonce}
+        className="absolute"
+        style={{ left: `${state.x * 100}%`, top: `${state.y * 100}%` }}
+      >
+        {[0, 0.5].map((delay) => (
+          <span
+            key={delay}
+            className="absolute rounded-full"
+            style={{
+              width: 44,
+              height: 44,
+              left: -22,
+              top: -22,
+              border: '3px solid rgba(239, 68, 68, 0.85)',
+              boxShadow: '0 0 6px rgba(239, 68, 68, 0.5)',
+              animation: `sp-ping 1.6s cubic-bezier(0, 0, 0.2, 1) ${delay}s infinite`,
+            }}
+          />
+        ))}
+        <span
+          className="absolute rounded-full"
+          style={{
+            width: 16,
+            height: 16,
+            left: -8,
+            top: -8,
+            background: '#ef4444',
+            border: '2.5px solid #ffffff',
+            boxShadow: '0 0 10px rgba(239, 68, 68, 0.9), 0 1px 4px rgba(0, 0, 0, 0.45)',
+            animation: 'sp-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)',
+          }}
+        />
+        {state.label ? (
+          <span
+            className="absolute whitespace-nowrap rounded-full"
+            style={{
+              top: 0,
+              ...(labelOnLeft ? { right: 22 } : { left: 22 }),
+              transform: 'translateY(-50%)',
+              maxWidth: 320,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              padding: '5px 12px',
+              background: 'rgba(23, 23, 23, 0.92)',
+              border: '1px solid rgba(255, 255, 255, 0.25)',
+              color: '#ffffff',
+              fontSize: 13,
+              fontWeight: 500,
+              boxShadow: '0 2px 10px rgba(0, 0, 0, 0.4)',
+              animation: 'sp-label-in 0.25s ease-out',
+            }}
+          >
+            {state.label}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { useState, useEffect, useCallback, useMemo } from "react"
-import { Server, Key, Shield, Palette, Monitor, Sun, Moon, Loader2, CheckCircle2, Plus, Minus, X, Wrench, Search, ChevronRight, Link2, Tags, Mail, BookOpen, User, Plug, HelpCircle, MessageCircle, Terminal, AlertTriangle, RefreshCw, PanelRight, Bell, Smartphone } from "lucide-react"
+import { Server, Key, Shield, ShieldCheck, Palette, Monitor, Sun, Moon, Loader2, CheckCircle2, Plus, Minus, X, Wrench, Search, ChevronRight, Link2, Tags, Mail, BookOpen, User, Plug, HelpCircle, MessageCircle, Terminal, AlertTriangle, RefreshCw, PanelRight, Bell, Smartphone } from "lucide-react"
 
 import {
   Dialog,
@@ -33,10 +33,11 @@ import { DEFAULT_TURN_LIMITS_SETTINGS } from "@x/shared/src/turn-limits.js"
 import type { ipc as ipcShared } from "@x/shared"
 import { startProvisioning, useProvisioning, enabledOptimistic, type AgentStatus, type CodeModeAgentStatus } from "@/lib/code-mode-provisioning"
 import { ModelSelectionSection } from "@/components/settings/model-selection-section"
+import { PermissionsSettings } from "@/components/settings/permissions-settings"
 import { ProvidersSection } from "@/components/settings/providers-section"
 import { useModels } from "@/hooks/use-models"
 
-type ConfigTab = "account" | "connections" | "mobile" | "models" | "mcp" | "security" | "code-mode" | "appearance" | "notifications" | "note-tagging" | "advanced" | "help"
+type ConfigTab = "account" | "connections" | "mobile" | "models" | "mcp" | "security" | "code-mode" | "appearance" | "notifications" | "permissions" | "note-tagging" | "advanced" | "help"
 
 interface TabConfig {
   id: ConfigTab
@@ -105,6 +106,12 @@ const tabs: TabConfig[] = [
     description: "Choose which notifications you receive",
   },
   {
+    id: "permissions",
+    label: "Permissions",
+    icon: ShieldCheck,
+    description: "What Rowboat can access, and how to grant it",
+  },
+  {
     id: "note-tagging",
     label: "Note Tagging",
     icon: Tags,
@@ -129,7 +136,7 @@ const tabs: TabConfig[] = [
 const NAV_SECTIONS: { label: string | null; ids: ConfigTab[] }[] = [
   { label: null, ids: ["account", "connections", "mobile"] },
   { label: "Configure", ids: ["models", "mcp", "security", "code-mode", "note-tagging", "advanced"] },
-  { label: "App", ids: ["appearance", "notifications", "help"] },
+  { label: "App", ids: ["appearance", "notifications", "permissions", "help"] },
 ]
 
 interface SettingsDialogProps {
@@ -1943,6 +1950,8 @@ export function SettingsDialog({ children, defaultTab = "account", open: control
                 <AppearanceSettings />
               ) : activeTab === "notifications" ? (
                 <NotificationSettings dialogOpen={open} />
+              ) : activeTab === "permissions" ? (
+                <PermissionsSettings dialogOpen={open} />
               ) : activeTab === "advanced" ? (
                 <AdvancedSettings dialogOpen={open} />
               ) : activeTab === "help" ? (

--- a/apps/x/apps/renderer/src/components/settings/permissions-settings.tsx
+++ b/apps/x/apps/renderer/src/components/settings/permissions-settings.tsx
@@ -1,0 +1,251 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { ExternalLink, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { ipc as ipcShared } from "@x/shared"
+
+/**
+ * Settings → Permissions: every OS permission Rowboat uses, grouped by the
+ * FEATURE it serves — the mental model is "enable what I use", never "make
+ * the checklist green" (over-granting is attack surface, especially
+ * Accessibility). Statuses are honest: where the OS gives us no read API
+ * (input monitoring outside a call, notifications, unprobed automation) the
+ * chip says so instead of faking a verdict. Just-in-time dialogs remain the
+ * primary grant path; this panel is the audit-and-repair surface.
+ */
+
+type PermissionsStatus = ipcShared.IPCChannels["permissions:getStatus"]["res"]
+type PermState = PermissionsStatus["microphone"]
+type RequestablePermission = ipcShared.IPCChannels["permissions:request"]["req"]["permission"]
+type SettingsSection = ipcShared.IPCChannels["app:openPrivacySettings"]["req"]["section"]
+
+const CHIP_STYLES: Record<string, string> = {
+  granted: "bg-green-500/10 text-green-600 dark:text-green-400",
+  denied: "bg-red-500/10 text-red-600 dark:text-red-400",
+  restricted: "bg-red-500/10 text-red-600 dark:text-red-400",
+  "not-determined": "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  unknown: "bg-muted text-muted-foreground",
+}
+
+const CHIP_LABELS: Record<string, string> = {
+  granted: "Granted",
+  denied: "Not granted",
+  restricted: "Restricted",
+  "not-determined": "Not requested yet",
+  unknown: "Unknown",
+}
+
+function StatusChip({ state }: { state: PermState }) {
+  if (state === "not-required") return null
+  return (
+    <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-xs font-medium", CHIP_STYLES[state])}>
+      {CHIP_LABELS[state]}
+    </span>
+  )
+}
+
+type RowSpec = {
+  key: keyof Omit<PermissionsStatus, "platform">
+  title: string
+  why: string
+  /** Extra guidance shown under the row for specific states. */
+  hint?: Partial<Record<PermState, string>>
+  /** Fires the OS grant flow (native prompt / dialog / probe), when one exists. */
+  request?: RequestablePermission
+  requestLabel?: string
+  /** Deep link into the OS settings pane. */
+  settingsSection: SettingsSection
+  /** Row is link-only: no status chip is shown even when state is 'unknown'. */
+  linkOnly?: boolean
+}
+
+type GroupSpec = {
+  title: string
+  description?: string
+  rows: RowSpec[]
+}
+
+const GROUPS: GroupSpec[] = [
+  {
+    title: "Voice calls",
+    rows: [
+      {
+        key: "microphone",
+        title: "Microphone",
+        why: "Hear you on calls and for dictation.",
+        request: "microphone",
+        requestLabel: "Grant",
+        settingsSection: "microphone",
+      },
+      {
+        key: "inputMonitoring",
+        title: "Input Monitoring",
+        why: "Right ⌘ push-to-talk while you're in any app.",
+        hint: {
+          unknown:
+            "macOS gives no way to read this outside a call — it's verified the moment key events arrive on your next call. If holding right ⌘ from another app does nothing, grant it here.",
+        },
+        request: "input-monitoring",
+        requestLabel: "Request",
+        settingsSection: "input-monitoring",
+      },
+    ],
+  },
+  {
+    title: "Video calls",
+    rows: [
+      {
+        key: "camera",
+        title: "Camera",
+        why: "See you on video calls and practice sessions.",
+        request: "camera",
+        requestLabel: "Grant",
+        settingsSection: "camera",
+      },
+    ],
+  },
+  {
+    title: "Screen sharing",
+    rows: [
+      {
+        key: "screenRecording",
+        title: "Screen Recording",
+        why: "Share your screen on calls so the assistant can see it.",
+        hint: {
+          granted: "Just granted it? macOS applies a fresh Screen Recording grant only after the app relaunches.",
+          denied: "macOS doesn't allow apps to prompt for this — enable Rowboat in the pane, then relaunch the app.",
+        },
+        settingsSection: "screen-recording",
+      },
+    ],
+  },
+  {
+    title: "Notifications",
+    rows: [
+      {
+        key: "notifications",
+        title: "Notifications",
+        why: "Background agents and reminders can notify you when something needs attention.",
+        settingsSection: "notifications",
+        linkOnly: true,
+      },
+    ],
+  },
+]
+
+export function PermissionsSettings({ dialogOpen }: { dialogOpen: boolean }) {
+  const [status, setStatus] = useState<PermissionsStatus | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const refresh = useCallback(() => {
+    void window.ipc
+      .invoke("permissions:getStatus", null)
+      .then(setStatus)
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (dialogOpen) refresh()
+  }, [dialogOpen, refresh])
+
+  // Statuses change while the user is off in System Settings — re-poll when
+  // the app window comes back into focus so the chips are fresh.
+  useEffect(() => {
+    window.addEventListener("focus", refresh)
+    return () => window.removeEventListener("focus", refresh)
+  }, [refresh])
+
+  const request = useCallback(
+    async (permission: RequestablePermission) => {
+      setBusy(permission)
+      try {
+        await window.ipc.invoke("permissions:request", { permission })
+      } catch {
+        // Statuses re-read below either way.
+      }
+      setBusy(null)
+      refresh()
+    },
+    [refresh],
+  )
+
+  const openPane = useCallback((section: SettingsSection) => {
+    void window.ipc.invoke("app:openPrivacySettings", { section }).catch(() => {})
+  }, [])
+
+  if (!status) {
+    return <div className="py-8 text-center text-sm text-muted-foreground">Checking permissions…</div>
+  }
+
+  const visibleGroups = GROUPS.map((group) => ({
+    ...group,
+    rows: group.rows.filter((row) => status[row.key] !== "not-required"),
+  })).filter((group) => group.rows.length > 0)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-xs text-muted-foreground">
+          What Rowboat can access on this {status.platform === "darwin" ? "Mac" : "device"}, grouped by the feature
+          that uses it. Grant what you use — nothing here is required except for its feature.
+        </p>
+        <Button variant="ghost" size="sm" className="h-7 shrink-0 gap-1.5 text-xs" onClick={refresh}>
+          <RefreshCw className="h-3 w-3" />
+          Refresh
+        </Button>
+      </div>
+
+      {visibleGroups.map((group) => (
+        <div key={group.title} className="space-y-2">
+          <h4 className="text-sm font-semibold">{group.title}</h4>
+          {group.description && <p className="text-xs text-muted-foreground">{group.description}</p>}
+          <div className="divide-y rounded-md border">
+            {group.rows.map((row) => {
+              const state = status[row.key]
+              const hint = row.hint?.[state]
+              const showGrant = Boolean(row.request) && state !== "granted"
+              return (
+                <div key={row.key} className="flex flex-col gap-1.5 px-3 py-2.5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">{row.title}</span>
+                        {!row.linkOnly && <StatusChip state={state} />}
+                      </div>
+                      <p className="text-xs text-muted-foreground">{row.why}</p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      {showGrant && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          disabled={busy === row.request}
+                          onClick={() => row.request && void request(row.request)}
+                        >
+                          {busy === row.request ? "Requesting…" : row.requestLabel}
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 gap-1 text-xs text-muted-foreground"
+                        onClick={() => openPane(row.settingsSection)}
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                        System Settings
+                      </Button>
+                    </div>
+                  </div>
+                  {hint && <p className="text-xs text-muted-foreground/80">{hint}</p>}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/main.tsx
+++ b/apps/x/apps/renderer/src/main.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@/contexts/theme-context'
 import { configureAnalyticsContext } from './lib/analytics'
 import { MeetingDetectedPopup } from '@/components/meeting-detected-popup'
 import { QuickAskBar } from '@/components/quick-ask-bar'
+import { ScreenPointerOverlay } from '@/components/screen-pointer-overlay'
 
 // Fetch the stable installation ID from main so renderer + main share one
 // PostHog distinct_id. Falls back to PostHog's auto-generated anonymous ID
@@ -73,6 +74,13 @@ if (window.location.hash === '#meeting-detected') {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <QuickAskBar />
+    </StrictMode>,
+  )
+} else if (window.location.hash === '#screen-pointer') {
+  // Assistant's pointer over the shared screen; same pattern.
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <ScreenPointerOverlay />
     </StrictMode>,
   )
 } else {

--- a/apps/x/packages/core/src/application/screen-pointer/service.ts
+++ b/apps/x/packages/core/src/application/screen-pointer/service.ts
@@ -1,0 +1,28 @@
+// Screen pointer: lets the assistant point at a spot on the user's SHARED
+// screen during a call (an animated overlay marker, not the OS cursor).
+// Core owns the tool; the Electron main process implements the service
+// (overlay window + share-state tracking) and registers it in the DI
+// container, same seam as IBrowserControlService.
+
+export type ScreenPointerTarget = {
+  /** Horizontal position as a fraction of the shared screen, 0 (left) to 1 (right). */
+  x: number;
+  /** Vertical position as a fraction of the shared screen, 0 (top) to 1 (bottom). */
+  y: number;
+  /** Short caption rendered next to the pointer. */
+  label?: string;
+  /** How long the pointer stays up before auto-hiding. */
+  durationMs?: number;
+};
+
+export type ScreenPointerResult = {
+  success: boolean;
+  error?: string;
+};
+
+export interface IScreenPointerService {
+  /** Whether the user is currently sharing their screen (call or quick-ask). */
+  isShareActive(): boolean;
+  point(target: ScreenPointerTarget): Promise<ScreenPointerResult>;
+  hide(): Promise<void>;
+}

--- a/apps/x/packages/core/src/di/container.ts
+++ b/apps/x/packages/core/src/di/container.ts
@@ -28,6 +28,7 @@ import { CodeSessionService } from "../code-mode/sessions/service.js";
 import { CodeSessionStatusTracker } from "../code-mode/sessions/status-tracker.js";
 import type { IBrowserControlService } from "../application/browser-control/service.js";
 import type { INotificationService } from "../application/notification/service.js";
+import type { IScreenPointerService } from "../application/screen-pointer/service.js";
 import { SystemClock, type IClock } from "../runtime/turns/clock.js";
 import { FSTurnRepo } from "../runtime/turns/fs-repo.js";
 import type { ITurnRepo } from "../runtime/turns/repo.js";
@@ -163,5 +164,11 @@ export function registerBrowserControlService(service: IBrowserControlService): 
 export function registerNotificationService(service: INotificationService): void {
     container.register({
         notificationService: asValue(service),
+    });
+}
+
+export function registerScreenPointerService(service: IScreenPointerService): void {
+    container.register({
+        screenPointerService: asValue(service),
     });
 }

--- a/apps/x/packages/core/src/runtime/assembly/__snapshots__/compose-instructions.test.ts.snap
+++ b/apps/x/packages/core/src/runtime/assembly/__snapshots__/compose-instructions.test.ts.snap
@@ -194,6 +194,7 @@ Screen sharing:
 - When screen frames are present, treat them as the primary subject: the user is usually asking about, or working on, what's visible there. Read the screen carefully — code, documents, error messages, UI state — and help with it concretely.
 - The LAST screen frame is the most current view of their screen; earlier ones show how it changed while they spoke.
 - Frames are downscaled captures: small text may be hard to read. If something crucial is illegible, say what you need ("zoom into the error message" / "make that panel bigger") rather than guessing.
+- You can POINT at their screen: the screen-pointer tool (attached by the app-navigation skill — load it first) puts an animated pointer on the user's real display at fractional coordinates (x/y in 0-1) you estimate from the LATEST screen frame. When you explain something visible on their screen — a chart region, a button, a line — point at it while speaking ("this dip here is the weekend") instead of describing where it is. One spot at a time; it auto-hides, or hide it when you move on. Pointing is the limit — you cannot click or type on their screen; to act on a web page, drive the embedded browser instead.
 
 Etiquette:
 - Do not narrate or list what you see in every response. Bring up visual observations only when relevant to the user's request or clearly worth mentioning.
@@ -334,6 +335,7 @@ Screen sharing:
 - When screen frames are present, treat them as the primary subject: the user is usually asking about, or working on, what's visible there. Read the screen carefully — code, documents, error messages, UI state — and help with it concretely.
 - The LAST screen frame is the most current view of their screen; earlier ones show how it changed while they spoke.
 - Frames are downscaled captures: small text may be hard to read. If something crucial is illegible, say what you need ("zoom into the error message" / "make that panel bigger") rather than guessing.
+- You can POINT at their screen: the screen-pointer tool (attached by the app-navigation skill — load it first) puts an animated pointer on the user's real display at fractional coordinates (x/y in 0-1) you estimate from the LATEST screen frame. When you explain something visible on their screen — a chart region, a button, a line — point at it while speaking ("this dip here is the weekend") instead of describing where it is. One spot at a time; it auto-hides, or hide it when you move on. Pointing is the limit — you cannot click or type on their screen; to act on a web page, drive the embedded browser instead.
 
 Etiquette:
 - Do not narrate or list what you see in every response. Bring up visual observations only when relevant to the user's request or clearly worth mentioning.

--- a/apps/x/packages/core/src/runtime/assembly/capabilities/modes.ts
+++ b/apps/x/packages/core/src/runtime/assembly/capabilities/modes.ts
@@ -78,6 +78,7 @@ Screen sharing:
 - When screen frames are present, treat them as the primary subject: the user is usually asking about, or working on, what's visible there. Read the screen carefully — code, documents, error messages, UI state — and help with it concretely.
 - The LAST screen frame is the most current view of their screen; earlier ones show how it changed while they spoke.
 - Frames are downscaled captures: small text may be hard to read. If something crucial is illegible, say what you need ("zoom into the error message" / "make that panel bigger") rather than guessing.
+- You can POINT at their screen: the screen-pointer tool (attached by the app-navigation skill — load it first) puts an animated pointer on the user's real display at fractional coordinates (x/y in 0-1) you estimate from the LATEST screen frame. When you explain something visible on their screen — a chart region, a button, a line — point at it while speaking ("this dip here is the weekend") instead of describing where it is. One spot at a time; it auto-hides, or hide it when you move on. Pointing is the limit — you cannot click or type on their screen; to act on a web page, drive the embedded browser instead.
 
 Etiquette:
 - Do not narrate or list what you see in every response. Bring up visual observations only when relevant to the user's request or clearly worth mentioning.

--- a/apps/x/packages/core/src/runtime/assembly/skills/app-navigation/skill.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/app-navigation/skill.ts
@@ -83,6 +83,38 @@ Open a knowledge file in the editor. ` + "`path`" + `: full workspace-relative p
 (e.g. ` + "`knowledge/People/John Smith.md`" + `). Use ` + "`file-grep`" + ` first if unsure
 of the exact path.
 
+## Pointing at the user's shared screen (calls)
+
+While the user is SHARING THEIR SCREEN on a call you also have the
+` + "`screen-pointer`" + ` tool: it puts an animated pointer (with an optional tiny
+label) at a position on their REAL screen — like reaching over and pointing
+at their monitor. Use it whenever you're explaining something visible in the
+screen-share frames: "this line here", "that button", "this is where the
+spike is".
+
+- ` + "`screen-pointer({ action: \"point\", x, y, label? })`" + ` — ` + "`x`" + `/` + "`y`" + ` are
+  FRACTIONS 0-1 of the LATEST screen-share frame (x: 0 left → 1 right,
+  y: 0 top → 1 bottom). Estimate them from the most recent screen frame.
+- ` + "`label`" + ` is a few words at most ("weekend dip") — say the explanation out
+  loud instead of writing it into the label.
+- The pointer auto-hides after ~8s (tune with ` + "`durationMs`" + `); pointing again
+  MOVES it. ` + "`screen-pointer({ action: \"hide\" })`" + ` dismisses it early — hide
+  when you're done referring to the spot.
+- Point at ONE thing at a time, and speak while you point.
+- Only works during a live screen share; it fails with an explanation
+  otherwise (ask the user to share their screen).
+- Pointing is where your screen abilities END: you cannot click or type on
+  the user's screen. If they ask you to act there, point at the target and
+  talk them through it — or drive the embedded browser (browser-control)
+  when the task is a web page.
+
+**Worked example — "walk my post-doc through this dashboard" (screen share live):**
+1. Read the latest screen frame: the growth chart's weekend dip sits at
+   roughly 62% across, 40% down.
+2. ` + "`screen-pointer({ action: \"point\", x: 0.62, y: 0.4, label: \"weekend dip\" })`" + `
+3. Say: "This dip here is the weekend — usage recovers Monday morning."
+4. Point at the next feature as you continue, or ` + "`hide`" + ` when done.
+
 ### update-base-view / get-base-state / create-base
 Knowledge-base table control (unchanged):
 - ` + "`update-base-view`" + `: ` + "`filters`" + ` (` + "`set/add/remove/clear`" + ` of ` + "`{category, value}`" + `),

--- a/apps/x/packages/core/src/runtime/assembly/skills/index.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/index.ts
@@ -139,9 +139,9 @@ const definitions: SkillDefinition[] = [
   {
     id: "app-navigation",
     title: "App Navigation",
-    summary: "Navigate the app UI - open notes, switch views, answer from an installed Rowboat app's data and surface it, filter/search the knowledge base, and manage saved views.",
+    summary: "Navigate the app UI - open notes, switch views, answer from an installed Rowboat app's data and surface it, filter/search the knowledge base, manage saved views, and point at the user's shared screen during calls.",
     content: appNavigationSkill,
-    tools: ["app-navigation", "app-read-data", "app-set-data"],
+    tools: ["app-navigation", "app-read-data", "app-set-data", "screen-pointer"],
   },
   {
     id: "code-with-agents",

--- a/apps/x/packages/core/src/runtime/tools/catalog.test.ts
+++ b/apps/x/packages/core/src/runtime/tools/catalog.test.ts
@@ -205,6 +205,7 @@ const HISTORICAL_KEY_ORDER = [
     "todo-add",
     "todo-propose",
     "todo-report",
+    "screen-pointer",
     "spawn-agent",
 ];
 

--- a/apps/x/packages/core/src/runtime/tools/catalog.ts
+++ b/apps/x/packages/core/src/runtime/tools/catalog.ts
@@ -23,6 +23,7 @@ import { liveNoteTools } from "./domains/live-note.js";
 import { backgroundTaskTools } from "./domains/background-tasks.js";
 import { notificationTools } from "./domains/notifications.js";
 import { todoTools } from "./domains/todo.js";
+import { screenPointerTools } from "./domains/screen-pointer.js";
 import { BuiltinToolsSchema } from "./types.js";
 export { coalesceCodeRunEvents } from "./domains/code.js";
 
@@ -96,6 +97,7 @@ export const BuiltinTools: z.infer<typeof BuiltinToolsSchema> = {
     ...codeTaskTools,
     ...notificationTools,
     ...todoTools,
+    ...screenPointerTools,
 
     [SPAWN_AGENT_TOOL_NAME]: {
         permission: "none",

--- a/apps/x/packages/core/src/runtime/tools/domains/screen-pointer.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/screen-pointer.ts
@@ -1,0 +1,56 @@
+// Builtin tools: screen-pointer domain. Lets the assistant point at things
+// on the user's SHARED screen during a call — an animated overlay marker on
+// the real display, driven by the Electron main process via the DI seam
+// (IScreenPointerService). Only works while a screen share is live.
+
+import { z } from "zod";
+import container from "../../../di/container.js";
+import type { IScreenPointerService } from "../../../application/screen-pointer/service.js";
+import { BuiltinToolsSchema } from "../types.js";
+
+export const screenPointerTools: z.infer<typeof BuiltinToolsSchema> = {
+    'screen-pointer': {
+        permission: "none",
+        description: "Point at a spot on the user's SHARED screen during a call: an animated pointer with an optional label appears at that position on their real display. Coordinates are fractions (0-1) of the LATEST screen-share frame — x left→right, y top→bottom. Only works while the user is sharing their screen. Use it to show what you mean while explaining ('this line here'); action 'hide' dismisses the pointer.",
+        inputSchema: z.object({
+            action: z.enum(["point", "hide"]).describe("point: show the pointer at x/y. hide: dismiss it."),
+            x: z.number().min(0).max(1).optional().describe("Horizontal position as a fraction of the latest screen-share frame: 0 = left edge, 1 = right edge. Required for point."),
+            y: z.number().min(0).max(1).optional().describe("Vertical position as a fraction of the latest screen-share frame: 0 = top edge, 1 = bottom edge. Required for point."),
+            label: z.string().max(60).optional().describe("Short caption shown next to the pointer (a few words, e.g. 'weekend dip'). Speak the explanation; keep this label tiny."),
+            durationMs: z.number().int().min(1000).max(30000).optional().describe("How long the pointer stays visible before auto-hiding (default 8000)."),
+        }),
+        isAvailable: async () => {
+            try {
+                container.resolve<IScreenPointerService>('screenPointerService');
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        execute: async (input: { action: "point" | "hide"; x?: number; y?: number; label?: string; durationMs?: number }) => {
+            let service: IScreenPointerService;
+            try {
+                service = container.resolve<IScreenPointerService>('screenPointerService');
+            } catch {
+                return { success: false, action: input.action, error: 'Screen pointing is unavailable in this environment.' };
+            }
+            if (input.action === 'hide') {
+                await service.hide();
+                return { success: true, action: 'hide' };
+            }
+            if (typeof input.x !== 'number' || typeof input.y !== 'number') {
+                return { success: false, action: 'point', error: 'point requires x and y (fractions 0-1 of the latest screen-share frame).' };
+            }
+            if (!service.isShareActive()) {
+                return { success: false, action: 'point', error: 'No screen share is live — pointing only works while the user shares their screen. Ask them to start sharing (or check the share toggle).' };
+            }
+            const result = await service.point({
+                x: input.x,
+                y: input.y,
+                ...(input.label ? { label: input.label } : {}),
+                ...(input.durationMs ? { durationMs: input.durationMs } : {}),
+            });
+            return { ...result, action: 'point', x: input.x, y: input.y, ...(input.label ? { label: input.label } : {}) };
+        },
+    },
+};

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1272,16 +1272,10 @@ const ipcSchemas = {
     req: z.object({ collapsed: z.boolean() }),
     res: z.object({}),
   },
-  // Bar → main → app window: the companion's expanded card is TEXT MODE —
-  // replies render silently there (entering it hushes in-flight speech).
-  'quickAsk:setTextMode': {
-    req: z.object({ textMode: z.boolean() }),
-    res: z.object({}),
-  },
-  'quick-ask:text-mode': {
-    req: z.object({ textMode: z.boolean() }),
-    res: z.null(),
-  },
+  // (The old quickAsk:setTextMode / quick-ask:text-mode channels are gone:
+  // whether a reply is SPOKEN now follows the question's modality — spoken
+  // questions get spoken replies, typed ones stay silent — plus the
+  // explicit speaker mute on the Skipper.)
   // App window → main: open the bar (the discoverability toast's "Try it").
   'quickAsk:show': {
     req: z.null(),
@@ -2397,6 +2391,8 @@ const ipcSchemas = {
       // User mute: mic audio and frame capture are both paused.
       micMuted: z.boolean(),
       screenSharing: z.boolean(),
+      // Output mute: replies are not spoken while set (input mute is micMuted).
+      speakerMuted: z.boolean(),
       // Live transcript of the in-progress utterance.
       interimText: z.string().nullable(),
       // A quick ⌘ tap locked hands-free capture (until the next tap).
@@ -2428,6 +2424,7 @@ const ipcSchemas = {
           cameraOn: z.boolean(),
           micMuted: z.boolean(),
           screenSharing: z.boolean(),
+          speakerMuted: z.boolean(),
           interimText: z.string().nullable(),
           pttLocked: z.boolean(),
           responseText: z.string().nullable(),
@@ -2443,7 +2440,7 @@ const ipcSchemas = {
   // typed message from the popout's input.
   'video:popoutAction': {
     req: z.object({
-      action: z.enum(['toggle-mic', 'toggle-camera', 'toggle-share', 'stop-speaking', 'ptt-down', 'ptt-up', 'send-text', 'end-call', 'expand']),
+      action: z.enum(['toggle-mic', 'toggle-camera', 'toggle-share', 'toggle-speaker', 'stop-speaking', 'ptt-down', 'ptt-up', 'send-text', 'end-call', 'expand']),
       text: z.string().optional(),
     }),
     res: z.object({}),
@@ -2456,6 +2453,8 @@ const ipcSchemas = {
       cameraOn: z.boolean(),
       micMuted: z.boolean(),
       screenSharing: z.boolean(),
+      // Output mute: replies are not spoken while set (input mute is micMuted).
+      speakerMuted: z.boolean(),
       interimText: z.string().nullable(),
       pttLocked: z.boolean(),
       responseText: z.string().nullable(),
@@ -2466,7 +2465,7 @@ const ipcSchemas = {
   // Push channel: main → app window with a popout control-bar action.
   'video:popout-action': {
     req: z.object({
-      action: z.enum(['toggle-mic', 'toggle-camera', 'toggle-share', 'stop-speaking', 'ptt-down', 'ptt-up', 'send-text', 'end-call', 'expand']),
+      action: z.enum(['toggle-mic', 'toggle-camera', 'toggle-share', 'toggle-speaker', 'stop-speaking', 'ptt-down', 'ptt-up', 'send-text', 'end-call', 'expand']),
       text: z.string().optional(),
     }),
     res: z.null(),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1145,12 +1145,41 @@ const ipcSchemas = {
     req: z.null(),
     res: z.object({ success: z.boolean() }),
   },
-  // Deep-link to a macOS Privacy & Security pane (permission dialogs).
+  // Deep-link to a macOS Privacy & Security pane (permission dialogs and the
+  // Settings → Permissions panel). 'notifications' opens the OS notification
+  // settings (not under Privacy on either platform).
   'app:openPrivacySettings': {
     req: z.object({
-      section: z.enum(['microphone', 'camera', 'screen-recording', 'input-monitoring']),
+      section: z.enum(['microphone', 'camera', 'screen-recording', 'input-monitoring', 'notifications']),
     }),
     res: z.object({ success: z.boolean() }),
+  },
+  // Aggregate OS-permission snapshot for Settings → Permissions. States are
+  // HONEST: 'unknown' means the OS gives us no way to read it (input
+  // monitoring outside a call, notifications, unprobed automation) — the UI
+  // must say so rather than fake a verdict. 'not-required' rows are hidden
+  // (that permission doesn't exist on this platform).
+  'permissions:getStatus': {
+    req: z.null(),
+    res: z.object({
+      platform: z.enum(['darwin', 'win32', 'linux']),
+      microphone: z.enum(['granted', 'denied', 'not-determined', 'restricted', 'unknown', 'not-required']),
+      camera: z.enum(['granted', 'denied', 'not-determined', 'restricted', 'unknown', 'not-required']),
+      screenRecording: z.enum(['granted', 'denied', 'not-determined', 'restricted', 'unknown', 'not-required']),
+      inputMonitoring: z.enum(['granted', 'denied', 'not-determined', 'restricted', 'unknown', 'not-required']),
+      notifications: z.enum(['granted', 'denied', 'not-determined', 'restricted', 'unknown', 'not-required']),
+    }),
+  },
+  // Fire the OS grant flow for one permission where a programmatic path
+  // exists: mic/camera native prompts, or re-arming the input-monitoring
+  // key hook (its consent prompt). Returns the state afterwards.
+  'permissions:request': {
+    req: z.object({
+      permission: z.enum(['microphone', 'camera', 'input-monitoring']),
+    }),
+    res: z.object({
+      state: z.enum(['granted', 'denied', 'not-determined', 'restricted', 'unknown', 'not-required']),
+    }),
   },
   // Relaunch the app — macOS requires it for a fresh Screen Recording grant
   // to take effect.
@@ -2441,6 +2470,44 @@ const ipcSchemas = {
       text: z.string().optional(),
     }),
     res: z.null(),
+  },
+  // Renderer → main: whether a screen share (call or quick-ask) is currently
+  // live. Gates the assistant's screen-pointer tool — pointing at a screen
+  // the user isn't sharing would be pure confusion — and tears the pointer
+  // overlay down the moment the share ends.
+  'screenPointer:setShareActive': {
+    req: z.object({ active: z.boolean() }),
+    res: z.object({}),
+  },
+  // Push channel: main → pointer-overlay window with the current pointer
+  // state. `nonce` re-triggers the ping animation when the assistant points
+  // twice at the same spot; coordinates are fractions of the display.
+  'screen-pointer:state': {
+    req: z.object({
+      visible: z.boolean(),
+      x: z.number(),
+      y: z.number(),
+      label: z.string().nullable(),
+      nonce: z.number(),
+    }),
+    res: z.null(),
+  },
+  // Overlay window → fetch the current pointer state on mount. Same race as
+  // video:getPopoutState: the did-finish-load replay can fire before the
+  // React listener registers, and a missed push means an invisible pointer.
+  'screenPointer:getState': {
+    req: z.null(),
+    res: z.object({
+      state: z
+        .object({
+          visible: z.boolean(),
+          x: z.number(),
+          y: z.number(),
+          label: z.string().nullable(),
+          nonce: z.number(),
+        })
+        .nullable(),
+    }),
   },
   'meeting:checkScreenPermission': {
     req: z.null(),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2393,6 +2393,9 @@ const ipcSchemas = {
       screenSharing: z.boolean(),
       // Output mute: replies are not spoken while set (input mute is micMuted).
       speakerMuted: z.boolean(),
+      // High-level "what's happening" while a turn runs ("Searching the
+      // web…", "Reasoning…") — tool NAMES only, never arguments.
+      activityText: z.string().nullable(),
       // Live transcript of the in-progress utterance.
       interimText: z.string().nullable(),
       // A quick ⌘ tap locked hands-free capture (until the next tap).
@@ -2425,6 +2428,7 @@ const ipcSchemas = {
           micMuted: z.boolean(),
           screenSharing: z.boolean(),
           speakerMuted: z.boolean(),
+          activityText: z.string().nullable(),
           interimText: z.string().nullable(),
           pttLocked: z.boolean(),
           responseText: z.string().nullable(),
@@ -2455,6 +2459,9 @@ const ipcSchemas = {
       screenSharing: z.boolean(),
       // Output mute: replies are not spoken while set (input mute is micMuted).
       speakerMuted: z.boolean(),
+      // High-level "what's happening" while a turn runs ("Searching the
+      // web…", "Reasoning…") — tool NAMES only, never arguments.
+      activityText: z.string().nullable(),
       interimText: z.string().nullable(),
       pttLocked: z.boolean(),
       responseText: z.string().nullable(),


### PR DESCRIPTION
## What this adds

On calls with a live screen share, the assistant can now **point at the user's real screen**, and the voice companion ("Skipper") becomes **one coherent surface** — mascot with a foldable text panel — with modality-based speech and live activity status.

### Screen pointer (`screen-pointer` builtin, permission: none)
- Animated laser-dot + ping rings + optional label at fractional coordinates estimated from the latest screen-share frame; rendered on a transparent, click-through, screen-saver-level panel over the shared (primary) display; torn down the instant the share ends.
- Executes via a main-process DI service (same seam as browser control), hard-gated on a live share reported by the renderer. State is pushed **and** pulled on overlay mount (fixes the load race that made the first pointer invisible).
- Prompt surface: video-mode fragment + app-navigation skill teach point-while-explaining, and state pointing as the *limit* — acting on web pages routes to the embedded browser. A click/type `screen-control` tool was explored and deliberately removed pre-merge (blind-between-frames sequencing made it overclaim); design notes + CGEvent/TCC lessons are in VIDEO_MODE.md.

### Settings → Permissions panel
- Every OS permission grouped by the feature it serves (voice calls / video / screen sharing / notifications), honest statuses (unknowables say "Unknown" instead of faking a verdict), native grant buttons where macOS allows prompting, System Settings deep links elsewhere, refresh on focus. Platform-aware (Windows collapses to mic/camera/notifications).

### Unified Skipper
- Voice sessions land as ONE corner-anchored unit: mascot + text panel **open by default**, bottom-right of the cursor's display; fold/unfold keeps the mascot pixel-fixed (same mounted node, corner-anchored window); the mascot is the drag handle; blur no longer steals the text away.
- **Modality-based speech**: spoken questions get spoken replies (even with text open), typed questions render silently — replaces the old surface-based gating and its IPC channels. Speaker mute lives on the text panel (a "read instead of listen" choice); folding auto-unmutes so the voice-only state can never go silent.
- One control surface: the pin cluster (hold-to-talk/Stop, share bow light, fold/unfold, end) rides the mascot in both presentations, with the same status line beneath.
- **⌥⇧Space toggles the text panel** during a session; fold state is self-healing (main is the single source of truth; geometry re-applied idempotently — fixes a renderer/main desync that made all controls appear dead after popping a chat out).
- **Live activity label** while a turn runs: "Searching the web…"/"Reasoning…" (tool names only, never arguments) on the Skipper chip, text panel, tucked chip, and pill — with an ~800ms anti-flicker hold.
- Push-to-talk feedback: pulsing green listening halo + loud status chip while the mic gate is open, in every presentation.
- Fixes: history peek no longer repeats the current exchange; auto-permission classifier now runs for voice/PTT submissions (they silently fell back to manual mode, carding every gated tool mid-call); status chip stays one centered line.

## Verification
- `npm run deps` + `npm run typecheck` (all packages incl. main) + `npm run lint` green; core suite **587/587** passing on the rebased head.
- Pinned surfaces updated intentionally: builtin catalog key order, permission audit, compose-instructions golden snapshots.

## Notes for review
- `packages/shared/src/ipc.ts` gains screen-pointer + permissions channels and extends the popout mirror (`speakerMuted`, `activityText`, `toggle-speaker`); the old `quickAsk:setTextMode`/`quick-ask:text-mode` channels are removed.
- Remote branch was force-updated once: the original push contained a click/type tool that was removed by amend before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)