### PR TITLE
feat(x): right-click context menus across the app

### DIFF
--- a/apps/x/apps/main/src/browser/view.ts
+++ b/apps/x/apps/main/src/browser/view.ts
@@ -9,6 +9,7 @@ import type {
   DisplayMediaRequest,
   HttpAuthRequest,
 } from '@x/shared/dist/browser-control.js';
+import { attachTextEditContextMenu } from '../context-menu.js';
 import { normalizeNavigationTarget } from './navigation.js';
 import {
   buildClickScript,
@@ -468,6 +469,9 @@ export class BrowserViewManager extends EventEmitter {
       invalidateAndEmit();
     });
     wc.on('page-title-updated', this.emitState.bind(this));
+
+    // Web pages in tabs get the standard edit/selection/link right-click menu.
+    attachTextEditContextMenu(wc);
 
     this.wireWindowPolicy(wc);
   }

--- a/apps/x/apps/main/src/context-menu.ts
+++ b/apps/x/apps/main/src/context-menu.ts
@@ -1,0 +1,56 @@
+import { BrowserWindow, clipboard, Menu, type MenuItemConstructorOptions, type WebContents } from "electron";
+
+/**
+ * Native right-click menu for text editing and selections.
+ *
+ * Electron shows no context menu by default, so without this, right-clicking
+ * an input, the note editor, or selected text does nothing. The renderer's
+ * in-DOM Radix menus call preventDefault() on contextmenu, which suppresses
+ * this event entirely — so the two never fight: DOM menus win wherever they
+ * exist, and this handler covers everything they don't (cut/copy/paste,
+ * spellcheck suggestions, link copying).
+ */
+export function attachTextEditContextMenu(wc: WebContents): void {
+  wc.on("context-menu", (_event, params) => {
+    const template: MenuItemConstructorOptions[] = [];
+
+    if (params.misspelledWord) {
+      for (const suggestion of params.dictionarySuggestions.slice(0, 5)) {
+        template.push({
+          label: suggestion,
+          click: () => wc.replaceMisspelling(suggestion),
+        });
+      }
+      template.push({
+        label: "Add to Dictionary",
+        click: () => wc.session.addWordToSpellCheckerDictionary(params.misspelledWord),
+      });
+      template.push({ type: "separator" });
+    }
+
+    if (params.isEditable) {
+      template.push(
+        { role: "cut", enabled: params.editFlags.canCut },
+        { role: "copy", enabled: params.editFlags.canCopy },
+        { role: "paste", enabled: params.editFlags.canPaste },
+        { type: "separator" },
+        { role: "selectAll", enabled: params.editFlags.canSelectAll },
+      );
+    } else if (params.selectionText.trim()) {
+      template.push({ role: "copy" });
+    }
+
+    if (params.linkURL) {
+      if (template.length > 0) template.push({ type: "separator" });
+      template.push({
+        label: "Copy Link Address",
+        click: () => clipboard.writeText(params.linkURL),
+      });
+    }
+
+    if (template.length === 0) return;
+    Menu.buildFromTemplate(template).popup({
+      window: BrowserWindow.fromWebContents(wc) ?? undefined,
+    });
+  });
+}

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -17,6 +17,7 @@ import {
   stopWorkspaceWatcher
 } from "./ipc.js";
 import { disposeAllTerminals } from "./terminal.js";
+import { attachTextEditContextMenu } from "./context-menu.js";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname } from "node:path";
 import { initUpdater } from "./updater.js";
