### PR TITLE
feat(x): navigate to people notes from the email thread view

### DIFF
--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -725,6 +725,35 @@
   line-height: 1.55;
 }
 
+/* People on the thread who have a knowledge note — one click to open it. */
+.gmail-thread-people {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.gmail-thread-person {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border: 1px solid var(--gm-border);
+  border-radius: 999px;
+  background: var(--gm-bg-pill);
+  color: var(--gm-text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.gmail-thread-person:hover {
+  background: var(--gm-bg-pill-hover);
+  color: var(--gm-text-strong);
+  border-color: var(--gm-border-strong);
+}
+
 .gmail-message-stack {
   display: flex;
   flex-direction: column;

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -5028,6 +5028,12 @@ function App() {
   const navigateToViewRef = useRef(navigateToView)
   useEffect(() => { navigateToViewRef.current = navigateToView }, [navigateToView])
 
+  // Stable across navigations (EmailView's memoized rows compare prop
+  // identity) — the email view's people-note chips navigate through the ref.
+  const openNoteFromEmail = useCallback((path: string) => {
+    void navigateToViewRef.current({ type: 'file', path })
+  }, [])
+
   useEffect(() => {
     const handle = (url: string) => {
       const view = parseDeepLink(url)
@@ -6657,7 +6663,7 @@ function App() {
                 </div>
               ) : isEmailOpen ? (
                 <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-                  <EmailView initialThreadId={emailInitialThreadId} threadIdVersion={emailThreadIdVersion} initialSearchQuery={emailInitialSearchQuery} searchQueryVersion={emailSearchQueryVersion} />
+                  <EmailView initialThreadId={emailInitialThreadId} threadIdVersion={emailThreadIdVersion} initialSearchQuery={emailInitialSearchQuery} searchQueryVersion={emailSearchQueryVersion} onOpenNote={openNoteFromEmail} />
                 </div>
               ) : isWorkspaceOpen ? (
                 <div className="flex-1 min-h-0 flex flex-col overflow-hidden">

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Archive, Bold, CheckCheck, Forward, Italic, Link as LinkIcon, List, ListOrdered, LoaderIcon, Mail, Paperclip, Quote, Redo2, RefreshCw, Reply, ReplyAll, Search, Send, SlidersHorizontal, Sparkles, SquarePen, Star, StarOff, Strikethrough, Trash2, Undo2, X } from 'lucide-react'
+import { Archive, Bold, BookUser, CheckCheck, Forward, Italic, Link as LinkIcon, List, ListOrdered, LoaderIcon, Mail, Paperclip, Quote, Redo2, RefreshCw, Reply, ReplyAll, Search, Send, SlidersHorizontal, Sparkles, SquarePen, Star, StarOff, Strikethrough, Trash2, Undo2, X } from 'lucide-react'
 import { useEditor, EditorContent, type Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
@@ -252,6 +252,44 @@ function dedupeRecipients(tokens: string[], exclude: Set<string>): string[] {
     if (!addr || seen.has(addr)) continue
     seen.add(addr)
     out.push(token)
+  }
+  return out
+}
+
+// A person on the thread who has a knowledge note. Mirrors the
+// `meeting-prep:resolve` IPC response (people only — orgs are ignored here).
+type ThreadPersonNote = {
+  label: string
+  path: string
+  role?: string
+  organization?: string
+}
+
+// Everyone on the thread (from/to/cc across all messages) as resolve-ready
+// attendees, deduped by address. `self` marks the connected account so the
+// resolver skips the user's own note.
+function collectThreadParticipants(thread: GmailThread, selfEmail: string): { email?: string; displayName?: string; self?: boolean }[] {
+  const seen = new Set<string>()
+  const out: { email?: string; displayName?: string; self?: boolean }[] = []
+  const self = selfEmail.trim().toLowerCase()
+  for (const message of thread.messages) {
+    const tokens = [
+      ...(message.from ? [message.from] : []),
+      ...splitAddresses(message.to),
+      ...splitAddresses(message.cc),
+    ]
+    for (const token of tokens) {
+      const address = extractAddress(token).trim()
+      const email = address.includes('@') ? address.toLowerCase() : ''
+      if (!email || seen.has(email)) continue
+      seen.add(email)
+      const named = token.match(/^\s*"?([^"<]+?)"?\s*<[^>]+>\s*$/)
+      out.push({
+        email,
+        displayName: named?.[1]?.trim() || undefined,
+        self: self !== '' && email === self,
+      })
+    }
   }
   return out
 }
@@ -2054,6 +2092,7 @@ function ThreadDetail({
   onComposingChange,
   onSetCategory,
   labels = BUILTIN_LABELS,
+  onOpenNote,
 }: {
   thread: GmailThread
   onClose: () => void
@@ -2066,9 +2105,15 @@ function ThreadDetail({
   onSetCategory?: (threadId: string, category: EmailCategory) => Promise<void>
   /** The label registry (built-ins + user-defined) for the chip and correction dropdown. */
   labels?: EmailLabelInfo[]
+  /** Opens a knowledge note (workspace-relative path); enables the people strip. */
+  onOpenNote?: (path: string) => void
 }) {
   const [composeMode, setComposeMode] = useState<ComposeMode | null>(null)
   const [selfEmail, setSelfEmail] = useState<string>('')
+  // null until gmail:getAccountEmail settles — the people lookup waits so the
+  // user's own note never flashes in as a chip.
+  const [selfEmailLoaded, setSelfEmailLoaded] = useState(false)
+  const [peopleNotes, setPeopleNotes] = useState<ThreadPersonNote[]>([])
   const [expandedIndices, setExpandedIndices] = useState<Set<number>>(
     () => new Set(thread.messages.length > 0 ? [thread.messages.length - 1] : [])
   )
@@ -2079,8 +2124,44 @@ function ThreadDetail({
     window.ipc.invoke('gmail:getAccountEmail', {})
       .then((res) => { if (!cancelled && res?.email) setSelfEmail(res.email) })
       .catch(() => {})
+      .finally(() => { if (!cancelled) setSelfEmailLoaded(true) })
     return () => { cancelled = true }
   }, [])
+
+  // Match everyone on the thread against the knowledge base (same deterministic
+  // email-then-name resolver the meeting prep card uses) so people with a note
+  // are one click away from it. Keyed on the participant signature, not the
+  // thread object — sync ticks swap thread identity without changing who's on it.
+  const participants = useMemo(() => collectThreadParticipants(thread, selfEmail), [thread, selfEmail])
+  const participantsKey = useMemo(
+    () => participants.map((p) => (p.self ? '!' : '') + p.email).join(','),
+    [participants],
+  )
+  const participantsRef = useRef(participants)
+  participantsRef.current = participants
+  useEffect(() => {
+    if (!onOpenNote || !selfEmailLoaded) return
+    const attendees = participantsRef.current
+    if (attendees.length === 0) {
+      setPeopleNotes([])
+      return
+    }
+    let cancelled = false
+    window.ipc.invoke('meeting-prep:resolve', { attendees })
+      .then((res) => {
+        if (cancelled) return
+        setPeopleNotes(res.attendees
+          .filter((a) => a.note != null)
+          .map((a) => ({
+            label: a.note!.name || a.label,
+            path: a.note!.path,
+            role: a.note!.role,
+            organization: a.note!.organization,
+          })))
+      })
+      .catch(() => { if (!cancelled) setPeopleNotes([]) })
+    return () => { cancelled = true }
+  }, [participantsKey, selfEmailLoaded, onOpenNote])
 
   const replyAllRecipients = useMemo(
     () => buildRecipients('replyAll', thread, selfEmail),
@@ -2183,6 +2264,22 @@ function ThreadDetail({
             <span className="gmail-thread-summary-text">{thread.summary}</span>
           </div>
         )}
+        {peopleNotes.length > 0 && onOpenNote && (
+          <div className="gmail-thread-people">
+            {peopleNotes.map((person) => (
+              <button
+                key={person.path}
+                type="button"
+                className="gmail-thread-person"
+                title={[person.role, person.organization].filter(Boolean).join(' · ') || 'Open note'}
+                onClick={() => onOpenNote(person.path)}
+              >
+                <BookUser size={13} />
+                {person.label}
+              </button>
+            ))}
+          </div>
+        )}
         <div className="gmail-message-stack">
           {thread.messages.map((message, index) => {
             const isExpanded = expandedIndices.has(index)
@@ -2275,6 +2372,7 @@ const ThreadRow = memo(function ThreadRow({
   onHoverOut,
   onCloseThread,
   onComposingChange,
+  onOpenNote,
 }: {
   thread: GmailThread
   isSelected: boolean
@@ -2299,6 +2397,8 @@ const ThreadRow = memo(function ThreadRow({
   onHoverOut: () => void
   onCloseThread: () => void
   onComposingChange: (composing: boolean) => void
+  /** Opens a knowledge note — forwarded to ThreadDetail's people strip. */
+  onOpenNote?: (path: string) => void
 }) {
   const latest = latestMessage(thread)
   const isUnread = thread.unread === true
@@ -2388,6 +2488,7 @@ const ThreadRow = memo(function ThreadRow({
           onComposingChange={onComposingChange}
           onSetCategory={onSetCategory}
           labels={labels}
+          onOpenNote={onOpenNote}
         />
       )}
     </div>
@@ -2596,9 +2697,12 @@ export type EmailViewProps = {
   initialSearchQuery?: string | null
   /** Bump to re-apply the same search query. */
   searchQueryVersion?: number
+  /** Opens a knowledge note (workspace-relative path) — enables the "people on
+   *  this email with a note" strip in the thread view. */
+  onOpenNote?: (path: string) => void
 }
 
-export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery, searchQueryVersion }: EmailViewProps = {}) {
+export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery, searchQueryVersion, onOpenNote }: EmailViewProps = {}) {
   const [important, setImportant] = useState<SectionState>(() => clearLoadingFlag(persistedImportant))
   const [other, setOther] = useState<SectionState>(() => clearLoadingFlag(persistedOther))
   const hadPersistedDataOnMount = useRef(persistedImportant !== null)
@@ -3529,6 +3633,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
         onHoverOut={cancelHoverPrefetch}
         onCloseThread={closeThread}
         onComposingChange={setActiveThreadComposing}
+        onOpenNote={onOpenNote}
       />
     )
   }


### PR DESCRIPTION
## Summary

For every person on an open email thread (from/to/cc across all messages), if a knowledge note exists for them, the thread view now shows a clickable pill that navigates straight to their note.

- Participants are matched against the knowledge base using the existing `meeting-prep:resolve` IPC — the same deterministic resolver the meeting-prep card uses (email-exact match first, then unambiguous name/alias match). No new matching logic, no LLM.
- Matched people render as a pill strip under the thread summary, with role · organization as the tooltip. Clicking navigates to the note through the normal view stack, so Back returns to the email.
- The connected account is excluded (no self-chip) and unmatched people are omitted, so threads with no known contacts show nothing.

## Implementation notes

- The lookup waits for `gmail:getAccountEmail` to settle so the user's own note never flashes in as a chip.
- The resolve effect is keyed on a participant signature rather than the thread object — the 30s inbox sync swaps thread identities without changing who's on the thread, and shouldn't re-run the IPC for every open detail.
- `EmailView` gets an optional `onOpenNote` prop; App passes a ref-stable callback (existing `navigateToViewRef` pattern) because `navigateToView` changes identity per navigation and the memoized thread rows compare props by identity.

## Test plan

- [ ] Open a thread whose sender has a People note → pill appears under the summary; click opens the note; Back returns to the email.
- [ ] Open a thread with multiple known participants (to/cc) → one pill per matched person, deduped.
- [ ] Newsletter / cold-outreach thread with no known contacts → no strip.
- [ ] Search-result threads show the strip too (same `ThreadRow` path).
- [ ] `npm run typecheck` and `npm run lint` pass (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)