### PR TITLE
feat(x): message queueing + steering for chat sessions

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1490,6 +1490,20 @@ export function setupIpcHandlers() {
     'sessions:sendMessage': async (_event, args) => {
       return container.resolve<ISessions>('sessions').sendMessage(args.sessionId, args.input, args.config);
     },
+    'sessions:sendOrQueueMessage': async (_event, args) => {
+      return container.resolve<ISessions>('sessions').sendOrQueueMessage(args.sessionId, args.input, args.config);
+    },
+    'sessions:listQueued': async (_event, args) => {
+      return { queue: container.resolve<ISessions>('sessions').listQueued(args.sessionId) };
+    },
+    'sessions:editQueued': async (_event, args) => {
+      container.resolve<ISessions>('sessions').editQueued(args.sessionId, args.queueId, args.message);
+      return { success: true };
+    },
+    'sessions:removeQueued': async (_event, args) => {
+      const removed = container.resolve<ISessions>('sessions').removeQueued(args.sessionId, args.queueId);
+      return { removed: removed ?? null };
+    },
     'sessions:respondToPermission': async (_event, args) => {
       await container.resolve<ISessions>('sessions').respondToPermission(args.turnId, args.toolCallId, args.decision, args.metadata);
       return { success: true };
@@ -1499,8 +1513,8 @@ export function setupIpcHandlers() {
       return { success: true };
     },
     'sessions:stopTurn': async (_event, args) => {
-      await container.resolve<ISessions>('sessions').stopTurn(args.turnId, args.reason);
-      return { success: true };
+      const { dequeued } = await container.resolve<ISessions>('sessions').stopTurn(args.turnId, args.reason);
+      return { success: true, dequeued };
     },
     'sessions:resumeTurn': async (_event, args) => {
       await container.resolve<ISessions>('sessions').resumeTurn(args.sessionId);

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -12,7 +12,7 @@ import { ChatSidebar } from './components/chat-sidebar';
 import { useSessionChat } from '@/hooks/useSessionChat';
 import { subscribeSessionFeed } from '@/lib/session-chat/feed';
 import { ChatHeader } from './components/chat-header';
-import { ChatSessionPane, ChatSessionComposer } from './components/chat-session';
+import { ChatSessionPane, ChatSessionComposer, queuedMessageText } from './components/chat-session';
 // Value import: the Home to-do surface mounts a standalone composer directly
 // (not tab-bound); chat tabs render theirs through ChatSessionComposer.
 import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from './components/chat-input-with-mentions';
@@ -3577,12 +3577,12 @@ function App() {
     codeMode?: 'claude' | 'codex',
     permissionMode?: PermissionMode,
   ) => {
-    if (activeIsProcessing) {
+    if (activeIsProcessing && (inCallRef.current || quickAskActiveRef.current)) {
       // In-call and quick-ask input arrives at arbitrary moments — a hard
       // drop here silently ate utterances submitted while the previous turn
       // was still stopping (the PTT interrupt is async). Finish the stop and
-      // proceed with this message instead.
-      if (!inCallRef.current && !quickAskActiveRef.current) return
+      // proceed with this message instead. Ordinary typed sends proceed while
+      // busy: sessions:sendOrQueueMessage queues them to steer the live turn.
       await stopRunRef.current?.()
     }
 
@@ -3767,19 +3767,13 @@ function App() {
         }
       }
 
-      // One retry: an in-call submit can land while the previous turn's
-      // abort hasn't fully settled in the runtime — losing the message (and
-      // its spoken answer) over that race is much worse than a short delay.
-      const sendSessionMessage = async (payload: Parameters<typeof window.ipc.invoke<'sessions:sendMessage'>>[1]) => {
-        try {
-          await window.ipc.invoke('sessions:sendMessage', payload)
-        } catch (err) {
-          console.error('[chat] sendMessage failed, retrying once:', err)
-          await new Promise((resolve) => setTimeout(resolve, 600))
-          await window.ipc.invoke('sessions:sendMessage', payload)
-        }
-      }
+      // Deliver-ASAP: a busy session queues the message (it steers the live
+      // turn at the next model-call boundary or starts the next turn), so a
+      // mid-turn send is never rejected or dropped.
+      const sendSessionMessage = (payload: Parameters<typeof window.ipc.invoke<'sessions:sendOrQueueMessage'>>[1]) =>
+        window.ipc.invoke('sessions:sendOrQueueMessage', payload)
 
+      let sendResult: Awaited<ReturnType<typeof sendSessionMessage>>
       if (hasAttachments || hasMentions || videoFrames.length > 0) {
         type ContentPart =
           | { type: 'text'; text: string }
@@ -3840,7 +3834,7 @@ function App() {
         }
 
         const middlePaneContext = await buildMiddlePaneContext()
-        await sendSessionMessage({
+        sendResult = await sendSessionMessage({
           sessionId: currentRunId,
           input: {
             role: 'user',
@@ -3856,7 +3850,7 @@ function App() {
         })
       } else {
         const middlePaneContext = await buildMiddlePaneContext()
-        await sendSessionMessage({
+        sendResult = await sendSessionMessage({
           sessionId: currentRunId,
           input: {
             role: 'user',
@@ -3870,6 +3864,14 @@ function App() {
           voiceOutput: ttsEnabledRef.current ? ttsModeRef.current : undefined,
           searchEnabled: searchEnabled || undefined,
         })
+      }
+
+      // Queued (the latest turn was still running): there is no turn for
+      // this message yet — the pending chip above the composer represents it,
+      // and the real bubble arrives via turn events when it is delivered.
+      // Retract the optimistic bubble so it can't double-render.
+      if (sendResult.queued) {
+        setConversation((prev) => prev.filter((item) => item.id !== userMessageId))
       }
 
       pendingVoiceInputRef.current = false
@@ -3918,12 +3920,44 @@ function App() {
     ttsRef.current.cancel()
     setAssistantCaption('')
     try {
-      await sessionChat.stop()
+      // Stop drains the pending queue (queued messages must not auto-start
+      // after an explicit stop) — restore their text into the composer so
+      // nothing the user typed is lost.
+      const dequeued = await sessionChat.stop()
+      const drainedText = dequeued
+        .map((entry) => queuedMessageText(entry.message))
+        .filter(Boolean)
+        .join('\n\n')
+      if (drainedText) {
+        const draft = chatDraftsRef.current
+          .get(chatIdForTab(activeChatTabIdRef.current))
+          ?.trim()
+        setPresetMessage(draft ? `${draft}\n\n${drainedText}` : drainedText)
+      }
     } catch (error) {
       console.error('Failed to stop turn:', error)
     }
-  }, [runId, sessionChat])
+  }, [runId, sessionChat, chatIdForTab])
   stopRunRef.current = handleStop
+
+  // Pending-queue chips (messages sent while the turn was running): ✕
+  // discards the message; clicking the chip body pulls it back out of the
+  // queue and into the composer for editing.
+  const handleRemoveQueued = useCallback((queueId: string) => {
+    sessionChat.removeQueued(queueId).catch((error) => {
+      console.error('Failed to remove queued message:', error)
+    })
+  }, [sessionChat])
+
+  const handlePullQueued = useCallback(async (queueId: string) => {
+    try {
+      const removed = await sessionChat.removeQueued(queueId)
+      const text = removed ? queuedMessageText(removed.message) : ''
+      if (text) setPresetMessage(text)
+    } catch (error) {
+      console.error('Failed to pull back queued message:', error)
+    }
+  }, [sessionChat])
 
   const handlePermissionResponse = useCallback(async (
     toolCallId: string,
@@ -7692,6 +7726,15 @@ function App() {
                           onStop={handleStop}
                           activeIsProcessing={activeIsProcessing}
                           isStopping={isStopping}
+                          // The single session store follows the ACTIVE tab's
+                          // run — only that tab's composer shows its queue.
+                          queued={
+                            isActive && tab.runId && sessionChat.sessionId === tab.runId
+                              ? sessionChat.queued
+                              : undefined
+                          }
+                          onRemoveQueued={handleRemoveQueued}
+                          onPullQueued={handlePullQueued}
                           presetMessage={presetMessage}
                           onPresetMessageConsumed={() => setPresetMessage(undefined)}
                           codeSessionLocks={codeSessionLocks}
@@ -7791,6 +7834,11 @@ function App() {
                 isStopping={isStopping}
                 onStop={handleStop}
                 onSubmit={handlePromptSubmit}
+                queuedForActive={
+                  runId && sessionChat.sessionId === runId ? sessionChat.queued : undefined
+                }
+                onRemoveQueued={handleRemoveQueued}
+                onPullQueued={handlePullQueued}
                 knowledgeFiles={knowledgeFiles}
                 recentFiles={recentWikiFiles}
                 visibleFiles={visibleKnowledgeFiles}

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -213,6 +213,13 @@ interface ChatInputInnerProps {
   onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
   onStop?: () => void
   isProcessing: boolean
+  /**
+   * Let Enter submit while a turn is processing (the message queues/steers
+   * instead of being dropped). Session-chat only — other consumers keep the
+   * legacy submit-blocked-while-busy behavior. The Stop button still replaces
+   * the send button while processing either way.
+   */
+  allowSubmitWhileProcessing?: boolean
   isStopping?: boolean
   isActive: boolean
   presetMessage?: string
@@ -270,6 +277,7 @@ function ChatInputInner({
   onSubmit,
   onStop,
   isProcessing,
+  allowSubmitWhileProcessing = false,
   isStopping,
   isActive,
   presetMessage,
@@ -304,7 +312,8 @@ function ChatInputInner({
   const [attachments, setAttachments] = useState<StagedAttachment[]>([])
   const [focusNonce, setFocusNonce] = useState(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const canSubmit = (Boolean(message.trim()) || attachments.length > 0) && !isProcessing
+  const canSubmit = (Boolean(message.trim()) || attachments.length > 0)
+    && (allowSubmitWhileProcessing || !isProcessing)
 
   // Shared model-catalog store (one fetch app-wide); sign-in state also
   // gates search availability below.
@@ -1473,6 +1482,8 @@ export interface ChatInputWithMentionsProps {
   onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
   onStop?: () => void
   isProcessing: boolean
+  /** Let Enter submit while processing (queue/steer) — see ChatInputInner. */
+  allowSubmitWhileProcessing?: boolean
   isStopping?: boolean
   isActive?: boolean
   presetMessage?: string
@@ -1516,6 +1527,7 @@ export function ChatInputWithMentions({
   onSubmit,
   onStop,
   isProcessing,
+  allowSubmitWhileProcessing,
   isStopping,
   isActive = true,
   presetMessage,
@@ -1551,6 +1563,7 @@ export function ChatInputWithMentions({
         onSubmit={onSubmit}
         onStop={onStop}
         isProcessing={isProcessing}
+        allowSubmitWhileProcessing={allowSubmitWhileProcessing}
         isStopping={isStopping}
         isActive={isActive}
         presetMessage={presetMessage}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Clock, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Conversation,
@@ -22,6 +23,7 @@ import { streamdownComponents } from '@/lib/markdown-render'
 import { useSmoothedText } from '@/hooks/useSmoothedText'
 import type { useVoiceMode } from '@/hooks/useVoiceMode'
 import type { PermissionDecision } from '@x/shared/src/code-mode.js'
+import type { QueuedSessionMessage } from '@x/shared/src/sessions.js'
 import { ChatEmptyState } from './chat-empty-state'
 import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from './chat-input-with-mentions'
 import { type ChatTab } from './tab-bar'
@@ -35,6 +37,18 @@ import {
 function SmoothStreamingMessage({ text, components }: { text: string; components: typeof streamdownComponents }) {
   const smoothText = useSmoothedText(text)
   return <MessageResponse components={components}>{smoothText}</MessageResponse>
+}
+
+// The typed text of a queued (not-yet-delivered) message — for the pending
+// chip's preview and for restoring the text into the composer (chip pull-back,
+// stop-drained queue). Attachment/image parts are elided.
+export function queuedMessageText(message: QueuedSessionMessage['message']): string {
+  if (typeof message.content === 'string') return message.content.trim()
+  return message.content
+    .map((part) => (part.type === 'text' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n')
+    .trim()
 }
 
 export interface ChatSessionPaneProps {
@@ -203,6 +217,16 @@ export interface ChatSessionComposerProps {
   onStop?: () => void | Promise<void>
   activeIsProcessing: boolean
   isStopping?: boolean
+  /**
+   * Messages waiting in this session's pending queue (sent while the latest
+   * turn was still running) — rendered as chips above the input until they
+   * steer the live turn or start the next one.
+   */
+  queued?: QueuedSessionMessage[]
+  /** Discard a queued message (chip ×). */
+  onRemoveQueued?: (queueId: string) => void
+  /** Pull a queued message back into the composer for editing (chip body click). */
+  onPullQueued?: (queueId: string) => void
   presetMessage: string | undefined
   onPresetMessageConsumed: () => void
   codeSessionLocks: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
@@ -257,6 +281,9 @@ export function ChatSessionComposer({
   onStop,
   activeIsProcessing,
   isStopping,
+  queued = [],
+  onRemoveQueued,
+  onPullQueued,
   presetMessage,
   onPresetMessageConsumed,
   codeSessionLocks,
@@ -288,6 +315,38 @@ export function ChatSessionComposer({
       data-chat-input-panel={tab.id}
       aria-hidden={!isActive}
     >
+      {queued.length > 0 && (
+        /* Pending queue: messages accepted mid-turn, waiting to steer the live
+           turn (or start the next one). Clicking a chip pulls it back into the
+           composer for editing; ✕ discards it. */
+        <div className="mb-1.5 flex flex-col gap-1">
+          {queued.map((entry) => (
+            <div
+              key={entry.queueId}
+              className="group flex items-center gap-2 rounded-lg border border-border/50 bg-muted/60 px-2.5 py-1.5 text-xs text-muted-foreground"
+            >
+              <Clock className="h-3 w-3 shrink-0 opacity-70" aria-hidden />
+              <button
+                type="button"
+                onClick={() => onPullQueued?.(entry.queueId)}
+                className="min-w-0 flex-1 truncate text-left transition-colors hover:text-foreground"
+                title="Queued — click to edit"
+              >
+                {queuedMessageText(entry.message) || 'Attachment'}
+              </button>
+              <span className="shrink-0 text-[10px] uppercase tracking-wider opacity-60">Queued</span>
+              <button
+                type="button"
+                onClick={() => onRemoveQueued?.(entry.queueId)}
+                aria-label="Remove queued message"
+                className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full opacity-60 transition-[opacity,color] hover:opacity-100 hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       <ChatInputWithMentions
         knowledgeFiles={knowledgeFiles}
         recentFiles={recentFiles}
@@ -295,6 +354,9 @@ export function ChatSessionComposer({
         onSubmit={onSubmit}
         onStop={onStop}
         isProcessing={isActive && activeIsProcessing}
+        // Session chats never drop a mid-turn send: Enter queues/steers via
+        // sessions:sendOrQueueMessage (the Stop button still shows while busy).
+        allowSubmitWhileProcessing
         isStopping={isActive && isStopping}
         isActive={isActive}
         presetMessage={isActive ? presetMessage : undefined}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -10,6 +10,7 @@ import { FileCardProvider } from '@/contexts/file-card-context'
 import { type ChatTab } from '@/components/tab-bar'
 import { type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from '@/components/chat-input-with-mentions'
 import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
+import type { QueuedSessionMessage } from '@x/shared/src/sessions.js'
 import { useTabMeta } from '@/lib/tab-meta'
 import { useSidebar } from '@/components/ui/sidebar'
 import type { ChatPaneSize } from '@/contexts/theme-context'
@@ -79,6 +80,10 @@ interface ChatSidebarProps {
   isStopping?: boolean
   onStop?: () => void
   onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
+  /** Pending-queue mirror for the ACTIVE tab's session (single store — see App). */
+  queuedForActive?: QueuedSessionMessage[]
+  onRemoveQueued?: (queueId: string) => void
+  onPullQueued?: (queueId: string) => void
   knowledgeFiles?: string[]
   recentFiles?: string[]
   visibleFiles?: string[]
@@ -156,6 +161,9 @@ export function ChatSidebar({
   isStopping,
   onStop,
   onSubmit,
+  queuedForActive,
+  onRemoveQueued,
+  onPullQueued,
   knowledgeFiles = [],
   recentFiles = [],
   visibleFiles = [],
@@ -483,6 +491,9 @@ export function ChatSidebar({
                         onStop={onStop}
                         activeIsProcessing={isProcessing}
                         isStopping={isStopping}
+                        queued={isActive ? queuedForActive : undefined}
+                        onRemoveQueued={onRemoveQueued}
+                        onPullQueued={onPullQueued}
                         presetMessage={localPresetMessage ?? presetMessage}
                         onPresetMessageConsumed={() => {
                           setLocalPresetMessage(undefined)

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
@@ -38,6 +38,18 @@ function makeDeps() {
       calls.push({ method: 'sendMessage', args })
       return { turnId: 'turn-2' }
     },
+    sendOrQueueMessage: async (...args) => {
+      calls.push({ method: 'sendOrQueueMessage', args })
+      return { queued: false as const, turnId: 'turn-2' }
+    },
+    listQueued: async () => ({ queue: [] }),
+    editQueued: async (...args) => {
+      calls.push({ method: 'editQueued', args })
+    },
+    removeQueued: async (...args) => {
+      calls.push({ method: 'removeQueued', args })
+      return { removed: null }
+    },
     respondToPermission: async (...args) => {
       calls.push({ method: 'respondToPermission', args })
     },
@@ -46,6 +58,7 @@ function makeDeps() {
     },
     stopTurn: async (...args) => {
       calls.push({ method: 'stopTurn', args })
+      return { dequeued: [] }
     },
     resumeTurn: async () => undefined,
     setTitle: async () => undefined,
@@ -60,6 +73,7 @@ function makeDeps() {
           unsubscribed += 1
         }
       },
+      subscribeSessionFeed: () => () => undefined,
       subscribeDeltas: (turnId: string) => {
         deltaSubs.push(turnId)
         return () => {

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.ts
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { ipcSessionsClient } from '@/lib/session-chat/client'
 import { subscribeTurnFeed } from '@/lib/turn-feed'
+import { subscribeSessionFeed } from '@/lib/session-chat/feed'
 import { SessionChatStore, type SessionChatStoreDeps } from '@/lib/session-chat/store'
 
 // Declare "this window is watching turn X" so main forwards its deltas.
@@ -16,6 +17,7 @@ function subscribeDeltas(turnId: string): () => void {
 const defaultDeps: SessionChatStoreDeps = {
   client: ipcSessionsClient,
   subscribeTurnFeed,
+  subscribeSessionFeed,
   subscribeDeltas,
 }
 
@@ -36,6 +38,9 @@ export function useSessionChat(
     () => ({
       ...snapshot,
       sendMessage: store.sendMessage,
+      sendOrQueueMessage: store.sendOrQueueMessage,
+      editQueued: store.editQueued,
+      removeQueued: store.removeQueued,
       respondToPermission: store.respondToPermission,
       answerAskHuman: store.answerAskHuman,
       stop: store.stop,

--- a/apps/x/apps/renderer/src/lib/session-chat/client.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/client.ts
@@ -1,7 +1,11 @@
 import type { z } from 'zod'
 import type { UseCase } from '@x/shared/src/analytics.js'
 import type { UserMessage } from '@x/shared/src/message.js'
-import type { SessionIndexEntry, SessionState } from '@x/shared/src/sessions.js'
+import type {
+  QueuedSessionMessage,
+  SessionIndexEntry,
+  SessionState,
+} from '@x/shared/src/sessions.js'
 import type { JsonValue, RequestedAgent, TurnEvent } from '@x/shared/src/turns.js'
 
 // Narrow, injectable surface over the sessions IPC channels so stores are
@@ -24,6 +28,24 @@ export interface SessionsClient {
     input: z.infer<typeof UserMessage>,
     config: SendMessageConfig,
   ): Promise<{ turnId: string }>
+  // Deliver-ASAP: starts a turn when settled, queues (main-process memory)
+  // when the latest turn is still running — queued messages steer the live
+  // turn at its next boundary or promote to a new turn at settle.
+  sendOrQueueMessage(
+    sessionId: string,
+    input: z.infer<typeof UserMessage>,
+    config: SendMessageConfig,
+  ): Promise<{ queued: false; turnId: string } | { queued: true; queueId: string }>
+  listQueued(sessionId: string): Promise<{ queue: QueuedSessionMessage[] }>
+  editQueued(
+    sessionId: string,
+    queueId: string,
+    message: z.infer<typeof UserMessage>,
+  ): Promise<void>
+  removeQueued(
+    sessionId: string,
+    queueId: string,
+  ): Promise<{ removed: QueuedSessionMessage | null }>
   respondToPermission(
     turnId: string,
     toolCallId: string,
@@ -31,7 +53,12 @@ export interface SessionsClient {
     metadata?: JsonValue,
   ): Promise<void>
   respondToAskHuman(turnId: string, toolCallId: string, answer: string): Promise<void>
-  stopTurn(turnId: string, reason?: string): Promise<void>
+  // Also drains the pending queue (stop must not auto-start queued work);
+  // the drained messages come back for composer restore.
+  stopTurn(
+    turnId: string,
+    reason?: string,
+  ): Promise<{ dequeued: QueuedSessionMessage[] }>
   resumeTurn(sessionId: string): Promise<void>
   setTitle(sessionId: string, title: string): Promise<void>
   delete(sessionId: string): Promise<void>
@@ -44,6 +71,14 @@ export const ipcSessionsClient: SessionsClient = {
   getTurn: (turnId) => window.ipc.invoke('sessions:getTurn', { turnId }),
   sendMessage: (sessionId, input, config) =>
     window.ipc.invoke('sessions:sendMessage', { sessionId, input, config }),
+  sendOrQueueMessage: (sessionId, input, config) =>
+    window.ipc.invoke('sessions:sendOrQueueMessage', { sessionId, input, config }),
+  listQueued: (sessionId) => window.ipc.invoke('sessions:listQueued', { sessionId }),
+  editQueued: async (sessionId, queueId, message) => {
+    await window.ipc.invoke('sessions:editQueued', { sessionId, queueId, message })
+  },
+  removeQueued: (sessionId, queueId) =>
+    window.ipc.invoke('sessions:removeQueued', { sessionId, queueId }),
   respondToPermission: async (turnId, toolCallId, decision, metadata) => {
     await window.ipc.invoke('sessions:respondToPermission', {
       turnId,
@@ -56,10 +91,11 @@ export const ipcSessionsClient: SessionsClient = {
     await window.ipc.invoke('sessions:respondToAskHuman', { turnId, toolCallId, answer })
   },
   stopTurn: async (turnId, reason) => {
-    await window.ipc.invoke('sessions:stopTurn', {
+    const { dequeued } = await window.ipc.invoke('sessions:stopTurn', {
       turnId,
       ...(reason === undefined ? {} : { reason }),
     })
+    return { dequeued }
   },
   resumeTurn: async (sessionId) => {
     await window.ipc.invoke('sessions:resumeTurn', { sessionId })

--- a/apps/x/apps/renderer/src/lib/session-chat/store.test.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/store.test.ts
@@ -65,6 +65,21 @@ class FakeClient implements SessionsClient {
     this.record('sendMessage', sessionId, input, config)
     return { turnId: 'turn-next' }
   }
+  async sendOrQueueMessage(sessionId: string, input: unknown, config: unknown) {
+    this.record('sendOrQueueMessage', sessionId, input, config)
+    return { queued: false as const, turnId: 'turn-next' }
+  }
+  async listQueued(sessionId: string) {
+    this.record('listQueued', sessionId)
+    return { queue: [] }
+  }
+  async editQueued(...args: unknown[]) {
+    this.record('editQueued', ...args)
+  }
+  async removeQueued(...args: unknown[]) {
+    this.record('removeQueued', ...args)
+    return { removed: null }
+  }
   async respondToPermission(...args: unknown[]) {
     this.record('respondToPermission', ...args)
   }
@@ -73,6 +88,7 @@ class FakeClient implements SessionsClient {
   }
   async stopTurn(...args: unknown[]) {
     this.record('stopTurn', ...args)
+    return { dequeued: [] }
   }
   async resumeTurn(...args: unknown[]) {
     this.record('resumeTurn', ...args)
@@ -104,6 +120,7 @@ function makeStore() {
         emit = () => undefined
       }
     },
+    subscribeSessionFeed: () => () => undefined,
     subscribeDeltas: (turnId) => {
       deltaSubs.push(turnId)
       return () => {
@@ -289,7 +306,11 @@ describe('SessionChatStore', () => {
     await store.answerAskHuman('ah1', '42')
     await store.stop()
 
-    expect(client.calls.filter((c) => c.method !== 'get' && c.method !== 'getTurn')).toEqual([
+    expect(
+      client.calls.filter(
+        (c) => c.method !== 'get' && c.method !== 'getTurn' && c.method !== 'listQueued',
+      ),
+    ).toEqual([
       { method: 'sendMessage', args: [S1, user('next'), { agent: { agentId: 'copilot' } }] },
       { method: 'respondToPermission', args: ['turn-1', 'tc1', 'allow', undefined] },
       { method: 'respondToAskHuman', args: ['turn-1', 'ah1', '42'] },

--- a/apps/x/apps/renderer/src/lib/session-chat/store.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/store.ts
@@ -1,6 +1,10 @@
 import type { z } from 'zod'
 import type { UserMessage } from '@x/shared/src/message.js'
-import type { SessionBusEvent, SessionIndexEntry } from '@x/shared/src/sessions.js'
+import type {
+  QueuedSessionMessage,
+  SessionBusEvent,
+  SessionIndexEntry,
+} from '@x/shared/src/sessions.js'
 import {
   isDurableTurnEvent,
   reduceTurn,
@@ -25,6 +29,10 @@ export interface SessionChatSnapshot {
   sessionId: string | null
   chatState: SessionChatState | null
   latestTurnId: string | null
+  // Messages accepted while the latest turn runs, waiting in the ephemeral
+  // main-process queue to steer it (or start the next turn). Mirrored from
+  // queue-changed bus events; editable/removable until delivered.
+  queued: QueuedSessionMessage[]
   loading: boolean
   error: string | null
 }
@@ -34,6 +42,8 @@ export interface SessionChatStoreDeps {
   // The turns:events spine (durable events with offsets, plus deltas for
   // turns this window subscribed to).
   subscribeTurnFeed: (listener: (event: TurnBusEvent) => void) => () => void
+  // sessions:events — queue-changed mirrors for the active session.
+  subscribeSessionFeed: (listener: (event: SessionBusEvent) => void) => () => void
   // Declares "this window is watching turn X" so main forwards its deltas;
   // returns the unsubscribe.
   subscribeDeltas: (turnId: string) => () => void
@@ -46,8 +56,10 @@ export interface SessionChatStoreDeps {
 export class SessionChatStore {
   private readonly client: SessionsClient
   private readonly subscribeTurnFeed: (listener: (event: TurnBusEvent) => void) => () => void
+  private readonly subscribeSessionFeed: (listener: (event: SessionBusEvent) => void) => () => void
   private readonly subscribeDeltas: (turnId: string) => () => void
   private feedDisconnect: (() => void) | null = null
+  private sessionFeedDisconnect: (() => void) | null = null
   private readonly listeners = new Set<() => void>()
 
   private sessionId: string | null = null
@@ -56,6 +68,7 @@ export class SessionChatStore {
   // The latest turn's raw event log; re-reduced on each durable event.
   private latestEvents: TEvent[] | null = null
   private overlay: LiveOverlay = emptyOverlay()
+  private queued: QueuedSessionMessage[] = []
   private loading = false
   private error: string | null = null
   // Guards stale async loads after a session switch.
@@ -68,6 +81,7 @@ export class SessionChatStore {
     sessionId: null,
     chatState: null,
     latestTurnId: null,
+    queued: [],
     loading: false,
     error: null,
   }
@@ -75,6 +89,7 @@ export class SessionChatStore {
   constructor(deps: SessionChatStoreDeps) {
     this.client = deps.client
     this.subscribeTurnFeed = deps.subscribeTurnFeed
+    this.subscribeSessionFeed = deps.subscribeSessionFeed
     this.subscribeDeltas = deps.subscribeDeltas
   }
 
@@ -84,11 +99,14 @@ export class SessionChatStore {
   connect(): () => void {
     if (!this.feedDisconnect) {
       this.feedDisconnect = this.subscribeTurnFeed(this.onTurnEvent)
+      this.sessionFeedDisconnect = this.subscribeSessionFeed(this.onSessionEvent)
       this.syncDeltas()
     }
     return () => {
       this.feedDisconnect?.()
       this.feedDisconnect = null
+      this.sessionFeedDisconnect?.()
+      this.sessionFeedDisconnect = null
       this.syncDeltas()
     }
   }
@@ -125,6 +143,7 @@ export class SessionChatStore {
     this.priorTurns = []
     this.latestEvents = null
     this.overlay = emptyOverlay()
+    this.queued = []
     this.error = null
     this.loading = sessionId !== null
     this.syncDeltas()
@@ -133,13 +152,16 @@ export class SessionChatStore {
 
     try {
       const state = await this.client.get(sessionId)
-      const turns = await Promise.all(
-        state.turns.map((ref) => this.client.getTurn(ref.turnId)),
-      )
+      const [turns, queued] = await Promise.all([
+        Promise.all(state.turns.map((ref) => this.client.getTurn(ref.turnId))),
+        // Seed the pending-queue mirror; queue-changed events keep it live.
+        this.client.listQueued(sessionId).then(({ queue }) => queue),
+      ])
       if (generation !== this.generation) return
       const reduced = turns.map((turn) => reduceTurn(turn.events))
       this.priorTurns = reduced.slice(0, -1)
       this.latestEvents = turns.length > 0 ? turns[turns.length - 1].events : null
+      this.queued = queued
       this.loading = false
       this.syncDeltas()
       this.emit()
@@ -150,6 +172,12 @@ export class SessionChatStore {
       this.error = error instanceof Error ? error.message : String(error)
       this.emit()
     }
+  }
+
+  private onSessionEvent = (event: SessionBusEvent): void => {
+    if (event.kind !== 'queue-changed' || event.sessionId !== this.sessionId) return
+    this.queued = event.queue
+    this.emit()
   }
 
   private onTurnEvent = (event: TurnBusEvent): void => {
@@ -226,6 +254,33 @@ export class SessionChatStore {
     return this.client.sendMessage(this.sessionId, input, config)
   }
 
+  // Deliver-ASAP send: never rejects for a busy session — the message queues
+  // and steers the live turn (or starts the next one) at the earliest safe
+  // point.
+  sendOrQueueMessage = async (
+    input: z.infer<typeof UserMessage>,
+    config: SendMessageConfig,
+  ): Promise<{ queued: false; turnId: string } | { queued: true; queueId: string }> => {
+    if (!this.sessionId) throw new Error('No active session')
+    return this.client.sendOrQueueMessage(this.sessionId, input, config)
+  }
+
+  editQueued = async (
+    queueId: string,
+    message: z.infer<typeof UserMessage>,
+  ): Promise<void> => {
+    if (!this.sessionId) return
+    await this.client.editQueued(this.sessionId, queueId, message)
+  }
+
+  removeQueued = async (
+    queueId: string,
+  ): Promise<QueuedSessionMessage | null> => {
+    if (!this.sessionId) return null
+    const { removed } = await this.client.removeQueued(this.sessionId, queueId)
+    return removed
+  }
+
   respondToPermission = async (
     toolCallId: string,
     decision: 'allow' | 'deny',
@@ -242,10 +297,14 @@ export class SessionChatStore {
     await this.client.respondToAskHuman(turnId, toolCallId, answer)
   }
 
-  stop = async (): Promise<void> => {
+  // Stops the latest turn. Pending queued messages are drained by the stop
+  // (never auto-started after it) and returned so the composer can restore
+  // their text.
+  stop = async (): Promise<QueuedSessionMessage[]> => {
     const turnId = this.snapshot.latestTurnId
-    if (!turnId) return
-    await this.client.stopTurn(turnId)
+    if (!turnId) return []
+    const { dequeued } = await this.client.stopTurn(turnId)
+    return dequeued
   }
 
   // ── Derivation ──────────────────────────────────────────────────────────
@@ -276,6 +335,7 @@ export class SessionChatStore {
           ? buildSessionChatState(turns, this.overlay)
           : null,
       latestTurnId: latest?.definition.turnId ?? null,
+      queued: this.queued,
       loading: this.loading,
       error,
     }

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
@@ -282,20 +282,36 @@ export function buildTurnConversation(state: TurnState): ConversationItem[] {
   let seq = 0
   const ts = () => Date.parse(state.definition.ts) + seq++
 
-  const userText = extractText(state.definition.input.content)
-  const attachments = extractAttachments(state.definition.input.content)
-  if (userText || attachments) {
-    items.push({
-      id: `${turnId}:user`,
-      role: 'user',
-      content: userText,
-      timestamp: ts(),
-      ...(attachments ? { attachments } : {}),
-    } satisfies ChatMessage)
+  const pushUser = (
+    message: TurnState['definition']['input'],
+    idSuffix: string,
+  ) => {
+    const userText = extractText(message.content)
+    const attachments = extractAttachments(message.content)
+    if (userText || attachments) {
+      items.push({
+        id: `${turnId}:user${idSuffix}`,
+        role: 'user',
+        content: userText,
+        timestamp: ts(),
+        ...(attachments ? { attachments } : {}),
+      } satisfies ChatMessage)
+    }
+  }
+  pushUser(state.definition.input, '')
+  // Steered messages (input_added) render at the boundary the model saw
+  // them: before the model call that first transmitted them.
+  const pushAddedInputs = (boundary: number) => {
+    for (const added of state.addedInputs) {
+      if (added.firstAffectedModelCallIndex === boundary) {
+        pushUser(added.event.message, `:${added.event.inputIndex}`)
+      }
+    }
   }
 
   const toolCallsById = new Map(state.toolCalls.map((tc) => [tc.toolCallId, tc]))
   for (const call of state.modelCalls) {
+    pushAddedInputs(call.index)
     if (call.response === undefined) continue
     const content = call.response.content
     // The model's thought process precedes what it produced. Encrypted-only
@@ -349,6 +365,10 @@ export function buildTurnConversation(state: TurnState): ConversationItem[] {
       }
     }
   }
+
+  // Inputs accepted after the last requested call (turn stopped before the
+  // next request) still render — they were durably accepted.
+  pushAddedInputs(state.modelCalls.length)
 
   if (state.terminal?.type === 'turn_failed') {
     // Interactive turns normally wrap up gracefully before hitting the

--- a/apps/x/packages/core/docs/session-design.md
+++ b/apps/x/packages/core/docs/session-design.md
@@ -1,7 +1,7 @@
 # Session Layer Technical Specification
 
-Status: design complete for the session layer v1. No implementation exists
-yet.
+Status: implemented and live (`core/src/runtime/sessions/`), including the
+post-v1 queued-messages + steering design of sections 12.1/12.4.
 
 This document specifies the session layer that sits above the turn runtime
 defined in `turn-runtime-design.md`. That document is assumed context; this
@@ -25,8 +25,10 @@ The session layer must:
 
 ## 2. Non-goals (v1)
 
-- Queued user messages. The committed future shape is in section 12.1.
-- Steering / mid-turn message injection (section 12.4).
+- Queued user messages — SINCE IMPLEMENTED; the as-built design is in
+  section 12.1 (which supersedes the originally committed durable shape).
+- Steering / mid-turn message injection — SINCE IMPLEMENTED; see section
+  12.4.
 - Session-scoped permission grants ("always allow for this chat"); every
   applicable tool call prompts in v1 (section 12.2).
 - Context compaction; a viable mechanism sketch is recorded in section 12.3.
@@ -273,6 +275,16 @@ interface ISessions {
     config: SendMessageConfig,
   ): Promise<{ turnId: string }>;
 
+  // Deliver-ASAP send + ephemeral pending-queue operations (section 12.1).
+  sendOrQueueMessage(
+    sessionId: string,
+    input: UserMessage,
+    config: SendMessageConfig,
+  ): Promise<{ queued: false; turnId: string } | { queued: true; queueId: string }>;
+  listQueued(sessionId: string): QueuedSessionMessage[];
+  editQueued(sessionId: string, queueId: string, message: UserMessage): void;
+  removeQueued(sessionId: string, queueId: string): QueuedSessionMessage | undefined;
+
   respondToPermission(
     turnId: string,
     toolCallId: string,
@@ -292,7 +304,10 @@ interface ISessions {
     result: ToolResultData,
   ): Promise<void>;
 
-  stopTurn(turnId: string, reason?: string): Promise<void>;
+  // Also drains the session's pending queue (a stop must never be followed
+  // by a queued message auto-starting work) and returns the drained
+  // messages so the UI can restore their text to the composer.
+  stopTurn(turnId: string, reason?: string): Promise<{ dequeued: QueuedSessionMessage[] }>;
   resumeTurn(sessionId: string): Promise<void>;
 
   setTitle(sessionId: string, title: string): Promise<void>;
@@ -412,23 +427,65 @@ function runHeadlessTurn(input: {
 - Standalone turns never appear in the index; callers keep their own turn
   IDs if they need history.
 
-## 12. Deferred designs with committed shapes
+## 12. Follow-on designs
 
-These are not implemented in v1. Their shapes are recorded so v1 decisions
-stay compatible; each arrives as a session schema version bump.
+12.1 and 12.4 are IMPLEMENTED (they shipped together as one deliver-ASAP
+feature); the remaining subsections stay deferred with committed shapes.
 
-### 12.1 Queued messages
+### 12.1 Queued messages (implemented — ephemeral, superseding the committed durable shape)
 
-```ts
-{ type: "message_queued", queueId, message, ts }
-{ type: "queued_message_replaced", queueId, message, ts } // edit
-{ type: "queued_message_removed", queueId, ts }           // cancel
-// promotion: turn_appended gains consumedQueueIds?: string[]
-```
+This section originally committed durable session events
+(`message_queued` / `queued_message_replaced` / `queued_message_removed`,
+with `turn_appended.consumedQueueIds` for promotion). The implementation
+deliberately supersedes that shape: **the pending queue is process memory
+only** (`SessionsImpl.pending`), never written to the session file. A
+message becomes durable exactly once, at delivery — as an `input_added`
+turn event when it steers the live turn, or as `turn_created.input` when it
+is promoted into a new turn.
 
-The reducer derives the pending queue by supersession. Promotion rules
-(collapse-into-one-turn vs FIFO, behavior after failed turns) are decided
-together with steering.
+Why ephemeral won:
+
+- One durability point. The durable-queue design needed cross-file
+  consistency between the session file (queue state) and the turn file
+  (consumption), with `queueId` reconciliation to avoid double delivery
+  after a crash. Ephemeral pending state deletes that seam entirely.
+- Consistency with §4.2 of the turn spec: durable events record facts, not
+  intent. A pending message is intent-not-yet-acted-on — kin to the
+  composer draft, which is also not durable.
+- Coherent crash loss. A crash kills the in-flight turn (it comes back
+  `idle`, needing manual resume); losing the message that was steering it
+  is the consistent outcome, and matches the no-auto-resume stance — a
+  durable queue promoting at startup would start model calls unprompted.
+- Precedent: pi's steering/follow-up queues are in-memory; opencode's
+  shipping desktop queue is client-side state.
+
+Accepted trade-off, recorded deliberately: a remote sender (channel
+bridge) whose message is queued loses it silently if the app crashes;
+the local user at least sees the chip vanish. The bridge still uses strict
+`sendMessage` today, so nothing regresses until it opts in.
+
+Behavior (one user-facing mode — deliver-ASAP; there is no queue-vs-steer
+choice):
+
+- `sendOrQueueMessage` starts a turn when the session is settled and the
+  queue is empty; otherwise it appends `{queueId, message, config, ts}` to
+  the pending queue (arrival order is preserved even against a
+  settled-but-unpromoted queue).
+- Pending entries steer the live turn at its next model-call boundary
+  (section 12.4). Entries still pending when a turn settles are promoted:
+  the head becomes a new turn via the normal locked send path, using the
+  config it arrived with; the remainder stays queued and steers the new
+  turn at its first boundary (call 0) — the earliest the model can see it.
+- The enqueue and the settled-check share one session-lock hold, and
+  promotion re-checks everything under the same lock, so a concurrent
+  settle cannot strand a message (no lost wakeup).
+- Promotion failure (e.g. agent resolution) leaves the entry queued,
+  visible, and editable rather than silently dropping user text.
+- `stopTurn` drains the queue first and returns the drained messages; a
+  stop is never followed by queued work auto-starting.
+- The renderer mirror rides a new `queue-changed` session-bus event kind
+  carrying the full queue (`QueuedSessionMessage[]` in shared/sessions.ts);
+  `listQueued` seeds it on session open. Edit/remove are plain methods.
 
 ### 12.2 Session permission grants
 
@@ -449,12 +506,43 @@ after a compaction uses **inline** context (summary message + kept
 transcript), which restarts the reference chain and bounds resolution depth
 by construction. Trigger policy and summarizer design are unspecified.
 
-### 12.4 Steering
+### 12.4 Steering (implemented)
 
-Rides the queue events with a different promotion rule, and additionally
-requires a turn-level `steer` external input (a turn schema bump) with an
-injection boundary after tool-batch completion. Recorded here so the session
-design does not foreclose it.
+A pending message reaches the RUNNING turn at its next model-call boundary.
+Mechanism (see turn-runtime-design.md §8.6/§15.2 for the turn half):
+
+- Every advance the session layer starts — sendMessage, promotion,
+  permission/ask-human/async-result routing, resumeTurn — passes a
+  `takeInputs` drain callback in `advanceTurn` options. The loop polls it
+  once per iteration at the boundary (batch settled, completion ruled out,
+  before the budget check and the next request) and appends the drained
+  messages as durable `input_added` turn events, which the very next
+  `model_call_requested` must reference (`input:<n>` refs).
+- No `steer` external input was needed, contrary to this section's original
+  sketch: a suspended turn's queue drains automatically when the advance
+  that answers its permission/async result reaches the boundary.
+- Injection is purely additive (never cancels in-flight work), the message
+  lands as a plain user message after the batch's tool results, and each
+  accepted input resets the turn's model-call budget (counts since last
+  input) — fresh user input buys the allowance a fresh turn would get.
+- If the final response is already streaming (no next model call), the turn
+  completes normally and the message promotes as a new turn instead;
+  delivery is "earliest safe point", never "guaranteed same turn".
+
+Rejected alternative, recorded for the road not taken: **supersede-at-
+boundary** (gracefully cancel the running turn at the batch boundary with
+`reason: "steered"`, then promote the message as a new turn referencing
+it). Zero turn-schema change and it collapses queueing/steering into one
+promotion path, but it loses on behavior: (a) transmit-time elision
+(context-elision.ts) would replace the just-executed batch's large tool
+results with placeholders at the very next call — the model forgets what
+it just read precisely when steered mid-task; (b) cross-turn provider
+continuation stripping (shared/turns.ts) would drop reasoning
+signatures/blobs of a cancelled turn, breaking interleaved-thinking
+continuity on every steer; (c) it is destructive by construction to turns
+suspended on permissions (cancelling their pending calls), violating the
+additive-only property. Within-turn injection preserves all three by
+construction.
 
 ### 12.5 Persisted index cache
 
@@ -533,6 +621,21 @@ All tests use the in-memory/mocked turn runtime and repo fakes.
 - Standalone turns: `sessionId: null`, auto permission, human unavailable,
   absent from the index.
 
+### 13.9 Pending queue (12.1/12.4)
+
+- `sendOrQueueMessage`: immediate start on a settled session; queue while
+  the latest turn is non-terminal (queue-changed mirrored on the bus).
+- Arrival order preserved when the session settled but promotion has not
+  run yet.
+- The steer drain hands every advance the pending queue and empties it.
+- Promotion on settle: head becomes a new turn with its arrival config and
+  a context reference to the settled turn; the rest stays queued.
+- Edit/remove before delivery; unknown queueIds error/return undefined.
+- `stopTurn` drains first, returns the drained messages, and no promotion
+  fires afterward.
+- Promotion failure keeps the entry queued.
+- `deleteSession` drops the pending queue.
+
 ## 14. Suggested module layout
 
 ```text
@@ -580,8 +683,10 @@ The session layer is implementation-complete only when:
 2. Session files follow the partitioned append-only JSONL layout with
    strict validation.
 3. Turn-file-first write ordering is enforced; orphan turns are benign.
-4. `sendMessage` rejects non-terminal latest turns with a typed error; no
-   implicit queueing, steering, or ask-human routing exists.
+4. `sendMessage` rejects non-terminal latest turns with a typed error and
+   never routes to ask-human. Queueing and steering are explicit opt-in
+   through `sendOrQueueMessage` only (section 12.1); programmatic callers
+   keep the strict contract.
 5. Ask-human answers flow only through the dedicated endpoint.
 6. The index is write-through with a startup scan, no watcher, and no
    persisted cache; single-instance is enforced.

--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -38,7 +38,8 @@ The turn runtime must:
 The first implementation will not include:
 
 - Session storage or session scheduling.
-- Queued user messages.
+- Queued user messages. (The queue stayed a session concern when it later
+  shipped; the turn loop's half is the `takeInputs` drain of section 8.6.)
 - Enforcement of the session-level one-active-turn rule.
 - Context pruning or compaction.
 - Agent-as-tool behavior. An agent tool handler may implement this separately,
@@ -61,7 +62,10 @@ The first implementation will not include:
 ### 3.1 Turn
 
 A turn starts with one intentional user message and contains all agent work
-caused by that message:
+caused by that message. The caller may offer ADDITIONAL user messages while
+the turn runs (steering); each is accepted durably at a model-call boundary
+as an `input_added` event (section 8.6), so a turn has one or more inputs —
+the first arriving in `turn_created`. A turn's work includes:
 
 - Model requests and responses.
 - Permission checks and decisions.
@@ -601,7 +605,8 @@ execution is controlled manually by the turn loop.
 ```ts
 // Compact string refs, so raw JSONL reads naturally:
 //   "context"                  the inline context block
-//   "input"                    the turn's user message
+//   "input"                    the turn's user message (input index 0)
+//   "input:<n>"                → the nth input_added message (n >= 1)
 //   "assistant:<index>"        → that model_call_completed's message
 //   "toolResult:<toolCallId>"  → that tool_result
 type ModelRequestMessageRef = string;
@@ -628,7 +633,10 @@ is new since the previous model call — call 0 is `["context"?, "input"]`
 (context only when inline and nonempty; cross-turn prefixes ride
 `contextRef`); call N is `["assistant:N-1", …that batch's
 "toolResult:<id>" refs in source order]`; a re-issued call after an
-interruption is `[]`. The system
+interruption is `[]`. Every base list is followed by the `input:<n>` refs
+of inputs accepted at that boundary (section 8.6) — a request MUST
+reference every input added before it, so an accepted message can never be
+silently dropped. The system
 prompt and tool set are not repeated: they are byte-identical to
 `turn_created.agent.resolved` by construction.
 
@@ -712,6 +720,47 @@ Only the primary model calls directly controlled by the turn loop are recorded
 as model calls. Internal model calls hidden inside the permission classifier or
 tool implementations belong to those dependencies and are not turn-loop model
 calls.
+
+### 8.6 Added inputs (steering)
+
+```ts
+interface InputAdded extends BaseTurnEvent {
+  type: "input_added";
+  inputIndex: number; // 1-based; index 0 is turn_created.input
+  message: UserMessage;
+}
+```
+
+A user message accepted into the RUNNING turn at a model-call boundary.
+Like `tools_extended`, this is a sanctioned, durable, ordered exception to
+turn-definition immutability. Rules:
+
+- The messages come from a caller-supplied drain (`takeInputs`,
+  section 15.2) polled once per loop iteration at the boundary: the tool
+  batch has settled, completion was ruled out, the budget check and the
+  next `model_call_requested` are about to run. The loop never learns where
+  the messages come from (session queue, test fixture).
+- Injection is purely additive. It never interrupts an in-flight model
+  stream or tool execution and never cancels pending work; the message
+  lands as a plain user message positioned after the batch's tool results.
+- The very next `model_call_requested` must reference every input added
+  before it (`input:<n>` refs) — the reducer enforces this, which is also
+  what makes recovery correct: an `input_added` orphaned by a crash before
+  its request is picked up by the re-issued request's refs.
+- `input_added` may not appear while a model call is unsettled or while
+  tool calls lack terminal results; `inputIndex` is strictly sequential.
+- Each accepted input RESETS the model-call budget: the limit counts calls
+  since the last input (section 20). Fresh user input buys the allowance a
+  fresh turn would get.
+- `turnTranscript` and the request composer place added inputs at the
+  boundary the model saw them, so cross-turn context, the classifier's
+  conversation view, and the UI all render them in position. Inputs
+  accepted after the last request (turn cancelled first) close the
+  transcript, so the next turn still sees them.
+- If the model's final response has no tool calls, the turn completes even
+  if the caller still has pending messages — there is no next call to
+  inject before; the session layer promotes them into a new turn instead.
+  Delivery is "earliest safe point", never "guaranteed same turn".
 
 ## 9. Permission model
 
@@ -1123,6 +1172,7 @@ type TurnEvent =
   | ToolInvocationRequested
   | ToolProgress
   | ToolResult
+  | InputAdded
   | TurnSuspended
   | TurnCompleted
   | TurnFailed
@@ -1337,13 +1387,20 @@ interface CreateTurnInput {
   };
 }
 
+// Steering drain (section 8.6): returned messages are treated as consumed
+// and appended durably as input_added events at the boundary. The dual of
+// the abort signal — both are ephemeral per-invocation channels into a live
+// advance that become durable only when acted on (turn_cancelled /
+// input_added respectively).
+type TakeAddedInputs = () => UserMessage[] | Promise<UserMessage[]>;
+
 interface ITurnRuntime {
   createTurn(input: CreateTurnInput): Promise<string>;
 
   advanceTurn(
     turnId: string,
     input?: TurnExternalInput,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; takeInputs?: TakeAddedInputs },
   ): TurnExecution;
 
   getTurn(turnId: string): Promise<Turn>;
@@ -1534,19 +1591,22 @@ At a high level, `advanceTurn` performs:
    d. Expose eligible async tools.
    e. If external work remains, append turn_suspended and settle.
    f. If a tool batch is complete, build ordered tool-result messages.
-   g. If no model-call budget remains, fail.
-   h. Append model_call_requested with exact input.
-   i. Call streamText for one step.
-   j. Persist normalized non-delta events and stream deltas.
-   k. Append model_call_completed or model_call_failed.
-   l. Complete when the response has no tool calls.
+   g. Drain takeInputs; append input_added for each accepted message.
+   h. If no model-call budget remains (counted since the last input), fail.
+   i. Append model_call_requested with exact input.
+   j. Call streamText for one step.
+   k. Persist normalized non-delta events and stream deltas.
+   l. Append model_call_completed or model_call_failed.
+   m. Complete when the response has no tool calls.
 11. Publish turn-processing-end in finalization.
 12. Release the lock.
 13. Resolve/reject outcome and close/error event stream.
 ```
 
-The loop does not read session queues, accept new user messages, switch agents,
-or transform context.
+The loop does not read session queues, switch agents, or transform context.
+Additional user input arrives only through the caller-supplied `takeInputs`
+drain at the section 8.6 boundary — the loop stays ignorant of where the
+messages come from.
 
 ## 19. Context and model requests
 
@@ -1569,7 +1629,11 @@ Within-turn storage size is not treated as a constraint.
 ## 20. Model-call limit
 
 `maxModelCalls` limits primary agent model calls, not permission-classifier or
-tool-internal model calls.
+tool-internal model calls. The budget counts calls SINCE THE LAST ACCEPTED
+INPUT (`input_added`, section 8.6): a turn with no added inputs behaves
+exactly as before, and each steer resets the allowance — the same budget a
+fresh turn would have granted. The reducer enforces the same rule as its
+append gate.
 
 When the final allowed model call returns tool calls:
 
@@ -1667,6 +1731,7 @@ Calling `advanceTurn(turnId)` with no external input is the recovery entry point
 | Async `tool_invocation_requested` without result | Remain suspended awaiting external result. |
 | Some async results present | Preserve them and await remaining inputs. |
 | All tool results present before next model request | Safely initiate the next model call. |
+| `input_added` without a following `model_call_requested` | The next request's refs carry the input by construction (section 8.6); nothing special to do. |
 | Terminal event present | Return existing outcome without writing or executing. |
 | Corrupt JSONL | Reject as infrastructure error. |
 
@@ -1719,7 +1784,10 @@ but the first turn implementation does not enforce it.
 - Request references that do not match the transcript: call 0 must be
   `[{context}?, {input}]`; call N must reference the previous completed
   call's response and its batch's tool results in source order (or nothing,
-  after an interrupted call).
+  after an interrupted call); every list is followed by exactly the
+  `input:<n>` refs of inputs accepted at that boundary (section 8.6).
+- `input_added` while a model call is unsettled, while tool calls lack
+  terminal results, or with a non-sequential `inputIndex`.
 
 The reducer validates `context` structurally but treats it as opaque; it
 never resolves references (section 6.6).
@@ -1995,8 +2063,9 @@ implicitly added to the turn loop:
 The session layer is specified in `session-design.md`. It covers the session
 JSONL schema, turn references and ordering, one-active-turn enforcement,
 context assembly through turn references, the in-memory index, session UI
-projections, and startup reconciliation. Queued user messages, steering,
-session-level permission grants, and compaction remain deferred there with
+projections, and startup reconciliation. Queued user messages and steering
+shipped there (its sections 12.1/12.4, riding this document's section 8.6);
+session-level permission grants and compaction remain deferred with
 committed future shapes.
 
 ### 29.2 Agent-as-tool

--- a/apps/x/packages/core/src/runtime/sessions/api.ts
+++ b/apps/x/packages/core/src/runtime/sessions/api.ts
@@ -2,6 +2,7 @@ import type { z } from "zod";
 import type { UseCase } from "@x/shared/dist/analytics.js";
 import type { UserMessage } from "@x/shared/dist/message.js";
 import type {
+    QueuedSessionMessage,
     SessionIndexEntry,
     SessionState,
 } from "@x/shared/dist/sessions.js";
@@ -34,12 +35,41 @@ export interface ISessions {
 
     // Rejects with TurnNotSettledError while the latest turn is non-terminal.
     // Returns as soon as the turn is created, referenced, and advancing;
-    // progress flows through the bus.
+    // progress flows through the bus. Programmatic callers that need the
+    // strict "no implicit queueing" contract use this; the chat UI uses
+    // sendOrQueueMessage.
     sendMessage(
         sessionId: string,
         input: z.infer<typeof UserMessage>,
         config: SendMessageConfig,
     ): Promise<{ turnId: string }>;
+
+    // Deliver-ASAP: starts a turn immediately when the session is settled,
+    // otherwise accepts the message into the ephemeral pending queue. Queued
+    // messages steer the live turn at its next model-call boundary (durable
+    // input_added events), or — if the turn settles first — promote FIFO into
+    // a new turn; either way the message reaches the model at the earliest
+    // safe point. The queue is process memory only: a crash drops it together
+    // with the turn it was steering.
+    sendOrQueueMessage(
+        sessionId: string,
+        input: z.infer<typeof UserMessage>,
+        config: SendMessageConfig,
+    ): Promise<SendOrQueueOutcome>;
+
+    // Pending-queue introspection and pre-delivery editing. All are
+    // process-memory operations; queue-changed bus events mirror every
+    // mutation to the renderer.
+    listQueued(sessionId: string): QueuedSessionMessage[];
+    editQueued(
+        sessionId: string,
+        queueId: string,
+        message: z.infer<typeof UserMessage>,
+    ): void;
+    removeQueued(
+        sessionId: string,
+        queueId: string,
+    ): QueuedSessionMessage | undefined;
 
     // External inputs, one advanceTurn each. These settle with that
     // invocation's outcome; turn-runtime input rejections pass through.
@@ -61,13 +91,23 @@ export interface ISessions {
         result: z.infer<typeof ToolResultData>,
     ): Promise<void>;
 
-    stopTurn(turnId: string, reason?: string): Promise<void>;
+    // Stopping also drains the session's pending queue — a stop must not be
+    // followed by a queued message auto-starting work — and returns the
+    // drained messages so the UI can restore their text to the composer.
+    stopTurn(
+        turnId: string,
+        reason?: string,
+    ): Promise<{ dequeued: QueuedSessionMessage[] }>;
     // Recovery entry for turns left idle by a crash; runs in the background.
     resumeTurn(sessionId: string): Promise<void>;
 
     setTitle(sessionId: string, title: string): Promise<void>;
     deleteSession(sessionId: string): Promise<void>;
 }
+
+export type SendOrQueueOutcome =
+    | { queued: false; turnId: string }
+    | { queued: true; queueId: string };
 
 export class TurnNotSettledError extends Error {
     constructor(

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -9,6 +9,7 @@ import type {
 import type {
     CreateTurnInput,
     ITurnRuntime,
+    TakeAddedInputs,
     Turn,
     TurnExecution,
     TurnExternalInput,
@@ -184,7 +185,11 @@ type AdvanceScript = (call: {
 
 class FakeTurnRuntime implements ITurnRuntime {
     createTurnInputs: CreateTurnInput[] = [];
-    advanceCalls: Array<{ turnId: string; input?: TurnExternalInput }> = [];
+    advanceCalls: Array<{
+        turnId: string;
+        input?: TurnExternalInput;
+        takeInputs?: TakeAddedInputs;
+    }> = [];
     logs = new Map<string, TEvent[]>();
     createError?: Error;
     script?: AdvanceScript;
@@ -222,9 +227,9 @@ class FakeTurnRuntime implements ITurnRuntime {
     advanceTurn(
         turnId: string,
         input?: TurnExternalInput,
-        options?: { signal?: AbortSignal },
+        options?: { signal?: AbortSignal; takeInputs?: TakeAddedInputs },
     ): TurnExecution {
-        this.advanceCalls.push({ turnId, input });
+        this.advanceCalls.push({ turnId, input, takeInputs: options?.takeInputs });
         const stream = new HotStream<TurnStreamEvent, TurnOutcome>();
         const result = this.script?.({ turnId, input, signal: options?.signal }) ?? {
             outcome: completedOutcome(),
@@ -405,7 +410,9 @@ describe("sendMessage (13.3)", () => {
                 title: "Fix the bug in parser",
             }),
         );
-        expect(fake.advanceCalls).toEqual([{ turnId, input: undefined }]);
+        expect(fake.advanceCalls).toEqual([
+            { turnId, input: undefined, takeInputs: expect.any(Function) },
+        ]);
     });
 
     it("subsequent messages reference the latest turn and skip the title", async () => {
@@ -566,6 +573,7 @@ describe("external input routing (13.5)", () => {
                     decision: "allow",
                     metadata: { scope: "once" },
                 },
+                takeInputs: expect.any(Function),
             },
         ]);
     });
@@ -581,6 +589,7 @@ describe("external input routing (13.5)", () => {
                     toolCallId: "B",
                     result: { output: "the answer is 42", isError: false },
                 },
+                takeInputs: expect.any(Function),
             },
         ]);
     });
@@ -632,7 +641,11 @@ describe("stopTurn and resumeTurn", () => {
         fake.advanceCalls.length = 0;
         await sessions.stopTurn(turnId, "user stop");
         expect(fake.advanceCalls).toEqual([
-            { turnId, input: { type: "cancel", reason: "user stop" } },
+            {
+                turnId,
+                input: { type: "cancel", reason: "user stop" },
+                takeInputs: expect.any(Function),
+            },
         ]);
     });
 
@@ -645,7 +658,9 @@ describe("stopTurn and resumeTurn", () => {
         await flush();
         fake.advanceCalls.length = 0;
         await sessions.resumeTurn(sessionId);
-        expect(fake.advanceCalls).toEqual([{ turnId, input: undefined }]);
+        expect(fake.advanceCalls).toEqual([
+            { turnId, input: undefined, takeInputs: expect.any(Function) },
+        ]);
     });
 
     it("resumeTurn on a session with no turns throws", async () => {
@@ -732,7 +747,9 @@ describe("stopTurn and resumeTurn", () => {
         fake.script = () => ({
             error: new TurnInputError(`turn ${turnId} is terminal; input rejected`),
         });
-        await expect(sessions.stopTurn(turnId)).resolves.toBeUndefined();
+        await expect(sessions.stopTurn(turnId)).resolves.toEqual({
+            dequeued: [],
+        });
     });
 
     it("rethrows a cancel-input rejection when the turn is not terminal", async () => {
@@ -1213,5 +1230,220 @@ describe("active-skill carry-forward", () => {
         });
         const second = fake.createTurnInputs[1];
         expect(second.agent).toEqual({ agentId: "copilot" });
+    });
+});
+
+describe("pending queue (sendOrQueueMessage, steering, promotion)", () => {
+    function queueEventsOf(bus: RecordingBus) {
+        return bus.events.filter((e) => e.kind === "queue-changed");
+    }
+
+    it("starts immediately on a settled session", async () => {
+        const { sessions, fake } = makeSessions();
+        const sessionId = await sessions.createSession();
+        const result = await sessions.sendOrQueueMessage(sessionId, user("go"), {
+            agent: { agentId: "copilot" },
+        });
+        expect(result).toMatchObject({ queued: false });
+        expect(fake.createTurnInputs).toHaveLength(1);
+        expect(sessions.listQueued(sessionId)).toEqual([]);
+    });
+
+    it("queues while the latest turn is non-terminal and mirrors the queue on the bus", async () => {
+        const { sessions, fake, bus } = makeSessions();
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        void turnId; // default log stays idle (non-terminal)
+
+        const result = await sessions.sendOrQueueMessage(sessionId, user("two"), {
+            agent: { agentId: "copilot" },
+        });
+        expect(result).toMatchObject({ queued: true });
+        expect(fake.createTurnInputs).toHaveLength(1); // no second turn
+        const queued = sessions.listQueued(sessionId);
+        expect(queued).toHaveLength(1);
+        expect(queued[0].message).toEqual(user("two"));
+        const mirrored = queueEventsOf(bus);
+        expect(mirrored[mirrored.length - 1]).toMatchObject({
+            sessionId,
+            queue: [expect.objectContaining({ message: user("two") })],
+        });
+    });
+
+    it("hands the pending queue to every session advance as a steer source", async () => {
+        const { sessions, fake } = makeSessions();
+        const sessionId = await sessions.createSession();
+        await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("steer me in"), {
+            agent: { agentId: "copilot" },
+        });
+
+        const takeInputs = fake.advanceCalls[0].takeInputs;
+        expect(takeInputs).toBeDefined();
+        // The loop draining the source consumes the queue.
+        expect(await takeInputs!()).toEqual([user("steer me in")]);
+        expect(sessions.listQueued(sessionId)).toEqual([]);
+        // A second drain finds nothing.
+        expect(await takeInputs!()).toEqual([]);
+    });
+
+    it("promotes the pending head into a new turn when the running turn settles", async () => {
+        const { sessions, fake } = makeSessions();
+        let settle!: (outcome: TurnOutcome) => void;
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>((resolve) => {
+                settle = resolve;
+            }),
+        });
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("after you finish"), {
+            agent: { agentId: "copilot" },
+            useCase: "todo_item_agent",
+        });
+        expect(sessions.listQueued(sessionId)).toHaveLength(1);
+
+        fake.script = undefined; // the promoted turn settles synchronously
+        fake.setLog(turnId, turnLog(turnId, sessionId, "completed"));
+        settle(completedOutcome());
+        await flush();
+        await flush();
+
+        expect(sessions.listQueued(sessionId)).toEqual([]);
+        expect(fake.createTurnInputs).toHaveLength(2);
+        expect(fake.createTurnInputs[1]).toMatchObject({
+            input: user("after you finish"),
+            context: { previousTurnId: turnId },
+            analytics: { useCase: "todo_item_agent" },
+        });
+    });
+
+    it("queues behind existing entries even when the session is settled, preserving arrival order", async () => {
+        const { sessions, fake } = makeSessions();
+        let settle!: (outcome: TurnOutcome) => void;
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>((resolve) => {
+                settle = resolve;
+            }),
+        });
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("second"), {
+            agent: { agentId: "copilot" },
+        });
+        // The turn settles, but promotion has not run yet (its lock acquisition
+        // is queued); a new send must not jump the pending entry.
+        fake.setLog(turnId, turnLog(turnId, sessionId, "completed"));
+        const third = await sessions.sendOrQueueMessage(sessionId, user("third"), {
+            agent: { agentId: "copilot" },
+        });
+        expect(third).toMatchObject({ queued: true });
+        expect(
+            sessions.listQueued(sessionId).map((q) => q.message),
+        ).toEqual([user("second"), user("third")]);
+        fake.script = undefined;
+        settle(completedOutcome());
+        await flush();
+        await flush();
+        // Promotion started the head; the rest stays queued for steering.
+        expect(fake.createTurnInputs[1]).toMatchObject({ input: user("second") });
+        expect(
+            sessions.listQueued(sessionId).map((q) => q.message),
+        ).toEqual([user("third")]);
+    });
+
+    it("edits and removes pending entries before delivery", async () => {
+        const { sessions } = makeSessions();
+        const sessionId = await sessions.createSession();
+        await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        const a = await sessions.sendOrQueueMessage(sessionId, user("a"), {
+            agent: { agentId: "copilot" },
+        });
+        const b = await sessions.sendOrQueueMessage(sessionId, user("b"), {
+            agent: { agentId: "copilot" },
+        });
+        if (!a.queued || !b.queued) throw new Error("expected queued");
+
+        sessions.editQueued(sessionId, a.queueId, user("a, but sharper"));
+        expect(sessions.listQueued(sessionId)[0].message).toEqual(
+            user("a, but sharper"),
+        );
+        expect(() =>
+            sessions.editQueued(sessionId, "nope", user("x")),
+        ).toThrowError(/no queued message/);
+
+        const removed = sessions.removeQueued(sessionId, b.queueId);
+        expect(removed?.message).toEqual(user("b"));
+        expect(sessions.removeQueued(sessionId, b.queueId)).toBeUndefined();
+        expect(sessions.listQueued(sessionId)).toHaveLength(1);
+    });
+
+    it("stopTurn drains the queue first and returns the text; nothing auto-starts after", async () => {
+        const { sessions, fake } = makeSessions();
+        fake.script = () => ({ untilAbort: true });
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("queued text"), {
+            agent: { agentId: "copilot" },
+        });
+
+        fake.setLog(turnId, turnLog(turnId, sessionId, "cancelled"));
+        const { dequeued } = await sessions.stopTurn(turnId);
+        expect(dequeued.map((q) => q.message)).toEqual([user("queued text")]);
+        expect(sessions.listQueued(sessionId)).toEqual([]);
+        await flush();
+        await flush();
+        expect(fake.createTurnInputs).toHaveLength(1); // no promotion fired
+    });
+
+    it("keeps the entry queued when promotion fails to create the turn", async () => {
+        const { sessions, fake } = makeSessions();
+        let settle!: (outcome: TurnOutcome) => void;
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>((resolve) => {
+                settle = resolve;
+            }),
+        });
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("stranded?"), {
+            agent: { agentId: "copilot" },
+        });
+
+        fake.setLog(turnId, turnLog(turnId, sessionId, "completed"));
+        fake.createError = new Error("model not configured");
+        settle(completedOutcome());
+        await flush();
+        await flush();
+        // Still visible and editable rather than silently dropped.
+        expect(sessions.listQueued(sessionId)).toHaveLength(1);
+    });
+
+    it("deleteSession drops the pending queue", async () => {
+        const { sessions, fake } = makeSessions();
+        fake.script = () => ({ untilAbort: true });
+        const sessionId = await sessions.createSession();
+        await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("bye"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.deleteSession(sessionId);
+        expect(sessions.listQueued(sessionId)).toEqual([]);
     });
 });

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type { UserMessage } from "@x/shared/dist/message.js";
 import {
+    type QueuedSessionMessage,
     SessionCreated,
     type SessionEvent,
     type SessionIndexEntry,
@@ -57,6 +58,20 @@ interface ActiveAdvance {
     execution: TurnExecution;
 }
 
+// One pending-queue entry (QueuedSessionMessage plus the SendMessageConfig it
+// arrived with — used only if the entry is promoted to a new turn; a steered
+// entry joins the live turn, whose configuration wins).
+interface PendingSessionEntry {
+    queueId: string;
+    message: z.infer<typeof UserMessage>;
+    config: SendMessageConfig;
+    ts: string;
+}
+
+function publicQueueEntry(entry: PendingSessionEntry): QueuedSessionMessage {
+    return { queueId: entry.queueId, message: entry.message, ts: entry.ts };
+}
+
 // The session layer per session-design.md: owns conversations as ordered
 // chains of turn references, enforces one active turn per session, assembles
 // context as a reference to the previous turn, and maintains the in-memory
@@ -75,6 +90,12 @@ export class SessionsImpl implements ISessions {
     // invocation plus external-input invocations queued on the turn lock —
     // so entries accumulate per turn and each advance removes only its own.
     private readonly active = new Map<string, Set<ActiveAdvance>>();
+    // Ephemeral pending queue per session (session-design.md §12.1,
+    // deliberately NOT durable): messages accepted while the latest turn was
+    // running, waiting to steer it (input_added at the next boundary) or to
+    // be promoted into a new turn at settle. A crash drops the queue along
+    // with the in-flight turn it was steering — coherent loss.
+    private readonly pending = new Map<string, PendingSessionEntry[]>();
 
     constructor({
         sessionRepo,
@@ -162,12 +183,9 @@ export class SessionsImpl implements ISessions {
         return this.sessionRepo.withLock(sessionId, async () => {
             const events = await this.sessionRepo.read(sessionId);
             const state = reduceSession(events);
-
-            let agentRequest = config.agent;
-            if (state.latestTurnId) {
-                const turn = await this.turnRuntime.getTurn(state.latestTurnId);
-                const turnState = reduceTurn(turn.events);
-                const status = deriveTurnStatus(turnState);
+            const latestTurnState = await this.latestTurnState(state);
+            if (latestTurnState) {
+                const status = deriveTurnStatus(latestTurnState);
                 if (
                     status !== "completed" &&
                     status !== "failed" &&
@@ -175,79 +193,192 @@ export class SessionsImpl implements ISessions {
                 ) {
                     throw new TurnNotSettledError(
                         sessionId,
-                        state.latestTurnId,
+                        state.latestTurnId as string,
                         status,
                     );
                 }
-                agentRequest = withActiveSkills(
-                    agentRequest,
-                    deriveActiveSkills(turnState),
-                );
             }
-
-            const turnId = await this.turnRuntime.createTurn({
-                agent: agentRequest,
+            return this.startTurnLocked(
                 sessionId,
-                context: state.latestTurnId
-                    ? { previousTurnId: state.latestTurnId }
-                    : [],
+                events,
+                state,
+                latestTurnState,
                 input,
-                analytics: {
-                    useCase: config.useCase ?? "copilot_chat",
-                    ...(config.subUseCase
-                        ? { subUseCase: config.subUseCase }
-                        : {}),
-                },
-                config: {
-                    humanAvailable: true,
-                    ...(config.autoPermission === undefined
-                        ? {}
-                        : { autoPermission: config.autoPermission }),
-                    ...(config.maxModelCalls === undefined
-                        ? {}
-                        : { maxModelCalls: config.maxModelCalls }),
-                    ...(config.reasoningEffort === undefined
-                        ? {}
-                        : { reasoningEffort: config.reasoningEffort }),
-                },
-            });
-
-            const batch: Array<z.infer<typeof SessionEvent>> = [
-                {
-                    type: "turn_appended",
-                    sessionId,
-                    ts: this.clock.now(),
-                    turnId,
-                    sessionSeq: state.turns.length + 1,
-                    agentId: isInlineAgentRequest(config.agent)
-                        ? inlineAgentId(config.agent.inline.name)
-                        : config.agent.agentId,
-                    model: await this.resolvedModelOf(turnId),
-                },
-            ];
-            if (!state.title) {
-                batch.push({
-                    type: "title_changed",
-                    sessionId,
-                    ts: this.clock.now(),
-                    title: defaultTitle(input),
-                });
-            }
-            await this.sessionRepo.append(sessionId, batch);
-
-            this.publishEntry(
-                sessionIndexEntry(reduceSession([...events, ...batch]), "idle"),
+                config,
             );
-            if (!state.title) {
-                this.generateTitleInBackground(
-                    sessionId,
-                    defaultTitle(input),
-                    messageText(input),
-                );
-            }
-            this.startTrackedAdvance(sessionId, turnId);
-            return { turnId };
         });
+    }
+
+    // Deliver-ASAP (see api.ts): start a turn when settled, queue otherwise.
+    // The enqueue and the settled-check share one lock hold, and promotion
+    // (promoteQueued) always re-checks under the same lock, so a turn that
+    // settles concurrently with the enqueue cannot strand the message — the
+    // promotion queued behind this lock will see both the terminal turn and
+    // the pending entry (opencode's pendingWake problem, solved by ordering).
+    async sendOrQueueMessage(
+        sessionId: string,
+        input: z.infer<typeof UserMessage>,
+        config: SendMessageConfig,
+    ): Promise<{ queued: false; turnId: string } | { queued: true; queueId: string }> {
+        return this.sessionRepo.withLock(sessionId, async () => {
+            const events = await this.sessionRepo.read(sessionId);
+            const state = reduceSession(events);
+            const latestTurnState = await this.latestTurnState(state);
+            const status = latestTurnState
+                ? deriveTurnStatus(latestTurnState)
+                : "none";
+            const settled =
+                status === "none" ||
+                status === "completed" ||
+                status === "failed" ||
+                status === "cancelled";
+            // A settled session with an empty queue starts immediately. With
+            // entries still pending (promotion hasn't run yet), the new
+            // message queues behind them to keep arrival order.
+            if (settled && (this.pending.get(sessionId) ?? []).length === 0) {
+                const { turnId } = await this.startTurnLocked(
+                    sessionId,
+                    events,
+                    state,
+                    latestTurnState,
+                    input,
+                    config,
+                );
+                return { queued: false as const, turnId };
+            }
+            const entry: PendingSessionEntry = {
+                queueId: await this.idGenerator.next(),
+                message: input,
+                config,
+                ts: this.clock.now(),
+            };
+            const queue = this.pending.get(sessionId) ?? [];
+            queue.push(entry);
+            this.pending.set(sessionId, queue);
+            this.publishQueue(sessionId);
+            return { queued: true as const, queueId: entry.queueId };
+        });
+    }
+
+    listQueued(sessionId: string): QueuedSessionMessage[] {
+        return (this.pending.get(sessionId) ?? []).map(publicQueueEntry);
+    }
+
+    editQueued(
+        sessionId: string,
+        queueId: string,
+        message: z.infer<typeof UserMessage>,
+    ): void {
+        const entry = (this.pending.get(sessionId) ?? []).find(
+            (e) => e.queueId === queueId,
+        );
+        if (!entry) {
+            throw new Error(`no queued message ${queueId} in session ${sessionId}`);
+        }
+        entry.message = message;
+        this.publishQueue(sessionId);
+    }
+
+    removeQueued(
+        sessionId: string,
+        queueId: string,
+    ): QueuedSessionMessage | undefined {
+        const queue = this.pending.get(sessionId) ?? [];
+        const at = queue.findIndex((e) => e.queueId === queueId);
+        if (at < 0) {
+            return undefined;
+        }
+        const [removed] = queue.splice(at, 1);
+        this.publishQueue(sessionId);
+        return publicQueueEntry(removed);
+    }
+
+    private async latestTurnState(
+        state: SessionState,
+    ): Promise<TurnState | undefined> {
+        if (!state.latestTurnId) {
+            return undefined;
+        }
+        const turn = await this.turnRuntime.getTurn(state.latestTurnId);
+        return reduceTurn(turn.events);
+    }
+
+    // The create-and-start core shared by sendMessage, sendOrQueueMessage,
+    // and queue promotion. Caller holds the session lock.
+    private async startTurnLocked(
+        sessionId: string,
+        events: Array<z.infer<typeof SessionEvent>>,
+        state: SessionState,
+        latestTurnState: TurnState | undefined,
+        input: z.infer<typeof UserMessage>,
+        config: SendMessageConfig,
+    ): Promise<{ turnId: string }> {
+        const agentRequest = latestTurnState
+            ? withActiveSkills(config.agent, deriveActiveSkills(latestTurnState))
+            : config.agent;
+
+        const turnId = await this.turnRuntime.createTurn({
+            agent: agentRequest,
+            sessionId,
+            context: state.latestTurnId
+                ? { previousTurnId: state.latestTurnId }
+                : [],
+            input,
+            analytics: {
+                useCase: config.useCase ?? "copilot_chat",
+                ...(config.subUseCase
+                    ? { subUseCase: config.subUseCase }
+                    : {}),
+            },
+            config: {
+                humanAvailable: true,
+                ...(config.autoPermission === undefined
+                    ? {}
+                    : { autoPermission: config.autoPermission }),
+                ...(config.maxModelCalls === undefined
+                    ? {}
+                    : { maxModelCalls: config.maxModelCalls }),
+                ...(config.reasoningEffort === undefined
+                    ? {}
+                    : { reasoningEffort: config.reasoningEffort }),
+            },
+        });
+
+        const batch: Array<z.infer<typeof SessionEvent>> = [
+            {
+                type: "turn_appended",
+                sessionId,
+                ts: this.clock.now(),
+                turnId,
+                sessionSeq: state.turns.length + 1,
+                agentId: isInlineAgentRequest(config.agent)
+                    ? inlineAgentId(config.agent.inline.name)
+                    : config.agent.agentId,
+                model: await this.resolvedModelOf(turnId),
+            },
+        ];
+        if (!state.title) {
+            batch.push({
+                type: "title_changed",
+                sessionId,
+                ts: this.clock.now(),
+                title: defaultTitle(input),
+            });
+        }
+        await this.sessionRepo.append(sessionId, batch);
+
+        this.publishEntry(
+            sessionIndexEntry(reduceSession([...events, ...batch]), "idle"),
+        );
+        if (!state.title) {
+            this.generateTitleInBackground(
+                sessionId,
+                defaultTitle(input),
+                messageText(input),
+            );
+        }
+        this.startTrackedAdvance(sessionId, turnId);
+        return { turnId };
     }
 
     async respondToPermission(
@@ -288,7 +419,33 @@ export class SessionsImpl implements ISessions {
         });
     }
 
-    async stopTurn(turnId: string, reason?: string): Promise<void> {
+    async stopTurn(
+        turnId: string,
+        reason?: string,
+    ): Promise<{ dequeued: QueuedSessionMessage[] }> {
+        // Drain the session's pending queue BEFORE aborting: a stop must not
+        // be followed by promotion auto-starting the next queued message.
+        // The drained text goes back to the caller (composer restore). A
+        // message the loop already steered in is durable and stays — it was
+        // delivered, then the user stopped.
+        const dequeued: QueuedSessionMessage[] = [];
+        try {
+            const sessionId = await this.sessionIdOf(turnId);
+            if (sessionId !== null) {
+                const queue = this.pending.get(sessionId) ?? [];
+                dequeued.push(...queue.splice(0).map(publicQueueEntry));
+                if (dequeued.length > 0) {
+                    this.publishQueue(sessionId);
+                }
+            }
+        } catch {
+            // Unreadable turn: nothing to drain; the abort below still runs.
+        }
+        await this.abortOrCancel(turnId, reason);
+        return { dequeued };
+    }
+
+    private async abortOrCancel(turnId: string, reason?: string): Promise<void> {
         const running = this.active.get(turnId);
         if (running && running.size > 0) {
             // Abort every live advance for this turn: the running invocation
@@ -394,6 +551,9 @@ export class SessionsImpl implements ISessions {
     // turn files behind — the same inert orphans the pre-cleanup design
     // produced, invisible and harmless.
     async deleteSession(sessionId: string): Promise<void> {
+        // Pending messages die with the session (they are ephemeral by
+        // design); dropping them first keeps promotion from racing deletion.
+        this.pending.delete(sessionId);
         // Abort every live advance this process is driving for the session
         // and wait for them to settle (mirrors stopTurn's abort path).
         const advances = [...this.active.values()]
@@ -501,6 +661,13 @@ export class SessionsImpl implements ISessions {
         }
         const execution = this.turnRuntime.advanceTurn(turnId, input, {
             signal: controller.signal,
+            // Steering: every session advance offers the pending queue to the
+            // loop, which drains it at each model-call boundary into durable
+            // input_added events. Suspended turns get this for free — the
+            // advance a permission answer starts polls the same source.
+            ...(sessionId === null
+                ? {}
+                : { takeInputs: () => this.drainQueuedForSteer(sessionId) }),
         });
         if (sessionId !== null) {
             void execution.outcome.catch(() => undefined).finally(() => chatActivity.exit());
@@ -556,6 +723,87 @@ export class SessionsImpl implements ISessions {
             ...entry,
             latestTurnStatus: outcome.status,
             updatedAt: this.clock.now(),
+        });
+        // Messages the settled turn never got to steer promote into a new
+        // turn. Suspended is not terminal: those messages steer the resuming
+        // advance instead.
+        if (outcome.status !== "suspended") {
+            void this.promoteQueued(sessionId);
+        }
+    }
+
+    // Promote the pending head into a new turn once the session is settled.
+    // Runs under the session lock and re-checks everything there, so it is
+    // safe against every interleaving with sendOrQueueMessage (which enqueues
+    // under the same lock). The remaining entries stay queued: they steer the
+    // just-started turn at its first model-call boundary, which is the
+    // earliest the model can see them.
+    private async promoteQueued(sessionId: string): Promise<void> {
+        try {
+            await this.sessionRepo.withLock(sessionId, async () => {
+                const queue = this.pending.get(sessionId) ?? [];
+                if (queue.length === 0) {
+                    return;
+                }
+                const events = await this.sessionRepo.read(sessionId);
+                const state = reduceSession(events);
+                const latestTurnState = await this.latestTurnState(state);
+                if (latestTurnState) {
+                    const status = deriveTurnStatus(latestTurnState);
+                    if (
+                        status !== "completed" &&
+                        status !== "failed" &&
+                        status !== "cancelled"
+                    ) {
+                        return; // a newer turn is live; steering owns the queue
+                    }
+                }
+                const head = queue[0];
+                await this.startTurnLocked(
+                    sessionId,
+                    events,
+                    state,
+                    latestTurnState,
+                    head.message,
+                    head.config,
+                );
+                // Dequeue only after the turn exists: a createTurn failure
+                // (agent resolution, repo fault) leaves the entry pending and
+                // editable instead of silently dropping the user's text.
+                queue.shift();
+                this.publishQueue(sessionId);
+            });
+        } catch (error) {
+            // The entry stays queued and visible; the user can edit, remove,
+            // or retry by sending again. Promotion has no requester to
+            // surface the error to.
+            console.error(
+                `[sessions] queued-message promotion failed for ${sessionId}:`,
+                error,
+            );
+        }
+    }
+
+    // The loop-facing drain (TakeAddedInputs): hand every pending message to
+    // the live turn. Synchronous mutation — no interleaving with the
+    // lock-holding paths' own synchronous queue access is possible.
+    private drainQueuedForSteer(
+        sessionId: string,
+    ): Array<z.infer<typeof UserMessage>> {
+        const queue = this.pending.get(sessionId);
+        if (!queue || queue.length === 0) {
+            return [];
+        }
+        const messages = queue.splice(0).map((entry) => entry.message);
+        this.publishQueue(sessionId);
+        return messages;
+    }
+
+    private publishQueue(sessionId: string): void {
+        this.sessionBus.publish({
+            kind: "queue-changed",
+            sessionId,
+            queue: this.listQueued(sessionId),
         });
     }
 

--- a/apps/x/packages/core/src/runtime/turns/api.ts
+++ b/apps/x/packages/core/src/runtime/turns/api.ts
@@ -28,6 +28,19 @@ export interface CreateTurnInput {
     };
 }
 
+// Steering: a caller-supplied drain the advance polls at each model-call
+// boundary (after the tool batch settles and completion is ruled out,
+// immediately before the next model call is requested). Returned messages
+// are treated as consumed and appended durably as input_added events, so
+// they ride the very next request. The dual of the abort signal: both are
+// ephemeral per-invocation channels into a live advance that become durable
+// only when acted on. The turn layer never learns where the messages come
+// from (session queue, test fixture); an accepted input resets the
+// model-call budget.
+export type TakeAddedInputs = () =>
+    | Array<z.infer<typeof UserMessage>>
+    | Promise<Array<z.infer<typeof UserMessage>>>;
+
 // Exactly one external input per advanceTurn invocation.
 export type TurnExternalInput =
     | {
@@ -92,7 +105,7 @@ export interface ITurnRuntime {
     advanceTurn(
         turnId: string,
         input?: TurnExternalInput,
-        options?: { signal?: AbortSignal },
+        options?: { signal?: AbortSignal; takeInputs?: TakeAddedInputs },
     ): TurnExecution;
     getTurn(turnId: string): Promise<Turn>;
     // Removes the turn's file. Idempotent — a missing turn is not an error.

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -3188,3 +3188,226 @@ describe("model-call limit resolution", () => {
         ).toBe(3);
     });
 });
+
+describe("added inputs (steering)", () => {
+    // A takeInputs fake that only offers its message once armed — letting
+    // tests target a specific boundary despite the drain running at every
+    // one (including before call 0).
+    function armedSteer(text: string) {
+        const state = { armed: false, drained: 0 };
+        const takeInputs = () => {
+            state.drained += 1;
+            if (!state.armed) {
+                return [];
+            }
+            state.armed = false;
+            return [user(text)];
+        };
+        return { state, takeInputs };
+    }
+
+    it("injects a message offered at the tool-batch boundary before the next model call", async () => {
+        const { state, takeInputs } = armedSteer("also check the tests");
+        const tools: RuntimeTool[] = [
+            syncTool(echoDescriptor, async () => {
+                state.armed = true; // steer arrives while the tool runs
+                return { output: "ok", isError: false };
+            }),
+            ...defaultTools.filter(
+                (t) => t.descriptor.toolId !== echoDescriptor.toolId,
+            ),
+        ];
+        const { runtime, repo, models } = makeRuntime({
+            tools,
+            models: [
+                respond(completedResp(assistantCalls(toolCallPart("tc1", "echo")))),
+                respond(completedResp(assistantText("done"))),
+            ],
+        });
+        const turnId = await newTurn(runtime);
+        const { outcome } = await advanceAndSettle(runtime, turnId, undefined, {
+            takeInputs,
+        });
+        expect(outcome?.status).toBe("completed");
+
+        const log = await persisted(repo, turnId);
+        expect(typesOf(log)).toEqual([
+            "turn_created",
+            "model_call_requested",
+            "model_call_completed",
+            "tool_invocation_requested",
+            "tool_result",
+            "input_added",
+            "model_call_requested",
+            "model_call_completed",
+            "turn_completed",
+        ]);
+        expect(log[5]).toMatchObject({
+            inputIndex: 1,
+            message: user("also check the tests"),
+        });
+        expect(log[6]).toMatchObject({
+            request: {
+                messages: ["assistant:0", "toolResult:tc1", "input:1"],
+            },
+        });
+        // The wire request carries the injected message after the tool result.
+        const wire = models.requests[1].messages as Array<{ role: string }>;
+        expect(wire[wire.length - 1]).toEqual(user("also check the tests"));
+    });
+
+    it("injects a message already pending before the first model call on call 0", async () => {
+        const pending = [user("and one more thing")];
+        const { runtime, repo, models } = makeRuntime({
+            models: [respond(completedResp(assistantText("done")))],
+        });
+        const turnId = await newTurn(runtime);
+        const { outcome } = await advanceAndSettle(runtime, turnId, undefined, {
+            takeInputs: () => pending.splice(0),
+        });
+        expect(outcome?.status).toBe("completed");
+        const log = await persisted(repo, turnId);
+        expect(typesOf(log)).toEqual([
+            "turn_created",
+            "input_added",
+            "model_call_requested",
+            "model_call_completed",
+            "turn_completed",
+        ]);
+        expect(log[2]).toMatchObject({
+            request: { messages: ["input", "input:1"] },
+        });
+        expect(models.requests[0].messages).toEqual([
+            user("hello"),
+            user("and one more thing"),
+        ]);
+    });
+
+    it("an accepted input resets the model-call budget", async () => {
+        const { state, takeInputs } = armedSteer("keep going");
+        const tools: RuntimeTool[] = [
+            syncTool(echoDescriptor, async () => {
+                state.armed = true;
+                return { output: "ok", isError: false };
+            }),
+            ...defaultTools.filter(
+                (t) => t.descriptor.toolId !== echoDescriptor.toolId,
+            ),
+        ];
+        const { runtime } = makeRuntime({
+            tools,
+            models: [
+                respond(completedResp(assistantCalls(toolCallPart("tc1", "echo")))),
+                respond(completedResp(assistantText("done"))),
+            ],
+        });
+        // maxModelCalls 1: without the steer this fails with the limit code
+        // after call 0's batch (26.9); the accepted input buys call 1.
+        const turnId = await newTurn(runtime, {
+            config: { humanAvailable: true, maxModelCalls: 1 },
+        });
+        const { outcome } = await advanceAndSettle(runtime, turnId, undefined, {
+            takeInputs,
+        });
+        expect(outcome?.status).toBe("completed");
+    });
+
+    it("drains the steer source when an external input resumes a suspended turn", async () => {
+        const checker = new FakePermissionChecker({
+            echo: { request: { tool: "echo" } },
+        });
+        const { runtime, repo } = makeRuntime({
+            checker,
+            models: [
+                respond(completedResp(assistantCalls(toolCallPart("tc1", "echo")))),
+                respond(completedResp(assistantText("done"))),
+            ],
+        });
+        const turnId = await newTurn(runtime);
+        const first = await advanceAndSettle(runtime, turnId);
+        expect(first.outcome?.status).toBe("suspended");
+
+        // The message typed while suspended rides the resuming advance.
+        const pending = [user("typed while waiting")];
+        const { outcome } = await advanceAndSettle(
+            runtime,
+            turnId,
+            { type: "permission_decision", toolCallId: "tc1", decision: "allow" },
+            { takeInputs: () => pending.splice(0) },
+        );
+        expect(outcome?.status).toBe("completed");
+        const log = await persisted(repo, turnId);
+        const added = log.find((e) => e.type === "input_added");
+        expect(added).toMatchObject({ message: user("typed while waiting") });
+        const second = log.filter((e) => e.type === "model_call_requested")[1];
+        expect(second).toMatchObject({
+            request: {
+                messages: ["assistant:0", "toolResult:tc1", "input:1"],
+            },
+        });
+    });
+
+    it("recovery re-issues the request with an input left unreferenced by a crash", async () => {
+        const SEED_ID = "2026-07-02T10-00-00Z-0000001-000";
+        const repo = new InMemoryTurnRepo();
+        repo.seed([
+            {
+                type: "turn_created",
+                schemaVersion: 1,
+                turnId: SEED_ID,
+                ts: TS,
+                sessionId: null,
+                agent: {
+                    requested: { agentId: "copilot" },
+                    resolved: defaultAgent,
+                },
+                context: [],
+                input: user("hello"),
+                config: {
+                    autoPermission: false,
+                    humanAvailable: true,
+                    maxModelCalls: 20,
+                },
+            },
+            {
+                type: "input_added",
+                turnId: SEED_ID,
+                ts: TS,
+                inputIndex: 1,
+                message: user("accepted just before the crash"),
+            },
+        ]);
+        const { runtime, models } = makeRuntime({
+            repo,
+            models: [respond(completedResp(assistantText("done")))],
+        });
+        const { outcome } = await advanceAndSettle(runtime, SEED_ID);
+        expect(outcome?.status).toBe("completed");
+        const log = await persisted(repo, SEED_ID);
+        expect(log[2]).toMatchObject({
+            request: { messages: ["input", "input:1"] },
+        });
+        expect(models.requests[0].messages).toEqual([
+            user("hello"),
+            user("accepted just before the crash"),
+        ]);
+    });
+
+    it("an empty drain appends nothing", async () => {
+        const { runtime, repo } = makeRuntime({
+            models: [respond(completedResp(assistantText("done")))],
+        });
+        const turnId = await newTurn(runtime);
+        const { outcome } = await advanceAndSettle(runtime, turnId, undefined, {
+            takeInputs: () => [],
+        });
+        expect(outcome?.status).toBe("completed");
+        const log = await persisted(repo, turnId);
+        expect(typesOf(log)).toEqual([
+            "turn_created",
+            "model_call_requested",
+            "model_call_completed",
+            "turn_completed",
+        ]);
+    });
+});

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -9,7 +9,10 @@ import {
     type ModelRequest,
     type ResolvedAgent,
     type ResolvedAgentSnapshot,
+    addedInputMessagesAt,
     assistantRef,
+    inputRef,
+    modelCallBudgetBase,
     toolResultRef,
     type ToolCallState,
     ToolDescriptor,
@@ -34,6 +37,7 @@ import type { IAgentResolver } from "./agent-resolver.js";
 import {
     type CreateTurnInput,
     type ITurnRuntime,
+    type TakeAddedInputs,
     type Turn,
     TurnDependencyError,
     type TurnExecution,
@@ -200,12 +204,12 @@ export class TurnRuntime implements ITurnRuntime {
     advanceTurn(
         turnId: string,
         input?: TurnExternalInput,
-        options?: { signal?: AbortSignal },
+        options?: { signal?: AbortSignal; takeInputs?: TakeAddedInputs },
     ): TurnExecution {
         const stream = new HotStream<TurnStreamEvent, TurnOutcome>();
         void this.turnRepo
             .withLock(turnId, () =>
-                this.advanceLocked(turnId, input, options?.signal, stream),
+                this.advanceLocked(turnId, input, options, stream),
             )
             .then(
                 (outcome) => stream.end(outcome),
@@ -217,12 +221,12 @@ export class TurnRuntime implements ITurnRuntime {
     private async advanceLocked(
         turnId: string,
         input: TurnExternalInput | undefined,
-        externalSignal: AbortSignal | undefined,
+        options: { signal?: AbortSignal; takeInputs?: TakeAddedInputs } | undefined,
         stream: HotStream<TurnStreamEvent, TurnOutcome>,
     ): Promise<TurnOutcome> {
         this.lifecycleBus.publish({ type: "turn-processing-start", turnId });
         try {
-            return await this.advance(turnId, input, externalSignal, stream);
+            return await this.advance(turnId, input, options, stream);
         } finally {
             this.lifecycleBus.publish({ type: "turn-processing-end", turnId });
         }
@@ -237,9 +241,10 @@ export class TurnRuntime implements ITurnRuntime {
     private async advance(
         turnId: string,
         input: TurnExternalInput | undefined,
-        externalSignal: AbortSignal | undefined,
+        options: { signal?: AbortSignal; takeInputs?: TakeAddedInputs } | undefined,
         stream: HotStream<TurnStreamEvent, TurnOutcome>,
     ): Promise<TurnOutcome> {
+        const externalSignal = options?.signal;
         const events = await this.turnRepo.read(turnId);
         const state = reduceTurn(events);
 
@@ -311,6 +316,7 @@ export class TurnRuntime implements ITurnRuntime {
             usageReporter: this.usageReporter,
             resolveTool: (descriptor) => this.toolRegistry.resolve(descriptor),
             signal: controller.signal,
+            takeInputs: options?.takeInputs,
             turnRepo: this.turnRepo,
             clock: this.clock,
             permissionChecker: this.permissionChecker,
@@ -368,6 +374,7 @@ class TurnAdvance {
         descriptor: z.infer<typeof ToolDescriptor>,
     ) => Promise<RuntimeTool>;
     private readonly signal: AbortSignal;
+    private readonly takeInputs: TakeAddedInputs | undefined;
     private readonly turnRepo: ITurnRepo;
     private readonly clock: IClock;
     private readonly permissionChecker: IPermissionChecker;
@@ -392,6 +399,7 @@ class TurnAdvance {
             descriptor: z.infer<typeof ToolDescriptor>,
         ) => Promise<RuntimeTool>;
         signal: AbortSignal;
+        takeInputs: TakeAddedInputs | undefined;
         turnRepo: ITurnRepo;
         clock: IClock;
         permissionChecker: IPermissionChecker;
@@ -407,6 +415,7 @@ class TurnAdvance {
         this.usageReporter = init.usageReporter;
         this.resolveTool = init.resolveTool;
         this.signal = init.signal;
+        this.takeInputs = init.takeInputs;
         this.turnRepo = init.turnRepo;
         this.clock = init.clock;
         this.permissionChecker = init.permissionChecker;
@@ -559,6 +568,7 @@ class TurnAdvance {
             if (completed) {
                 return completed;
             }
+            await this.drainAddedInputs();
             const exhausted = await this.failIfExhausted();
             if (exhausted) {
                 return exhausted;
@@ -568,6 +578,33 @@ class TurnAdvance {
                 return settled;
             }
         }
+    }
+
+    // Steering: drain caller-offered user messages at the model-call
+    // boundary — after the batch settled, after completion was ruled out,
+    // before the budget check (an accepted input resets the budget, so a
+    // steer can rescue a turn about to exhaust) and before the next request
+    // is composed (the reducer requires that request to reference every
+    // accepted input). appendWith computes indices inside the serialized
+    // commit slot, so straggler appends cannot race the numbering.
+    private async drainAddedInputs(): Promise<void> {
+        if (!this.takeInputs || this.signal.aborted) {
+            return;
+        }
+        const messages = await this.takeInputs();
+        if (messages.length === 0) {
+            return;
+        }
+        await this.appendWith(() => {
+            const base = this.state.addedInputs.length;
+            return messages.map((message, i) => ({
+                type: "input_added" as const,
+                turnId: this.turnId,
+                ts: this.now(),
+                inputIndex: base + i + 1,
+                message,
+            }));
+        });
     }
 
     // §11.2: exactly one input, validated against durable pending state.
@@ -757,14 +794,16 @@ class TurnAdvance {
         }
     }
 
-    // Conversation context for the classifier: resolved context, the turn
-    // input, and completed assistant responses (the current batch's tool
-    // results are not yet terminal, so tool messages are omitted).
+    // Conversation context for the classifier: resolved context, the turn's
+    // inputs in the positions the model saw them, and completed assistant
+    // responses (the current batch's tool results are not yet terminal, so
+    // tool messages are omitted).
     private conversationSoFar(): Array<z.infer<typeof ConversationMessage>> {
         const messages: Array<z.infer<typeof ConversationMessage>> = [
             this.state.definition.input,
         ];
         for (const call of this.state.modelCalls) {
+            messages.push(...addedInputMessagesAt(this.state, call.index));
             if (call.response !== undefined) {
                 messages.push(call.response);
             }
@@ -1151,9 +1190,14 @@ class TurnAdvance {
     }
 
     // §20: limit exhaustion is a distinguishable outcome; the transcript is
-    // structurally complete, so sessions can offer continuation.
+    // structurally complete, so sessions can offer continuation. The budget
+    // counts calls since the last accepted input (mirrors the reducer's
+    // append gate): each steer buys the allowance a fresh turn would get.
     private async failIfExhausted(): Promise<TurnOutcome | undefined> {
-        if (this.state.modelCalls.length < this.definition.config.maxModelCalls) {
+        if (
+            this.state.modelCalls.length - modelCallBudgetBase(this.state) <
+            this.definition.config.maxModelCalls
+        ) {
             return undefined;
         }
         const error = `Model call limit of ${this.definition.config.maxModelCalls} reached before the turn completed.`;
@@ -1202,6 +1246,14 @@ class TurnAdvance {
                       ]
                     : []; // re-issue after an interrupted call adds nothing new
         }
+        // Inputs accepted at this boundary (a fresh drain, or ones left
+        // unreferenced by a crash between input_added and the request —
+        // recovery picks them up here by construction).
+        refs.push(
+            ...this.state.addedInputs
+                .filter((added) => added.firstAffectedModelCallIndex === index)
+                .map((added) => inputRef(added.event.inputIndex)),
+        );
         // The turn's reasoning effort is stamped on every call's persisted
         // parameters (turn-runtime-design.md §8.3): each step durably records
         // what it ran with, and the model bridge maps the canonical value to

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -17,7 +17,7 @@ import {
 } from './background-task.js';
 import { UserMessage, UserMessageContent } from './message.js';
 import { RequestedAgent, type TurnBusEvent, type TurnEvent } from './turns.js';
-import type { SessionBusEvent, SessionIndexEntry, SessionState } from './sessions.js';
+import type { QueuedSessionMessage, SessionBusEvent, SessionIndexEntry, SessionState } from './sessions.js';
 import { RowboatApiConfig } from './rowboat-account.js';
 import { ZListToolkitsResponse } from './composio.js';
 import { AppSummarySchema, RegistryRecordSchema, RowboatAppManifestSchema } from './rowboat-app.js';
@@ -638,6 +638,43 @@ const ipcSchemas = {
     }),
     res: z.object({ turnId: z.string() }),
   },
+  // Deliver-ASAP send: starts a turn when the session is settled, otherwise
+  // queues (ephemeral, main-process memory) — queued messages steer the live
+  // turn at its next model-call boundary or promote to a new turn at settle.
+  'sessions:sendOrQueueMessage': {
+    req: z.object({
+      sessionId: z.string(),
+      input: UserMessage,
+      config: z.object({
+        agent: RequestedAgent,
+        useCase: UseCase.optional(),
+        subUseCase: z.string().optional(),
+        autoPermission: z.boolean().optional(),
+        maxModelCalls: z.number().int().positive().optional(),
+        reasoningEffort: ReasoningEffort.optional(),
+      }),
+    }),
+    res: z.union([
+      z.object({ queued: z.literal(false), turnId: z.string() }),
+      z.object({ queued: z.literal(true), queueId: z.string() }),
+    ]),
+  },
+  'sessions:listQueued': {
+    req: z.object({ sessionId: z.string() }),
+    res: z.object({ queue: z.array(z.custom<QueuedSessionMessage>()) }),
+  },
+  'sessions:editQueued': {
+    req: z.object({
+      sessionId: z.string(),
+      queueId: z.string(),
+      message: UserMessage,
+    }),
+    res: z.object({ success: z.literal(true) }),
+  },
+  'sessions:removeQueued': {
+    req: z.object({ sessionId: z.string(), queueId: z.string() }),
+    res: z.object({ removed: z.custom<QueuedSessionMessage>().nullable() }),
+  },
   'sessions:respondToPermission': {
     req: z.object({
       turnId: z.string(),
@@ -660,7 +697,13 @@ const ipcSchemas = {
       turnId: z.string(),
       reason: z.string().optional(),
     }),
-    res: z.object({ success: z.literal(true) }),
+    // dequeued: pending messages drained by the stop (a stop must not be
+    // followed by a queued message auto-starting) — the UI restores their
+    // text to the composer.
+    res: z.object({
+      success: z.literal(true),
+      dequeued: z.array(z.custom<QueuedSessionMessage>()),
+    }),
   },
   'sessions:resumeTurn': {
     req: z.object({ sessionId: z.string() }),

--- a/apps/x/packages/shared/src/sessions.ts
+++ b/apps/x/packages/shared/src/sessions.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { UserMessage } from "./message.js";
 import { ModelDescriptor, type TurnStatus } from "./turns.js";
 
 // Durable session contract for the session layer (see
@@ -167,14 +168,35 @@ export interface SessionIndexEntry {
     error?: string;
 }
 
+// A message accepted while the session's latest turn was still running,
+// waiting in the EPHEMERAL pending queue (deliberately not durable: it
+// becomes durable only at delivery — as an input_added turn event when it
+// steers the live turn, or as turn_created.input when it is promoted to a
+// new turn after settle; see session-design.md §12.1). Held in main-process
+// memory, mirrored to the renderer via queue-changed, editable and removable
+// until delivered. A crash loses it along with the turn it was steering.
+export interface QueuedSessionMessage {
+    queueId: string;
+    message: z.infer<typeof UserMessage>;
+    ts: string;
+}
+
 // What the renderer's session-feed consumer receives over IPC: session index
-// updates only. Turn events (durable + deltas) travel on the turns:events
-// spine (TurnBusEvent in turns.ts). entry: null signals deletion.
-export type SessionBusEvent = {
-    kind: "index-changed";
-    sessionId: string;
-    entry: SessionIndexEntry | null;
-};
+// updates and pending-queue mirrors. Turn events (durable + deltas) travel on
+// the turns:events spine (TurnBusEvent in turns.ts). entry: null signals
+// deletion. queue-changed carries the full pending queue (small by nature),
+// so consumers replace rather than patch.
+export type SessionBusEvent =
+    | {
+          kind: "index-changed";
+          sessionId: string;
+          entry: SessionIndexEntry | null;
+      }
+    | {
+          kind: "queue-changed";
+          sessionId: string;
+          queue: QueuedSessionMessage[];
+      };
 
 export function sessionIndexEntry(
     state: SessionState,

--- a/apps/x/packages/shared/src/turns.test.ts
+++ b/apps/x/packages/shared/src/turns.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
     type JsonValue,
+    InputAdded,
     ModelCallCompleted,
     ModelCallFailed,
     ModelCallRequested,
+    ModelRequestMessageRef,
     ModelStepEvent,
     MODEL_CALL_LIMIT_ERROR_CODE,
     ToolDescriptor,
@@ -23,12 +25,17 @@ import {
     TurnEvent,
     TurnFailed,
     TurnSuspended,
+    addedInputMessagesAt,
     deriveTurnStatus,
     effectiveTools,
     extendedToolsFor,
+    inputRef,
+    modelCallBudgetBase,
     outstandingAsyncTools,
     outstandingPermissions,
+    parseRequestRef,
     reduceTurn,
+    requestMessagesFor,
     turnTranscript,
 } from "./turns.js";
 
@@ -1576,5 +1583,260 @@ describe("mid-turn tool extension", () => {
             ],
             /model call is unsettled/,
         );
+    });
+});
+
+describe("added inputs (steering)", () => {
+    function inputAdded(
+        inputIndex: number,
+        text: string,
+    ): z.infer<typeof InputAdded> {
+        return {
+            type: "input_added",
+            turnId: TURN_ID,
+            ts: TS,
+            inputIndex,
+            message: user(text),
+        };
+    }
+
+    // One sync tool round trip with a steer injected at the batch boundary.
+    function steeredSequence(): TEvent[] {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        return [
+            created(),
+            requested(0, ["input"]),
+            completed(0, call0),
+            permRequired("tc1", "echo"),
+            permResolved("tc1", "allow"),
+            invocation("tc1"),
+            result("tc1", "echo"),
+            inputAdded(1, "actually, use the other file"),
+            requested(1, ["assistant:0", "toolResult:tc1", "input:1"]),
+            completed(1, assistantText("done")),
+            turnCompletedEv(),
+        ];
+    }
+
+    it("ref helpers parse and print every input spelling", () => {
+        expect(inputRef(0)).toBe("input");
+        expect(inputRef(3)).toBe("input:3");
+        expect(parseRequestRef("input")).toEqual({ kind: "input", inputIndex: 0 });
+        expect(parseRequestRef("input:2")).toEqual({ kind: "input", inputIndex: 2 });
+        expect(() => parseRequestRef("input:0")).toThrowError(/malformed/);
+        expect(() => parseRequestRef("input:-1")).toThrowError(/malformed/);
+        expect(ModelRequestMessageRef.safeParse("input:1").success).toBe(true);
+        expect(ModelRequestMessageRef.safeParse("input:0").success).toBe(false);
+        expect(ModelRequestMessageRef.safeParse("input:01").success).toBe(false);
+    });
+
+    it("folds an input at the batch boundary and threads it through refs, request messages, and transcript", () => {
+        const state = reduceTurn(steeredSequence());
+        expect(state.addedInputs).toHaveLength(1);
+        expect(state.addedInputs[0].firstAffectedModelCallIndex).toBe(1);
+        expect(addedInputMessagesAt(state, 1)).toEqual([
+            user("actually, use the other file"),
+        ]);
+        expect(addedInputMessagesAt(state, 0)).toEqual([]);
+        expect(requestMessagesFor(state, 1)).toEqual([
+            assistantCalls(toolCallPart("tc1", "echo")),
+            toolMsg("tc1", "echo"),
+            user("actually, use the other file"),
+        ]);
+        expect(turnTranscript(state)).toEqual([
+            user("hello"),
+            assistantCalls(toolCallPart("tc1", "echo")),
+            toolMsg("tc1", "echo"),
+            user("actually, use the other file"),
+            assistantText("done"),
+        ]);
+    });
+
+    it("accepts an input before the first model call, referenced by call 0", () => {
+        const state = reduceTurn([
+            created(),
+            inputAdded(1, "one more thing"),
+            requested(0, ["input", "input:1"]),
+            completed(0, assistantText("done")),
+            turnCompletedEv(),
+        ]);
+        expect(state.addedInputs[0].firstAffectedModelCallIndex).toBe(0);
+        expect(requestMessagesFor(state, 0)).toEqual([
+            user("hello"),
+            user("one more thing"),
+        ]);
+    });
+
+    it("coalesces several inputs at one boundary in acceptance order", () => {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        const state = reduceTurn([
+            created(),
+            requested(0, ["input"]),
+            completed(0, call0),
+            permRequired("tc1", "echo"),
+            permResolved("tc1", "allow"),
+            invocation("tc1"),
+            result("tc1", "echo"),
+            inputAdded(1, "first"),
+            inputAdded(2, "second"),
+            requested(1, ["assistant:0", "toolResult:tc1", "input:1", "input:2"]),
+            completed(1, assistantText("done")),
+            turnCompletedEv(),
+        ]);
+        expect(state.addedInputs.map((a) => a.event.inputIndex)).toEqual([1, 2]);
+    });
+
+    it("keeps a trailing input (accepted, then cancelled before the next call) in the transcript", () => {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        const state = reduceTurn([
+            created(),
+            requested(0, ["input"]),
+            completed(0, call0),
+            permRequired("tc1", "echo"),
+            permResolved("tc1", "allow"),
+            invocation("tc1"),
+            result("tc1", "echo"),
+            inputAdded(1, "wait--"),
+            turnCancelledEv("user stop"),
+        ]);
+        expect(turnTranscript(state)).toEqual([
+            user("hello"),
+            assistantCalls(toolCallPart("tc1", "echo")),
+            toolMsg("tc1", "echo"),
+            user("wait--"),
+        ]);
+    });
+
+    it("keeps the boundary input when its first model call failed", () => {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        const state = reduceTurn([
+            created(),
+            requested(0, ["input"]),
+            completed(0, call0),
+            permRequired("tc1", "echo"),
+            permResolved("tc1", "allow"),
+            invocation("tc1"),
+            result("tc1", "echo"),
+            inputAdded(1, "steer"),
+            requested(1, ["assistant:0", "toolResult:tc1", "input:1"]),
+            callFailed(1),
+            turnFailedEv("provider exploded"),
+        ]);
+        expect(turnTranscript(state)).toEqual([
+            user("hello"),
+            assistantCalls(toolCallPart("tc1", "echo")),
+            toolMsg("tc1", "echo"),
+            user("steer"),
+        ]);
+    });
+
+    it("resets the model-call budget at each accepted input", () => {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        const base: TEvent[] = [
+            created({ config: { autoPermission: false, humanAvailable: true, maxModelCalls: 1 } }),
+            requested(0, ["input"]),
+            completed(0, call0),
+            permRequired("tc1", "echo"),
+            permResolved("tc1", "allow"),
+            invocation("tc1"),
+            result("tc1", "echo"),
+        ];
+        // Without an input, call 1 exceeds maxModelCalls 1.
+        expectCorruption(
+            [...base, requested(1, ["assistant:0", "toolResult:tc1"])],
+            /exceeds maxModelCalls/,
+        );
+        // An accepted input resets the allowance; the budget base moves.
+        const steered = reduceTurn([
+            ...base,
+            inputAdded(1, "keep going"),
+            requested(1, ["assistant:0", "toolResult:tc1", "input:1"]),
+            completed(1, assistantText("done")),
+            turnCompletedEv(),
+        ]);
+        expect(modelCallBudgetBase(steered)).toBe(1);
+    });
+
+    it("rejects an input while a model call is unsettled", () => {
+        expectCorruption(
+            [created(), requested(0, ["input"]), inputAdded(1, "nope")],
+            /input added while a model call is unsettled/,
+        );
+    });
+
+    it("rejects an input while tool calls are unresolved", () => {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        expectCorruption(
+            [
+                created(),
+                requested(0, ["input"]),
+                completed(0, call0),
+                inputAdded(1, "nope"),
+            ],
+            /input added while tool calls are unresolved/,
+        );
+    });
+
+    it("rejects out-of-order input indices", () => {
+        expectCorruption(
+            [created(), inputAdded(2, "skipped ahead")],
+            /input index 2 out of order; expected 1/,
+        );
+        expectCorruption(
+            [created(), inputAdded(1, "a"), inputAdded(1, "b")],
+            /input index 1 out of order; expected 2/,
+        );
+    });
+
+    it("rejects a request that omits an accepted input", () => {
+        const call0 = assistantCalls(toolCallPart("tc1", "echo"));
+        expectCorruption(
+            [
+                created(),
+                requested(0, ["input"]),
+                completed(0, call0),
+                permRequired("tc1", "echo"),
+                permResolved("tc1", "allow"),
+                invocation("tc1"),
+                result("tc1", "echo"),
+                inputAdded(1, "must ride the next call"),
+                requested(1, ["assistant:0", "toolResult:tc1"]),
+            ],
+            /references do not match/,
+        );
+    });
+
+    it("rejects a request referencing an input that was never added", () => {
+        expectCorruption(
+            [created(), requested(0, ["input", "input:1"])],
+            /references do not match/,
+        );
+    });
+
+    it("rejects an input after a terminal event", () => {
+        expectCorruption(
+            [
+                created(),
+                requested(0, ["input"]),
+                completed(0, assistantText("done")),
+                turnCompletedEv(),
+                inputAdded(1, "too late"),
+            ],
+            /event after terminal turn event/,
+        );
+    });
+
+    it("a re-issued call after an interruption carries the boundary's inputs", () => {
+        const state = reduceTurn([
+            created(),
+            requested(0, ["input"]),
+            callFailed(0, "interrupted"),
+            inputAdded(1, "and also this"),
+            requested(1, ["input:1"]),
+            completed(1, assistantText("done")),
+            turnCompletedEv(),
+        ]);
+        expect(state.addedInputs[0].firstAffectedModelCallIndex).toBe(1);
+        expect(requestMessagesFor(state, 1)).toEqual([user("and also this")]);
     });
 });

--- a/apps/x/packages/shared/src/turns.ts
+++ b/apps/x/packages/shared/src/turns.ts
@@ -203,14 +203,18 @@ export const TurnCreated = z.object({
 // provider payload is rebuilt deterministically by the request composer
 // (core), which is the same code path the loop sends through.
 // Compact string refs so raw JSONL reads naturally:
-//   "context" | "input" | "assistant:<modelCallIndex>" | "toolResult:<toolCallId>"
+//   "context" | "input" | "input:<inputIndex>" | "assistant:<modelCallIndex>"
+//   | "toolResult:<toolCallId>"
+// "input" is the turn-defining message (index 0); "input:<n>" (n >= 1) is the
+// nth input_added message. Index 0 has exactly one spelling so every
+// referenced byte keeps a single canonical ref.
 export const ModelRequestMessageRef = z
     .string()
-    .regex(/^(context|input|assistant:\d+|toolResult:.+)$/);
+    .regex(/^(context|input(:[1-9]\d*)?|assistant:\d+|toolResult:.+)$/);
 
 export type ParsedRequestRef =
     | { kind: "context" }
-    | { kind: "input" }
+    | { kind: "input"; inputIndex: number }
     | { kind: "assistant"; modelCallIndex: number }
     | { kind: "toolResult"; toolCallId: string };
 
@@ -218,10 +222,22 @@ export const assistantRef = (modelCallIndex: number): string =>
     `assistant:${modelCallIndex}`;
 export const toolResultRef = (toolCallId: string): string =>
     `toolResult:${toolCallId}`;
+export const inputRef = (inputIndex: number): string =>
+    inputIndex === 0 ? "input" : `input:${inputIndex}`;
 
 export function parseRequestRef(ref: string): ParsedRequestRef {
-    if (ref === "context" || ref === "input") {
-        return { kind: ref };
+    if (ref === "context") {
+        return { kind: "context" };
+    }
+    if (ref === "input") {
+        return { kind: "input", inputIndex: 0 };
+    }
+    if (ref.startsWith("input:")) {
+        const inputIndex = Number(ref.slice("input:".length));
+        if (!Number.isInteger(inputIndex) || inputIndex < 1) {
+            throw new Error(`malformed request ref: ${ref}`);
+        }
+        return { kind: "input", inputIndex };
     }
     if (ref.startsWith("assistant:")) {
         const modelCallIndex = Number(ref.slice("assistant:".length));
@@ -389,6 +405,22 @@ export const ToolsExtended = z.object({
     tools: z.array(ToolDescriptor).min(1),
 });
 
+// A user message accepted into the RUNNING turn at a model-call boundary
+// (steering). Like tools_extended, this is a sanctioned, durable, ordered
+// exception to turn-definition immutability: a turn has one or more inputs,
+// the first arriving in turn_created. Injection is purely additive — it never
+// cancels in-flight work — and lands only between a settled tool batch and
+// the next model call, so the very next model_call_requested references every
+// input added before it ("input:<n>" refs) and an accepted message can never
+// be silently dropped. inputIndex is 1-based; index 0 is turn_created.input.
+export const InputAdded = z.object({
+    type: z.literal("input_added"),
+    turnId: z.string(),
+    ts: z.string(),
+    inputIndex: z.number().int().positive(),
+    message: UserMessage,
+});
+
 export const TurnSuspended = z.object({
     type: z.literal("turn_suspended"),
     turnId: z.string(),
@@ -453,6 +485,7 @@ export const TurnEvent = z.discriminatedUnion("type", [
     ToolProgress,
     ToolResult,
     ToolsExtended,
+    InputAdded,
     TurnSuspended,
     TurnCompleted,
     TurnFailed,
@@ -552,11 +585,19 @@ export interface ToolExtensionState {
     firstAffectedModelCallIndex: number;
 }
 
+export interface AddedInputState {
+    event: z.infer<typeof InputAdded>;
+    // Inputs land between model calls; the call requested at this index is
+    // the first whose request references (and transmits) the message.
+    firstAffectedModelCallIndex: number;
+}
+
 export interface TurnState {
     definition: z.infer<typeof TurnCreated>;
     modelCalls: ModelCallState[];
     toolCalls: ToolCallState[];
     toolExtensions: ToolExtensionState[];
+    addedInputs: AddedInputState[];
     suspension?: z.infer<typeof TurnSuspended>;
     terminal?:
         | z.infer<typeof TurnCompleted>
@@ -599,6 +640,13 @@ function batchToolCalls(state: TurnState, modelCallIndex: number): ToolCallState
         .sort((a, b) => a.order - b.order);
 }
 
+// The model-call index the budget counts from: 0, or the boundary of the
+// most recent added input (each accepted input resets the allowance).
+export function modelCallBudgetBase(state: TurnState): number {
+    const last = state.addedInputs[state.addedInputs.length - 1];
+    return last ? last.firstAffectedModelCallIndex : 0;
+}
+
 function addUsage(
     total: z.infer<typeof TurnUsage>,
     usage: z.infer<typeof TurnUsage>,
@@ -628,9 +676,14 @@ function applyModelCallRequested(
             `model call index ${event.modelCallIndex} out of order; expected ${expectedIndex}`,
         );
     }
-    if (expectedIndex >= state.definition.config.maxModelCalls) {
+    // The budget counts calls since the last accepted input: a mid-turn
+    // input_added buys the same allowance a fresh turn would get.
+    if (
+        expectedIndex - modelCallBudgetBase(state) >=
+        state.definition.config.maxModelCalls
+    ) {
         fail(
-            `model call index ${event.modelCallIndex} exceeds maxModelCalls ${state.definition.config.maxModelCalls}`,
+            `model call index ${event.modelCallIndex} exceeds maxModelCalls ${state.definition.config.maxModelCalls} since the last input`,
         );
     }
     if (openModelCall(state)) {
@@ -674,6 +727,16 @@ function applyModelCallRequested(
                   ]
                 : []; // re-issue after an interrupted call adds nothing new
     }
+    // Every input accepted since the previous call must ride this request —
+    // the invariant that makes a durably accepted message impossible to drop.
+    expectedRefs.push(
+        ...state.addedInputs
+            .filter(
+                (added) =>
+                    added.firstAffectedModelCallIndex === event.modelCallIndex,
+            )
+            .map((added) => inputRef(added.event.inputIndex)),
+    );
     if (JSON.stringify(event.request.messages) !== JSON.stringify(expectedRefs)) {
         fail(
             `model request references do not match the transcript: expected ${JSON.stringify(
@@ -942,6 +1005,33 @@ function applyToolsExtended(
     });
 }
 
+function applyInputAdded(
+    state: TurnState,
+    event: z.infer<typeof InputAdded>,
+): void {
+    if (openModelCall(state)) {
+        fail("input added while a model call is unsettled");
+    }
+    const unresolved = state.toolCalls.filter((tc) => !tc.result);
+    if (unresolved.length > 0) {
+        fail(
+            `input added while tool calls are unresolved: ${unresolved
+                .map((tc) => tc.toolCallId)
+                .join(", ")}`,
+        );
+    }
+    const expected = state.addedInputs.length + 1;
+    if (event.inputIndex !== expected) {
+        fail(
+            `input index ${event.inputIndex} out of order; expected ${expected}`,
+        );
+    }
+    state.addedInputs.push({
+        event,
+        firstAffectedModelCallIndex: state.modelCalls.length,
+    });
+}
+
 function sortedIds(ids: string[]): string {
     return [...ids].sort().join(",");
 }
@@ -1031,6 +1121,7 @@ export function reduceTurn(
         modelCalls: [],
         toolCalls: [],
         toolExtensions: [],
+        addedInputs: [],
         usage: {},
     };
 
@@ -1083,6 +1174,9 @@ export function reduceTurn(
             case "tools_extended":
                 applyToolsExtended(state, event);
                 break;
+            case "input_added":
+                applyInputAdded(state, event);
+                break;
             case "turn_suspended":
                 applyTurnSuspended(state, event);
                 break;
@@ -1132,6 +1226,21 @@ export function effectiveTools(
 ): Array<z.infer<typeof ToolDescriptor>> {
     const extended = extendedToolsFor(state, modelCallIndex);
     return extended.length === 0 ? baseTools : [...baseTools, ...extended];
+}
+
+// The messages of inputs accepted at a given model-call boundary: those a
+// request at `modelCallIndex` is the first to transmit. Position consumers
+// (transcript, classifier context, timeline UIs) share this so an added
+// input renders exactly where the model saw it.
+export function addedInputMessagesAt(
+    state: TurnState,
+    modelCallIndex: number,
+): Array<z.infer<typeof UserMessage>> {
+    return state.addedInputs
+        .filter(
+            (added) => added.firstAffectedModelCallIndex === modelCallIndex,
+        )
+        .map((added) => added.event.message);
 }
 
 export function outstandingPermissions(state: TurnState): ToolCallState[] {
@@ -1221,8 +1330,18 @@ export function requestMessagesFor(
                 }
                 return context;
             }
-            case "input":
-                return [state.definition.input];
+            case "input": {
+                if (ref.inputIndex === 0) {
+                    return [state.definition.input];
+                }
+                const added = state.addedInputs[ref.inputIndex - 1];
+                if (!added) {
+                    throw new Error(
+                        `input ref to unknown added input ${ref.inputIndex}`,
+                    );
+                }
+                return [added.event.message];
+            }
             case "assistant": {
                 const response = state.modelCalls[ref.modelCallIndex]?.response;
                 if (response === undefined) {
@@ -1245,12 +1364,13 @@ export function requestMessagesFor(
     });
 }
 
-// The messages this turn contributed to the conversation: its input plus, per
-// completed model call, the assistant response and its tool results in source
-// order. Failed model calls contribute nothing. The turn's context prefix is
-// NOT included; materializing the full conversation is the context resolver's
-// job (core). Requires every tool call to have a terminal result, which holds
-// for all terminal turns.
+// The messages this turn contributed to the conversation: its inputs in the
+// positions the model saw them plus, per completed model call, the assistant
+// response and its tool results in source order. Failed model calls
+// contribute nothing (added inputs at their boundary still do). The turn's
+// context prefix is NOT included; materializing the full conversation is the
+// context resolver's job (core). Requires every tool call to have a terminal
+// result, which holds for all terminal turns.
 export function turnTranscript(
     state: TurnState,
 ): Array<z.infer<typeof ConversationMessage>> {
@@ -1258,6 +1378,7 @@ export function turnTranscript(
         state.definition.input,
     ];
     for (const call of state.modelCalls) {
+        messages.push(...addedInputMessagesAt(state, call.index));
         if (call.response === undefined) {
             continue;
         }
@@ -1271,6 +1392,10 @@ export function turnTranscript(
             messages.push(toolResultMessage(toolCall));
         }
     }
+    // Inputs accepted after the last requested call (the turn was cancelled
+    // or crashed before the next request) were still durably accepted; they
+    // close the transcript so the next turn's model sees them.
+    messages.push(...addedInputMessagesAt(state, state.modelCalls.length));
     return messages;
 }
 


### PR DESCRIPTION
Sending a message while the assistant is mid-turn no longer drops it. One behavior, deliver-ASAP: the message waits in an ephemeral pending queue, **steers the live turn** at its next model-call boundary (injected as a durable `input_added` event, visible to the model right after the current tool batch's results), or **starts the next turn** the moment the current one settles. No queue-vs-steer mode picker — the runtime picks the earliest safe delivery, matching what pi and opencode both converged on.

## Design (recorded in the design docs, updated in this PR)

- **Turn layer** (`turn-runtime-design.md` §8.6): a turn now has 1+ inputs. `input_added` generalizes the existing `input` concept (refs gain `input:<n>`), following the `tools_extended` precedent for durable mid-turn schema additions. The loop drains a caller-supplied `takeInputs` callback at the boundary — the dual of the abort signal (both are ephemeral per-invocation channels, durable only when acted on). The reducer requires the very next request to reference every accepted input, which is also exactly what makes crash recovery correct. Each accepted input resets the model-call budget.
- **Session layer** (`session-design.md` §12.1/§12.4): the pending queue is **process memory only** — a message becomes durable exactly once, at delivery. This deliberately supersedes the originally committed durable-queue events: it deletes the cross-file queue/consumption reconciliation seam, matches the "events record facts, not intent" principle, and keeps crash loss coherent (the queue dies with the in-flight turn it was steering). Promotion on settle runs under the session lock (no lost-wakeup window); the head becomes a new turn, the rest steers it at call 0. `stopTurn` drains the queue first and returns the text — a stop is never followed by queued work auto-starting.
- **Rejected alternative, recorded in §12.4**: supersede-at-boundary (gracefully cancel + promote as a new turn). Zero schema change, but it loses on behavior: transmit-time elision would blank the just-executed batch's tool results, continuation stripping would drop reasoning signatures on every steer, and it's destructive to turns suspended on permissions.
- Injection preserves within-turn fidelity by construction: provider reasoning signatures and full tool results stay intact, and steering while suspended needs no special input — the advance that answers the permission drains the same source.
- `sendMessage` keeps its strict `TurnNotSettledError` contract; queueing is opt-in via the new `sendOrQueueMessage`. The channel bridge and todo runner are deliberately unchanged.

## UI

Enter submits while the assistant is streaming (session chats only; Stop button unchanged). Queued messages show as chips above the composer — ✕ discards, clicking pulls the text back for editing. Stop restores drained queue text into the composer. Steered messages render in the transcript at the position the model saw them.

## Verification

- Typecheck (shared/core/renderer) and lint clean.
- 1,055 tests passing: 121 shared + 622 core + 312 renderer, including new coverage for the reducer invariants (ref completeness, index ordering, boundary placement), loop injection/recovery/budget-reset, session queue lifecycle (promotion, arrival order, stop-drain, failure keeps entry queued), and store wiring.
- Not yet done: a live dogfood pass steering a real model mid-task — worth doing before merge.

Commits are staged by layer (turn → session → IPC/UI) and are individually revertable; squash-merge is also fine per the docs' integration convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)