@@ -468,6 +469,10 @@ function createWindow(options: { startHidden?: boolean } = {}) {
 
   // Cmd/Ctrl + (+ / − / 0) zoom shortcuts for the renderer UI.
   setupZoomShortcuts(win);
+
+  // Native cut/copy/paste + spellcheck menu for inputs, the note editor, and
+  // text selections (the in-DOM Radix menus suppress this event where they apply).
+  attachTextEditContextMenu(win.webContents);
 
   if (app.isPackaged) {
     win.loadURL("app://-/index.html");

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -30,6 +30,7 @@
  * opens/folds), like the old popout window.
  */
 import { DEV_SERVER_URL } from './dev-server.js';
+import { attachTextEditContextMenu } from './context-menu.js';
 import { app, BrowserWindow, globalShortcut, screen } from 'electron';
 import { loadAppSettings, saveAppSettings } from '@x/core/dist/config/app_settings.js';
 import { quickAskShortcut } from '@x/shared';
@@ -241,6 +242,8 @@ function createWindow(): BrowserWindow {
   win.on('closed', () => {
     if (quickAskWin === win) quickAskWin = null;
   });
+  // Native cut/copy/paste menu for the composer input.
+  attachTextEditContextMenu(win.webContents);
   // Zoom factor resets on navigation — apply it once the page is in, and
   // replay the state the renderer needs to pick up where things stand.
   win.webContents.on('did-finish-load', () => {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -6621,6 +6621,7 @@ function App() {
                     onTakeMeetingNotes={() => { void handleToggleMeeting() }}
                     meetingState={meetingTranscription.state}
                     meetingSummarizing={meetingSummarizing}
+                    actions={knowledgeActions}
                   />
                 </div>
               ) : isCodeOpen ? (

--- a/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -86,8 +86,14 @@ const getActiveTab = (state: BrowserState) =>
   state.tabs.find((tab) => tab.id === state.activeTabId) ?? null
 
 const isVisibleOverlayElement = (el: HTMLElement) => {
+  // Opacity is deliberately NOT checked: Radix overlays animate in from
+  // opacity 0, and this check runs on the mount frame (all the portal's
+  // mutations coalesce into one rAF, and the CSS animation itself fires no
+  // further mutations) — an opacity test would classify an opening menu as
+  // absent and leave the native view painting over it. Closing overlays are
+  // already excluded by the [data-state="open"] query.
   const style = window.getComputedStyle(el)
-  if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+  if (style.display === 'none' || style.visibility === 'hidden') {
     return false
   }
   const rect = el.getBoundingClientRect()

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Archive, Bold, BookUser, CheckCheck, Forward, Italic, Link as LinkIcon, List, ListOrdered, LoaderIcon, Mail, Paperclip, Quote, Redo2, RefreshCw, Reply, ReplyAll, Search, Send, SlidersHorizontal, Sparkles, SquarePen, Star, StarOff, Strikethrough, Trash2, Undo2, X } from 'lucide-react'
+import { Archive, Bold, BookUser, CheckCheck, Forward, Italic, Link as LinkIcon, List, ListOrdered, LoaderIcon, Mail, MailOpen, Paperclip, Quote, Redo2, RefreshCw, Reply, ReplyAll, Search, Send, SlidersHorizontal, Sparkles, SquarePen, Star, StarOff, Strikethrough, Trash2, Undo2, X } from 'lucide-react'
 import { useEditor, EditorContent, type Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
@@ -21,6 +21,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 
 type GmailThread = blocks.GmailThread
 type GmailThreadMessage = blocks.GmailThreadMessage
@@ -2415,68 +2422,97 @@ const ThreadRow = memo(function ThreadRow({
   }
   return (
     <div className={cn('gmail-row-group', !isMounted && 'gmail-row-group-cv', isLeaving && 'gmail-row-group-leaving')}>
-      <div
-        className={cn('gmail-row-shell', isSelected && 'gmail-row-shell-selected')}
-        data-thread-id={thread.threadId}
-        onMouseEnter={() => onHoverIn(thread)}
-        onMouseLeave={onHoverOut}
-      >
-        <button
-          type="button"
-          className={cn('gmail-row', isSelected && 'gmail-row-selected', isUnread && 'gmail-row-unread', isFocused && 'gmail-row-focused')}
-          onClick={() => onToggle(thread)}
-        >
-          <span className="gmail-row-dot" aria-hidden />
-          <span className="gmail-row-sender">{extractName(latest?.from || thread.from)}</span>
-          <span className="gmail-row-content">
-            <strong>{thread.summary || thread.subject || '(No subject)'}</strong>
-            <span>{thread.summary ? thread.subject : snippet(thread.preview || latest?.body || thread.latest_email)}</span>
-            {categoryChip && <span className="gmail-row-chip">{categoryChip}</span>}
-            {chip && <span className={cn('gmail-row-chip', chipWaiting ? 'gmail-row-chip-waiting' : 'gmail-row-chip-ready')}>{chip}</span>}
-          </span>
-          <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
-        </button>
-        <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
-          {section && (
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            className={cn('gmail-row-shell', isSelected && 'gmail-row-shell-selected')}
+            data-thread-id={thread.threadId}
+            onMouseEnter={() => onHoverIn(thread)}
+            onMouseLeave={onHoverOut}
+          >
             <button
               type="button"
-              className="gmail-row-action"
-              title={section === 'important' ? 'Not important — teach the classifier' : 'Important — teach the classifier'}
-              aria-label={section === 'important' ? 'Mark as not important' : 'Mark as important'}
-              onClick={(e) => { stop(e); void onSetImportance(thread.threadId, section === 'important' ? 'other' : 'important') }}
+              className={cn('gmail-row', isSelected && 'gmail-row-selected', isUnread && 'gmail-row-unread', isFocused && 'gmail-row-focused')}
+              onClick={() => onToggle(thread)}
             >
-              {section === 'important' ? <StarOff size={15} /> : <Star size={15} />}
+              <span className="gmail-row-dot" aria-hidden />
+              <span className="gmail-row-sender">{extractName(latest?.from || thread.from)}</span>
+              <span className="gmail-row-content">
+                <strong>{thread.summary || thread.subject || '(No subject)'}</strong>
+                <span>{thread.summary ? thread.subject : snippet(thread.preview || latest?.body || thread.latest_email)}</span>
+                {categoryChip && <span className="gmail-row-chip">{categoryChip}</span>}
+                {chip && <span className={cn('gmail-row-chip', chipWaiting ? 'gmail-row-chip-waiting' : 'gmail-row-chip-ready')}>{chip}</span>}
+              </span>
+              <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
             </button>
+            <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
+              {section && (
+                <button
+                  type="button"
+                  className="gmail-row-action"
+                  title={section === 'important' ? 'Not important — teach the classifier' : 'Important — teach the classifier'}
+                  aria-label={section === 'important' ? 'Mark as not important' : 'Mark as important'}
+                  onClick={(e) => { stop(e); void onSetImportance(thread.threadId, section === 'important' ? 'other' : 'important') }}
+                >
+                  {section === 'important' ? <StarOff size={15} /> : <Star size={15} />}
+                </button>
+              )}
+              <button
+                type="button"
+                className="gmail-row-action"
+                title={isUnread ? 'Mark as read' : 'Mark as unread'}
+                aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
+                onClick={(e) => { stop(e); void onMarkRead(thread.threadId, isUnread) }}
+              >
+                {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
+              </button>
+              <button
+                type="button"
+                className="gmail-row-action"
+                title="Archive"
+                aria-label="Archive"
+                onClick={(e) => { stop(e); void onArchive(thread.threadId) }}
+              >
+                <Archive size={15} />
+              </button>
+              <button
+                type="button"
+                className="gmail-row-action gmail-row-action-danger"
+                title="Delete"
+                aria-label="Delete"
+                onClick={(e) => { stop(e); void onTrash(thread.threadId) }}
+              >
+                <Trash2 size={15} />
+              </button>
+            </div>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-56">
+          <ContextMenuItem onClick={() => onToggle(thread)}>
+            {isSelected ? <X className="mr-2 size-4" /> : <MailOpen className="mr-2 size-4" />}
+            {isSelected ? 'Close thread' : 'Open thread'}
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => void onMarkRead(thread.threadId, isUnread)}>
+            {isUnread ? <CheckCheck className="mr-2 size-4" /> : <Mail className="mr-2 size-4" />}
+            {isUnread ? 'Mark as read' : 'Mark as unread'}
+          </ContextMenuItem>
+          {section && (
+            <ContextMenuItem onClick={() => void onSetImportance(thread.threadId, section === 'important' ? 'other' : 'important')}>
+              {section === 'important' ? <StarOff className="mr-2 size-4" /> : <Star className="mr-2 size-4" />}
+              {section === 'important' ? 'Mark as not important' : 'Mark as important'}
+            </ContextMenuItem>
           )}
-          <button
-            type="button"
-            className="gmail-row-action"
-            title={isUnread ? 'Mark as read' : 'Mark as unread'}
-            aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
-            onClick={(e) => { stop(e); void onMarkRead(thread.threadId, isUnread) }}
-          >
-            {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
-          </button>
-          <button
-            type="button"
-            className="gmail-row-action"
-            title="Archive"
-            aria-label="Archive"
-            onClick={(e) => { stop(e); void onArchive(thread.threadId) }}
-          >
-            <Archive size={15} />
-          </button>
-          <button
-            type="button"
-            className="gmail-row-action gmail-row-action-danger"
-            title="Delete"
-            aria-label="Delete"
-            onClick={(e) => { stop(e); void onTrash(thread.threadId) }}
-          >
-            <Trash2 size={15} />
-          </button>
-        </div>
-      </div>
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => void onArchive(thread.threadId)}>
+            <Archive className="mr-2 size-4" />
+            Archive
+          </ContextMenuItem>
+          <ContextMenuItem variant="destructive" onClick={() => void onTrash(thread.threadId)}>
+            <Trash2 className="mr-2 size-4" />
+            Delete
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
       {/* Drop the detail as soon as the row starts leaving — the collapse
           keyframe assumes row height, and the thread is being removed anyway. */}
       {isMounted && !isLeaving && (

--- a/apps/x/apps/renderer/src/components/live-notes-view.tsx
+++ b/apps/x/apps/renderer/src/components/live-notes-view.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Radio, Loader2, Square, AlertCircle } from 'lucide-react'
+import { Radio, Loader2, Square, AlertCircle, FileText, Pause, Play } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { stripKnowledgePrefix, wikiLabel } from '@/lib/wiki-links'
 import { toast } from '@/lib/toast'
 import { formatRelativeTime } from '@/lib/relative-time'
@@ -254,87 +261,115 @@ export function LiveNotesView({ onOpenNote, onAddNewLiveNote }: LiveNotesViewPro
                   const objectivePreview = note.objective.split('\n')[0].trim()
                   const hasError = !isRunning && !!note.lastRunError
                   return (
-                    <tr
-                      key={note.path}
-                      className={`border-b border-border/50 last:border-b-0 transition-colors ${isRunning ? 'bg-primary/5' : 'hover:bg-muted/20'}`}
-                    >
-                      <td className="px-4 py-3 align-top">
-                        <div className="flex min-w-0 flex-col gap-1">
-                          <div className="flex items-center gap-1.5">
-                            {hasError && (
-                              <AlertCircle
-                                className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
-                                aria-label="Last run failed"
-                              >
-                                <title>Last run failed: {note.lastRunError}</title>
-                              </AlertCircle>
-                            )}
-                            <button
-                              type="button"
-                              onClick={() => onOpenNote(note.path)}
-                              className="truncate text-left text-sm font-medium text-foreground hover:text-primary"
-                              title={note.path}
-                            >
-                              {wikiLabel(note.path)}
-                            </button>
-                          </div>
-                          <div className="truncate text-xs text-muted-foreground">
-                            {stripKnowledgePrefix(note.path)}
-                          </div>
-                          {objectivePreview && (
-                            <div className="truncate text-xs text-muted-foreground/80" title={note.objective}>
-                              {objectivePreview}
+                    <ContextMenu key={note.path}>
+                      <ContextMenuTrigger asChild>
+                        <tr
+                          className={`border-b border-border/50 last:border-b-0 transition-colors ${isRunning ? 'bg-primary/5' : 'hover:bg-muted/20'}`}
+                        >
+                          <td className="px-4 py-3 align-top">
+                            <div className="flex min-w-0 flex-col gap-1">
+                              <div className="flex items-center gap-1.5">
+                                {hasError && (
+                                  <AlertCircle
+                                    className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+                                    aria-label="Last run failed"
+                                  >
+                                    <title>Last run failed: {note.lastRunError}</title>
+                                  </AlertCircle>
+                                )}
+                                <button
+                                  type="button"
+                                  onClick={() => onOpenNote(note.path)}
+                                  className="truncate text-left text-sm font-medium text-foreground hover:text-primary"
+                                  title={note.path}
+                                >
+                                  {wikiLabel(note.path)}
+                                </button>
+                              </div>
+                              <div className="truncate text-xs text-muted-foreground">
+                                {stripKnowledgePrefix(note.path)}
+                              </div>
+                              {objectivePreview && (
+                                <div className="truncate text-xs text-muted-foreground/80" title={note.objective}>
+                                  {objectivePreview}
+                                </div>
+                              )}
+                              {hasError && note.lastRunError && (
+                                <div className="truncate text-xs text-amber-600 dark:text-amber-400" title={note.lastRunError}>
+                                  {note.lastRunError}
+                                </div>
+                              )}
                             </div>
-                          )}
-                          {hasError && note.lastRunError && (
-                            <div className="truncate text-xs text-amber-600 dark:text-amber-400" title={note.lastRunError}>
-                              {note.lastRunError}
-                            </div>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-sm text-foreground/80">
-                        {formatDateLabel(note.createdAt)}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-foreground/80">
-                        {formatLastRanLabel(note.lastRunAt)}
-                      </td>
-                      <td className="px-4 py-3">
-                        {isRunning ? (
-                          <div className="flex items-center gap-2">
-                            <span className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-foreground animate-pulse">
-                              <Loader2 className="size-3 animate-spin" />
-                              Updating…
-                            </span>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => handleStop(note)}
-                              disabled={isStopping}
-                            >
-                              {isStopping ? <Loader2 className="size-3 animate-spin" /> : <Square className="size-3" />}
-                              Stop
-                            </Button>
-                          </div>
-                        ) : (
-                          <div className="flex items-center gap-3">
-                            {isUpdating ? (
-                              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                          </td>
+                          <td className="px-4 py-3 text-sm text-foreground/80">
+                            {formatDateLabel(note.createdAt)}
+                          </td>
+                          <td className="px-4 py-3 text-sm text-foreground/80">
+                            {formatLastRanLabel(note.lastRunAt)}
+                          </td>
+                          <td className="px-4 py-3">
+                            {isRunning ? (
+                              <div className="flex items-center gap-2">
+                                <span className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-foreground animate-pulse">
+                                  <Loader2 className="size-3 animate-spin" />
+                                  Updating…
+                                </span>
+                                <Button
+                                  variant="destructive"
+                                  size="sm"
+                                  onClick={() => handleStop(note)}
+                                  disabled={isStopping}
+                                >
+                                  {isStopping ? <Loader2 className="size-3 animate-spin" /> : <Square className="size-3" />}
+                                  Stop
+                                </Button>
+                              </div>
                             ) : (
-                              <span className="size-4 shrink-0" aria-hidden="true" />
+                              <div className="flex items-center gap-3">
+                                {isUpdating ? (
+                                  <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                                ) : (
+                                  <span className="size-4 shrink-0" aria-hidden="true" />
+                                )}
+                                <Switch
+                                  checked={note.isActive}
+                                  onCheckedChange={(checked) => { void handleToggleState(note, checked) }}
+                                  disabled={isUpdating}
+                                />
+                                <span className="min-w-16 text-xs font-medium text-foreground/80">
+                                  {note.isActive ? 'Active' : 'Inactive'}
+                                </span>
+                              </div>
                             )}
-                            <Switch
-                              checked={note.isActive}
-                              onCheckedChange={(checked) => { void handleToggleState(note, checked) }}
-                              disabled={isUpdating}
-                            />
-                            <span className="min-w-16 text-xs font-medium text-foreground/80">
-                              {note.isActive ? 'Active' : 'Inactive'}
-                            </span>
-                          </div>
+                          </td>
+                        </tr>
+                      </ContextMenuTrigger>
+                      <ContextMenuContent className="w-52">
+                        <ContextMenuItem onClick={() => onOpenNote(note.path)}>
+                          <FileText className="mr-2 size-4" />
+                          Open note
+                        </ContextMenuItem>
+                        <ContextMenuSeparator />
+                        {isRunning ? (
+                          <ContextMenuItem
+                            variant="destructive"
+                            disabled={isStopping}
+                            onClick={() => { void handleStop(note) }}
+                          >
+                            <Square className="mr-2 size-4" />
+                            Stop run
+                          </ContextMenuItem>
+                        ) : (
+                          <ContextMenuItem
+                            disabled={isUpdating}
+                            onClick={() => { void handleToggleState(note, !note.isActive) }}
+                          >
+                            {note.isActive ? <Pause className="mr-2 size-4" /> : <Play className="mr-2 size-4" />}
+                            {note.isActive ? 'Deactivate' : 'Activate'}
+                          </ContextMenuItem>
                         )}
-                      </td>
-                    </tr>
+                      </ContextMenuContent>
+                    </ContextMenu>
                   )
                 })}
               </tbody>

--- a/apps/x/apps/renderer/src/components/meetings-view.tsx
+++ b/apps/x/apps/renderer/src/components/meetings-view.tsx
@@ -1,10 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Calendar, ChevronDown, ChevronRight, Clock, ExternalLink, FileText, Loader2, MapPin, Mic, Sparkles, Square, UserPlus, UserRound, UsersRound, Video, X } from 'lucide-react'
+import { Calendar, ChevronDown, ChevronRight, Clock, Copy, ExternalLink, FileText, FolderOpen, Loader2, MapPin, Mic, Pencil, Sparkles, Square, Trash2, UserPlus, UserRound, UsersRound, Video, X } from 'lucide-react'
 import { Streamdown } from 'streamdown'
 
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { formatRelativeTime } from '@/lib/relative-time'
 import * as analytics from '@/lib/analytics'
@@ -56,11 +63,29 @@ type MeetingNoteRow = {
   mtimeMs: number
 }
 
+// Subset of App's knowledgeActions the notes-table context menu needs —
+// meeting notes are ordinary workspace files, so the same handlers apply.
+type MeetingsViewActions = {
+  rename: (path: string, newName: string, isDir: boolean) => Promise<void>
+  remove: (path: string) => Promise<void>
+  copyPath: (path: string) => void
+  revealInFileManager: (path: string, isDir: boolean) => void
+}
+
 type MeetingsViewProps = {
   onOpenNote: (path: string) => void
   onTakeMeetingNotes: () => void
   meetingState: MeetingTranscriptionState
   meetingSummarizing?: boolean
+  actions?: MeetingsViewActions
+}
+
+function getFileManagerName(): string {
+  if (typeof navigator === 'undefined') return 'File Manager'
+  const platform = navigator.platform.toLowerCase()
+  if (platform.includes('mac')) return 'Finder'
+  if (platform.includes('win')) return 'Explorer'
+  return 'File Manager'
 }
 
 function isMeetingPath(path: string | undefined): boolean {
@@ -1144,7 +1169,112 @@ function getMeetingButtonLabel(state: MeetingTranscriptionState): string {
   }
 }
 
-export function MeetingsView({ onOpenNote, onTakeMeetingNotes, meetingState, meetingSummarizing = false }: MeetingsViewProps) {
+function MeetingNoteTableRow({ note, actions, onOpenNote }: {
+  note: MeetingNoteRow
+  actions?: MeetingsViewActions
+  onOpenNote: (path: string) => void
+}) {
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [newName, setNewName] = useState('')
+  const isSubmittingRef = useRef(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isRenaming) inputRef.current?.focus()
+  }, [isRenaming])
+
+  // note.name is display-formatted; rename works on the raw filename.
+  const baseName = note.path.split('/').pop()?.replace(/\.md$/, '') ?? note.name
+
+  const handleRenameSubmit = useCallback(async () => {
+    if (isSubmittingRef.current) return
+    const trimmed = newName.trim()
+    if (!trimmed || trimmed === baseName) {
+      setIsRenaming(false)
+      return
+    }
+    isSubmittingRef.current = true
+    try {
+      await actions?.rename(note.path, trimmed, false)
+    } catch {
+      // ignore
+    }
+    setIsRenaming(false)
+    isSubmittingRef.current = false
+  }, [newName, baseName, actions, note.path])
+
+  const handleOpen = () => {
+    analytics.meetingNoteOpened()
+    onOpenNote(note.path)
+  }
+
+  const row = (
+    <tr className="border-b border-border/50 last:border-b-0 hover:bg-muted/20">
+      <td className="px-4 py-3 align-top">
+        {isRenaming ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onBlur={() => void handleRenameSubmit()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleRenameSubmit()
+              if (e.key === 'Escape') setIsRenaming(false)
+            }}
+            className="w-full bg-transparent text-sm font-medium outline-none ring-1 ring-ring rounded px-1"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="block w-full min-w-0 text-left text-sm font-medium text-foreground hover:underline"
+          >
+            <span className="block truncate">{note.name}</span>
+          </button>
+        )}
+      </td>
+      <td className="px-4 py-3 align-top text-sm text-muted-foreground">{note.dateLabel}</td>
+      <td className="px-4 py-3 align-top text-sm text-muted-foreground">
+        {note.mtimeMs > 0 ? (formatRelativeTime(new Date(note.mtimeMs).toISOString()) || '—') : '—'}
+      </td>
+    </tr>
+  )
+
+  if (!actions) return row
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        <ContextMenuItem onClick={handleOpen}>
+          <FileText className="mr-2 size-4" />
+          Open
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => actions.copyPath(note.path)}>
+          <Copy className="mr-2 size-4" />
+          Copy Path
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => actions.revealInFileManager(note.path, false)}>
+          <FolderOpen className="mr-2 size-4" />
+          Open in {getFileManagerName()}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => { setNewName(baseName); isSubmittingRef.current = false; setIsRenaming(true) }}>
+          <Pencil className="mr-2 size-4" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem variant="destructive" onClick={() => void actions.remove(note.path)}>
+          <Trash2 className="mr-2 size-4" />
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+export function MeetingsView({ onOpenNote, onTakeMeetingNotes, meetingState, meetingSummarizing = false, actions }: MeetingsViewProps) {
   const [notes, setNotes] = useState<MeetingNoteRow[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -1307,21 +1437,7 @@ export function MeetingsView({ onOpenNote, onTakeMeetingNotes, meetingState, mee
               </thead>
               <tbody>
                 {notes.map((note) => (
-                  <tr key={note.path} className="border-b border-border/50 last:border-b-0 hover:bg-muted/20">
-                    <td className="px-4 py-3 align-top">
-                      <button
-                        type="button"
-                        onClick={() => { analytics.meetingNoteOpened(); onOpenNote(note.path) }}
-                        className="block w-full min-w-0 text-left text-sm font-medium text-foreground hover:underline"
-                      >
-                        <span className="block truncate">{note.name}</span>
-                      </button>
-                    </td>
-                    <td className="px-4 py-3 align-top text-sm text-muted-foreground">{note.dateLabel}</td>
-                    <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                      {note.mtimeMs > 0 ? (formatRelativeTime(new Date(note.mtimeMs).toISOString()) || '—') : '—'}
-                    </td>
-                  </tr>
+                  <MeetingNoteTableRow key={note.path} note={note} actions={actions} onOpenNote={onOpenNote} />
                 ))}
               </tbody>
             </table>

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -1100,13 +1100,44 @@ export function SidebarContentPanel({
                         </div>
                       ) : (
                         <>
-                          <SidebarMenuButton onClick={() => onOpenRun?.(chat.id)} className={onRenameRun ? 'pr-7' : undefined}>
-                            <MessageSquare className="size-4 shrink-0 text-muted-foreground" />
-                            <span className="flex-1 truncate">{chat.title || '(Untitled chat)'}</span>
-                            {pinnedChatIds.includes(chat.id) && (
-                              <Pin className="size-3 shrink-0 text-muted-foreground/70 transition-opacity group-hover/menu-item:opacity-0" />
-                            )}
-                          </SidebarMenuButton>
+                          <ContextMenu>
+                            <ContextMenuTrigger asChild>
+                              <SidebarMenuButton onClick={() => onOpenRun?.(chat.id)} className={onRenameRun ? 'pr-7' : undefined}>
+                                <MessageSquare className="size-4 shrink-0 text-muted-foreground" />
+                                <span className="flex-1 truncate">{chat.title || '(Untitled chat)'}</span>
+                                {pinnedChatIds.includes(chat.id) && (
+                                  <Pin className="size-3 shrink-0 text-muted-foreground/70 transition-opacity group-hover/menu-item:opacity-0" />
+                                )}
+                              </SidebarMenuButton>
+                            </ContextMenuTrigger>
+                            {/* Mirrors the "…" dropdown below — right-click and the kebab offer the same actions. */}
+                            <ContextMenuContent>
+                              <ContextMenuItem onClick={() => toggleChatPin(chat.id)}>
+                                <Pin className="mr-2 size-3.5" />
+                                {pinnedChatIds.includes(chat.id) ? 'Unpin' : 'Pin'}
+                              </ContextMenuItem>
+                              {onRenameRun && (
+                                <ContextMenuItem
+                                  onClick={() => {
+                                    setRenameDraft(chat.title || '')
+                                    setRenamingChatId(chat.id)
+                                  }}
+                                >
+                                  <Pencil className="mr-2 size-3.5" />
+                                  Rename
+                                </ContextMenuItem>
+                              )}
+                              {onDeleteRun && (
+                                <ContextMenuItem
+                                  variant="destructive"
+                                  onClick={() => setDeleteChatTarget({ id: chat.id, title: chat.title || '(Untitled chat)' })}
+                                >
+                                  <Trash2 className="mr-2 size-3.5" />
+                                  Delete
+                                </ContextMenuItem>
+                              )}
+                            </ContextMenuContent>
+                          </ContextMenu>
                           {onRenameRun && (
                             <DropdownMenu>
                               <DropdownMenuTrigger asChild>

--- a/apps/x/apps/renderer/src/components/tab-bar.tsx
+++ b/apps/x/apps/renderer/src/components/tab-bar.tsx
@@ -2,6 +2,13 @@ import * as React from "react"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAllTabMeta } from "@/lib/tab-meta"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 
 export type ChatTab = {
   id: string
@@ -66,39 +73,79 @@ export function TabBar<T>({
         // content-first and exposed as data-busy for styling/tests.
         const busy = meta?.busy ?? isProcessing?.(tab) ?? false
 
+        // Close Others / Close to the Right funnel through onCloseTab per id,
+        // so parents (local tab state, browser IPC) need no new callbacks.
+        const closeOthers = () => {
+          for (const t of tabs) {
+            const id = getTabId(t)
+            if (id !== tabId) onCloseTab(id)
+          }
+        }
+        const closeToTheRight = () => {
+          for (const t of tabs.slice(index + 1)) onCloseTab(getTabId(t))
+        }
+        const canClose = allowSingleTabClose || tabs.length > 1
+
         return (
           <React.Fragment key={tabId}>
             {index > 0 && (
               <div className="self-stretch w-px bg-border/70 shrink-0" aria-hidden="true" />
             )}
-            <button
-              type="button"
-              onClick={() => onSwitchTab(tabId)}
-              data-busy={busy || undefined}
-              className={cn(
-                'rowboat-tab titlebar-no-drag group/tab relative flex items-center gap-1.5 px-3 self-stretch text-xs transition-colors',
-                layout === 'scroll' ? 'min-w-[140px] max-w-[240px]' : 'min-w-0 max-w-[220px]',
-                isActive
-                  ? 'bg-background text-foreground'
-                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-              )}
-              style={layout === 'scroll' ? { flex: '0 0 auto' } : { flex: '1 1 0px' }}
-            >
-              <span className="truncate flex-1 text-left">{title}</span>
-              {(allowSingleTabClose || tabs.length > 1) && (
-                <span
-                  role="button"
-                  className="shrink-0 flex items-center justify-center rounded-sm p-0.5 opacity-0 group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10 transition-all"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onCloseTab(tabId)
-                  }}
-                  aria-label="Close tab"
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => onSwitchTab(tabId)}
+                  data-busy={busy || undefined}
+                  className={cn(
+                    'rowboat-tab titlebar-no-drag group/tab relative flex items-center gap-1.5 px-3 self-stretch text-xs transition-colors',
+                    layout === 'scroll' ? 'min-w-[140px] max-w-[240px]' : 'min-w-0 max-w-[220px]',
+                    isActive
+                      ? 'bg-background text-foreground'
+                      : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                  )}
+                  style={layout === 'scroll' ? { flex: '0 0 auto' } : { flex: '1 1 0px' }}
                 >
-                  <X className="size-3" />
-                </span>
-              )}
-            </button>
+                  <span className="truncate flex-1 text-left">{title}</span>
+                  {(allowSingleTabClose || tabs.length > 1) && (
+                    <span
+                      role="button"
+                      className="shrink-0 flex items-center justify-center rounded-sm p-0.5 opacity-0 group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10 transition-all"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onCloseTab(tabId)
+                      }}
+                      aria-label="Close tab"
+                    >
+                      <X className="size-3" />
+                    </span>
+                  )}
+                </button>
+              </ContextMenuTrigger>
+              <ContextMenuContent className="w-48">
+                <ContextMenuItem disabled={!canClose} onClick={() => onCloseTab(tabId)}>
+                  Close Tab
+                </ContextMenuItem>
+                <ContextMenuItem disabled={tabs.length <= 1} onClick={closeOthers}>
+                  Close Other Tabs
+                </ContextMenuItem>
+                <ContextMenuItem disabled={index >= tabs.length - 1} onClick={closeToTheRight}>
+                  Close Tabs to the Right
+                </ContextMenuItem>
+                {allowSingleTabClose && (
+                  <>
+                    <ContextMenuSeparator />
+                    <ContextMenuItem
+                      onClick={() => {
+                        for (const t of tabs) onCloseTab(getTabId(t))
+                      }}
+                    >
+                      Close All Tabs
+                    </ContextMenuItem>
+                  </>
+                )}
+              </ContextMenuContent>
+            </ContextMenu>
             {/* Right edge divider after last tab to close off the section */}
             {index === tabs.length - 1 && (
               <div className="self-stretch w-px bg-border/70 shrink-0" aria-hidden="true" />


### PR DESCRIPTION
## What

Adds right-click context menus to the surfaces that were missing them, plus the native text-editing menu Electron doesn't provide by default.

### Renderer (shared Radix `ContextMenu`, existing action handlers)

- **Email inbox rows** — Open/Close thread, Mark read/unread, Mark important/not important (section-aware), Archive, Delete. Mirrors the hover buttons.
- **Browser tab strip** — Close Tab, Close Other Tabs, Close Tabs to the Right (and Close All where single-tab close is allowed). Implemented in the generic `TabBar` and funneled through the existing `onCloseTab` callback, so no parent changes were needed.
- **Sidebar recent chats** — Pin/Unpin, Rename, Delete; mirrors the kebab dropdown, matching the pinned-apps rows that already had a context menu.
- **Meetings notes table** — Open, Copy Path, Open in file manager, inline Rename, Delete. Wired to App's `knowledgeActions` through a new optional `actions` prop, so rename keeps wiki-link rewriting and delete goes to trash.
- **Live notes table** — Open note, Activate/Deactivate, Stop run (while running).

### Main process

- New `context-menu.ts`: native right-click menu for text editing and selections — cut/copy/paste/select-all, spellcheck suggestions + Add to Dictionary, Copy Link Address. Attached to the main window, the quick-ask window, and embedded browser tabs. The in-DOM Radix menus call `preventDefault()` on `contextmenu`, which suppresses this event entirely, so the two systems never conflict.

### Fix

- `BrowserPane`'s blocking-overlay detection treated `opacity: 0` as "no overlay", but Radix overlays mount at opacity 0 (enter animation) and the check runs exactly once on the mount frame — so menus/dropdowns/dialogs opened over the embedded browser were clipped by the native `WebContentsView` instead of hiding it. Dropped the opacity condition; closing overlays are already excluded via `data-state="open"`.

## Testing

- `npm run deps`, `npm run lint`, `npm run typecheck` (plus a manual `tsc` over `apps/main`) all pass.
- Manually verified the browser tab menu now renders unclipped with the view hidden while open.