### PR TITLE
fix(x): code-mode sign-in detection via engine probe, account identity in settings

### DIFF
--- a/apps/x/apps/main/package.json
+++ b/apps/x/apps/main/package.json
@@ -13,8 +13,8 @@
         "make": "electron-forge make"
     },
     "dependencies": {
-        "@agentclientprotocol/claude-agent-acp": "^0.55.0",
-        "@agentclientprotocol/codex-acp": "^1.1.0",
+        "@agentclientprotocol/claude-agent-acp": "^0.67.0",
+        "@agentclientprotocol/codex-acp": "^1.2.0",
         "@x/core": "workspace:*",
         "@x/shared": "workspace:*",
         "agent-slack": "0.9.3",

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -1157,6 +1157,14 @@ function NoteTaggingSettings({ dialogOpen }: { dialogOpen: boolean }) {
 
 // --- Code Mode Settings ---
 
+// Human label for the raw subscription tier the engine reports
+// (claude: "max" / "pro" / "enterprise"; codex: ChatGPT plan types like "go" / "plus").
+function formatPlan(agent: 'claude' | 'codex', plan: string | undefined): string | null {
+  if (!plan) return null
+  const cap = plan.charAt(0).toUpperCase() + plan.slice(1)
+  return agent === 'codex' ? `ChatGPT ${cap}` : cap
+}
+
 function AgentStatusRow({
   name,
   agent,
@@ -1177,50 +1185,70 @@ function AgentStatusRow({
 
   // Treat a just-enabled engine as installed even before the status refresh lands.
   const installed = (status?.installed ?? false) || enabledOptimistic.has(agent)
-  const ready = installed && status?.signedIn
+  const signedIn = status?.signedIn ?? false
+  const email = status?.account?.email
+  const plan = formatPlan(agent, status?.account?.plan)
   return (
-    <div className="rounded-md border px-3 py-2.5 flex items-center gap-3">
-      {agent === 'claude' ? (
-        <AnthropicIcon className="size-5 shrink-0" />
-      ) : (
-        <OpenAIIcon className="size-5 shrink-0" />
-      )}
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium">{name}</div>
-        <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-3">
-          <span className={cn("inline-flex items-center gap-1", installed ? "text-green-600" : "text-muted-foreground")}>
-            {installed ? <CheckCircle2 className="size-3" /> : <X className="size-3" />}
-            {installed ? 'Engine ready' : 'Not enabled'}
-          </span>
-          <span className={cn("inline-flex items-center gap-1", status?.signedIn ? "text-green-600" : "text-muted-foreground")}>
-            {status?.signedIn ? <CheckCircle2 className="size-3" /> : <X className="size-3" />}
-            Signed in
-          </span>
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {agent === 'claude' ? (
+            <AnthropicIcon className="size-4 shrink-0" />
+          ) : (
+            <OpenAIIcon className="size-4 shrink-0" />
+          )}
+          {name}
         </div>
-        {error && <div className="text-xs text-red-600 mt-1 break-words">{error}</div>}
+        {provisioning ? (
+          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground tabular-nums">
+            <Loader2 className="size-3 animate-spin" />
+            {prov?.pct != null ? `${prov.pct}%` : null}
+          </span>
+        ) : !installed ? (
+          <button
+            type="button"
+            onClick={enable}
+            className="rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:opacity-90"
+          >
+            Enable
+          </button>
+        ) : null}
       </div>
-      {provisioning ? (
-        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground shrink-0 tabular-nums">
-          <Loader2 className="size-3 animate-spin" />
-          {prov?.pct != null ? `${prov.pct}%` : null}
-        </span>
-      ) : ready ? (
-        <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium leading-none text-green-600">
-          Ready
-        </span>
-      ) : !installed ? (
-        <button
-          type="button"
-          onClick={enable}
-          className="rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 shrink-0"
-        >
-          Enable
-        </button>
-      ) : (
-        <span className="text-xs text-muted-foreground shrink-0">
-          Run <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">{signInCommand}</code>
-        </span>
-      )}
+      <div className="rounded-md border px-3 py-2.5 flex items-center gap-3 min-h-12">
+        {signedIn ? (
+          <>
+            <div className="size-7 shrink-0 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground uppercase">
+              {(email ?? name).charAt(0)}
+            </div>
+            <div className="flex-1 min-w-0 text-sm font-medium truncate">
+              {email ?? 'Signed in'}
+            </div>
+            {installed && (
+              <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium leading-none text-green-600 shrink-0">
+                Active
+              </span>
+            )}
+            {plan && (
+              <span className="rounded-full border px-2 py-0.5 text-[10px] font-medium leading-none text-muted-foreground shrink-0">
+                {plan}
+              </span>
+            )}
+          </>
+        ) : (
+          <div className="text-xs text-muted-foreground">
+            {installed ? (
+              <>
+                Not signed in — run{' '}
+                <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">{signInCommand}</code>{' '}
+                in your terminal, then Re-check.
+              </>
+            ) : (
+              'Not enabled — click Enable to download the engine.'
+            )}
+          </div>
+        )}
+      </div>
+      {error && <div className="text-xs text-red-600 break-words">{error}</div>}
     </div>
   )
 }

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -1188,67 +1188,60 @@ function AgentStatusRow({
   const signedIn = status?.signedIn ?? false
   const email = status?.account?.email
   const plan = formatPlan(agent, status?.account?.plan)
+  const active = installed && signedIn
   return (
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          {agent === 'claude' ? (
-            <AnthropicIcon className="size-4 shrink-0" />
-          ) : (
-            <OpenAIIcon className="size-4 shrink-0" />
+    <div className="flex items-center gap-3 rounded-md border px-3 py-2.5">
+      {agent === 'claude' ? (
+        <AnthropicIcon className="size-5 shrink-0" />
+      ) : (
+        <OpenAIIcon className="size-5 shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{name}</span>
+          {signedIn && plan && (
+            <span className="rounded-full border px-1.5 py-px text-[10px] font-medium leading-4 text-muted-foreground shrink-0">
+              {plan}
+            </span>
           )}
-          {name}
         </div>
-        {provisioning ? (
-          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground tabular-nums">
-            <Loader2 className="size-3 animate-spin" />
-            {prov?.pct != null ? `${prov.pct}%` : null}
-          </span>
-        ) : !installed ? (
-          <button
-            type="button"
-            onClick={enable}
-            className="rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:opacity-90"
-          >
-            Enable
-          </button>
-        ) : null}
-      </div>
-      <div className="rounded-md border px-3 py-2.5 flex items-center gap-3 min-h-12">
-        {signedIn ? (
-          <>
-            <div className="size-7 shrink-0 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-muted-foreground uppercase">
-              {(email ?? name).charAt(0)}
-            </div>
-            <div className="flex-1 min-w-0 text-sm font-medium truncate">
-              {email ?? 'Signed in'}
-            </div>
-            {installed && (
-              <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium leading-none text-green-600 shrink-0">
-                Active
-              </span>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+          <span
+            className={cn(
+              "size-2 rounded-full shrink-0",
+              active ? "bg-green-500" : installed ? "bg-amber-500" : "bg-muted-foreground/30",
             )}
-            {plan && (
-              <span className="rounded-full border px-2 py-0.5 text-[10px] font-medium leading-none text-muted-foreground shrink-0">
-                {plan}
-              </span>
-            )}
-          </>
-        ) : (
-          <div className="text-xs text-muted-foreground">
-            {installed ? (
+          />
+          <span className="truncate">
+            {provisioning ? (
+              'Downloading engine…'
+            ) : active ? (
+              <>Active{email ? ` · ${email}` : ''}</>
+            ) : installed ? (
               <>
-                Not signed in — run{' '}
+                Run{' '}
                 <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">{signInCommand}</code>{' '}
-                in your terminal, then Re-check.
+                in your terminal, then Re-check
               </>
+            ) : email ? (
+              `${email} · engine not enabled`
             ) : (
-              'Not enabled — click Enable to download the engine.'
+              'Not enabled'
             )}
-          </div>
-        )}
+          </span>
+        </div>
+        {error && <div className="text-xs text-destructive mt-1 break-words">{error}</div>}
       </div>
-      {error && <div className="text-xs text-red-600 break-words">{error}</div>}
+      {provisioning ? (
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground shrink-0 tabular-nums">
+          <Loader2 className="size-3 animate-spin" />
+          {prov?.pct != null ? `${prov.pct}%` : null}
+        </span>
+      ) : !installed ? (
+        <Button variant="outline" size="sm" onClick={enable} className="shrink-0">
+          Enable
+        </Button>
+      ) : null}
     </div>
   )
 }

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -1341,22 +1341,18 @@ function CodeModeSettings({ dialogOpen }: { dialogOpen: boolean }) {
     <div className="space-y-5">
       <div className="space-y-2 text-sm text-muted-foreground leading-relaxed">
         <p>
-          <strong className="text-foreground">Code mode</strong> lets the assistant delegate coding tasks
-          to <strong className="text-foreground">Claude Code</strong> or <strong className="text-foreground">Codex</strong> running
-          on your machine. Pick the agent inline from the composer; the assistant runs it on-device
-          and streams its work — tool calls, file diffs, and approvals — back into chat.
+          <strong className="text-foreground">Code mode</strong> lets the assistant hand coding tasks
+          to <strong className="text-foreground">Claude Code</strong> or <strong className="text-foreground">Codex</strong> on
+          your machine. Pick the agent in the composer, and everything it does — commands, file
+          changes, approvals — shows up in the chat.
         </p>
         <p>
-          Requires an active <strong className="text-foreground">Claude Code</strong> subscription or
-          a <strong className="text-foreground">ChatGPT/Codex</strong> subscription. You can have one or both.
-        </p>
-        <p>
-          For each agent you want to use, you must have it{' '}
-          <strong className="text-foreground">installed and logged in</strong> on this machine: click{' '}
-          <strong className="text-foreground">Enable</strong> below to download its engine, and sign in by
-          running <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">claude login</code>{' '}
+          To set up an agent, click <strong className="text-foreground">Enable</strong> below to download
+          it, then sign in by running{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">claude login</code>{' '}
           or <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground">codex login</code>{' '}
-          in your terminal. Code mode uses that saved login.
+          in your terminal. You need a <strong className="text-foreground">Claude</strong> or{' '}
+          <strong className="text-foreground">ChatGPT</strong> subscription — either one works, or both.
         </p>
       </div>
 

--- a/apps/x/apps/renderer/src/lib/code-mode-provisioning.ts
+++ b/apps/x/apps/renderer/src/lib/code-mode-provisioning.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 
-export type AgentStatus = { installed: boolean; signedIn: boolean }
+export type AgentAccount = { email?: string; plan?: string }
+export type AgentStatus = { installed: boolean; signedIn: boolean; account?: AgentAccount }
 export type CodeModeAgentStatus = { claude: AgentStatus; codex: AgentStatus }
 
 // Engine provisioning runs in the main process and keeps going even if the UI that

--- a/apps/x/packages/core/package.json
+++ b/apps/x/packages/core/package.json
@@ -14,9 +14,9 @@
     "inspect": "node dist/runtime/turns/inspect-cli.js"
   },
   "dependencies": {
-    "@agentclientprotocol/claude-agent-acp": "^0.55.0",
-    "@agentclientprotocol/codex-acp": "^1.1.0",
-    "@agentclientprotocol/sdk": "^1.1.0",
+    "@agentclientprotocol/claude-agent-acp": "^0.67.0",
+    "@agentclientprotocol/codex-acp": "^1.2.0",
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@ai-sdk/anthropic": "^4.0.12",
     "@ai-sdk/google": "^4.0.12",
     "@ai-sdk/openai": "^4.0.11",

--- a/apps/x/packages/core/src/code-mode/acp/engine-manifest.ts
+++ b/apps/x/packages/core/src/code-mode/acp/engine-manifest.ts
@@ -4,96 +4,96 @@
 
 export const ENGINE_MANIFEST = {
     "claude": {
-        "version": "0.3.198",
+        "version": "0.3.232",
         "platforms": {
             "darwin-arm64": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-darwin-arm64",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
-                "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.232.tgz",
+                "integrity": "sha512-+/4PX+dwmQAjlOlooocwa3kClulZfMo133xQH3LYDlK7D5bzze16lwlDGPVAYGEarpvXg7G5JK8QjfWAJ2HYbg=="
             },
             "darwin-x64": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-darwin-x64",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
-                "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.232.tgz",
+                "integrity": "sha512-EHZ1Y3aGyZ2mFZ6QLR1bM3/HiIn2cLrPjU+k3/oCIW6omJFodfzf410aWjDPSnMj7CE4d6t7MSjBWekMUbcv0g=="
             },
             "linux-x64": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-linux-x64",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
-                "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.232.tgz",
+                "integrity": "sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ=="
             },
             "linux-arm64": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-linux-arm64",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
-                "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.232.tgz",
+                "integrity": "sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw=="
             },
             "linux-x64-musl": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
-                "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.232.tgz",
+                "integrity": "sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q=="
             },
             "linux-arm64-musl": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
-                "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.232.tgz",
+                "integrity": "sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg=="
             },
             "win32-x64": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-win32-x64",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
-                "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.232.tgz",
+                "integrity": "sha512-Hc/9uy1BI9mqKVyB1b/zoUnm3MFgtVNzQY6p5zgaq9DaIjCKDpR4a4L1aDZM4lMqUcWFMZM+u7juOhh+m39NBQ=="
             },
             "win32-arm64": {
                 "pkg": "@anthropic-ai/claude-agent-sdk-win32-arm64",
-                "pkgVersion": "0.3.198",
-                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
-                "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ=="
+                "pkgVersion": "0.3.232",
+                "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.232.tgz",
+                "integrity": "sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw=="
             }
         }
     },
     "codex": {
-        "version": "0.142.5",
+        "version": "0.147.0",
         "platforms": {
             "darwin-arm64": {
                 "pkg": "@openai/codex",
-                "pkgVersion": "0.142.5-darwin-arm64",
-                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz",
-                "integrity": "sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA=="
+                "pkgVersion": "0.147.0-darwin-arm64",
+                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+                "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw=="
             },
             "darwin-x64": {
                 "pkg": "@openai/codex",
-                "pkgVersion": "0.142.5-darwin-x64",
-                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-x64.tgz",
-                "integrity": "sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg=="
+                "pkgVersion": "0.147.0-darwin-x64",
+                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+                "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw=="
             },
             "linux-x64": {
                 "pkg": "@openai/codex",
-                "pkgVersion": "0.142.5-linux-x64",
-                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-x64.tgz",
-                "integrity": "sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg=="
+                "pkgVersion": "0.147.0-linux-x64",
+                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+                "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw=="
             },
             "linux-arm64": {
                 "pkg": "@openai/codex",
-                "pkgVersion": "0.142.5-linux-arm64",
-                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-arm64.tgz",
-                "integrity": "sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA=="
+                "pkgVersion": "0.147.0-linux-arm64",
+                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+                "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg=="
             },
             "win32-x64": {
                 "pkg": "@openai/codex",
-                "pkgVersion": "0.142.5-win32-x64",
-                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-x64.tgz",
-                "integrity": "sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A=="
+                "pkgVersion": "0.147.0-win32-x64",
+                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+                "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA=="
             },
             "win32-arm64": {
                 "pkg": "@openai/codex",
-                "pkgVersion": "0.142.5-win32-arm64",
-                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-arm64.tgz",
-                "integrity": "sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ=="
+                "pkgVersion": "0.147.0-win32-arm64",
+                "tarball": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
+                "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA=="
             }
         }
     }

--- a/apps/x/packages/core/src/code-mode/status.ts
+++ b/apps/x/packages/core/src/code-mode/status.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
-import { CodeModeAgentStatus } from './types.js';
+import { AgentAccount, CodeModeAgentStatus } from './types.js';
 import { isEngineProvisioned, getProvisionedEnginePath } from './acp/engine-provisioner.js';
 import { decodeJwtPayload } from '../auth/jwt.js';
 
@@ -114,16 +114,25 @@ function execFailureDetails(err: unknown): { exitCode: number | null; killed: bo
     };
 }
 
+interface AgentAuthState {
+    signedIn: boolean;
+    account?: AgentAccount;
+}
+
 // Parse `claude auth status` output: a JSON object with a boolean `loggedIn`
-// (plus authMethod/email/subscriptionType we don't need here). Returns null if
-// the output doesn't contain that shape.
-function parseClaudeAuthStatus(stdout: string): boolean | null {
+// plus, when logged in, identity fields (email, subscriptionType, authMethod).
+// Returns null if the output doesn't contain that shape.
+function parseClaudeAuthStatus(stdout: string): AgentAuthState | null {
     const start = stdout.indexOf('{');
     const end = stdout.lastIndexOf('}');
     if (start < 0 || end <= start) return null;
     try {
         const parsed = JSON.parse(stdout.slice(start, end + 1)) as Record<string, unknown>;
-        return typeof parsed.loggedIn === 'boolean' ? parsed.loggedIn : null;
+        if (typeof parsed.loggedIn !== 'boolean') return null;
+        if (!parsed.loggedIn) return { signedIn: false };
+        const email = typeof parsed.email === 'string' ? parsed.email : undefined;
+        const plan = typeof parsed.subscriptionType === 'string' ? parsed.subscriptionType : undefined;
+        return { signedIn: true, account: email || plan ? { email, plan } : undefined };
     } catch {
         return null;
     }
@@ -136,7 +145,7 @@ function parseClaudeAuthStatus(stdout: string): boolean | null {
 // so we don't have to guess where they live. Returns null when the engine
 // isn't provisioned or the probe itself failed to run (spawn error, timeout);
 // the caller then falls back to the credential-file heuristic.
-async function checkClaudeSignedInViaEngine(): Promise<boolean | null> {
+async function checkClaudeSignedInViaEngine(): Promise<AgentAuthState | null> {
     if (!isEngineProvisioned('claude')) return null;
     const engine = getProvisionedEnginePath('claude');
     try {
@@ -148,25 +157,61 @@ async function checkClaudeSignedInViaEngine(): Promise<boolean | null> {
         const parsed = parseClaudeAuthStatus(stdout);
         if (parsed !== null) return parsed;
         // Ran to completion without status output — engine says it can't auth.
-        if (exitCode !== null) return false;
+        if (exitCode !== null) return { signedIn: false };
         return null;
+    }
+}
+
+// Best-effort account identity for the fallback path: Claude Code caches the
+// signed-in account (emailAddress etc.) in ~/.claude.json under `oauthAccount`.
+// The same approach OSS account switchers (claude-swap, CCSwitcher) use.
+async function readClaudeAccountFromConfig(): Promise<AgentAccount | undefined> {
+    try {
+        const raw = await fs.readFile(path.join(os.homedir(), '.claude.json'), 'utf-8');
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const acct = parsed.oauthAccount as Record<string, unknown> | undefined;
+        const email = typeof acct?.emailAddress === 'string' ? acct.emailAddress : undefined;
+        return email ? { email } : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+// Account identity for Codex: the id_token in ~/.codex/auth.json is a JWT whose
+// claims carry the email and the ChatGPT plan type ("plus", "go", "pro", …).
+// Decoded locally without verification — display only, never an auth decision.
+async function readCodexAccountFromAuthJson(): Promise<AgentAccount | undefined> {
+    try {
+        const raw = await fs.readFile(path.join(os.homedir(), '.codex', 'auth.json'), 'utf-8');
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const tokens = parsed.tokens as Record<string, unknown> | undefined;
+        const idToken = typeof tokens?.id_token === 'string' ? tokens.id_token : '';
+        const claims = idToken ? decodeJwtPayload(idToken) : null;
+        if (!claims) return undefined;
+        const email = typeof claims.email === 'string' ? claims.email : undefined;
+        const auth = claims['https://api.openai.com/auth'] as Record<string, unknown> | undefined;
+        const plan = typeof auth?.chatgpt_plan_type === 'string' ? auth.chatgpt_plan_type : undefined;
+        return email || plan ? { email, plan } : undefined;
+    } catch {
+        return undefined;
     }
 }
 
 // Ask the provisioned Codex engine whether it is signed in. `codex login status`
 // exits 0 when logged in and non-zero ("Not logged in") when not. Returns null
-// when the engine isn't provisioned or the probe didn't run.
-async function checkCodexSignedInViaEngine(): Promise<boolean | null> {
+// when the engine isn't provisioned or the probe didn't run. The status output
+// has no identity, so a signed-in result is enriched from auth.json separately.
+async function checkCodexSignedInViaEngine(): Promise<AgentAuthState | null> {
     if (!isEngineProvisioned('codex')) return null;
     const engine = getProvisionedEnginePath('codex');
     try {
         await execFileAsync(engine, ['login', 'status'], { timeout: ENGINE_PROBE_TIMEOUT_MS });
-        return true;
+        return { signedIn: true };
     } catch (err) {
         const { exitCode, killed } = execFailureDetails(err);
-        if (killed) return null;                 // timed out — engine state unknown
-        if (exitCode !== null) return false;     // ran and reported logged-out
-        return null;                             // spawn failure — fall back
+        if (killed) return null;                        // timed out — engine state unknown
+        if (exitCode !== null) return { signedIn: false }; // ran and reported logged-out
+        return null;                                    // spawn failure — fall back
     }
 }
 
@@ -224,19 +269,32 @@ async function checkCodexSignedInHeuristic(): Promise<boolean> {
     return false;
 }
 
-// Exported for diagnostics — silenced unused-var warning by re-export only.
-export { decodeJwtPayload };
+// Resolve one agent's auth state: the engine probe is authoritative when it
+// ran; otherwise fall back to the credential-file heuristic. A signed-in state
+// missing identity (heuristic path; codex always) is enriched best-effort from
+// the local account metadata.
+async function resolveAgentAuth(
+    viaEngine: Promise<AgentAuthState | null>,
+    heuristic: () => Promise<boolean>,
+    readAccount: () => Promise<AgentAccount | undefined>,
+): Promise<AgentAuthState> {
+    const state = (await viaEngine) ?? { signedIn: await heuristic() };
+    if (state.signedIn && !state.account) {
+        return { signedIn: true, account: await readAccount() };
+    }
+    return state;
+}
 
 export async function checkCodeModeAgentStatus(): Promise<CodeModeAgentStatus> {
-    const [claudeSignedIn, codexSignedIn] = await Promise.all([
-        checkClaudeSignedInViaEngine().then((viaEngine) => viaEngine ?? checkClaudeSignedInHeuristic()),
-        checkCodexSignedInViaEngine().then((viaEngine) => viaEngine ?? checkCodexSignedInHeuristic()),
+    const [claude, codex] = await Promise.all([
+        resolveAgentAuth(checkClaudeSignedInViaEngine(), checkClaudeSignedInHeuristic, readClaudeAccountFromConfig),
+        resolveAgentAuth(checkCodexSignedInViaEngine(), checkCodexSignedInHeuristic, readCodexAccountFromAuthJson),
     ]);
     // `installed` means the engine is provisioned (downloaded) locally — the user has
     // clicked Enable in Settings → Code Mode. We no longer look for a global claude/codex
     // CLI on PATH; code mode runs our own pinned engine from ~/.rowboat/engines.
     return {
-        claude: { installed: isEngineProvisioned('claude'), signedIn: claudeSignedIn },
-        codex: { installed: isEngineProvisioned('codex'), signedIn: codexSignedIn },
+        claude: { installed: isEngineProvisioned('claude'), signedIn: claude.signedIn, account: claude.account },
+        codex: { installed: isEngineProvisioned('codex'), signedIn: codex.signedIn, account: codex.account },
     };
 }

--- a/apps/x/packages/core/src/code-mode/status.ts
+++ b/apps/x/packages/core/src/code-mode/status.ts
@@ -1,13 +1,19 @@
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
 import { CodeModeAgentStatus } from './types.js';
-import { isEngineProvisioned } from './acp/engine-provisioner.js';
+import { isEngineProvisioned, getProvisionedEnginePath } from './acp/engine-provisioner.js';
 import { decodeJwtPayload } from '../auth/jwt.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+// Generous ceiling for the engine's auth-status probe: the engine is a bundled
+// node runtime with a noticeable cold start, and on macOS its first credential
+// read can block on a one-time Keychain authorization dialog.
+const ENGINE_PROBE_TIMEOUT_MS = 15_000;
 
 // Where claude.cmd / codex.cmd typically live when installed via npm/pnpm/yarn.
 // We scan these directly because Electron's spawned shell sometimes doesn't
@@ -94,10 +100,82 @@ async function readClaudeKeychainCredential(): Promise<string | null> {
     }
 }
 
-// Validates Claude Code auth. On macOS the credentials live in the login
-// Keychain; on Linux/Windows in ~/.claude/.credentials.json (or ~/.config
-// fallback). We check both so detection works across platforms.
-async function checkClaudeSignedIn(): Promise<boolean> {
+// On exec failure, promisified execFile rejects with the process's captured
+// stdout/stderr and exit info attached to the error — pull those back out.
+function execFailureDetails(err: unknown): { exitCode: number | null; killed: boolean; stdout: string; stderr: string } {
+    const e = err as { code?: unknown; killed?: boolean; stdout?: unknown; stderr?: unknown };
+    return {
+        // `code` is the numeric exit code when the process ran, or a string
+        // errno (e.g. 'ENOENT') when the spawn itself failed.
+        exitCode: typeof e.code === 'number' ? e.code : null,
+        killed: e.killed === true,
+        stdout: typeof e.stdout === 'string' ? e.stdout : '',
+        stderr: typeof e.stderr === 'string' ? e.stderr : '',
+    };
+}
+
+// Parse `claude auth status` output: a JSON object with a boolean `loggedIn`
+// (plus authMethod/email/subscriptionType we don't need here). Returns null if
+// the output doesn't contain that shape.
+function parseClaudeAuthStatus(stdout: string): boolean | null {
+    const start = stdout.indexOf('{');
+    const end = stdout.lastIndexOf('}');
+    if (start < 0 || end <= start) return null;
+    try {
+        const parsed = JSON.parse(stdout.slice(start, end + 1)) as Record<string, unknown>;
+        return typeof parsed.loggedIn === 'boolean' ? parsed.loggedIn : null;
+    } catch {
+        return null;
+    }
+}
+
+// Ask the provisioned Claude engine itself whether it is signed in
+// (`claude auth status` prints a JSON blob with `loggedIn`). This is ground
+// truth: the engine resolves credentials exactly the way a real code-mode
+// session will — macOS Keychain, CLAUDE_CONFIG_DIR, managed/enterprise auth —
+// so we don't have to guess where they live. Returns null when the engine
+// isn't provisioned or the probe itself failed to run (spawn error, timeout);
+// the caller then falls back to the credential-file heuristic.
+async function checkClaudeSignedInViaEngine(): Promise<boolean | null> {
+    if (!isEngineProvisioned('claude')) return null;
+    const engine = getProvisionedEnginePath('claude');
+    try {
+        const { stdout } = await execFileAsync(engine, ['auth', 'status'], { timeout: ENGINE_PROBE_TIMEOUT_MS });
+        return parseClaudeAuthStatus(stdout);
+    } catch (err) {
+        // A logged-out engine may exit non-zero but still print the status JSON.
+        const { exitCode, stdout } = execFailureDetails(err);
+        const parsed = parseClaudeAuthStatus(stdout);
+        if (parsed !== null) return parsed;
+        // Ran to completion without status output — engine says it can't auth.
+        if (exitCode !== null) return false;
+        return null;
+    }
+}
+
+// Ask the provisioned Codex engine whether it is signed in. `codex login status`
+// exits 0 when logged in and non-zero ("Not logged in") when not. Returns null
+// when the engine isn't provisioned or the probe didn't run.
+async function checkCodexSignedInViaEngine(): Promise<boolean | null> {
+    if (!isEngineProvisioned('codex')) return null;
+    const engine = getProvisionedEnginePath('codex');
+    try {
+        await execFileAsync(engine, ['login', 'status'], { timeout: ENGINE_PROBE_TIMEOUT_MS });
+        return true;
+    } catch (err) {
+        const { exitCode, killed } = execFailureDetails(err);
+        if (killed) return null;                 // timed out — engine state unknown
+        if (exitCode !== null) return false;     // ran and reported logged-out
+        return null;                             // spawn failure — fall back
+    }
+}
+
+// Fallback heuristic when the engine isn't available to ask: look for Claude
+// Code's credentials on disk. On macOS they live in the login Keychain; on
+// Linux/Windows in ~/.claude/.credentials.json (or ~/.config fallback). This
+// can false-negative (Keychain-only installs, CLAUDE_CONFIG_DIR, enterprise
+// apiKeyHelper setups) — the engine probe above is authoritative.
+async function checkClaudeSignedInHeuristic(): Promise<boolean> {
     const home = os.homedir();
     const candidates = [
         path.join(home, '.claude', '.credentials.json'),
@@ -119,11 +197,12 @@ async function checkClaudeSignedIn(): Promise<boolean> {
     return false;
 }
 
-// Validates Codex auth at ~/.codex/auth.json on all platforms.
-// Considered signed in if API key set, or a refresh_token / access_token
-// exists. id_token expiry is intentionally NOT used as a rejection signal —
-// id_tokens are short-lived (~1h) but refresh_tokens persist for weeks.
-async function checkCodexSignedIn(): Promise<boolean> {
+// Fallback heuristic when the engine isn't available to ask: Codex auth at
+// ~/.codex/auth.json on all platforms. Considered signed in if API key set,
+// or a refresh_token / access_token exists. id_token expiry is intentionally
+// NOT used as a rejection signal — id_tokens are short-lived (~1h) but
+// refresh_tokens persist for weeks.
+async function checkCodexSignedInHeuristic(): Promise<boolean> {
     const home = os.homedir();
     const full = path.join(home, '.codex', 'auth.json');
     try {
@@ -150,8 +229,8 @@ export { decodeJwtPayload };
 
 export async function checkCodeModeAgentStatus(): Promise<CodeModeAgentStatus> {
     const [claudeSignedIn, codexSignedIn] = await Promise.all([
-        checkClaudeSignedIn(),
-        checkCodexSignedIn(),
+        checkClaudeSignedInViaEngine().then((viaEngine) => viaEngine ?? checkClaudeSignedInHeuristic()),
+        checkCodexSignedInViaEngine().then((viaEngine) => viaEngine ?? checkCodexSignedInHeuristic()),
     ]);
     // `installed` means the engine is provisioned (downloaded) locally — the user has
     // clicked Enable in Settings → Code Mode. We no longer look for a global claude/codex

--- a/apps/x/packages/core/src/code-mode/types.ts
+++ b/apps/x/packages/core/src/code-mode/types.ts
@@ -9,9 +9,19 @@ export const CodeModeConfig = z.object({
 });
 export type CodeModeConfig = z.infer<typeof CodeModeConfig>;
 
+// Who is signed in, when detectable. `plan` is the raw subscription tier as
+// reported by the agent ("max", "pro", "enterprise" for Claude; ChatGPT plan
+// types like "plus" / "go" for Codex) — the UI formats it for display.
+export const AgentAccount = z.object({
+    email: z.string().optional(),
+    plan: z.string().optional(),
+});
+export type AgentAccount = z.infer<typeof AgentAccount>;
+
 export const AgentStatus = z.object({
     installed: z.boolean(),
     signedIn: z.boolean(),
+    account: AgentAccount.optional(),
 });
 export type AgentStatus = z.infer<typeof AgentStatus>;
 

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1532,8 +1532,18 @@ const ipcSchemas = {
   'codeMode:checkAgentStatus': {
     req: z.null(),
     res: z.object({
-      claude: z.object({ installed: z.boolean(), signedIn: z.boolean() }),
-      codex: z.object({ installed: z.boolean(), signedIn: z.boolean() }),
+      claude: z.object({
+        installed: z.boolean(),
+        signedIn: z.boolean(),
+        // Who is signed in, when detectable: email plus the subscription tier
+        // ("max", "pro", "enterprise" for Claude; "plus", "go", … for Codex).
+        account: z.object({ email: z.string().optional(), plan: z.string().optional() }).optional(),
+      }),
+      codex: z.object({
+        installed: z.boolean(),
+        signedIn: z.boolean(),
+        account: z.object({ email: z.string().optional(), plan: z.string().optional() }).optional(),
+      }),
     }),
   },
   // Download + install an agent's native engine (the Settings "Enable" action).

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    vitest:
+      specifier: 4.1.7
+      version: 4.1.7
+
 overrides:
   vscode-jsonrpc: 8.2.0
 
@@ -47,11 +53,11 @@ importers:
   apps/main:
     dependencies:
       '@agentclientprotocol/claude-agent-acp':
-        specifier: ^0.55.0
-        version: 0.55.0(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))
+        specifier: ^0.67.0
+        version: 0.67.0(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))
       '@agentclientprotocol/codex-acp':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       '@x/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -431,14 +437,14 @@ importers:
   packages/core:
     dependencies:
       '@agentclientprotocol/claude-agent-acp':
-        specifier: ^0.55.0
-        version: 0.55.0(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))
+        specifier: ^0.67.0
+        version: 0.67.0(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))
       '@agentclientprotocol/codex-acp':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       '@agentclientprotocol/sdk':
-        specifier: ^1.1.0
-        version: 1.1.0(zod@4.2.1)
+        specifier: ^1.3.0
+        version: 1.3.0(zod@4.2.1)
       '@ai-sdk/anthropic':
         specifier: ^4.0.12
         version: 4.0.12(zod@4.2.1)
@@ -594,17 +600,17 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@agentclientprotocol/claude-agent-acp@0.55.0':
-    resolution: {integrity: sha512-zZ4EpT6OppURh3lrTTvQR42+ggPi5Q42TC7Nig+Vt0RGBAmw73xAnM6W5BpdNRL7VcT/2aRndV0Z7fuGrruMGA==}
+  '@agentclientprotocol/claude-agent-acp@0.67.0':
+    resolution: {integrity: sha512-CVZ50H5Ez+i6Hpzlc15tkHEnFq1x+3vcMMS4SXo9YaL4meboSSOwUp9cluJczioIo8kHslV/y7FdURPD0juaMw==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@agentclientprotocol/codex-acp@1.1.0':
-    resolution: {integrity: sha512-EdUwW6n12yy4khxS6YpOgT8dd4JbVeOP8qPLdCEj795kp85qVI6369EWUXHq1CrnvOmGVwieUMvnrMlsqJaRWg==}
+  '@agentclientprotocol/codex-acp@1.2.0':
+    resolution: {integrity: sha512-nj23pM4OfaCOB5Du5rsSq0kcyki5H8D5ql96+AwIv7lnu0YEKj9R2YDsxbOKzwLlt+5QD6s0mn4Grkm7SSAUUA==}
     hasBin: true
 
-  '@agentclientprotocol/sdk@1.1.0':
-    resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -651,48 +657,52 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.198':
-    resolution: {integrity: sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
+    resolution: {integrity: sha512-+/4PX+dwmQAjlOlooocwa3kClulZfMo133xQH3LYDlK7D5bzze16lwlDGPVAYGEarpvXg7G5JK8QjfWAJ2HYbg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.198':
-    resolution: {integrity: sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232':
+    resolution: {integrity: sha512-EHZ1Y3aGyZ2mFZ6QLR1bM3/HiIn2cLrPjU+k3/oCIW6omJFodfzf410aWjDPSnMj7CE4d6t7MSjBWekMUbcv0g==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.198':
-    resolution: {integrity: sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232':
+    resolution: {integrity: sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.198':
-    resolution: {integrity: sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
+    resolution: {integrity: sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.198':
-    resolution: {integrity: sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
+    resolution: {integrity: sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.198':
-    resolution: {integrity: sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
+    resolution: {integrity: sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.198':
-    resolution: {integrity: sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
+    resolution: {integrity: sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.198':
-    resolution: {integrity: sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232':
+    resolution: {integrity: sha512-Hc/9uy1BI9mqKVyB1b/zoUnm3MFgtVNzQY6p5zgaq9DaIjCKDpR4a4L1aDZM4lMqUcWFMZM+u7juOhh+m39NBQ==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.198':
-    resolution: {integrity: sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.232':
+    resolution: {integrity: sha512-8od7hJk9fZnF1/oYYiR9PvroGbZRQrpmNgKirjHNGoj5ur5YcAZLohI70XVUAUe3KvjB1msLxtkvmlAT9sqFAg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -1313,7 +1323,7 @@ packages:
     engines: {node: '>=14'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -2153,30 +2163,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.80':
     resolution: {integrity: sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
     resolution: {integrity: sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.80':
     resolution: {integrity: sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.80':
     resolution: {integrity: sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.80':
     resolution: {integrity: sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==}
@@ -2316,43 +2331,43 @@ packages:
     resolution: {integrity: sha512-6gH/bLQJSJEg7OEpkH4wGQdA8KXHRbzL1YkGyUO12YNAgV3jxKy4K9kvfXj4+9T0OLug5k58cnPCKSSIKzp7pg==}
     engines: {node: '>=8.0'}
 
-  '@openai/codex@0.142.5':
-    resolution: {integrity: sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==}
+  '@openai/codex@0.147.0':
+    resolution: {integrity: sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.142.5-darwin-arm64':
-    resolution: {integrity: sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==}
+  '@openai/codex@0.147.0-darwin-arm64':
+    resolution: {integrity: sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.142.5-darwin-x64':
-    resolution: {integrity: sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==}
+  '@openai/codex@0.147.0-darwin-x64':
+    resolution: {integrity: sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.142.5-linux-arm64':
-    resolution: {integrity: sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==}
+  '@openai/codex@0.147.0-linux-arm64':
+    resolution: {integrity: sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.142.5-linux-x64':
-    resolution: {integrity: sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==}
+  '@openai/codex@0.147.0-linux-x64':
+    resolution: {integrity: sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.142.5-win32-arm64':
-    resolution: {integrity: sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==}
+  '@openai/codex@0.147.0-win32-arm64':
+    resolution: {integrity: sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.142.5-win32-x64':
-    resolution: {integrity: sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==}
+  '@openai/codex@0.147.0-win32-x64':
+    resolution: {integrity: sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4474,6 +4489,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -5103,6 +5119,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -9276,29 +9293,29 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@agentclientprotocol/claude-agent-acp@0.55.0(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))':
+  '@agentclientprotocol/claude-agent-acp@0.67.0(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))':
     dependencies:
-      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
-      '@anthropic-ai/claude-agent-sdk': 0.3.198(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))(zod@4.4.3)
+      '@agentclientprotocol/sdk': 1.3.0(zod@4.4.3)
+      '@anthropic-ai/claude-agent-sdk': 0.3.232(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@anthropic-ai/sdk'
       - '@modelcontextprotocol/sdk'
 
-  '@agentclientprotocol/codex-acp@1.1.0':
+  '@agentclientprotocol/codex-acp@1.2.0':
     dependencies:
-      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
-      '@openai/codex': 0.142.5
+      '@agentclientprotocol/sdk': 1.3.0(zod@4.4.3)
+      '@openai/codex': 0.147.0
       diff: 9.0.0
       open: 11.0.0
       vscode-jsonrpc: 8.2.0
       zod: 4.4.3
 
-  '@agentclientprotocol/sdk@1.1.0(zod@4.2.1)':
+  '@agentclientprotocol/sdk@1.3.0(zod@4.2.1)':
     dependencies:
       zod: 4.2.1
 
-  '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
@@ -9350,44 +9367,44 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.198':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.198(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.232(@anthropic-ai/sdk@0.100.1(zod@4.2.1))(@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.2.1))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.100.1(zod@4.2.1)
       '@modelcontextprotocol/sdk': 1.25.1(hono@4.11.3)(zod@4.2.1)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.198
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.198
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.232
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.232
 
   '@anthropic-ai/sdk@0.100.1(zod@4.2.1)':
     dependencies:
@@ -11679,31 +11696,31 @@ snapshots:
 
   '@oozcitak/util@8.3.4': {}
 
-  '@openai/codex@0.142.5':
+  '@openai/codex@0.147.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.142.5-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.142.5-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.142.5-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.142.5-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.142.5-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.142.5-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.147.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.147.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.147.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.147.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.147.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.147.0-win32-x64'
 
-  '@openai/codex@0.142.5-darwin-arm64':
+  '@openai/codex@0.147.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.142.5-darwin-x64':
+  '@openai/codex@0.147.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.142.5-linux-arm64':
+  '@openai/codex@0.147.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.142.5-linux-x64':
+  '@openai/codex@0.147.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.142.5-win32-arm64':
+  '@openai/codex@0.147.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.142.5-win32-x64':
+  '@openai/codex@0.147.0-win32-x64':
     optional: true
 
   '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.22(zod@4.2.1))(zod@4.2.1)':

--- a/apps/x/pnpm-workspace.yaml
+++ b/apps/x/pnpm-workspace.yaml
@@ -39,3 +39,15 @@ onlyBuiltDependencies:
   - fs-xattr
   - macos-alias
   - protobufjs
+
+minimumReleaseAgeExclude:
+  - '@agentclientprotocol/claude-agent-acp@0.67.0'
+  - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232'
+  - '@anthropic-ai/claude-agent-sdk@0.3.232'


### PR DESCRIPTION
## Problem

Reported by an enterprise Claude Code user: Settings → Code Mode showed the engine as ready but **"not signed in"**, and Re-check never changed it — even though `claude` worked fine in their terminal.

Detection guessed by grepping for credential files (`~/.claude/.credentials.json`, a 5s macOS Keychain read). Any setup that stores credentials elsewhere — Keychain-only installs, `CLAUDE_CODE_CONFIG_DIR`, enterprise managed auth / `apiKeyHelper` — false-negatived forever.

## Changes

- **Ask the engine instead of guessing** (`code-mode/status.ts`): probe the provisioned engines directly — `claude auth status` (JSON: `loggedIn`, email, subscription) and `codex login status` (exit code). The engine resolves credentials exactly the way a real session does, so the settings pill now matches reality. The old file/keychain heuristic survives only as a fallback when the engine isn't provisioned or the probe fails to spawn.
- **Engine + adapter bump**: claude-agent-acp 0.55.0 → 0.67.0 (engine 0.3.198 → 0.3.232), codex-acp 1.1.0 → 1.2.0 (engine 0.142.5 → 0.147.0), ACP SDK → 1.3.0; manifest regenerated.
- **Account identity in settings**: each agent row now shows who is signed in — email + plan chip (Max / ChatGPT Go). Claude identity from the auth-status JSON (fallback: `oauthAccount` in `~/.claude.json`); Codex from the `id_token` JWT claims in `~/.codex/auth.json`, decoded locally, display-only.
- **UI**: agent rows restyled to the provider-row idiom (status dot: green active / amber sign-in needed / gray not enabled); settings intro copy simplified.

## Verification

- `deps` / `typecheck` / `lint` clean
- Live: engines downloaded via `ensureEngine`, ACP `initialize` handshake OK on both new adapters, status probe returns correct signed-in state + identity for both agents; logged-out path tested with an empty `HOME`
- Existing users must click Enable once after this ships (new engine versions don't match the old provisioned ones)

## Out of scope (follow-ups)

- Routing assistant/chat models through a Claude subscription (new provider flavor — the reporter's second ask)
- Multi-account backup/swap and usage meters