### PR TITLE
feat(x): customizable quick-ask shortcut

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -30,6 +30,7 @@ import {
   getCompanionMode,
   getExpandedSurface,
   getPopoutState,
+  getQuickAskShortcutState,
   getQuickAskWindow,
   hideQuickAsk,
   isPinnedCollapsed,
@@ -40,6 +41,8 @@ import {
   resizeCompanionPinned,
   setCompanionPinned,
   setPinnedCollapsed,
+  setQuickAskShortcut,
+  setShortcutCaptureActive,
   showQuickAsk,
 } from './quick-ask.js';
 import { screenPointerService } from './screen-pointer.js';
@@ -1132,6 +1135,16 @@ export function setupIpcHandlers() {
       }
     },
     // --- Quick-ask bar relays ---
+    'quickAsk:getShortcut': async () => {
+      return getQuickAskShortcutState();
+    },
+    'quickAsk:setShortcut': async (_event, args) => {
+      return setQuickAskShortcut(args.accelerator);
+    },
+    'quickAsk:setShortcutCaptureActive': async (_event, args) => {
+      setShortcutCaptureActive(args.active);
+      return {};
+    },
     'quickAsk:submit': async (_event, args) => {
       findMainAppWindow()?.webContents.send('quick-ask:submit', args);
       return {};

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -31,6 +31,10 @@
  */
 import { DEV_SERVER_URL } from './dev-server.js';
 import { app, BrowserWindow, globalShortcut, screen } from 'electron';
+import { loadAppSettings, saveAppSettings } from '@x/core/dist/config/app_settings.js';
+import { quickAskShortcut } from '@x/shared';
+
+const { DEFAULT_QUICK_ASK_SHORTCUT, normalizeShortcut, isSystemReservedShortcut } = quickAskShortcut;
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -576,15 +580,152 @@ export function pushChatContext(ctx: ChatContext) {
   getQuickAskWindow()?.webContents.send('quick-ask:chat-context', ctx);
 }
 
-export function initQuickAsk() {
-  // ⌥⇧Space: plain ⌥Space is the most contested launcher chord on macOS
-  // (Raycast, ChatGPT desktop, …) — registering it would silently lose or,
-  // worse, double-fire alongside whatever owns it.
-  const ok = globalShortcut.register('Alt+Shift+Space', toggleQuickAsk);
+// --- Customizable global chord ---
+// One accelerator is the source of truth (app_settings.json). `registered`
+// tracks whether the OS actually granted it — false means another app owns
+// the chord and quick-ask is unreachable until the user rebinds (we notify,
+// we never silently rebind: a shortcut that moves on its own is worse than
+// one that's honestly broken).
+let currentShortcut = DEFAULT_QUICK_ASK_SHORTCUT;
+let shortcutRegistered = false;
+// Subscribers outside this module (the tray menu shows the chord next to
+// "Quick Ask") — a callback instead of an import, because tray.ts already
+// imports toggleQuickAsk from here.
+const shortcutChangeListeners: (() => void)[] = [];
+export function onQuickAskShortcutChanged(listener: () => void) {
+  shortcutChangeListeners.push(listener);
+}
+
+export function getQuickAskShortcutState(): {
+  accelerator: string;
+  registered: boolean;
+  isDefault: boolean;
+} {
+  return {
+    accelerator: currentShortcut,
+    registered: shortcutRegistered,
+    isDefault: currentShortcut === DEFAULT_QUICK_ASK_SHORTCUT,
+  };
+}
+
+function broadcastShortcutState() {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send('quick-ask:shortcut-changed', {
+      accelerator: currentShortcut,
+      registered: shortcutRegistered,
+    });
+  }
+  for (const listener of shortcutChangeListeners) listener();
+}
+
+// The shortcut-recorder modal is capturing keys: the current chord is
+// released so pressing it lands in the modal as keystrokes to display,
+// instead of summoning the bar over the recorder.
+let captureSuspended = false;
+
+export function setShortcutCaptureActive(active: boolean) {
+  if (captureSuspended === active) return;
+  captureSuspended = active;
+  if (!shortcutRegistered) return;
+  if (active) {
+    globalShortcut.unregister(currentShortcut);
+    return;
+  }
+  // Resume. The grab can fail if another app snatched the chord during the
+  // capture window — same treatment as a boot-time conflict (broadcast so
+  // the settings row shows the "not active" notice).
+  let ok = false;
+  try {
+    ok = globalShortcut.register(currentShortcut, toggleQuickAsk);
+  } catch {
+    ok = false;
+  }
   if (!ok) {
-    // Another app owns the chord — quick-ask is simply unavailable rather
-    // than fighting over it.
-    console.warn('[quick-ask] failed to register Alt+Shift+Space (already taken?)');
+    shortcutRegistered = false;
+    broadcastShortcutState();
+  }
+}
+
+/**
+ * Rebind the global chord (null = reset to default). The NEW chord is
+ * registered before the old one is released — a rejected rebind (invalid,
+ * system-reserved, or owned by another app) leaves the current binding
+ * fully intact. register() returning false is the OS-level conflict signal
+ * (RegisterEventHotKey / RegisterHotKey failing because another app holds
+ * the chord); macOS system chords that would "register" but never fire are
+ * rejected up front via the shared blocklist.
+ */
+export function setQuickAskShortcut(accelerator: string | null): {
+  ok: boolean;
+  accelerator: string;
+  registered: boolean;
+  error: string | null;
+} {
+  const requested = accelerator === null
+    ? DEFAULT_QUICK_ASK_SHORTCUT
+    : normalizeShortcut(accelerator);
+  const fail = (error: string) => ({
+    ok: false,
+    accelerator: currentShortcut,
+    registered: shortcutRegistered,
+    error,
+  });
+  if (!requested) {
+    return fail('Use one or two modifier keys plus a regular key.');
+  }
+  if (isSystemReservedShortcut(requested, process.platform)) {
+    return fail('That shortcut is reserved by the system.');
+  }
+  if (requested === currentShortcut && shortcutRegistered) {
+    return { ok: true, accelerator: currentShortcut, registered: true, error: null };
+  }
+  const previous = currentShortcut;
+  const previousRegistered = shortcutRegistered;
+  let ok = false;
+  try {
+    ok = globalShortcut.register(requested, toggleQuickAsk);
+  } catch {
+    return fail('That key combination can’t be used as a shortcut.');
+  }
+  if (!ok) {
+    return fail('That shortcut is already in use by another app.');
+  }
+  // While the recorder modal is capturing, nothing may stay grabbed — the
+  // register() above was purely the conflict check. The resume in
+  // setShortcutCaptureActive re-grabs whatever chord is current by then.
+  if (captureSuspended) {
+    globalShortcut.unregister(requested);
+  }
+  if (previousRegistered && previous !== requested && !captureSuspended) {
+    globalShortcut.unregister(previous);
+  }
+  currentShortcut = requested;
+  shortcutRegistered = true;
+  saveAppSettings({
+    quickAskShortcut: requested === DEFAULT_QUICK_ASK_SHORTCUT ? undefined : requested,
+  });
+  broadcastShortcutState();
+  return { ok: true, accelerator: currentShortcut, registered: true, error: null };
+}
+
+export function initQuickAsk() {
+  // Default ⌥⇧Space: plain ⌥Space is the most contested launcher chord on
+  // macOS (Raycast, ChatGPT desktop, …) — registering it would silently
+  // lose or, worse, double-fire alongside whatever owns it.
+  const saved = loadAppSettings().quickAskShortcut;
+  currentShortcut =
+    (saved ? normalizeShortcut(saved) : null) ?? DEFAULT_QUICK_ASK_SHORTCUT;
+  try {
+    shortcutRegistered = globalShortcut.register(currentShortcut, toggleQuickAsk);
+  } catch {
+    shortcutRegistered = false;
+  }
+  if (!shortcutRegistered) {
+    // Another app owns the chord — quick-ask stays unavailable rather than
+    // fighting over it. The app window surfaces this on boot (it invokes
+    // quickAsk:getShortcut) with a "Change shortcut" action.
+    console.warn(`[quick-ask] failed to register ${currentShortcut} (already taken?)`);
   }
   app.on('will-quit', () => {
     globalShortcut.unregisterAll();

--- a/apps/x/apps/main/src/tray.ts
+++ b/apps/x/apps/main/src/tray.ts
@@ -1,5 +1,9 @@
 import { app, Menu, Tray, nativeImage } from "electron";
-import { toggleQuickAsk } from "./quick-ask.js";
+import {
+  getQuickAskShortcutState,
+  onQuickAskShortcutChanged,
+  toggleQuickAsk,
+} from "./quick-ask.js";
 
 /**
  * Menu bar / system tray presence (Granola-style resident app).
@@ -69,6 +73,8 @@ export function createAppTray(trayActions: TrayActions): void {
   }
 
   rebuildMenu();
+  // The menu shows the quick-ask chord — follow rebinds live.
+  onQuickAskShortcutChanged(() => rebuildMenu());
 
   // macOS opens the context menu on any click. On Windows/Linux a plain
   // left-click should open the app; the menu stays on right-click.
@@ -153,10 +159,13 @@ function rebuildMenu(): void {
     { label: "Open Rowboat", click: () => actions?.openApp() },
     // Permanent discoverability for the global quick-ask shortcut — the
     // accelerator renders next to the label (display only; the real binding
-    // is the globalShortcut in quick-ask.ts).
+    // is the globalShortcut in quick-ask.ts). Hidden while the chord is
+    // unregistered (another app owns it) — showing a dead chord would lie.
     {
       label: "Quick Ask",
-      accelerator: "Alt+Shift+Space",
+      ...(getQuickAskShortcutState().registered
+        ? { accelerator: getQuickAskShortcutState().accelerator }
+        : {}),
       registerAccelerator: false,
       click: () => toggleQuickAsk(),
     },

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
-import { workspace } from '@x/shared';
+import { workspace, quickAskShortcut } from '@x/shared';
 import { RunEvent } from '@x/shared/src/runs.js';
 import type { ToolUIPart } from 'ai';
 import './App.css'
@@ -1848,14 +1848,19 @@ function App() {
   }, [handleToggleMic, handleToggleCamera, handleToggleScreenShare, handleInterruptAssistant, handlePttDown, handlePttUp, endCall, video])
 
   // Discoverability: nothing else in the UI reveals the global quick-ask
-  // shortcut. One toast, once per install, shortly after launch.
+  // shortcut. One toast, once per install, shortly after launch. The chord
+  // is fetched at fire time — it's customizable (Settings → Shortcuts).
   useEffect(() => {
     if (localStorage.getItem('quick-ask-tip-shown')) return
-    const timer = setTimeout(() => {
+    const timer = setTimeout(async () => {
       localStorage.setItem('quick-ask-tip-shown', '1')
+      const accelerator = await window.ipc
+        .invoke('quickAsk:getShortcut', null)
+        .then((s) => s.accelerator)
+        .catch(() => quickAskShortcut.DEFAULT_QUICK_ASK_SHORTCUT)
       playPopCue()
       toast('Ask Rowboat from anywhere', {
-        description: `Press ${isMac ? '⌥⇧Space' : 'Alt+Shift+Space'} in any app for a quick question — the answer shows up right there and in your chat.`,
+        description: `Press ${quickAskShortcut.formatShortcut(accelerator, isMac)} in any app for a quick question — the answer shows up right there and in your chat.`,
         duration: 12000,
         closeButton: true,
         // Lift the card off the page, and move sonner's close button (which
@@ -5628,6 +5633,31 @@ function App() {
     }).catch(() => { /* settings unavailable — try again next launch */ })
   }, [])
 
