### PR TITLE
fix(renderer): refresh externally modified notes

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -26,6 +26,10 @@ import { PptxEditor } from '@/components/pptx-editor';
 import { PersistentViewerCache } from '@/components/persistent-viewer-cache';
 import { UnsupportedFileViewer } from '@/components/unsupported-file-viewer';
 import { getViewerType, isCacheableViewerPath } from '@/lib/file-types';
+import {
+  readFileAfterExternalChangesSettle,
+  reloadCleanActiveMarkdownAfterExternalChange,
+} from '@/lib/active-markdown-external-change';
 import { useDebounce } from './hooks/use-debounce';
 import { SidebarContentPanel } from '@/components/sidebar-content';
 import { SuggestedTopicsView } from '@/components/suggested-topics-view';
@@ -864,7 +868,8 @@ function App() {
   const editorPathRef = useRef<string | null>(null)
   const fileLoadRequestIdRef = useRef(0)
   const initialContentByPathRef = useRef<Map<string, string>>(new Map())
-  const recentLocalMarkdownWritesRef = useRef<Map<string, number>>(new Map())
+  const documentRevisionByPathRef = useRef<Map<string, number>>(new Map())
+  const externalChangeRevisionByPathRef = useRef<Map<string, number>>(new Map())
   const untitledRenameReadyPathsRef = useRef<Set<string>>(new Set())
 
   // Pending app-navigation result to process once navigation functions are ready
@@ -2677,38 +2682,29 @@ function App() {
     })
   }, [])
 
