### PR TITLE
feat(x): native application menu bar

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -100,6 +100,7 @@ import { isLoginItemEnabled, setLoginItemEnabled } from './login_item.js';
 import { setSelfCaptureActive } from '@x/core/dist/meetings/detector.js';
 import { notifyIfEnabled } from '@x/core/dist/application/notification/notifier.js';
 import { consumePendingToggleMeetingNotes, setTrayRecordingState } from './tray.js';
+import { setMenuRecordingState } from './menu.js';
 import { closeMeetingPopup, getMeetingPopupPayload, handleMeetingPopupAction } from './meeting-popup.js';
 
 // Ambient meeting detection must ignore Rowboat's own mic use: meeting
@@ -894,6 +895,7 @@ export function setupIpcHandlers() {
     },
     'meeting:setRecordingState': async (_event, args) => {
       setTrayRecordingState(args.recording);
+      setMenuRecordingState(args.recording);
       meetingRecordingActive = args.recording;
       updateSelfCaptureState();
       // Recording started through another path — a lingering "Take Notes?"

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -69,6 +69,8 @@ import { startModelsDevRefresh } from "@x/core/dist/models/models-dev.js";
 import { ensureLoginItemRegistration } from "./login_item.js";
 import { init as initMeetingDetection } from "@x/core/dist/meetings/detector.js";
 import { createAppTray, hasTray, isRecordingActive, markPendingToggleMeetingNotes } from "./tray.js";
+import { installAppMenu } from "./menu.js";
+import { setupZoomShortcuts } from "./zoom.js";
 import { initMeetingPopup, showMeetingPopup } from "./meeting-popup.js";
 import { initQuickAsk, onAppWindowClosed } from "./quick-ask.js";
 
@@ -357,38 +359,6 @@ function configureAppDisplayMediaHandler(targetSession: Session): void {
   });
 }
 
-// Wire Ctrl/Cmd + (+ / − / 0) to zoom the renderer in/out/reset.
-// The app sets no application menu, so the default menu's zoom roles aren't
-// available — and on Linux the menu bar is suppressed by the frameless
-// `hiddenInset` title bar — so handle the accelerators directly here.
-// `event.preventDefault()` stops the keystroke from leaking into the editor.
-function setupZoomShortcuts(win: BrowserWindow) {
-  const ZOOM_STEP = 0.5; // zoom-level units (factor = 1.2 ^ level, ~9.5% per step)
-  const MIN_ZOOM_LEVEL = -3;
-  const MAX_ZOOM_LEVEL = 3;
-  const wc = win.webContents;
-
-  wc.on("before-input-event", (event, input) => {
-    if (input.type !== "keyDown") return;
-    // Cmd on macOS, Ctrl elsewhere.
-    if (!(process.platform === "darwin" ? input.meta : input.control)) return;
-
-    // input.key is the produced character: "+"/"=" share a physical key (as do
-    // "-"/"_"), and numpad +/- produce the same characters, so this covers both.
-    const key = input.key;
-    if (key === "+" || key === "=") {
-      wc.setZoomLevel(Math.min(wc.getZoomLevel() + ZOOM_STEP, MAX_ZOOM_LEVEL));
-      event.preventDefault();
-    } else if (key === "-" || key === "_") {
-      wc.setZoomLevel(Math.max(wc.getZoomLevel() - ZOOM_STEP, MIN_ZOOM_LEVEL));
-      event.preventDefault();
-    } else if (key === "0") {
-      wc.setZoomLevel(0);
-      event.preventDefault();
-    }
-  });
-}
-
 // Resident-app plumbing (Granola-style): the main window may exist hidden
 // (launched at login) or not at all (closed on macOS) while the app keeps
 // running from the tray. showApp() is the single "bring the app up" path