+  // The quick-ask chord failed to register at boot — another app owns it.
+  // Say so (once per launch) with a path to fix it, instead of quick-ask
+  // being silently dead. Deliberately no automatic rebinding: a shortcut
+  // that moves on its own is worse than one that's honestly broken.
+  const [shortcutSettingsOpen, setShortcutSettingsOpen] = useState(false)
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      try {
+        const s = await window.ipc.invoke('quickAsk:getShortcut', null)
+        if (s.registered) return
+        const isMacHere = navigator.platform.toLowerCase().includes('mac')
+        toast.warning('Quick Ask shortcut unavailable', {
+          description: `${quickAskShortcut.formatShortcut(s.accelerator, isMacHere)} is in use by another app, so Quick Ask can't be summoned right now. Pick a different shortcut in Settings.`,
+          duration: 15000,
+          closeButton: true,
+          action: {
+            label: 'Change shortcut',
+            onClick: () => setShortcutSettingsOpen(true),
+          },
+        })
+      } catch { /* stale preload — channel not there yet */ }
+    }, 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
   // Report the UI theme to the apps server (spec §7.1): apps read it from
   // GET /_rowboat/app and get live changes via the SSE theme event.
   useEffect(() => {
@@ -7952,6 +7982,11 @@ function App() {
         open={retentionSettingsOpen}
         onOpenChange={setRetentionSettingsOpen}
         defaultTab="advanced"
+      />
+      <SettingsDialog
+        open={shortcutSettingsOpen}
+        onOpenChange={setShortcutSettingsOpen}
+        defaultTab="shortcuts"
       />
       <OnboardingModal
         open={showOnboarding}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -37,6 +37,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { reduceTurn } from '@x/shared/src/turns.js'
+import * as quickAskShortcut from '@x/shared/src/quick-ask-shortcut.js'
+import { useQuickAskShortcut } from '@/hooks/use-quick-ask-shortcut'
 
 import { TalkingHead } from '@/components/talking-head'
 import { useVoiceMode } from '@/hooks/useVoiceMode'
@@ -126,6 +128,9 @@ const PINNED_RESPONSE_HEIGHT = 560
  * click there dismisses the bar — preserving the click-away feel.
  */
 export function QuickAskBar() {
+  // The global summon chord (customizable) — drives hold-to-talk release
+  // detection, so it must track rebinds live.
+  const shortcut = useQuickAskShortcut()
   const [asked, setAsked] = useState<string | null>(null)
   const [answer, setAnswer] = useState<{ processing: boolean; text: string; statusText: string | null } | null>(null)
   // Only answer pushes that follow OUR submit render — the app window's chat
@@ -487,11 +492,12 @@ export function QuickAskBar() {
     setRecording(false)
   }, [voice])
 
-  // Hold-⌥⇧Space-to-talk (the Wispr gesture): a chord summon starts
+  // Hold-chord-to-talk (the Wispr gesture, default ⌥⇧Space — the chord is
+  // customizable in Settings → Shortcuts): a chord summon starts
   // capturing IMMEDIATELY — one gesture from anywhere to a spoken question.
   // Electron's global shortcut can't see the key-UP, so the release is
-  // detected here once the window has focus: any chord key's keyup (Space /
-  // Alt / Shift), or any event whose modifier state shows Alt+Shift are no
+  // detected here once the window has focus: any chord key's keyup, or any
+  // event whose modifier state shows the chord's modifiers are no
   // longer held, finalizes and submits. A quick TAP falls out for free —
   // nothing was said, the transcript comes back empty, and an empty
   // transcript doesn't submit, leaving the composer focused for typing.
@@ -519,9 +525,10 @@ export function QuickAskBar() {
     })
   }, [pinned, startRecording])
   useEffect(() => {
-    const CHORD_CODES = ['Space', 'AltLeft', 'AltRight', 'ShiftLeft', 'ShiftRight']
+    const chordCodes = quickAskShortcut.shortcutChordCodes(shortcut.accelerator)
+    const chordModifiers = quickAskShortcut.shortcutModifierStates(shortcut.accelerator)
     const onKeyUp = (e: KeyboardEvent) => {
-      if (chordRef.current && CHORD_CODES.includes(e.code)) endChord('submit')
+      if (chordRef.current && chordCodes.includes(e.code)) endChord('submit')
     }
     const onKeyDown = (e: KeyboardEvent) => {
       if (!chordRef.current) return
@@ -530,12 +537,12 @@ export function QuickAskBar() {
         return
       }
       // A non-chord key means they're typing — get out of the way.
-      if (!CHORD_CODES.includes(e.code)) endChord('cancel')
+      if (!chordCodes.includes(e.code)) endChord('cancel')
     }
     const onMouseMove = (e: MouseEvent) => {
       // Backup release signal: the chord's modifiers are no longer held
       // (its keyups were delivered before this window took focus).
-      if (chordRef.current && !e.getModifierState('Alt') && !e.getModifierState('Shift')) {
+      if (chordRef.current && chordModifiers.every((m) => !e.getModifierState(m))) {
         endChord('submit')
       }
     }
@@ -557,7 +564,7 @@ export function QuickAskBar() {
       window.removeEventListener('blur', onBlur)
       clearInterval(cap)
     }
-  }, [endChord])
+  }, [endChord, shortcut.accelerator])
   useEffect(() => {
     capStartedAtRef.current = recording ? Date.now() : null
   }, [recording])