+  const bumpDocumentRevisionForPath = useCallback((path: string) => {
+    const revisions = documentRevisionByPathRef.current
+    revisions.set(path, (revisions.get(path) ?? 0) + 1)
+  }, [])
+
+  const setInitialContentForPath = useCallback((path: string, content: string) => {
+    initialContentByPathRef.current.set(path, content)
+    bumpDocumentRevisionForPath(path)
+  }, [bumpDocumentRevisionForPath])
+
+  const deleteInitialContentForPath = useCallback((path: string) => {
+    initialContentByPathRef.current.delete(path)
+    bumpDocumentRevisionForPath(path)
+  }, [bumpDocumentRevisionForPath])
+
   const removeEditorCacheForPath = useCallback((path: string) => {
     editorContentByPathRef.current.delete(path)
-    untitledRenameReadyPathsRef.current.delete(path)
     setEditorContentByPath((prev) => {
       if (!(path in prev)) return prev
       const next = { ...prev }
       delete next[path]
       return next
     })
-  }, [])
-
-  const markRecentLocalMarkdownWrite = useCallback((path: string) => {
-    if (!path.endsWith('.md')) return
-    const now = Date.now()
-    recentLocalMarkdownWritesRef.current.set(path, now)
-    if (recentLocalMarkdownWritesRef.current.size > 200) {
-      for (const [knownPath, timestamp] of recentLocalMarkdownWritesRef.current.entries()) {
-        if (now - timestamp > 10_000) {
-          recentLocalMarkdownWritesRef.current.delete(knownPath)
-        }
-      }
-    }
-  }, [])
-
-  const consumeRecentLocalMarkdownWrite = useCallback((path: string, windowMs: number = 2_500) => {
-    const timestamp = recentLocalMarkdownWritesRef.current.get(path)
-    if (timestamp === undefined) return false
-    const isRecent = Date.now() - timestamp <= windowMs
-    if (!isRecent) {
-      recentLocalMarkdownWritesRef.current.delete(path)
-    }
-    return isRecent
   }, [])
 
   const reloadMarkdownFileIntoEditor = useCallback(async (path: string) => {
@@ -2720,11 +2716,11 @@ function App() {
     setEditorCacheForPath(path, body)
     editorContentRef.current = body
     editorPathRef.current = path
-    initialContentByPathRef.current.set(path, body)
+    setInitialContentForPath(path, body)
     initialContentRef.current = body
     setLastSaved(new Date())
     setEditorSessionByPath((prev) => ({ ...prev, [path]: (prev[path] ?? 0) + 1 }))
-  }, [setEditorCacheForPath])
+  }, [setEditorCacheForPath, setInitialContentForPath])
 
   const handleEditorChange = useCallback((path: string, markdown: string) => {
     setEditorCacheForPath(path, markdown)
@@ -2745,10 +2741,8 @@ function App() {
     if (!path || !path.startsWith('knowledge/') || !path.endsWith('.md')) return
 
     setGoogleDocSyncDirection('down')
-    markRecentLocalMarkdownWrite(path)
     try {
       await window.ipc.invoke('google-docs:refreshSnapshot', { path })
-      markRecentLocalMarkdownWrite(path)
       await reloadMarkdownFileIntoEditor(path)
       toast.success('Pulled latest Google Doc')
     } catch (err) {
@@ -2757,7 +2751,7 @@ function App() {
     } finally {
       setGoogleDocSyncDirection(null)
     }
-  }, [markRecentLocalMarkdownWrite, reloadMarkdownFileIntoEditor])
+  }, [reloadMarkdownFileIntoEditor])
 
   const syncGoogleDocUp = useCallback(async (targetPath?: string) => {
     const path = targetPath ?? selectedPathRef.current
@@ -2766,7 +2760,6 @@ function App() {
     const body = editorContentByPathRef.current.get(path) ?? editorContentRef.current
     const markdown = joinFrontmatter(frontmatterByPathRef.current.get(path) ?? null, body)
     setGoogleDocSyncDirection('up')
-    markRecentLocalMarkdownWrite(path)
     try {
       let result = await window.ipc.invoke('google-docs:sync', { path, markdown })
       if (result.conflict) {
@@ -2784,7 +2777,6 @@ function App() {
       if (!result.synced) {
         throw new Error(result.error || 'This note is not linked to a Google Doc.')
       }
-      markRecentLocalMarkdownWrite(path)
       await reloadMarkdownFileIntoEditor(path)
       toast.success('Pushed changes to Google Doc')
     } catch (err) {
@@ -2793,7 +2785,7 @@ function App() {
     } finally {
       setGoogleDocSyncDirection(null)
     }
-  }, [markRecentLocalMarkdownWrite, reloadMarkdownFileIntoEditor])
+  }, [reloadMarkdownFileIntoEditor])
   // Keep processingRunIdsRef in sync for use in async callbacks
   useEffect(() => {
     processingRunIdsRef.current = processingRunIds
@@ -2884,6 +2876,15 @@ function App() {
       })()
       const selectedPathAtEvent = selectedPathRef.current
 
+      // Initial hydration owns its read until editorPath/baseline are ready.
+      // Record every Markdown event so that loader can detect an in-flight
+      // stale snapshot and repeat the read instead of losing this notification.
+      for (const path of new Set(eventPaths)) {
+        if (!path.endsWith('.md')) continue
+        const revisions = externalChangeRevisionByPathRef.current
+        revisions.set(path, (revisions.get(path) ?? 0) + 1)
+      }
+
       // Reload background tasks if agent-schedule.json changed
       if (
         changedPath === 'config/agent-schedule.json'
@@ -2905,7 +2906,7 @@ function App() {
         if (!path.endsWith('.md')) continue
         if (selectedPathAtEvent && path === selectedPathAtEvent) continue
         removeEditorCacheForPath(path)
-        initialContentByPathRef.current.delete(path)
+        deleteInitialContentForPath(path)
       }
 
       // Keep selection stable if a file is moved externally.
@@ -2925,33 +2926,50 @@ function App() {
         changedPath === pathToReload || changedPaths.includes(pathToReload)
 
       if (isCurrentFileChanged) {
-        // Ignore immediate watcher echoes of our own autosaves to preserve undo history.
-        if (consumeRecentLocalMarkdownWrite(pathToReload)) {
-          return
-        }
-        // Only reload if no unsaved edits
-        const baseline = initialContentByPathRef.current.get(pathToReload) ?? initialContentRef.current
-        if (editorContentRef.current === baseline) {
-          const result = await window.ipc.invoke('workspace:readFile', { path: pathToReload })
-          if (selectedPathRef.current !== pathToReload) return
-          setFileContent(result.data)
-          const { raw: fm, body } = splitFrontmatter(result.data)
-          frontmatterByPathRef.current.set(pathToReload, fm)
-          setEditorContent(body)
-          setEditorCacheForPath(pathToReload, body)
-          editorContentRef.current = body
-          editorPathRef.current = pathToReload
-          initialContentByPathRef.current.set(pathToReload, body)
-          initialContentRef.current = body
-        }
+        await reloadCleanActiveMarkdownAfterExternalChange({
+          path: pathToReload,
+          getSelectedPath: () => selectedPathRef.current,
+          getEditorPath: () => editorPathRef.current,
+          getEditorContent: () => editorContentRef.current,
+          getBaseline: () => initialContentByPathRef.current.get(pathToReload),
+          getDocumentRevision: () => documentRevisionByPathRef.current.get(pathToReload) ?? 0,
+          invalidateCache: () => {
+            removeEditorCacheForPath(pathToReload)
+          },
+          beginRequest: () => (fileLoadRequestIdRef.current += 1),
+          isCurrentRequest: (requestId) => fileLoadRequestIdRef.current === requestId,
+          readFile: () => window.ipc.invoke('workspace:readFile', { path: pathToReload }),
+          getDiskEditorContent: (data) => splitFrontmatter(data).body,
+          applyReload: (data) => {
+            setFileContent(data)
+            const { raw: fm, body } = splitFrontmatter(data)
+            frontmatterByPathRef.current.set(pathToReload, fm)
+            setEditorContent(body)
+            setEditorCacheForPath(pathToReload, body)
+            editorContentRef.current = body
+            editorPathRef.current = pathToReload
+            setInitialContentForPath(pathToReload, body)
+            initialContentRef.current = body
+          },
+          applyUnchangedReload: (data) => {
+            setFileContent(data)
+            const { raw: fm, body } = splitFrontmatter(data)
+            frontmatterByPathRef.current.set(pathToReload, fm)
+            setEditorCacheForPath(pathToReload, body)
+            setInitialContentForPath(pathToReload, body)
+            initialContentRef.current = body
+          },
+          onReadError: (error) => console.error('Failed to reload externally changed file:', error),
+        })
       }
     })
     return cleanup
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadDirectory, removeEditorCacheForPath, setEditorCacheForPath])
+  }, [deleteInitialContentForPath, loadDirectory, removeEditorCacheForPath, setEditorCacheForPath, setInitialContentForPath])
 
   // Load file content when selected
   useEffect(() => {
+    const requestId = (fileLoadRequestIdRef.current += 1)
     if (!selectedPath) {
       setFileContent('')
       setEditorContent('')
@@ -2999,7 +3017,6 @@ function App() {
         return
       }
     }
-    const requestId = (fileLoadRequestIdRef.current += 1)
     const pathToLoad = selectedPath
     // Only the markdown editor still consumes fileContent. Every other viewer
     // (media + UnsupportedFileViewer) self-loads, so skip the generic UTF-8
@@ -3025,8 +3042,16 @@ function App() {
             return
           }
         }
-        const result = await window.ipc.invoke('workspace:readFile', { path: pathToLoad })
-        if (cancelled || fileLoadRequestIdRef.current !== requestId || selectedPathRef.current !== pathToLoad) return
+        const result = await readFileAfterExternalChangesSettle({
+          getExternalRevision: () => externalChangeRevisionByPathRef.current.get(pathToLoad) ?? 0,
+          isCurrent: () => (
+            !cancelled
+            && fileLoadRequestIdRef.current === requestId
+            && selectedPathRef.current === pathToLoad
+          ),
+          readFile: () => window.ipc.invoke('workspace:readFile', { path: pathToLoad }),
+        })
+        if (!result) return
         setFileContent(result.data)
         const { raw: fm, body } = splitFrontmatter(result.data)
         frontmatterByPathRef.current.set(pathToLoad, fm)
@@ -3045,7 +3070,7 @@ function App() {
           }
           editorContentRef.current = body
           editorPathRef.current = pathToLoad
-          initialContentByPathRef.current.set(pathToLoad, body)
+          setInitialContentForPath(pathToLoad, body)
           initialContentRef.current = body
           setLastSaved(null)
         } else {
@@ -3065,7 +3090,7 @@ function App() {
     return () => {
       cancelled = true
     }
-  }, [selectedPath, setEditorCacheForPath])
+  }, [selectedPath, setEditorCacheForPath, setInitialContentForPath])
 
   // Track recently opened markdown files for wiki links
   useEffect(() => {
@@ -3135,7 +3160,7 @@ function App() {
                 const fmEntry = frontmatterByPathRef.current.get(pathAtStart)
                 frontmatterByPathRef.current.delete(pathAtStart)
                 frontmatterByPathRef.current.set(targetPath, fmEntry ?? null)
-                initialContentByPathRef.current.delete(pathAtStart)
+                deleteInitialContentForPath(pathAtStart)
                 const cachedContent = editorContentByPathRef.current.get(pathAtStart)
                 if (cachedContent !== undefined) {
                   const rewrittenCachedContent = rewriteWikiLinksForRenamedFileInMarkdown(
@@ -3172,10 +3197,9 @@ function App() {
           data: contentToSave,
           opts: { encoding: 'utf8' }
         })
-        markRecentLocalMarkdownWrite(pathToSave)
         analytics.noteEdited(pathToSave)
         // Store body-only baseline (matches what debouncedContent compares against)
-        initialContentByPathRef.current.set(pathToSave, splitFrontmatter(contentToSave).body)
+        setInitialContentForPath(pathToSave, splitFrontmatter(contentToSave).body)
 
         // If we renamed the active file, update state/history AFTER the write completes so the editor
         // doesn't reload stale on-disk content mid-typing (which can drop the latest character).
@@ -3209,7 +3233,7 @@ function App() {
       }
     }
     saveFile()
-  }, [debouncedContent, markRecentLocalMarkdownWrite, setHistory])
+  }, [debouncedContent, deleteInitialContentForPath, setHistory, setInitialContentForPath])
 
   // Close version history panel when switching files
   useEffect(() => {
@@ -5751,8 +5775,8 @@ function App() {
         }
         const baseline = initialContentByPathRef.current.get(oldPath)
         if (baseline !== undefined) {
-          initialContentByPathRef.current.delete(oldPath)
-          initialContentByPathRef.current.set(newPath, rewriteForRename(baseline))
+          deleteInitialContentForPath(oldPath)
+          setInitialContentForPath(newPath, rewriteForRename(baseline))
         }
         const cachedContent = editorContentByPathRef.current.get(oldPath)
         if (cachedContent !== undefined) {
@@ -5784,7 +5808,7 @@ function App() {
         await window.ipc.invoke('workspace:remove', { path, opts: { trash: true } })
         if (path.endsWith('.md')) {
           removeEditorCacheForPath(path)
-          initialContentByPathRef.current.delete(path)
+          deleteInitialContentForPath(path)
           untitledRenameReadyPathsRef.current.delete(path)
           frontmatterByPathRef.current.delete(path)
         }
@@ -5814,7 +5838,7 @@ function App() {
         console.error('Failed to open in file manager:', err)
       })
     },
-  }), [tree, selectedPath, isGraphOpen, selectedBackgroundTask, workspaceRoot, navigateToFile, navigateToView, removeEditorCacheForPath])
+  }), [deleteInitialContentForPath, setInitialContentForPath, tree, selectedPath, isGraphOpen, selectedBackgroundTask, workspaceRoot, navigateToFile, navigateToView, removeEditorCacheForPath])
 
   // Drives the mascot product tour through the app's main sections
   const handleTourNavigate = useCallback((target: TourNavTarget) => {
@@ -6837,7 +6861,7 @@ function App() {
                                 // Write updated frontmatter to disk immediately
                                 const currentBody = editorContentRef.current
                                 const fullContent = joinFrontmatter(newRaw, currentBody)
-                                initialContentByPathRef.current.set(notePath, splitFrontmatter(fullContent).body)
+                                setInitialContentForPath(notePath, splitFrontmatter(fullContent).body)
                                 initialContentRef.current = splitFrontmatter(fullContent).body
                                 void window.ipc.invoke('workspace:writeFile', {
                                   path: notePath,

--- a/apps/x/apps/renderer/src/lib/active-markdown-external-change.test.ts
+++ b/apps/x/apps/renderer/src/lib/active-markdown-external-change.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  readFileAfterExternalChangesSettle,
+  reloadCleanActiveMarkdownAfterExternalChange,
+} from './active-markdown-external-change'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('reloadCleanActiveMarkdownAfterExternalChange', () => {
+  it('does not reuse stale cache after switching away during a disk read', async () => {
+    let selectedPath = 'knowledge/A.md'
+    const diskRead = deferred<{ data: string }>()
+    const cache = new Map([['knowledge/A.md', 'old content']])
+    let requestId = 0
+    const readFile = vi.fn(() => diskRead.promise)
+    const applyReload = vi.fn((data: string) => cache.set('knowledge/A.md', data))
+
+    const reload = reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => selectedPath,
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'old content',
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache: () => cache.delete('knowledge/A.md'),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile,
+      getDiskEditorContent: (data) => data,
+      applyReload,
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    })
+
+    expect(cache.has('knowledge/A.md')).toBe(false)
+
+    // Reproduce switching tabs while the external-change read is in flight.
+    selectedPath = 'knowledge/B.md'
+    diskRead.resolve({ data: 'modified externally' })
+    await reload
+
+    expect(applyReload).not.toHaveBeenCalled()
+
+    // Switching back trusts a cache hit; a correctly invalidated cache instead
+    // falls through to the normal disk loader and receives the external edit.
+    selectedPath = 'knowledge/A.md'
+    if (!cache.has(selectedPath)) cache.set(selectedPath, 'modified externally')
+    expect(cache.get(selectedPath)).toBe('modified externally')
+  })
+
+  it('applies a successful reload when the clean file stays selected', async () => {
+    let requestId = 0
+    const invalidateCache = vi.fn()
+    const applyReload = vi.fn()
+
+    await reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'old content',
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache,
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: vi.fn(async () => ({ data: 'modified externally' })),
+      getDiskEditorContent: (data) => data,
+      applyReload,
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    })
+
+    expect(invalidateCache).toHaveBeenCalledOnce()
+    expect(applyReload).toHaveBeenCalledWith('modified externally')
+  })
+
+  it('preserves a dirty active file without invalidating or reading from disk', async () => {
+    const invalidateCache = vi.fn()
+    const readFile = vi.fn(async () => ({ data: 'modified externally' }))
+    const applyReload = vi.fn()
+
+    await reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'unsaved draft',
+      getBaseline: () => 'last saved content',
+      getDocumentRevision: () => 0,
+      invalidateCache,
+      beginRequest: vi.fn(() => 1),
+      isCurrentRequest: vi.fn(() => true),
+      readFile,
+      getDiskEditorContent: (data) => data,
+      applyReload,
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    })
+
+    expect(invalidateCache).not.toHaveBeenCalled()
+    expect(readFile).not.toHaveBeenCalled()
+    expect(applyReload).not.toHaveBeenCalled()
+  })
+
+  it('leaves revision-aware hydration in control until the editor belongs to the selected path', async () => {
+    let requestId = 7
+    const beginRequest = vi.fn(() => ++requestId)
+    const invalidateCache = vi.fn()
+    const readFile = vi.fn(async () => ({ data: 'B content' }))
+
+    await reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/B.md',
+      getSelectedPath: () => 'knowledge/B.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'A content',
+      getBaseline: () => undefined,
+      getDocumentRevision: () => 0,
+      invalidateCache,
+      beginRequest,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile,
+      getDiskEditorContent: (data) => data,
+      applyReload: vi.fn(),
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    })
+
+    expect(beginRequest).not.toHaveBeenCalled()
+    expect(requestId).toBe(7)
+    expect(invalidateCache).not.toHaveBeenCalled()
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('repeats an in-flight hydration read after a workspace change', async () => {
+    let externalRevision = 0
+    const staleRead = deferred<{ data: string }>()
+    const freshRead = deferred<{ data: string }>()
+    const reads = [staleRead, freshRead]
+    const readFile = vi.fn(() => reads.shift()!.promise)
+
+    const hydration = readFileAfterExternalChangesSettle({
+      getExternalRevision: () => externalRevision,
+      isCurrent: () => true,
+      readFile,
+    })
+
+    externalRevision += 1
+    staleRead.resolve({ data: 'stale B content' })
+    await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2))
+    freshRead.resolve({ data: 'fresh B content' })
+
+    await expect(hydration).resolves.toEqual({ data: 'fresh B content' })
+  })
+
+  it('does not overwrite edits made while the disk read is in flight', async () => {
+    let editorContent = 'old content'
+    let requestId = 0
+    const diskRead = deferred<{ data: string }>()
+    const applyReload = vi.fn()
+    const reload = reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => editorContent,
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: () => diskRead.promise,
+      getDiskEditorContent: (data) => data,
+      applyReload,
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    })
+
+    editorContent = 'draft typed during read'
+    diskRead.resolve({ data: 'modified externally' })
+    await reload
+
+    expect(applyReload).not.toHaveBeenCalled()
+  })
+
+  it('applies only the newest external read when responses arrive out of order', async () => {
+    let requestId = 0
+    const firstRead = deferred<{ data: string }>()
+    const secondRead = deferred<{ data: string }>()
+    const reads = [firstRead, secondRead]
+    const applied: string[] = []
+    const options = {
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'old content',
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate: number) => candidate === requestId,
+      readFile: () => reads.shift()!.promise,
+      getDiskEditorContent: (data: string) => data,
+      applyReload: (data: string) => applied.push(data),
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    }
+
+    const firstReload = reloadCleanActiveMarkdownAfterExternalChange(options)
+    const secondReload = reloadCleanActiveMarkdownAfterExternalChange(options)
+    secondRead.resolve({ data: 'newest content' })
+    await secondReload
+    firstRead.resolve({ data: 'older content' })
+    await firstReload
+
+    expect(applied).toEqual(['newest content'])
+  })
+
+  it('reports a read failure without applying content', async () => {
+    let requestId = 0
+    const error = new Error('disk read failed')
+    const applyReload = vi.fn()
+    const onReadError = vi.fn()
+
+    await expect(reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'old content',
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: async () => { throw error },
+      getDiskEditorContent: (data) => data,
+      applyReload,
+      applyUnchangedReload: vi.fn(),
+      onReadError,
+    })).resolves.toBeUndefined()
+
+    expect(onReadError).toHaveBeenCalledWith(error)
+    expect(applyReload).not.toHaveBeenCalled()
+  })
+
+  it('refreshes metadata without replacing the editor for an unchanged local-write echo', async () => {
+    let requestId = 0
+    const applyReload = vi.fn()
+    const applyUnchangedReload = vi.fn()
+    const cache = new Map([['knowledge/A.md', 'saved content']])
+    const renameReadyPaths = new Set(['knowledge/A.md'])
+
+    await reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'saved content',
+      getBaseline: () => 'saved content',
+      getDocumentRevision: () => 0,
+      invalidateCache: () => cache.delete('knowledge/A.md'),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: async () => ({ data: '---\ntag: updated\n---\nsaved content' }),
+      getDiskEditorContent: () => 'saved content',
+      applyReload,
+      applyUnchangedReload,
+      onReadError: vi.fn(),
+    })
+
+    expect(applyReload).not.toHaveBeenCalled()
+    expect(applyUnchangedReload).toHaveBeenCalledWith('---\ntag: updated\n---\nsaved content')
+    expect(cache.has('knowledge/A.md')).toBe(false)
+    expect(renameReadyPaths.has('knowledge/A.md')).toBe(true)
+  })
+
+  it('does not replace newer local frontmatter with an older in-flight read', async () => {
+    let requestId = 0
+    let documentRevision = 0
+    const diskRead = deferred<{ data: string }>()
+    const applyReload = vi.fn()
+    const applyUnchangedReload = vi.fn()
+    const reload = reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'saved content',
+      getBaseline: () => 'saved content',
+      getDocumentRevision: () => documentRevision,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: () => diskRead.promise,
+      getDiskEditorContent: () => 'saved content',
+      applyReload,
+      applyUnchangedReload,
+      onReadError: vi.fn(),
+    })
+
+    // onFrontmatterChange advances the per-path document revision even though
+    // the Markdown body baseline remains byte-for-byte identical.
+    documentRevision += 1
+    diskRead.resolve({ data: '---\ntag: stale\n---\nsaved content' })
+    await reload
+
+    expect(applyReload).not.toHaveBeenCalled()
+    expect(applyUnchangedReload).not.toHaveBeenCalled()
+  })
+
+  it('does not apply a read after the saved baseline and editor complete an ABA cycle', async () => {
+    let requestId = 0
+    let editorContent = 'old content'
+    let baseline = 'old content'
+    let documentRevision = 0
+    const diskRead = deferred<{ data: string }>()
+    const applyReload = vi.fn()
+    const applyUnchangedReload = vi.fn()
+    const reload = reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => editorContent,
+      getBaseline: () => baseline,
+      getDocumentRevision: () => documentRevision,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: () => diskRead.promise,
+      getDiskEditorContent: (data) => data,
+      applyReload,
+      applyUnchangedReload,
+      onReadError: vi.fn(),
+    })
+
+    editorContent = 'new saved content'
+    baseline = 'new saved content'
+    documentRevision += 1
+    editorContent = 'old content'
+    baseline = 'old content'
+    documentRevision += 1
+    diskRead.resolve({ data: 'modified externally' })
+    await reload
+
+    expect(applyReload).not.toHaveBeenCalled()
+    expect(applyUnchangedReload).not.toHaveBeenCalled()
+  })
+
+  it('discards an external read invalidated by an A to B to A selection generation', async () => {
+    let selectedPath = 'knowledge/A.md'
+    let requestId = 0
+    const diskRead = deferred<{ data: string }>()
+    const applied: string[] = []
+    const reload = reloadCleanActiveMarkdownAfterExternalChange({
+      path: 'knowledge/A.md',
+      getSelectedPath: () => selectedPath,
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => 'old content',
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate) => candidate === requestId,
+      readFile: () => diskRead.promise,
+      getDiskEditorContent: (data) => data,
+      applyReload: (data) => applied.push(data),
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    })
+
+    selectedPath = 'knowledge/B.md'
+    requestId += 1
+    selectedPath = 'knowledge/A.md'
+    requestId += 1
+    applied.push('fresh selection read')
+    diskRead.resolve({ data: 'stale external read' })
+    await reload
+
+    expect(applied).toEqual(['fresh selection read'])
+  })
+
+  it('uses a dirty watcher event to cancel an older clean read', async () => {
+    let requestId = 0
+    let editorContent = 'old content'
+    const diskRead = deferred<{ data: string }>()
+    const applyReload = vi.fn()
+    const readFile = vi.fn(() => diskRead.promise)
+    const options = {
+      path: 'knowledge/A.md',
+      getSelectedPath: () => 'knowledge/A.md',
+      getEditorPath: () => 'knowledge/A.md',
+      getEditorContent: () => editorContent,
+      getBaseline: () => 'old content',
+      getDocumentRevision: () => 0,
+      invalidateCache: vi.fn(),
+      beginRequest: () => ++requestId,
+      isCurrentRequest: (candidate: number) => candidate === requestId,
+      readFile,
+      getDiskEditorContent: (data: string) => data,
+      applyReload,
+      applyUnchangedReload: vi.fn(),
+      onReadError: vi.fn(),
+    }
+
+    const oldReload = reloadCleanActiveMarkdownAfterExternalChange(options)
+    editorContent = 'unsaved draft'
+    await reloadCleanActiveMarkdownAfterExternalChange(options)
+    diskRead.resolve({ data: 'stale external read' })
+    await oldReload
+
+    expect(requestId).toBe(2)
+    expect(readFile).toHaveBeenCalledOnce()
+    expect(applyReload).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/lib/active-markdown-external-change.ts
+++ b/apps/x/apps/renderer/src/lib/active-markdown-external-change.ts
@@ -1,0 +1,106 @@
+export interface ActiveMarkdownExternalChangeOptions {
+  path: string
+  getSelectedPath: () => string | null
+  getEditorPath: () => string | null
+  getEditorContent: () => string
+  getBaseline: () => string | undefined
+  getDocumentRevision: () => number
+  invalidateCache: () => void
+  beginRequest: () => number
+  isCurrentRequest: (requestId: number) => boolean
+  readFile: () => Promise<{ data: string }>
+  getDiskEditorContent: (data: string) => string
+  applyReload: (data: string) => void
+  applyUnchangedReload: (data: string) => void
+  onReadError: (error: unknown) => void
+}
+
+export interface StableExternalReadOptions<T> {
+  getExternalRevision: () => number
+  isCurrent: () => boolean
+  readFile: () => Promise<T>
+}
+
+/**
+ * Read a file for initial hydration, repeating the read when a workspace event
+ * arrives before the previous snapshot can be applied. This keeps the normal
+ * loader authoritative without losing changes reported while it is in flight.
+ */
+export async function readFileAfterExternalChangesSettle<T>(
+  options: StableExternalReadOptions<T>,
+): Promise<T | undefined> {
+  let observedRevision = options.getExternalRevision()
+
+  while (true) {
+    const result = await options.readFile()
+    if (!options.isCurrent()) return undefined
+
+    const latestRevision = options.getExternalRevision()
+    if (latestRevision === observedRevision) return result
+    observedRevision = latestRevision
+  }
+}
+
+/**
+ * Reload a clean active Markdown file after the workspace watcher reports an
+ * external change. Selection is checked again after the asynchronous read so
+ * a late response cannot overwrite whichever file the user switched to.
+ */
+export async function reloadCleanActiveMarkdownAfterExternalChange(
+  options: ActiveMarkdownExternalChangeOptions,
+): Promise<void> {
+  const {
+    path,
+    getSelectedPath,
+    getEditorPath,
+    getEditorContent,
+    getBaseline,
+    getDocumentRevision,
+    invalidateCache,
+    beginRequest,
+    isCurrentRequest,
+    readFile,
+    getDiskEditorContent,
+    applyReload,
+    applyUnchangedReload,
+    onReadError,
+  } = options
+
+  // Do not let a watcher take over hydration for a newly selected file. Until
+  // both the editor and its path-specific baseline belong to this path, the
+  // normal loader remains the sole owner of the read.
+  if (getSelectedPath() !== path || getEditorPath() !== path) return
+  const contentAtStart = getEditorContent()
+  const baselineAtStart = getBaseline()
+  if (baselineAtStart === undefined) return
+  const documentRevisionAtStart = getDocumentRevision()
+
+  // Every watcher event for a hydrated file advances the shared request
+  // generation, including events received while the editor is dirty. That
+  // makes a dirty event a cancellation barrier for any older read in flight.
+  const requestId = beginRequest()
+  if (contentAtStart !== baselineAtStart) return
+
+  invalidateCache()
+
+  let result: { data: string }
+  try {
+    result = await readFile()
+  } catch (error) {
+    onReadError(error)
+    return
+  }
+
+  if (!isCurrentRequest(requestId)) return
+  if (getSelectedPath() !== path) return
+  if (getEditorPath() !== path) return
+  if (getDocumentRevision() !== documentRevisionAtStart) return
+  if (getBaseline() !== baselineAtStart) return
+  if (getEditorContent() !== baselineAtStart) return
+
+  if (getDiskEditorContent(result.data) === contentAtStart) {
+    applyUnchangedReload(result.data)
+  } else {
+    applyReload(result.data)
+  }
+}


### PR DESCRIPTION
## Summary

- invalidate the active Markdown cache before an external-change read begins
- replace timestamp-based watcher suppression with request, path, editor, and document-revision guards
- repeat initial hydration reads when a workspace event arrives while an older snapshot is in flight
- preserve the editor and undo history when a local-write echo has unchanged Markdown content

## Why

The active-file watcher previously waited for an asynchronous read before updating the cache. Switching tabs during that window discarded the read but left stale cached content available when the file was reopened. The local-write timestamp heuristic could also suppress a coalesced external change without proving the event's origin.

The new flow invalidates cache synchronously, applies only reads that still own the selected hydrated document, and makes initial hydration observe file-event revisions so stale snapshots are retried. Dirty drafts, frontmatter-only edits, ABA state changes, and out-of-order responses are explicitly guarded.

## Validation

- `npm test` — 1,069 tests passed
- `npm run lint`
- `npm run typecheck`
- Electron Forge package smoke test for Darwin arm64

Fixes #434
