### PR TITLE
docs: add multilingual READMEs (zh-CN, ja, ko, es, fr, pt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="docs/readme/README.zh-CN.md">简体中文</a> · <a href="docs/readme/README.ja.md">日本語</a> · <a href="docs/readme/README.ko.md">한국어</a> · <a href="docs/readme/README.es.md">Español</a> · <a href="docs/readme/README.fr.md">Français</a> · <a href="docs/readme/README.pt.md">Português</a>
+</p>
+
 </h5>
 
 Rowboat indexes your work into a living knowledge graph and uses that to get work done on your machine. It includes work surfaces for collaborating with AI: email client, notes, browser, code mode, meeting note taker, and workspaces for different projects.

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="../../README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · Español · <a href="README.fr.md">Français</a> · <a href="README.pt.md">Português</a>
+</p>
+
+<a href="https://www.youtube.com/watch?v=5AWoGo-L16I" target="_blank" rel="noopener noreferrer">
+  <img width="1339" height="607" alt="rowboat-github-2" src="../../assets/readme-dark/hero-video.png" />
+</a>
+
+<h5 align="center">
+
+<h1 align="center">Rowboat</h1>
+<p align="center">Un compañero de trabajo de IA para escritorio con memoria de tu trabajo y superficies integradas para actuar sobre él.</p>
+
+<p align="center" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+  <a href="https://trendshift.io/repositories/13609" target="blank">
+    <img src="https://trendshift.io/api/badge/repositories/13609" alt="rowboatlabs/rowboat | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://www.rowboatlabs.com/" target="_blank" rel="noopener">
+    <img alt="Website" src="https://img.shields.io/badge/Website-10b981?labelColor=10b981&logo=window&logoColor=white">
+  </a>
+  <a href="https://discord.gg/wajrgmJQ6b" target="_blank" rel="noopener">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&labelColor=5865F2">
+  </a>
+  <a href="https://x.com/intent/user?screen_name=rowboatlabshq" target="_blank" rel="noopener">
+    <img alt="Twitter" src="https://img.shields.io/twitter/follow/rowboatlabshq?style=social">
+  </a>
+  <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
+    <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
+  </a>
+</p>
+
+</h5>
+
+Rowboat indexa tu trabajo en un grafo de conocimiento vivo y lo usa para sacar el trabajo adelante en tu máquina. Incluye superficies de trabajo para colaborar con la IA: cliente de correo electrónico, notas, navegador, modo de código, tomador de notas de reuniones y espacios de trabajo para distintos proyectos.
+
+
+Descarga la última versión para Mac/Windows/Linux: [Descargar](https://www.rowboatlabs.com/downloads)
+
+<p align="center">
+<a href="https://www.youtube.com/watch?v=et5yQABJ3xI">
+<img width="800" height="450" alt="Rowboat Apps to Code demo" src="../../apps/x/demo.gif" />
+</a>
+</p>
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=et5yQABJ3xI"> Demo - de apps a código </a> · <a href="https://www.youtube.com/watch?v=7xTpciZCfpw"> Demo - grafo de conocimiento</a>
+</p>
+
+
+⭐ Si Rowboat te resulta útil, dale una estrella al repositorio. Ayuda a que más personas lo descubran.
+
+---
+## Visión general
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>Cerebro</h3>
+Rowboat indexa el correo electrónico, las reuniones, Slack y las conversaciones con el asistente en un grafo de conocimiento vivo con enlaces bidireccionales al estilo de Obsidian.
+</td>
+<td width="60%">
+<img width="1502" height="939" alt="Brain graph screenshot" src="../../assets/readme-dark/brain.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Correo electrónico</h3>
+El cliente de correo integrado clasifica los correos en importantes y todo lo demás. Rowboat redacta automáticamente borradores de respuesta para los correos importantes usando todo el contexto de tu trabajo.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Email screenshot" src="../../assets/readme-dark/email.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Agentes en segundo plano</h3>
+Puedes configurar agentes en segundo plano que se ejecutan ante eventos, como la llegada de un correo nuevo, o de forma programada, como cada día a las 8am. Pueden conectarse a herramientas, buscar en la web, usar el navegador y escribir código con Claude Code o Codex.
+</td>
+<td width="60%">
+<img width="1512" height="951" alt="Background agents screenshot" src="../../assets/readme-dark/background-agents.png" />
+
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Navegador integrado</h3>
+Rowboat incluye un navegador que te permite colaborar con el asistente en tareas web. Como está aislado de tu navegador principal, puedes iniciar sesión solo en las cuentas a las que quieras que el asistente tenga acceso.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Browser screenshot" src="../../assets/readme-dark/browser.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Notas de reuniones</h3>
+Un tomador de notas de reuniones local que capta el micrófono y el altavoz, genera una transcripción en vivo, resume la reunión en un archivo Markdown y actualiza el grafo de conocimiento.
+</td>
+<td width="60%">
+<img width="1512" height="947" alt="Meeting notes screenshot" src="../../assets/readme-dark/meeting-notes.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Modo de código</h3>
+El modo de código te permite lanzar agentes de programación en paralelo con Claude Code o Codex, y hacer que Rowboat los dirija con todo el contexto de tu trabajo cuando haga falta.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Code mode screenshot" src="../../assets/readme-dark/code-mode.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Apps</h3>
+Puedes crear tus propias superficies de trabajo dentro de Rowboat: tienen acceso a todas las herramientas e integraciones, y puedes compartirlas con otras personas.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Apps screenshot" src="../../assets/readme-dark/apps.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Integraciones</h3>
+Incluye integraciones de un solo clic con los productos más populares.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Integrations screenshot" src="../../assets/readme-dark/integrations.png" />
+</td>
+</tr>
+
+</table>
+
+---
+
+## Instalación
+
+**Descarga la última versión para Mac/Windows/Linux:** [Descargar](https://www.rowboatlabs.com/downloads)
+
+**Todos los archivos de la versión:**   https://github.com/rowboatlabs/rowboat/releases/latest
+
+### Configuración de Google
+Para conectar los servicios de Google (Gmail, Calendar y Drive), sigue la [configuración de Google](https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md).
+
+### Entrada de voz
+Para habilitar la entrada de voz y las notas de voz (opcional), añade una clave de API de Deepgram en `~/.rowboat/config/deepgram.json`
+
+### Salida de voz
+
+Para habilitar la salida de voz (opcional), añade una clave de API de ElevenLabs en `~/.rowboat/config/elevenlabs.json`
+
+### Búsqueda web
+
+Para usar la búsqueda de investigación de Exa (opcional), añade la clave de API de Exa en `~/.rowboat/config/exa-search.json`
+
+### Herramientas externas
+
+Para habilitar herramientas externas (opcional), puedes añadir cualquier servidor MCP o usar las herramientas de Composio añadiendo una clave de API en `~/.rowboat/config/composio.json`
+
+Todos los archivos de claves de API usan el mismo formato:
+```
+{
+  "apiKey": "<key>"
+}
+```
+
+
+## En qué se diferencia
+
+La mayoría de las herramientas de IA reconstruyen el contexto bajo demanda buscando en transcripciones o documentos.
+
+Rowboat, en cambio, mantiene **conocimiento de larga duración**:
+- el contexto se acumula con el tiempo
+- las relaciones son explícitas e inspeccionables
+- las notas las editas tú, no están ocultas dentro de un modelo
+- todo vive en tu máquina como Markdown plano
+
+El resultado es una memoria que se acumula y crece, en lugar de una recuperación que empieza de cero cada vez.
+
+## Trae tu propio modelo
+
+Rowboat funciona con la configuración de modelos que prefieras:
+- **Modelos locales** a través de Ollama o LM Studio
+- **Modelos alojados** (trae tu propia clave de API/proveedor)
+- Cambia de modelo cuando quieras — tus datos permanecen en tu bóveda local de Markdown
+
+## Amplía Rowboat con herramientas (MCP)
+
+Rowboat puede conectarse a herramientas y servicios externos mediante el **Model Context Protocol (MCP)**.
+Eso significa que puedes conectar (por ejemplo) buscadores, bases de datos, CRMs, herramientas de soporte y automatizaciones, o tus propias herramientas internas.
+
+Ejemplos: Exa (búsqueda web), Twitter/X, ElevenLabs (voz), Slack, Linear/Jira, GitHub y más.
+
+## Local primero por diseño
+
+- Todos los datos se almacenan localmente como Markdown plano
+- Sin formatos propietarios ni dependencia de servicios alojados
+- Puedes inspeccionar, editar, respaldar o eliminar todo en cualquier momento
+
+---
+<div align="center">
+
+[Discord](https://discord.gg/wajrgmJQ6b) · [Twitter](https://x.com/intent/user?screen_name=rowboatlabshq)
+</div>

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="../../README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.es.md">Español</a> · Français · <a href="README.pt.md">Português</a>
+</p>
+
+<a href="https://www.youtube.com/watch?v=5AWoGo-L16I" target="_blank" rel="noopener noreferrer">
+  <img width="1339" height="607" alt="rowboat-github-2" src="../../assets/readme-dark/hero-video.png" />
+</a>
+
+<h5 align="center">
+
+<h1 align="center">Rowboat</h1>
+<p align="center">Un coéquipier IA de bureau doté d'une mémoire de votre travail et de surfaces intégrées pour agir dessus.</p>
+
+<p align="center" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+  <a href="https://trendshift.io/repositories/13609" target="blank">
+    <img src="https://trendshift.io/api/badge/repositories/13609" alt="rowboatlabs/rowboat | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://www.rowboatlabs.com/" target="_blank" rel="noopener">
+    <img alt="Website" src="https://img.shields.io/badge/Website-10b981?labelColor=10b981&logo=window&logoColor=white">
+  </a>
+  <a href="https://discord.gg/wajrgmJQ6b" target="_blank" rel="noopener">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&labelColor=5865F2">
+  </a>
+  <a href="https://x.com/intent/user?screen_name=rowboatlabshq" target="_blank" rel="noopener">
+    <img alt="Twitter" src="https://img.shields.io/twitter/follow/rowboatlabshq?style=social">
+  </a>
+  <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
+    <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
+  </a>
+</p>
+
+</h5>
+
+Rowboat indexe votre travail dans un graphe de connaissances vivant et s'en sert pour accomplir des tâches sur votre machine. Il comprend des surfaces de travail pour collaborer avec l'IA : client e-mail, notes, navigateur, mode code, preneur de notes de réunion et espaces de travail pour différents projets.
+
+
+Télécharger la dernière version pour Mac/Windows/Linux : [Télécharger](https://www.rowboatlabs.com/downloads)
+
+<p align="center">
+<a href="https://www.youtube.com/watch?v=et5yQABJ3xI">
+<img width="800" height="450" alt="Rowboat Apps to Code demo" src="../../apps/x/demo.gif" />
+</a>
+</p>
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=et5yQABJ3xI"> Démo - des apps au code </a> · <a href="https://www.youtube.com/watch?v=7xTpciZCfpw"> Démo - graphe de connaissances</a>
+</p>
+
+
+⭐ Si vous trouvez Rowboat utile, merci de mettre une étoile au dépôt. Cela aide davantage de personnes à le découvrir.
+
+---
+## Aperçu
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>Cerveau</h3>
+Rowboat indexe les e-mails, les réunions, Slack et les conversations avec l'assistant dans un graphe de connaissances vivant à liens croisés, à la manière d'Obsidian.
+</td>
+<td width="60%">
+<img width="1502" height="939" alt="Brain graph screenshot" src="../../assets/readme-dark/brain.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>E-mail</h3>
+Le client e-mail intégré trie les messages entre les importants et tout le reste. Rowboat rédige automatiquement des brouillons de réponse pour les e-mails importants en s'appuyant sur tout le contexte de travail.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Email screenshot" src="../../assets/readme-dark/email.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Agents en arrière-plan</h3>
+Vous pouvez configurer des agents en arrière-plan qui se déclenchent sur des événements, comme l'arrivée d'un nouvel e-mail, ou selon un calendrier, par exemple tous les jours à 8 h. Ils peuvent se connecter à des outils, effectuer des recherches sur le web, utiliser le navigateur et écrire du code avec Claude Code ou Codex.
+</td>
+<td width="60%">
+<img width="1512" height="951" alt="Background agents screenshot" src="../../assets/readme-dark/background-agents.png" />
+
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Navigateur intégré</h3>
+Rowboat inclut un navigateur qui vous permet, à vous et à l'assistant, de collaborer sur des tâches web. Comme il est isolé de votre navigateur principal, vous pouvez ne vous connecter qu'aux comptes auxquels vous souhaitez donner accès à l'assistant.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Browser screenshot" src="../../assets/readme-dark/browser.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Notes de réunion</h3>
+Un preneur de notes de réunion local qui capte le micro et le haut-parleur, produit une transcription en direct, résume la réunion dans un fichier Markdown et met à jour le graphe de connaissances.
+</td>
+<td width="60%">
+<img width="1512" height="947" alt="Meeting notes screenshot" src="../../assets/readme-dark/meeting-notes.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Mode code</h3>
+Le mode code vous permet de lancer des agents de codage en parallèle avec Claude Code ou Codex, et de laisser Rowboat les piloter avec tout le contexte de travail là où c'est nécessaire.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Code mode screenshot" src="../../assets/readme-dark/code-mode.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Apps</h3>
+Vous pouvez créer vos propres surfaces de travail dans Rowboat — elles ont accès à tous les outils et intégrations, et vous pouvez les partager avec d'autres personnes.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Apps screenshot" src="../../assets/readme-dark/apps.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Intégrations</h3>
+Inclut des intégrations en un clic vers les produits les plus populaires.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Integrations screenshot" src="../../assets/readme-dark/integrations.png" />
+</td>
+</tr>
+
+</table>
+
+---
+
+## Installation
+
+**Télécharger la dernière version pour Mac/Windows/Linux :** [Télécharger](https://www.rowboatlabs.com/downloads)
+
+**Tous les fichiers de release :**   https://github.com/rowboatlabs/rowboat/releases/latest
+
+### Configuration Google
+Pour connecter les services Google (Gmail, Calendar et Drive), suivez la [Configuration Google](https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md).
+
+### Entrée vocale
+Pour activer l'entrée vocale et les notes vocales (optionnel), ajoutez une clé API Deepgram dans `~/.rowboat/config/deepgram.json`
+
+### Sortie vocale
+
+Pour activer la sortie vocale (optionnel), ajoutez une clé API ElevenLabs dans `~/.rowboat/config/elevenlabs.json`
+
+### Recherche web
+
+Pour utiliser la recherche Exa (optionnel), ajoutez la clé API Exa dans `~/.rowboat/config/exa-search.json`
+
+### Outils externes
+
+Pour activer des outils externes (optionnel), vous pouvez ajouter n'importe quel serveur MCP ou utiliser les outils Composio en ajoutant une clé API dans `~/.rowboat/config/composio.json`
+
+Tous les fichiers de clés API utilisent le même format :
+```
+{
+  "apiKey": "<key>"
+}
+```
+
+
+## En quoi c'est différent
+
+La plupart des outils IA reconstruisent le contexte à la demande en cherchant dans des transcriptions ou des documents.
+
+Rowboat entretient au contraire une **connaissance durable** :
+- le contexte s'accumule au fil du temps
+- les relations sont explicites et inspectables
+- les notes sont modifiables par vous, et non cachées dans un modèle
+- tout réside sur votre machine sous forme de simple Markdown
+
+Le résultat est une mémoire qui se capitalise, plutôt qu'une récupération qui repart de zéro à chaque fois.
+
+## Apportez votre propre modèle
+
+Rowboat fonctionne avec la configuration de modèles de votre choix :
+- **Modèles locaux** via Ollama ou LM Studio
+- **Modèles hébergés** (apportez votre propre clé API/fournisseur)
+- Changez de modèle à tout moment — vos données restent dans votre coffre Markdown local
+
+## Étendez Rowboat avec des outils (MCP)
+
+Rowboat peut se connecter à des outils et services externes via le **Model Context Protocol (MCP)**.
+Vous pouvez ainsi brancher (par exemple) de la recherche, des bases de données, des CRM, des outils de support et des automatisations — ou vos propres outils internes.
+
+Exemples : Exa (recherche web), Twitter/X, ElevenLabs (voix), Slack, Linear/Jira, GitHub, et bien d'autres.
+
+## Local d'abord, par conception
+
+- Toutes les données sont stockées localement sous forme de simple Markdown
+- Pas de formats propriétaires ni de verrouillage dans un service hébergé
+- Vous pouvez tout inspecter, modifier, sauvegarder ou supprimer à tout moment
+
+---
+<div align="center">
+
+[Discord](https://discord.gg/wajrgmJQ6b) · [Twitter](https://x.com/intent/user?screen_name=rowboatlabshq)
+</div>

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="../../README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · 日本語 · <a href="README.ko.md">한국어</a> · <a href="README.es.md">Español</a> · <a href="README.fr.md">Français</a> · <a href="README.pt.md">Português</a>
+</p>
+
+<a href="https://www.youtube.com/watch?v=5AWoGo-L16I" target="_blank" rel="noopener noreferrer">
+  <img width="1339" height="607" alt="rowboat-github-2" src="../../assets/readme-dark/hero-video.png" />
+</a>
+
+<h5 align="center">
+
+<h1 align="center">Rowboat</h1>
+<p align="center">あなたの仕事の記憶を持ち、それをもとに行動するための作業サーフェスを内蔵した、デスクトップ AI コワーカー。</p>
+
+<p align="center" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+  <a href="https://trendshift.io/repositories/13609" target="blank">
+    <img src="https://trendshift.io/api/badge/repositories/13609" alt="rowboatlabs/rowboat | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://www.rowboatlabs.com/" target="_blank" rel="noopener">
+    <img alt="Website" src="https://img.shields.io/badge/Website-10b981?labelColor=10b981&logo=window&logoColor=white">
+  </a>
+  <a href="https://discord.gg/wajrgmJQ6b" target="_blank" rel="noopener">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&labelColor=5865F2">
+  </a>
+  <a href="https://x.com/intent/user?screen_name=rowboatlabshq" target="_blank" rel="noopener">
+    <img alt="Twitter" src="https://img.shields.io/twitter/follow/rowboatlabshq?style=social">
+  </a>
+  <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
+    <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
+  </a>
+</p>
+
+</h5>
+
+Rowboat はあなたの仕事を生きたナレッジグラフとしてインデックス化し、それを活用してあなたのマシン上で仕事をこなします。AI と協働するための作業サーフェスとして、メールクライアント、ノート、ブラウザ、コードモード、会議ノートテイカー、そしてプロジェクトごとのワークスペースを備えています。
+
+
+Mac/Windows/Linux 向け最新版のダウンロード: [ダウンロード](https://www.rowboatlabs.com/downloads)
+
+<p align="center">
+<a href="https://www.youtube.com/watch?v=et5yQABJ3xI">
+<img width="800" height="450" alt="Rowboat Apps to Code demo" src="../../apps/x/demo.gif" />
+</a>
+</p>
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=et5yQABJ3xI"> デモ - アプリからコードへ </a> · <a href="https://www.youtube.com/watch?v=7xTpciZCfpw"> デモ - ナレッジグラフ</a>
+</p>
+
+
+⭐ Rowboat が役に立ったら、ぜひリポジトリにスターを付けてください。より多くの人に見つけてもらう助けになります。
+
+---
+## 概要
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>ブレイン</h3>
+Rowboat はメール、会議、Slack、アシスタントとの会話を、Obsidian スタイルのバックリンクでつながった生きたナレッジグラフとしてインデックス化します。
+</td>
+<td width="60%">
+<img width="1502" height="939" alt="Brain graph screenshot" src="../../assets/readme-dark/brain.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>メール</h3>
+内蔵のメールクライアントが、メールを「重要」と「それ以外」に自動で仕分けます。重要なメールに対しては、Rowboat が仕事のコンテキストをすべて活用して返信の下書きを自動作成します。
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Email screenshot" src="../../assets/readme-dark/email.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>バックグラウンドエージェント</h3>
+新着メールなどのイベントをトリガーに、あるいは毎日午前 8 時のようなスケジュールで動作するバックグラウンドエージェントを設定できます。エージェントはツールに接続し、Web を検索し、ブラウザを操作し、Claude Code や Codex を使ってコードを書くことができます。
+</td>
+<td width="60%">
+<img width="1512" height="951" alt="Background agents screenshot" src="../../assets/readme-dark/background-agents.png" />
+
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>内蔵ブラウザ</h3>
+Rowboat には、あなたとアシスタントが Web 上のタスクで協働できるブラウザが内蔵されています。メインのブラウザから隔離されているため、アシスタントにアクセスさせたいアカウントだけにログインできます。
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Browser screenshot" src="../../assets/readme-dark/browser.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>会議ノート</h3>
+マイクとスピーカーの音声を取り込み、ライブの文字起こしを生成し、会議の内容を Markdown ファイルに要約してナレッジグラフを更新する、ローカル動作の会議ノートテイカーです。
+</td>
+<td width="60%">
+<img width="1512" height="947" alt="Meeting notes screenshot" src="../../assets/readme-dark/meeting-notes.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>コードモード</h3>
+コードモードでは、Claude Code や Codex を使って複数のコーディングエージェントを並列に立ち上げ、必要に応じて Rowboat が仕事のコンテキストをすべて携えてそれらを指揮します。
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Code mode screenshot" src="../../assets/readme-dark/code-mode.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>アプリ</h3>
+Rowboat の中に独自の作業サーフェスを構築できます。作成したアプリはすべてのツールと連携機能にアクセスでき、他の人と共有することもできます。
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Apps screenshot" src="../../assets/readme-dark/apps.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>連携機能</h3>
+人気の高い各種プロダクトとのワンクリック連携を備えています。
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Integrations screenshot" src="../../assets/readme-dark/integrations.png" />
+</td>
+</tr>
+
+</table>
+
+---
+
+## インストール
+
+**Mac/Windows/Linux 向け最新版のダウンロード:** [ダウンロード](https://www.rowboatlabs.com/downloads)
+
+**すべてのリリースファイル:**   https://github.com/rowboatlabs/rowboat/releases/latest
+
+### Google のセットアップ
+Google サービス（Gmail、カレンダー、ドライブ）に接続するには、[Google のセットアップ](https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md)に従ってください。
+
+### 音声入力
+音声入力とボイスノートを有効にするには（任意）、`~/.rowboat/config/deepgram.json` に Deepgram の API キーを追加してください。
+
+### 音声出力
+
+音声出力を有効にするには（任意）、`~/.rowboat/config/elevenlabs.json` に ElevenLabs の API キーを追加してください。
+
+### Web 検索
+
+Exa のリサーチ検索を利用するには（任意）、`~/.rowboat/config/exa-search.json` に Exa の API キーを追加してください。
+
+### 外部ツール
+
+外部ツールを有効にするには（任意）、任意の MCP サーバーを追加するか、`~/.rowboat/config/composio.json` に API キーを追加して Composio のツールを利用できます。
+
+すべての API キーファイルは同じ形式です:
+```
+{
+  "apiKey": "<key>"
+}
+```
+
+
+## 何が違うのか
+
+多くの AI ツールは、トランスクリプトやドキュメントを検索して、その都度コンテキストを再構築します。
+
+Rowboat はその代わりに、**長期的に維持されるナレッジ**を保持します:
+- コンテキストは時間とともに蓄積される
+- 関係性は明示的で、いつでも確認できる
+- ノートはモデルの中に隠されるのではなく、あなた自身が編集できる
+- すべてがプレーンな Markdown としてあなたのマシン上に存在する
+
+その結果得られるのは、毎回ゼロから始まる検索ではなく、複利のように積み上がる記憶です。
+
+## 好みのモデルを持ち込む
+
+Rowboat はあなたの好みのモデル構成で動作します:
+- Ollama や LM Studio 経由の**ローカルモデル**
+- **ホスト型モデル**（お手持ちの API キー/プロバイダーを利用）
+- モデルはいつでも切り替え可能 — データはローカルの Markdown ボルトに保持されます
+
+## ツールで Rowboat を拡張（MCP）
+
+Rowboat は **Model Context Protocol（MCP）** を介して外部のツールやサービスに接続できます。
+つまり、検索、データベース、CRM、サポートツール、自動化など（一例です）、あるいは社内の独自ツールも接続できます。
+
+例: Exa（Web 検索）、Twitter/X、ElevenLabs（音声）、Slack、Linear/Jira、GitHub など。
+
+## 設計思想としてのローカルファースト
+
+- すべてのデータはプレーンな Markdown としてローカルに保存されます
+- 独自形式やホスティングによるロックインはありません
+- すべてをいつでも確認、編集、バックアップ、削除できます
+
+---
+<div align="center">
+
+[Discord](https://discord.gg/wajrgmJQ6b) · [Twitter](https://x.com/intent/user?screen_name=rowboatlabshq)
+</div>

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="../../README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · 한국어 · <a href="README.es.md">Español</a> · <a href="README.fr.md">Français</a> · <a href="README.pt.md">Português</a>
+</p>
+
+<a href="https://www.youtube.com/watch?v=5AWoGo-L16I" target="_blank" rel="noopener noreferrer">
+  <img width="1339" height="607" alt="rowboat-github-2" src="../../assets/readme-dark/hero-video.png" />
+</a>
+
+<h5 align="center">
+
+<h1 align="center">Rowboat</h1>
+<p align="center">당신의 업무를 기억하고, 그 위에서 곧바로 행동할 수 있는 내장 작업 화면을 갖춘 데스크톱 AI 동료.</p>
+
+<p align="center" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+  <a href="https://trendshift.io/repositories/13609" target="blank">
+    <img src="https://trendshift.io/api/badge/repositories/13609" alt="rowboatlabs/rowboat | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://www.rowboatlabs.com/" target="_blank" rel="noopener">
+    <img alt="Website" src="https://img.shields.io/badge/Website-10b981?labelColor=10b981&logo=window&logoColor=white">
+  </a>
+  <a href="https://discord.gg/wajrgmJQ6b" target="_blank" rel="noopener">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&labelColor=5865F2">
+  </a>
+  <a href="https://x.com/intent/user?screen_name=rowboatlabshq" target="_blank" rel="noopener">
+    <img alt="Twitter" src="https://img.shields.io/twitter/follow/rowboatlabshq?style=social">
+  </a>
+  <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
+    <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
+  </a>
+</p>
+
+</h5>
+
+Rowboat은 당신의 업무를 살아 있는 지식 그래프로 인덱싱하고, 이를 활용해 당신의 컴퓨터에서 일을 처리합니다. AI와 협업할 수 있는 작업 화면으로 이메일 클라이언트, 노트, 브라우저, 코드 모드, 회의록 작성 도구, 그리고 프로젝트별 워크스페이스를 제공합니다.
+
+
+Mac/Windows/Linux용 최신 버전 다운로드: [다운로드](https://www.rowboatlabs.com/downloads)
+
+<p align="center">
+<a href="https://www.youtube.com/watch?v=et5yQABJ3xI">
+<img width="800" height="450" alt="Rowboat Apps to Code demo" src="../../apps/x/demo.gif" />
+</a>
+</p>
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=et5yQABJ3xI"> 데모 - 앱에서 코드로 </a> · <a href="https://www.youtube.com/watch?v=7xTpciZCfpw"> 데모 - 지식 그래프</a>
+</p>
+
+
+⭐ Rowboat이 유용하다면 리포지토리에 스타를 눌러 주세요. 더 많은 사람이 발견하는 데 도움이 됩니다.
+
+---
+## 개요
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>브레인</h3>
+Rowboat은 이메일, 회의, Slack, 어시스턴트와의 대화를 Obsidian 스타일의 백링크로 연결된 살아 있는 지식 그래프로 인덱싱합니다.
+</td>
+<td width="60%">
+<img width="1502" height="939" alt="Brain graph screenshot" src="../../assets/readme-dark/brain.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>이메일</h3>
+내장 이메일 클라이언트가 이메일을 '중요'와 '그 외'로 분류합니다. 중요한 이메일에는 Rowboat이 모든 업무 컨텍스트를 활용해 자동으로 답장 초안을 작성합니다.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Email screenshot" src="../../assets/readme-dark/email.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>백그라운드 에이전트</h3>
+새 이메일 같은 이벤트가 발생할 때 또는 매일 오전 8시 같은 일정에 따라 실행되는 백그라운드 에이전트를 설정할 수 있습니다. 에이전트는 도구에 연결하고, 웹을 검색하고, 브라우저를 사용하며, Claude Code나 Codex로 코드를 작성할 수 있습니다.
+</td>
+<td width="60%">
+<img width="1512" height="951" alt="Background agents screenshot" src="../../assets/readme-dark/background-agents.png" />
+
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>내장 브라우저</h3>
+Rowboat에는 당신과 어시스턴트가 웹 작업을 함께 수행할 수 있는 브라우저가 내장되어 있습니다. 기본 브라우저와 격리되어 있어, 어시스턴트가 접근해도 되는 계정에만 로그인할 수 있습니다.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Browser screenshot" src="../../assets/readme-dark/browser.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>회의록</h3>
+마이크와 스피커 소리를 받아 실시간 트랜스크립트를 생성하고, 회의 내용을 Markdown 파일로 요약하며, 지식 그래프를 업데이트하는 로컬 회의록 작성 도구입니다.
+</td>
+<td width="60%">
+<img width="1512" height="947" alt="Meeting notes screenshot" src="../../assets/readme-dark/meeting-notes.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>코드 모드</h3>
+코드 모드에서는 Claude Code나 Codex로 병렬 코딩 에이전트를 여러 개 띄우고, 필요할 때 Rowboat이 모든 업무 컨텍스트를 가지고 이들을 지휘하게 할 수 있습니다.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Code mode screenshot" src="../../assets/readme-dark/code-mode.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>앱</h3>
+Rowboat 안에서 자신만의 작업 화면을 만들 수 있습니다. 모든 도구와 통합에 접근할 수 있으며, 다른 사람과 공유할 수도 있습니다.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Apps screenshot" src="../../assets/readme-dark/apps.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>통합</h3>
+가장 인기 있는 제품들과의 원클릭 통합을 제공합니다.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Integrations screenshot" src="../../assets/readme-dark/integrations.png" />
+</td>
+</tr>
+
+</table>
+
+---
+
+## 설치
+
+**Mac/Windows/Linux용 최신 버전 다운로드:** [다운로드](https://www.rowboatlabs.com/downloads)
+
+**모든 릴리스 파일:**   https://github.com/rowboatlabs/rowboat/releases/latest
+
+### Google 설정
+Google 서비스(Gmail, Calendar, Drive)를 연결하려면 [Google 설정](https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md)을 따르세요.
+
+### 음성 입력
+음성 입력과 음성 노트를 사용하려면(선택 사항) `~/.rowboat/config/deepgram.json`에 Deepgram API 키를 추가하세요
+
+### 음성 출력
+
+음성 출력을 사용하려면(선택 사항) `~/.rowboat/config/elevenlabs.json`에 ElevenLabs API 키를 추가하세요
+
+### 웹 검색
+
+Exa 리서치 검색을 사용하려면(선택 사항) `~/.rowboat/config/exa-search.json`에 Exa API 키를 추가하세요
+
+### 외부 도구
+
+외부 도구를 사용하려면(선택 사항) 아무 MCP 서버나 추가하거나, `~/.rowboat/config/composio.json`에 API 키를 추가해 Composio 도구를 사용할 수 있습니다
+
+모든 API 키 파일은 동일한 형식을 사용합니다:
+```
+{
+  "apiKey": "<key>"
+}
+```
+
+
+## 무엇이 다른가
+
+대부분의 AI 도구는 대화 기록이나 문서를 검색해 필요할 때마다 컨텍스트를 다시 구성합니다.
+
+Rowboat은 그 대신 **오래 지속되는 지식**을 유지합니다:
+- 컨텍스트가 시간이 지날수록 축적됩니다
+- 관계가 명시적이고 직접 살펴볼 수 있습니다
+- 노트는 모델 안에 숨겨져 있지 않고 당신이 직접 편집할 수 있습니다
+- 모든 것이 일반 Markdown으로 당신의 컴퓨터에 저장됩니다
+
+그 결과, 매번 처음부터 시작하는 검색이 아니라 복리처럼 쌓이는 기억을 얻게 됩니다.
+
+## 원하는 모델 사용하기
+
+Rowboat은 당신이 선호하는 모델 구성으로 동작합니다:
+- **로컬 모델** — Ollama 또는 LM Studio 사용
+- **호스팅 모델**(자신의 API 키/프로바이더 사용)
+- 언제든 모델 교체 가능 — 데이터는 로컬 Markdown 볼트에 그대로 남습니다
+
+## 도구로 Rowboat 확장하기 (MCP)
+
+Rowboat은 **Model Context Protocol(MCP)**을 통해 외부 도구 및 서비스에 연결할 수 있습니다.
+즉, 예를 들어 검색, 데이터베이스, CRM, 고객 지원 도구, 자동화는 물론 자체 내부 도구도 연결할 수 있습니다.
+
+예: Exa(웹 검색), Twitter/X, ElevenLabs(음성), Slack, Linear/Jira, GitHub 등.
+
+## 로컬 우선 설계
+
+- 모든 데이터는 일반 Markdown으로 로컬에 저장됩니다
+- 독점 포맷이나 호스팅 종속이 없습니다
+- 언제든 모든 것을 확인, 편집, 백업, 삭제할 수 있습니다
+
+---
+<div align="center">
+
+[Discord](https://discord.gg/wajrgmJQ6b) · [Twitter](https://x.com/intent/user?screen_name=rowboatlabshq)
+</div>

--- a/docs/readme/README.pt.md
+++ b/docs/readme/README.pt.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="../../README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.es.md">Español</a> · <a href="README.fr.md">Français</a> · Português
+</p>
+
+<a href="https://www.youtube.com/watch?v=5AWoGo-L16I" target="_blank" rel="noopener noreferrer">
+  <img width="1339" height="607" alt="rowboat-github-2" src="../../assets/readme-dark/hero-video.png" />
+</a>
+
+<h5 align="center">
+
+<h1 align="center">Rowboat</h1>
+<p align="center">Um colega de trabalho de IA para desktop, com memória do seu trabalho e superfícies integradas para agir sobre ele.</p>
+
+<p align="center" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+  <a href="https://trendshift.io/repositories/13609" target="blank">
+    <img src="https://trendshift.io/api/badge/repositories/13609" alt="rowboatlabs/rowboat | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://www.rowboatlabs.com/" target="_blank" rel="noopener">
+    <img alt="Website" src="https://img.shields.io/badge/Website-10b981?labelColor=10b981&logo=window&logoColor=white">
+  </a>
+  <a href="https://discord.gg/wajrgmJQ6b" target="_blank" rel="noopener">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&labelColor=5865F2">
+  </a>
+  <a href="https://x.com/intent/user?screen_name=rowboatlabshq" target="_blank" rel="noopener">
+    <img alt="Twitter" src="https://img.shields.io/twitter/follow/rowboatlabshq?style=social">
+  </a>
+  <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
+    <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
+  </a>
+</p>
+
+</h5>
+
+O Rowboat indexa o seu trabalho em um grafo de conhecimento vivo e o utiliza para realizar tarefas na sua máquina. Inclui superfícies de trabalho para colaborar com a IA: cliente de e-mail, notas, navegador, modo de código, assistente de notas de reunião e espaços de trabalho para diferentes projetos.
+
+
+Baixe a versão mais recente para Mac/Windows/Linux: [Download](https://www.rowboatlabs.com/downloads)
+
+<p align="center">
+<a href="https://www.youtube.com/watch?v=et5yQABJ3xI">
+<img width="800" height="450" alt="Rowboat Apps to Code demo" src="../../apps/x/demo.gif" />
+</a>
+</p>
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=et5yQABJ3xI"> Demo — de apps a código </a> · <a href="https://www.youtube.com/watch?v=7xTpciZCfpw"> Demo — grafo de conhecimento</a>
+</p>
+
+
+⭐ Se o Rowboat for útil para você, deixe uma estrela no repositório. Isso ajuda mais pessoas a encontrá-lo.
+
+---
+## Visão geral
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>Cérebro</h3>
+O Rowboat indexa e-mails, reuniões, Slack e conversas com o assistente em um grafo de conhecimento vivo, com backlinks no estilo do Obsidian.
+</td>
+<td width="60%">
+<img width="1502" height="939" alt="Brain graph screenshot" src="../../assets/readme-dark/brain.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>E-mail</h3>
+O cliente de e-mail integrado separa os e-mails entre importantes e todo o resto. O Rowboat redige automaticamente respostas para os e-mails importantes usando todo o contexto do seu trabalho.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Email screenshot" src="../../assets/readme-dark/email.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Agentes em segundo plano</h3>
+Você pode configurar agentes em segundo plano que são executados a partir de eventos, como a chegada de um novo e-mail, ou de forma agendada, como todos os dias às 8h. Eles podem se conectar a ferramentas, pesquisar na web, usar o navegador e escrever código com o Claude Code ou o Codex.
+</td>
+<td width="60%">
+<img width="1512" height="951" alt="Background agents screenshot" src="../../assets/readme-dark/background-agents.png" />
+
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Navegador integrado</h3>
+O Rowboat inclui um navegador que permite que você e o assistente colaborem em tarefas na web. Como ele é isolado do seu navegador principal, você pode fazer login apenas nas contas que quiser que o assistente acesse.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Browser screenshot" src="../../assets/readme-dark/browser.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Notas de reunião</h3>
+Um assistente local de notas de reunião que captura o microfone e o alto-falante, produz uma transcrição ao vivo, resume a reunião em um arquivo Markdown e atualiza o grafo de conhecimento.
+</td>
+<td width="60%">
+<img width="1512" height="947" alt="Meeting notes screenshot" src="../../assets/readme-dark/meeting-notes.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Modo de código</h3>
+O modo de código permite iniciar agentes de programação em paralelo com o Claude Code ou o Codex, e deixar que o Rowboat os conduza com todo o contexto do seu trabalho onde for necessário.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Code mode screenshot" src="../../assets/readme-dark/code-mode.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Apps</h3>
+Você pode criar suas próprias superfícies de trabalho dentro do Rowboat — elas têm acesso a todas as ferramentas e integrações, e você pode compartilhá-las com outras pessoas.
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Apps screenshot" src="../../assets/readme-dark/apps.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Integrações</h3>
+Inclui integrações de um clique com os produtos mais populares.
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Integrations screenshot" src="../../assets/readme-dark/integrations.png" />
+</td>
+</tr>
+
+</table>
+
+---
+
+## Instalação
+
+**Baixe a versão mais recente para Mac/Windows/Linux:** [Download](https://www.rowboatlabs.com/downloads)
+
+**Todos os arquivos de release:**   https://github.com/rowboatlabs/rowboat/releases/latest
+
+### Configuração do Google
+Para conectar os serviços do Google (Gmail, Agenda e Drive), siga a [Configuração do Google](https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md).
+
+### Entrada de voz
+Para habilitar a entrada de voz e as notas de voz (opcional), adicione uma chave de API da Deepgram em `~/.rowboat/config/deepgram.json`
+
+### Saída de voz
+
+Para habilitar a saída de voz (opcional), adicione uma chave de API da ElevenLabs em `~/.rowboat/config/elevenlabs.json`
+
+### Pesquisa na web
+
+Para usar a pesquisa avançada da Exa (opcional), adicione a chave de API da Exa em `~/.rowboat/config/exa-search.json`
+
+### Ferramentas externas
+
+Para habilitar ferramentas externas (opcional), você pode adicionar qualquer servidor MCP ou usar as ferramentas da Composio adicionando uma chave de API em `~/.rowboat/config/composio.json`
+
+Todos os arquivos de chave de API usam o mesmo formato:
+```
+{
+  "apiKey": "<key>"
+}
+```
+
+
+## Como ele é diferente
+
+A maioria das ferramentas de IA reconstrói o contexto sob demanda, pesquisando transcrições ou documentos.
+
+O Rowboat, em vez disso, mantém **conhecimento de longa duração**:
+- o contexto se acumula ao longo do tempo
+- as relações são explícitas e inspecionáveis
+- as notas podem ser editadas por você, em vez de ficarem escondidas dentro de um modelo
+- tudo fica na sua máquina como Markdown simples
+
+O resultado é uma memória que se acumula e se valoriza, em vez de uma recuperação que começa do zero a cada vez.
+
+## Traga seu próprio modelo
+
+O Rowboat funciona com a configuração de modelos que você preferir:
+- **Modelos locais** via Ollama ou LM Studio
+- **Modelos hospedados** (traga sua própria chave de API/provedor)
+- Troque de modelo a qualquer momento — seus dados permanecem no seu cofre local de Markdown
+
+## Estenda o Rowboat com ferramentas (MCP)
+
+O Rowboat pode se conectar a ferramentas e serviços externos por meio do **Model Context Protocol (MCP)**.
+Isso significa que você pode conectar (por exemplo) pesquisa, bancos de dados, CRMs, ferramentas de suporte e automações — ou suas próprias ferramentas internas.
+
+Exemplos: Exa (pesquisa na web), Twitter/X, ElevenLabs (voz), Slack, Linear/Jira, GitHub e muito mais.
+
+## Local em primeiro lugar, por design
+
+- Todos os dados são armazenados localmente como Markdown simples
+- Sem formatos proprietários nem dependência de serviços hospedados
+- Você pode inspecionar, editar, fazer backup ou excluir tudo a qualquer momento
+
+---
+<div align="center">
+
+[Discord](https://discord.gg/wajrgmJQ6b) · [Twitter](https://x.com/intent/user?screen_name=rowboatlabshq)
+</div>

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -1,0 +1,205 @@
+<p align="center">
+  <a href="../../README.md">English</a> · 简体中文 · <a href="README.ja.md">日本語</a> · <a href="README.ko.md">한국어</a> · <a href="README.es.md">Español</a> · <a href="README.fr.md">Français</a> · <a href="README.pt.md">Português</a>
+</p>
+
+<a href="https://www.youtube.com/watch?v=5AWoGo-L16I" target="_blank" rel="noopener noreferrer">
+  <img width="1339" height="607" alt="rowboat-github-2" src="../../assets/readme-dark/hero-video.png" />
+</a>
+
+<h5 align="center">
+
+<h1 align="center">Rowboat</h1>
+<p align="center">一款能记住你的工作、并通过内置工作界面付诸行动的桌面 AI 同事。</p>
+
+<p align="center" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
+  <a href="https://trendshift.io/repositories/13609" target="blank">
+    <img src="https://trendshift.io/api/badge/repositories/13609" alt="rowboatlabs/rowboat | Trendshift" width="250" height="55"/>
+  </a>
+</p>
+
+<p align="center">
+    <a href="https://www.rowboatlabs.com/" target="_blank" rel="noopener">
+    <img alt="Website" src="https://img.shields.io/badge/Website-10b981?labelColor=10b981&logo=window&logoColor=white">
+  </a>
+  <a href="https://discord.gg/wajrgmJQ6b" target="_blank" rel="noopener">
+    <img alt="Discord" src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&labelColor=5865F2">
+  </a>
+  <a href="https://x.com/intent/user?screen_name=rowboatlabshq" target="_blank" rel="noopener">
+    <img alt="Twitter" src="https://img.shields.io/twitter/follow/rowboatlabshq?style=social">
+  </a>
+  <a href="https://www.ycombinator.com" target="_blank" rel="noopener">
+    <img alt="Y Combinator" src="https://img.shields.io/badge/Y%20Combinator-S24-orange">
+  </a>
+</p>
+
+</h5>
+
+Rowboat 将你的工作索引成一个持续更新的知识图谱，并利用它在你的电脑上完成工作。它内置了多种与 AI 协作的工作界面：邮件客户端、笔记、浏览器、代码模式、会议记录助手，以及面向不同项目的工作区。
+
+
+下载最新版（Mac/Windows/Linux）：[下载](https://www.rowboatlabs.com/downloads)
+
+<p align="center">
+<a href="https://www.youtube.com/watch?v=et5yQABJ3xI">
+<img width="800" height="450" alt="Rowboat Apps to Code demo" src="../../apps/x/demo.gif" />
+</a>
+</p>
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=et5yQABJ3xI"> 演示 - 从应用到代码 </a> · <a href="https://www.youtube.com/watch?v=7xTpciZCfpw"> 演示 - 知识图谱</a>
+</p>
+
+
+⭐ 如果你觉得 Rowboat 有用，请为本仓库点个 Star，让更多人发现它。
+
+---
+## 概览
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>大脑</h3>
+Rowboat 将邮件、会议、Slack 和助手对话索引成一个持续更新、带有 Obsidian 风格双向链接的知识图谱。
+</td>
+<td width="60%">
+<img width="1502" height="939" alt="Brain graph screenshot" src="../../assets/readme-dark/brain.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>邮件</h3>
+内置邮件客户端会把邮件分为重要邮件和其他邮件两类。对于重要邮件，Rowboat 会利用全部工作上下文自动起草回复。
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Email screenshot" src="../../assets/readme-dark/email.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>后台代理</h3>
+你可以设置后台代理，让它们在新邮件等事件发生时运行，或按计划运行（例如每天早上 8 点）。它们可以连接工具、搜索网页、使用浏览器，并通过 Claude Code 或 Codex 编写代码。
+</td>
+<td width="60%">
+<img width="1512" height="951" alt="Background agents screenshot" src="../../assets/readme-dark/background-agents.png" />
+
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>内置浏览器</h3>
+Rowboat 内置了一个浏览器，让你和助手可以协作完成网页任务。由于它与你的主浏览器相互隔离，你可以只登录那些允许助手访问的账号。
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Browser screenshot" src="../../assets/readme-dark/browser.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>会议记录</h3>
+本地运行的会议记录助手，接入麦克风和扬声器，生成实时转录，将会议总结成 Markdown 文件，并更新知识图谱。
+</td>
+<td width="60%">
+<img width="1512" height="947" alt="Meeting notes screenshot" src="../../assets/readme-dark/meeting-notes.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>代码模式</h3>
+代码模式让你可以使用 Claude Code 或 Codex 启动多个并行的编码代理，并在需要时让 Rowboat 携带全部工作上下文来驱动它们。
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Code mode screenshot" src="../../assets/readme-dark/code-mode.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>应用</h3>
+你可以在 Rowboat 中构建自己的工作界面——它们可以访问所有工具和集成，你还可以将它们分享给其他人。
+</td>
+<td width="60%">
+<img width="1512" height="949" alt="Apps screenshot" src="../../assets/readme-dark/apps.png" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>集成</h3>
+内置对大多数主流产品的一键集成。
+</td>
+<td width="60%">
+<img width="1512" height="948" alt="Integrations screenshot" src="../../assets/readme-dark/integrations.png" />
+</td>
+</tr>
+
+</table>
+
+---
+
+## 安装
+
+**下载最新版（Mac/Windows/Linux）：** [下载](https://www.rowboatlabs.com/downloads)
+
+**所有发布文件：**   https://github.com/rowboatlabs/rowboat/releases/latest
+
+### Google 设置
+要连接 Google 服务（Gmail、Calendar 和 Drive），请参照 [Google 设置](https://github.com/rowboatlabs/rowboat/blob/main/google-setup.md)。
+
+### 语音输入
+要启用语音输入和语音笔记（可选），请在 `~/.rowboat/config/deepgram.json` 中添加 Deepgram API 密钥
+
+### 语音输出
+
+要启用语音输出（可选），请在 `~/.rowboat/config/elevenlabs.json` 中添加 ElevenLabs API 密钥
+
+### 网页搜索
+
+要使用 Exa 研究搜索（可选），请在 `~/.rowboat/config/exa-search.json` 中添加 Exa API 密钥
+
+### 外部工具
+
+要启用外部工具（可选），你可以添加任意 MCP 服务器，或通过在 `~/.rowboat/config/composio.json` 中添加 API 密钥来使用 Composio 工具
+
+所有 API 密钥文件都使用相同的格式：
+```
+{
+  "apiKey": "<key>"
+}
+```
+
+
+## 有何不同
+
+大多数 AI 工具通过搜索转录或文档来按需重建上下文。
+
+Rowboat 则维护着**长期存续的知识**：
+- 上下文随时间不断积累
+- 关系是显式的、可检视的
+- 笔记由你来编辑，而不是隐藏在模型内部
+- 一切都以纯 Markdown 形式保存在你的电脑上
+
+由此得到的是不断复利增长的记忆，而不是每次都从零开始的检索。
+
+## 自带模型
+
+Rowboat 支持你偏好的模型配置：
+- **本地模型**：通过 Ollama 或 LM Studio
+- **托管模型**（自带 API 密钥/提供商）
+- 随时切换模型——你的数据始终保存在本地 Markdown 库中
+
+## 通过工具扩展 Rowboat（MCP）
+
+Rowboat 可以通过**模型上下文协议（Model Context Protocol，MCP）**连接外部工具和服务。
+这意味着你可以接入（例如）搜索、数据库、CRM、客服工具和自动化流程——或者你自己的内部工具。
+
+示例：Exa（网页搜索）、Twitter/X、ElevenLabs（语音）、Slack、Linear/Jira、GitHub 等。
+
+## 本地优先的设计
+
+- 所有数据都以纯 Markdown 格式保存在本地
+- 没有专有格式，也没有托管锁定
+- 你可以随时检视、编辑、备份或删除所有内容
+
+---
+<div align="center">
+
+[Discord](https://discord.gg/wajrgmJQ6b) · [Twitter](https://x.com/intent/user?screen_name=rowboatlabshq)
+</div>


### PR DESCRIPTION
## What

- Adds six translated READMEs under `docs/readme/`: Simplified Chinese (`README.zh-CN.md`), Japanese (`README.ja.md`), Korean (`README.ko.md`), Spanish (`README.es.md`), French (`README.fr.md`), and Portuguese (`README.pt.md`).
- Adds a language switcher to the top of the English `README.md` linking to all six translations; each translation carries the same switcher (with an English link) so readers can move between languages from any page.

## Review pass

Each translation went through a review pass checking that:
- Product names, feature names, and technical terms (knowledge graph, work surfaces, MCP, etc.) are handled consistently and left in English where that's the convention for the language.
- All links, badges, images, and anchors match the English README.
- Section structure and content stay 1:1 with the current English README — nothing added or dropped.

## Maintenance note

These translations are snapshots of the English README as of this PR. When `README.md` changes, the six files in `docs/readme/` should be re-synced to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)