### PR TITLE
fix(storage): calculate turnCount dynamically from jsonl log lines to…

### DIFF
--- a/apps/cli/src/runs/repo.ts
+++ b/apps/cli/src/runs/repo.ts
@@ -11,6 +11,8 @@ export const ListRunsResponse = z.object({
         id: true,
         createdAt: true,
         agentId: true,
+    }).extend({
+        turnCount: z.number().optional(),
     })),
     nextCursor: z.string().optional(),
 });
@@ -112,24 +114,30 @@ export class FSRunsRepo implements IRunsRepo {
         const selected = files.slice(startIndex, startIndex + PAGE_SIZE);
         const runs: z.infer<typeof ListRunsResponse>['runs'] = [];
 
-        for (const name of selected) {
-            const runId = name.slice(0, -'.jsonl'.length);
-            try {
-                const contents = await fsp.readFile(path.join(runsDir, name), 'utf8');
-                const firstLine = contents.split('\n').find(line => line.trim() !== '');
-                if (!firstLine) {
-                    continue;
-                }
-                const start = StartEvent.parse(JSON.parse(firstLine));
-                runs.push({
-                    id: runId,
-                    createdAt: start.ts!,
-                    agentId: start.agentName,
-                });
-            } catch {
-                continue;
-            }
+    for (const name of selected) {
+    const runId = name.slice(0, -'.jsonl'.length);
+    try {
+        const contents = await fsp.readFile(path.join(runsDir, name), 'utf8');
+        const lines = contents.split('\n').filter(line => line.trim() !== '');
+        if (lines.length === 0) {
+            continue;
         }
+
+        const start = StartEvent.parse(JSON.parse(lines[0]));
+
+        // Calculate actual turns from remaining log lines if present
+        const turnCount = lines.length - 1; 
+
+        runs.push({
+            id: runId,
+            createdAt: start.ts!,
+            agentId: start.agentName,
+            turnCount: turnCount > 0 ? turnCount : 0,
+        });
+    } catch {
+        continue;
+    }
+}
 
         const hasMore = startIndex + PAGE_SIZE < files.length;
         const nextCursor = hasMore && selected.length > 0

--- a/apps/cli/src/runs/runs.ts
+++ b/apps/cli/src/runs/runs.ts
@@ -20,8 +20,9 @@ export const AskHumanResponsePayload = AskHumanResponseEvent.pick({
 
 export const Run = z.object({
     id: z.string(),
-    createdAt: z.iso.datetime(),
+    createdAt: z.string().datetime(),
     agentId: z.string(),
+    turnCount: z.number().optional(),
     log: z.array(RunEvent),
 });
 


### PR DESCRIPTION
Fixes #763

### Description
Updates the run listing logic to derive `turnCount` dynamically from `.jsonl` log lines so that session data remains intact in the UI history list even if the application process is force-closed or interrupted.