### PR TITLE
fix(x): Gmail sync reliability — rate-limit retry, reconnect backfill, missed-reply recovery, watcher-safe purge

### DIFF
--- a/apps/x/packages/core/src/knowledge/agent_notes.ts
+++ b/apps/x/packages/core/src/knowledge/agent_notes.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import { google } from 'googleapis';
 import { WorkDir } from '../config/config.js';
 import { runWhenPossible } from '../runtime/assembly/headless-app.js';
 import { asRunModelOptions, getKgModel } from '../models/defaults.js';
@@ -201,7 +200,7 @@ async function ensureUserEmail(): Promise<string | null> {
     try {
         const auth = await GoogleClientFactory.getClient();
         if (auth) {
-            const gmail = google.gmail({ version: 'v1', auth });
+            const gmail = GoogleClientFactory.gmailClient(auth);
             const profile = await gmail.users.getProfile({ userId: 'me' });
             if (profile.data.emailAddress) {
                 updateUserEmail(profile.data.emailAddress);

--- a/apps/x/packages/core/src/knowledge/classify_thread.ts
+++ b/apps/x/packages/core/src/knowledge/classify_thread.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
-import { google } from 'googleapis';
 import type { OAuth2Client } from 'google-auth-library';
+import { GoogleClientFactory } from './google-client-factory.js';
 import { WorkDir } from '../config/config.js';
 import { createLanguageModel } from '../models/models.js';
 import { generateObjectSafe } from '../models/structured.js';
@@ -92,7 +92,7 @@ let cachedUserEmail: string | null = null;
 export async function getUserEmail(auth: OAuth2Client): Promise<string | null> {
     if (cachedUserEmail) return cachedUserEmail;
     try {
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         const res = await gmailClient.users.getProfile({ userId: 'me' });
         if (res.data.emailAddress) {
             cachedUserEmail = res.data.emailAddress.toLowerCase();

--- a/apps/x/packages/core/src/knowledge/email/store.ts
+++ b/apps/x/packages/core/src/knowledge/email/store.ts
@@ -524,9 +524,19 @@ export function listCategoryThreadIds(category: string): string[] {
  * cache. Outlook's delta state goes too so a reconnect starts with a full sync.
  */
 export function purgeEmailCaches(): void {
+    // Empty the cache directories IN PLACE rather than rm -rf'ing them:
+    // inbox_lists/ is a workspace-watcher root, and chokidar cannot re-attach
+    // to a watched root that is deleted and recreated — the email view would
+    // stop receiving live updates until app restart (stuck on the empty state
+    // while the reconnect sync refills the cache behind it). Per-entry deletes
+    // also emit change events, so the inbox clears — and later refills —
+    // without a manual refresh.
     for (const dir of [CACHE_DIR, SEARCH_CACHE_DIR, path.join(WorkDir, 'outlook_sync')]) {
         try {
-            fs.rmSync(dir, { recursive: true, force: true });
+            if (!fs.existsSync(dir)) continue;
+            for (const name of fs.readdirSync(dir)) {
+                fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+            }
         } catch (err) {
             console.warn(`[Email store] cache purge failed for ${dir}:`, err);
         }

--- a/apps/x/packages/core/src/knowledge/gmail_sent_contacts.ts
+++ b/apps/x/packages/core/src/knowledge/gmail_sent_contacts.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
-import { google, gmail_v1 as gmail } from 'googleapis';
+import { gmail_v1 as gmail } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
@@ -192,7 +192,7 @@ async function processInBatches<T>(items: T[], size: number, fn: (item: T) => Pr
 }
 
 async function fullSync(auth: OAuth2Client, selfEmail: string): Promise<{ map: Map<string, IndexEntry>; historyId: string | null }> {
-    const client = google.gmail({ version: 'v1', auth });
+    const client = GoogleClientFactory.gmailClient(auth);
 
     // Lock in the current historyId BEFORE we start listing, so any messages
     // sent during the sync get caught by the next incremental run.
@@ -231,7 +231,7 @@ async function incrementalSync(
     startHistoryId: string,
     map: Map<string, IndexEntry>,
 ): Promise<{ historyId: string | null; added: number } | null> {
-    const client = google.gmail({ version: 'v1', auth });
+    const client = GoogleClientFactory.gmailClient(auth);
     const added: string[] = [];
     let pageToken: string | undefined;
     let latestHistoryId: string | null = null;

--- a/apps/x/packages/core/src/knowledge/google-client-factory.ts
+++ b/apps/x/packages/core/src/knowledge/google-client-factory.ts
@@ -1,4 +1,5 @@
 import { OAuth2Client } from 'google-auth-library';
+import { google, gmail_v1, type Common } from 'googleapis';
 import container from '../di/container.js';
 import { IOAuthRepo } from '../auth/repo.js';
 import { IClientRegistrationRepo } from '../auth/client-repo.js';
@@ -13,6 +14,23 @@ import {
 } from '../auth/google-backend-oauth.js';
 
 type Mode = 'byok' | 'rowboat';
+
+const RATE_LIMIT_REASONS = new Set(['rateLimitExceeded', 'userRateLimitExceeded']);
+
+/** 429 anywhere, or Gmail's alternate 403-with-rate-limit-reason form. */
+function isRateLimitError(err: Common.GaxiosError): boolean {
+    const status = err.response?.status ?? err.status;
+    if (status === 429) return true;
+    if (status !== 403) return false;
+    const data = err.response?.data as { error?: { errors?: { reason?: string }[] } } | undefined;
+    return (data?.error?.errors ?? []).some((e) => e.reason !== undefined && RATE_LIMIT_REASONS.has(e.reason));
+}
+
+/** Retry-After in ms, capped at 30s; 2s when the header is absent/unparsable. */
+function rateLimitDelayMs(err: Common.GaxiosError): number {
+    const seconds = Number(err.response?.headers?.get('retry-after'));
+    return Number.isFinite(seconds) && seconds > 0 ? Math.min(seconds, 30) * 1000 : 2000;
+}
 
 /**
  * Factory for creating and managing Google OAuth2Client instances.
@@ -326,6 +344,32 @@ export class GoogleClientFactory {
         this.cache.clientId = clientId;
         this.cache.clientSecret = clientSecret ?? null;
         console.log('[OAuth] Google OAuth configuration initialized');
+    }
+
+    /**
+     * Gmail API client with rate-limit retry — parity with Outlook's
+     * graphFetch (outlook-client-factory.ts): one retry per request on a
+     * throttled response, waiting out Retry-After capped at 30s (2s when the
+     * header is absent). gaxios' stock retry can't express this — its delay
+     * formula never reads Retry-After, and its default method list excludes
+     * POST, which modify/trash/send all use — so both hooks are custom. A
+     * request still throttled after the retry fails like any other error.
+     */
+    static gmailClient(auth: OAuth2Client): gmail_v1.Gmail {
+        return google.gmail({
+            version: 'v1',
+            auth,
+            retryConfig: {
+                retry: 1,
+                shouldRetry: (err) =>
+                    (err.config.retryConfig?.currentRetryAttempt ?? 0) < 1 && isRateLimitError(err),
+                retryBackoff: (err) => {
+                    const waitMs = rateLimitDelayMs(err);
+                    console.warn(`[Gmail] rate limited — retrying after ${waitMs}ms`);
+                    return new Promise((resolve) => setTimeout(resolve, waitMs));
+                },
+            },
+        });
     }
 
     /** BYOK OAuth2Client — has client_id + secret + refresh_token. */

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -22,6 +22,7 @@ import {
     writeSearchSnapshot,
     mirrorThreadReadState,
     mirrorThreadDraft,
+    listCachedThreadIds,
     stampClassificationFrontmatter,
     notifyNewEmailThreads,
     publishEmailSyncEvent,
@@ -863,20 +864,63 @@ function shouldRunRecentBackfill(stateFile: string): boolean {
     return Date.now() - lastRunMs >= RECENT_BACKFILL_INTERVAL_MS;
 }
 
+/** Recent threads still carrying the INBOX label — the set the inbox cache
+ *  should contain for the lookback window. The date query matches messages,
+ *  so an old thread with a recent reply is included (unlike a bare
+ *  newest-N threads.list, which orders by thread creation). */
+async function listRecentInboxThreadIds(gmailClient: gmail.Gmail, lookbackDays: number): Promise<string[]> {
+    const dateQuery = recentDateQuery(lookbackDays);
+    const ids: string[] = [];
+    const seen = new Set<string>();
+    let pageToken: string | undefined;
+
+    do {
+        const res = await gmailClient.users.threads.list({
+            userId: 'me',
+            labelIds: ['INBOX'],
+            q: `after:${dateQuery}`,
+            maxResults: 500,
+            pageToken,
+        });
+        for (const thread of res.data.threads || []) {
+            if (!thread.id || seen.has(thread.id)) continue;
+            seen.add(thread.id);
+            ids.push(thread.id);
+        }
+        pageToken = res.data.nextPageToken ?? undefined;
+    } while (pageToken);
+
+    return ids;
+}
+
 async function backfillMissingRecentThreads(
     auth: OAuth2Client,
     syncDir: string,
     attachmentsDir: string,
     stateFile: string,
     lookbackDays: number,
+    opts: { force?: boolean } = {},
 ): Promise<SyncedThread[]> {
-    if (!shouldRunRecentBackfill(stateFile)) return [];
+    if (!opts.force && !shouldRunRecentBackfill(stateFile)) return [];
 
     const gmailClient = GoogleClientFactory.gmailClient(auth);
     const recentThreads = await listRecentNonDeletedThreadIds(gmailClient, lookbackDays);
-    const missingThreadIds = recentThreads
-        .map((thread) => thread.threadId)
-        .filter((threadId) => !fs.existsSync(path.join(syncDir, `${threadId}.md`)));
+    const missingThreadIds = new Set(
+        recentThreads
+            .map((thread) => thread.threadId)
+            .filter((threadId) => !fs.existsSync(path.join(syncDir, `${threadId}.md`))),
+    );
+
+    // A markdown mirror alone doesn't mean the thread is synced: disconnect
+    // wipes the inbox cache but keeps gmail_sync/, and a cache-rebuilding full
+    // sync misses old threads with new replies entirely. So a recent thread
+    // still in INBOX with no cache entry counts as missing too. Scoped to
+    // INBOX so archived threads (deliberately uncached — caching would
+    // resurrect them in the inbox UI) aren't re-processed every pass.
+    const cached = new Set(listCachedThreadIds());
+    for (const threadId of await listRecentInboxThreadIds(gmailClient, lookbackDays)) {
+        if (!cached.has(threadId)) missingThreadIds.add(threadId);
+    }
 
     const synced: SyncedThread[] = [];
     for (const threadId of missingThreadIds) {
@@ -884,11 +928,22 @@ async function backfillMissingRecentThreads(
         if (result) synced.push(result);
     }
 
-    const profile = await gmailClient.users.getProfile({ userId: 'me' });
-    saveState(profile.data.historyId!, stateFile, { last_recent_backfill: new Date().toISOString() });
+    // Advance the history watermark only on the timer-driven pass. A forced
+    // pass runs right after a full sync, whose deliberately-early historyId
+    // (captured before listing) must survive so the next partial sync replays
+    // anything that arrived while the full sync was processing.
+    if (opts.force) {
+        const state = loadState(stateFile);
+        if (state.historyId) {
+            saveState(state.historyId, stateFile, { last_recent_backfill: new Date().toISOString() });
+        }
+    } else {
+        const profile = await gmailClient.users.getProfile({ userId: 'me' });
+        saveState(profile.data.historyId!, stateFile, { last_recent_backfill: new Date().toISOString() });
+    }
 
-    if (missingThreadIds.length > 0) {
-        console.log(`Recent Gmail backfill synced ${synced.length}/${missingThreadIds.length} missing thread(s).`);
+    if (missingThreadIds.size > 0) {
+        console.log(`Recent Gmail backfill synced ${synced.length}/${missingThreadIds.size} missing thread(s).`);
     }
     return synced;
 }
@@ -1356,6 +1411,7 @@ async function performSync() {
         // which is count-bounded (the newest maxEmails threads).
         const gapMs = state.last_sync ? Date.now() - new Date(state.last_sync).getTime() : 0;
         const gapTooLarge = gapMs > LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+        let ranFullSync = true;
         if (!state.historyId) {
             console.log("No history ID found, starting full sync...");
             await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);
@@ -1373,6 +1429,19 @@ async function performSync() {
         } else {
             console.log("History ID found, starting partial sync...");
             await partialSync(auth, state.historyId, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);
+            ranFullSync = false;
+        }
+
+        // A full sync lists the newest N threads, but threads.list orders by
+        // thread CREATION date — an old thread whose latest reply arrived an
+        // hour ago is invisible to it. Run the recent-window backfill
+        // immediately (its date query matches messages, so it catches those)
+        // instead of waiting out the 15-minute timer.
+        if (ranFullSync) {
+            const backfilled = await backfillMissingRecentThreads(
+                auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS, { force: true },
+            );
+            await publishGmailSyncEvent(backfilled);
         }
 
         // Keep inbox_lists/ in lock-step with Gmail's INBOX label —

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { google, gmail_v1 as gmail } from 'googleapis';
+import { gmail_v1 as gmail } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
 import { getMaxEmails } from '../config/gmail_sync_config.js';
@@ -91,7 +91,7 @@ const RECENT_BACKFILL_INTERVAL_MS = 15 * 60 * 1000;
 async function getGmailClientOrThrow() {
     const auth = await GoogleClientFactory.getClient();
     if (!auth) throw new Error('Gmail is not connected.');
-    return google.gmail({ version: 'v1', auth });
+    return GoogleClientFactory.gmailClient(auth);
 }
 
 export async function archiveThread(threadId: string): Promise<ThreadActionResult> {
@@ -324,7 +324,7 @@ export async function listRecentThreadIds(daysAgo: number = 2): Promise<RecentTh
         throw new Error('Gmail is not connected.');
     }
 
-    const gmailClient = google.gmail({ version: 'v1', auth });
+    const gmailClient = GoogleClientFactory.gmailClient(auth);
     const since = new Date();
     since.setDate(since.getDate() - daysAgo);
     const dateQuery = since.toISOString().split('T')[0].replace(/-/g, '/');
@@ -641,7 +641,7 @@ export async function downloadAttachment(args: {
 // --- Sync Logic ---
 
 async function processThread(auth: OAuth2Client, threadId: string, syncDir: string, attachmentsDir: string): Promise<SyncedThread | null> {
-    const gmail = google.gmail({ version: 'v1', auth });
+    const gmail = GoogleClientFactory.gmailClient(auth);
     try {
         const res = await gmail.users.threads.get({ userId: 'me', id: threadId });
         const thread = res.data;
@@ -745,7 +745,7 @@ async function processThread(auth: OAuth2Client, threadId: string, syncDir: stri
 async function pruneInboxCache(auth: OAuth2Client): Promise<void> {
     if (!fs.existsSync(CACHE_DIR)) return;
     try {
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         const inInbox = new Set<string>();
         // threads.list returns a per-thread snippet for free — used below to
         // backfill `preview` on cache entries written before the field existed.
@@ -872,7 +872,7 @@ async function backfillMissingRecentThreads(
 ): Promise<SyncedThread[]> {
     if (!shouldRunRecentBackfill(stateFile)) return [];
 
-    const gmailClient = google.gmail({ version: 'v1', auth });
+    const gmailClient = GoogleClientFactory.gmailClient(auth);
     const recentThreads = await listRecentNonDeletedThreadIds(gmailClient, lookbackDays);
     const missingThreadIds = recentThreads
         .map((thread) => thread.threadId)
@@ -894,7 +894,7 @@ async function backfillMissingRecentThreads(
 }
 
 async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: string, stateFile: string, lookbackDays: number) {
-    const gmail = google.gmail({ version: 'v1', auth });
+    const gmail = GoogleClientFactory.gmailClient(auth);
 
     // The onboarding / recovery fetch is bounded by a COUNT of the most recent
     // threads (maxEmails, configurable — default 500), not by a fixed date
@@ -1032,7 +1032,7 @@ async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: str
 
 async function partialSync(auth: OAuth2Client, startHistoryId: string, syncDir: string, attachmentsDir: string, stateFile: string, lookbackDays: number) {
     console.log(`Checking updates since historyId ${startHistoryId}...`);
-    const gmail = google.gmail({ version: 'v1', auth });
+    const gmail = GoogleClientFactory.gmailClient(auth);
 
     let run: ServiceRunContext | null = null;
     const ensureRun = async () => {
@@ -1211,7 +1211,7 @@ async function sweepUnclassifiedMarkdown(auth: OAuth2Client, llmBudget: number =
     } catch {
         return;
     }
-    const gmailClient = google.gmail({ version: 'v1', auth });
+    const gmailClient = GoogleClientFactory.gmailClient(auth);
     let classified = 0;
     let stamped = 0;
     for (const name of names) {
@@ -1403,7 +1403,7 @@ export async function getAccountName(): Promise<string | null> {
     try {
         const auth = await GoogleClientFactory.getClient();
         if (!auth) return null;
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         const list = await gmailClient.users.messages.list({ userId: 'me', labelIds: ['SENT'], maxResults: 1 });
         const id = list.data.messages?.[0]?.id;
         if (!id) {
@@ -1651,7 +1651,7 @@ export async function sendThreadReply(opts: SendReplyOptions): Promise<SendReply
         const auth = await GoogleClientFactory.getClient();
         if (!auth) return { error: 'Gmail is not connected.' };
 
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         const userEmail = await getUserEmail(auth);
         if (!userEmail) return { error: 'Could not determine your Gmail address.' };
 
@@ -1712,7 +1712,7 @@ export async function saveThreadDraft(opts: SaveDraftOptions): Promise<SaveDraft
         const auth = await GoogleClientFactory.getClient();
         if (!auth) return { error: 'Gmail is not connected.' };
 
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         const userEmail = await getUserEmail(auth);
         if (!userEmail) return { error: 'Could not determine your Gmail address.' };
 
@@ -1781,7 +1781,7 @@ export async function deleteThreadDraft(draftId: string): Promise<{ ok: boolean;
         const auth = await GoogleClientFactory.getClient();
         if (!auth) return { ok: false, error: 'Gmail is not connected.' };
 
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         await gmailClient.users.drafts.delete({ userId: 'me', id: draftId });
         triggerSync();
         return { ok: true };
@@ -1877,7 +1877,7 @@ export async function listDraftThreads(): Promise<{ threads: EmailThreadSnapshot
             return { threads: [], error: 'Gmail is not connected.' };
         }
 
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         const list = await gmailClient.users.drafts.list({ userId: 'me', maxResults: 50 });
         const drafts = list.data.drafts || [];
 
@@ -1934,7 +1934,7 @@ export async function searchThreads(query: string, opts: { limit?: number } = {}
         const auth = await GoogleClientFactory.getClient();
         if (!auth) return { threads: [], error: 'Gmail is not connected.' };
 
-        const gmailClient = google.gmail({ version: 'v1', auth });
+        const gmailClient = GoogleClientFactory.gmailClient(auth);
         // Generous cap so the index isn't artificially small (Gmail allows 500).
         const limit = Math.max(1, Math.min(200, opts.limit ?? 100));
         const list = await gmailClient.users.threads.list({ userId: 'me', q, maxResults: limit });

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -893,7 +893,7 @@ async function backfillMissingRecentThreads(
     return synced;
 }
 
-async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: string, stateFile: string, lookbackDays: number) {
+async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: string, stateFile: string, lookbackDays: number, opts: { ignoreLastSync?: boolean } = {}) {
     const gmail = GoogleClientFactory.gmailClient(auth);
 
     // The onboarding / recovery fetch is bounded by a COUNT of the most recent
@@ -908,11 +908,17 @@ async function fullSync(auth: OAuth2Client, syncDir: string, attachmentsDir: str
     // With no resumable last_sync (first connect, or a gap longer than the
     // lookback window) we drop the date floor entirely and just take the newest
     // `maxEmails` threads.
+    //
+    // ignoreLastSync: the caller needs the whole window re-walked even though
+    // last_sync is recent — the cache-backfill case, where inbox_lists/ was
+    // wiped (disconnect) but sync_state.json survived. Resuming from last_sync
+    // there would only re-list mail newer than the wipe, so the old inbox
+    // would never come back.
     const maxEmails = getMaxEmails();
     const state = loadState(stateFile);
     const lookbackFloor = new Date();
     lookbackFloor.setDate(lookbackFloor.getDate() - lookbackDays);
-    const resumeFrom = state.last_sync && new Date(state.last_sync) > lookbackFloor
+    const resumeFrom = !opts.ignoreLastSync && state.last_sync && new Date(state.last_sync) > lookbackFloor
         ? new Date(state.last_sync)
         : null;
     if (resumeFrom) {
@@ -1354,8 +1360,13 @@ async function performSync() {
             console.log("No history ID found, starting full sync...");
             await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);
         } else if (cacheMissing) {
+            // ignoreLastSync: after a disconnect→reconnect, purgeEmailCaches()
+            // wiped inbox_lists/ but sync_state.json (inside gmail_sync/, kept
+            // as knowledge source material) survived with a recent last_sync.
+            // Resuming from it would only re-list brand-new mail, so the old
+            // inbox would never be backfilled.
             console.log("History ID present but inbox cache empty — running full sync to backfill snapshots...");
-            await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);
+            await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS, { ignoreLastSync: true });
         } else if (gapTooLarge) {
             console.log(`Last sync older than ${LOOKBACK_DAYS} days — running count-bounded full sync instead of partial sync...`);
             await fullSync(auth, SYNC_DIR, ATTACHMENTS_DIR, STATE_FILE, LOOKBACK_DAYS);


### PR DESCRIPTION
Three Gmail sync reliability fixes, found while debugging one user report ("after disconnect/reconnect my old emails are gone" → "and now today's are missing").

## 1. Retry Gmail API calls once on rate limit, honoring Retry-After

Parity with Outlook's `graphFetch` (outlook-client-factory.ts): every Gmail API call retries **once** on a throttled response, waiting out `Retry-After` capped at 30s (2s when absent), with a `[Gmail] rate limited — retrying after Xms` warning. Still-throttled requests fail like any other error — no infinite retries.

- New `GoogleClientFactory.gmailClient(auth)` carries the retry config; all 18 Gmail client creation sites (`sync_gmail.ts`, `classify_thread.ts`, `agent_notes.ts`, `gmail_sent_contacts.ts`) go through it.
- gaxios' stock retry can't express this: its delay formula never reads `Retry-After`, and its default method list excludes POST (`threads.modify`/trash/send). Custom `shouldRetry`/`retryBackoff` hooks.
- 403 with a `rateLimitExceeded`/`userRateLimitExceeded` reason counts the same as a 429.

## 2. Backfill the full inbox after disconnect/reconnect wipes the cache

`disconnectProvider`'s `purgeEmailCaches()` wipes `inbox_lists/` but keeps `gmail_sync/` — including `sync_state.json` with a recent `last_sync`. On reconnect, the cache-backfill full sync floored its query at `last_sync`, so only mail newer than the disconnect was re-listed and the old inbox never came back. `fullSync` now takes `ignoreLastSync`, passed by the cache-backfill branch.

## 3. Catch old threads with new replies that full sync misses

Gmail's `threads.list` orders by thread **creation** date, not last activity (verified empirically: a Sep-2024 thread with a reply from 8 hours ago was absent from the first 1500 results). So any full sync's "newest maxEmails threads" pull silently drops old conversations with fresh replies — exactly the user's most valuable threads. In the reported mailbox, 6 recent INBOX threads were missing, including an important investor conversation, while newsletters synced fine.

The 15-minute recent backfill should have healed this (its `after:` date query matches messages), but it skipped anything whose markdown mirror exists — and markdown survives the disconnect that wipes the inbox cache.

- `backfillMissingRecentThreads` now treats a recent thread as missing when its **inbox cache entry** is gone, not only its markdown. The cache check is scoped to INBOX-labeled threads so archived threads (deliberately uncached) aren't re-processed every pass.
- `performSync` runs the backfill immediately after any full sync (`force` bypasses the 15-minute timer). A forced pass preserves the full sync's deliberately-early history watermark instead of advancing it past unprocessed changes.

## 4. Keep the live-update watcher alive through disconnect

`purgeEmailCaches()` deleted `inbox_lists/` wholesale — but it's a workspace-watcher root, and chokidar can't re-attach to a watched root that's deleted and recreated. After a disconnect, the email view stopped receiving live updates until app restart: the reconnect full sync refilled the cache behind a UI stuck on "No email threads in your inbox cache yet" until a manual reload (observed live: 222 cached threads while the view claimed empty).

The purge now empties the cache directories **in place** (per-entry deletes) instead of removing them. The watcher root never disappears, and the per-entry events mean the inbox visibly clears on disconnect and streams back in during the reconnect sync — no manual refresh at either end. Verified against a scratch workdir: all three dirs survive with zero entries (nested subdirs included); contact state files still removed.

## Out of scope (follow-ups)

- Sync-status UI (last-synced time, "rate limited — retrying at HH:MM") — both failures above were invisible until the service logs were read.
- Cross-cycle rate-limit cooldown honoring Gmail's "Retry after <timestamp>" lockouts.
- Outlook's run-abort parity and Google Calendar/Drive retry coverage.

## Test plan

- [x] Rate limit: local-server harness — 429 + `Retry-After: 1` then 200 → one retry, honored wait, success; persistent 429 → exactly one retry, error surfaces.
- [x] Missed replies: read-only dry run of the new detection against the affected mailbox — finds all 6 missing INBOX threads, including the reported one.
- [ ] Disconnect Gmail → reconnect → inbox fully repopulates (old threads + old-threads-with-new-replies) on the next sync cycle.
- [x] `npm run deps`, `npm run typecheck`, `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
