### PR TITLE
fix(x): don't replay historical billing errors as live popups

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -936,8 +936,24 @@ function App() {
   // Watch the conversation that is actually rendered — the sessions-runtime
   // one when loaded, the legacy state otherwise — so billing failures
   // (out of credits, subscription lapsed) always pop the upgrade dialog.
+  // Only errors that APPEAR while a conversation is on screen count: when a
+  // context first renders (session loaded/switched, app relaunched), errors
+  // already in its transcript are history — replaying them would pop the
+  // dialog and flip the credit state on every open of that chat.
   const billingWatchedConversation = sessionChat.chatState?.conversation ?? conversation
+  const billingContextKeyRef = useRef<string | null>(null)
   useEffect(() => {
+    const contextKey = sessionChat.chatState ? `session:${sessionChat.sessionId}` : 'legacy'
+    const isNewContext = billingContextKeyRef.current !== contextKey
+    billingContextKeyRef.current = contextKey
+    if (isNewContext) {
+      for (const item of billingWatchedConversation) {
+        if (isErrorMessage(item) && matchBillingError(item.message)) {
+          handledBillingErrorIdsRef.current.add(item.id)
+        }
+      }
+      return
+    }
     for (let i = billingWatchedConversation.length - 1; i >= 0; i--) {
       const item = billingWatchedConversation[i]
       if (!isErrorMessage(item)) continue
@@ -951,7 +967,7 @@ function App() {
       }
       return
     }
-  }, [billingWatchedConversation])
+  }, [billingWatchedConversation, sessionChat.chatState, sessionChat.sessionId])
   const runIdRef = useRef<string | null>(null)
   const loadRunRequestIdRef = useRef(0)
   const [isProcessing, setIsProcessing] = useState(false)


### PR DESCRIPTION
## Problem

Opening a chat whose transcript ends in a billing failure (e.g. "not enough credits") re-popped the upgrade dialog on every app launch, even when credits had since reset. The billing-error watcher in `App.tsx` deduped popups by conversation-item id in an in-memory ref, so a persisted error replayed from session storage always looked new after a relaunch. It also re-dispatched `dispatchCreditExhausted()`, wrongly flipping the app's global "out of credits" state.

## Fix

The watcher now distinguishes history from live failures. When a conversation context first renders — session loaded, session switched, app relaunched — billing errors already present in the transcript are seeded into the handled set silently. Only a billing error that appears while the conversation is already on screen (a turn failing right now) pops the dialog and dispatches the credit-exhausted event.

The context key comes from `sessionChat.sessionId` (the store snapshot's own session id) rather than `runId`, since the snapshot's session id and conversation always agree within a single emit — avoiding a stale-render race during session switches.

The historical error still renders inline in the transcript via `BillingErrorNotice`, which is correct: it's part of the chat's history, it just no longer masquerades as a current billing problem.

## Testing

- `npm run typecheck` and `npm run lint` in `apps/x` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)