### PR TITLE
fix(x): OAuth callback eaten by dead flow's server via keep-alive socket reuse

### DIFF
--- a/apps/x/apps/main/src/auth-server.ts
+++ b/apps/x/apps/main/src/auth-server.ts
@@ -62,7 +62,13 @@ function tryBindPort(
   opts: CallbackHandlingOpts,
 ): Promise<AuthServerResult> {
   return new Promise((resolve, reject) => {
-    const server = createServer((req, res) => {
+    const handler = (req: import('http').IncomingMessage, res: import('http').ServerResponse): void => {
+      // No keep-alive, ever. These servers are per-flow and short-lived; a
+      // pooled connection outlives server.close() (close() only stops
+      // listening) and the browser then delivers the NEXT flow's callback to
+      // this DEAD flow's handler. Seen live: Chrome reused the Rowboat
+      // sign-in's socket for the Microsoft connect redirect minutes later.
+      res.setHeader('Connection', 'close');
       if (!req.url) {
         res.writeHead(400);
         res.end('Bad Request');
@@ -76,6 +82,7 @@ function tryBindPort(
         // onCallback (a stale tab's redirect must never settle a live flow).
         const rejection = opts.validateCallback?.(url) ?? null;
         if (rejection) {
+          console.warn(`[OAuth] Callback server rejected ${req.method} ${url.pathname} (state=${url.searchParams.get('state') ?? '<none>'}): ${rejection}`);
           renderErrorPage(res, rejection);
           return;
         }
@@ -87,39 +94,98 @@ function tryBindPort(
           // cancels consent) so the caller can settle its flow instead of
           // waiting for the timeout. Callers that don't opt in keep the old
           // behaviour: the error page renders and the flow times out.
+          console.warn(`[OAuth] Callback carried provider error: ${error}`);
           opts.onError?.(error);
           renderErrorPage(res, `Error: ${error}`);
           return;
         }
 
-        // Handle callback - pass full URL so params like iss (OpenID Connect) are preserved for token exchange
-        onCallback(url);
+        console.log(`[OAuth] Callback server handling ${req.method} ${url.pathname} (state=${url.searchParams.get('state') ?? '<none>'})`);
 
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end(`
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <title>Authorization Successful</title>
-              <style>
-                body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
-                .success { color: #2e7d32; }
-              </style>
-            </head>
-            <body>
-              <h1 class="success">Authorization Successful</h1>
-              <p>You can close this window.</p>
-              <script>setTimeout(() => window.close(), 2000);</script>
-            </body>
-          </html>
-        `);
+        // Await the handler before responding: the browser tab must reflect
+        // what actually happened. Rendering "Authorization Successful" while
+        // the handler failed hides the failure from the user and leaves the
+        // app-side flow spinning with no visible cause.
+        Promise.resolve(onCallback(url)).then(() => {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end(`
+            <!DOCTYPE html>
+            <html>
+              <head>
+                <title>Authorization Successful</title>
+                <style>
+                  body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
+                  .success { color: #2e7d32; }
+                </style>
+              </head>
+              <body>
+                <h1 class="success">Authorization Successful</h1>
+                <p>You can close this window.</p>
+                <script>setTimeout(() => window.close(), 2000);</script>
+              </body>
+            </html>
+          `);
+        }).catch((err: unknown) => {
+          console.error('[OAuth] Callback handling failed:', err);
+          renderErrorPage(res, err instanceof Error ? err.message : 'Callback handling failed');
+        });
       } else {
+        console.log(`[OAuth] Callback server ignoring ${req.method} ${url.pathname} (404)`);
         res.writeHead(404);
         res.end('Not Found');
       }
-    });
+    };
 
-    server.listen(port, 'localhost', () => {
+    const server = createServer(handler);
+
+    // Bind both loopback families. Browsers deliver the localhost redirect on
+    // whichever family they pick (Happy Eyeballs), and a single-family bind
+    // leaves the other one connection-refused — the redirect then dies before
+    // the app ever sees it. IPv4 is the primary bind (port availability is
+    // judged on it); ::1 is best-effort, mirroring apps/server.ts.
+    server.listen(port, '127.0.0.1', () => {
+      const twin = createServer(handler);
+      let twinListening = false;
+      let closed = false;
+      twin.on('listening', () => {
+        twinListening = true;
+        if (closed) twin.close();
+      });
+      twin.on('error', (err: NodeJS.ErrnoException) => {
+        console.warn(`[OAuth] IPv6 loopback bind failed on port ${port} (${err.code}); continuing IPv4-only`);
+      });
+      twin.listen(port, '::1');
+
+      // Callers hold only the primary server; closing it must tear down the
+      // twin too, or the port stays half-occupied for the next flow. Also
+      // destroy IDLE accepted sockets (e.g. browser preconnects that never
+      // carried a request): close() alone leaves them alive with this flow's
+      // (now dead) handler attached. Idle-only, NOT closeAllConnections —
+      // callers close from inside onCallback, before the awaited success page
+      // has flushed, and killing that in-flight socket makes the browser show
+      // a connection error instead of the page. The socket that served the
+      // callback can't be reused later anyway: every response carries
+      // Connection: close (see handler above).
+      const originalClose = server.close.bind(server);
+      server.close = ((cb?: (err?: Error) => void) => {
+        closed = true;
+        if (twinListening) {
+          twin.close();
+          twin.closeIdleConnections();
+        }
+        const result = originalClose(cb);
+        server.closeIdleConnections();
+        // closeIdleConnections spares sockets that never carried a request
+        // (browser preconnects), which would otherwise linger attached to
+        // this dead handler. Destroy all stragglers once the in-flight
+        // response has had ample time to flush.
+        setTimeout(() => {
+          server.closeAllConnections();
+          twin.closeAllConnections();
+        }, 5000).unref();
+        return result;
+      }) as typeof server.close;
+
       resolve({ server, port });
     });
 

--- a/apps/x/apps/main/src/chatgpt-signin.ts
+++ b/apps/x/apps/main/src/chatgpt-signin.ts
@@ -107,8 +107,13 @@ function startAttempt(): ActiveAttempt {
   let timeoutHandle: NodeJS.Timeout | null = null;
   let serverClosed: Promise<void> | null = null;
 
-  // Close the listening socket AND any keep-alive connections (the browser
-  // holds one open after the callback response) so 1455 frees immediately.
+  // Close the listening socket AND any idle sockets (browser preconnects
+  // that never carried a request) so 1455 frees promptly. Idle-only: finish()
+  // runs from inside onCallback, BEFORE auth-server has flushed the response
+  // page for the in-flight request — closeAllConnections here would destroy
+  // that socket and the browser would show a connection error instead of the
+  // result page. Served sockets can't linger anyway: auth-server stamps
+  // Connection: close on every response.
   const closeServer = (): Promise<void> => {
     if (serverClosed) return serverClosed;
     const s = server;
@@ -117,7 +122,11 @@ function startAttempt(): ActiveAttempt {
       ? Promise.resolve()
       : new Promise<void>((resolve) => {
           s.close(() => resolve());
-          s.closeAllConnections();
+          s.closeIdleConnections();
+          // Preconnect sockets that never carried a request survive
+          // closeIdleConnections; destroy stragglers once the in-flight
+          // response has flushed.
+          setTimeout(() => s.closeAllConnections(), 5000).unref();
         });
     return serverClosed;
   };

--- a/apps/x/apps/main/src/oauth-handler.ts
+++ b/apps/x/apps/main/src/oauth-handler.ts
@@ -288,25 +288,18 @@ export async function connectProvider(provider: string, credentials?: { clientId
     const { server, port: boundPort } = await createAuthServer(
       startPort,
       async (callbackUrl) => {
-        // Guard against duplicate callbacks (browser may send multiple requests)
+        // Guard against duplicate callbacks (browser may send multiple
+        // requests). validateCallback below has already matched `state`, so
+        // only genuine duplicates of the live callback are dropped here — a
+        // stale or foreign request can no longer consume the one-shot guard.
         if (callbackHandled) return;
         callbackHandled = true;
-        const receivedState = callbackUrl.searchParams.get('state');
-        if (receivedState == null || receivedState === '') {
-          throw new Error(
-            'OAuth callback missing state parameter. Complete sign-in in the browser or check the redirect URI.'
-          );
-        }
-        if (receivedState !== state) {
-          throw new Error('Invalid state parameter - possible CSRF attack');
-        }
-
-        const flow = activeFlows.get(state);
-        if (!flow || flow.provider !== provider) {
-          throw new Error('Invalid OAuth flow state');
-        }
 
         try {
+          const flow = activeFlows.get(state);
+          if (!flow || flow.provider !== provider) {
+            throw new Error('Invalid OAuth flow state');
+          }
           // Use full callback URL (includes iss, scope, etc.) so openid-client validation succeeds
           console.log(`[OAuth] Exchanging authorization code for tokens (${provider})...`);
           const tokens = await oauthClient.exchangeCodeForTokens(
@@ -398,7 +391,44 @@ export async function connectProvider(provider: string, credentials?: { clientId
       // Static providers (Google BYOK) keep fixed-port behaviour to match the
       // pre-registered redirect URI at the provider's console. DCR providers
       // can fall back since we register the actual bound port below.
-      { fallback: !isStaticClient },
+      {
+        fallback: !isStaticClient,
+        // Gatekeeper: requests whose `state` doesn't match the live flow (a
+        // leftover tab from an earlier sign-in, a prefetch, a scanner) get a
+        // polite close-this-tab page and never reach onError/onCallback — so
+        // they can neither settle nor poison the live flow. Runs before the
+        // provider-error branch too, keeping stale access_denied tabs inert.
+        validateCallback: (url) => {
+          const receivedState = url.searchParams.get('state');
+          if (receivedState == null || receivedState === '') {
+            return 'The sign-in response is missing its state parameter. Close this tab and retry from Rowboat.';
+          }
+          if (receivedState !== state) {
+            console.warn(`[OAuth] ${provider}: received state ${receivedState} does not match live flow state ${state || '<unset>'}`);
+            return 'This sign-in attempt is no longer active. Close this tab and retry from Rowboat.';
+          }
+          return null;
+        },
+        // Provider returned an error for the live flow (state already matched
+        // above) — e.g. the user declined consent. Settle immediately instead
+        // of leaving the renderer spinning until the 10-minute timeout.
+        onError: (error) => {
+          console.error(`[OAuth] Provider returned error for ${provider}: ${error}`);
+          emitOAuthEvent({
+            provider,
+            success: false,
+            error: error === 'access_denied'
+              ? 'Sign-in was cancelled in the browser.'
+              : `Sign-in failed: ${error}`,
+          });
+          activeFlows.delete(state);
+          if (activeFlow && activeFlow.state === state) {
+            clearTimeout(activeFlow.cleanupTimeout);
+            activeFlow.server.close();
+            activeFlow = null;
+          }
+        },
+      },
     );
 
     // Server is bound. Any throw between here and `activeFlow = ...` would
@@ -454,6 +484,7 @@ export async function connectProvider(provider: string, credentials?: { clientId
       };
 
       // Open in system browser (shares cookies/sessions with user's regular browser)
+      console.log(`[OAuth] ${provider}: opening browser with flow state=${state} (authUrl state=${authUrl.searchParams.get('state') ?? '<missing>'})`);
       shell.openExternal(authUrl.toString());
 
       return { success: true };


### PR DESCRIPTION
## Problem

The first OAuth account connect after a sign-in (e.g. Microsoft Outlook right after Rowboat sign-in during onboarding) would spin forever on macOS. The browser showed "Authorization Successful", the app never received the callback, and only a retry worked. Windows machines were typically unaffected.

## Root cause

Each OAuth flow spawns its own callback server on `localhost:8080`, and the browser pools its connection to that host:port for minutes. `server.close()` only stops *listening* — it does not destroy already-accepted sockets. So after the first flow (Rowboat sign-in) settled and "closed" its server:

1. The browser's keep-alive socket stayed alive, wired to the **dead flow's** request handler.
2. The next flow (Microsoft connect) bound fresh listeners on the freed port and redirected the user to consent.
3. The provider redirected back with a perfectly valid state — and the browser delivered it **down the pooled socket into the dead flow's closure**.
4. The old code swallowed the resulting state mismatch silently: validation threw outside the event-emitting try/catch, `onCallback` was fire-and-forget, the success page rendered unconditionally, and the one-shot `callbackHandled` guard was consumed before validation. Result: browser says success, renderer spins until the 10-minute timeout.

Timing-dependent (the pooled socket lives ~4–6 minutes), which is why fast onboarding reproduced it reliably on one machine and never on another. Root-caused via live instrumented repros — the rejected callback carried the exact state the Microsoft flow had just generated, logged as received by the *rowboat* flow's handler.

## Fixes

- **`Connection: close` on every callback response** — one-shot per-flow servers must never participate in connection pooling. This kills the zombie-socket class outright.
- On close, also `closeIdleConnections()` plus a deferred (5s) `closeAllConnections()` for browser preconnect sockets (which idle-close spares). Deliberately *not* an immediate `closeAllConnections()`: flows close the server from inside `onCallback`, before the awaited response has flushed, and killing that socket shows the user a connection error instead of the result page. `chatgpt-signin` had the same latent race and gets the same fix.
- **Await `onCallback` before responding**, rendering an honest error page on failure instead of an unconditional "Authorization Successful".
- **`validateCallback` gatekeeper** in `connectProvider`: requests whose `state` doesn't match the live flow get a polite close-this-tab page and can no longer consume the one-shot guard; remaining validation moved inside the try/catch so every failure emits `oauth:didConnect` and the renderer spinner always settles.
- **`onError` settles immediately** on provider errors (e.g. `access_denied` when the user cancels consent) instead of spinning until the timeout.
- **Dual-stack loopback bind** (127.0.0.1 primary, ::1 best-effort) — `listen('localhost')` binds a single family chosen by the resolver, leaving the other family connection-refused; mirrors `apps/server.ts`.
- **Request logging** on the callback server (path, state, decision) so any future incident is diagnosable straight from the terminal.

## Verification

- Fresh-install onboarding flow verified live on macOS: Rowboat sign-in → Microsoft Outlook connect completes first try, success page renders, sync starts.
- Standalone smoke tests: response page delivered even when the handler closes the server from its own `finally`; idle/preconnect sockets culled after the grace period; next flow on the same port receives its own callback; stale-state requests rejected without consuming the live flow.
- `npm run typecheck` and `npm run lint` green on this base.

Note: the ChatGPT sign-in change is the same race fix, smoke-tested but not live-tested in this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)