@@ -1257,6 +1264,11 @@ function SkipperPins({
   textPin: 'expand' | 'collapse'
   onTextPin: () => void
 }) {
+  const shortcutState = useQuickAskShortcut()
+  const shortcutLabel = quickAskShortcut.formatShortcut(
+    shortcutState.accelerator,
+    typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac'),
+  )
   // The mic and Stop are exclusive states of ONE control: while a turn is
   // in flight the mic is dead anyway, so the hat's single pin morphs.
   const busy = state.status === 'thinking' || state.status === 'speaking'
@@ -1336,7 +1348,7 @@ function SkipperPins({
         type="button"
         onClick={onTextPin}
         aria-label={textPin === 'expand' ? 'Bring the text back' : 'Tuck the text away'}
-        title={textPin === 'expand' ? 'Bring the text back (⌥⇧Space works too)' : 'Tuck the text away — the session keeps going'}
+        title={textPin === 'expand' ? `Bring the text back (${shortcutLabel} works too)` : 'Tuck the text away — the session keeps going'}
         className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
         style={{ ...noDragRegion, left: '18%', top: '68%' }}
       >

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { useState, useEffect, useCallback, useMemo } from "react"
-import { Server, Key, Shield, ShieldCheck, Palette, Monitor, Sun, Moon, Loader2, CheckCircle2, Plus, Minus, X, Wrench, Search, ChevronRight, Link2, Tags, Mail, BookOpen, User, Plug, HelpCircle, MessageCircle, Terminal, AlertTriangle, RefreshCw, PanelRight, Bell, Smartphone } from "lucide-react"
+import { Server, Key, Shield, ShieldCheck, Palette, Monitor, Sun, Moon, Loader2, CheckCircle2, Plus, Minus, X, Wrench, Search, ChevronRight, Link2, Tags, Mail, BookOpen, User, Plug, HelpCircle, MessageCircle, Terminal, AlertTriangle, RefreshCw, PanelRight, Bell, Smartphone, Keyboard } from "lucide-react"
 
 import {
   Dialog,
@@ -34,10 +34,11 @@ import type { ipc as ipcShared } from "@x/shared"
 import { startProvisioning, useProvisioning, enabledOptimistic, type AgentStatus, type CodeModeAgentStatus } from "@/lib/code-mode-provisioning"
 import { ModelSelectionSection } from "@/components/settings/model-selection-section"
 import { PermissionsSettings } from "@/components/settings/permissions-settings"
+import { ShortcutSettings } from "@/components/settings/shortcut-settings"
 import { ProvidersSection } from "@/components/settings/providers-section"
 import { useModels } from "@/hooks/use-models"
 
-type ConfigTab = "account" | "connections" | "mobile" | "models" | "mcp" | "security" | "code-mode" | "appearance" | "notifications" | "permissions" | "note-tagging" | "advanced" | "help"
+type ConfigTab = "account" | "connections" | "mobile" | "models" | "mcp" | "security" | "code-mode" | "appearance" | "shortcuts" | "notifications" | "permissions" | "note-tagging" | "advanced" | "help"
 
 interface TabConfig {
   id: ConfigTab
@@ -100,6 +101,12 @@ const tabs: TabConfig[] = [
     description: "Customize the look and feel",
   },
   {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: Keyboard,
+    description: "Customize keyboard shortcuts",
+  },
+  {
     id: "notifications",
     label: "Notifications",
     icon: Bell,
@@ -136,7 +143,7 @@ const tabs: TabConfig[] = [
 const NAV_SECTIONS: { label: string | null; ids: ConfigTab[] }[] = [
   { label: null, ids: ["account", "connections", "mobile"] },
   { label: "Configure", ids: ["models", "mcp", "security", "code-mode", "note-tagging", "advanced"] },
-  { label: "App", ids: ["appearance", "notifications", "permissions", "help"] },
+  { label: "App", ids: ["appearance", "shortcuts", "notifications", "permissions", "help"] },
 ]
 
 interface SettingsDialogProps {
@@ -1856,7 +1863,7 @@ export function SettingsDialog({ children, defaultTab = "account", open: control
   }
 
   const loadConfig = useCallback(async (tab: ConfigTab) => {
-    if (tab === "appearance" || tab === "models" || tab === "note-tagging" || tab === "account" || tab === "connections" || tab === "help" || tab === "code-mode" || tab === "notifications" || tab === "advanced") return
+    if (tab === "appearance" || tab === "shortcuts" || tab === "models" || tab === "note-tagging" || tab === "account" || tab === "connections" || tab === "help" || tab === "code-mode" || tab === "notifications" || tab === "advanced") return
     const tabConfig = tabs.find((t) => t.id === tab)!
     if (!tabConfig.path) return
     setLoading(true)
@@ -1925,7 +1932,7 @@ export function SettingsDialog({ children, defaultTab = "account", open: control
     <Dialog open={open} onOpenChange={setOpen}>
       {children && <DialogTrigger asChild>{children}</DialogTrigger>}
       <DialogContent
-        className="max-w-[900px]! w-[900px] h-[600px] p-0 gap-0 overflow-hidden"
+        className="max-w-[900px]! w-[900px] h-[660px] max-h-[85vh] p-0 gap-0 overflow-hidden"
       >
         <div className="flex h-full overflow-hidden">
           {/* Sidebar */}
@@ -2019,6 +2026,8 @@ export function SettingsDialog({ children, defaultTab = "account", open: control
                 <NoteTaggingSettings dialogOpen={open} />
               ) : activeTab === "appearance" ? (
                 <AppearanceSettings />
+              ) : activeTab === "shortcuts" ? (
+                <ShortcutSettings />
               ) : activeTab === "notifications" ? (
                 <NotificationSettings dialogOpen={open} />
               ) : activeTab === "permissions" ? (

--- a/apps/x/apps/renderer/src/components/settings/shortcut-settings.tsx
+++ b/apps/x/apps/renderer/src/components/settings/shortcut-settings.tsx
@@ -1,0 +1,330 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { AlertTriangle, RotateCcw } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useQuickAskShortcut } from "@/hooks/use-quick-ask-shortcut"
+import {
+  DEFAULT_QUICK_ASK_SHORTCUT,
+  eventCodeToShortcutKey,
+  formatShortcut,
+  shortcutDisplayParts,
+  type ShortcutModifier,
+} from "@x/shared/src/quick-ask-shortcut.js"
+
+const isMac = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac")
+
+const MOD_GLYPHS: Record<ShortcutModifier, string> = isMac
+  ? { Control: "⌃", Alt: "⌥", Shift: "⇧", Command: "⌘", Super: "⌘" }
+  : { Control: "Ctrl", Alt: "Alt", Shift: "Shift", Command: "Win", Super: "Win" }
+const KEY_GLYPHS: Record<string, string> = {
+  Up: "↑", Down: "↓", Left: "←", Right: "→",
+  Enter: "↵", Backspace: "⌫", Delete: "⌦",
+}
+
+/** Modifiers currently held, read off the event, in canonical order. */
+function heldModifiers(e: KeyboardEvent): ShortcutModifier[] {
+  const mods: ShortcutModifier[] = []
+  if (e.ctrlKey) mods.push("Control")
+  if (e.altKey) mods.push("Alt")
+  if (e.shiftKey) mods.push("Shift")
+  if (e.metaKey) mods.push(isMac ? "Command" : "Super")
+  return mods
+}
+
+function Keycap({
+  children,
+  ghost,
+  size = "md",
+}: {
+  children: React.ReactNode
+  ghost?: boolean
+  size?: "md" | "lg"
+}) {
+  return (
+    <kbd
+      className={cn(
+        "inline-flex items-center justify-center rounded-md font-medium",
+        size === "lg" ? "h-11 min-w-11 px-3 text-lg" : "h-8 min-w-8 px-2 text-[13px]",
+        ghost
+          ? "border border-dashed border-muted-foreground/40 text-muted-foreground/60"
+          : "border border-border bg-muted text-foreground shadow-[inset_0_-1.5px_0_rgba(0,0,0,0.08)] dark:shadow-[inset_0_-1.5px_0_rgba(255,255,255,0.06)]",
+      )}
+    >
+      {children}
+    </kbd>
+  )
+}
+
+type PendingChord = { mods: ShortcutModifier[]; key: string }
+
+/**
+ * The Shortcuts tab: the current Quick Ask chord, changed through a modal
+ * recorder. The modal shows every key the user presses live as keycaps,
+ * holds the last complete chord (1–2 modifiers + one key), and only applies
+ * it on an explicit Save — pressing another combination before saving simply
+ * replaces the pending one. Rejections (shape violations, system-reserved
+ * chords, or the OS refusing the grab because another app owns it) surface
+ * inline in the modal and leave the existing binding untouched.
+ */
+export function ShortcutSettings() {
+  const current = useQuickAskShortcut()
+  const [open, setOpen] = useState(false)
+  const [heldMods, setHeldMods] = useState<ShortcutModifier[]>([])
+  const [pending, setPending] = useState<PendingChord | null>(null)
+  const [hint, setHint] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const savingRef = useRef(false)
+
+  const resetCapture = useCallback(() => {
+    setHeldMods([])
+    setPending(null)
+    setHint(null)
+    setError(null)
+    setSaving(false)
+    savingRef.current = false
+  }, [])
+
+  const openModal = useCallback(() => {
+    resetCapture()
+    setOpen(true)
+  }, [resetCapture])
+
+  const closeModal = useCallback(() => {
+    setOpen(false)
+    resetCapture()
+  }, [resetCapture])
+
+  const apply = useCallback(
+    async (accelerator: string | null): Promise<boolean> => {
+      if (savingRef.current) return false
+      savingRef.current = true
+      setSaving(true)
+      try {
+        const res = await window.ipc.invoke("quickAsk:setShortcut", { accelerator })
+        if (res.ok) return true
+        setError(res.error ?? "That shortcut can’t be used.")
+        return false
+      } catch {
+        setError("Couldn’t update the shortcut. Try again.")
+        return false
+      } finally {
+        savingRef.current = false
+        setSaving(false)
+      }
+    },
+    [],
+  )
+
+  const save = useCallback(async () => {
+    if (!pending) return
+    if (await apply([...pending.mods, pending.key].join("+"))) closeModal()
+  }, [pending, apply, closeModal])
+
+  // While the modal is up, main releases the current global chord —
+  // otherwise pressing it would summon the quick-ask bar over the recorder
+  // instead of showing up as keycaps here.
+  useEffect(() => {
+    if (!open) return
+    void window.ipc.invoke("quickAsk:setShortcutCaptureActive", { active: true }).catch(() => {})
+    return () => {
+      void window.ipc.invoke("quickAsk:setShortcutCaptureActive", { active: false }).catch(() => {})
+    }
+  }, [open])
+
+  // Capture-phase listeners while the modal is up: keys tried out here must
+  // reach nothing else in the app. Esc always closes (cancel).
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.key === "Escape") {
+        closeModal()
+        return
+      }
+      const mods = heldModifiers(e)
+      const isModifierKey = ["Control", "Alt", "Shift", "Meta"].includes(e.key)
+      if (isModifierKey) {
+        setHeldMods(mods)
+        setError(null)
+        setHint(mods.length > 2 ? "Use at most two modifier keys" : null)
+        return
+      }
+      // A regular key landed — try to complete a chord.
+      if (mods.length === 0) {
+        setHint(isMac ? "Hold a modifier first — ⌃, ⌥ or ⌘" : "Hold a modifier first — Ctrl, Alt or Win")
+        return
+      }
+      if (mods.length > 2) {
+        setHint("Use at most two modifier keys")
+        return
+      }
+      if (mods.every((m) => m === "Shift")) {
+        setHint(isMac ? "Include ⌃, ⌥ or ⌘ — Shift alone is just typing" : "Include Ctrl, Alt or Win")
+        return
+      }
+      const key = eventCodeToShortcutKey(e.code)
+      if (!key) {
+        setHint("That key can’t be part of a shortcut")
+        return
+      }
+      setPending({ mods, key })
+      setHint(null)
+      setError(null)
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setHeldMods(heldModifiers(e))
+    }
+    window.addEventListener("keydown", onKeyDown, true)
+    window.addEventListener("keyup", onKeyUp, true)
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true)
+      window.removeEventListener("keyup", onKeyUp, true)
+    }
+  }, [open, closeModal])
+
+  const currentParts = shortcutDisplayParts(current.accelerator, isMac)
+  // heldModifiers() builds modifiers in canonical order, so a plain join
+  // matches the normalized accelerator from main.
+  const pendingIsCurrent =
+    pending !== null && [...pending.mods, pending.key].join("+") === current.accelerator
+  // Stage display: keys being held right now win; otherwise the last
+  // complete chord; otherwise the waiting placeholder.
+  const stage: React.ReactNode = heldMods.length > 0 ? (
+    <>
+      {heldMods.map((m) => (
+        <Keycap key={m} size="lg">{MOD_GLYPHS[m]}</Keycap>
+      ))}
+      <Keycap ghost size="lg">key</Keycap>
+    </>
+  ) : pending ? (
+    <>
+      {pending.mods.map((m) => (
+        <Keycap key={m} size="lg">{MOD_GLYPHS[m]}</Keycap>
+      ))}
+      <Keycap size="lg">{KEY_GLYPHS[pending.key] ?? pending.key}</Keycap>
+    </>
+  ) : (
+    <span className="animate-pulse text-sm text-muted-foreground">Press a key combination…</span>
+  )
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h4 className="text-sm font-medium mb-3">Quick Ask</h4>
+        <p className="text-xs text-muted-foreground mb-4">
+          Summon the Quick Ask bar from anywhere — press the shortcut in any app.
+        </p>
+        <div className="rounded-lg border border-border p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <div className="text-sm font-medium">Keyboard shortcut</div>
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                One or two modifiers plus a key
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {!current.isDefault && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 gap-1.5 text-xs text-muted-foreground"
+                  onClick={() => void apply(null)}
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Reset to {formatShortcut(DEFAULT_QUICK_ASK_SHORTCUT, isMac)}
+                </Button>
+              )}
+              <button
+                type="button"
+                onClick={openModal}
+                className="flex min-h-11 items-center justify-center gap-1.5 rounded-lg border border-border bg-background px-3 py-1.5 transition-colors hover:bg-muted/60"
+                aria-label="Change shortcut"
+              >
+                {currentParts.map((part, i) => (
+                  <Keycap key={i}>{part}</Keycap>
+                ))}
+              </button>
+            </div>
+          </div>
+          {!current.registered && (
+            <div className="mt-3 flex items-center gap-2 text-xs text-amber-600 dark:text-amber-500">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              <span>
+                Not active — another app is using {formatShortcut(current.accelerator, isMac)}.
+                Pick a different shortcut, or free it up in the other app and{" "}
+                <button
+                  type="button"
+                  className="underline underline-offset-2 hover:text-foreground"
+                  onClick={() => void apply(current.accelerator)}
+                >
+                  try again
+                </button>
+                .
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={(next) => { if (!next) closeModal() }}>
+        <DialogContent className="sm:max-w-[420px]" onOpenAutoFocus={(e) => e.preventDefault()}>
+          <DialogHeader>
+            <DialogTitle>Change shortcut</DialogTitle>
+            <DialogDescription>
+              Press the new combination — one or two modifiers plus a key.
+            </DialogDescription>
+          </DialogHeader>
+          <div
+            className={cn(
+              "flex h-24 items-center justify-center gap-2 rounded-lg border transition-colors",
+              pending && heldMods.length === 0
+                ? "border-primary/60 bg-primary/5"
+                : "border-dashed border-border bg-muted/30",
+            )}
+          >
+            {stage}
+          </div>
+          <div className="min-h-4 -mt-1">
+            {error ? (
+              <p className="text-xs text-destructive">{error}</p>
+            ) : hint ? (
+              <p className="text-xs text-amber-600 dark:text-amber-500">{hint}</p>
+            ) : pendingIsCurrent ? (
+              <p className="text-xs text-amber-600 dark:text-amber-500">
+                This is already your current shortcut — press a different combination.
+              </p>
+            ) : pending ? (
+              <p className="text-xs text-muted-foreground">
+                Press another combination to replace it, or save.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">Esc to cancel</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeModal}>
+              Cancel
+            </Button>
+            <Button onClick={() => void save()} disabled={!pending || pendingIsCurrent || saving}>
+              {saving ? "Saving…" : "Save shortcut"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/hooks/use-quick-ask-shortcut.ts
+++ b/apps/x/apps/renderer/src/hooks/use-quick-ask-shortcut.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { DEFAULT_QUICK_ASK_SHORTCUT } from '@x/shared/src/quick-ask-shortcut.js'
+
+export type QuickAskShortcutState = {
+  accelerator: string
+  registered: boolean
+  isDefault: boolean
+}
+
+/**
+ * The current global quick-ask chord, live: seeded via quickAsk:getShortcut
+ * and updated on every rebind through the quick-ask:shortcut-changed push.
+ * Works in any window (app, quick-ask bar) — same preload bridge.
+ */
+export function useQuickAskShortcut(): QuickAskShortcutState {
+  const [state, setState] = useState<QuickAskShortcutState>({
+    accelerator: DEFAULT_QUICK_ASK_SHORTCUT,
+    registered: true,
+    isDefault: true,
+  })
+  useEffect(() => {
+    let alive = true
+    try {
+      void window.ipc
+        .invoke('quickAsk:getShortcut', null)
+        .then((s) => {
+          if (alive) setState(s)
+        })
+        .catch(() => {})
+    } catch {
+      // Stale preload (app not restarted since the channel was added) throws
+      // synchronously from schema validation — keep the default silently.
+    }
+    let off: (() => void) | undefined
+    try {
+      off = window.ipc.on('quick-ask:shortcut-changed', ({ accelerator, registered }) => {
+        setState({
+          accelerator,
+          registered,
+          isDefault: accelerator === DEFAULT_QUICK_ASK_SHORTCUT,
+        })
+      })
+    } catch {
+      // Same stale-preload guard.
+    }
+    return () => {
+      alive = false
+      off?.()
+    }
+  }, [])
+  return state
+}

--- a/apps/x/packages/core/src/config/app_settings.ts
+++ b/apps/x/packages/core/src/config/app_settings.ts
@@ -20,6 +20,13 @@ export interface AppSettings {
      * rewrites that registry entry in place (see apps/main/src/login_item.ts).
      */
     loginItemRegisteredV2?: boolean;
+    /**
+     * Custom global quick-ask chord (Electron accelerator format, e.g.
+     * "Control+Alt+K"). Absent = the default (Alt+Shift+Space). Validated
+     * against the shared chord rules on load — an invalid hand-edited value
+     * falls back to the default.
+     */
+    quickAskShortcut?: string;
 }
 
 export function loadAppSettings(): AppSettings {

--- a/apps/x/packages/shared/src/index.ts
+++ b/apps/x/packages/shared/src/index.ts
@@ -25,4 +25,5 @@ export * as channels from './channels.js';
 export * as time from './time.js';
 export * as todo from './todo.js';
 export * as rowboatApp from './rowboat-app.js';
+export * as quickAskShortcut from './quick-ask-shortcut.js';
 export { PrefixLogger };

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1383,6 +1383,46 @@ const ipcSchemas = {
     }),
     res: z.null(),
   },
+  // Any window → main: the current global quick-ask chord and whether the
+  // OS actually granted it (false = another app owns it — quick-ask is
+  // unreachable until the user picks a different chord).
+  'quickAsk:getShortcut': {
+    req: z.null(),
+    res: z.object({
+      accelerator: z.string(),
+      registered: z.boolean(),
+      isDefault: z.boolean(),
+    }),
+  },
+  // Settings → main: rebind the global chord (null = reset to default).
+  // Main registers the NEW chord before releasing the old one — a rejected
+  // rebind (invalid, system-reserved, or taken by another app) leaves the
+  // old binding untouched and comes back ok:false with a human-readable
+  // reason for the recorder to show inline.
+  'quickAsk:setShortcut': {
+    req: z.object({ accelerator: z.string().nullable() }),
+    res: z.object({
+      ok: z.boolean(),
+      accelerator: z.string(),
+      registered: z.boolean(),
+      error: z.string().nullable(),
+    }),
+  },
+  // Settings → main: the shortcut-recorder modal is capturing keys. While
+  // active, main releases the current global chord so pressing it lands in
+  // the modal (as keys to display) instead of summoning the quick-ask bar
+  // over the recorder. Re-registered when capture ends.
+  'quickAsk:setShortcutCaptureActive': {
+    req: z.object({ active: z.boolean() }),
+    res: z.object({}),
+  },
+  // Push: main → every window after a successful rebind (or a boot-time
+  // registration failure), so the tray tooltip, toast copy, and the bar's
+  // hold-to-talk chord detection all follow the one source of truth.
+  'quick-ask:shortcut-changed': {
+    req: z.object({ accelerator: z.string(), registered: z.boolean() }),
+    res: z.null(),
+  },
   // --- Ambient meeting detection popup (own always-on-top window) ---
   // Main → popup: the detection to display.
   'meetingDetect:payload': {

--- a/apps/x/packages/shared/src/quick-ask-shortcut.ts
+++ b/apps/x/packages/shared/src/quick-ask-shortcut.ts
@@ -1,0 +1,207 @@
+/**
+ * The customizable global quick-ask chord, shared between main (register /
+ * validate) and renderer (recorder UI, display strings, hold-to-talk release
+ * detection). One accelerator string (Electron format, e.g. "Alt+Shift+Space")
+ * is the single source of truth; everything else — keycap displays, tray
+ * accelerators, KeyboardEvent codes — derives from it here.
+ *
+ * Chord shape rule: 2–3 keys total — one or two modifiers plus exactly one
+ * regular key. At least one modifier must be a "strong" one (Ctrl / Alt /
+ * Cmd / Win): Shift alone plus a character key is just typing, and a global
+ * grab on it would swallow capital letters system-wide.
+ */
+
+/** Modifier tokens we emit, in canonical order (parse accepts aliases). */
+export const MODIFIER_ORDER = ['Control', 'Alt', 'Shift', 'Command', 'Super'] as const;
+export type ShortcutModifier = (typeof MODIFIER_ORDER)[number];
+
+export const DEFAULT_QUICK_ASK_SHORTCUT = 'Alt+Shift+Space';
+
+const MODIFIER_ALIASES: Record<string, ShortcutModifier> = {
+  control: 'Control',
+  ctrl: 'Control',
+  alt: 'Alt',
+  option: 'Alt',
+  shift: 'Shift',
+  command: 'Command',
+  cmd: 'Command',
+  super: 'Super',
+  meta: 'Super',
+};
+
+/** Non-modifier keys the recorder accepts, as Electron accelerator tokens. */
+const NAMED_KEYS = new Set([
+  'Space', 'Tab', 'Enter', 'Backspace', 'Delete', 'Escape',
+  'Up', 'Down', 'Left', 'Right',
+  'Home', 'End', 'PageUp', 'PageDown',
+  ...Array.from({ length: 24 }, (_, i) => `F${i + 1}`),
+]);
+const CHAR_KEY = /^[A-Z0-9`~!@#$%^&*()\-_=+[\]{};:'",<.>/?\\|]$/;
+
+export type ParsedShortcut = {
+  modifiers: ShortcutModifier[];
+  key: string;
+};
+
+/**
+ * Parse an accelerator into canonical parts. Returns null when the string
+ * is not a chord this feature accepts (shape rule above) — used both to
+ * validate recorder output and to reject a hand-edited settings file.
+ */
+export function parseShortcut(accelerator: string): ParsedShortcut | null {
+  if (typeof accelerator !== 'string' || !accelerator.trim()) return null;
+  const tokens = accelerator.split('+').map((t) => t.trim()).filter(Boolean);
+  const modifiers: ShortcutModifier[] = [];
+  const keys: string[] = [];
+  for (const token of tokens) {
+    const mod = MODIFIER_ALIASES[token.toLowerCase()];
+    if (mod) {
+      if (!modifiers.includes(mod)) modifiers.push(mod);
+      continue;
+    }
+    const upper = token.length === 1 ? token.toUpperCase() : token;
+    const named = NAMED_KEYS.has(token) ? token
+      : NAMED_KEYS.has(capitalize(token)) ? capitalize(token)
+      : null;
+    if (named) keys.push(named);
+    else if (CHAR_KEY.test(upper)) keys.push(upper);
+    else return null;
+  }
+  if (keys.length !== 1) return null;
+  if (modifiers.length < 1 || modifiers.length > 2) return null;
+  // Shift-only chords are typing, not shortcuts.
+  if (modifiers.every((m) => m === 'Shift')) return null;
+  modifiers.sort((a, b) => MODIFIER_ORDER.indexOf(a) - MODIFIER_ORDER.indexOf(b));
+  return { modifiers, key: keys[0] };
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+/** Canonical accelerator string (stable order — safe to compare). */
+export function normalizeShortcut(accelerator: string): string | null {
+  const parsed = parseShortcut(accelerator);
+  return parsed ? [...parsed.modifiers, parsed.key].join('+') : null;
+}
+
+/**
+ * Chords macOS owns at a level where Electron's register() "succeeds" but
+ * never fires — the undetectable conflicts, rejected up front. (Ordinary
+ * app-level conflicts DO surface as register() returning false.)
+ */
+const MACOS_SYSTEM_CHORDS = new Set([
+  'Command+Space',       // Spotlight
+  'Alt+Command+Space',   // Finder search
+  'Command+Tab',         // App switcher
+  'Shift+Command+Tab',
+  'Command+Q',           // Quit — grabbing it globally breaks every app
+]);
+
+export function isSystemReservedShortcut(accelerator: string, platform: string): boolean {
+  const normalized = normalizeShortcut(accelerator);
+  if (!normalized) return false;
+  return platform === 'darwin' && MACOS_SYSTEM_CHORDS.has(normalized);
+}
+
+// --- Display ---
+
+const MAC_MODIFIER_GLYPHS: Record<ShortcutModifier, string> = {
+  Control: '⌃',
+  Alt: '⌥',
+  Shift: '⇧',
+  Command: '⌘',
+  Super: '⌘',
+};
+const GENERIC_MODIFIER_LABELS: Record<ShortcutModifier, string> = {
+  Control: 'Ctrl',
+  Alt: 'Alt',
+  Shift: 'Shift',
+  Command: 'Win',
+  Super: 'Win',
+};
+const KEY_DISPLAY: Record<string, string> = {
+  Up: '↑', Down: '↓', Left: '←', Right: '→',
+  Enter: '↵', Backspace: '⌫', Delete: '⌦', Escape: 'Esc',
+};
+
+/** Per-keycap labels for the recorder UI (["⌥", "⇧", "Space"]). */
+export function shortcutDisplayParts(accelerator: string, isMac: boolean): string[] {
+  const parsed = parseShortcut(accelerator);
+  if (!parsed) return [];
+  const mods = parsed.modifiers.map((m) =>
+    isMac ? MAC_MODIFIER_GLYPHS[m] : GENERIC_MODIFIER_LABELS[m],
+  );
+  return [...mods, KEY_DISPLAY[parsed.key] ?? parsed.key];
+}
+
+/** One-string display form: "⌥⇧Space" on mac, "Alt+Shift+Space" elsewhere. */
+export function formatShortcut(accelerator: string, isMac: boolean): string {
+  const parts = shortcutDisplayParts(accelerator, isMac);
+  if (!parts.length) return accelerator;
+  return isMac ? parts.join('') : parts.join('+');
+}
+
+// --- KeyboardEvent bridging (recorder capture + hold-to-talk release) ---
+
+/** KeyboardEvent.code → accelerator key token (null = not a chordable key). */
+export function eventCodeToShortcutKey(code: string): string | null {
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5);
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(code)) return code;
+  const named: Record<string, string> = {
+    Space: 'Space', Tab: 'Tab', Enter: 'Enter',
+    Backspace: 'Backspace', Delete: 'Delete',
+    ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
+    Home: 'Home', End: 'End', PageUp: 'PageUp', PageDown: 'PageDown',
+    Comma: ',', Period: '.', Slash: '/', Semicolon: ';', Quote: "'",
+    BracketLeft: '[', BracketRight: ']', Backslash: '\\',
+    Minus: '-', Equal: '=', Backquote: '`',
+  };
+  return named[code] ?? null;
+}
+
+const KEY_TO_CODES: Record<string, string[]> = {
+  Space: ['Space'], Tab: ['Tab'], Enter: ['Enter', 'NumpadEnter'],
+  Backspace: ['Backspace'], Delete: ['Delete'],
+  Up: ['ArrowUp'], Down: ['ArrowDown'], Left: ['ArrowLeft'], Right: ['ArrowRight'],
+  Home: ['Home'], End: ['End'], PageUp: ['PageUp'], PageDown: ['PageDown'],
+  ',': ['Comma'], '.': ['Period'], '/': ['Slash'], ';': ['Semicolon'], "'": ['Quote'],
+  '[': ['BracketLeft'], ']': ['BracketRight'], '\\': ['Backslash'],
+  '-': ['Minus'], '=': ['Equal'], '`': ['Backquote'],
+};
+const MODIFIER_CODES: Record<ShortcutModifier, string[]> = {
+  Control: ['ControlLeft', 'ControlRight'],
+  Alt: ['AltLeft', 'AltRight'],
+  Shift: ['ShiftLeft', 'ShiftRight'],
+  Command: ['MetaLeft', 'MetaRight'],
+  Super: ['MetaLeft', 'MetaRight'],
+};
+
+/**
+ * Every KeyboardEvent.code that is part of the chord — the hold-to-talk
+ * release detector treats any of these keys' keyup as "chord released".
+ */
+export function shortcutChordCodes(accelerator: string): string[] {
+  const parsed = parseShortcut(accelerator);
+  if (!parsed) return [];
+  const codes = parsed.modifiers.flatMap((m) => MODIFIER_CODES[m]);
+  if (KEY_TO_CODES[parsed.key]) codes.push(...KEY_TO_CODES[parsed.key]);
+  else if (/^[A-Z]$/.test(parsed.key)) codes.push(`Key${parsed.key}`);
+  else if (/^[0-9]$/.test(parsed.key)) codes.push(`Digit${parsed.key}`);
+  else codes.push(parsed.key); // F-keys: code === token
+  return codes;
+}
+
+/**
+ * getModifierState() names for the chord's modifiers — the backup release
+ * signal ("none of the chord's modifiers are held anymore").
+ */
+export function shortcutModifierStates(accelerator: string): string[] {
+  const parsed = parseShortcut(accelerator);
+  if (!parsed) return [];
+  const map: Record<ShortcutModifier, string> = {
+    Control: 'Control', Alt: 'Alt', Shift: 'Shift', Command: 'Meta', Super: 'Meta',
+  };
+  return [...new Set(parsed.modifiers.map((m) => map[m]))];
+}


### PR DESCRIPTION
## What

The global quick-ask chord (default ⌥⇧Space) is now user-configurable in **Settings → Shortcuts**.

- **Modal recorder**: pressed keys render live as keycaps while capturing; a complete chord (1–2 modifiers + one regular key, 2–3 keys total) is held on screen and applied only on an explicit **Save**. Esc/Cancel backs out with the old binding untouched.
- **Single source of truth**: the accelerator lives in `app_settings.json`; the tray menu accelerator, discoverability toast, mascot tooltip, and the bar's hold-to-talk release detection all derive from it (`packages/shared/src/quick-ask-shortcut.ts`) and follow rebinds live.

## Conflict handling

- **Set-time**: the new chord is registered before the old one is released — a rejected rebind (invalid shape, macOS system-reserved, or owned by another app via `globalShortcut.register()` returning false) leaves the existing binding intact and shows an inline error.
- **Boot-time**: if the saved chord fails to register (another app took it), a warning toast offers a *Change shortcut* action and the settings row shows a *Not active* notice with retry. No silent rebinding.
- **Undetectable macOS system chords** (⌘Space, ⌘Tab, ⌘Q — these register but never fire): rejected up front via a blocklist.
- **While recording**: the current chord's OS grab is suspended so pressing it lands in the modal (flagged as "already your current shortcut") instead of summoning the bar over the recorder.

## Testing

- `npm run deps` + `npm run typecheck` + `npm run lint` clean.
- Manually verified in dev: rebinding, reset to default, same-chord detection, conflict error with another app holding the chord, and hold-to-talk on a custom chord.