### PR TITLE
fix(x): stop the inbox list from lurching upward during scroll

### DIFF
--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -2977,12 +2977,12 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
   // reload to be discarded whenever Other was reloaded in the same tick.)
   const epochsRef = useRef<Record<InboxSection, number>>({ important: 0, other: 0 })
 
-  const fetchSectionPage = useCallback(async (section: InboxSection, cursor?: string) => {
+  const fetchSectionPage = useCallback(async (section: InboxSection, cursor?: string, limit: number = PAGE_SIZE) => {
     const result = section === 'important'
-      ? await window.ipc.invoke('gmail:getImportant', { cursor, limit: PAGE_SIZE })
+      ? await window.ipc.invoke('gmail:getImportant', { cursor, limit })
       : await window.ipc.invoke('gmail:getEverythingElse', {
           cursor,
-          limit: PAGE_SIZE,
+          limit,
           category: otherCategoryRef.current ?? undefined,
         })
     // Counts describe the whole 'other' section regardless of filter/page —
@@ -3015,20 +3015,47 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
     }
   }, [important, other, setSection, fetchSectionPage])
 
+  // Section states mirrored into refs so reloadFirstPage can read the current
+  // pagination depth without depending on them (its identity must stay stable
+  // for the watcher effect).
+  const importantRef = useRef(important)
+  importantRef.current = important
+  const otherRef = useRef(other)
+  otherRef.current = other
+
   const reloadFirstPage = useCallback(async (section: InboxSection, options: { silent?: boolean } = {}) => {
     const epoch = ++epochsRef.current[section]
+    // A silent live reload must refresh the list AT ITS CURRENT DEPTH, not
+    // reset it to page 1: replacing a deep-scrolled list with one page
+    // shrinks the scroller, which clamps scrollTop — the list visibly lurches
+    // upward mid-scroll. (The watcher fires on any inbox_lists/ write —
+    // mark-read mirrors, body-height saves — not just new mail.) So walk
+    // pages until the previously-loaded depth is re-covered, then swap the
+    // array once.
+    const prevDepth = options.silent
+      ? (section === 'important' ? importantRef.current : otherRef.current).threads.length
+      : 0
     if (options.silent) {
       setSection(section, (prev) => ({ ...prev, loadingPage: true }))
     } else {
       setSection(section, () => ({ ...initialSectionState, loadingPage: true }))
     }
     try {
-      const result = await fetchSectionPage(section)
-      if (epoch !== epochsRef.current[section]) return
+      const threads: GmailThread[] = []
+      let nextCursor: string | null = null
+      let cursor: string | undefined
+      do {
+        const limit = Math.min(100, Math.max(PAGE_SIZE, prevDepth - threads.length))
+        const result = await fetchSectionPage(section, cursor, limit)
+        if (epoch !== epochsRef.current[section]) return
+        threads.push(...result.threads)
+        nextCursor = result.nextCursor
+        cursor = result.nextCursor ?? undefined
+      } while (cursor && threads.length < prevDepth)
       setSection(section, () => ({
-        threads: result.threads,
-        nextCursor: result.nextCursor,
-        hasReachedEnd: result.nextCursor === null,
+        threads,
+        nextCursor,
+        hasReachedEnd: nextCursor === null,
         loadingPage: false,
       }))
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes the email list "scrolls up a bit by itself" while scrolling.

**Root cause:** the live-update watcher silently reloads the visible inbox sections whenever anything in `inbox_lists/` changes — and cache writes happen for many reasons besides new mail (mark-read mirrors, message body-height persistence, classification updates). Each silent reload replaced the whole section with **page 1 only** (25 rows). With the list scrolled a few pages deep, the scroller's content collapsed, `scrollTop` clamped upward (the visible lurch), and the bottom pagination sentinel quietly re-fetched the dropped pages — so the cycle repeated as the user kept scrolling.

**Fix:** silent reloads now refresh the section **at its current pagination depth** — walking pages (each IPC request is capped at 100) until the previously-loaded count is re-covered, then swapping the threads array once. The scroller's height never shrinks mid-scroll, so the scroll position has nothing to clamp against. Bonus: live updates now refresh every loaded row instead of only the first 25.

User-initiated reloads (opening the view, changing the category filter) still reset to page 1, unchanged.

## Test plan

- [ ] Scroll several pages deep in Inbox, then mark a thread read / open and close a thread while continuing to scroll — previously the list lurched upward within ~3s; position should now hold.
- [ ] Live updates still land: with the list open, receive/classify new mail and confirm rows update in place.
- [ ] Category filter change and view reopen still load from the top as before.
- [x] `npm run typecheck` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)