### PR TITLE
fix/apps-corner-cases

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -43,6 +43,7 @@ import { init as initBackgroundTaskScheduler } from "@x/core/dist/background-tas
 import { backgroundTaskEventConsumer } from "@x/core/dist/background-tasks/event-consumer.js";
 import { startSkillsWatcher, stopSkillsWatcher } from "@x/core/dist/runtime/assembly/skills/watcher.js";
 import { init as initAppsServer, shutdown as shutdownAppsServer } from "@x/core/dist/apps/server.js";
+import { cleanInstallTmp } from "@x/core/dist/apps/installer.js";
 import { registerAppsHostApi } from "@x/core/dist/apps/host-api.js";
 import { setTokenCipher as setGithubTokenCipher } from "@x/core/dist/apps/github-auth.js";
 import { setTokenCipher as setChatGPTTokenCipher } from "@x/core/dist/auth/chatgpt-auth.js";
@@ -567,6 +568,13 @@ app.whenReady().then(async () => {
     isAvailable: () => safeStorage.isEncryptionAvailable(),
     encrypt: (plain) => safeStorage.encryptString(plain).toString('base64'),
     decrypt: (encrypted) => safeStorage.decryptString(Buffer.from(encrypted, 'base64')),
+  });
+  // Startup hygiene: drop leftover install/update stagings. A cancelled URL
+  // preview retains its staging by design and a failed download leaves a
+  // partial bundle.zip; nothing else ever removes them, so they accumulate
+  // across launches. Fire-and-forget — never block or fail startup on it.
+  cleanInstallTmp().catch((error) => {
+    console.error('[Apps] Failed to clear install stagings:', error);
   });
   initAppsServer().catch((error) => {
     console.error('[Apps] Failed to start:', error);

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -4554,7 +4554,7 @@ function App() {
       case 'meetings': return 'Meetings'
       case 'live-notes': return 'Live notes'
       case 'bg-tasks': return 'Background tasks'
-      case 'apps': return 'Mini Apps'
+      case 'apps': return 'Apps'
       case 'workspace': return 'Workspace'
       case 'knowledge-view': return 'Brain'
       case 'graph': return 'Graph View'
@@ -5099,6 +5099,16 @@ function App() {
     void navigateToView({ type: 'apps' })
   }, [navigateToView])
 
+  // navigateToView early-returns when the apps view is already showing, so
+  // `openAppsView` alone is a no-op while an app is open — the sidebar "Apps"
+  // item did nothing. Bumping the version with a null folder tells AppsView to
+  // drop its selection (mirrors onOpenBgTasks).
+  const openAppsGrid = useCallback(() => {
+    setAppInitialId(null)
+    setAppIdVersion((v) => v + 1)
+    openAppsView()
+  }, [openAppsView])
+
   const openMeetingsView = useCallback(() => {
     void navigateToView({ type: 'meetings' })
   }, [navigateToView])
@@ -5387,7 +5397,7 @@ function App() {
         case 'knowledge': void navigateToView({ type: 'knowledge-view' }); break
         case 'workspace': void navigateToView({ type: 'workspace' }); break
         case 'code': void navigateToView({ type: 'code' }); break
-        case 'apps': openAppsView(); break
+        case 'apps': openAppsGrid(); break
       }
     }
 
@@ -5511,7 +5521,7 @@ function App() {
         break
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navigateToFile, navigateToView, selectedPath])
+  }, [navigateToFile, navigateToView, openAppsGrid, selectedPath])
 
   // Legacy runs:events path: handleRunEvent stashes the result in a ref;
   // polled every render (the triggering event always causes one).
@@ -6049,13 +6059,13 @@ function App() {
         openBgTasksView()
         break
       case 'apps':
-        openAppsView()
+        openAppsGrid()
         break
       case 'workspaces':
         knowledgeActions.openWorkspaceAt()
         break
     }