@@ -652,24 +622,35 @@ app.whenReady().then(async () => {
   // we never re-register on boot.
   ensureLoginItemRegistration();
 
+  // Shared by the tray menu and the application menu: reveal the app and
+  // toggle meeting notes. If the renderer isn't ready to receive the toggle
+  // (window closed or still loading), park it as a pending command the
+  // renderer drains on mount — same pull pattern as pending deep links.
+  const toggleMeetingNotesFromMenus = () => {
+    const hadWindow = mainWindow !== null && !mainWindow.isDestroyed();
+    showApp();
+    const win = mainWindow;
+    if (!hadWindow || !win || win.webContents.isLoading()) {
+      markPendingToggleMeetingNotes();
+      return;
+    }
+    win.webContents.send("app:toggleMeetingNotes", null);
+  };
+
+  // Application menu (File/Edit/View/Go/Tools/Window/Help) — installed
+  // before the window so Linux/Windows never paint the default menu.
+  installAppMenu({
+    openApp: showApp,
+    getMainWindow: () => mainWindow,
+    toggleMeetingNotes: toggleMeetingNotesFromMenus,
+  });
+
   createWindow({ startHidden: wasLaunchedAtLogin() });
 
-  // Menu bar icon: open the app / start-stop meeting notes without the
-  // window. If the renderer isn't ready to receive the toggle (window closed
-  // or still loading), park it as a pending command the renderer drains on
-  // mount — same pull pattern as pending deep links.
+  // Menu bar icon: open the app / start-stop meeting notes without the window.
   createAppTray({
     openApp: showApp,
-    toggleMeetingNotes: () => {
-      const hadWindow = mainWindow !== null && !mainWindow.isDestroyed();
-      showApp();
-      const win = mainWindow;
-      if (!hadWindow || !win || win.webContents.isLoading()) {
-        markPendingToggleMeetingNotes();
-        return;
-      }
-      win.webContents.send("app:toggleMeetingNotes", null);
-    },
+    toggleMeetingNotes: toggleMeetingNotesFromMenus,
   });
 
   // Ambient meeting detection (Granola-style): the mic-monitor helper +

--- a/apps/x/apps/main/src/menu.ts
+++ b/apps/x/apps/main/src/menu.ts
@@ -1,0 +1,404 @@
+import { app, dialog, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from "electron";
+import { WorkDir } from "@x/core/dist/config/config.js";
+import type { ipc } from "@x/shared";
+import { dispatchDeepLink } from "./deeplink.js";
+import {
+  getQuickAskShortcutState,
+  onQuickAskShortcutChanged,
+  toggleQuickAsk,
+} from "./quick-ask.js";
+import {
+  checkForUpdates,
+  getUpdaterStatus,
+  onUpdaterStatusChanged,
+  quitAndInstallUpdate,
+} from "./updater.js";
+import { zoomIn, zoomOut, zoomReset } from "./zoom.js";
+
+/**
+ * Native application menu (File / Edit / View / Go / Tools / Window / Help).
+ *
+ * Until this module existed the app ran on Electron's factory-default menu:
+ * Help pointed at electronjs.org and Reload / Toggle Developer Tools shipped
+ * enabled in production. The menu here mirrors the tray's structure
+ * (tray.ts): a static template rebuilt whenever dynamic state changes —
+ * recording on/off, quick-ask chord rebinds, updater transitions.
+ *
+ * Commands land in the renderer over two channels: `menu:command` (one
+ * discriminated payload for everything the renderer owns) and
+ * `menu:toggleSidebar` (its own channel — the handler must live inside the
+ * SidebarProvider). Go-menu navigation instead rides the existing deep-link
+ * pipeline (dispatchDeepLink → app:openUrl / pending-link drain), which
+ * already parks URLs while the renderer loads and covers every section.
+ *
+ * Accelerator ownership: chords the renderer already handles via document
+ * keydown (⌘K, ⌘N, ⌘L, ⌘Z/⇧⌘Z) are display-only here on Windows/Linux
+ * (`registerAccelerator: false`) so those handlers keep receiving the keys;
+ * on macOS the page gets first chance at a chord and those handlers call
+ * preventDefault, so behavior is identical either way. Zoom keystrokes stay
+ * in zoom.ts's before-input-event hook (see the comment there).
+ */
+
+const REPO_URL = "https://github.com/rowboatlabs/rowboat";
+
+type MenuCommand = ipc.IPCChannels["menu:command"]["req"];
+
+interface MenuActions {
+  openApp: () => void;
+  getMainWindow: () => BrowserWindow | null;
+  toggleMeetingNotes: () => void;
+}
+
+let actions: MenuActions | null = null;
+let recording = false;
+
+export function installAppMenu(menuActions: MenuActions): void {
+  actions = menuActions;
+  if (process.platform === "darwin") {
+    app.setAboutPanelOptions({
+      applicationName: "Rowboat",
+      applicationVersion: app.getVersion(),
+    });
+  }
+  rebuildMenu();
+  onQuickAskShortcutChanged(() => rebuildMenu());
+  onUpdaterStatusChanged(() => rebuildMenu());
+}
+
+/** Mirror of setTrayRecordingState — both surfaces relabel together. */
+export function setMenuRecordingState(isRecording: boolean): void {
+  if (recording === isRecording) return;
+  recording = isRecording;
+  rebuildMenu();
+}
+
+/**
+ * Deliver a renderer-owned command, revealing the window first (on macOS the
+ * app menu is reachable with no window at all). A still-loading renderer gets
+ * it after did-finish-load — same pattern as the meeting popup in main.ts.
+ */
+function sendToRenderer(channel: "menu:command" | "menu:toggleSidebar", payload: MenuCommand | null): void {
+  if (!actions) return;
+  actions.openApp();
+  const win = actions.getMainWindow();
+  if (!win || win.isDestroyed()) return;
+  if (win.webContents.isLoading()) {
+    win.webContents.once("did-finish-load", () => {
+      if (!win.isDestroyed()) win.webContents.send(channel, payload);
+    });
+    return;
+  }
+  win.webContents.send(channel, payload);
+}
+
+function sendCommand(payload: MenuCommand): void {
+  sendToRenderer("menu:command", payload);
+}
+
+/**
+ * Go-menu navigation rides the deep-link pipeline — parseDeepLink in the
+ * renderer covers every section and dispatchDeepLink parks the URL while the
+ * renderer loads, so the menu needs no navigation channel of its own.
+ */
+function navigate(type: string): void {
+  actions?.openApp();
+  dispatchDeepLink(`rowboat://open?type=${type}`);
+}
+
+function withMainWindow(fn: (win: BrowserWindow) => void): void {
+  const win = actions?.getMainWindow();
+  if (win && !win.isDestroyed()) fn(win);
+}
+
+function showAboutDialog(): void {
+  const opts = {
+    type: "info" as const,
+    title: "About Rowboat",
+    message: `Rowboat ${app.getVersion()}`,
+    detail: `Electron ${process.versions.electron} · Chromium ${process.versions.chrome} · Node ${process.versions.node}`,
+  };
+  const win = actions?.getMainWindow();
+  if (win && !win.isDestroyed()) void dialog.showMessageBox(win, opts);
+  else void dialog.showMessageBox(opts);
+}
+
+/** "Check for Updates…" in the state the updater is actually in. */
+function updateMenuItem(): MenuItemConstructorOptions {
+  const status = getUpdaterStatus();
+  switch (status.state) {
+    case "checking":
+      return { label: "Checking for Updates…", enabled: false };
+    case "downloading":
+      return { label: "Downloading Update…", enabled: false };
+    case "ready":
+      return {
+        label: `Restart to Update${status.newVersion ? ` to v${status.newVersion}` : ""}`,
+        click: () => quitAndInstallUpdate(),
+      };
+    case "disabled":
+      // Dev build — nothing to check against.
+      return { label: "Check for Updates…", enabled: false };
+    case "unsupported":
+      // Linux (deb/zip installs) and macOS outside /Applications have no
+      // auto-update path — point at the releases page instead.
+      return {
+        label: "Check for Updates on GitHub…",
+        click: () => void shell.openExternal(`${REPO_URL}/releases`),
+      };
+    default:
+      return { label: "Check for Updates…", click: () => void checkForUpdates() };
+  }
+}
+
+/** Ordered as the dock is. Number keys cover its nine primary destinations. */
+const GO_ITEMS: ReadonlyArray<{ label: string; type: string; accelerator?: string }> = [
+  { label: "Home", type: "home", accelerator: "CmdOrCtrl+1" },
+  { label: "Spaces", type: "spaces", accelerator: "CmdOrCtrl+2" },
+  { label: "Email", type: "email", accelerator: "CmdOrCtrl+3" },
+  { label: "Code", type: "code", accelerator: "CmdOrCtrl+4" },
+  { label: "Meetings", type: "meetings", accelerator: "CmdOrCtrl+5" },
+  { label: "Brain", type: "knowledge-view", accelerator: "CmdOrCtrl+6" },
+  { label: "Apps", type: "apps", accelerator: "CmdOrCtrl+7" },
+  { label: "Background Agents", type: "bg-tasks", accelerator: "CmdOrCtrl+8" },
+  { label: "Workspaces", type: "workspace", accelerator: "CmdOrCtrl+9" },
+  { label: "Chat History", type: "chat-history" },
+  { label: "Live Notes", type: "live-notes" },
+  { label: "Graph", type: "graph" },
+];
+
+function rebuildMenu(): void {
+  const isMac = process.platform === "darwin";
+
+  const settingsItem: MenuItemConstructorOptions = {
+    label: "Settings…",
+    accelerator: "CmdOrCtrl+,",
+    click: () => sendCommand({ command: "open-settings" }),
+  };
+
+  const macAppMenu: MenuItemConstructorOptions = {
+    label: app.name,
+    submenu: [
+      { role: "about" },
+      { type: "separator" },
+      settingsItem,
+      updateMenuItem(),
+      { type: "separator" },
+      { role: "services" },
+      { type: "separator" },
+      { role: "hide" },
+      { role: "hideOthers" },
+      { role: "unhide" },
+      { type: "separator" },
+      { role: "quit" },
+    ],
+  };
+
+  const fileMenu: MenuItemConstructorOptions = {
+    label: "File",
+    submenu: [
+      {
+        label: "New Chat",
+        accelerator: "CmdOrCtrl+N",
+        registerAccelerator: false,
+        click: () => sendCommand({ command: "new-chat" }),
+      },
+      {
+        label: "New Note",
+        accelerator: "CmdOrCtrl+Shift+N",
+        click: () => sendCommand({ command: "new-note" }),
+      },
+      {
+        label: "New Presentation…",
+        click: () => sendCommand({ command: "new-presentation" }),
+      },
+      { type: "separator" },
+      {
+        label: "Export Note",
+        submenu: [
+          { label: "Markdown (.md)", click: () => sendCommand({ command: "export-note", format: "md" }) },
+          { label: "PDF (.pdf)", click: () => sendCommand({ command: "export-note", format: "pdf" }) },
+          { label: "Word (.docx)", click: () => sendCommand({ command: "export-note", format: "docx" }) },
+        ],
+      },
+      { type: "separator" },
+      ...(isMac ? [] : [settingsItem, { type: "separator" } as MenuItemConstructorOptions]),
+      { role: "close" },
+      ...(isMac ? [] : [{ role: "quit" } as MenuItemConstructorOptions]),
+    ],
+  };
+
+  // macOS keeps the standard roles — clipboard and undo in native inputs are
+  // menu-driven there, and the renderer's markdown history routing already
+  // preempts ⌘Z when it applies (exactly as with the old default menu).
+  // Windows/Linux route undo/redo through the renderer instead, display-only
+  // accelerators, so the document-level handlers keep owning the keystrokes.
+  const editMenu: MenuItemConstructorOptions = {
+    label: "Edit",
+    submenu: isMac
+      ? [
+          { role: "undo" },
+          { role: "redo" },
+          { type: "separator" },
+          { role: "cut" },
+          { role: "copy" },
+          { role: "paste" },
+          { role: "pasteAndMatchStyle" },
+          { role: "delete" },
+          { role: "selectAll" },
+        ]
+      : [
+          {
+            label: "Undo",
+            accelerator: "CmdOrCtrl+Z",
+            registerAccelerator: false,
+            click: () => sendCommand({ command: "undo" }),
+          },
+          {
+            label: "Redo",
+            accelerator: "CmdOrCtrl+Shift+Z",
+            registerAccelerator: false,
+            click: () => sendCommand({ command: "redo" }),
+          },
+          { type: "separator" },
+          { role: "cut" },
+          { role: "copy" },
+          { role: "paste" },
+          { role: "delete" },
+          { role: "selectAll" },
+        ],
+  };
+
+  const viewMenu: MenuItemConstructorOptions = {
+    label: "View",
+    submenu: [
+      {
+        label: "Search…",
+        accelerator: "CmdOrCtrl+K",
+        registerAccelerator: false,
+        click: () => sendCommand({ command: "open-search" }),
+      },
+      { type: "separator" },
+      {
+        label: "Toggle Sidebar",
+        accelerator: "CmdOrCtrl+\\",
+        click: () => sendToRenderer("menu:toggleSidebar", null),
+      },
+      {
+        label: "Toggle Browser",
+        click: () => sendCommand({ command: "toggle-browser" }),
+      },
+      {
+        label: "Full-Screen Chat",
+        accelerator: "CmdOrCtrl+L",
+        registerAccelerator: false,
+        click: () => sendCommand({ command: "toggle-full-screen-chat" }),
+      },
+      { type: "separator" },
+      // Display-only in effect: the keystrokes are consumed (and the menu
+      // accelerators suppressed) by zoom.ts's before-input-event hook.
+      { label: "Zoom In", accelerator: "CmdOrCtrl+Plus", click: () => withMainWindow(zoomIn) },
+      { label: "Zoom Out", accelerator: "CmdOrCtrl+-", click: () => withMainWindow(zoomOut) },
+      { label: "Actual Size", accelerator: "CmdOrCtrl+0", click: () => withMainWindow(zoomReset) },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+      // Chromium debugging stays out of production builds.
+      ...(app.isPackaged
+        ? []
+        : [
+            { type: "separator" } as MenuItemConstructorOptions,
+            { role: "reload" } as MenuItemConstructorOptions,
+            { role: "forceReload" } as MenuItemConstructorOptions,
+            { role: "toggleDevTools" } as MenuItemConstructorOptions,
+          ]),
+    ],
+  };
+
+  const goMenu: MenuItemConstructorOptions = {
+    label: "Go",
+    submenu: [
+      {
+        label: "Back",
+        accelerator: isMac ? "Cmd+[" : "Alt+Left",
+        click: () => sendCommand({ command: "go-back" }),
+      },
+      {
+        label: "Forward",
+        accelerator: isMac ? "Cmd+]" : "Alt+Right",
+        click: () => sendCommand({ command: "go-forward" }),
+      },
+      { type: "separator" },
+      ...GO_ITEMS.map((item): MenuItemConstructorOptions => ({
+        label: item.label,
+        ...(item.accelerator ? { accelerator: item.accelerator } : {}),
+        click: () => navigate(item.type),
+      })),
+    ],
+  };
+
+  const toolsMenu: MenuItemConstructorOptions = {
+    label: "Tools",
+    submenu: [
+      // The accelerator renders next to the label (display only; the real
+      // binding is the globalShortcut in quick-ask.ts). Hidden while the
+      // chord is unregistered — showing a dead chord would lie.
+      {
+        label: "Quick Ask",
+        ...(getQuickAskShortcutState().registered
+          ? { accelerator: getQuickAskShortcutState().accelerator }
+          : {}),
+        registerAccelerator: false,
+        click: () => toggleQuickAsk(),
+      },
+      recording
+        ? {
+            label: "Stop Recording and Generate Notes",
+            click: () => actions?.toggleMeetingNotes(),
+          }
+        : {
+            label: "Start Meeting Notes",
+            click: () => actions?.toggleMeetingNotes(),
+          },
+    ],
+  };
+
+  const windowMenu: MenuItemConstructorOptions = isMac
+    ? { role: "windowMenu" }
+    : { label: "Window", submenu: [{ role: "minimize" }, { role: "close" }] };
+
+  const helpMenu: MenuItemConstructorOptions = {
+    role: "help",
+    submenu: [
+      { label: "Rowboat on GitHub", click: () => void shell.openExternal(REPO_URL) },
+      { label: "Report an Issue…", click: () => void shell.openExternal(`${REPO_URL}/issues/new`) },
+      { label: "Release Notes", click: () => void shell.openExternal(`${REPO_URL}/releases`) },
+      { type: "separator" },
+      {
+        label: "Keyboard Shortcuts…",
+        click: () => sendCommand({ command: "open-settings", tab: "shortcuts" }),
+      },
+      // ~/.rowboat — configs, caches, synced calendars; the place support
+      // asks people to look, now one click away.
+      { label: "Open Data Folder", click: () => void shell.openPath(WorkDir) },
+      ...(isMac
+        ? []
+        : [
+            { type: "separator" } as MenuItemConstructorOptions,
+            updateMenuItem(),
+            { label: "About Rowboat", click: () => showAboutDialog() } as MenuItemConstructorOptions,
+          ]),
+    ],
+  };
+
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac ? [macAppMenu] : []),
+    fileMenu,
+    editMenu,
+    viewMenu,
+    goMenu,
+    toolsMenu,
+    windowMenu,
+    helpMenu,
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/apps/x/apps/main/src/menu.ts
+++ b/apps/x/apps/main/src/menu.ts
@@ -1,4 +1,4 @@
-import { app, dialog, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from "electron";
+import { app, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from "electron";
 import { WorkDir } from "@x/core/dist/config/config.js";
 import type { ipc } from "@x/shared";
 import { dispatchDeepLink } from "./deeplink.js";
@@ -54,12 +54,6 @@ let recording = false;
 
 export function installAppMenu(menuActions: MenuActions): void {
   actions = menuActions;
-  if (process.platform === "darwin") {
-    app.setAboutPanelOptions({
-      applicationName: "Rowboat",
-      applicationVersion: app.getVersion(),
-    });
-  }
   rebuildMenu();
   onQuickAskShortcutChanged(() => rebuildMenu());
   onUpdaterStatusChanged(() => rebuildMenu());
@@ -111,15 +105,7 @@ function withMainWindow(fn: (win: BrowserWindow) => void): void {
 }
 
 function showAboutDialog(): void {
-  const opts = {
-    type: "info" as const,
-    title: "About Rowboat",
-    message: `Rowboat ${app.getVersion()}`,
-    detail: `Electron ${process.versions.electron} · Chromium ${process.versions.chrome} · Node ${process.versions.node}`,
-  };
-  const win = actions?.getMainWindow();
-  if (win && !win.isDestroyed()) void dialog.showMessageBox(win, opts);
-  else void dialog.showMessageBox(opts);
+  sendCommand({ command: "open-about" });
 }
 
 /** "Check for Updates…" in the state the updater is actually in. */
@@ -178,7 +164,7 @@ function rebuildMenu(): void {
   const macAppMenu: MenuItemConstructorOptions = {
     label: app.name,
     submenu: [
-      { role: "about" },
+      { label: "About Rowboat", click: () => showAboutDialog() },
       { type: "separator" },
       settingsItem,
       updateMenuItem(),

--- a/apps/x/apps/main/src/updater.ts
+++ b/apps/x/apps/main/src/updater.ts
@@ -9,6 +9,8 @@ const CHECK_INTERVAL_MS = 10 * 60 * 1000;
 
 let status: UpdaterStatus = { state: "disabled", version: "", reason: "dev" };
 
+const statusListeners = new Set<(status: UpdaterStatus) => void>();
+
 function setStatus(next: Omit<UpdaterStatus, "version">): void {
   status = { version: status.version, ...next };
   for (const win of BrowserWindow.getAllWindows()) {
@@ -16,10 +18,21 @@ function setStatus(next: Omit<UpdaterStatus, "version">): void {
       win.webContents.send("updater:status", status);
     }
   }
+  for (const listener of statusListeners) listener(status);
 }
 
 export function getUpdaterStatus(): UpdaterStatus {
   return status;
+}
+
+/**
+ * Main-process subscription to updater state changes — the application menu
+ * relabels its "Check for Updates…" item on each transition (menu.ts).
+ * Returns an unsubscribe function.
+ */
+export function onUpdaterStatusChanged(listener: (status: UpdaterStatus) => void): () => void {
+  statusListeners.add(listener);
+  return () => statusListeners.delete(listener);
 }
 
 // 32x32 green dot with a white ring (scratchpad-generated PNG). Windows'

--- a/apps/x/apps/main/src/zoom.ts
+++ b/apps/x/apps/main/src/zoom.ts
@@ -1,0 +1,48 @@
+import type { BrowserWindow } from "electron";
+
+// Renderer zoom, shared by the Cmd/Ctrl + (+ / − / 0) keystrokes and the
+// View-menu items (menu.ts).
+//
+// Keystrokes are handled via before-input-event rather than as menu
+// accelerators: "+"/"=" share a physical key (as do "-"/"_"), and numpad
+// +/- produce the same characters, so this covers combinations a single
+// accelerator string can't. `event.preventDefault()` stops the keystroke
+// from leaking into the editor — and, per Electron's contract, suppresses
+// any matching menu accelerator, so the View items never double-fire.
+const ZOOM_STEP = 0.5; // zoom-level units (factor = 1.2 ^ level, ~9.5% per step)
+const MIN_ZOOM_LEVEL = -3;
+const MAX_ZOOM_LEVEL = 3;
+
+export function zoomIn(win: BrowserWindow): void {
+  const wc = win.webContents;
+  wc.setZoomLevel(Math.min(wc.getZoomLevel() + ZOOM_STEP, MAX_ZOOM_LEVEL));
+}
+
+export function zoomOut(win: BrowserWindow): void {
+  const wc = win.webContents;
+  wc.setZoomLevel(Math.max(wc.getZoomLevel() - ZOOM_STEP, MIN_ZOOM_LEVEL));
+}
+
+export function zoomReset(win: BrowserWindow): void {
+  win.webContents.setZoomLevel(0);
+}
+
+export function setupZoomShortcuts(win: BrowserWindow): void {
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.type !== "keyDown") return;
+    // Cmd on macOS, Ctrl elsewhere.
+    if (!(process.platform === "darwin" ? input.meta : input.control)) return;
+
+    const key = input.key;
+    if (key === "+" || key === "=") {
+      zoomIn(win);
+      event.preventDefault();
+    } else if (key === "-" || key === "_") {
+      zoomOut(win);
+      event.preventDefault();
+    } else if (key === "0") {
+      zoomReset(win);
+      event.preventDefault();
+    }
+  });
+}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -71,6 +71,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { SettingsDialog, type ConfigTab } from "@/components/settings-dialog"
+import { AboutDialog } from "@/components/about-dialog"
 import { Button } from "@/components/ui/button"
 import { Toaster } from "@/components/ui/sonner"
 import { UpdateCard } from "@/components/update-card"
@@ -888,6 +889,7 @@ function App() {
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
   const [recentWikiFiles, setRecentWikiFiles] = useState<string[]>([])
   const [isGraphOpen, setIsGraphOpen] = useState(false)
+  const [aboutOpen, setAboutOpen] = useState(false)
   const [isBrowserOpen, setIsBrowserOpen] = useState(false)
   const [isSuggestedTopicsOpen, setIsSuggestedTopicsOpen] = useState(false)
   const [isMeetingsOpen, setIsMeetingsOpen] = useState(false)
@@ -6260,6 +6262,9 @@ function App() {
         case 'open-settings':
           setMenuSettings({ open: true, tab: cmd.tab ?? 'account' })
           break
+        case 'open-about':
+          setAboutOpen(true)
+          break
         case 'export-note': {
           const path = selectedPath
           if (!path || !path.endsWith('.md')) {
@@ -7931,6 +7936,7 @@ function App() {
         onOpenChange={setRetentionSettingsOpen}
         defaultTab="advanced"
       />
+      <AboutDialog open={aboutOpen} onOpenChange={setAboutOpen} />
       <SettingsDialog
         open={shortcutSettingsOpen}
         onOpenChange={setShortcutSettingsOpen}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Activity, useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
-import { workspace, quickAskShortcut, pttKey } from '@x/shared';
+import { workspace, quickAskShortcut, pttKey, type ipc } from '@x/shared';
 import { RunEvent } from '@x/shared/src/runs.js';
 import type { ToolUIPart } from 'ai';
 import './App.css'
@@ -70,7 +70,7 @@ import {
 } from "@/components/ui/sidebar"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
-import { SettingsDialog } from "@/components/settings-dialog"
+import { SettingsDialog, type ConfigTab } from "@/components/settings-dialog"
 import { Button } from "@/components/ui/button"
 import { Toaster } from "@/components/ui/sonner"
 import { UpdateCard } from "@/components/update-card"
@@ -793,6 +793,17 @@ function FixedSidebarToggle({
       <CaffeinateToggle />
     </div>
   )
+}
+
+/** Application-menu "View > Toggle Sidebar" (menu:toggleSidebar). A bridge
+ * component because useSidebar() must be called under the SidebarProvider,
+ * below where the menu:command dispatcher sits. Renders nothing. */
+function MenuSidebarToggleBridge() {
+  const { toggleSidebar } = useSidebar()
+  const toggleRef = useRef(toggleSidebar)
+  useEffect(() => { toggleRef.current = toggleSidebar }, [toggleSidebar])
+  useEffect(() => window.ipc.on('menu:toggleSidebar', () => toggleRef.current()), [])
+  return null
 }
 
 /** Main content header. Expanded, the panel absorbs the fixed toggle cluster
@@ -6185,6 +6196,90 @@ function App() {
     },
   }), [deleteInitialContentForPath, setInitialContentForPath, tree, selectedPath, isGraphOpen, selectedBackgroundTask, workspaceRoot, navigateToFile, navigateToView, removeEditorCacheForPath])
 
+  // Settings opened from the application menu (Settings… / Keyboard
+  // Shortcuts…) — its own dialog instance so the menu can deep-link any tab.
+  const [menuSettings, setMenuSettings] = useState<{ open: boolean; tab: ConfigTab }>({ open: false, tab: 'account' })
+
+  // Native application-menu commands (apps/main/src/menu.ts). The dispatcher
+  // lives in a ref refreshed every render so the one-time IPC subscription
+  // below always routes into the current handlers — same pattern as
+  // navigateToViewRef above. Each command reuses the exact code path of the
+  // in-app control it mirrors.
+  const menuCommandRef = useRef<(cmd: ipc.IPCChannels['menu:command']['req']) => void>(() => {})
+  useEffect(() => {
+    menuCommandRef.current = (cmd) => {
+      switch (cmd.command) {
+        case 'new-chat':
+          handleNewChatTab()
+          break
+        case 'new-note':
+          void knowledgeActions.createNote()
+          break
+        case 'new-presentation':
+          knowledgeActions.createPresentation()
+          break
+        case 'undo':
+        case 'redo': {
+          // Mirrors the ⌘Z keydown routing above: the open markdown editor's
+          // history when it applies, the focused input's native undo otherwise.
+          const active = document.activeElement
+          const inTipTap = active instanceof HTMLElement && Boolean(active.closest('.tiptap-editor'))
+          const inOtherTextInput = (
+            active instanceof HTMLInputElement
+            || active instanceof HTMLTextAreaElement
+            || (active instanceof HTMLElement && active.isContentEditable)
+          ) && !inTipTap
+          const handlers = fileHistoryHandlersRef.current
+          if (!inOtherTextInput && selectedPath?.endsWith('.md') && handlers) {
+            if (cmd.command === 'undo') handlers.undo()
+            else handlers.redo()
+          } else {
+            document.execCommand(cmd.command)
+          }
+          break
+        }
+        case 'open-search':
+          setIsSearchOpen(true)
+          break
+        case 'toggle-browser':
+          handleToggleBrowser()
+          break
+        case 'toggle-full-screen-chat':
+          if (isFullScreenChat && expandedFrom) {
+            handleCloseFullScreenChat()
+          } else {
+            navigateToFullScreenChat()
+          }
+          break
+        case 'go-back':
+          void navigateBack()
+          break
+        case 'go-forward':
+          void navigateForward()
+          break
+        case 'open-settings':
+          setMenuSettings({ open: true, tab: cmd.tab ?? 'account' })
+          break
+        case 'export-note': {
+          const path = selectedPath
+          if (!path || !path.endsWith('.md')) {
+            toast('Open a note to export it')
+            break
+          }
+          const markdown = editorContentByPath[path]
+            ?? (editorPathRef.current === path ? editorContent : '')
+          void window.ipc.invoke('export:note', { markdown, format: cmd.format, title: getBaseName(path) })
+            .then(() => analytics.noteExported(cmd.format))
+            .catch((err) => { console.error('Export failed:', err) })
+          break
+        }
+      }
+    }
+  })
+  useEffect(() => {
+    return window.ipc.on('menu:command', (cmd) => menuCommandRef.current(cmd))
+  }, [])
+
   // Drives the mascot product tour through the app's main sections
   const handleTourNavigate = useCallback((target: TourNavTarget) => {
     switch (target) {
@@ -7786,6 +7881,7 @@ function App() {
               onNewChat={handleNewChat}
               onWidthChange={setTitlebarControlsWidthPx}
             />
+            <MenuSidebarToggleBridge />
           </SidebarProvider>
         </div>
         <CommandPalette
@@ -7839,6 +7935,12 @@ function App() {
         open={shortcutSettingsOpen}
         onOpenChange={setShortcutSettingsOpen}
         defaultTab="shortcuts"
+      />
+      {/* Application menu: Settings… / Help > Keyboard Shortcuts… */}
+      <SettingsDialog
+        open={menuSettings.open}
+        onOpenChange={(open) => setMenuSettings((s) => ({ ...s, open }))}
+        defaultTab={menuSettings.tab}
       />
       <SettingsDialog
         open={voiceSetupOpen}

--- a/apps/x/apps/renderer/src/components/about-dialog.test.tsx
+++ b/apps/x/apps/renderer/src/components/about-dialog.test.tsx
@@ -1,0 +1,96 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ipc as ipcShared } from "@x/shared"
+import { AboutDialog } from "./about-dialog"
+
+type UpdaterStatus = ipcShared.IPCChannels["updater:status"]["req"]
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub
+;(Element.prototype as unknown as { hasPointerCapture: () => boolean }).hasPointerCapture = () => false
+
+let updaterStatus: UpdaterStatus
+let invokeCalls: string[]
+let updaterListener: ((status: UpdaterStatus) => void) | null
+const writeText = vi.fn<(text: string) => Promise<void>>(async () => undefined)
+
+;(window as unknown as { ipc: unknown }).ipc = {
+  send: () => undefined,
+  on: (channel: string, handler: (status: UpdaterStatus) => void) => {
+    if (channel === "updater:status") updaterListener = handler
+    return () => {
+      updaterListener = null
+    }
+  },
+  invoke: async (channel: string) => {
+    invokeCalls.push(channel)
+    if (channel === "updater:getStatus" || channel === "updater:check") return updaterStatus
+    if (channel === "app:getVersions") {
+      return { electron: "39.2.7", chrome: "142.0.0.0", node: "22.0.0" }
+    }
+    if (channel === "updater:quitAndInstall") return {}
+    throw new Error(`no handler: ${channel}`)
+  },
+}
+
+Object.defineProperty(navigator, "clipboard", {
+  configurable: true,
+  value: { writeText },
+})
+
+beforeEach(() => {
+  updaterStatus = { state: "idle", version: "1.2.3", lastCheckedAt: Date.now() }
+  invokeCalls = []
+  updaterListener = null
+  writeText.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("AboutDialog", () => {
+  it("shows product identity, versions, and live update status", async () => {
+    render(<AboutDialog open onOpenChange={() => undefined} />)
+
+    expect(screen.getByRole("heading", { name: "Rowboat" })).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "Rowboat logo" })).toHaveAttribute("src", "./logo-only.png")
+    expect(screen.getByText(/remembers the work/i)).toBeInTheDocument()
+    expect(await screen.findByText("You’re up to date")).toBeInTheDocument()
+    expect(screen.getByText("Version 1.2.3 · Desktop")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("Technical details"))
+    expect(await screen.findByText("39.2.7")).toBeInTheDocument()
+
+    act(() => updaterListener?.({ state: "checking", version: "1.2.3" }))
+    expect(await screen.findByText("Checking for updates")).toBeInTheDocument()
+  })
+
+  it("checks for updates and copies diagnostics", async () => {
+    render(<AboutDialog open onOpenChange={() => undefined} />)
+    await screen.findByText("You’re up to date")
+
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }))
+    await waitFor(() => expect(invokeCalls).toContain("updater:check"))
+
+    fireEvent.click(screen.getByText("Technical details"))
+    fireEvent.click(screen.getByRole("button", { name: "Copy diagnostics" }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText.mock.calls[0][0]).toContain("Rowboat 1.2.3")
+    expect(writeText.mock.calls[0][0]).toContain("Electron 39.2.7")
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument()
+  })
+
+  it("offers the installed update restart action", async () => {
+    updaterStatus = { state: "ready", version: "1.2.3", newVersion: "1.3.0" }
+    render(<AboutDialog open onOpenChange={() => undefined} />)
+
+    expect(await screen.findByText("Rowboat 1.3.0 is ready to install.")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Restart" }))
+    await waitFor(() => expect(invokeCalls).toContain("updater:quitAndInstall"))
+  })
+})

--- a/apps/x/apps/renderer/src/components/about-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/about-dialog.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react"
+import { AlertTriangle, CheckCircle2, ChevronDown, Copy, Loader2, RefreshCw } from "lucide-react"
+import type { ipc as ipcShared } from "@x/shared"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+
+type UpdaterStatus = ipcShared.IPCChannels["updater:status"]["req"]
+type Versions = ipcShared.IPCChannels["app:getVersions"]["res"]
+
+const WEBSITE_URL = "https://www.rowboatlabs.com/"
+const RELEASES_URL = "https://github.com/rowboatlabs/rowboat/releases"
+const REPO_URL = "https://github.com/rowboatlabs/rowboat"
+const SUPPORT_URL = "mailto:contact@rowboatlabs.com"
+
+interface AboutDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function platformLabel(): string {
+  const platform = navigator.platform || "Desktop"
+  if (/mac/i.test(platform)) return "macOS"
+  if (/win/i.test(platform)) return "Windows"
+  if (/linux/i.test(platform)) return "Linux"
+  return platform
+}
+
+function AboutUpdate({ status }: { status: UpdaterStatus | null }) {
+  const checkNow = () => {
+    void window.ipc.invoke("updater:check", null)
+  }
+
+  if (!status) {
+    return (
+      <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Reading update status…</p>
+      </div>
+    )
+  }
+
+  if (status.state === "checking" || status.state === "downloading") {
+    return (
+      <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium">
+            {status.state === "checking" ? "Checking for updates" : "Downloading update"}
+          </p>
+          <p className="text-xs text-muted-foreground">This usually takes only a moment.</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (status.state === "ready") {
+    const version = status.newVersion?.replace(/^v/, "")
+    return (
+      <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+        <span className="size-2.5 shrink-0 rounded-full bg-[var(--rowboat-attention)]" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium">Update ready</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {version ? `Rowboat ${version} is ready to install.` : "A new version is ready to install."}
+          </p>
+        </div>
+        <Button size="sm" className="shrink-0" onClick={() => void window.ipc.invoke("updater:quitAndInstall", null)}>
+          Restart
+        </Button>
+      </div>
+    )
+  }
+
+  if (status.state === "error") {
+    return (
+      <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+        <AlertTriangle className="size-4 shrink-0 text-destructive" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium">Couldn’t check for updates</p>
+          <p className="truncate text-xs text-muted-foreground">{status.error ?? "Try again in a moment."}</p>
+        </div>
+        <Button size="sm" variant="outline" className="shrink-0" onClick={checkNow}>
+          Try again
+        </Button>
+      </div>
+    )
+  }
+
+  if (status.state === "disabled") {
+    return (
+      <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+        <span className="size-2.5 shrink-0 rounded-full bg-muted-foreground/60" aria-hidden />
+        <div>
+          <p className="text-sm font-medium">Development build</p>
+          <p className="text-xs text-muted-foreground">Automatic updates are disabled.</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (status.state === "unsupported") {
+    return (
+      <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+        <RefreshCw className="size-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium">Manual updates</p>
+          <p className="truncate text-xs text-muted-foreground">Get the latest Rowboat release from GitHub.</p>
+        </div>
+        <Button size="sm" variant="outline" className="shrink-0" onClick={() => window.open(`${RELEASES_URL}/latest`, "_blank")}>
+          Releases
+        </Button>
+      </div>
+    )
+  }
+
+  const lastChecked = status.lastCheckedAt === undefined
+    ? "Updates are checked automatically."
+    : `Last checked ${new Date(status.lastCheckedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}.`
+
+  return (
+    <div className="flex min-h-14 items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-2.5">
+      <CheckCircle2 className="size-4 shrink-0 text-[var(--rowboat-success)]" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium">You’re up to date</p>
+        <p className="truncate text-xs text-muted-foreground">{lastChecked}</p>
+      </div>
+      <Button size="sm" variant="outline" className="shrink-0" onClick={checkNow}>
+        Check again
+      </Button>
+    </div>
+  )
+}
+
+export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
+  const [status, setStatus] = useState<UpdaterStatus | null>(null)
+  const [versions, setVersions] = useState<Versions | null>(null)
+  const [copied, setCopied] = useState(false)
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    void window.ipc.invoke("updater:getStatus", null).then((next) => {
+      if (!cancelled) setStatus(next)
+    })
+    void window.ipc.invoke("app:getVersions", null).then((next) => {
+      if (!cancelled) setVersions(next)
+    })
+    const unsubscribe = window.ipc.on("updater:status", setStatus)
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [open])
+
+  useEffect(() => () => {
+    if (copyResetRef.current) clearTimeout(copyResetRef.current)
+  }, [])
+
+  const appVersion = status?.version || "—"
+  const copyDiagnostics = async () => {
+    const lines = [
+      `Rowboat ${appVersion}`,
+      versions?.electron ? `Electron ${versions.electron}` : null,
+      versions?.chrome ? `Chromium ${versions.chrome}` : null,
+      versions?.node ? `Node ${versions.node}` : null,
+      `Platform ${platformLabel()}`,
+    ].filter((line): line is string => Boolean(line))
+    try {
+      await navigator.clipboard.writeText(lines.join("\n"))
+      setCopied(true)
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+      copyResetRef.current = setTimeout(() => setCopied(false), 1500)
+    } catch (error) {
+      console.error("Failed to copy diagnostics:", error)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[540px]" aria-describedby="about-rowboat-description">
+        <header className="grid justify-items-center px-8 pb-8 pt-10 text-center">
+          <img src="./logo-only.png" alt="Rowboat logo" width={82} height={82} className="size-[82px] object-contain" />
+          <DialogTitle className="mt-4 text-2xl font-semibold tracking-tight">
+            Rowboat
+          </DialogTitle>
+          <p className="mt-1 text-xs text-muted-foreground">Version {appVersion} · Desktop</p>
+          <DialogDescription id="about-rowboat-description" className="mt-3 max-w-[360px] text-sm leading-relaxed">
+            Your AI coworker that remembers the work, not just the conversation.
+          </DialogDescription>
+        </header>
+
+        <div className="px-7 pb-6">
+          <AboutUpdate status={status} />
+
+          <nav className="mt-4 flex flex-wrap justify-center gap-x-5 gap-y-2 text-xs font-medium" aria-label="About Rowboat links">
+            <a className="text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4" href={WEBSITE_URL} target="_blank" rel="noreferrer">Website</a>
+            <a className="text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4" href={RELEASES_URL} target="_blank" rel="noreferrer">Release notes</a>
+            <a className="text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4" href={REPO_URL} target="_blank" rel="noreferrer">GitHub</a>
+            <a className="text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4" href={SUPPORT_URL} target="_blank" rel="noreferrer">Support</a>
+          </nav>
+
+          <details className="group mt-4 border-y border-border/60">
+            <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between text-xs font-medium text-muted-foreground marker:hidden">
+              Technical details
+              <ChevronDown className="size-3.5 transition-transform group-open:rotate-180" />
+            </summary>
+            <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-2 pb-3 text-xs">
+              <dt className="text-muted-foreground">Rowboat</dt><dd>Version {appVersion}</dd>
+              <dt className="text-muted-foreground">Electron</dt><dd>{versions?.electron ?? "—"}</dd>
+              <dt className="text-muted-foreground">Chromium</dt><dd>{versions?.chrome ?? "—"}</dd>
+              <dt className="text-muted-foreground">Node.js</dt><dd>{versions?.node ?? "—"}</dd>
+              <dt className="text-muted-foreground">Platform</dt><dd>{platformLabel()}</dd>
+            </dl>
+            <Button size="sm" variant="outline" className="mb-3 gap-1.5" onClick={() => void copyDiagnostics()}>
+              <Copy className="size-3.5" />
+              {copied ? "Copied" : "Copy diagnostics"}
+            </Button>
+          </details>
+
+          <p className="mt-4 text-center text-[0.7rem] text-muted-foreground">Made by Rowboat Labs · Apache 2.0</p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -41,7 +41,7 @@ import { ShortcutSettings } from "@/components/settings/shortcut-settings"
 import { ProvidersSection } from "@/components/settings/providers-section"
 import { useModels } from "@/hooks/use-models"
 
-type ConfigTab = "account" | "connections" | "mobile" | "phone" | "models" | "mcp" | "security" | "code-mode" | "appearance" | "shortcuts" | "notifications" | "permissions" | "note-tagging" | "advanced" | "help"
+export type ConfigTab = "account" | "connections" | "mobile" | "phone" | "models" | "mcp" | "security" | "code-mode" | "appearance" | "shortcuts" | "notifications" | "permissions" | "note-tagging" | "advanced" | "help"
 
 interface TabConfig {
   id: ConfigTab

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1222,6 +1222,7 @@ export const ipcSchemas = {
       z.object({ command: z.literal('undo') }),
       z.object({ command: z.literal('redo') }),
       z.object({ command: z.literal('open-search') }),
+      z.object({ command: z.literal('open-about') }),
       z.object({ command: z.literal('toggle-browser') }),
       z.object({ command: z.literal('toggle-full-screen-chat') }),
       z.object({ command: z.literal('go-back') }),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1210,6 +1210,45 @@ export const ipcSchemas = {
     req: z.null(),
     res: z.null(),
   },
+  // Main → renderer: native application-menu commands (apps/main/src/menu.ts).
+  // One channel for all of them; each routes into the same handler the
+  // corresponding in-app control uses. Go-menu navigation is NOT here — it
+  // rides the existing deep-link pipeline (app:openUrl / pending-link drain).
+  'menu:command': {
+    req: z.discriminatedUnion('command', [
+      z.object({ command: z.literal('new-chat') }),
+      z.object({ command: z.literal('new-note') }),
+      z.object({ command: z.literal('new-presentation') }),
+      z.object({ command: z.literal('undo') }),
+      z.object({ command: z.literal('redo') }),
+      z.object({ command: z.literal('open-search') }),
+      z.object({ command: z.literal('toggle-browser') }),
+      z.object({ command: z.literal('toggle-full-screen-chat') }),
+      z.object({ command: z.literal('go-back') }),
+      z.object({ command: z.literal('go-forward') }),
+      z.object({
+        command: z.literal('open-settings'),
+        // Mirrors the renderer's settings-dialog ConfigTab union.
+        tab: z.enum([
+          'account', 'connections', 'mobile', 'phone', 'models', 'mcp', 'security',
+          'code-mode', 'appearance', 'shortcuts', 'notifications',
+          'permissions', 'note-tagging', 'advanced', 'help',
+        ]).optional(),
+      }),
+      z.object({
+        command: z.literal('export-note'),
+        format: z.enum(['md', 'pdf', 'docx']),
+      }),
+    ]),
+    res: z.null(),
+  },
+  // Main → renderer: View > Toggle Sidebar. Its own channel because the
+  // handler must live inside the SidebarProvider, below where menu:command's
+  // dispatcher sits.
+  'menu:toggleSidebar': {
+    req: z.null(),
+    res: z.null(),
+  },
   // The ⌥/⌃+Tab section switcher, forwarded from the main process when an
   // embedded page (e.g. the browser <webview>) holds keyboard focus — its
   // keystrokes go to the guest and never reach the app renderer's listeners.


### PR DESCRIPTION
## What

Replaces Electron's factory-default menu (electronjs.org Help links, DevTools and Reload enabled in production) with a full native application menu for the desktop app.

- **File** — New Chat (⌘N), New Note (⇧⌘N), Export Note (md / pdf / docx)
- **Edit** — undo/redo + clipboard. On Windows/Linux undo/redo route through the renderer so the markdown editor's history routing keeps working; macOS keeps the standard roles, identical to the old default menu
- **View** — Search (⌘K), Toggle Sidebar (⌘\), Full-Screen Chat (⌘L), zoom controls, full screen; Reload / Force Reload / DevTools are now dev-only
- **Go** — Back/Forward plus all ten sections (Home, Email, Meetings, Brain, Apps, Code, Live Notes, Chat History, Background Tasks, Graph) with ⌘1–9
- **Tools** — Quick Ask (shows the live global chord, hidden when unregistered), Start/Stop Meeting Notes with dynamic relabel (same hook as the tray)
- **Help** — GitHub / Report an Issue / Release Notes, Keyboard Shortcuts (deep-links the settings tab), Open Data Folder (~/.rowboat), About, and a state-aware "Check for Updates…" that becomes "Restart to Update" when an update is staged, and links to GitHub releases on Linux where autoUpdater is unsupported

## How

- New `apps/main/src/menu.ts`, installed before the window is created so Linux/Windows never paint the default menu. Rebuilt on recording-state changes, quick-ask rebinds, and updater transitions — mirrors `tray.ts`.
- Two new typed IPC channels: `menu:command` (one discriminated payload; each command reuses the exact code path of the in-app control it mirrors) and `menu:toggleSidebar` (its own channel because the handler must live under the SidebarProvider). Go-menu navigation needs no channel — it rides the existing deep-link pipeline (`dispatchDeepLink` → `app:openUrl`), which already parks URLs while the renderer loads.
- Zoom logic extracted from `main.ts` into `zoom.ts` so menu clicks and the `before-input-event` keystroke handler share one implementation; the stale "Linux suppresses the menu bar" comment is corrected in the move.
- Chords the renderer already handles (⌘K/⌘N/⌘L/⌘Z) are display-only in the menu on Windows/Linux (`registerAccelerator: false`), so existing keyboard behavior is untouched.
- `updater.ts` gains `onUpdaterStatusChanged`; menu-opened Settings gets its own dialog instance that can deep-link any tab (`ConfigTab` is now exported).

## Testing

- `npm run deps`, `npm run lint`, `npm run typecheck` all pass; `apps/main` additionally typechecked directly with `tsc --noEmit` (it is not covered by the workspace typecheck script).
- 75-second dev-app boot on Linux: no main-process errors, menu renders with all sections.
- Linux menu bar stays always-visible; flipping to Alt-to-reveal is a one-line `autoHideMenuBar` change if preferred.