### PR TITLE
fix(x): escalate auto-permission classifier denials to the user when present

### DIFF
--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
@@ -627,6 +627,38 @@ describe('buildSessionChatState', () => {
     expect(state.isWaitingOnHuman).toBe(true)
   })
 
+  it('marks the turn as waiting when automatic permission classification denies with a human available', () => {
+    const turnCreated = created(T1, S1)
+    const turn = reduceTurn([
+      {
+        ...turnCreated,
+        config: { ...turnCreated.config, autoPermission: true },
+      },
+      requested(T1, 0),
+      completed(T1, 0, assistantCalls(toolCallPart('p1', 'executeCommand'))),
+      {
+        type: 'tool_permission_required',
+        turnId: T1,
+        ts: TS,
+        toolCallId: 'p1',
+        toolName: 'executeCommand',
+        request: { kind: 'command', commandNames: ['rm'] },
+      },
+      {
+        type: 'tool_permission_classified',
+        turnId: T1,
+        ts: TS,
+        toolCallId: 'p1',
+        decision: 'deny',
+        reason: 'destructive command',
+      },
+    ])
+    const state = buildSessionChatState([turn], emptyOverlay())
+    expect(state.allPermissionRequests.has('p1')).toBe(true)
+    expect(state.isProcessing).toBe(true)
+    expect(state.isWaitingOnHuman).toBe(true)
+  })
+
   it('tracks reasoning only between reasoning_start and reasoning_end', () => {
     const events: TEvent[] = [
       created(T1, S1),

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
@@ -426,10 +426,11 @@ function toolCallPartOf(tc: ToolCallState) {
 }
 
 // An unresolved permission is not necessarily waiting on the user. In auto
-// mode the classifier advances it without human input unless it defers (or
-// cannot classify the request). Keeping this distinction here prevents both
-// a transient permission card and a false human-wait state while the classifier
-// is working.
+// mode the classifier advances it without human input unless it defers,
+// denies (a deny with a human available escalates to them rather than
+// resolving), or cannot classify the request. Keeping this distinction here
+// prevents both a transient permission card and a false human-wait state
+// while the classifier is working.
 function permissionNeedsHuman(state: TurnState, tc: ToolCallState): boolean {
   if (!state.definition.config.humanAvailable) return false
   if (!state.definition.config.autoPermission) return true
@@ -437,7 +438,8 @@ function permissionNeedsHuman(state: TurnState, tc: ToolCallState): boolean {
   return (
     permission?.required.checkerError !== undefined ||
     permission?.classificationFailed === true ||
-    permission?.classification?.decision === 'defer'
+    permission?.classification?.decision === 'defer' ||
+    permission?.classification?.decision === 'deny'
   )
 }
 

--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -821,13 +821,16 @@ Only `tool_permission_resolved` is an effective execution decision.
 | --- | --- | --- |
 | false | true | Ask human and suspend. |
 | false | false | Deny and continue with an error tool result. |
-| true | true | Classify; deferred calls ask human. |
-| true | false | Classify; deferred calls are denied. |
+| true | true | Classify; deferred and denied calls ask human. |
+| true | false | Classify; deferred and denied calls are denied. |
 
 Classifier decisions behave as follows:
 
 - `allow`: resolve allow and execute/dispatch immediately.
-- `deny`: resolve deny and create an error tool result.
+- `deny`: with a human available, escalate to them (the classified event keeps
+  the objection on record; the human makes the effective decision); otherwise
+  resolve deny and create an error tool result carrying the classifier's
+  reason.
 - `defer`: ask a human if available; otherwise deny.
 - Classifier failure or omitted decision: record failure and treat as `defer`.
 
@@ -1821,7 +1824,8 @@ Assertions:
 
 - Classifier decisions and effective decisions are distinct records.
 - Allow executes.
-- Deny creates an error result without invocation.
+- Deny escalates to a human when available; their allow executes the call.
+- Deny creates an error result without invocation when no human is available.
 - Defer asks a human when available.
 - Defer denies when no human is available.
 - Classifier failure and missing decisions normalize to defer.

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -838,7 +838,10 @@ describe("automatic permission classification (26.4)", () => {
 
     it("handles allow, deny, and defer in one batch with a human available", async () => {
         const { runtime, repo, classifier } = makeRuntime({
-            models: [respond(completedResp(batch))],
+            models: [
+                respond(completedResp(batch)),
+                respond(completedResp(assistantText("done"))),
+            ],
             checker: new FakePermissionChecker(checkerRules),
             classifier: new FakePermissionClassifier(classifierImpl),
         });
@@ -847,10 +850,13 @@ describe("automatic permission classification (26.4)", () => {
         });
         const { outcome } = await advanceAndSettle(runtime, turnId);
 
-        // Deferred call asks the human.
+        // Denied and deferred calls both escalate to the human.
         expect(outcome).toMatchObject({
             status: "suspended",
-            pendingPermissions: [expect.objectContaining({ toolCallId: "CF" })],
+            pendingPermissions: [
+                expect.objectContaining({ toolCallId: "CD" }),
+                expect.objectContaining({ toolCallId: "CF" }),
+            ],
         });
         expect(classifier.batches).toHaveLength(1);
         expect(classifier.batches[0].map((r) => r.toolCallId)).toEqual([
@@ -864,28 +870,44 @@ describe("automatic permission classification (26.4)", () => {
             messageCount: 2,
         });
 
-        const log = await persisted(repo, turnId);
-        // Classifier provenance and effective decisions are distinct records.
+        let log = await persisted(repo, turnId);
+        // Classifier provenance and effective decisions are distinct records:
+        // the deny is on record but only the allow resolved.
         expect(
             log.filter((e) => e.type === "tool_permission_classified"),
         ).toHaveLength(3);
-        const resolved = log.filter((e) => e.type === "tool_permission_resolved");
-        expect(resolved).toEqual([
+        expect(log.filter((e) => e.type === "tool_permission_resolved")).toEqual([
             expect.objectContaining({ toolCallId: "CA", decision: "allow", source: "classifier" }),
-            expect.objectContaining({ toolCallId: "CD", decision: "deny", source: "classifier" }),
         ]);
-        // Allow executed; deny got an error result without invocation.
         expect(
             log.some((e) => e.type === "tool_result" && e.toolCallId === "CA" && e.source === "sync"),
         ).toBe(true);
+
+        // The human overrides the classifier's deny; their decisions resolve.
+        await advanceAndSettle(runtime, turnId, {
+            type: "permission_decision",
+            toolCallId: "CD",
+            decision: "allow",
+        });
+        const final = await advanceAndSettle(runtime, turnId, {
+            type: "permission_decision",
+            toolCallId: "CF",
+            decision: "deny",
+        });
+        expect(final.outcome?.status).toBe("completed");
+
+        log = await persisted(repo, turnId);
         expect(
-            log.some(
-                (e) => e.type === "tool_invocation_requested" && e.toolCallId === "CD",
+            log.find(
+                (e) => e.type === "tool_permission_resolved" && e.toolCallId === "CD",
             ),
-        ).toBe(false);
+        ).toMatchObject({ decision: "allow", source: "human" });
+        expect(
+            log.some((e) => e.type === "tool_result" && e.toolCallId === "CD" && e.source === "sync"),
+        ).toBe(true);
     });
 
-    it("denies deferred calls when no human is available", async () => {
+    it("denies deferred and denied calls when no human is available", async () => {
         const { runtime, repo } = makeRuntime({
             models: [
                 respond(completedResp(batch)),
@@ -905,6 +927,23 @@ describe("automatic permission classification (26.4)", () => {
                 (e) => e.type === "tool_permission_resolved" && e.toolCallId === "CF",
             ),
         ).toMatchObject({ decision: "deny", source: "human_unavailable" });
+        // The classifier's deny hard-denies with its reason on the result.
+        expect(
+            log.find(
+                (e) => e.type === "tool_permission_resolved" && e.toolCallId === "CD",
+            ),
+        ).toMatchObject({ decision: "deny", source: "classifier" });
+        expect(
+            log.find((e) => e.type === "tool_result" && e.toolCallId === "CD"),
+        ).toMatchObject({
+            source: "runtime",
+            result: { isError: true, output: "Permission denied: because deny" },
+        });
+        expect(
+            log.some(
+                (e) => e.type === "tool_invocation_requested" && e.toolCallId === "CD",
+            ),
+        ).toBe(false);
     });
 
     it("classifier failure records the failure and defers to the human", async () => {

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -852,24 +852,31 @@ class TurnAdvance {
                     ),
                 );
             } else if (decision.decision === "deny") {
-                await this.append(
-                    resolvedEvent(
-                        this.turnId,
-                        this.now(),
-                        tc.toolCallId,
-                        "deny",
-                        "classifier",
-                        decision.reason,
-                    ),
-                );
-                await this.append(
-                    runtimeResultEvent(this.turnId, this.now(), tc, {
-                        output: `Permission denied: ${decision.reason}`,
-                        isError: true,
-                    }),
-                );
+                // With a human available, a classifier deny escalates to them
+                // instead of resolving: the classified event keeps the
+                // objection on record while the human makes the effective
+                // decision. Hard denies are reserved for unattended turns.
+                if (!this.definition.config.humanAvailable) {
+                    await this.append(
+                        resolvedEvent(
+                            this.turnId,
+                            this.now(),
+                            tc.toolCallId,
+                            "deny",
+                            "classifier",
+                            decision.reason,
+                        ),
+                    );
+                    await this.append(
+                        runtimeResultEvent(this.turnId, this.now(), tc, {
+                            output: `Permission denied: ${decision.reason}`,
+                            isError: true,
+                        }),
+                    );
+                }
             }
-            // "defer" falls through to the human/deny fallback.
+            // "defer" (and escalated "deny") falls through to the human/deny
+            // fallback.
         }
     }
 


### PR DESCRIPTION
## Problem

In copilot chat with permission mode **Auto**, when the auto-permission classifier denied a tool call it hard-denied it — the user watched calls get "Auto-denied" one after another instead of being asked, even though they were sitting right there in an interactive chat.

Two things conspired:

- The turns runtime's §9.3 semantics only escalate classifier **`defer`** to the human; **`deny`** resolves immediately with an error result.
- The real LLM classifier (`security/auto-permission-classifier.ts`) has a binary allow/deny schema and never emits `defer` — so the defer-to-human path was unreachable in practice, and everything not allowed became a hard deny.

The legacy engine got this right: on a classifier deny it fell back to a permission prompt.

## Fix

A classifier `deny` is now advisory when a human is available:

- **`runtime.ts`** — in `classifyBatch`, a deny with `humanAvailable: true` no longer resolves; the classified event keeps the objection on record and the call falls through to the human-ask path (turn suspends, permission card shows, the human's decision resolves it). Unattended turns (`humanAvailable: false` — background tasks, headless subagents) keep the hard deny with the classifier's reason on the error result.
- **`turn-view.ts`** — `permissionNeedsHuman` treats a classified deny like defer so the permission card actually renders; without this the turn would suspend with no visible prompt.
- **`turn-runtime-design.md`** — §9.3 behavior matrix and §26.4 test plan updated to match.

## Tests

- Runtime batch test now expects deny + defer both pending with a human available, and proves a human **allow** overrides the classifier's deny and executes the tool.
- No-human test pins the hard-deny path: classifier source and reason on the error result, no invocation.
- New renderer test: classified deny renders the permission card and marks the turn waiting on the human.

`npm run typecheck`, `npm run lint`, core (607) and renderer (313) suites all green. Manually verified in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)