-  }, [navigateToView, openEmailView, openMeetingsView, openCodeView, knowledgeActions, openBgTasksView, openAppsView])
+  }, [navigateToView, openEmailView, openMeetingsView, openCodeView, knowledgeActions, openBgTasksView, openAppsGrid])
 
   // Handler for when a voice note is created/updated
   const handleVoiceNoteCreated = useCallback(async (notePath: string) => {
@@ -6544,7 +6554,7 @@ function App() {
               onOpenCode={openCodeView}
               onOpenBgTasks={() => { setBgTaskInitialSlug(null); setBgTaskSlugVersion((v) => v + 1); openBgTasksView() }}
               onOpenAgent={(slug) => { setBgTaskInitialSlug(slug); setBgTaskSlugVersion((v) => v + 1); openBgTasksView() }}
-              onOpenApps={openAppsView}
+              onOpenApps={openAppsGrid}
               onOpenApp={(folder) => { setAppInitialId(folder); setAppIdVersion((v) => v + 1); openAppsView() }}
               recentRuns={runs}
               onOpenRun={(rid) => void navigateToView({ type: 'chat', runId: rid })}

--- a/apps/x/apps/renderer/src/components/apps/apps-view.tsx
+++ b/apps/x/apps/renderer/src/components/apps/apps-view.tsx
@@ -194,7 +194,7 @@ export function AppsView({ initialAppFolder, initialVersion, onNewApp }: {
   const [appliedVersion, setAppliedVersion] = useState(initialVersion)
   if (initialVersion !== appliedVersion) {
     setAppliedVersion(initialVersion)
-    if (initialAppFolder) setSelectedFolder(initialAppFolder)
+    setSelectedFolder(initialAppFolder ?? null)
   }
 
   useEffect(() => {
@@ -229,7 +229,7 @@ export function AppsView({ initialAppFolder, initialVersion, onNewApp }: {
 
   const selected = selectedFolder ? apps.find((a) => a.folder === selectedFolder) : undefined
   if (selected) {
-    return <AppFrame app={selected} onBack={() => setSelectedFolder(null)} />
+    return <AppFrame key={selected.folder} app={selected} onBack={() => setSelectedFolder(null)} />
   }
 
   const noOwnApps = appsLoaded && apps.length === 0

--- a/apps/x/packages/core/src/apps/indexer.ts
+++ b/apps/x/packages/core/src/apps/indexer.ts
@@ -99,7 +99,15 @@ export async function listApps(): Promise<AppSummary[]> {
     }
     const out: AppSummary[] = [];
     for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
+        // A Dirent reports a symlink as a symlink, not a directory, so a linked
+        // app folder (a dev repo linked into ~/.rowboat/apps) was skipped here
+        // while the server — which stats the path — served it fine: an app you
+        // could open by URL but never see in the grid. Resolve links first.
+        let isDir = entry.isDirectory();
+        if (!isDir && entry.isSymbolicLink()) {
+            try { isDir = (await fs.stat(path.join(APPS_DIR, entry.name))).isDirectory(); } catch { isDir = false; }
+        }
+        if (!isDir) continue;
         if (!FOLDER_SLUG_RE.test(entry.name)) {
             if (!entry.name.startsWith('.')) {
                 console.warn(`[Apps] ignoring folder with invalid slug: ${entry.name}`);

--- a/apps/x/packages/core/src/apps/installer.ts
+++ b/apps/x/packages/core/src/apps/installer.ts
@@ -56,6 +56,14 @@ export interface InstallDone {
 
 const RELEASE_MANAGED = ['rowboat-app.json', 'dist', 'agents', 'defaults'];
 
+// Losing the network mid-download used to hang the install forever: the
+// socket stays half-open, `reader.read()` never settles, and the UI sits
+// on "Installing…" with no way out. Two bounds, because one can't do both
+// jobs: a short one for the initial response, a long one for the whole
+// transfer (a large bundle on a slow link is legitimate).
+const DOWNLOAD_CONNECT_TIMEOUT_MS = 20_000;
+const DOWNLOAD_TOTAL_TIMEOUT_MS = 180_000;
+
 // ---------------------------------------------------------------------------
 // Bundle download + extraction (shared by catalog + URL installs)
 // ---------------------------------------------------------------------------
@@ -63,28 +71,48 @@ const RELEASE_MANAGED = ['rowboat-app.json', 'dist', 'agents', 'defaults'];
 async function downloadBundle(url: string, destDir: string): Promise<{ zipPath: string; sha256: string }> {
     await fsp.mkdir(destDir, { recursive: true });
     const zipPath = path.join(destDir, 'bundle.zip');
-    const res = await fetch(url, { redirect: 'follow' });
-    if (!res.ok) throw new InstallError('download_failed', `bundle download: HTTP ${res.status}`);
+    const controller = new AbortController();
+    const totalTimer = setTimeout(() => controller.abort(), DOWNLOAD_TOTAL_TIMEOUT_MS);
+    let out: fs.WriteStream | undefined;
+    try {
+        const res = await fetch(url, {
+            redirect: 'follow',
+            signal: AbortSignal.any([controller.signal, AbortSignal.timeout(DOWNLOAD_CONNECT_TIMEOUT_MS)]),
+        });
+        if (!res.ok) throw new InstallError('download_failed', `bundle download: HTTP ${res.status}`);
 
-    const hash = crypto.createHash('sha256');
-    const out = fs.createWriteStream(zipPath);
-    const reader = res.body?.getReader();
-    if (!reader) throw new InstallError('download_failed', 'empty response body');
-    let received = 0;
-    for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        received += value.byteLength;
-        if (received > MAX_BUNDLE_COMPRESSED) {
-            out.destroy();
-            await fsp.rm(zipPath, { force: true });
-            throw new InstallError('bundle_too_large', `bundle exceeds ${MAX_BUNDLE_COMPRESSED} bytes compressed`);
+        const hash = crypto.createHash('sha256');
+        out = fs.createWriteStream(zipPath);
+        const reader = res.body?.getReader();
+        if (!reader) throw new InstallError('download_failed', 'empty response body');
+        controller.signal.addEventListener('abort', () => { void reader.cancel().catch(() => {}); });
+        let received = 0;
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += value.byteLength;
+            if (received > MAX_BUNDLE_COMPRESSED) {
+                out.destroy();
+                await fsp.rm(zipPath, { force: true });
+                throw new InstallError('bundle_too_large', `bundle exceeds ${MAX_BUNDLE_COMPRESSED} bytes compressed`);
+            }
+            hash.update(value);
+            await new Promise<void>((resolve, reject) => out!.write(value, (e) => (e ? reject(e) : resolve())));
         }
-        hash.update(value);
-        await new Promise<void>((resolve, reject) => out.write(value, (e) => (e ? reject(e) : resolve())));
+        await new Promise<void>((resolve, reject) => out!.end((e?: Error | null) => (e ? reject(e) : resolve())));
+        return { zipPath, sha256: hash.digest('hex') };
+    } catch (err) {
+        if (err instanceof InstallError) throw err;
+        const aborted = err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+        if (aborted) {
+            out?.destroy();
+            await fsp.rm(zipPath, { force: true });
+            throw new InstallError('download_failed', 'bundle download timed out — check your connection and try again');
+        }
+        throw err;
+    } finally {
+        clearTimeout(totalTimer);
     }
-    await new Promise<void>((resolve, reject) => out.end((e?: Error | null) => (e ? reject(e) : resolve())));
-    return { zipPath, sha256: hash.digest('hex') };
 }
 
 /**

--- a/apps/x/packages/core/src/apps/server.ts
+++ b/apps/x/packages/core/src/apps/server.ts
@@ -222,8 +222,17 @@ const BOOTSTRAP = String.raw`<script>
 </script>`;
 
 function injectBootstrap(htmlContent: string): string {
-    if (/<\/body>/i.test(htmlContent)) return htmlContent.replace(/<\/body>/i, `${BOOTSTRAP}\n</body>`);
-    return `${htmlContent}\n${BOOTSTRAP}`;
+    // Inject before the LAST </body>, not the first. An app whose markup
+    // contains a literal "</body>" earlier — a template inside a <textarea>,
+    // an HTML string inside a <script> — got the bootstrap spliced into that
+    // text instead: visible junk at best, a broken <script> at worst, and no
+    // live reload either way. (Regex loop rather than toLowerCase+lastIndexOf:
+    // case mapping can change string length and misalign the index.)
+    const re = /<\/body>/gi;
+    let idx = -1;
+    for (let m = re.exec(htmlContent); m; m = re.exec(htmlContent)) idx = m.index;
+    if (idx === -1) return `${htmlContent}\n${BOOTSTRAP}`;
+    return `${htmlContent.slice(0, idx)}${BOOTSTRAP}\n${htmlContent.slice(idx)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/x/packages/core/src/apps/server.ts
+++ b/apps/x/packages/core/src/apps/server.ts
@@ -762,7 +762,17 @@ async function startWatcher(): Promise<void> {
         if (!['add', 'addDir', 'change', 'unlink', 'unlinkDir'].includes(eventName)) return;
         const hit = slugFromAbsolutePath(absolutePath);
         if (!hit || hit.rel.endsWith('.tmp') || /\.tmp-[0-9a-f]+$/.test(hit.rel)) return;
-        const area: 'dist' | 'data' = hit.rel === 'data' || hit.rel.startsWith('data/') ? 'data' : 'dist';
+        // Only dist/, data/ and the manifest change what the app serves.
+        // Everything else in the folder fell into the "dist" bucket and forced
+        // a full page reload — README.md, .rowboat-install.json,
+        // .rowboat-publish.json (rewritten at every publish step), agents/,
+        // defaults/, .previous/ — discarding whatever the user had typed in the
+        // open app for a file the app never reads.
+        const top = hit.rel.split('/')[0];
+        let area: 'dist' | 'data';
+        if (top === 'data') area = 'data';
+        else if (top === 'dist' || hit.rel === 'rowboat-app.json') area = 'dist';
+        else return;
         scheduleChangeBroadcast(hit.slug, area, hit.rel);
         if (hit.rel === 'data/config.json' && (eventName === 'add' || eventName === 'change')) {
             scheduleAgentKick(hit.slug);

--- a/apps/x/packages/core/src/apps/server.ts
+++ b/apps/x/packages/core/src/apps/server.ts
@@ -617,6 +617,16 @@ async function handleStatic(
         return html503(res, 'App entry not found', `dist/${entryRel} does not exist.`);
     }
 
+    // The entry itself is missing. `dist/index.html` has an extension, so the
+    // SPA-fallback branch above never catches it and this fell through to the
+    // JSON asset error — opening the app showed a raw {"error":...} blob
+    // instead of a page. This is the common copilot failure shape: manifest
+    // and dist/ get written, the entry does not.
+    const entryOnDisk = confinePath(distRoot, `/${entryRel}`);
+    if (entryOnDisk && resolved === entryOnDisk) {
+        return html503(res, 'App entry not found', `dist/${entryRel} does not exist.`);
+    }
+
     sendError(res, 404, 'not_found', 'asset not found');
 }
 
@@ -651,6 +661,13 @@ function createApp(): express.Express {
             }
             const slug = match[1];
             if (!FOLDER_SLUG_RE.test(slug) || !fs.existsSync(appDirFor(slug))) {
+                // A browser navigating here — the app frame reloading after its folder
+                // was deleted or renamed — should get a page, not a JSON blob. Asset and
+                // XHR requests keep the machine-readable error.
+                if (req.method === 'GET' && (req.headers.accept ?? '').includes('text/html')) {
+                    html503(res, 'App not found', `There is no app folder named “${slug}”. It may have been deleted or renamed.`);
+                    return;
+                }
                 sendError(res, 404, 'app_not_found', `no app folder named "${slug}"`);
                 return;
             }


### PR DESCRIPTION
## Summary

A pass over the Apps section fixing corner cases — situations that don't come up
in the happy path, so they were never exercised: navigating back to the grid
from inside an app, switching between apps, apps whose files are missing or
half-written, apps whose own markup collides with what the server injects,
installs that lose the network mid-download, and staging directories that were
never cleaned up.

These were found by working through the Apps section manually rather than from a
single bug report. Each commit is independent and can be reviewed on its own.

This PR is a draft — more fixes from the same pass are still landing. The list of
what's still outstanding is at the bottom.

## 1. Sidebar "Apps" was a no-op while an app was open

**What was wrong.** With an app open, clicking "Apps" in the sidebar did nothing.
The only way back to the grid was the toolbar's "← Apps" button. A person who
reached for the sidebar just saw a dead click.

**Why.** `isAppsOpen` is already true in that state, so `currentViewState` is
already `{ type: 'apps' }`. `navigateToView` compares with `viewStatesEqual`,
finds them equal, and early-returns — `applyViewState` never runs, `AppsView`
never receives new props, and its internal `selectedFolder` keeps pointing at the
open app. The bg-tasks view doesn't have this problem because `onOpenBgTasks`
already clears its slug and bumps a version counter.

**How it's fixed.** A sibling helper `openAppsGrid` mirrors that pattern: clear
`appInitialId`, bump `appIdVersion`, then call `openAppsView`. Used at the three
call sites that mean "show me the grid" — the sidebar item,
`navigateToNamedView`'s `'apps'` case, and the product tour. The `open-app` path
and `onOpenApp` are deliberately untouched; those target a specific app and
already work.

`AppsView`'s adjust-during-render block now does
`setSelectedFolder(initialAppFolder ?? null)` instead of
`if (initialAppFolder) setSelectedFolder(initialAppFolder)`, so a null folder
actually clears the selection rather than being ignored.

**Also in this commit.** `AppFrame` is now keyed by `key={selected.folder}`.
Without it, switching from app A to app B (via a pinned sidebar entry or
`open-app`) reused the same component instance, so `showDetail`, `showPublish`
and `reloadNonce` carried over — with the publish dialog open on app A, switching
to B left it open and pointed at B. The header title for the apps view also said
"Mini Apps" while every other surface said "Apps".

Files: `apps/renderer/src/App.tsx`,
`apps/renderer/src/components/apps/apps-view.tsx`

## 2. A raw JSON error blob where the app should be

**What was wrong.** Opening an app whose `dist/index.html` was missing rendered
`{"error":{"code":"not_found","message":"asset not found"}}` as plain text in the
app pane. Same class of failure after an app's folder was deleted or renamed
while it was open — the frame reloaded and showed a JSON blob for a second or two
before the grid took over.

**Why this matters more than it looks.** This is the visible face of a
half-written app. The copilot writes `rowboat-app.json` and creates `dist/`, then
fails before writing the entry — and the person opens the app and gets an error
blob. From the outside it reads as "the app didn't get built", which is exactly
the shape of the failure reports we've had.

**Why it happened.** `handleStatic` maps `/` to `/${manifest.entry}`, i.e.
`index.html`. The friendly "App entry not found" page lives behind
`if (!path.extname(resolved))` — the SPA fallback branch for extensionless paths.
`index.html` has an extension, so that branch is skipped and the request falls
through to the JSON asset error at the end of the function. The friendly page
existed but was unreachable for the one case it was written for: you could only
see it by requesting an extensionless path.

**How it's fixed.** Two changes in `server.ts`:

- In `handleStatic`, before the final `sendError`, the resolved path is compared
  against the manifest entry. If they match, the entry itself is missing and the
  friendly page is returned regardless of extension.
- In the router's "no such app folder" branch, a document navigation (`GET` with
  `Accept: text/html`) gets an "App not found" page explaining the folder may
  have been deleted or renamed. Asset and XHR requests keep the JSON error — app
  code calling `fetch` still needs the machine-readable shape.

Deciding by `Accept` rather than by path keeps the two audiences separate: the
browser frame gets a page, the app's own JavaScript gets JSON.

File: `packages/core/src/apps/server.ts`

## 3. Losing the network mid-install hung forever

**What was wrong.** Turning off Wi-Fi during an install left the UI on
"Installing…" indefinitely — no error, no timeout, no way out except restarting
the app.

**Why.** `downloadBundle` had no timeout anywhere. `fetch` itself can stall on
connect, and the streaming read loop is worse: the socket stays half-open, so
`reader.read()` never settles and the loop parks on it forever at whatever byte
count it had reached.

**How it's fixed.** Two bounds, because one value can't serve both purposes — a
short one would kill legitimate large bundles on slow links, a long one would
leave a dead connection hanging for minutes:

- `DOWNLOAD_CONNECT_TIMEOUT_MS` (20s) for the initial response.
- `DOWNLOAD_TOTAL_TIMEOUT_MS` (180s) for the whole transfer.

A single `AbortController` drives both; on abort the reader is cancelled, the
partial `bundle.zip` is removed, and an `InstallError('download_failed', …)`
surfaces in the catalog's error banner. Hashing, the compressed-size cap and the
write stream are unchanged.

File: `packages/core/src/apps/installer.ts`

## 4. Install stagings were never cleaned up

**What was wrong.** `~/.rowboat/tmp/app-install-*` and `app-update-*` directories
accumulated across launches, each holding a bundle zip.

**Why.** `cleanInstallTmp` was written and exported but never called from
anywhere. `installFromRegistry` and `updateApp` clean their own staging in a
`finally`, but the URL-install flow retains its staging by design — it is
two-phase, and preview must survive until the person confirms. Cancel the preview
and that directory is orphaned; the in-memory `urlStagings` map is gone on the
next launch, so nothing can ever find it again. A download that fails or times
out (see #3) leaves the same residue.

**How it's fixed.** `cleanInstallTmp()` is called once at startup, immediately
before `initAppsServer()`, fire-and-forget with a logged catch so it can never
block or fail launch. It only removes entries matching the two known prefixes,
never the whole tmp directory.

File: `apps/main/src/main.ts`

## 5. The live-reload bootstrap landed in the middle of the page

**What was wrong.** An app whose markup contains a literal `</body>` before the
document end — an HTML template inside a `<textarea>`, an HTML string inside a
`<script>` — got the injected reload bootstrap spliced into that text. The script
source showed up as visible junk on the page, and live reload stopped working for
that app entirely.

**Why.** `injectBootstrap` used `String.replace` with a non-global regex, which
replaces the **first** match. For every normal app the first `</body>` is also the
last one, so this was invisible until an app quoted HTML in its own content.

**How it's fixed.** Scan for the last `</body>` and splice there; fall back to
appending when the document has none. Uses a `/gi` regex loop rather than
`toLowerCase()` + `lastIndexOf` — case mapping can change string length and
misalign the index.

File: `packages/core/src/apps/server.ts`

## 6. Symlinked app folders were invisible in the grid

**What was wrong.** An app folder that is a symlink (linking a dev checkout into
`~/.rowboat/apps`) never appeared in the grid, while the server happily served it
— `curl` against its origin returned 200 and the app rendered. An app you could
open by URL but never see.

**Why.** `listApps` filters on `entry.isDirectory()`, and a `Dirent` reports a
symlink as a symlink, not a directory, so the entry was skipped before it was
ever summarized. The server takes a different path — it `existsSync`es the
resolved directory — so the two disagreed.

**How it's fixed.** When the entry is a symlink, `stat` the target and treat it as
a directory if it resolves to one. Everything downstream (slug validation,
manifest parsing, the `dist/` guard) is unchanged, and a broken link still fails
closed.

File: `packages/core/src/apps/indexer.ts`

## 7. Any file change in the app folder forced a full page reload

The watcher bucketed everything not under `data/` as "dist", so `README.md`,
`.rowboat-install.json`, `.rowboat-publish.json` (rewritten at every publish
step), `agents/` and `.previous/` all reloaded the open app — discarding
whatever the person had typed, for files the app never reads. Now only `dist/`,
`data/` and the manifest trigger a reload. Verified by hand: a README append no
longer reloads, a `dist/` edit and a `data/` write still do.

File: `packages/core/src/apps/server.ts`


## How to test

Build and run: `cd apps/x && npm run deps && npm run dev`

**Navigation**

1. Apps → open any app → click "Apps" in the **sidebar** (not the toolbar) → the
   grid should come back.
2. Pin two apps (right-click a card → "Add to sidebar"). Open app A, open its
   detail panel with the "i" button, then click app B in the sidebar → B opens
   with a fresh panel. Repeat with the Publish dialog open on A → it should close
   rather than follow you to B.
3. Ask the copilot to "open the `<name>` app" → still opens that app directly.
4. Header title reads "Apps".

