### PR TITLE
feat(x): interactive question card for ask-human

### DIFF
--- a/apps/x/apps/renderer/src/components/ai-elements/ask-human-request.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/ask-human-request.tsx
@@ -2,122 +2,415 @@
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { ASK_HUMAN_SKIP_ANSWER } from "@/lib/chat-conversation";
 import { cn } from "@/lib/utils";
-import { MessageCircleIcon, ArrowUpIcon } from "lucide-react";
+import { MessageCircleQuestionMarkIcon } from "lucide-react";
 import type { ComponentProps } from "react";
-import { useState, useRef, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const letterFor = (index: number): string => String.fromCharCode(65 + index);
+
+// Monochrome panel shared by the pending card and the settled Q&A card.
+const CARD_SHELL_CLASS =
+  "not-prose my-1.5 w-full rounded-xl border border-border/70 bg-muted/30 px-4 py-3 text-[13px]";
+
+const CHOICE_ROW_CLASS =
+  "-mx-1.5 flex items-center gap-2.5 rounded-md px-1.5 py-[5px] text-left";
+
+const LetterChip = ({ char, active, selected }: { char: string; active?: boolean; selected?: boolean }) => (
+  <kbd
+    className={cn(
+      "flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[5px] border font-mono text-[10.5px] transition-colors",
+      selected
+        ? "border-primary bg-primary text-primary-foreground"
+        : active
+          ? "border-primary/60 bg-muted/70 text-primary"
+          : "border-border bg-muted/70 text-muted-foreground"
+    )}
+  >
+    {char}
+  </kbd>
+);
+
+/** Circled-letter glyph for the answer line (no lucide equivalent). */
+const CircleAGlyph = () => (
+  <span
+    aria-hidden
+    className="flex size-4 shrink-0 items-center justify-center rounded-full border border-muted-foreground/50 font-mono text-[9px] leading-none text-muted-foreground/70"
+  >
+    A
+  </span>
+);
+
+/** Question text with the question-bubble icon (and, for a batch of
+ *  questions, a "1 of 5" counter) riding the right edge. */
+const QuestionLine = ({ question, counter }: { question: string; counter?: string }) => (
+  <div className="flex items-start justify-between gap-3">
+    <p className="min-w-0 flex-1 whitespace-pre-wrap font-medium leading-relaxed text-foreground">
+      {question}
+    </p>
+    <span className="mt-0.5 flex shrink-0 items-center gap-1.5">
+      {counter && (
+        <span className="text-[11px] tabular-nums leading-4 text-muted-foreground/60">{counter}</span>
+      )}
+      <MessageCircleQuestionMarkIcon aria-hidden className="size-4 shrink-0 text-muted-foreground/60" />
+    </span>
+  </div>
+);
+
+export type AskHumanSettledProps = {
+  question: string;
+  answer: string;
+  skipped: boolean;
+  isError?: boolean;
+};
+
+/**
+ * Settled transcript card for an answered/skipped/cancelled ask-human call:
+ * the question line, then the answer line (italic "Skipped" for the skip
+ * sentinel) with a circled-A glyph on the right edge.
+ */
+export const AskHumanSettled = ({ question, answer, skipped, isError = false }: AskHumanSettledProps) => (
+  <div className={cn(CARD_SHELL_CLASS, "grid gap-1")}>
+    {question && <QuestionLine question={question} />}
+    <div className="flex items-start justify-between gap-3">
+      <p
+        className={cn(
+          "min-w-0 flex-1 whitespace-pre-wrap break-words leading-relaxed text-muted-foreground",
+          skipped && "italic text-muted-foreground/80",
+          isError && "text-red-600 dark:text-red-500"
+        )}
+      >
+        {skipped ? "Skipped" : answer}
+      </p>
+      <span className="mt-0.5 flex h-4 items-center">
+        <CircleAGlyph />
+      </span>
+    </div>
+  </div>
+);
 
 export type AskHumanRequestProps = ComponentProps<"div"> & {
   query: string;
   options?: string[];
+  /** Options become toggles (pick all that apply); the answer joins every
+   *  selected label (plus any "Other" text) with ", ". */
+  multiSelect?: boolean;
+  /** Position within a batch of simultaneous questions ("1 of 5"). Omitted
+   *  for a lone question. */
+  progress?: { current: number; total: number };
   onResponse: (response: string) => void;
   isProcessing?: boolean;
 };
 
+/**
+ * Inline card for a pending `ask-human` tool call (the turn is suspended on
+ * it). With options: lettered A/B/C/D rows plus an always-present
+ * "Other (type your answer)" row — picking stages a choice, Continue (or
+ * Enter) confirms it. Without options: a free-text field. Skip resolves the
+ * call with ASK_HUMAN_SKIP_ANSWER so the model proceeds on its own.
+ *
+ * Keyboard (options mode): letters/digits pick a row, arrows move the
+ * cursor, Enter confirms. The window listener stands down whenever focus is
+ * on a focusable control (composer, buttons, the Other field) so it never
+ * eats keystrokes meant elsewhere; the card grabs focus on mount so keys
+ * work immediately.
+ */
 export const AskHumanRequest = ({
   className,
   query,
   options,
+  multiSelect = false,
+  progress,
   onResponse,
   isProcessing = false,
   ...props
 }: AskHumanRequestProps) => {
-  const [response, setResponse] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const hasOptions = Array.isArray(options) && options.length > 0;
+  const choices = hasOptions ? options : [];
+  const isMulti = multiSelect && hasOptions;
+
+  const [draft, setDraft] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  // Multi-select: the set of toggled option indices. Unlike single-select,
+  // toggles and "Other" text are additive, not mutually exclusive.
+  const [selectedSet, setSelectedSet] = useState<ReadonlySet<number>>(new Set());
+  // Keyboard cursor. 0..choices.length-1 are the options; the trailing index
+  // (=== choices.length) is the "Other" free-text row.
+  const [activeIndex, setActiveIndex] = useState(0);
+  // Latched after a successful submit so a slow round-trip can't double-send.
+  const [submitted, setSubmitted] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const disabled = isProcessing || submitted;
+  const trimmedDraft = draft.trim();
+  const stagedAnswer = isMulti
+    ? [...[...selectedSet].sort((a, b) => a - b).map((i) => choices[i]), ...(trimmedDraft ? [trimmedDraft] : [])].join(
+        ", "
+      ) || null
+    : selectedIndex !== null
+      ? choices[selectedIndex]
+      : trimmedDraft || null;
 
   useEffect(() => {
-    // Auto-focus the textarea when in free-text mode; nothing to focus for buttons.
+    // Free-text mode: focus the field. Options mode: focus the card container
+    // so letter/arrow/Enter keys work without a click.
     if (!hasOptions) {
       textareaRef.current?.focus();
+    } else {
+      containerRef.current?.focus();
     }
   }, [hasOptions]);
 
-  const handleSubmit = () => {
-    const trimmed = response.trim();
-    if (trimmed && !isProcessing) {
-      onResponse(trimmed);
-      setResponse("");
-    }
+  const respond = useCallback(
+    (answer: string) => {
+      if (disabled || !answer) return;
+      setSubmitted(true);
+      onResponse(answer);
+    },
+    [disabled, onResponse]
+  );
+
+  const selectChoice = useCallback(
+    (index: number) => {
+      if (disabled) return;
+      if (isMulti) {
+        // Toggle; selections and "Other" text are additive in multi mode.
+        setSelectedSet((prev) => {
+          const next = new Set(prev);
+          if (next.has(index)) next.delete(index);
+          else next.add(index);
+          return next;
+        });
+      } else {
+        // Picking a choice and typing are mutually exclusive answers.
+        setDraft("");
+        setSelectedIndex(index);
+      }
+      setActiveIndex(index);
+      // Return focus to the card so Enter confirms instead of re-clicking
+      // the row button the click just focused.
+      containerRef.current?.focus();
+    },
+    [disabled, isMulti]
+  );
+
+  const submitStaged = useCallback(() => {
+    if (stagedAnswer) respond(stagedAnswer);
+  }, [respond, stagedAnswer]);
+
+  const onDraftChange = (value: string) => {
+    setDraft(value);
+    // Single-select: typing is its own answer — drop any picked choice so the
+    // two inputs can't both look selected. Multi-select: additive, keep both.
+    if (!isMulti && value.trim()) setSelectedIndex(null);
   };
 
-  const handleOptionClick = (option: string) => {
-    if (isProcessing) return;
-    onResponse(option);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleTextareaKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      handleSubmit();
+      submitStaged();
     }
   };
 
-  const canSubmit = Boolean(response.trim()) && !isProcessing;
+  // Window-level shortcuts for options mode.
+  useEffect(() => {
+    if (!hasOptions || disabled) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.defaultPrevented) return;
+
+      const active = document.activeElement as HTMLElement | null;
+      if (
+        active &&
+        active !== containerRef.current &&
+        (active.isContentEditable ||
+          active.matches('a[href], button, input, select, textarea, [role="button"]'))
+      ) {
+        return;
+      }
+
+      const itemCount = choices.length + 1; // + the Other row
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const delta = event.key === "ArrowDown" ? 1 : -1;
+        // Single-select: a move is not a pick — clear the staged choice so
+        // the cursor and the selection can't disagree. Multi-select keeps its
+        // toggles; the cursor just browses.
+        if (!isMulti) setSelectedIndex(null);
+        setActiveIndex((index) => (index + delta + itemCount) % itemCount);
+        return;
+      }
+
+      // Multi-select: Space toggles the highlighted row (checkbox convention).
+      if (isMulti && event.key === " " && activeIndex < choices.length) {
+        event.preventDefault();
+        selectChoice(activeIndex);
+        return;
+      }
+
+      let index = -1;
+      if (/^[1-9]$/.test(event.key)) {
+        index = Number(event.key) - 1;
+      } else {
+        const key = event.key.toLowerCase();
+        if (key.length === 1 && key >= "a" && key <= "z") {
+          index = key.charCodeAt(0) - 97;
+        }
+      }
+      // Only the rows this card renders; anything past the Other row belongs
+      // to the rest of the app.
+      if (index >= 0) {
+        if (index < choices.length) {
+          event.preventDefault();
+          selectChoice(index);
+        } else if (index === choices.length) {
+          event.preventDefault();
+          setActiveIndex(index);
+          textareaRef.current?.focus();
+        }
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        if (stagedAnswer) {
+          submitStaged();
+        } else if (activeIndex < choices.length) {
+          if (isMulti) {
+            // Nothing toggled yet: Enter stages the highlighted row rather
+            // than submitting — multi-select answers are confirmed explicitly.
+            selectChoice(activeIndex);
+          } else {
+            // Enter on a highlighted, unstaged row answers with it directly.
+            respond(choices[activeIndex]);
+          }
+        } else {
+          textareaRef.current?.focus();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeIndex, choices, disabled, hasOptions, isMulti, respond, selectChoice, stagedAnswer, submitStaged]);
 
   return (
     <div
-      className={cn(
-        "not-prose mb-4 w-full rounded-md border border-blue-500/50 bg-blue-50/50 dark:bg-blue-950/20",
-        className
-      )}
+      ref={containerRef}
+      tabIndex={-1}
+      className={cn(CARD_SHELL_CLASS, "outline-none", className)}
       {...props}
     >
-      <div className="p-4 space-y-4">
-        <div className="flex items-start gap-3">
-          <MessageCircleIcon className="size-5 text-blue-600 dark:text-blue-500 shrink-0 mt-0.5" />
-          <div className="flex-1 space-y-3">
-            <div>
-              <h3 className="font-semibold text-sm text-foreground mb-1">
-                Question from Agent
-              </h3>
-              <p className="text-sm text-foreground whitespace-pre-wrap">
-                {query}
-              </p>
-            </div>
-            {hasOptions ? (
-              <div className="flex flex-wrap gap-2">
-                {options!.map((option) => (
-                  <Button
-                    key={option}
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleOptionClick(option)}
-                    disabled={isProcessing}
-                    className="bg-background"
-                  >
-                    {option}
-                  </Button>
-                ))}
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <Textarea
-                  ref={textareaRef}
-                  dir="auto"
-                  value={response}
-                  onChange={(e) => setResponse(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  placeholder="Type your response..."
-                  disabled={isProcessing}
-                  rows={3}
-                  className="resize-none"
-                />
-                <div className="flex justify-end">
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={handleSubmit}
-                    disabled={!canSubmit}
-                    className="gap-2"
-                  >
-                    <ArrowUpIcon className="size-4" />
-                    Send Response
-                  </Button>
-                </div>
-              </div>
-            )}
+      <QuestionLine
+        question={query}
+        counter={progress ? `${progress.current} of ${progress.total}` : undefined}
+      />
+      {isMulti && (
+        <p className="mt-0.5 text-xs text-muted-foreground/70">Select all that apply</p>
+      )}
+
+      <div className="mt-2 pl-1">
+        {hasOptions ? (
+          <div className="flex flex-col gap-px" role="group" aria-multiselectable={isMulti || undefined}>
+            {choices.map((choice, index) => {
+              const isSelected = isMulti ? selectedSet.has(index) : selectedIndex === index;
+              return (
+                <button
+                  key={`${index}-${choice}`}
+                  type="button"
+                  aria-current={activeIndex === index || undefined}
+                  aria-pressed={isMulti ? isSelected : undefined}
+                  aria-keyshortcuts={`${letterFor(index)} ${index + 1}`}
+                  disabled={disabled}
+                  onClick={() => selectChoice(index)}
+                  className={cn(
+                    CHOICE_ROW_CLASS,
+                    "text-foreground/90 hover:bg-muted/60",
+                    "disabled:cursor-not-allowed disabled:opacity-50",
+                    activeIndex === index && !isSelected && "bg-muted/60",
+                    isSelected && "text-foreground"
+                  )}
+                >
+                  <LetterChip
+                    char={letterFor(index)}
+                    active={activeIndex === index}
+                    selected={isSelected}
+                  />
+                  <span className="min-w-0 flex-1 break-words leading-relaxed">{choice}</span>
+                </button>
+              );
+            })}
+            <label
+              className={cn(
+                CHOICE_ROW_CLASS,
+                "cursor-text",
+                activeIndex === choices.length && "bg-muted/60"
+              )}
+            >
+              <LetterChip
+                char={letterFor(choices.length)}
+                active={activeIndex === choices.length}
+                selected={Boolean(trimmedDraft)}
+              />
+              <Textarea
+                ref={textareaRef}
+                dir="auto"
+                rows={1}
+                value={draft}
+                disabled={disabled}
+                placeholder="Other (type your answer)"
+                onChange={(e) => onDraftChange(e.target.value)}
+                onFocus={() => {
+                  // Single-select: focusing "Other" abandons a picked row.
+                  // Multi-select: additive — toggles stay.
+                  if (!isMulti) setSelectedIndex(null);
+                  setActiveIndex(choices.length);
+                }}
+                onKeyDown={handleTextareaKey}
+                className="min-h-0 flex-1 resize-none rounded-md border-transparent bg-transparent px-1.5 py-0.5 text-[13px] leading-relaxed shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0 dark:bg-transparent"
+              />
+            </label>
           </div>
+        ) : (
+          <Textarea
+            ref={textareaRef}
+            dir="auto"
+            rows={2}
+            value={draft}
+            disabled={disabled}
+            placeholder="Type your answer…"
+            onChange={(e) => onDraftChange(e.target.value)}
+            onKeyDown={handleTextareaKey}
+            className="min-h-0 resize-none text-[13px]"
+          />
+        )}
+
+        <div className="mt-2 flex items-center justify-end gap-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled}
+            onClick={() => respond(ASK_HUMAN_SKIP_ANSWER)}
+            className="h-7 rounded-full px-3 text-xs text-muted-foreground hover:text-foreground"
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            disabled={disabled || !stagedAnswer}
+            onClick={submitStaged}
+            className="h-7 rounded-full px-3 text-xs"
+          >
+            Continue
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -92,6 +92,17 @@ export function ChatSessionPane({
     busy: isActive && activeIsProcessing ? true : undefined,
   })
 
+  // Batched ask-human calls (several questions in one model response) render
+  // ONE card at a time, numbered "1 of N". The pending map only holds
+  // unanswered questions, so remember the batch's high-water mark while it
+  // drains to know N (and which question we're on); reset once it empties.
+  // A lone question (the common sequential case) never shows a counter.
+  const pendingAsks = Array.from(tabState.pendingAskHumanRequests.values())
+  const askBatchMaxRef = React.useRef(0)
+  askBatchMaxRef.current = pendingAsks.length === 0 ? 0 : Math.max(askBatchMaxRef.current, pendingAsks.length)
+  const askBatchTotal = askBatchMaxRef.current
+  const currentAsk = pendingAsks[0]
+
   const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
   const tabConversationContentClassName = cn(
     'mx-auto w-full max-w-4xl',
@@ -136,15 +147,21 @@ export function ChatSessionPane({
               />
 
 
-              {onAskHumanResponse && Array.from(tabState.pendingAskHumanRequests.values()).map((request) => (
+              {onAskHumanResponse && currentAsk && (
                 <AskHumanRequest
-                  key={request.toolCallId}
-                  query={request.query}
-                  options={request.options}
-                  onResponse={(response) => onAskHumanResponse(request.toolCallId, request.subflow, response)}
+                  key={currentAsk.toolCallId}
+                  query={currentAsk.query}
+                  options={currentAsk.options}
+                  multiSelect={currentAsk.multiSelect}
+                  progress={
+                    askBatchTotal > 1
+                      ? { current: askBatchTotal - pendingAsks.length + 1, total: askBatchTotal }
+                      : undefined
+                  }
+                  onResponse={(response) => onAskHumanResponse(currentAsk.toolCallId, currentAsk.subflow, response)}
                   isProcessing={isActive && activeIsWorking}
                 />
-              ))}
+              )}
 
               {/* In-flight model call's thought stream: open with a
                   "Thinking..." shimmer while reasoning streams, auto-collapses

--- a/apps/x/apps/renderer/src/components/turn-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.tsx
@@ -13,6 +13,7 @@ import { AutoPermissionDecision } from '@/components/ai-elements/auto-permission
 import { WebSearchResult } from '@/components/ai-elements/web-search-result'
 import { AppActionCard } from '@/components/ai-elements/app-action-card'
 import { ComposioConnectCard } from '@/components/ai-elements/composio-connect-card'
+import { AskHumanSettled } from '@/components/ai-elements/ask-human-request'
 import { CodingRunBlock } from '@/components/coding-run'
 import { SubAgentBlock } from '@/components/sub-agent-block'
 import { TerminalOutput } from '@/components/terminal-output'
@@ -27,6 +28,7 @@ import {
   type ChatTabViewState,
   type ConversationItem,
   getAppActionCardData,
+  getAskHumanCardData,
   getComposioConnectCardData,
   getToolErrorText,
   getToolRowSummary,
@@ -233,6 +235,23 @@ export function TurnConversation({
             item={item}
             open={isToolOpen(item.id)}
             onOpenChange={(open) => onToolOpenChange(item.id, open)}
+          />
+        )
+      }
+      const askHumanData = getAskHumanCardData(item)
+      if (askHumanData) {
+        // Pending: the interactive card (mounted by the pane below the
+        // conversation) is the question's representation — a transcript row
+        // here would duplicate it. Settled (answered/skipped/cancelled):
+        // compact question → answer block.
+        if (askHumanData.answer === null) return null
+        return (
+          <AskHumanSettled
+            key={item.id}
+            question={askHumanData.question}
+            answer={askHumanData.answer}
+            skipped={askHumanData.skipped}
+            isError={item.status === 'error'}
           />
         )
       }

--- a/apps/x/apps/renderer/src/lib/chat-conversation.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.ts
@@ -184,6 +184,29 @@ export const getToolErrorText = (tool: ToolCall): string | undefined => {
   return 'Tool error'
 }
 
+/**
+ * Sentinel answer the ask-human card sends when the user skips the question.
+ * Phrased as an instruction so the model proceeds on its own; the settled
+ * transcript row matches on it to render "Skipped".
+ */
+export const ASK_HUMAN_SKIP_ANSWER =
+  'User skipped the question. Use your best judgment and proceed.'
+
+export type AskHumanCardData = {
+  question: string
+  /** The user's answer (or a runtime/cancel message). Null while pending. */
+  answer: string | null
+  skipped: boolean
+}
+
+export const getAskHumanCardData = (tool: ToolCall): AskHumanCardData | null => {
+  if (tool.name !== 'ask-human') return null
+  const input = normalizeToolInput(tool.input) as Record<string, unknown> | undefined
+  const question = typeof input?.question === 'string' ? input.question : ''
+  const answer = typeof tool.result === 'string' && tool.result.trim() ? tool.result : null
+  return { question, answer, skipped: answer === ASK_HUMAN_SKIP_ANSWER }
+}
+
 export type WebSearchCardResult = { title: string; url: string; description: string }
 
 export type WebSearchCardData = {
@@ -951,6 +974,7 @@ const isPlainToolCall = (item: ConversationItem): item is ToolCall => {
   if (!isToolCall(item)) return false
   if (item.name === 'code_agent_run') return false // rich standalone block, never grouped
   if (item.name === 'spawn-agent') return false // rich standalone block, never grouped
+  if (item.name === 'ask-human') return false // question card, never swallowed into a tool group
   if (getWebSearchCardData(item)) return false
   if (getComposioConnectCardData(item)) return false
   if (getAppActionCardData(item)) return false

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
@@ -515,16 +515,16 @@ export function buildSessionChatState(
     }
     for (const tc of outstandingAsyncTools(latest)) {
       if (tc.toolName !== 'ask-human') continue
-      const input = (tc.input ?? {}) as { question?: unknown; options?: unknown }
+      const input = (tc.input ?? {}) as { question?: unknown; options?: unknown; multiSelect?: unknown }
+      const hasOptions = Array.isArray(input.options) && input.options.every((o) => typeof o === 'string')
       pendingAskHumanRequests.set(tc.toolCallId, {
         runId: latestTurnId,
         type: 'ask-human-request',
         toolCallId: tc.toolCallId,
         subflow: [],
         query: typeof input.question === 'string' ? input.question : '',
-        ...(Array.isArray(input.options) && input.options.every((o) => typeof o === 'string')
-          ? { options: input.options }
-          : {}),
+        ...(hasOptions ? { options: input.options as string[] } : {}),
+        ...(hasOptions && input.multiSelect === true ? { multiSelect: true } : {}),
       })
     }
   }

--- a/apps/x/packages/core/src/runtime/assembly/copilot/base-tools.ts
+++ b/apps/x/packages/core/src/runtime/assembly/copilot/base-tools.ts
@@ -9,6 +9,11 @@
 // revisit once code-mode migrates to the turns runtime.
 export const COPILOT_BASE_TOOLS: readonly string[] = [
     "loadSkill",
+    // Blocking user question (async, requiresHuman) — resolved as a special
+    // descriptor in real-agent-resolver, not a BuiltinTools catalog entry.
+    // Headless/background turns run humanAvailable:false, where the runtime
+    // answers it immediately with "Human input is unavailable for this turn."
+    "ask-human",
     "file-getRoot",
     "file-exists",
     "file-list",

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-agent-resolver.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-agent-resolver.ts
@@ -28,18 +28,57 @@ const ASK_HUMAN_DESCRIPTOR: z.infer<typeof ToolDescriptor> = {
     toolId: `builtin:${ASK_HUMAN_TOOL}`,
     name: ASK_HUMAN_TOOL,
     description:
-        "Ask a human before proceeding. Optionally pass `options` (an array of short button labels) when a small set of choices would help the human answer quickly.",
+        "Ask the user a question and wait for their answer before proceeding. " +
+        "Three modes:\n\n" +
+        "1. Single choice — provide up to 4 `options`. The UI renders them as " +
+        "selectable rows and always appends its own 'Other (type your answer)' " +
+        "row, so never add an 'Other'/'Something else' option yourself.\n" +
+        "2. Multiple choice — additionally set `multiSelect: true` when several " +
+        "options can apply at once ('pick all that apply'). The answer lists " +
+        "every selected option.\n" +
+        "3. Open-ended — omit `options` entirely. The user types a free-form " +
+        "answer.\n\n" +
+        "CRITICAL: when offering choices, put each choice ONLY in the `options` " +
+        "array — NEVER enumerate the choices inside the `question` text. The UI " +
+        "renders `options` as pickable rows; choices written into the question " +
+        "string render as dead prose the user can't pick. " +
+        "Right: question='Which deployment target?', options=['staging', 'prod']. " +
+        "Wrong: question='Which target? 1) staging 2) prod', options=[].\n\n" +
+        "Use this tool when:\n" +
+        "- The task is ambiguous and the user must choose an approach\n" +
+        "- A decision has meaningful trade-offs the user should weigh in on\n" +
+        "- You need a fact only the user knows before you can proceed\n\n" +
+        "Do NOT use it for low-stakes decisions — make a reasonable choice " +
+        "yourself and proceed. The user can skip the question; if the answer " +
+        "says they skipped, use your best judgment and continue without asking " +
+        "again.",
     inputSchema: {
         type: "object",
         properties: {
             question: {
                 type: "string",
-                description: "The question to ask the human",
+                description:
+                    "The question itself, and ONLY the question (e.g. 'Which " +
+                    "deployment target?'). Do NOT embed the answer choices here " +
+                    "— pass them as separate elements in `options`.",
             },
             options: {
                 type: "array",
                 items: { type: "string" },
-                description: "Optional short button labels the human can pick from",
+                maxItems: 4,
+                description:
+                    "REQUIRED whenever you are presenting selectable choices: " +
+                    "each distinct choice is its own short label (up to 4). The " +
+                    "UI auto-appends an 'Other (type your answer)' row. Omit " +
+                    "entirely ONLY for a genuinely open-ended question.",
+            },
+            multiSelect: {
+                type: "boolean",
+                description:
+                    "When true, the user can select MULTIPLE options " +
+                    "(checkboxes); the answer lists all selected options. " +
+                    "When false (default), single selection. No effect when " +
+                    "`options` is omitted.",
             },
         },
         required: ["question"],

--- a/apps/x/packages/shared/src/runs.ts
+++ b/apps/x/packages/shared/src/runs.ts
@@ -75,6 +75,9 @@ export const AskHumanRequestEvent = BaseRunEvent.extend({
     toolCallId: z.string(),
     query: z.string(),
     options: z.array(z.string()).optional(),
+    // Render options as multi-select (pick all that apply); the answer is the
+    // selected labels joined with ", ".
+    multiSelect: z.boolean().optional(),
 });
 
 export const AskHumanResponseEvent = BaseRunEvent.extend({


### PR DESCRIPTION
## Summary

Gives the main assistant the ability to ask the user structured questions mid-turn, rendered as an interactive card in chat (modeled on Claude Code's AskUserQuestion). The `ask-human` async tool existed end-to-end (suspend/resume, IPC, session API) but was attached to no agent and rendered as a bare-bones card.

## Changes

**Core**
- `real-agent-resolver.ts` — rewrote the tool description with explicit gating (use for ambiguity / real trade-offs / facts only the user knows; never for low-stakes decisions; choices go ONLY in `options`, never enumerated in the question text). Options capped at 4. New `multiSelect` flag for pick-all-that-apply questions.
- `base-tools.ts` — attached `ask-human` to the copilot's base toolset.

**Renderer**
- `ask-human-request.tsx` — full card rewrite: lettered A/B/C/D option rows, always-present "Other (type your answer)" row, Skip / Continue pills. Keyboard: letters/digits pick, arrows move, Space toggles (multi-select), Enter confirms. Skip sends a sentinel answer telling the model to proceed on its own. New `AskHumanSettled` compact Q→A card for the transcript.
- `turn-conversation.tsx` — pending ask-human suppressed in the transcript (the interactive card is the representation); settled calls render the Q→A card.
- `chat-conversation.ts` — skip sentinel, `getAskHumanCardData` extractor, ask-human excluded from "Ran N tools" grouping.
- `chat-session.tsx` — batched questions render one card at a time with a "1 of N" counter (high-water mark over the pending set).
- `turn-view.ts` / `runs.ts` — carry `multiSelect` through the pending-request derivation.

## Safety

- Only the chat copilot gets the tool; knowledge-graph / meeting-notes / live-note / background agents never see it in their tool list.
- Defense in depth: `requiresHuman: true` + `humanAvailable: false` turns resolve immediately with "Human input is unavailable for this turn" — no hangs in headless flows.
- Answer stays a plain string, so the existing Slack-channel and todo-runner ask paths keep working unchanged.

## Test plan

- `npm run typecheck`, `npm run lint`, `npm run deps` all clean
- Resolver/catalog tests (23) and renderer session-chat tests (51) pass
- Manual in dev: single-choice, multi-select, open-ended, skip, batched "1 of N", answered/skipped/cancelled settled states in light+dark