### PR TITLE
fix(x): hover follow-ups — "Try it" toast summons the real companion; Windows push-to-talk (right Ctrl)

### DIFF
--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -2,7 +2,7 @@
 
 Calls let the user talk to the assistant while it *sees* them (webcam) and
 their screen (screen share). There is ONE call engine — push-to-talk voice
-input (hold Right ⌘ to talk, quick-tap to lock hands-free), forced
+input (hold the PTT key — right ⌘ on macOS, right Ctrl on Windows/Linux — to talk, quick-tap to lock hands-free), forced
 read-aloud TTS, frame capture — entered through four presets that differ
 only in starting devices. This doc covers the product flow, the technical
 pipeline, and the LLM prompt surface with exact pointers.

--- a/apps/x/apps/main/src/ptt.ts
+++ b/apps/x/apps/main/src/ptt.ts
@@ -18,8 +18,11 @@ import { BrowserWindow, shell } from 'electron';
 
 type PttKeyEvent = { type: 'down' | 'up' | 'chord' };
 
-// libuiohook VC_META_R — the Right ⌘ key.
-const META_RIGHT = 3676;
+// The PTT key, per platform. macOS: libuiohook VC_META_R (right ⌘).
+// Windows/Linux: VC_CONTROL_R (right Ctrl) — the right-Meta position is the
+// right Win key there, which the OS owns (a tap opens the Start menu), so
+// hooking it made PTT effectively unusable outside macOS.
+const META_RIGHT = process.platform === 'darwin' ? 3676 /* VC_META_R */ : 3613 /* VC_CONTROL_R */;
 
 type UiohookModule = typeof import('uiohook-napi');
 

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1517,6 +1517,9 @@ function App() {
   // (unbound) chat defer-binds, so the first utterance creates ONE session
   // both surfaces share. ⌥⇧Space summons keep the companion's previous
   // conversation instead (no composer context to seed from).
+  const startHoverCallRef = useRef<() => Promise<void>>(startHoverCall)
+  startHoverCallRef.current = startHoverCall
+
   const handleStartCall = useCallback((preset: CallPreset) => {
     const activeTab = chatTabsRef.current.find((t) => t.id === activeChatTabIdRef.current)
     const seedRunId = activeTab?.runId ?? null
@@ -1977,7 +1980,7 @@ function App() {
         .catch(() => quickAskShortcut.DEFAULT_QUICK_ASK_SHORTCUT)
       playPopCue()
       toast('Ask Rowboat from anywhere', {
-        description: `Press ${quickAskShortcut.formatShortcut(accelerator, isMac)} in any app for a quick question — the answer shows up right there and in your chat.`,
+        description: `Press ${quickAskShortcut.formatShortcut(accelerator, isMac)} in any app and your floating companion pops up on a live voice session — ask out loud, it answers right there.`,
         duration: 12000,
         closeButton: true,
         // Lift the card off the page, and move sonner's close button (which
@@ -1986,7 +1989,10 @@ function App() {
           'shadow-xl shadow-black/25 [&_[data-close-button]]:!left-auto [&_[data-close-button]]:!right-0 [&_[data-close-button]]:!translate-x-[15%] [&_[data-close-button]]:!-translate-y-[15%]',
         action: {
           label: 'Try it',
-          onClick: () => void window.ipc.invoke('quickAsk:show', null).catch(() => {}),
+          // The SAME flow as the shortcut itself (hover companion, with the
+          // text-card fallback when voice isn't configured) — quickAsk:show
+          // here was a remnant that summoned the pre-hover legacy bar.
+          onClick: () => void startHoverCallRef.current?.().catch(() => {}),
         },
       })
     }, 3000)

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -134,6 +134,11 @@ const graphPalette = [
 // submits). PTT_EDGE_ECHO_MS collapses the same key edge arriving from two
 // sources at once (global uiohook hook + in-window DOM listener).
 const PTT_TAP_MS = 350
+// The PTT key per platform (matches main/ptt.ts's global hook): right ⌘ on
+// macOS, right Ctrl elsewhere (the right Win key is OS-owned on Windows).
+const APP_IS_MAC = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
+const PTT_EVENT_CODE = APP_IS_MAC ? 'MetaRight' : 'ControlRight'
+const PTT_KEY_LABEL = quickAskShortcut.pttKeyLabel(APP_IS_MAC)
 // Mic-ownership token for the Home composer (chat composers use their chatId).
 const HOME_VOICE_HOLDER = 'home-composer'
 const PTT_EDGE_ECHO_MS = 80
@@ -1689,7 +1694,7 @@ function App() {
       if (shown < 2) {
         localStorage.setItem('ptt-hold-tip-shown', String(shown + 1))
         toast('No need to keep holding', {
-          description: 'For longer turns, quick-tap right ⌘ instead — talk hands-free, then tap again to send.',
+          description: `For longer turns, quick-tap ${PTT_KEY_LABEL} instead — talk hands-free, then tap again to send.`,
           duration: 6000,
         })
       }
@@ -1726,7 +1731,7 @@ function App() {
       else handlePttChord()
     })
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.code === 'MetaRight') {
+      if (e.code === PTT_EVENT_CODE) {
         if (!e.repeat) handlePttDown()
         return
       }
@@ -1739,7 +1744,7 @@ function App() {
       else if (pttStatusRef.current === 'locked' && e.metaKey) handlePttChord()
     }
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code === 'MetaRight') handlePttUp()
+      if (e.code === PTT_EVENT_CODE) handlePttUp()
     }
     document.addEventListener('keydown', onKeyDown)
     document.addEventListener('keyup', onKeyUp)

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -59,6 +59,7 @@ import type { FileMention, PromptInputMessage } from '@/components/ai-elements/p
 // menu) — right Ctrl is the safe equivalent there.
 const IS_MAC = navigator.platform.startsWith('Mac')
 const PTT_CODE = IS_MAC ? 'MetaRight' : 'ControlRight'
+const PTT_KEY_LABEL = IS_MAC ? 'right \u2318' : 'right Ctrl'
 
 type CompanionMode = 'hidden' | 'summoned' | 'pinned'
 
@@ -1206,7 +1207,7 @@ export function QuickAskBar() {
 }
 
 const STATUS_DISPLAY: Record<NonNullable<CallState['status']>, { label: string; dotClass: string }> = {
-  idle: { label: 'Hold right ⌘ to talk', dotClass: 'bg-neutral-500' },
+  idle: { label: `Hold ${PTT_KEY_LABEL} to talk`, dotClass: 'bg-neutral-500' },
   listening: { label: 'Listening', dotClass: 'bg-green-500 animate-pulse' },
   thinking: { label: 'Thinking…', dotClass: 'bg-amber-400' },
   speaking: { label: 'Speaking', dotClass: 'bg-sky-400 animate-pulse' },
@@ -1301,7 +1302,7 @@ function SkipperPins({
             if (!state.micMuted) sendAction('ptt-up')
           }}
           aria-label="Hold to talk — tap for hands-free"
-          title="Hold to talk (tap for hands-free) — or hold the right ⌘ key"
+          title={`Hold to talk (tap for hands-free) — or hold the ${PTT_KEY_LABEL} key`}
           className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
           style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
         >
@@ -1411,7 +1412,7 @@ function SkipperStatusChip({ state, activity }: { state: CallState; activity?: s
         <>
           <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
           {state.status === 'idle'
-            ? 'Hold the mic — or right ⌘'
+            ? `Hold the mic — or ${PTT_KEY_LABEL}`
             : state.status === 'thinking' && activity
               ? activity
               : statusDisplay.label}

--- a/apps/x/apps/renderer/src/components/video-call-view.tsx
+++ b/apps/x/apps/renderer/src/components/video-call-view.tsx
@@ -6,6 +6,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import type { TTSState } from '@/hooks/useVoiceTTS'
 import { cn } from '@/lib/utils'
 
+const PTT_KEY_LABEL = navigator.platform.toLowerCase().includes('mac') ? 'right \u2318' : 'right Ctrl'
+
 export type VideoCallStatus = 'idle' | 'listening' | 'thinking' | 'speaking'
 
 export type PttStatus = 'idle' | 'held' | 'locked'
@@ -45,7 +47,7 @@ interface VideoCallViewProps {
 }
 
 const STATUS_DISPLAY: Record<VideoCallStatus, { label: string; dotClass: string }> = {
-  idle: { label: 'Hold right ⌘ to talk · press & release it to go hands-free', dotClass: 'bg-neutral-500' },
+  idle: { label: `Hold ${PTT_KEY_LABEL} to talk · press & release it to go hands-free`, dotClass: 'bg-neutral-500' },
   listening: { label: 'Listening — release to send', dotClass: 'bg-green-500 animate-pulse' },
   thinking: { label: 'Thinking…', dotClass: 'bg-amber-400' },
   speaking: { label: 'Speaking', dotClass: 'bg-sky-400 animate-pulse' },
@@ -209,7 +211,7 @@ export function VideoCallView({
           ) : pttStatus === 'locked' ? (
             <>
               <span className="block h-2 w-2 rounded-full bg-green-500 animate-pulse" />
-              Hands-free — press right ⌘ again to send
+              Hands-free — press {PTT_KEY_LABEL} again to send
             </>
           ) : (
             <>
@@ -245,7 +247,7 @@ export function VideoCallView({
               {pttStatus === 'idle' ? 'Hold to talk' : pttStatus === 'locked' ? 'Tap to send' : 'Release to send'}
             </button>
           </TooltipTrigger>
-          <TooltipContent className="z-[110]">Hold to talk (tap to go hands-free) — or hold the right ⌘ key</TooltipContent>
+          <TooltipContent className="z-[110]">Hold to talk (tap to go hands-free) — or hold the {PTT_KEY_LABEL} key</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/x/packages/shared/src/quick-ask-shortcut.ts
+++ b/apps/x/packages/shared/src/quick-ask-shortcut.ts
@@ -205,3 +205,11 @@ export function shortcutModifierStates(accelerator: string): string[] {
   };
   return [...new Set(parsed.modifiers.map((m) => map[m]))];
 }
+
+// The push-to-talk key's user-facing name. macOS: right ⌘. Windows/Linux:
+// right Ctrl (the right Win key's physical position is OS-owned — a tap
+// opens the Start menu). Keep in step with PTT_KEYCODE in main/ptt.ts and
+// the DOM fallbacks' event codes.
+export function pttKeyLabel(isMac: boolean): string {
+  return isMac ? 'right \u2318' : 'right Ctrl';
+}


### PR DESCRIPTION
Follow-up to #855. The once-per-install discoverability toast's **Try it** action still called `quickAsk:show` — the pre-hover fallback path — so the first thing a new user saw of "hover mode" was the legacy 800px summoned bar with the hatless mascot.

- **Try it** now runs the exact ⌥⇧Space flow (`startHoverCall`, via a ref so the 3s timer never captures a stale voice-availability closure) → lands on the Skipper card. The no-voice text-card fallback is preserved (`quickAsk:show` survives only as that deliberate fallback inside `startHoverCall`).
- Toast copy updated to describe what actually happens (voice companion, answers out loud).

Verified live: fresh profile → toast fires → Try it opens the 560px Skipper card (hat + pins + ↗), not the 800px legacy bar. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also: push-to-talk on Windows (right Ctrl, not right ⌘)

Bigger than a wording bug: the global PTT hook hardcoded `VC_META_R`, which on Windows is the **right Win key** — the OS owns it (tap = Start menu), so hold-to-talk was effectively unusable off macOS. Now every layer agrees on **right Ctrl** for Windows/Linux: the uiohook keycode in `main/ptt.ts`, the app window's DOM fallback (`ControlRight`), and every user-facing string (Skipper chip, call-view status line + talk-button tooltip, the hands-free teach toast) via a shared `pttKeyLabel` helper. The ⌥⇧Space hint was already platform-formatted (`Alt+Shift+Space` on Windows) and is unchanged.
