### PR TITLE
fix(x): close button on the post-update toast

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -5613,6 +5613,7 @@ function App() {
           onClick: () => window.open(`https://github.com/rowboatlabs/rowboat/releases/tag/v${version}`, '_blank'),
         },
         duration: 10000,
+        closeButton: true,
       })
     })
   }, [])

--- a/apps/x/apps/renderer/src/components/ui/sonner.tsx
+++ b/apps/x/apps/renderer/src/components/ui/sonner.tsx
@@ -30,6 +30,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             "bg-popover/90! backdrop-blur-xl! text-popover-foreground! border-border/60! rounded-xl! shadow-xl! shadow-black/10! gap-3! p-4!",
+          closeButton:
+            "size-6! rounded-full! bg-popover! border-border! text-muted-foreground! shadow-md! shadow-black/10! hover:text-foreground! hover:bg-muted! transition-colors! [&>svg]:size-3.5!",
           description: "text-muted-foreground! leading-relaxed! mt-0.5!",
           actionButton:
             "bg-primary! text-primary-foreground! rounded-md! font-medium! px-3! transition-colors! hover:bg-primary/85!",
@@ -43,6 +45,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
           "--border-radius": "var(--radius)",
+          // Sonner pins the close button to the toast's top-LEFT corner in
+          // LTR (only RTL flips it); these vars mirror it to the top-right.
+          "--toast-close-button-start": "unset",
+          "--toast-close-button-end": "0",
+          "--toast-close-button-transform": "translate(35%, -35%)",
         } as React.CSSProperties
       }
       {...props}


### PR DESCRIPTION
## Summary
The "Updated to vX.Y.Z" toast (shown on the first launch after an update) auto-dismissed after 10 seconds with no way to close it sooner.

- Enable sonner's `closeButton` for that toast
- Move the close button to the toast's **top-right** corner — sonner pins it top-left in LTR and only mirrors it to the right for RTL, so the position is overridden via its `--toast-close-button-*` CSS vars on the `Toaster`
- Style it as a small round bordered chip matching the app theme (popover background, muted × that brightens on hover)

## Testing
Verified live on Linux dev by lowering the persisted version stamp (`~/.rowboat/config/app-version.json`) and launching the app:
- Toast appears with the × chip on its top-right corner; clicking it dismisses the toast
- Reloading the renderer does not re-show the toast (consume-once in main is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)