### PR TITLE
fix(x): one hover companion — delete the summoned ask bar, no flash, no dead summons

### DIFF
--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -10,18 +10,28 @@ pipeline, and the LLM prompt surface with exact pointers.
 ## Product flow
 
 The composer has a **call split-button** (`chat-input-with-mentions.tsx`).
-The main click is the "work together" default — preset `share`: screen
-sharing ON, camera OFF, floating pill, so the user keeps working while the
-assistant watches along (the button tooltip discloses the screen share). The
-chevron menu holds the deviations. While a call is live the button turns red
-and ends it.
+The main click is the **hover companion** — preset `voice`: the SAME
+Skipper surface ⌥⇧Space summons (`startHoverCall()` in `App.tsx`), bound to
+this chat. The chevron menu holds the deviations. While a call is live the
+button turns red and ends it.
 
 | Preset | Starting devices | First surface |
 |--------|------------------|---------------|
-| `share` — main click | screen on, camera off | floating pill |
-| `voice` — no menu entry (programmatic only; the quick-ask bar's voice toggle covers this case) | camera off, screen off | floating mascot pill |
+| `voice` — main click, ⌥⇧Space, tray "Quick Ask", the card's tuck handle, the Home Skipper, the discoverability toast | camera off, screen off (sticky share replays if opted in) | the Skipper card (hover mode) |
+| `share` — "Share screen" | screen on, camera off | the Skipper card — the same hover summon with the screen shared from the start |
 | `video` — "Video call" | camera on | floating pill (camera in the pill; expand for full screen) |
 | `practice` — "Practice session" | camera on, + coaching persona | full-screen call |
+
+**ONE hover flow.** Every hover entry point ends in `startHoverCall()`:
+the chord / tray item / tuck handle / toast go main → `relaySummon()` →
+`quick-ask:tuck` → app; the call button and the Home Skipper call it
+directly. It acks the relay (`quickAsk:tuckAck`), starts the `voice`
+preset, and only THEN kicks off the (sticky or `share`-forced) screen
+share, fire-and-forget — the in-flight guard is released the moment the
+call engine settles, never held across device acquisition. A session that
+fails to start falls back to the text card (`quickAsk:show`), so a summon
+is never a silent no-op. Without voice configured the text card is the
+answer from the start.
 
 **One surface rule** (`callSurface` in `App.tsx`): full screen and screen
 sharing are mutually exclusive in both directions — a full-screen call covers
@@ -209,14 +219,37 @@ over `quick-ask:mode` (`'summoned' | 'pinned'`).
   the whole screen).
 - Pinned iff the derived `callSurface === 'popout'` (effect in `App.tsx`).
   Renderer asks `video:setPopout {show}`; main repositions the companion
-  window to the old popout geometry (top-right of the primary display,
-  content-sized; `video:popoutResize` grows it for the response panel) and
-  shows it with `showInactive()` so it never steals focus. Blur does NOT
-  hide it in this mode (Spotlight blur-dismiss applies to the summoned role
-  only), Esc never dismisses it, and ⌥⇧Space focuses it instead of
-  toggling.
+  window (Skipper card at its anchor corner, or the old popout geometry
+  top-right for camera calls; `video:popoutResize` grows the pill for the
+  response panel) and reveals it — focused when a summon is pending,
+  `showInactive()` otherwise so it never steals focus. Blur does NOT hide
+  it in this mode (Spotlight blur-dismiss applies to the summoned role
+  only), Esc never dismisses it, and ⌥⇧Space folds/unfolds its text panel
+  instead of toggling.
+- **Reveal protocol** (the fix for "the old bar flashes before the
+  Skipper"): every `quick-ask:mode` push carries a `seq`; the renderer acks
+  it over `quickAsk:modeApplied` two frames after committing that role
+  (i.e. once it is painted). Main orders the window in at opacity 0 so the
+  renderer can paint, then sets opacity 1 (+ focus) only on the ack —
+  never with the previous role's layout on screen. A fold also pushes
+  first and shrinks the window on the ack, so the open card is never
+  squeezed into mascot-sized bounds for a frame. Timeouts (600 ms; 6 s
+  while the page is still loading) keep a wedged renderer from blocking.
+  On the renderer side the role is UNKNOWN until the first push/fetch —
+  nothing paints before then — and `index.html` gives `#quick-ask` /
+  `#screen-pointer` a transparent background from the very first paint.
 - Call state streams over the `video:popout-state` push channel; main
-  caches the last payload (in quick-ask.ts) and replays it on window load.
+  caches the last payload (in quick-ask.ts) and replays it on window load
+  and on every pin. The renderer drops its mirror whenever it leaves the
+  pinned role; the app pushes an explicit idle state when a call ENDS (the
+  cache survives fullscreen ⇄ popout flaps of a live call, so a camera
+  call comes back as the pill, not a card that morphs).
+- No app window (the user closed it) or one still loading: the summon
+  recreates it hidden (`initQuickAsk({ ensureAppWindow })` in `main.ts`)
+  and re-fires the relay on the app's `quickAsk:appReady` handshake; the
+  text card falls back if nothing answers (1.5 s with an app window up,
+  8 s while it boots). Closing the app window mid-call unpins the
+  companion (`onAppWindowClosed`).
 - The pill captures its **own** camera preview (MediaStreams can't cross
   windows) and synthesizes the mascot mouth level (no audio in that
   window).
@@ -254,7 +287,11 @@ over `quick-ask:mode` (`'summoned' | 'pinned'`).
 - Screen: `getDisplayMedia` is auto-approved with the primary screen by
   `setDisplayMediaRequestHandler` in `main.ts` (no picker);
   `meeting:checkScreenPermission` registers the app in macOS Screen
-  Recording settings on first use.
+  Recording settings on first use. With the permission denied (or its
+  prompt unanswered) `getDisplayMedia` can hang forever, so
+  `useVideoMode.startScreenShare` time-boxes the whole acquisition
+  (10 s) and fails cleanly — a hung share used to wedge `screenState` at
+  'starting' for the rest of the session.
 - Input Monitoring (global PTT key hook): starting the uiohook event tap
   triggers the macOS consent prompt on first use, but a missing grant
   doesn't error — events just never arrive (`eventsSeen` stays false). A
@@ -391,6 +428,10 @@ the composer's Stop. The window is hidden, not destroyed, on dismiss
 bottom card paints; composer popovers open upward into the transparent
 zone, a click there dismisses, and no window resizing happens in this
 mode.
+
+Today this card is the FALLBACK surface: the chord's first job is the
+hover companion above; the card appears when voice isn't configured, when
+a session fails to start, or when nothing answers the relay.
 
 **Optional toggles** (`quickAsk:setOptions` → `quick-ask:set-options`;
 actual state echoes back over `quickAsk:optionsState` →

--- a/apps/x/VIDEO_MODE.md
+++ b/apps/x/VIDEO_MODE.md
@@ -96,10 +96,10 @@ The call button is disabled unless both voice input (Deepgram) and voice
 output (TTS) are configured. `call_started` (with `preset`) is captured in
 PostHog — the adoption metric for this feature.
 
-**Popout mechanics**: the floating pill is the COMPANION WINDOW's pinned
-role — the same always-on-top window as the ⌥⇧Space quick-ask bar, swapped
-to the pill layout (camera tile when on + mascot tile, live caption,
-control bar, composer) and repositioned top-right. It floats over every
+**Popout mechanics**: the floating pill is the COMPANION WINDOW (the same
+always-on-top window ⌥⇧Space summons) in its pill layout — camera tile when
+on + mascot tile, live caption, control bar, composer — repositioned
+top-right. It floats over every
 app — including Rowboat. Control-bar actions round-trip
 `video:popoutAction` → main → `video:popout-action` → app window, which
 owns the mic/camera/capture; `expand` also refocuses the app window
@@ -201,12 +201,13 @@ and starts the PTT session; ending restores everything. Composer dictation
 is disabled while a call owns the mic. Mute blocks PTT entirely (pressing
 the key while muted does nothing; muting mid-capture discards it).
 
-## The pill = the companion window's pinned role
+## The companion window (the hover surface)
 
-There is no separate popout window anymore: the quick-ask window
-(`apps/main/src/quick-ask.ts`, renderer `components/quick-ask-bar.tsx`,
-hash `#quick-ask`) plays both floating roles, switched by a mode pushed
-over `quick-ask:mode` (`'summoned' | 'pinned'`).
+One always-on-top window (`apps/main/src/quick-ask.ts`, renderer
+`components/quick-ask-bar.tsx`, hash `#quick-ask`) with ONE visible role,
+pushed over `quick-ask:mode` (`'pinned' | 'hidden'`): the Skipper — mascot
++ text panel, or the pill when a live camera needs its self-view. There is
+no separate popout window, and no second "ask bar" role.
 
 - The window is an NSPanel (`type: 'panel'`) with
   `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true,
@@ -222,22 +223,21 @@ over `quick-ask:mode` (`'summoned' | 'pinned'`).
   window (Skipper card at its anchor corner, or the old popout geometry
   top-right for camera calls; `video:popoutResize` grows the pill for the
   response panel) and reveals it — focused when a summon is pending,
-  `showInactive()` otherwise so it never steals focus. Blur does NOT hide
-  it in this mode (Spotlight blur-dismiss applies to the summoned role
-  only), Esc never dismisses it, and ⌥⇧Space folds/unfolds its text panel
-  instead of toggling.
-- **Reveal protocol** (the fix for "the old bar flashes before the
-  Skipper"): every `quick-ask:mode` push carries a `seq`; the renderer acks
-  it over `quickAsk:modeApplied` two frames after committing that role
-  (i.e. once it is painted). Main orders the window in at opacity 0 so the
-  renderer can paint, then sets opacity 1 (+ focus) only on the ack —
-  never with the previous role's layout on screen. A fold also pushes
+  `showInactive()` otherwise so it never steals focus. Blur does NOTHING
+  (a companion you work next to must not vanish when you click away), Esc
+  tucks the text rather than dismissing, and ⌥⇧Space folds/unfolds the
+  text panel.
+- **Reveal protocol**: every `quick-ask:mode` push carries a `seq`; the
+  renderer acks it over `quickAsk:modeApplied` two frames after committing
+  that presentation (i.e. once it is painted). Main orders the window in at
+  opacity 0 so the renderer can paint, then sets opacity 1 (+ focus) only
+  on the ack — never with a half-built layout on screen. A fold also pushes
   first and shrinks the window on the ack, so the open card is never
   squeezed into mascot-sized bounds for a frame. Timeouts (600 ms; 6 s
   while the page is still loading) keep a wedged renderer from blocking.
-  On the renderer side the role is UNKNOWN until the first push/fetch —
-  nothing paints before then — and `index.html` gives `#quick-ask` /
-  `#screen-pointer` a transparent background from the very first paint.
+  The renderer paints NOTHING until it knows its role (and nothing at all
+  while hidden), and `index.html` gives `#quick-ask` / `#screen-pointer` a
+  transparent background from the very first paint.
 - Call state streams over the `video:popout-state` push channel; main
   caches the last payload (in quick-ask.ts) and replays it on window load
   and on every pin. The renderer drops its mirror whenever it leaves the
@@ -246,10 +246,11 @@ over `quick-ask:mode` (`'summoned' | 'pinned'`).
   call comes back as the pill, not a card that morphs).
 - No app window (the user closed it) or one still loading: the summon
   recreates it hidden (`initQuickAsk({ ensureAppWindow })` in `main.ts`)
-  and re-fires the relay on the app's `quickAsk:appReady` handshake; the
-  text card falls back if nothing answers (1.5 s with an app window up,
-  8 s while it boots). Closing the app window mid-call unpins the
-  companion (`onAppWindowClosed`).
+  and re-fires the relay on the app's `quickAsk:appReady` handshake; an
+  unanswered relay is re-sent once by a watchdog (1.5 s with an app window
+  up, 8 s while it boots) and then logged, never answered with some other
+  surface. Closing the app window mid-call unpins the companion
+  (`onAppWindowClosed`).
 - The pill captures its **own** camera preview (MediaStreams can't cross
   windows) and synthesizes the mascot mouth level (no audio in that
   window).
@@ -269,15 +270,10 @@ over `quick-ask:mode` (`'summoned' | 'pinned'`).
   pushed with `quick-ask:mode`). The mascot is the drag handle; hover
   reveals hold-to-talk / bring-text-back / end-call; a one-line caption
   shows interim speech and the spoken reply's tail; an active screen share
-  KEEPS its consent badge. The summoned bar's tuck handle (») enters this
-  state via `quickAsk:tuck` → `quick-ask:tuck` → the app starts the
-  `voice`-preset call (which opens minimized → floating surface) or, if a
-  call is already live, minimizes it. Tucking from the bar places the
-  mascot bottom-right of the cursor's display (it stays with the user);
-  collapsing an existing pill shrinks it in place toward its nearest
-  corner. ⌥⇧Space while tucked brings the text back; tuck/untuck never
-  ends the call — only the end-call control does. This is the `voice`
-  preset's "floating mascot pill" surface, finally shipped.
+  KEEPS its consent badge. The card's tuck handle (»), Esc, a click on the
+  stage near the card, and the mascot's text pin all enter this state;
+  ⌥⇧Space toggles it. Tuck/untuck never ends the session — only End &
+  close does.
 
 ## Permissions
 
@@ -332,8 +328,8 @@ a finger on the chart.
   no renderer round-trip, and it hard-fails with an explanation when no
   share is live.
 - Share gate: an App.tsx effect reports `video.screenState === 'live'` over
-  `screenPointer:setShareActive` (covers call AND quick-ask shares); share
-  end tears the pointer down instantly.
+  `screenPointer:setShareActive`; share end tears the pointer down
+  instantly.
 - Overlay: `apps/main/src/screen-pointer.ts` creates a transparent,
   click-through (`setIgnoreMouseEvents`), non-focusable, screen-saver-level
   NSPanel covering the primary display (the share always captures the
@@ -409,43 +405,36 @@ distribution (utterance → submit → first speak → audio playing):
 - **Acknowledgment cue** (`lib/call-sounds.ts`): a soft blip the instant an
   utterance is accepted — perceived latency matters as much as measured.
 
-## Quick-ask bar (the companion window's summoned role)
+## Typing on the Skipper
 
-Global ⌥⇧Space summons a Spotlight-style bar over any app — the SAME
-window as the call pill above, in its `summoned` mode. The input is the
-real chat composer (`ChatInputWithMentions`): @-mentions over knowledge
-notes, attachments, model/effort picker, search/code/permission toggles.
-Type — or hold Right ⌘ for local dictation (DOM events; the bar has
-focus, no Input Monitoring needed) — and the submit relays through main
-into the current chat with the FULL composer payload (`quickAsk:submit`
-→ `quick-ask:submit` → `handlePromptSubmit`, with the bar's model/effort
-applied to the active tab first); the answer mirrors back over
-`quickAsk:state` → `quick-ask:state` (streaming text from
-`currentAssistantMessage`, final text from the conversation — only
-messages timestamped after the submit count), and `quickAsk:stop` relays
-the composer's Stop. The window is hidden, not destroyed, on dismiss
-(blur or Esc). Geometry: a FIXED tall transparent frame — only the
-bottom card paints; composer popovers open upward into the transparent
-zone, a click there dismisses, and no window resizing happens in this
-mode.
+The Skipper's card hosts the REAL chat composer
+(`ChatInputWithMentions`): @-mentions over knowledge notes, attachments,
+model/effort picker, search/code/permission toggles. A submit relays
+through main with the FULL payload (`quickAsk:submit` →
+`quick-ask:submit` → `handleHoverSubmit`) into the COMPANION's session —
+never the app window's chat — and the reply comes back through the same
+call mirror a spoken one does (`video:popoutState` → `video:popout-state`),
+so there is no second answer channel. Speech follows the QUESTION's
+modality: typed questions render silently, spoken ones are read aloud,
+plus the explicit speaker mute on the card.
 
-Today this card is the FALLBACK surface: the chord's first job is the
-hover companion above; the card appears when voice isn't configured, when
-a session fails to start, or when nothing answers the relay.
+The strip above the composer carries the destination chip (which chat
+this session continues, with a recents switcher and Command Center
+first), new-chat, the history peek, the speaker mute, and Open-in-Rowboat.
+Device controls (mic, share, end) live on the mascot's pins, in both the
+open and tucked states.
 
-**Optional toggles** (`quickAsk:setOptions` → `quick-ask:set-options`;
-actual state echoes back over `quickAsk:optionsState` →
-`quick-ask:options-state`): **voice response** speaks the bar's answers
-aloud — per-turn (`speakTurnRef` set at submit for quick-ask turns), so
-composer messages outside the bar never start talking; the segment player
-and fallback-speech net honor it. **Screen share** reuses the call
-engine's capture wholesale (`video.start({camera:false})` +
-`startScreenShare`, black-frame permission check included): frames ride
-along with bar submits and `composition.videoMode` is set. The bar owns
-the consent surface outside calls — a lit share toggle with a pulsing dot
-is the badge, no floating pill appears, and the share STOPS whenever the
-bar goes away (blur, Esc, the Open-in-Rowboat jump). Bar toggles never
-touch devices while a call is live.
+**Retired** (2026-08): the `summoned` role — a standalone Spotlight-style
+ask bar with its own answer panel (`quickAsk:state`), local dictation
+(`quick-ask:summoned` hold-to-talk), Stop relay (`quickAsk:stop`),
+dismiss (`quickAsk:hide` / blur), and voice-out + share-without-a-call
+toggles (`quickAsk:setOptions` / `quickAsk:optionsState`). Those channels
+and their App-side plumbing (`speakTurnRef`, `quickAskActiveRef`,
+`quickAskOptionsRef`) are gone. ⌥⇧Space has exactly ONE outcome now, so
+there is no second layout to flash, race, or get stuck in. A summon that
+can't become a session (voice unconfigured, or the engine failed to
+start) is explained in the APP window — brought to the front with a toast
+that opens Settings — never by showing a different floating surface.
 
 ## Cost notes
 

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -32,8 +32,6 @@ import {
   getExpandedSurface,
   getPopoutState,
   getQuickAskShortcutState,
-  getQuickAskWindow,
-  hideQuickAsk,
   onAppReady,
   onModeApplied,
   isPinnedCollapsed,
@@ -46,7 +44,6 @@ import {
   setPinnedCollapsed,
   setQuickAskShortcut,
   setShortcutCaptureActive,
-  showQuickAsk,
 } from './quick-ask.js';
 import { screenPointerService } from './screen-pointer.js';
 import { RunEvent } from '@x/shared/dist/runs.js';
@@ -1158,7 +1155,7 @@ export function setupIpcHandlers() {
         }
       }
     },
-    // --- Quick-ask bar relays ---
+    // --- Hover companion relays ---
     'quickAsk:getShortcut': async () => {
       return getQuickAskShortcutState();
     },
@@ -1171,10 +1168,6 @@ export function setupIpcHandlers() {
     },
     'quickAsk:submit': async (_event, args) => {
       findMainAppWindow()?.webContents.send('quick-ask:submit', args);
-      return {};
-    },
-    'quickAsk:stop': async () => {
-      findMainAppWindow()?.webContents.send('quick-ask:stop', null);
       return {};
     },
     'quickAsk:getMode': async () => {
@@ -1217,24 +1210,8 @@ export function setupIpcHandlers() {
       findMainAppWindow()?.webContents.send('quick-ask:select-chat', args);
       return {};
     },
-    'quickAsk:hide': async () => {
-      hideQuickAsk();
-      return {};
-    },
-    'quickAsk:show': async () => {
-      showQuickAsk();
-      return {};
-    },
     'quickAsk:newChat': async () => {
       findMainAppWindow()?.webContents.send('quick-ask:new-chat', null);
-      return {};
-    },
-    'quickAsk:setOptions': async (_event, args) => {
-      findMainAppWindow()?.webContents.send('quick-ask:set-options', args);
-      return {};
-    },
-    'quickAsk:optionsState': async (_event, args) => {
-      getQuickAskWindow()?.webContents.send('quick-ask:options-state', args);
       return {};
     },
     'quickAsk:openChat': async () => {
@@ -1246,10 +1223,6 @@ export function setupIpcHandlers() {
         app.focus({ steal: true });
         main.webContents.send('quick-ask:open-chat', null);
       }
-      return {};
-    },
-    'quickAsk:state': async (_event, args) => {
-      getQuickAskWindow()?.webContents.send('quick-ask:state', args);
       return {};
     },
     'meeting:notifyNotesReady': async (_event, args) => {

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -28,13 +28,16 @@ let caffeinateBlockerId: number | null = null;
 import { initPtt, setPttActive, getPttStatus, retryPttHook, openInputMonitoringSettings } from './ptt.js';
 import {
   getCompanionMode,
+  getModeSeq,
   getExpandedSurface,
   getPopoutState,
   getQuickAskShortcutState,
   getQuickAskWindow,
   hideQuickAsk,
+  onAppReady,
+  onModeApplied,
   isPinnedCollapsed,
-  markSummonPending,
+  relaySummon,
   ackSummon,
   pushChatContext,
   pushPopoutState,
@@ -1176,17 +1179,26 @@ export function setupIpcHandlers() {
     },
     'quickAsk:getMode': async () => {
       return {
+        seq: getModeSeq(),
         mode: getCompanionMode(),
         collapsed: isPinnedCollapsed(),
         surface: getExpandedSurface(),
       };
     },
+    'quickAsk:modeApplied': async (_event, args) => {
+      onModeApplied(args.seq);
+      return {};
+    },
+    'quickAsk:appReady': async () => {
+      onAppReady();
+      return {};
+    },
     'quickAsk:tuck': async () => {
-      // The next pin gets focus (the user asked for their companion); the
-      // app window decides HOW to get there (start a voice call, or
-      // minimize a live call to the floating surface).
-      markSummonPending();
-      findMainAppWindow()?.webContents.send('quick-ask:tuck', null);
+      // The card's tuck handle: the SAME relay as the chord (the next pin
+      // gets focus; the app window decides HOW to get there — start a voice
+      // call, or minimize a live call to the floating surface; a missing or
+      // loading app window is waited for; nothing answering falls back).
+      relaySummon();
       return {};
     },
     'quickAsk:tuckAck': async () => {

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -81,7 +81,7 @@ import { ensureLoginItemRegistration } from "./login_item.js";
 import { init as initMeetingDetection } from "@x/core/dist/meetings/detector.js";
 import { createAppTray, hasTray, isRecordingActive, markPendingToggleMeetingNotes } from "./tray.js";
 import { initMeetingPopup, showMeetingPopup } from "./meeting-popup.js";
-import { initQuickAsk } from "./quick-ask.js";
+import { initQuickAsk, onAppWindowClosed } from "./quick-ask.js";
 
 // Captured as early as possible so it reflects actual process start. Used to
 // gate grace-eligible notifications (e.g. the burst of background-task
@@ -416,6 +416,8 @@ function createWindow(options: { startHidden?: boolean } = {}) {
   win.on("closed", () => {
     if (mainWindow === win) mainWindow = null;
     setMainWindowForDeepLinks(null);
+    // The call engine lived in this window — take its floating surface down.
+    onAppWindowClosed();
   });
 
   // Show window when content is ready to prevent blank screen.
@@ -536,9 +538,15 @@ app.whenReady().then(async () => {
   setupBrowserEventForwarding();
   setupBrowserExtensions();
 
-  // Quick-ask bar: global ⌥⇧Space summons a Spotlight-style ask-anything
-  // window over whatever app the user is in.
-  initQuickAsk();
+  // Quick-ask / hover companion: global ⌥⇧Space summons the Skipper over
+  // whatever app the user is in. The app window owns the call engine it
+  // relays to — if the user closed that window, the summon recreates it
+  // hidden so the shortcut keeps working from anywhere.
+  initQuickAsk({
+    ensureAppWindow: () => {
+      if (!mainWindow || mainWindow.isDestroyed()) createWindow({ startHidden: true });
+    },
+  });
 
   // Start the Rowboat Apps server (per-app origins on 127.0.0.1:3210) BEFORE
   // the window and the long service-init chain below. The Apps view is

--- a/apps/x/apps/main/src/meeting-popup.ts
+++ b/apps/x/apps/main/src/meeting-popup.ts
@@ -129,7 +129,7 @@ export function showMeetingPopup(meeting: DetectedMeeting): void {
     // seen while the user is IN the meeting, wherever that is.
     win.setAlwaysOnTop(true, "screen-saver");
     // `skipTransformProcessType` keeps the Dock icon (same as the video
-    // popout and quick-ask bar): without it, visibleOnFullScreen flips the
+    // popout and the hover companion): without it, visibleOnFullScreen flips the
     // app's activation policy to "accessory" — the Dock icon disappears and
     // an app.dock.show() repair is unreliable (the policy comes back, so
     // Cmd-Tab works, but the Dock tile often never re-registers until

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -1,40 +1,43 @@
 /**
- * The companion window: ONE always-on-top window that plays both floating
- * roles.
+ * The companion window: ONE always-on-top window playing ONE floating role —
+ * the SKIPPER, the hover companion.
  *
- * - `summoned` (global ⌥⇧Space): Spotlight-style — the real chat composer in
- *   a card at the bottom of a tall transparent frame, bottom-centered on the
- *   cursor's display. Takes focus; blur or Esc dismisses.
- * - `pinned` (a call's floating surface, the old #video-popout pill). Voice
- *   sessions land as the SKIPPER: mascot + text panel, one corner-anchored
- *   draggable unit (text visible by default, foldable to just the mascot —
- *   folding never moves the mascot). Camera calls use the pill, top-right.
- *   Both survive blur.
+ * `pinned`: a live voice session's floating surface. The mascot with its
+ * text panel, one corner-anchored draggable unit (text visible by default,
+ * foldable to just the mascot — folding never moves the mascot). A live
+ * CAMERA swaps the card for the pill (top-right), where the self-view
+ * lives. Both survive blur — this is a companion the user works next to.
  *
- * The window is created once and shown/hidden on toggle so summoning is
- * instant. It loads the renderer bundle with #quick-ask (see
- * renderer/src/main.tsx); the renderer swaps layouts on the pushed mode
- * (`quick-ask:mode`). Submits relay to the app window (which owns the chat
- * AND the call engine) over quickAsk:* channels; call state streams in over
- * `video:popout-state` exactly as it did for the old popout window.
+ * `hidden`: no session. Nothing else exists.
  *
- * Summoned geometry: a FIXED tall transparent frame. Only the card at the
- * bottom paints anything — the transparent zone above it exists so in-window
- * popovers (the @-mention list, the model picker, menus) can open upward
- * without being clipped by the window bounds, and so the response panel can
- * grow without any window resizing. A click in the transparent zone
- * dismisses the bar, preserving the click-away feel.
+ * (Retired: the `summoned` role — a standalone Spotlight-style ask bar with
+ * its own answer panel, dictation and voice/share toggles. It was only ever
+ * a fallback surface, and every "hover mode is glitchy" report came down to
+ * that bar appearing where the Skipper belonged. ⌥⇧Space now has exactly one
+ * outcome, so there is no second layout to flash, race, or get stuck in.)
  *
- * Pinned geometry: a compact pill sized to its content (the renderer asks
- * for height changes over video:popoutResize when its response panel
- * opens/folds), like the old popout window.
+ * The window is created once and shown/hidden so summoning is instant. It
+ * loads the renderer bundle with #quick-ask (see renderer/src/main.tsx);
+ * the renderer renders the presentation pushed over `quick-ask:mode`.
+ * Submits relay to the app window (which owns the chat AND the call engine)
+ * over quickAsk:* channels; call state streams in over `video:popout-state`
+ * exactly as it did for the old popout window.
+ *
+ * ⌥⇧Space (and the tray item) ALWAYS means "summon my companion": main
+ * relays to the app window, which starts the voice session and pins this
+ * window. While the Skipper is up the chord folds/unfolds its text panel.
+ *
+ * Geometry: a transparent frame with the card bottom-anchored and the mascot
+ * at the anchor corner. The zone above the card is invisible stage — it
+ * exists so in-window popovers (the @-mention list, the model picker, menus)
+ * can open upward without being clipped, and so the text panel can grow
+ * without any window resizing. The pill is sized to its content (the
+ * renderer asks for height changes over video:popoutResize).
  *
  * Reveal protocol: every `quick-ask:mode` push carries a sequence number and
- * the renderer acks it (`quickAsk:modeApplied`) once that role is PAINTED.
- * The window is revealed (opacity 0 → 1, focus) only after the ack for the
- * current role, so the user never sees the previous role's layout — the
- * summoned bar flashing for a frame (or, on first creation, for the whole
- * page load) before the Skipper replaces it.
+ * the renderer acks it (`quickAsk:modeApplied`) once that presentation is
+ * PAINTED. The window is revealed (opacity 0 → 1, focus) only after the ack,
+ * so a summon never shows a half-built or stale layout.
  */
 import { DEV_SERVER_URL } from './dev-server.js';
 import { app, BrowserWindow, globalShortcut, screen } from 'electron';
@@ -45,13 +48,9 @@ const { DEFAULT_QUICK_ASK_SHORTCUT, normalizeShortcut, isSystemReservedShortcut 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export type CompanionMode = 'hidden' | 'summoned' | 'pinned';
+export type CompanionMode = 'hidden' | 'pinned';
 
 // Design-space dimensions (what the renderer lays out against, in CSS px).
-// The summoned frame is deliberately taller than the card: the extra space
-// is the invisible stage for popovers and the growing response panel.
-const FRAME_WIDTH = 800;
-const FRAME_HEIGHT = 560;
 // Pinned pill bounds. Height is renderer-driven between base and max
 // (video:popoutResize), same contract as the old popout window.
 const PINNED_WIDTH = 400;
@@ -92,44 +91,56 @@ let appliedExpandedSurface: 'card' | 'pill' = 'pill';
 // so the shortcut is never a silent no-op. Time-boxed so a stale summon
 // can't leak into an unrelated call.
 let summonPendingAt = 0;
-// The ⌥⇧Space no-op fallback: shows the text card if nothing answers the
-// tuck relay. Cancelled the moment the app ACKS the relay (it may then take
-// seconds to acquire devices — that must not flash the text card).
-let summonFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+// Watchdog for an unanswered summon: the relay can be lost if the app
+// window is mid-reload or was just recreated. Cancelled the moment the app
+// ACKS (it may then take seconds to acquire devices — that must not
+// re-trigger anything).
+let summonWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+let summonRetried = false;
 // When the last tuck relay went out and has not been acked yet (0 = none).
 // A relay can be lost when the app window is still loading (login-hidden
 // start, or the window being recreated because the user had closed it) —
 // the app's `quickAsk:appReady` handshake re-sends a recent unacked one.
 let summonRelayAt = 0;
 const SUMMON_RELAY_RETRY_WINDOW_MS = 15_000;
-// How long a relay may go unanswered before the text card falls back: short
-// when an app window is up (the ack is synchronous on its side), longer
-// while the app window itself is booting.
-const SUMMON_FALLBACK_MS = 1500;
-const SUMMON_FALLBACK_APP_BOOT_MS = 8000;
+// How long a relay may go unanswered before it is re-sent: short when an
+// app window is up (the ack is synchronous on its side), longer while the
+// app window itself is booting.
+const SUMMON_WATCHDOG_MS = 1500;
+const SUMMON_WATCHDOG_APP_BOOT_MS = 8000;
 // Provided by main.ts: (re)create the app window hidden when a summon finds
 // none — the user closed it, but "Quick Ask from anywhere" must still work.
 let ensureAppWindow: (() => void) | null = null;
 
-function clearSummonFallback() {
-  if (summonFallbackTimer) {
-    clearTimeout(summonFallbackTimer);
-    summonFallbackTimer = null;
+function clearSummonWatchdog() {
+  if (summonWatchdogTimer) {
+    clearTimeout(summonWatchdogTimer);
+    summonWatchdogTimer = null;
   }
 }
 
-function armSummonFallback(ms: number) {
-  clearSummonFallback();
-  summonFallbackTimer = setTimeout(() => {
-    summonFallbackTimer = null;
-    if (mode === 'hidden') showSummonedCard(false);
+function armSummonWatchdog(ms: number) {
+  clearSummonWatchdog();
+  summonWatchdogTimer = setTimeout(() => {
+    summonWatchdogTimer = null;
+    // Landed while we waited — nothing to do.
+    if (mode === 'pinned') return;
+    if (!summonRetried) {
+      // One re-send: the app window was probably mid-reload when the first
+      // relay went out (its own `quickAsk:appReady` covers the common case;
+      // this covers a reload that raced past it).
+      relaySummon({ retry: true });
+      return;
+    }
+    console.warn('[companion] summon went unanswered — the app window never started a session');
   }, ms);
 }
 
 /** The app window acknowledged a tuck relay and is starting the session. */
 export function ackSummon() {
-  clearSummonFallback();
+  clearSummonWatchdog();
   summonRelayAt = 0;
+  summonRetried = false;
 }
 
 /**
@@ -309,8 +320,8 @@ function createWindow(): BrowserWindow {
     ? path.join(hereDir, '../preload/dist/preload.js')
     : path.join(hereDir, '../../../preload/dist/preload.js');
   const win = new BrowserWindow({
-    width: scaled(FRAME_WIDTH),
-    height: scaled(FRAME_HEIGHT),
+    width: scaled(SKIPPER_FRAME_WIDTH),
+    height: scaled(SKIPPER_FRAME_HEIGHT),
     frame: false,
     resizable: false,
     // Never fullscreenable — windows created while a fullscreen Space is
@@ -345,19 +356,10 @@ function createWindow(): BrowserWindow {
   if (process.platform === 'darwin') {
     win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
   }
-  // Spotlight behavior: clicking away dismisses the summoned bar. Pinned
-  // surfaces (Skipper card AND pill) survive blur — the Skipper is a
-  // companion the user carries around and works next to, so losing focus
-  // must never fold its text away; tucking is an explicit gesture (the
-  // handle, Esc, or clicking the transparent stage).
-  win.on('blur', () => {
-    if (win.isDestroyed() || !win.isVisible()) return;
-    if (mode === 'summoned') {
-      setMode('hidden', 'blur');
-      cancelPendingPaint();
-      win.hide();
-    }
-  });
+  // Blur does NOTHING: the Skipper is a companion the user carries around
+  // and works next to, so losing focus must never fold its text away or
+  // take it off screen. Tucking is an explicit gesture (the handle, Esc, or
+  // clicking the stage near the card); leaving is End & close.
   // Wherever the user drags the Skipper, that becomes its anchor — the
   // corner survives collapse/expand round-trips.
   win.on('move', () => {
@@ -391,30 +393,6 @@ function createWindow(): BrowserWindow {
   return win;
 }
 
-// Gap between the CARD's bottom edge (= the window's bottom edge, since the
-// card is bottom-anchored in the frame) and the bottom of the work area.
-const BOTTOM_MARGIN = 96;
-
-function positionSummoned(win: BrowserWindow) {
-  // The display the cursor is on — the user summons the bar where they're
-  // working, which may not be where the app window lives. Bottom-centered,
-  // dock-style.
-  win.setBounds({
-    width: scaled(FRAME_WIDTH),
-    height: scaled(FRAME_HEIGHT),
-  });
-  // The frame is mostly transparent — a native shadow would outline the
-  // whole invisible rectangle (the card draws its own CSS shadow).
-  win.setHasShadow(false);
-  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-  const { workArea } = display;
-  const [width, height] = win.getSize();
-  win.setPosition(
-    Math.round(workArea.x + (workArea.width - width) / 2),
-    Math.round(workArea.y + workArea.height - height - BOTTOM_MARGIN),
-  );
-}
-
 function positionPinned(win: BrowserWindow) {
   // Top-right of the primary display, like the old popout window.
   const workArea = screen.getPrimaryDisplay().workArea;
@@ -430,15 +408,6 @@ function positionPinned(win: BrowserWindow) {
   // outlines hugging old edges — the artifact the old bar fought with
   // invalidateShadow). The pill's hairline ring is its edge treatment.
   win.setHasShadow(false);
-}
-
-export function hideQuickAsk() {
-  const win = getQuickAskWindow();
-  // Never let a stray hide take down a live call surface.
-  if (mode === 'pinned') return;
-  setMode('hidden', 'dismiss');
-  cancelPendingPaint();
-  if (win?.isVisible()) win.hide();
 }
 
 // Duplicated from ipc.ts (importing it would be a cycle): the hashless
@@ -457,91 +426,43 @@ function findAppWindow(): BrowserWindow | undefined {
  * engine) to start the voice session that this window then pins as the
  * Skipper. No app window → it is recreated hidden (main.ts) and the relay
  * re-fires on its `quickAsk:appReady`; a window still loading is handled
- * the same way. Whatever happens, the text card falls back if nothing
- * answers, so the gesture is never a silent no-op.
+ * the same way; an unanswered relay is re-sent once by the watchdog. The
+ * app window is also where a summon that CAN'T start (voice unconfigured)
+ * explains itself — this window only ever shows the Skipper.
  */
-export function relaySummon() {
+export function relaySummon(opts: { retry?: boolean } = {}) {
   const appWin = findAppWindow();
   markSummonPending();
   summonRelayAt = Date.now();
+  if (!opts.retry) summonRetried = false;
   const appUp = !!appWin && !appWin.webContents.isLoading();
   if (appUp) {
     appWin.webContents.send('quick-ask:tuck', null);
   } else {
     ensureAppWindow?.();
   }
-  armSummonFallback(appUp ? SUMMON_FALLBACK_MS : SUMMON_FALLBACK_APP_BOOT_MS);
+  armSummonWatchdog(appUp ? SUMMON_WATCHDOG_MS : SUMMON_WATCHDOG_APP_BOOT_MS);
 }
 
-export type QuickAskTrigger = 'shortcut' | 'tray' | 'programmatic';
-
 /**
- * The global chord (and the tray item): summon the hover companion, or
- * operate it when it's already up.
+ * The global chord and the tray item: ONE outcome. While the Skipper is up
+ * the chord TOGGLES its text panel (folded → unfold and focus, about to
+ * read or type; open → fold it away) — handled here in main, so it works
+ * even if the window's own controls are wedged: the keyboard is the escape
+ * hatch. Otherwise it summons the companion.
  */
-export function toggleQuickAsk(trigger: QuickAskTrigger = 'shortcut') {
+export function toggleQuickAsk() {
   // Ghostwriter: remember which app the user was in at the summon — the
   // paste-at-cursor target — BEFORE any of our windows can take focus.
   void import('./text-insert.js').then((m) => m.textInsertService.captureTarget()).catch(() => {});
   const win = getQuickAskWindow();
-  // While the Skipper is up, the shortcut TOGGLES its text panel: folded →
-  // unfold and focus (about to read or type); open → fold it away. All in
-  // main, so it works even if the window's own controls are wedged — the
-  // keyboard is the escape hatch.
   if (mode === 'pinned' && win) {
     const expanding = pinnedCollapsed;
     setPinnedCollapsed(!pinnedCollapsed);
     if (expanding) win.focus();
     return;
   }
-  if (win?.isVisible()) {
-    setMode('hidden', 'toggle');
-    cancelPendingPaint();
-    win.hide();
-    return;
-  }
-  // VOICE-FIRST: the shortcut summons the mascot on a live voice session —
-  // the same relay as the card's tuck handle (the app starts the
-  // voice-preset call, and this window pins near the cursor). The text
-  // card is the FALLBACK: programmatic shows, the app declining because
-  // voice isn't configured (it calls quickAsk:show), or — via the timer in
-  // relaySummon — the app simply never answering.
-  if (trigger !== 'programmatic' && (findAppWindow() || ensureAppWindow)) {
-    relaySummon();
-    return;
-  }
-  showSummonedCard(trigger === 'shortcut');
-}
-
-/**
- * The text card. `holdToTalk`: the chord summoned it, so capturing starts
- * immediately (the renderer detects the chord's release). Never for the
- * tray item, programmatic shows, or a window still loading on first
- * creation — by the time that page is up, the chord is long released.
- */
-function showSummonedCard(holdToTalk: boolean) {
-  // A voice summon that fell back here must not leave its hint armed — the
-  // next unrelated call would grab focus.
-  summonPendingAt = 0;
-  clearSummonFallback();
-  let win = getQuickAskWindow();
-  if (!win) win = createWindow();
-  const fresh = win.webContents.isLoading();
-  setMode('summoned', fresh ? 'text card (fresh window)' : 'text card');
-  positionSummoned(win);
-  const seq = pushMode(win);
-  // Unlike the pinned pill, taking focus is the point — the user is about
-  // to type. The renderer focuses its input on window focus.
-  revealAfterMode(win, seq, { focus: true });
-  if (holdToTalk && !fresh) {
-    win.webContents.send('quick-ask:summoned', { viaShortcut: true });
-  }
-}
-
-/** Show the text card (never hide) — the app's voice-unavailable fallback. */
-export function showQuickAsk() {
-  if (mode === 'pinned') return;
-  if (!getQuickAskWindow()?.isVisible()) toggleQuickAsk('programmatic');
+  relaySummon();
 }
 
 /**
@@ -551,7 +472,7 @@ export function showQuickAsk() {
  */
 export function setCompanionPinned(pinned: boolean) {
   if (pinned) {
-    clearSummonFallback();
+    clearSummonWatchdog();
     if (mode === 'pinned') {
       summonPendingAt = 0;
       // Already pinned: re-assert the CURRENT presentation instead of
@@ -801,7 +722,7 @@ export function setShortcutCaptureActive(active: boolean) {
   // the settings row shows the "not active" notice).
   let ok = false;
   try {
-    ok = globalShortcut.register(currentShortcut, () => toggleQuickAsk('shortcut'));
+    ok = globalShortcut.register(currentShortcut, () => toggleQuickAsk());
   } catch {
     ok = false;
   }
@@ -848,7 +769,7 @@ export function setQuickAskShortcut(accelerator: string | null): {
   const previousRegistered = shortcutRegistered;
   let ok = false;
   try {
-    ok = globalShortcut.register(requested, () => toggleQuickAsk('shortcut'));
+    ok = globalShortcut.register(requested, () => toggleQuickAsk());
   } catch {
     return fail('That key combination can’t be used as a shortcut.');
   }
@@ -882,7 +803,7 @@ export function initQuickAsk(opts: { ensureAppWindow?: () => void } = {}) {
   currentShortcut =
     (saved ? normalizeShortcut(saved) : null) ?? DEFAULT_QUICK_ASK_SHORTCUT;
   try {
-    shortcutRegistered = globalShortcut.register(currentShortcut, () => toggleQuickAsk('shortcut'));
+    shortcutRegistered = globalShortcut.register(currentShortcut, () => toggleQuickAsk());
   } catch {
     shortcutRegistered = false;
   }

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -28,6 +28,13 @@
  * Pinned geometry: a compact pill sized to its content (the renderer asks
  * for height changes over video:popoutResize when its response panel
  * opens/folds), like the old popout window.
+ *
+ * Reveal protocol: every `quick-ask:mode` push carries a sequence number and
+ * the renderer acks it (`quickAsk:modeApplied`) once that role is PAINTED.
+ * The window is revealed (opacity 0 → 1, focus) only after the ack for the
+ * current role, so the user never sees the previous role's layout — the
+ * summoned bar flashing for a frame (or, on first creation, for the whole
+ * page load) before the Skipper replaces it.
  */
 import { DEV_SERVER_URL } from './dev-server.js';
 import { app, BrowserWindow, globalShortcut, screen } from 'electron';
@@ -67,21 +74,42 @@ const scaled = (v: number) => Math.round(v * SCALE);
 
 let quickAskWin: BrowserWindow | null = null;
 let mode: CompanionMode = 'hidden';
+// Role transitions are the breadcrumbs every "the companion vanished /
+// flashed / never came" report needs — one line each, nothing per-frame.
+function setMode(next: CompanionMode, why: string) {
+  if (next === mode) return;
+  console.log(`[companion] ${mode} → ${next} (${why})`);
+  mode = next;
+}
 // Pinned presentation: full surface vs tucked down to just the mascot.
 let pinnedCollapsed = false;
 // The expanded surface currently applied to the window geometry (so a
 // device flip mid-call can morph card ⇄ pill in place).
 let appliedExpandedSurface: 'card' | 'pill' = 'pill';
-// A hover summon (⌥⇧Space or the composer's call button relay) is in
-// flight: the NEXT pin gets focus (the user just asked for their
-// companion), and if no pin arrives shortly the text card falls back so
-// the shortcut is never a silent no-op. Time-boxed so a stale summon can't
-// leak into an unrelated call.
+// A hover summon (⌥⇧Space, the tray item, or the composer's call button
+// relay) is in flight: the NEXT pin gets focus (the user just asked for
+// their companion), and if no pin arrives shortly the text card falls back
+// so the shortcut is never a silent no-op. Time-boxed so a stale summon
+// can't leak into an unrelated call.
 let summonPendingAt = 0;
 // The ⌥⇧Space no-op fallback: shows the text card if nothing answers the
 // tuck relay. Cancelled the moment the app ACKS the relay (it may then take
 // seconds to acquire devices — that must not flash the text card).
 let summonFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+// When the last tuck relay went out and has not been acked yet (0 = none).
+// A relay can be lost when the app window is still loading (login-hidden
+// start, or the window being recreated because the user had closed it) —
+// the app's `quickAsk:appReady` handshake re-sends a recent unacked one.
+let summonRelayAt = 0;
+const SUMMON_RELAY_RETRY_WINDOW_MS = 15_000;
+// How long a relay may go unanswered before the text card falls back: short
+// when an app window is up (the ack is synchronous on its side), longer
+// while the app window itself is booting.
+const SUMMON_FALLBACK_MS = 1500;
+const SUMMON_FALLBACK_APP_BOOT_MS = 8000;
+// Provided by main.ts: (re)create the app window hidden when a summon finds
+// none — the user closed it, but "Quick Ask from anywhere" must still work.
+let ensureAppWindow: (() => void) | null = null;
 
 function clearSummonFallback() {
   if (summonFallbackTimer) {
@@ -90,9 +118,40 @@ function clearSummonFallback() {
   }
 }
 
+function armSummonFallback(ms: number) {
+  clearSummonFallback();
+  summonFallbackTimer = setTimeout(() => {
+    summonFallbackTimer = null;
+    if (mode === 'hidden') showSummonedCard(false);
+  }, ms);
+}
+
 /** The app window acknowledged a tuck relay and is starting the session. */
 export function ackSummon() {
   clearSummonFallback();
+  summonRelayAt = 0;
+}
+
+/**
+ * The app window's renderer registered its hover relay listener. A summon
+ * that went out while it was loading (or before it existed) is delivered
+ * now — the shortcut must never be a silent no-op just because the app
+ * window was closed or still booting.
+ */
+export function onAppReady() {
+  if (summonRelayAt && Date.now() - summonRelayAt < SUMMON_RELAY_RETRY_WINDOW_MS) {
+    relaySummon();
+  }
+}
+
+/**
+ * The app window is gone. A live call dies with it (the app owns the call
+ * engine), so a pinned companion must not linger as a dead surface — and
+ * its cached call state must not leak into the next session.
+ */
+export function onAppWindowClosed() {
+  lastPopoutState = null;
+  if (mode === 'pinned') setCompanionPinned(false);
 }
 
 // The Skipper's anchor: the bottom-right corner of the window, i.e. where
@@ -125,7 +184,8 @@ function cornerBounds(corner: { x: number; y: number }, w: number, h: number): E
 }
 
 // Last call state pushed by the app window — replayed when the window
-// (re)loads, so the pill never renders from a blank guess.
+// (re)loads and on every pin, so the surface never renders from a blank (or
+// stale) guess.
 type PopoutState = {
   ttsState: 'idle' | 'synthesizing' | 'speaking';
   status: 'idle' | 'listening' | 'thinking' | 'speaking' | null;
@@ -153,7 +213,7 @@ export function isPinnedCollapsed(): boolean {
   return pinnedCollapsed;
 }
 
-export function markSummonPending() {
+function markSummonPending() {
   summonPendingAt = Date.now();
 }
 
@@ -169,11 +229,77 @@ export function getExpandedSurface(): 'card' | 'pill' {
   return lastPopoutState?.cameraOn ? 'pill' : 'card';
 }
 
-function pushMode(win: BrowserWindow) {
+// --- Reveal protocol (see the file header) ---
+let modeSeq = 0;
+export function getModeSeq(): number {
+  return modeSeq;
+}
+// The one action waiting for the renderer to paint a pushed role. A newer
+// push supersedes it (the latest role wins); a timeout keeps a wedged or
+// still-loading renderer from holding the window hostage.
+let pendingPaint: { seq: number; fire: () => void; timer: ReturnType<typeof setTimeout> } | null = null;
+const PAINT_ACK_TIMEOUT_MS = 600;
+const PAINT_ACK_LOADING_TIMEOUT_MS = 6000;
+
+function pushMode(win: BrowserWindow): number {
+  modeSeq += 1;
   win.webContents.send('quick-ask:mode', {
+    seq: modeSeq,
     mode,
     collapsed: pinnedCollapsed,
     surface: getExpandedSurface(),
+  });
+  return modeSeq;
+}
+
+/**
+ * Run `action` once the renderer has painted the role pushed as `seq` (or
+ * any later one) — used to reveal the window, and to shrink it on fold so
+ * the old layout is never squeezed into the new bounds for a frame.
+ */
+function afterModePainted(win: BrowserWindow, seq: number, action: () => void) {
+  if (pendingPaint) clearTimeout(pendingPaint.timer);
+  const entry = {
+    seq,
+    fire: () => {
+      if (pendingPaint !== entry) return;
+      clearTimeout(entry.timer);
+      pendingPaint = null;
+      if (!win.isDestroyed()) action();
+    },
+    timer: setTimeout(() => entry.fire(), win.webContents.isLoading() ? PAINT_ACK_LOADING_TIMEOUT_MS : PAINT_ACK_TIMEOUT_MS),
+  };
+  pendingPaint = entry;
+}
+
+/** The renderer painted the role pushed as `seq`. */
+export function onModeApplied(seq: number) {
+  if (pendingPaint && seq >= pendingPaint.seq) pendingPaint.fire();
+}
+
+// A hide supersedes whatever reveal/resize was waiting on a paint — a late
+// ack must not focus (or resize) a window that's gone away meanwhile.
+function cancelPendingPaint() {
+  if (!pendingPaint) return;
+  clearTimeout(pendingPaint.timer);
+  pendingPaint = null;
+}
+
+/**
+ * Show the window for the role just pushed: ordered in immediately but
+ * fully transparent (so the renderer, which is paused while hidden, can
+ * paint), then made opaque — and focused when asked — once the paint ack
+ * lands. Revealing only after the ack is what keeps the previous role's
+ * layout from ever flashing.
+ */
+function revealAfterMode(win: BrowserWindow, seq: number, opts: { focus: boolean }) {
+  if (!win.isVisible()) {
+    win.setOpacity(0);
+    win.showInactive();
+  }
+  afterModePainted(win, seq, () => {
+    win.setOpacity(1);
+    if (opts.focus && win.isVisible()) win.focus();
   });
 }
 
@@ -227,7 +353,8 @@ function createWindow(): BrowserWindow {
   win.on('blur', () => {
     if (win.isDestroyed() || !win.isVisible()) return;
     if (mode === 'summoned') {
-      mode = 'hidden';
+      setMode('hidden', 'blur');
+      cancelPendingPaint();
       win.hide();
     }
   });
@@ -242,7 +369,9 @@ function createWindow(): BrowserWindow {
     if (quickAskWin === win) quickAskWin = null;
   });
   // Zoom factor resets on navigation — apply it once the page is in, and
-  // replay the state the renderer needs to pick up where things stand.
+  // replay the state the renderer needs to pick up where things stand. (The
+  // renderer also PULLS all of it on mount — these pushes can land before
+  // React has subscribed.)
   win.webContents.on('did-finish-load', () => {
     win.webContents.setZoomFactor(SCALE);
     pushMode(win);
@@ -307,7 +436,8 @@ export function hideQuickAsk() {
   const win = getQuickAskWindow();
   // Never let a stray hide take down a live call surface.
   if (mode === 'pinned') return;
-  mode = 'hidden';
+  setMode('hidden', 'dismiss');
+  cancelPendingPaint();
   if (win?.isVisible()) win.hide();
 }
 
@@ -322,7 +452,34 @@ function findAppWindow(): BrowserWindow | undefined {
   });
 }
 
-export function toggleQuickAsk(viaShortcut = true) {
+/**
+ * The ONE hover relay: ask the app window (it owns the chat AND the call
+ * engine) to start the voice session that this window then pins as the
+ * Skipper. No app window → it is recreated hidden (main.ts) and the relay
+ * re-fires on its `quickAsk:appReady`; a window still loading is handled
+ * the same way. Whatever happens, the text card falls back if nothing
+ * answers, so the gesture is never a silent no-op.
+ */
+export function relaySummon() {
+  const appWin = findAppWindow();
+  markSummonPending();
+  summonRelayAt = Date.now();
+  const appUp = !!appWin && !appWin.webContents.isLoading();
+  if (appUp) {
+    appWin.webContents.send('quick-ask:tuck', null);
+  } else {
+    ensureAppWindow?.();
+  }
+  armSummonFallback(appUp ? SUMMON_FALLBACK_MS : SUMMON_FALLBACK_APP_BOOT_MS);
+}
+
+export type QuickAskTrigger = 'shortcut' | 'tray' | 'programmatic';
+
+/**
+ * The global chord (and the tray item): summon the hover companion, or
+ * operate it when it's already up.
+ */
+export function toggleQuickAsk(trigger: QuickAskTrigger = 'shortcut') {
   // Ghostwriter: remember which app the user was in at the summon — the
   // paste-at-cursor target — BEFORE any of our windows can take focus.
   void import('./text-insert.js').then((m) => m.textInsertService.captureTarget()).catch(() => {});
@@ -338,60 +495,53 @@ export function toggleQuickAsk(viaShortcut = true) {
     return;
   }
   if (win?.isVisible()) {
-    mode = 'hidden';
+    setMode('hidden', 'toggle');
+    cancelPendingPaint();
     win.hide();
     return;
   }
   // VOICE-FIRST: the shortcut summons the mascot on a live voice session —
   // the same relay as the card's tuck handle (the app starts the
   // voice-preset call, and this window pins near the cursor). The text
-  // card is the FALLBACK: programmatic shows (the toast), no app window to
-  // relay to, the app declining because voice isn't configured (it calls
-  // quickAsk:show), or — via the timer below — the app simply never
-  // answering the relay, so the shortcut is never a silent no-op.
-  if (viaShortcut) {
-    const appWin = findAppWindow();
-    if (appWin) {
-      markSummonPending();
-      appWin.webContents.send('quick-ask:tuck', null);
-      clearSummonFallback();
-      summonFallbackTimer = setTimeout(() => {
-        summonFallbackTimer = null;
-        if (mode === 'hidden') showSummonedCard(false);
-      }, 1500);
-      return;
-    }
+  // card is the FALLBACK: programmatic shows, the app declining because
+  // voice isn't configured (it calls quickAsk:show), or — via the timer in
+  // relaySummon — the app simply never answering.
+  if (trigger !== 'programmatic' && (findAppWindow() || ensureAppWindow)) {
+    relaySummon();
+    return;
   }
-  showSummonedCard(viaShortcut);
+  showSummonedCard(trigger === 'shortcut');
 }
 
-function showSummonedCard(viaShortcut: boolean) {
+/**
+ * The text card. `holdToTalk`: the chord summoned it, so capturing starts
+ * immediately (the renderer detects the chord's release). Never for the
+ * tray item, programmatic shows, or a window still loading on first
+ * creation — by the time that page is up, the chord is long released.
+ */
+function showSummonedCard(holdToTalk: boolean) {
   // A voice summon that fell back here must not leave its hint armed — the
   // next unrelated call would grab focus.
   summonPendingAt = 0;
   clearSummonFallback();
   let win = getQuickAskWindow();
   if (!win) win = createWindow();
-  mode = 'summoned';
+  const fresh = win.webContents.isLoading();
+  setMode('summoned', fresh ? 'text card (fresh window)' : 'text card');
   positionSummoned(win);
-  pushMode(win);
+  const seq = pushMode(win);
   // Unlike the pinned pill, taking focus is the point — the user is about
   // to type. The renderer focuses its input on window focus.
-  win.show();
-  win.focus();
-  // Hold-to-talk: a chord summon starts capturing immediately (the renderer
-  // detects the release once it has focus). Skip on first-ever creation —
-  // the page is still loading, and by the time it's up the chord is long
-  // released.
-  if (!win.webContents.isLoading()) {
-    win.webContents.send('quick-ask:summoned', { viaShortcut });
+  revealAfterMode(win, seq, { focus: true });
+  if (holdToTalk && !fresh) {
+    win.webContents.send('quick-ask:summoned', { viaShortcut: true });
   }
 }
 
-/** Show (never hide) — the discoverability toast's "Try it" action. */
+/** Show the text card (never hide) — the app's voice-unavailable fallback. */
 export function showQuickAsk() {
   if (mode === 'pinned') return;
-  if (!getQuickAskWindow()?.isVisible()) toggleQuickAsk(false);
+  if (!getQuickAskWindow()?.isVisible()) toggleQuickAsk('programmatic');
 }
 
 /**
@@ -412,15 +562,16 @@ export function setCompanionPinned(pinned: boolean) {
       const win0 = getQuickAskWindow() ?? createWindow();
       if (pinnedCollapsed) positionTucked(win0);
       else applyExpandedSurface(win0, getExpandedSurface());
-      pushMode(win0);
-      if (!win0.isVisible()) win0.showInactive();
+      const seq0 = pushMode(win0);
+      if (lastPopoutState) win0.webContents.send('video:popout-state', lastPopoutState);
+      revealAfterMode(win0, seq0, { focus: false });
       return;
     }
     let win = getQuickAskWindow();
     if (!win) win = createWindow();
     const fromSummon = Date.now() - summonPendingAt < 5000;
     summonPendingAt = 0;
-    mode = 'pinned';
+    setMode('pinned', fromSummon ? 'call surface (summoned)' : 'call surface');
     // ONE landing for every entry point: the Skipper lands as one unit —
     // mascot with the text panel already open (text is the default;
     // tucking is the user's gesture, never the arrival state) — anchored
@@ -439,29 +590,28 @@ export function setCompanionPinned(pinned: boolean) {
       positionPinned(win);
       appliedExpandedSurface = 'pill';
     }
-    pushMode(win);
-    if (fromSummon) {
-      // The user just summoned their companion — focus so speaking, typing,
-      // and Esc all work immediately.
-      if (!win.isVisible()) win.show();
-      win.focus();
-    } else if (!win.isVisible()) {
-      // showInactive: appearing must not steal focus from the app the user
-      // switched to — that would be a focus grab mid-work.
-      win.showInactive();
-    }
+    const seq = pushMode(win);
+    // The renderer resets its call-state mirror whenever it leaves the
+    // pinned role — replay the live state so the Skipper never paints from
+    // a blank guess before the app's next push.
+    if (lastPopoutState) win.webContents.send('video:popout-state', lastPopoutState);
+    // The user just summoned their companion → focus so speaking, typing,
+    // and Esc all work immediately. Otherwise appearing must not steal
+    // focus from the app the user switched to — that would be a focus grab
+    // mid-work.
+    revealAfterMode(win, seq, { focus: fromSummon });
   } else {
     if (mode !== 'pinned') return;
-    mode = 'hidden';
+    setMode('hidden', 'unpinned');
     pinnedCollapsed = false;
     summonPendingAt = 0;
-    // The call is over — its device state must not leak into the next
-    // summon (a stale cameraOn here made the next companion flash the
-    // camera pill before morphing to the card).
-    lastPopoutState = null;
+    // (The cached call state is kept: a fullscreen ⇄ popout flap mid-call
+    // must return to the same surface — camera on → pill. The app pushes
+    // an idle state when the call ENDS, so nothing stale survives it.)
     const win = getQuickAskWindow();
     if (win) {
       pushMode(win);
+      cancelPendingPaint();
       if (win.isVisible()) win.hide();
     }
   }
@@ -484,23 +634,32 @@ export function setPinnedCollapsed(collapsed: boolean) {
   // and idempotent.
   pinnedCollapsed = collapsed;
   if (collapsed) {
-    if (appliedExpandedSurface === 'card') {
-      positionTucked(win);
-    } else {
-      const b = win.getBounds();
-      const wa = screen.getDisplayMatching(b).workArea;
-      const w = scaled(TUCKED_WIDTH);
-      const h = scaled(TUCKED_HEIGHT);
-      const inTopHalf = b.y + b.height / 2 < wa.y + wa.height / 2;
-      let x = b.x + b.width - w;
-      let y = inTopHalf ? b.y : b.y + b.height - h;
-      x = Math.max(wa.x + 8, Math.min(x, wa.x + wa.width - w - 8));
-      y = Math.max(wa.y + 8, Math.min(y, wa.y + wa.height - h - 8));
-      setBoundsGuarded(win, { x, y, width: w, height: h });
-    }
-    pushMode(win);
+    // Fold: push the layout FIRST and shrink the window once it's painted —
+    // shrinking first squeezes the still-open card into the mascot-sized
+    // bounds for a frame (every control looks dead). The mascot sits at
+    // the anchor corner in both layouts, so the shrink itself is invisible.
+    const seq = pushMode(win);
+    afterModePainted(win, seq, () => {
+      if (mode !== 'pinned' || !pinnedCollapsed) return;
+      if (appliedExpandedSurface === 'card') {
+        positionTucked(win);
+      } else {
+        const b = win.getBounds();
+        const wa = screen.getDisplayMatching(b).workArea;
+        const w = scaled(TUCKED_WIDTH);
+        const h = scaled(TUCKED_HEIGHT);
+        const inTopHalf = b.y + b.height / 2 < wa.y + wa.height / 2;
+        let x = b.x + b.width - w;
+        let y = inTopHalf ? b.y : b.y + b.height - h;
+        x = Math.max(wa.x + 8, Math.min(x, wa.x + wa.width - w - 8));
+        y = Math.max(wa.y + 8, Math.min(y, wa.y + wa.height - h - 8));
+        setBoundsGuarded(win, { x, y, width: w, height: h });
+      }
+    });
     return;
   }
+  // Unfold: grow the window first (the extra area is transparent stage —
+  // the mascot doesn't move), then the card paints into it.
   applyExpandedSurface(win, getExpandedSurface());
   pushMode(win);
   if (appliedExpandedSurface === 'card') win.focus();
@@ -642,7 +801,7 @@ export function setShortcutCaptureActive(active: boolean) {
   // the settings row shows the "not active" notice).
   let ok = false;
   try {
-    ok = globalShortcut.register(currentShortcut, toggleQuickAsk);
+    ok = globalShortcut.register(currentShortcut, () => toggleQuickAsk('shortcut'));
   } catch {
     ok = false;
   }
@@ -689,7 +848,7 @@ export function setQuickAskShortcut(accelerator: string | null): {
   const previousRegistered = shortcutRegistered;
   let ok = false;
   try {
-    ok = globalShortcut.register(requested, toggleQuickAsk);
+    ok = globalShortcut.register(requested, () => toggleQuickAsk('shortcut'));
   } catch {
     return fail('That key combination can’t be used as a shortcut.');
   }
@@ -714,7 +873,8 @@ export function setQuickAskShortcut(accelerator: string | null): {
   return { ok: true, accelerator: currentShortcut, registered: true, error: null };
 }
 
-export function initQuickAsk() {
+export function initQuickAsk(opts: { ensureAppWindow?: () => void } = {}) {
+  ensureAppWindow = opts.ensureAppWindow ?? null;
   // Default ⌥⇧Space: plain ⌥Space is the most contested launcher chord on
   // macOS (Raycast, ChatGPT desktop, …) — registering it would silently
   // lose or, worse, double-fire alongside whatever owns it.
@@ -722,7 +882,7 @@ export function initQuickAsk() {
   currentShortcut =
     (saved ? normalizeShortcut(saved) : null) ?? DEFAULT_QUICK_ASK_SHORTCUT;
   try {
-    shortcutRegistered = globalShortcut.register(currentShortcut, toggleQuickAsk);
+    shortcutRegistered = globalShortcut.register(currentShortcut, () => toggleQuickAsk('shortcut'));
   } catch {
     shortcutRegistered = false;
   }

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -60,9 +60,9 @@ const PINNED_MAX_HEIGHT = 560;
 // caption, everything else on hover.
 const TUCKED_WIDTH = 250;
 const TUCKED_HEIGHT = 250;
-// The Skipper card: the pinned text panel + mascot, one unit. Narrower than
-// the summoned frame (it hugs a corner instead of center-stage) but the same
-// tall transparent stage above the card for popovers and panel growth.
+// The Skipper card: the text panel + mascot, one unit. It hugs a corner,
+// with a tall transparent stage above the card for popovers and panel
+// growth.
 const SKIPPER_FRAME_WIDTH = 560;
 const SKIPPER_FRAME_HEIGHT = 560;
 // Uniform downscale: the window shrinks and the page zooms by the SAME
@@ -336,7 +336,7 @@ function createWindow(): BrowserWindow {
     alwaysOnTop: true,
     skipTaskbar: true,
     show: false,
-    // The summoned frame is mostly transparent — a native shadow would
+    // The frame is mostly transparent — a native shadow would
     // outline the whole invisible rectangle. Cards draw their own CSS
     // shadows in both modes.
     hasShadow: false,
@@ -706,7 +706,7 @@ function broadcastShortcutState() {
 
 // The shortcut-recorder modal is capturing keys: the current chord is
 // released so pressing it lands in the modal as keystrokes to display,
-// instead of summoning the bar over the recorder.
+// instead of summoning the companion over the recorder.
 let captureSuspended = false;
 
 export function setShortcutCaptureActive(active: boolean) {

--- a/apps/x/apps/main/src/tray.ts
+++ b/apps/x/apps/main/src/tray.ts
@@ -167,7 +167,9 @@ function rebuildMenu(): void {
         ? { accelerator: getQuickAskShortcutState().accelerator }
         : {}),
       registerAccelerator: false,
-      click: () => toggleQuickAsk(),
+      // Same hover summon as the chord — minus hold-to-talk, which only
+      // makes sense for a held key.
+      click: () => toggleQuickAsk('tray'),
     },
     recording
       ? {

--- a/apps/x/apps/main/src/tray.ts
+++ b/apps/x/apps/main/src/tray.ts
@@ -167,9 +167,8 @@ function rebuildMenu(): void {
         ? { accelerator: getQuickAskShortcutState().accelerator }
         : {}),
       registerAccelerator: false,
-      // Same hover summon as the chord — minus hold-to-talk, which only
-      // makes sense for a held key.
-      click: () => toggleQuickAsk('tray'),
+      // The same summon the chord performs.
+      click: () => toggleQuickAsk(),
     },
     recording
       ? {

--- a/apps/x/apps/renderer/index.html
+++ b/apps/x/apps/renderer/index.html
@@ -10,10 +10,19 @@
       html, body { margin: 0; padding: 0; }
       html.dark, html.dark body { background-color: #252525; }
       html.light, html.light body { background-color: #fff; }
+      /* Transparent utility windows (the hover companion, the screen-pointer
+         overlay) must never paint a backing slab — not even for the instant
+         before their React tree mounts and clears the backgrounds itself. */
+      html.transparent-window, html.transparent-window body { background: transparent; }
     </style>
     <script>
       // Apply theme class immediately before render
       (function() {
+        var hash = window.location.hash;
+        if (hash === '#quick-ask' || hash === '#screen-pointer') {
+          document.documentElement.classList.add('transparent-window');
+          return;
+        }
         var stored = localStorage.getItem('rowboat-theme');
         var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         var theme = stored || 'system';

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -137,6 +137,11 @@ const PTT_TAP_MS = 350
 // Mic-ownership token for the Home composer (chat composers use their chatId).
 const HOME_VOICE_HOLDER = 'home-composer'
 const PTT_EDGE_ECHO_MS = 80
+// How long a hover summon waits for the voice/TTS probe to settle before
+// deciding voice isn't configured. Long enough for a cold boot (config read
+// + oauth state), short enough that a hung probe still gets the user a
+// surface (the text card) instead of silence.
+const VOICE_PROBE_WAIT_MS = 4000
 
 // Speakable fallback for a call reply that skipped <voice> tags: strip the
 // markdown that reads terribly aloud and cap the length — a minute-long
@@ -992,6 +997,19 @@ function App() {
   // Voice mode state
   const [voiceAvailable, setVoiceAvailable] = useState(false)
   const [ttsAvailable, setTtsAvailable] = useState(false)
+  // Both start false and are filled by an async probe (two IPC round-trips
+  // at mount). A hover summon that lands before it resolves must NOT read
+  // that `false` as "no voice configured" — that answered the chord with
+  // the text card for the first seconds after every app start (the "old
+  // quick access comes up instead of hover mode" glitch). Refs + the
+  // in-flight promise let the summon WAIT for a real answer; the refs are
+  // written inside the probe too, so a waiter sees the result without
+  // depending on a React re-render.
+  const voiceAvailableRef = useRef(false)
+  voiceAvailableRef.current = voiceAvailable
+  const ttsAvailableRef = useRef(false)
+  ttsAvailableRef.current = ttsAvailable
+  const voiceProbeRef = useRef<Promise<void> | null>(null)
   // TTS plays only during calls now (the standing read-aloud toggle was
   // retired; a per-message "read aloud" action may replace it later).
   const ttsEnabledRef = useRef(false)
@@ -1232,23 +1250,45 @@ function App() {
 
   // Check if voice is available on mount and when OAuth state changes
   const refreshVoiceAvailability = useCallback(() => {
-    Promise.all([
+    const probe = Promise.all([
       window.ipc.invoke('voice:getConfig', null),
       window.ipc.invoke('oauth:getState', null),
     ]).then(([config, oauthState]) => {
       const rowboatConnected = oauthState.config?.rowboat?.connected ?? false
       const hasVoice = !!config.deepgram || rowboatConnected
+      const hasTts = !!config.elevenlabs || rowboatConnected
+      voiceAvailableRef.current = hasVoice
+      ttsAvailableRef.current = hasTts
       setVoiceAvailable(hasVoice)
-      setTtsAvailable(!!config.elevenlabs || rowboatConnected)
+      setTtsAvailable(hasTts)
       // Pre-cache auth details so mic click skips IPC round-trips
       if (hasVoice) {
         voice.warmup()
       }
     }).catch(() => {
+      voiceAvailableRef.current = false
+      ttsAvailableRef.current = false
       setVoiceAvailable(false)
       setTtsAvailable(false)
     })
+    voiceProbeRef.current = probe
+    return probe
   }, [voice.warmup])
+
+  /**
+   * Wait for a definitive voice/TTS answer before treating "not available"
+   * as the truth. Capped: a probe that never settles must not swallow the
+   * summon — the caller falls back to the text card instead.
+   */
+  const awaitVoiceProbe = useCallback(async () => {
+    // Start one if nothing has probed yet — a summon must never decide
+    // "no voice" off a value nobody has looked up.
+    const probe = voiceProbeRef.current ?? refreshVoiceAvailability()
+    await Promise.race([
+      probe,
+      new Promise((resolve) => setTimeout(resolve, VOICE_PROBE_WAIT_MS)),
+    ])
+  }, [refreshVoiceAvailability])
 
   useEffect(() => {
     refreshVoiceAvailability()
@@ -1526,14 +1566,27 @@ function App() {
     }
     // A start is already in flight — its pin is coming.
     if (companionVoiceStartingRef.current) return
-    if (!(voiceAvailable && ttsAvailable)) {
-      // Voice-first has no voice — fall back to the text card.
-      void window.ipc.invoke('quickAsk:show', null).catch(() => {})
-      return
-    }
-    companionVoiceRef.current = true
+    // Guard covers the probe wait too, so a second chord can't start a
+    // parallel session while we're deciding.
     companionVoiceStartingRef.current = true
     try {
+      if (!(voiceAvailableRef.current && ttsAvailableRef.current)) {
+        // Not "no voice" — just "not known yet" right after an app start.
+        await awaitVoiceProbe()
+      }
+      if (inCallRef.current) {
+        // Another entry point started a call while we waited — just make
+        // sure its floating surface is up.
+        setCallMinimized(true)
+        void window.ipc.invoke('video:setPopout', { show: true }).catch(() => {})
+        return
+      }
+      if (!(voiceAvailableRef.current && ttsAvailableRef.current)) {
+        // Voice-first genuinely has no voice — fall back to the text card.
+        void window.ipc.invoke('quickAsk:show', null).catch(() => {})
+        return
+      }
+      companionVoiceRef.current = true
       await startCall('voice')
     } finally {
       // Released the moment the call engine settles — NOT held across the
@@ -1558,7 +1611,7 @@ function App() {
         if (!shared) setPermissionDialog('screen-recording')
       })
     }
-  }, [voiceAvailable, ttsAvailable, startCall, video])
+  }, [awaitVoiceProbe, startCall, video])
   // Stable handle for the tuck-relay listener below — registered once,
   // always calling the latest closure.
   const startHoverCallRef = useRef(startHoverCall)

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -917,7 +917,7 @@ function App() {
   // The companion's OWN conversation binding. The hover bar, the Skipper,
   // and every call talk to THIS session — never to whatever chat the app
   // happens to be showing. Seeded from the chat a call was started on;
-  // switched from the bar's chip; untouched by app navigation, so hovering
+  // switched from the companion's chip; untouched by app navigation, so hovering
   // and browsing the app are fully independent.
   const [hoverRunId, setHoverRunId] = useState<string | null>(null)
   const hoverRunIdRef = useRef<string | null>(null)
@@ -1061,7 +1061,7 @@ function App() {
   }, [])
 
   // Speak newly completed <voice> blocks from the new runtime's live stream.
-  // Speech is a COMPANION concern (calls + the bar's voice toggle), so the
+  // Speech is a COMPANION concern (the hover session's replies), so the
   // segments come from the hover session's store — the app's visible chat
   // never starts talking, whatever it's bound to.
   const spokenVoiceRef = useRef<{ key: string | null; count: number }>({ key: null, count: 0 })
@@ -1553,9 +1553,9 @@ function App() {
   // falls back to the text card — and so does a session that fails to
   // start, so a summon is never a silent no-op.
   const startHoverCall = useCallback(async (opts: { share?: boolean } = {}) => {
-    // Tell main the relay landed and a session is coming — cancels the
-    // "nothing answered" text-card fallback so slow device startup can't
-    // flash the old summoned bar before the Skipper pins.
+    // Tell main the relay landed and a session is coming — stops its
+    // watchdog from re-sending the relay while devices are still starting
+    // up (acquisition can take seconds).
     void window.ipc.invoke('quickAsk:tuckAck', null).catch(() => {})
     if (inCallRef.current) {
       // Already on a call — just make sure the floating surface is up
@@ -2004,7 +2004,7 @@ function App() {
   // What's happening right now, at tool-NAME level ("Searching the web…",
   // "Reasoning…" — never arguments): the most recent activity wins — a
   // running tool by display name, else reasoning, else plain thinking.
-  // Feeds the summoned bar's status line AND the Skipper's chip/panel, so
+  // Feeds the Skipper's status chip and text panel, so
   // it reads the HOVER session's turn.
   const hoverActivityText = useMemo(() => {
     if (!hoverIsProcessing) return null
@@ -4601,7 +4601,7 @@ function App() {
     handleNewChatTabInSidebar()
   }, [chatTabs, handleNewChatTabInSidebar])
 
-  // Quick-ask "+": the bar wants a fresh COMPANION conversation for its next
+  // The companion's "+": a fresh COMPANION conversation for its next
   // question. The app window's chat is untouched.
   useEffect(() => {
     return window.ipc.on('quick-ask:new-chat', () => {
@@ -4610,7 +4610,7 @@ function App() {
   }, [])
 
   // Companion-bar chat context: which conversation the companion is bound to
-  // (shown as the bar's destination chip) plus recents for its switcher.
+  // (shown as the companion's destination chip) plus recents for its switcher.
   // This is the HOVER binding — the app window's chat plays no part in it.
   useEffect(() => {
     void window.ipc
@@ -5213,8 +5213,8 @@ function App() {
         const s = await window.ipc.invoke('quickAsk:getShortcut', null)
         if (s.registered) return
         const isMacHere = navigator.platform.toLowerCase().includes('mac')
-        toast.warning('Quick Ask shortcut unavailable', {
-          description: `${quickAskShortcut.formatShortcut(s.accelerator, isMacHere)} is in use by another app, so Quick Ask can't be summoned right now. Pick a different shortcut in Settings.`,
+        toast.warning('Hover shortcut unavailable', {
+          description: `${quickAskShortcut.formatShortcut(s.accelerator, isMacHere)} is in use by another app, so your Skipper can't be summoned right now. Pick a different shortcut in Settings.`,
           duration: 15000,
           closeButton: true,
           action: {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1017,6 +1017,11 @@ function App() {
   // t0 = utterance accepted, submit = message sent, speak = first TTS
   // speak(). Emitted as call_turn_latency when audio actually starts.
   const callTurnMarksRef = useRef<{ t0: number; submit?: number; speak?: number } | null>(null)
+  // A summon that CAN'T become a session (voice unconfigured, or the call
+  // engine failed to start) is explained by the APP window — the companion
+  // has no second surface of its own any more. Late-bound: the toast lives
+  // with the settings state far below.
+  const notifyVoiceUnavailableRef = useRef<((reason: 'voice' | 'failed') => void) | null>(null)
   // Late-bound handle to handleStop (defined much further down) so early
   // call handlers can stop the run without reordering the component.
   const stopRunRef = useRef<(() => Promise<void>) | null>(null)
@@ -1067,10 +1072,6 @@ function App() {
   // cleared at submit, set by the segment player; the fallback-speech net
   // fires only when this is still false at turn completion.
   const spokeSegmentThisTurnRef = useRef(false)
-  // The current turn should be spoken aloud even without a call — set at
-  // submit for quick-ask questions with the voice toggle on. Per-turn so
-  // composer messages outside the bar never start talking.
-  const speakTurnRef = useRef(false)
   // Fallback-speech bookkeeping, armed per call turn at submit (see
   // handlePromptSubmit) and consumed by the effect below the segment player.
   const callTurnVoiceRef = useRef<{ pending: boolean; submitAt: number }>({
@@ -1101,7 +1102,7 @@ function App() {
       const segment = voiceSegments[spokenVoiceRef.current.count]
       spokenVoiceRef.current.count += 1
       if (
-        (ttsEnabledRef.current || speakTurnRef.current) &&
+        ttsEnabledRef.current &&
         !suppressSpeechTurnRef.current &&
         !speakerMutedRef.current
       ) {
@@ -1127,8 +1128,8 @@ function App() {
       turn.pending = false
       return
     }
-    // Speaking this turn: call TTS, or the quick-ask voice toggle.
-    if (!(inCallRef.current ? ttsEnabledRef.current : speakTurnRef.current)) {
+    // Speaking this turn at all? (Only a live session speaks.)
+    if (!ttsEnabledRef.current) {
       turn.pending = false
       return
     }
@@ -1582,8 +1583,8 @@ function App() {
         return
       }
       if (!(voiceAvailableRef.current && ttsAvailableRef.current)) {
-        // Voice-first genuinely has no voice — fall back to the text card.
-        void window.ipc.invoke('quickAsk:show', null).catch(() => {})
+        // Genuinely no voice configured — say so in the app window.
+        notifyVoiceUnavailableRef.current?.('voice')
         return
       }
       companionVoiceRef.current = true
@@ -1597,9 +1598,10 @@ function App() {
     }
     if (!inCallRef.current) {
       // The session didn't start (device denied/unavailable — startCall
-      // already explained why). The gesture still deserves a surface.
+      // already raised the permission dialog). Bring the app forward so the
+      // user actually sees that explanation.
       companionVoiceRef.current = false
-      void window.ipc.invoke('quickAsk:show', null).catch(() => {})
+      notifyVoiceUnavailableRef.current?.('failed')
       return
     }
     // Sticky screen share: opted in once from the mascot's share pin →
@@ -2185,51 +2187,9 @@ function App() {
     lastScreenStateForNoticeRef.current = video.screenState
   }, [video.screenState])
 
-  // Quick-ask toggles (voice response / screen share), pushed from the bar.
-  // Screen share reuses the call engine's capture wholesale — the bar owns
-  // the share indicator, so no pill appears outside calls. Calls own the
-  // devices while live: bar toggles never fight an active call.
-  const quickAskOptionsRef = useRef({ voiceOutput: false, screenShare: false })
-  useEffect(() => {
-    return window.ipc.on('quick-ask:set-options', (opts) => {
-      quickAskOptionsRef.current = opts
-      if (inCallRef.current) return
-      if (opts.screenShare && video.screenState !== 'live') {
-        void (async () => {
-          await video.start({ camera: false })
-          const shared = await video.startScreenShare()
-          if (!shared) {
-            video.stop()
-            quickAskOptionsRef.current = { ...opts, screenShare: false }
-            setPermissionDialog('screen-recording')
-          }
-        })()
-      } else if (!opts.screenShare && video.screenState === 'live') {
-        video.stopScreenShare()
-        video.stop()
-      }
-    })
-  }, [video])
-
-  // Report the ACTUAL state back to the bar — its badge must reflect what
-  // capture is really doing (a denied permission means no share, whatever
-  // the toggle wished for).
-  useEffect(() => {
-    if (inCall) return
-    void window.ipc
-      .invoke('quickAsk:optionsState', {
-        voiceOutput: quickAskOptionsRef.current.voiceOutput,
-        screenSharing: video.screenState === 'live',
-      })
-      .catch(() => {})
-  }, [inCall, video.screenState])
-
-  // Quick-ask bar: a submit from the companion lands in the COMPANION's own
-  // session — never in whatever chat the app window is showing. The bar
-  // hosts the REAL composer, so the payload carries everything an in-app
-  // submit does; its model/effort picks are companion-scoped.
-  const quickAskActiveRef = useRef(false)
-  const quickAskStartedAtRef = useRef(0)
+  // (The companion's old standalone toggles — speak-the-answer and
+  // share-without-a-call — went with the retired ask bar. Sharing is a
+  // session control now: the Skipper's bow-light pin, on a live session.)
 
   // Send into the COMPANION's session. The lean twin of handlePromptSubmit:
   // same per-turn config (voice flags, frames, search/code, permissions,
@@ -2258,13 +2218,10 @@ function App() {
     if (inCallRef.current && marks && marks.submit === undefined) {
       marks.submit = performance.now()
     }
-    // Quick-ask voice toggle: this turn speaks its reply even without a call.
-    speakTurnRef.current =
-      !inCallRef.current && quickAskActiveRef.current && quickAskOptionsRef.current.voiceOutput
-    // Modality decides speech on calls: a TYPED question renders its reply
-    // silently; a SPOKEN one (PTT utterance) is read aloud.
+    // Speech follows the QUESTION's modality: a TYPED question renders its
+    // reply silently; a SPOKEN one (PTT utterance) is read aloud.
     suppressSpeechTurnRef.current = inCallRef.current && !pendingVoiceInputRef.current
-    if (inCallRef.current || speakTurnRef.current) {
+    if (inCallRef.current) {
       // A new question supersedes whatever of the previous reply was still
       // unspoken — silence it and drop the frozen backlog.
       ttsRef.current.cancel()
@@ -2314,9 +2271,7 @@ function App() {
       // dead air.
       const reasoningEffort =
         selected?.effort ??
-        ((inCallRef.current && companionVoiceRef.current) || quickAskActiveRef.current
-          ? ('low' as const)
-          : undefined)
+        (inCallRef.current && companionVoiceRef.current ? ('low' as const) : undefined)
       const chatMaxModelCalls = await window.ipc
         .invoke('turnLimits:getSettings', null)
         .then((settings) => settings.chatMaxModelCalls)
@@ -2329,11 +2284,7 @@ function App() {
             composition: {
               workDirId: sessionId,
               ...(pendingVoiceInputRef.current ? { voiceInput: true } : {}),
-              ...(ttsEnabledRef.current
-                ? { voiceOutput: ttsModeRef.current }
-                : speakTurnRef.current
-                  ? { voiceOutput: 'full' as const }
-                  : {}),
+              ...(ttsEnabledRef.current ? { voiceOutput: ttsModeRef.current } : {}),
               ...(searchEnabled ? { searchEnabled: true } : {}),
               ...(codeMode ? { codeMode } : {}),
               ...((inCallRef.current && video.cameraOn) || video.screenState === 'live'
@@ -2423,8 +2374,6 @@ function App() {
     return window.ipc.on('quick-ask:submit', (payload) => {
       const trimmed = payload.text.trim()
       if (!trimmed && !payload.attachments?.length) return
-      quickAskActiveRef.current = true
-      quickAskStartedAtRef.current = Date.now()
       if (payload.model) {
         hoverSelectionRef.current = {
           provider: payload.model.provider,
@@ -2449,14 +2398,6 @@ function App() {
     })
   }, [])
 
-  // Stop relay: the bar composer's send button becomes Stop while a turn is
-  // processing — the COMPANION's turn, not the app chat's.
-  useEffect(() => {
-    return window.ipc.on('quick-ask:stop', () => {
-      void hoverChatRef.current.stop().catch(() => {})
-    })
-  }, [])
-
   // (The old surface-based text-mode hush is gone: speech now follows each
   // question's modality, plus the explicit speaker mute below.)
 
@@ -2473,34 +2414,9 @@ function App() {
     return off
   }, [])
 
-  // Mirror the in-flight answer back to the bar while a quick-ask turn is
-  // live: streaming text while generating, the final assistant message when
-  // done (which also ends the mirror). Reads the LIVE chat state — the
-  // standalone conversation/currentAssistantMessage states are legacy
-  // pre-load fallbacks the new runtime never feeds (the original quick-ask
-  // read those, which is why its mirror never showed anything). Only
-  // messages from AFTER the submit count — the previous turn's answer is
-  // still the newest one in the conversation at submit time.
-  useEffect(() => {
-    if (!quickAskActiveRef.current) return
-    let text = hoverAssistantMessage
-    if (!text) {
-      for (let i = hoverConversation.length - 1; i >= 0; i--) {
-        const item = hoverConversation[i]
-        if (isChatMessage(item) && item.role === 'assistant') {
-          if (item.timestamp >= quickAskStartedAtRef.current) text = item.content
-          break
-        }
-      }
-    }
-    // Nothing new yet (run not started / no fresh answer): pushing would
-    // only flicker the bar's local "Thinking…" state away.
-    if (!text && !hoverIsProcessing) return
-    void window.ipc
-      .invoke('quickAsk:state', { processing: hoverIsProcessing, responseText: text || null, statusText: hoverActivityText })
-      .catch(() => {})
-    if (!hoverIsProcessing && text) quickAskActiveRef.current = false
-  }, [hoverIsProcessing, hoverActivityText, hoverAssistantMessage, hoverConversation])
+  // (No answer mirror any more: a typed question on the Skipper rides the
+  // SAME call mirror as a spoken one — video:popoutState — because there is
+  // always a live session behind the companion now.)
 
   // Enter to submit voice input, Escape to cancel
   useEffect(() => {
@@ -3997,8 +3913,8 @@ function App() {
     codeMode?: 'claude' | 'codex',
     permissionMode?: PermissionMode,
   ) => {
-    if (activeIsProcessing && (inCallRef.current || quickAskActiveRef.current)) {
-      // In-call and quick-ask input arrives at arbitrary moments — a hard
+    if (activeIsProcessing && inCallRef.current) {
+      // In-call input arrives at arbitrary moments — a hard
       // drop here silently ate utterances submitted while the previous turn
       // was still stopping (the PTT interrupt is async). Finish the stop and
       // proceed with this message instead. Ordinary typed sends proceed while
@@ -4021,11 +3937,6 @@ function App() {
       marks.submit = performance.now()
     }
 
-    // Quick-ask voice toggle: this turn speaks its reply even though no call
-    // is live. Per-turn (not a sticky flag) so composer messages typed
-    // outside the bar never start talking.
-    speakTurnRef.current =
-      !inCallRef.current && quickAskActiveRef.current && quickAskOptionsRef.current.voiceOutput
     // Modality decides speech on calls: a TYPED question (composer, Skipper
     // panel, popout input) renders its reply silently; a SPOKEN one (PTT
     // utterance — pendingVoiceInputRef is set just before submit) is spoken
@@ -4033,7 +3944,7 @@ function App() {
     // mid-reply never flips an in-flight answer.
     suppressSpeechTurnRef.current = inCallRef.current && !pendingVoiceInputRef.current
 
-    if (inCallRef.current || speakTurnRef.current) {
+    if (inCallRef.current) {
       // A new question supersedes whatever of the previous reply was still
       // unspoken — silence it and drop the frozen backlog so it never plays
       // over the new turn. (The overlay resets its segment list when the
@@ -4116,14 +4027,12 @@ function App() {
       // via the agent resolver; keep them session-sticky where possible so the
       // provider prefix cache survives across turns.
       // Effort rides the ModelSelection. Hover-mode turns (companion voice
-      // sessions and bar submits) default to FAST thinking when there's no
-      // explicit pick — voice-to-first-word is the experience, and a long
-      // reasoning phase is dead air.
+      // sessions) default to FAST thinking when there's no explicit pick —
+      // voice-to-first-word is the experience, and a long reasoning phase
+      // is dead air.
       const reasoningEffort =
         selected?.effort ??
-        ((inCallRef.current && companionVoiceRef.current) || quickAskActiveRef.current
-          ? ('low' as const)
-          : undefined)
+        (inCallRef.current && companionVoiceRef.current ? ('low' as const) : undefined)
       // The runtime defaults omitted maxModelCalls to the global limit; the
       // chat-specific override is the UI's job to pass explicitly. A failed
       // settings read just falls back to the global limit.
@@ -4143,11 +4052,7 @@ function App() {
             composition: {
               workDirId: currentRunId,
               ...(pendingVoiceInputRef.current ? { voiceInput: true } : {}),
-              ...(ttsEnabledRef.current
-                ? { voiceOutput: ttsModeRef.current }
-                : speakTurnRef.current
-                  ? { voiceOutput: 'full' as const }
-                  : {}),
+              ...(ttsEnabledRef.current ? { voiceOutput: ttsModeRef.current } : {}),
               ...(searchEnabled ? { searchEnabled: true } : {}),
               // Code-session pins: a bound chat always carries the session's
               // agent + cwd, so voice/quick-ask submits (which don't thread
@@ -5286,6 +5191,22 @@ function App() {
   // being silently dead. Deliberately no automatic rebinding: a shortcut
   // that moves on its own is worse than one that's honestly broken.
   const [shortcutSettingsOpen, setShortcutSettingsOpen] = useState(false)
+  // Voice-setup nudge for a summon that can't start a session (see
+  // notifyVoiceUnavailableRef). The user is in another app when they press
+  // the chord, so the app window has to come forward to be seen.
+  const [voiceSetupOpen, setVoiceSetupOpen] = useState(false)
+  const notifyVoiceUnavailable = useCallback((reason: 'voice' | 'failed') => {
+    void window.ipc.invoke('app:focusMainWindow', null).catch(() => {})
+    // 'failed' already raised its own permission dialog — don't double up.
+    if (reason === 'failed') return
+    toast('Hover mode needs voice', {
+      description:
+        'Sign in to Rowboat — or add your own Deepgram and ElevenLabs keys — to talk to your Skipper.',
+      duration: 8000,
+      action: { label: 'Open settings', onClick: () => setVoiceSetupOpen(true) },
+    })
+  }, [])
+  notifyVoiceUnavailableRef.current = notifyVoiceUnavailable
   useEffect(() => {
     const timer = setTimeout(async () => {
       try {
@@ -7505,6 +7426,11 @@ function App() {
         open={shortcutSettingsOpen}
         onOpenChange={setShortcutSettingsOpen}
         defaultTab="shortcuts"
+      />
+      <SettingsDialog
+        open={voiceSetupOpen}
+        onOpenChange={setVoiceSetupOpen}
+        defaultTab="account"
       />
       <OnboardingModal
         open={showOnboarding}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1504,11 +1504,14 @@ function App() {
     }
   }, [video, setPttState])
 
-  // ONE hover mode: the ⌥⇧Space relay, the card's tuck handle, and the
-  // composer's call button all start THIS — a companion voice session on
-  // the Skipper surface. Sticky screen share replays the user's standing
-  // choice; without voice configured it falls back to the text card.
-  const startHoverCall = useCallback(async () => {
+  // ONE hover mode: the ⌥⇧Space relay (chord, tray item, the card's tuck
+  // handle), the composer's call button, the Home Skipper, and the
+  // discoverability toast all start THIS — a companion voice session on the
+  // Skipper surface. Sticky screen share replays the user's standing choice
+  // (`share` forces it on for this summon); without voice configured it
+  // falls back to the text card — and so does a session that fails to
+  // start, so a summon is never a silent no-op.
+  const startHoverCall = useCallback(async (opts: { share?: boolean } = {}) => {
     // Tell main the relay landed and a session is coming — cancels the
     // "nothing answered" text-card fallback so slow device startup can't
     // flash the old summoned bar before the Skipper pins.
@@ -1521,6 +1524,7 @@ function App() {
       void window.ipc.invoke('video:setPopout', { show: true }).catch(() => {})
       return
     }
+    // A start is already in flight — its pin is coming.
     if (companionVoiceStartingRef.current) return
     if (!(voiceAvailable && ttsAvailable)) {
       // Voice-first has no voice — fall back to the text card.
@@ -1531,16 +1535,34 @@ function App() {
     companionVoiceStartingRef.current = true
     try {
       await startCall('voice')
-      // Sticky screen share: opted in once from the mascot's share pin →
-      // every summon starts already sharing, until toggled off.
-      if (localStorage.getItem('companion-share-sticky') === '1') {
-        const shared = await video.startScreenShare()
-        if (!shared) setPermissionDialog('screen-recording')
-      }
     } finally {
+      // Released the moment the call engine settles — NOT held across the
+      // screen share below: a share that stalls on the Screen Recording
+      // permission (getDisplayMedia can hang for seconds) used to leave
+      // this latched, and every later summon died silently against it.
       companionVoiceStartingRef.current = false
     }
+    if (!inCallRef.current) {
+      // The session didn't start (device denied/unavailable — startCall
+      // already explained why). The gesture still deserves a surface.
+      companionVoiceRef.current = false
+      void window.ipc.invoke('quickAsk:show', null).catch(() => {})
+      return
+    }
+    // Sticky screen share: opted in once from the mascot's share pin →
+    // every summon starts already sharing, until toggled off. Fire-and-
+    // forget: the Skipper is already up, the share badge lights when the
+    // capture is really live.
+    if (opts.share || localStorage.getItem('companion-share-sticky') === '1') {
+      void video.startScreenShare().then((shared) => {
+        if (!shared) setPermissionDialog('screen-recording')
+      })
+    }
   }, [voiceAvailable, ttsAvailable, startCall, video])
+  // Stable handle for the tuck-relay listener below — registered once,
+  // always calling the latest closure.
+  const startHoverCallRef = useRef(startHoverCall)
+  startHoverCallRef.current = startHoverCall
 
   // Composer call buttons: the call button on a chat always means "float
   // THIS chat". No call yet → start the hover session bound to it; call
@@ -1569,8 +1591,10 @@ function App() {
       void window.ipc.invoke('video:setPopout', { show: true }).catch(() => {})
       return
     }
-    if (preset === 'voice') {
-      void startHoverCall()
+    if (preset === 'voice' || preset === 'share') {
+      // Both are the hover companion — 'share' is the same summon with the
+      // screen shared from the start (the menu's "Share screen").
+      void startHoverCall({ share: preset === 'share' })
     } else {
       void startCall(preset)
     }
@@ -1947,7 +1971,29 @@ function App() {
   // The main process caches the latest state and replays it when the popout
   // loads.
   useEffect(() => {
-    if (!inCall) return
+    if (!inCall) {
+      // Call over (or not started): push an explicit idle state so main's
+      // cache can't carry a stale cameraOn/status into the next summon —
+      // main keeps the cache across fullscreen ⇄ popout flaps of a LIVE
+      // call (camera on must come back as the pill), so only this end
+      // marker clears it.
+      void window.ipc
+        .invoke('video:popoutState', {
+          ttsState: 'idle',
+          status: null,
+          cameraOn: false,
+          micMuted: false,
+          screenSharing: false,
+          speakerMuted: false,
+          activityText: null,
+          interimText: null,
+          pttLocked: false,
+          responseText: null,
+          questionText: null,
+        })
+        .catch(() => {})
+      return
+    }
     void window.ipc
       .invoke('video:popoutState', {
         ttsState: tts.state,
@@ -2037,7 +2083,7 @@ function App() {
         .catch(() => quickAskShortcut.DEFAULT_QUICK_ASK_SHORTCUT)
       playPopCue()
       toast('Ask Rowboat from anywhere', {
-        description: `Press ${quickAskShortcut.formatShortcut(accelerator, isMac)} in any app for a quick question — the answer shows up right there and in your chat.`,
+        description: `Press ${quickAskShortcut.formatShortcut(accelerator, isMac)} in any app to summon your Skipper — talk or type, the answer shows up right there.`,
         duration: 12000,
         closeButton: true,
         // Lift the card off the page, and move sonner's close button (which
@@ -2046,7 +2092,10 @@ function App() {
           'shadow-xl shadow-black/25 [&_[data-close-button]]:!left-auto [&_[data-close-button]]:!right-0 [&_[data-close-button]]:!translate-x-[15%] [&_[data-close-button]]:!-translate-y-[15%]',
         action: {
           label: 'Try it',
-          onClick: () => void window.ipc.invoke('quickAsk:show', null).catch(() => {}),
+          // The SAME summon the chord performs — through main's relay, so
+          // the Skipper lands focused exactly as it does for the shortcut
+          // (text card only as its own voice-unavailable fallback).
+          onClick: () => void window.ipc.invoke('quickAsk:tuck', null).catch(() => {}),
         },
       })
     }, 3000)
@@ -2358,12 +2407,18 @@ function App() {
   // (The old surface-based text-mode hush is gone: speech now follows each
   // question's modality, plus the explicit speaker mute below.)
 
-  // Tuck relay (⌥⇧Space, the card's tuck handle): the ONE hover flow.
+  // Tuck relay (⌥⇧Space, the tray item, the card's tuck handle): the ONE
+  // hover flow. Registered once (via the ref), then main is told this
+  // window can take relays — a summon that arrived while this window was
+  // still loading (or didn't exist yet: the user had closed it and the
+  // shortcut recreated it hidden) is delivered on that handshake.
   useEffect(() => {
-    return window.ipc.on('quick-ask:tuck', () => {
-      void startHoverCall()
+    const off = window.ipc.on('quick-ask:tuck', () => {
+      void startHoverCallRef.current()
     })
-  }, [startHoverCall])
+    void window.ipc.invoke('quickAsk:appReady', null).catch(() => {})
+    return off
+  }, [])
 
   // Mirror the in-flight answer back to the bar while a quick-ask turn is
   // live: streaming text while generating, the final assistant message when

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -170,31 +170,47 @@ export function QuickAskBar() {
   // Which role the window is playing: summoned Spotlight bar or pinned call
   // pill (the old #video-popout, folded into this window). Pushed by main on
   // every transition; fetched once to cover the load race. 'hidden' renders
-  // as summoned — the window is invisible then anyway.
-  const [mode, setMode] = useState<CompanionMode>('summoned')
+  // as summoned — the window is invisible then anyway. UNKNOWN until the
+  // first push/fetch lands: nothing is painted before then, so a freshly
+  // created window can't flash the wrong role (the summoned bar used to
+  // show for the whole first page load before the Skipper replaced it).
+  const [role, setRole] = useState<{ seq: number; mode: CompanionMode; collapsed: boolean; surface: 'card' | 'pill' } | null>(null)
+  useEffect(() => {
+    const apply = (m: { seq: number; mode: CompanionMode; collapsed: boolean; surface: 'card' | 'pill' }) => {
+      // Pushes and the fetch can interleave — the highest seq is the truth.
+      setRole((prev) => (prev && prev.seq > m.seq ? prev : { ...m, mode: m.mode === 'hidden' ? 'summoned' : m.mode }))
+    }
+    const cleanup = window.ipc.on('quick-ask:mode', apply)
+    void window.ipc.invoke('quickAsk:getMode', null).then(apply).catch(() => {})
+    return cleanup
+  }, [])
+  // Paint ack: once the pushed role is on screen, tell main — it reveals
+  // (or resizes) the window only then, never over the previous role's
+  // layout. Two frames in: the first rAF runs before this commit is
+  // painted, the second after it has been.
+  const roleSeq = role?.seq ?? 0
+  useEffect(() => {
+    if (!roleSeq) return
+    let cancelled = false
+    const raf1 = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (cancelled) return
+        void window.ipc.invoke('quickAsk:modeApplied', { seq: roleSeq }).catch(() => {})
+      })
+    })
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf1)
+    }
+  }, [roleSeq])
+  const mode: CompanionMode = role?.mode ?? 'summoned'
   // Pinned presentation: expanded vs tucked down to just the mascot, and
   // WHICH surface expanded means — untuck returns you to the surface you
   // tucked from ('card' for bar-originated voice calls, 'pill' for calls
   // with live pixels). Main owns both (it resizes the window); pushes keep
   // us in sync.
-  const [collapsed, setCollapsed] = useState(false)
-  const [surface, setSurface] = useState<'card' | 'pill'>('pill')
-  useEffect(() => {
-    const cleanup = window.ipc.on('quick-ask:mode', (m) => {
-      setMode(m.mode === 'hidden' ? 'summoned' : m.mode)
-      setCollapsed(m.collapsed)
-      setSurface(m.surface)
-    })
-    void window.ipc
-      .invoke('quickAsk:getMode', null)
-      .then((m) => {
-        setMode(m.mode === 'hidden' ? 'summoned' : m.mode)
-        setCollapsed(m.collapsed)
-        setSurface(m.surface)
-      })
-      .catch(() => {})
-    return cleanup
-  }, [])
+  const collapsed = role?.collapsed ?? false
+  const surface = role?.surface ?? 'card'
   const pinned = mode === 'pinned'
   // The bar-style card hosting a LIVE voice call ("bring the text back"
   // from a bar-originated tuck): same layout, call-aware contents.
@@ -244,6 +260,15 @@ export function QuickAskBar() {
   // this window only renders it (same contract as the old popout).
   const [callState, setCallState] = useState<CallState>(IDLE_CALL_STATE)
   speakerMutedRef.current = callState.speakerMuted
+  // Leaving the pinned role ends this window's view of the call: drop the
+  // mirror so a later summon never paints the previous call's status or
+  // reply for a frame (main replays the live state on every pin). Render-
+  // time previous-state adjustment (React's no-effect pattern).
+  const [prevPinned, setPrevPinned] = useState(pinned)
+  if (prevPinned !== pinned) {
+    setPrevPinned(pinned)
+    if (!pinned) setCallState(IDLE_CALL_STATE)
+  }
   // Flicker-held activity label shared by every surface this window renders
   // (Skipper chip + panel, tucked chip, pill chip).
   const heldActivity = useHeldLabel(callState.activityText)
@@ -706,6 +731,60 @@ export function QuickAskBar() {
     }
   }, [asked, pinned, surface, collapsed, requestCollapsed, sendAction, startRecording, submitRecording, cancelRecording, reset, dismiss])
 
+  // --- Derived values for the card layout. Computed BEFORE the early
+  // returns below: the useMemo is a hook, and a hook after a conditional
+  // return changes the hook count between renders (React throws "rendered
+  // more/fewer hooks" and unmounts the whole window — the old pill ⇄ card
+  // crash on camera toggles).
+
+  // The bar-style card — summoned (no call), or the SKIPPER (a live voice
+  // call on the card surface, text panel open or folded). One layout (the
+  // last return below): the mascot column is the SAME mounted node in both
+  // Skipper states — fold/unfold only adds/removes the card beside it, so
+  // the mascot never moves, resizes, or replays its entry animation. The
+  // exchange comes from the call's mirror on the call card, from the
+  // quick-ask mirror summoned.
+  const skipper = pinned && surface === 'card'
+  const panelAsked = callCard ? callState.questionText : asked
+  const panelText = callCard ? (callState.responseText ?? '') : (answer?.text ?? '')
+  const panelProcessing = callCard ? callState.status === 'thinking' : processing
+  const panelStatusText = callCard
+    ? (heldActivity ?? 'Thinking…')
+    : (answer?.statusText || 'Thinking…')
+  // One-line caption under the Skipper's mascot: the in-flight utterance
+  // wins; otherwise the tail of the reply while it speaks.
+  const skipperReplyTail =
+    skipper && (callState.ttsState !== 'idle' || callState.status === 'thinking')
+      ? (callState.responseText ?? '')
+          .replace(/[#*_`>[\]]/g, '')
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(-90)
+      : ''
+  const skipperCaption = skipper ? (callState.interimText || skipperReplyTail) : ''
+
+  // History includes the chat's LATEST messages — but the current exchange
+  // is already rendered below the "earlier" divider, so trim it off the
+  // tail. Matched on the question text (the reliable key: a streaming reply
+  // can differ from its stored copy): drop the newest user message and
+  // everything after it iff it IS the question on display.
+  const earlierItems = useMemo(() => {
+    if (!historyData) return historyData
+    const current = (panelAsked ?? '').trim()
+    if (!current) return historyData
+    for (let i = historyData.length - 1; i >= 0; i--) {
+      if (historyData[i].role !== 'user') continue
+      if (historyData[i].content.trim() === current) return historyData.slice(0, i)
+      break
+    }
+    return historyData
+  }, [historyData, panelAsked])
+
+  // Role not known yet (first load): paint NOTHING. Main only reveals the
+  // window after the role's paint ack anyway — this keeps the fallback path
+  // (a late ack) from ever showing the wrong layout.
+  if (!role) return null
+
   // Pinned PILL role, tucked: just the mascot (voice-to-voice). The card
   // surface does NOT branch here — its folded state renders inside the one
   // Skipper layout below, so the mascot never remounts (and never moves) on
@@ -752,48 +831,6 @@ export function QuickAskBar() {
       </>
     )
   }
-
-  // The bar-style card — summoned (no call), or the SKIPPER (a live voice
-  // call on the card surface, text panel open or folded). One layout: the
-  // mascot column below is the SAME mounted node in both Skipper states —
-  // fold/unfold only adds/removes the card beside it, so the mascot never
-  // moves, resizes, or replays its entry animation. The exchange comes from
-  // the call's mirror on the call card, from the quick-ask mirror summoned.
-  const skipper = pinned && surface === 'card'
-  const panelAsked = callCard ? callState.questionText : asked
-  const panelText = callCard ? (callState.responseText ?? '') : (answer?.text ?? '')
-  const panelProcessing = callCard ? callState.status === 'thinking' : processing
-  const panelStatusText = callCard
-    ? (heldActivity ?? 'Thinking…')
-    : (answer?.statusText || 'Thinking…')
-  // One-line caption under the Skipper's mascot: the in-flight utterance
-  // wins; otherwise the tail of the reply while it speaks.
-  const skipperReplyTail =
-    skipper && (callState.ttsState !== 'idle' || callState.status === 'thinking')
-      ? (callState.responseText ?? '')
-          .replace(/[#*_`>[\]]/g, '')
-          .replace(/\s+/g, ' ')
-          .trim()
-          .slice(-90)
-      : ''
-  const skipperCaption = skipper ? (callState.interimText || skipperReplyTail) : ''
-
-  // History includes the chat's LATEST messages — but the current exchange
-  // is already rendered below the "earlier" divider, so trim it off the
-  // tail. Matched on the question text (the reliable key: a streaming reply
-  // can differ from its stored copy): drop the newest user message and
-  // everything after it iff it IS the question on display.
-  const earlierItems = useMemo(() => {
-    if (!historyData) return historyData
-    const current = (panelAsked ?? '').trim()
-    if (!current) return historyData
-    for (let i = historyData.length - 1; i >= 0; i--) {
-      if (historyData[i].role !== 'user') continue
-      if (historyData[i].content.trim() === current) return historyData.slice(0, i)
-      break
-    }
-    return historyData
-  }, [historyData, panelAsked])
 
   return (
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden">

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1161,8 +1161,8 @@ function SkipperStatusChip({ state, activity }: { state: CallState; activity?: s
  * `video:popoutAction` to the app window, which owns the devices. Captures
  * its own webcam preview — MediaStreams can't cross windows.
  *
- * Wrapped in `.dark`: the pill keeps its dark skin even though the summoned
- * bar claims light tokens, so the composer inside renders dark too.
+ * Wrapped in `.dark`: the pill keeps its dark skin even though the Skipper
+ * card claims light tokens, so the composer inside renders dark too.
  */
 function PinnedPill({
   state,

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -44,7 +44,6 @@ import * as quickAskShortcut from '@x/shared/src/quick-ask-shortcut.js'
 import { useQuickAskShortcut } from '@/hooks/use-quick-ask-shortcut'
 
 import { TalkingHead } from '@/components/talking-head'
-import { useVoiceMode } from '@/hooks/useVoiceMode'
 import { isChatMessage } from '@/lib/chat-conversation'
 import { runLogToConversation } from '@/lib/run-to-conversation'
 import { buildTurnConversation, stripVoiceTags } from '@/lib/session-chat/turn-view'
@@ -63,7 +62,7 @@ import type { FileMention, PromptInputMessage } from '@/components/ai-elements/p
 const IS_MAC = navigator.platform.startsWith('Mac')
 const PTT_CODE = IS_MAC ? 'MetaRight' : 'ControlRight'
 
-type CompanionMode = 'hidden' | 'summoned' | 'pinned'
+type CompanionMode = 'hidden' | 'pinned'
 
 // Call state mirrored from the app window (the old #video-popout contract).
 type CallState = {
@@ -117,30 +116,25 @@ const PINNED_BASE_HEIGHT = 320
 const PINNED_RESPONSE_HEIGHT = 560
 
 /**
- * Content of the quick-ask window (global ⌥⇧Space — see main's quick-ask.ts).
- * The REAL chat composer (ChatInputWithMentions) in a floating card over
- * whatever the user is doing: type a question with @-mentions, attachments,
- * model picker and all — or hold Right ⌘ to speak it — and it lands in the
- * current chat in the app window; the answer streams back here over
- * `quick-ask:state`. The window is hidden, not destroyed, on dismiss — state
- * survives toggles.
+ * Content of the companion window (global ⌥⇧Space — see main's quick-ask.ts).
+ * ONE surface: the SKIPPER — the mascot with its text panel, hosting a live
+ * voice session. Two presentations of that one surface, both driven by main
+ * over `quick-ask:mode`: text panel open (mascot + card) or tucked to just
+ * the mascot; a live CAMERA swaps the card for the pill, where the self-view
+ * lives. The window is hidden, not destroyed, when the session ends.
  *
- * Geometry: the window is a fixed tall transparent frame (main never resizes
- * it). The card is bottom-anchored; the transparent zone above is where the
- * composer's popovers (mentions, model picker, menus) open upward, and a
- * click there dismisses the bar — preserving the click-away feel.
+ * (The old `summoned` role — a standalone Spotlight-style ask bar with its
+ * own answer panel, dictation, and voice/share toggles — is GONE. It existed
+ * only as a fallback surface, and every glitch report about hover mode was
+ * really that bar appearing where the Skipper belonged.)
+ *
+ * Geometry: a fixed transparent frame with the card bottom-anchored and the
+ * mascot at the corner. The transparent zone above is where the composer's
+ * popovers (mentions, model picker, menus) open upward; clicking it near the
+ * card tucks the text away.
  */
 export function QuickAskBar() {
-  // The global summon chord (customizable) — drives hold-to-talk release
-  // detection, so it must track rebinds live.
-  const shortcut = useQuickAskShortcut()
-  const [asked, setAsked] = useState<string | null>(null)
-  const [answer, setAnswer] = useState<{ processing: boolean; text: string; statusText: string | null } | null>(null)
-  // Only answer pushes that follow OUR submit render — the app window's chat
-  // may show unrelated turns from before the bar was opened.
-  const awaitingRef = useRef(false)
-
-  // Transparent window: clear every layer so only the card paints. The bar
+  // Transparent window: clear every layer so only the card paints. This
   // window skips the app's ThemeProvider — claim the LIGHT tokens explicitly
   // (the light-skin redesign, #810). Removing 'dark' matters: the
   // pre-light-redesign code added it, and the window persists across HMR, so
@@ -159,7 +153,7 @@ export function QuickAskBar() {
     if (root) root.style.background = 'transparent'
   }, [])
 
-  // Focus the composer whenever the window is summoned.
+  // Focus the composer whenever the window is (re)focused.
   const [focusSignal, setFocusSignal] = useState(1)
   useEffect(() => {
     const onFocus = () => setFocusSignal((n) => n + 1)
@@ -167,27 +161,24 @@ export function QuickAskBar() {
     return () => window.removeEventListener('focus', onFocus)
   }, [])
 
-  // Which role the window is playing: summoned Spotlight bar or pinned call
-  // pill (the old #video-popout, folded into this window). Pushed by main on
-  // every transition; fetched once to cover the load race. 'hidden' renders
-  // as summoned — the window is invisible then anyway. UNKNOWN until the
-  // first push/fetch lands: nothing is painted before then, so a freshly
-  // created window can't flash the wrong role (the summoned bar used to
-  // show for the whole first page load before the Skipper replaced it).
+  // The window's role, pushed by main on every transition and fetched once
+  // to cover the load race. There is exactly ONE visible role — `pinned`,
+  // the hover companion — plus `hidden`. UNKNOWN until the first push/fetch
+  // lands, and nothing paints before then.
   const [role, setRole] = useState<{ seq: number; mode: CompanionMode; collapsed: boolean; surface: 'card' | 'pill' } | null>(null)
   useEffect(() => {
     const apply = (m: { seq: number; mode: CompanionMode; collapsed: boolean; surface: 'card' | 'pill' }) => {
       // Pushes and the fetch can interleave — the highest seq is the truth.
-      setRole((prev) => (prev && prev.seq > m.seq ? prev : { ...m, mode: m.mode === 'hidden' ? 'summoned' : m.mode }))
+      setRole((prev) => (prev && prev.seq > m.seq ? prev : m))
     }
     const cleanup = window.ipc.on('quick-ask:mode', apply)
     void window.ipc.invoke('quickAsk:getMode', null).then(apply).catch(() => {})
     return cleanup
   }, [])
   // Paint ack: once the pushed role is on screen, tell main — it reveals
-  // (or resizes) the window only then, never over the previous role's
-  // layout. Two frames in: the first rAF runs before this commit is
-  // painted, the second after it has been.
+  // (or resizes) the window only then, never mid-transition. Two frames in:
+  // the first rAF runs before this commit is painted, the second after it
+  // has been.
   const roleSeq = role?.seq ?? 0
   useEffect(() => {
     if (!roleSeq) return
@@ -203,17 +194,14 @@ export function QuickAskBar() {
       cancelAnimationFrame(raf1)
     }
   }, [roleSeq])
-  const mode: CompanionMode = role?.mode ?? 'summoned'
-  // Pinned presentation: expanded vs tucked down to just the mascot, and
-  // WHICH surface expanded means — untuck returns you to the surface you
-  // tucked from ('card' for bar-originated voice calls, 'pill' for calls
-  // with live pixels). Main owns both (it resizes the window); pushes keep
-  // us in sync.
+  const pinned = role?.mode === 'pinned'
+  // Presentation: expanded vs tucked down to just the mascot, and WHICH
+  // surface expanded means — the Skipper card, or the pill when a live
+  // camera needs its self-view. Main owns both (it resizes the window);
+  // pushes keep us in sync.
   const collapsed = role?.collapsed ?? false
   const surface = role?.surface ?? 'card'
-  const pinned = mode === 'pinned'
-  // The bar-style card hosting a LIVE voice call ("bring the text back"
-  // from a bar-originated tuck): same layout, call-aware contents.
+  // The Skipper's text panel is open (mascot + card, the default landing).
   const callCard = pinned && !collapsed && surface === 'card'
 
   // Mirrors callState.speakerMuted for the fold callback below (which is
@@ -286,21 +274,17 @@ export function QuickAskBar() {
   }, [])
 
   // Relay a call control action to the app window (mic/camera/capture live
-  // there; the pill is a dumb terminal).
+  // there; this window is a dumb terminal).
   const sendAction = useCallback((action: PopoutAction) => {
     void window.ipc.invoke('video:popoutAction', { action }).catch(() => {})
   }, [])
 
-  // The summoned mascot has no audio pipeline — its mouth stays closed; the
-  // thinking bubbles (driven by ttsState) are its only active state here.
-  // During a call-card session the mascot lip-syncs off a synthesized level
-  // instead (the real audio plays in the app window).
-  const zeroLevel = useCallback(() => 0, [])
+  // The mascot lip-syncs off a synthesized level — the real audio plays in
+  // the app window, and MediaStreams can't cross windows.
   const synthLevel = useCallback(() => 0.45 + 0.35 * Math.sin(performance.now() / 90), [])
 
   // Knowledge files for @-mentions, fetched over IPC (this window has no
-  // App-owned tree). Refreshed on every summon — notes change while the bar
-  // is hidden.
+  // App-owned tree). Refreshed on focus — notes change while it's hidden.
   const [knowledgeFiles, setKnowledgeFiles] = useState<string[]>([])
   useEffect(() => {
     const refresh = () => {
@@ -322,21 +306,15 @@ export function QuickAskBar() {
     return () => window.removeEventListener('focus', refresh)
   }, [])
 
-  useEffect(() => {
-    return window.ipc.on('quick-ask:state', (s) => {
-      if (!awaitingRef.current) return
-      setAnswer({ processing: s.processing, text: s.responseText ?? '', statusText: s.statusText ?? null })
-    })
-  }, [])
-
-  // The bar composer's ModelSelection (model + effort, one value — main's
+  // The composer's ModelSelection (model + effort, one value — main's
   // unified shape) rides along with each submit; the app window applies it
-  // to the active chat before submitting. Hover asks default to FAST
-  // thinking at the submit boundary when the selection carries no effort.
+  // to the companion's session before submitting.
   const selectionRef = useRef<ModelSelection | null>(null)
 
-  const processing = answer?.processing ?? false
-
+  // Typed input during a session: the FULL composer payload relays to the
+  // app window, which submits it into the companion's chat exactly like an
+  // in-app message. The reply comes back through the call mirror
+  // (`video:popout-state`), same as a spoken one.
   const submit = useCallback(
     (
       message: PromptInputMessage,
@@ -348,9 +326,6 @@ export function QuickAskBar() {
     ) => {
       const text = message.text.trim()
       if (!text && !attachments?.length) return
-      setAsked(text || (attachments ?? []).map((a) => a.filename).join(', '))
-      awaitingRef.current = true
-      setAnswer({ processing: true, text: '', statusText: 'Thinking…' })
       void window.ipc
         .invoke('quickAsk:submit', {
           text,
@@ -369,22 +344,11 @@ export function QuickAskBar() {
     [],
   )
 
-  const stop = useCallback(() => {
-    void window.ipc.invoke('quickAsk:stop', null).catch(() => {})
-  }, [])
-
   // History peek — display is EXPLICIT (the no-history default is right for
-  // ~90% of asks), but the DATA is prefetched eagerly on summon/switch so
-  // the click is instant: a local IPC read of a few KB, no downside.
+  // ~90% of asks), but the DATA is prefetched eagerly on switch so the click
+  // is instant: a local IPC read of a few KB, no downside.
   const [historyData, setHistoryData] = useState<{ role: 'user' | 'assistant'; content: string }[] | null>(null)
   const [showHistory, setShowHistory] = useState(false)
-
-  const reset = useCallback(() => {
-    awaitingRef.current = false
-    setAsked(null)
-    setAnswer(null)
-    setShowHistory(false)
-  }, [])
 
   // Destination-chat context: which chat submits land in (title chip) plus
   // recents for the chip's switcher. Pushed by the app window; cached in
@@ -397,14 +361,9 @@ export function QuickAskBar() {
   useEffect(() => {
     return window.ipc.on('quick-ask:chat-context', (ctx) => setChatContext(ctx))
   }, [])
-  const selectChat = useCallback(
-    (rid: string) => {
-      // The panel's exchange belongs to the previous chat — clear it.
-      reset()
-      void window.ipc.invoke('quickAsk:selectChat', { runId: rid }).catch(() => {})
-    },
-    [reset],
-  )
+  const selectChat = useCallback((rid: string) => {
+    void window.ipc.invoke('quickAsk:selectChat', { runId: rid }).catch(() => {})
+  }, [])
 
   // A destination change from ANY side (chip, app tab switch, new chat)
   // invalidates a shown history — it belonged to the previous chat.
@@ -450,7 +409,7 @@ export function QuickAskBar() {
     }
   }, [])
 
-  // Prefetch on summon/switch so the peek opens instantly.
+  // Prefetch on switch so the peek opens instantly.
   useEffect(() => {
     if (!activeRunId) return
     let stale = false
@@ -479,253 +438,37 @@ export function QuickAskBar() {
     if (!activeRunId) return
     setShowHistory(true)
     // Show the prefetched copy immediately, refresh behind it — exchanges
-    // made since the prefetch (including from this bar) must show up.
+    // made since the prefetch (including from here) must show up.
     void fetchHistory(activeRunId).then((items) => setHistoryData(items))
   }, [showHistory, activeRunId, fetchHistory])
 
-  // Voice input: the composer's mic button, or hold the platform PTT key
-  // (right ⌘ on macOS, right Ctrl on Windows) while the bar is focused.
-  // Local dictation via the same Deepgram flow as the app composer — no
-  // global hook needed, the bar has keyboard focus by construction.
-  const voice = useVoiceMode()
-  const [recording, setRecording] = useState(false)
-  const recordingRef = useRef(false)
-  const [voiceAvailable, setVoiceAvailable] = useState(false)
-  const [ttsAvailable, setTtsAvailable] = useState(false)
-  // Whether the probe above has answered at all. Until it has, `false` means
-  // "not known yet", never "not configured".
-  const [voiceProbed, setVoiceProbed] = useState(false)
-  useEffect(() => {
-    Promise.all([
-      window.ipc.invoke('voice:getConfig', null),
-      window.ipc.invoke('oauth:getState', null),
-    ])
-      .then(([config, oauthState]) => {
-        const rowboatConnected = oauthState.config?.rowboat?.connected ?? false
-        setVoiceAvailable(!!config.deepgram || rowboatConnected)
-        setTtsAvailable(!!config.elevenlabs || rowboatConnected)
-      })
-      .catch(() => {
-        setVoiceAvailable(false)
-        setTtsAvailable(false)
-      })
-      .finally(() => setVoiceProbed(true))
-  }, [])
-  // Tucking starts a voice call — same gate as the call button, but
-  // OPTIMISTIC until this window's probe answers: the app window owns the
-  // authoritative check (and its own text-card fallback), so a summon that
-  // arrives first must relay, not die as a dimmed no-op click.
-  const callAvailable = voiceProbed ? voiceAvailable && ttsAvailable : true
-
-  const tuck = useCallback(() => {
-    void window.ipc.invoke('quickAsk:tuck', null).catch(() => {})
-  }, [])
-
-  const startRecording = useCallback(() => {
-    if (recordingRef.current) return
-    recordingRef.current = true
-    setRecording(true)
-    void voice.start().then((result) => {
-      if (result === 'mic-denied') {
-        recordingRef.current = false
-        setRecording(false)
-        void window.ipc.invoke('app:openPrivacySettings', { section: 'microphone' }).catch(() => {})
-      }
-    })
-  }, [voice])
-
-  const submitRecording = useCallback(async () => {
-    if (!recordingRef.current) return
-    recordingRef.current = false
-    setRecording(false)
-    const text = await voice.submit()
-    if (text) submit({ text, files: [] })
-  }, [voice, submit])
-
-  const cancelRecording = useCallback(() => {
-    voice.cancel()
-    recordingRef.current = false
-    setRecording(false)
-  }, [voice])
-
-  // Hold-chord-to-talk (the Wispr gesture, default ⌥⇧Space — the chord is
-  // customizable in Settings → Shortcuts): a chord summon starts
-  // capturing IMMEDIATELY — one gesture from anywhere to a spoken question.
-  // Electron's global shortcut can't see the key-UP, so the release is
-  // detected here once the window has focus: any chord key's keyup, or any
-  // event whose modifier state shows the chord's modifiers are no
-  // longer held, finalizes and submits. A quick TAP falls out for free —
-  // nothing was said, the transcript comes back empty, and an empty
-  // transcript doesn't submit, leaving the composer focused for typing.
-  // Typing, Esc, or blur cancels; a hard cap ends a stuck session.
-  const chordRef = useRef(false)
-  const capStartedAtRef = useRef<number | null>(null)
-  const voiceAvailableRef = useRef(false)
-  useEffect(() => {
-    voiceAvailableRef.current = voiceAvailable
-  }, [voiceAvailable])
-  const endChord = useCallback(
-    (how: 'submit' | 'cancel') => {
-      if (!chordRef.current) return
-      chordRef.current = false
-      if (how === 'submit') void submitRecording()
-      else cancelRecording()
-    },
-    [submitRecording, cancelRecording],
-  )
-  useEffect(() => {
-    return window.ipc.on('quick-ask:summoned', ({ viaShortcut }) => {
-      if (!viaShortcut || pinned || recordingRef.current || !voiceAvailableRef.current) return
-      chordRef.current = true
-      startRecording()
-    })
-  }, [pinned, startRecording])
-  useEffect(() => {
-    const chordCodes = quickAskShortcut.shortcutChordCodes(shortcut.accelerator)
-    const chordModifiers = quickAskShortcut.shortcutModifierStates(shortcut.accelerator)
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (chordRef.current && chordCodes.includes(e.code)) endChord('submit')
-    }
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!chordRef.current) return
-      if (e.key === 'Escape') {
-        endChord('cancel')
-        return
-      }
-      // A non-chord key means they're typing — get out of the way.
-      if (!chordCodes.includes(e.code)) endChord('cancel')
-    }
-    const onMouseMove = (e: MouseEvent) => {
-      // Backup release signal: the chord's modifiers are no longer held
-      // (its keyups were delivered before this window took focus).
-      if (chordRef.current && chordModifiers.every((m) => !e.getModifierState(m))) {
-        endChord('submit')
-      }
-    }
-    const onBlur = () => endChord('cancel')
-    document.addEventListener('keyup', onKeyUp)
-    document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('mousemove', onMouseMove)
-    window.addEventListener('blur', onBlur)
-    const cap = setInterval(() => {
-      // Stuck-session cap: no release signal for 45s means we missed it.
-      if (chordRef.current && capStartedAtRef.current && Date.now() - capStartedAtRef.current > 45_000) {
-        endChord('submit')
-      }
-    }, 5_000)
-    return () => {
-      document.removeEventListener('keyup', onKeyUp)
-      document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('mousemove', onMouseMove)
-      window.removeEventListener('blur', onBlur)
-      clearInterval(cap)
-    }
-  }, [endChord, shortcut.accelerator])
-  useEffect(() => {
-    capStartedAtRef.current = recording ? Date.now() : null
-  }, [recording])
-
-  // Optional toggles. voiceOut: answers to bar questions are spoken aloud.
-  // sharing: the app window's screen capture runs and frames ride along with
-  // bar submits — the ACTUAL state comes back over quick-ask:options-state
-  // (a denied permission must never leave a lying badge).
-  const [voiceOut, setVoiceOut] = useState(false)
-  const [sharing, setSharing] = useState(false)
-  const pushOptions = useCallback((voiceOutput: boolean, screenShare: boolean) => {
-    void window.ipc.invoke('quickAsk:setOptions', { voiceOutput, screenShare }).catch(() => {})
-  }, [])
-  useEffect(() => {
-    return window.ipc.on('quick-ask:options-state', (s) => {
-      setSharing(s.screenSharing)
-      setVoiceOut(s.voiceOutput)
-    })
-  }, [])
-  const toggleVoiceOut = useCallback(() => {
-    const next = !voiceOut
-    setVoiceOut(next)
-    pushOptions(next, sharing)
-  }, [voiceOut, sharing, pushOptions])
-  const toggleShare = useCallback(() => {
-    const next = !sharing
-    setSharing(next)
-    pushOptions(voiceOut, next)
-  }, [voiceOut, sharing, pushOptions])
-  // The bar owns the share's consent surface — when it goes away (blur,
-  // Esc, jump to the app), the share it started must stop with it. Nothing
-  // may keep capturing the screen with no indicator in sight.
-  const stopShareIfOn = useCallback(() => {
-    if (!sharing) return
-    setSharing(false)
-    pushOptions(voiceOut, false)
-  }, [sharing, voiceOut, pushOptions])
-  useEffect(() => {
-    const onBlur = () => stopShareIfOn()
-    window.addEventListener('blur', onBlur)
-    return () => window.removeEventListener('blur', onBlur)
-  }, [stopShareIfOn])
-
-  const dismiss = useCallback(() => {
-    stopShareIfOn()
-    void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
-  }, [stopShareIfOn])
-
-  // Jump to the full conversation: the question already lives in the app's
-  // active chat (the bar relays into it), so focusing the app window lands
-  // on this exact exchange. The bar gets out of the way.
-  const openInApp = useCallback(() => {
-    stopShareIfOn()
-    void window.ipc.invoke('quickAsk:openChat', null).catch(() => {})
-    void window.ipc.invoke('quickAsk:hide', null).catch(() => {})
-  }, [stopShareIfOn])
-
-  // Fresh conversation for the next question: resets the app's active chat
-  // (in the background) and clears the panel. The bar stays up.
+  // Fresh conversation for the next question: rebinds the companion's chat
+  // (in the app window). The session keeps going.
   const newChat = useCallback(() => {
     void window.ipc.invoke('quickAsk:newChat', null).catch(() => {})
-    reset()
-  }, [reset])
+  }, [])
 
-  // Hold the platform PTT key to speak. Outside a call: local dictation,
-  // release submits the transcript. During a call (pinned): the app's PTT
-  // machine owns the mic — relay the key edges to it instead (this works
-  // even without the Input Monitoring grant, since the pill has focus).
-  // Esc: cancel recording → clear the answer → dismiss, in that order —
-  // but never dismiss a live call surface.
+  // Jump to the full conversation in the app's side pane. The session keeps
+  // going — this window stays exactly as it is.
+  const openInApp = useCallback(() => {
+    void window.ipc.invoke('quickAsk:openChat', null).catch(() => {})
+  }, [])
+
+  // Hold the platform PTT key to speak: the app's PTT machine owns the mic,
+  // so relay the key edges to it (this works even without the Input
+  // Monitoring grant, since this window has focus). Esc never ends a
+  // session — it tucks the text back into the mascot.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.code === PTT_CODE && !e.repeat) {
-        if (pinned) {
-          sendAction('ptt-down')
-        } else if (!recordingRef.current) {
-          startRecording()
-        }
-      } else if (e.key === 'Escape') {
-        if (pinned) {
-          // Esc never ends a call — on the call card it tucks the text
-          // back into the mascot; on the pill it does nothing.
-          if (surface === 'card' && !collapsed) {
-            e.preventDefault()
-            requestCollapsed(true)
-          }
-          return
-        }
+        sendAction('ptt-down')
+      } else if (e.key === 'Escape' && callCard) {
         e.preventDefault()
-        if (recordingRef.current) {
-          cancelRecording()
-        } else if (asked) {
-          reset()
-        } else {
-          dismiss()
-        }
+        requestCollapsed(true)
       }
     }
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code !== PTT_CODE) return
-      if (pinned) {
-        sendAction('ptt-up')
-      } else if (recordingRef.current) {
-        void submitRecording()
-      }
+      if (e.code === PTT_CODE) sendAction('ptt-up')
     }
     // Capture phase: right ⌘ must work even while the embedded composer (or
     // any popover) has focus — "press ⌘ and speak" is promised in BOTH
@@ -736,39 +479,28 @@ export function QuickAskBar() {
       document.removeEventListener('keydown', onKeyDown, true)
       document.removeEventListener('keyup', onKeyUp, true)
     }
-  }, [asked, pinned, surface, collapsed, requestCollapsed, sendAction, startRecording, submitRecording, cancelRecording, reset, dismiss])
+  }, [callCard, requestCollapsed, sendAction])
 
   // --- Derived values for the card layout. Computed BEFORE the early
   // returns below: the useMemo is a hook, and a hook after a conditional
   // return changes the hook count between renders (React throws "rendered
   // more/fewer hooks" and unmounts the whole window — the old pill ⇄ card
   // crash on camera toggles).
-
-  // The bar-style card — summoned (no call), or the SKIPPER (a live voice
-  // call on the card surface, text panel open or folded). One layout (the
-  // last return below): the mascot column is the SAME mounted node in both
-  // Skipper states — fold/unfold only adds/removes the card beside it, so
-  // the mascot never moves, resizes, or replays its entry animation. The
-  // exchange comes from the call's mirror on the call card, from the
-  // quick-ask mirror summoned.
-  const skipper = pinned && surface === 'card'
-  const panelAsked = callCard ? callState.questionText : asked
-  const panelText = callCard ? (callState.responseText ?? '') : (answer?.text ?? '')
-  const panelProcessing = callCard ? callState.status === 'thinking' : processing
-  const panelStatusText = callCard
-    ? (heldActivity ?? 'Thinking…')
-    : (answer?.statusText || 'Thinking…')
+  const panelAsked = callState.questionText
+  const panelText = callState.responseText ?? ''
+  const panelProcessing = callState.status === 'thinking'
+  const panelStatusText = heldActivity ?? 'Thinking…'
   // One-line caption under the Skipper's mascot: the in-flight utterance
   // wins; otherwise the tail of the reply while it speaks.
   const skipperReplyTail =
-    skipper && (callState.ttsState !== 'idle' || callState.status === 'thinking')
+    callState.ttsState !== 'idle' || callState.status === 'thinking'
       ? (callState.responseText ?? '')
           .replace(/[#*_`>[\]]/g, '')
           .replace(/\s+/g, ' ')
           .trim()
           .slice(-90)
       : ''
-  const skipperCaption = skipper ? (callState.interimText || skipperReplyTail) : ''
+  const skipperCaption = callState.interimText || skipperReplyTail
 
   // History includes the chat's LATEST messages — but the current exchange
   // is already rendered below the "earlier" divider, so trim it off the
@@ -787,16 +519,16 @@ export function QuickAskBar() {
     return historyData
   }, [historyData, panelAsked])
 
-  // Role not known yet (first load): paint NOTHING. Main only reveals the
-  // window after the role's paint ack anyway — this keeps the fallback path
-  // (a late ack) from ever showing the wrong layout.
-  if (!role) return null
+  // No role yet, or no session: paint NOTHING. The window is hidden in that
+  // state anyway — and painting a placeholder is exactly how the retired
+  // summoned bar used to flash before the Skipper landed.
+  if (!pinned) return null
 
-  // Pinned PILL role, tucked: just the mascot (voice-to-voice). The card
+  // Tucked PILL (camera calls): just the mascot (voice-to-voice). The card
   // surface does NOT branch here — its folded state renders inside the one
   // Skipper layout below, so the mascot never remounts (and never moves) on
   // fold/unfold.
-  if (pinned && collapsed && surface !== 'card') {
+  if (collapsed && surface !== 'card') {
     return (
       <TuckedMascot
         state={callState}
@@ -807,10 +539,9 @@ export function QuickAskBar() {
     )
   }
 
-  // Pinned role, expanded to the PILL (camera/share calls): the call pill
-  // with the real composer as its typed input. Bar-originated voice calls
-  // fall through to the card layout below instead (callCard).
-  if (pinned && surface === 'pill') {
+  // Expanded to the PILL (camera calls): the call pill with the real
+  // composer as its typed input. Voice sessions use the card below.
+  if (surface === 'pill') {
     return (
       <>
         <PinnedPill
@@ -839,30 +570,31 @@ export function QuickAskBar() {
     )
   }
 
+  // THE SKIPPER — the one hover surface. One layout for both of its states:
+  // the mascot column below is the SAME mounted node whether the text panel
+  // is open or folded, so fold/unfold only adds/removes the card beside it
+  // and the mascot never moves, resizes, or replays its entry animation.
   return (
     <div className="flex h-screen w-screen select-none flex-col overflow-hidden">
-      {/* The invisible stage: popovers open into this zone; clicking it
-          dismisses the summoned bar (true Spotlight click-away — blur
-          dismisses it anyway, so stage and outside clicks agree). On the
-          call card, only clicks NEAR the visible card tuck the panel
-          (stageTuck hit-test) — the rest of the invisible frame is inert,
-          so clicking what looks like empty desktop never steals the panel.
-          Folded Skipper: the stage is a drag area, part of "carry it
-          around". */}
+      {/* The invisible stage: popovers open into this zone. With the text
+          open, only clicks NEAR the visible card tuck the panel (stageTuck
+          hit-test) — the rest of the invisible frame is inert, so clicking
+          what looks like empty desktop never steals the panel. Folded, the
+          stage is a drag area, part of "carry it around". */}
       <div
         className="min-h-0 flex-1"
-        style={skipper && collapsed ? dragRegion : undefined}
-        onMouseDown={callCard ? stageTuck : skipper ? undefined : dismiss}
+        style={collapsed ? dragRegion : undefined}
+        onMouseDown={collapsed ? undefined : stageTuck}
       />
 
       {/* Bottom row: card + the mascot riding alongside on the transparent
           stage. The row is PADDED so the card's CSS shadow fades inside the
           window instead of clipping at its rectangular edge (which read as
           a grey rectangle around the card). The paddings are IDENTICAL in
-          both Skipper states — with the corner-anchored window, that pins
-          the mascot to the exact same screen pixels across fold/unfold. */}
+          both states — with the corner-anchored window, that pins the
+          mascot to the exact same screen pixels across fold/unfold. */}
       <div className="flex shrink-0 items-end justify-end gap-1 px-6 pb-5">
-      {!(skipper && collapsed) && (
+      {!collapsed && (
       <div className="relative min-w-0 flex-1">
       {/* Light skin (#810): near-white card, hairline dark border, dark
           text. The window's native shadow is off (it would outline the
@@ -883,15 +615,13 @@ export function QuickAskBar() {
             border-color: rgba(0, 0, 0, 0.3) !important;
           }
         `}</style>
-        {/* Action strip: bar-level controls that aren't the composer's job.
-            Summoned: voice-out/share toggles (set before asking). Call
-            card: live-call status + mute + end — the call owns the devices,
-            replies are always spoken. */}
+        {/* Action strip: the destination affordances plus the speaker mute.
+            Device controls live on the MASCOT (the same pins as the folded
+            Skipper) — the call owns them. */}
         <div className="flex items-center justify-end gap-2 px-4 pt-3">
-          {/* Destination chip: WHICH chat this bar is continuing — click
+          {/* Destination chip: WHICH chat this session is continuing — click
               for the recents switcher (opens upward into the transparent
-              stage). Rendered in BOTH card modes: text mode mid-call
-              retargets subsequent questions just like the summoned bar. */}
+              stage). Retargets subsequent questions mid-session. */}
           <DropdownMenu>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -907,7 +637,7 @@ export function QuickAskBar() {
                 </DropdownMenuTrigger>
               </TooltipTrigger>
               <TooltipContent side="top">
-                Questions continue this chat — click to switch · Esc {panelProcessing ? 'dismisses' : 'clears'}
+                Questions continue this chat — click to switch · Esc tucks the text away
               </TooltipContent>
             </Tooltip>
             <DropdownMenuContent align="start" side="top" className="max-h-72 w-72 overflow-y-auto">
@@ -936,8 +666,8 @@ export function QuickAskBar() {
             </DropdownMenuContent>
           </DropdownMenu>
           {/* New chat rides RIGHT NEXT to the selector — it's a destination
-              choice too. Works mid-call: the session keeps going, the next
-              questions land in the fresh chat. */}
+              choice too. The session keeps going; the next questions land
+              in the fresh chat. */}
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -960,7 +690,7 @@ export function QuickAskBar() {
                 onClick={activeRunId ? toggleHistory : undefined}
                 aria-label={showHistory ? 'Hide history' : 'Peek at recent history'}
                 aria-disabled={!activeRunId}
-                className={`${callCard ? '' : 'mr-auto '}flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
                   showHistory
                     ? 'bg-black/[0.08] text-neutral-900 ring-black/15'
                     : activeRunId
@@ -979,78 +709,32 @@ export function QuickAskBar() {
                   : 'No history yet — this is a new chat'}
             </TooltipContent>
           </Tooltip>
-          {/* Call controls live on the MASCOT (the same pins as the folded
-              Skipper); this strip keeps chat-destination affordances plus
-              the speaker mute — a "read instead of listen" choice that only
+          {/* The speaker mute — a "read instead of listen" choice that only
               exists while the text panel does (folding auto-unmutes). */}
-          {callCard && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => sendAction('toggle-speaker')}
-                  aria-label={callState.speakerMuted ? 'Unmute spoken replies' : 'Mute spoken replies'}
-                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
-                    callState.speakerMuted
-                      ? 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                      : 'bg-sky-500/15 text-sky-700 ring-sky-500/30'
-                  }`}
-                >
-                  {callState.speakerMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                {callState.speakerMuted
-                  ? 'Replies are silent while the text is open — click to speak them again'
-                  : 'Spoken questions are answered aloud — click to read replies silently instead'}
-              </TooltipContent>
-            </Tooltip>
-          )}
-          {!callCard && (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={toggleVoiceOut}
-                    aria-label={voiceOut ? 'Stop speaking answers' : 'Speak answers aloud'}
-                    className={`flex h-7 w-7 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
-                      voiceOut
-                        ? 'bg-sky-500/15 text-sky-700 ring-sky-500/30'
-                        : 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                    }`}
-                  >
-                    <Volume2 className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {voiceOut ? 'Answers are spoken — click to mute' : 'Speak answers aloud'}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={toggleShare}
-                    aria-label={sharing ? 'Stop sharing your screen' : 'Share your screen'}
-                    className={`flex h-7 w-7 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
-                      sharing
-                        ? 'bg-emerald-500/15 text-emerald-700 ring-emerald-500/30'
-                        : 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                    }`}
-                  >
-                    <MonitorUp className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {sharing ? 'Sharing your screen with this chat — click to stop' : 'Share your screen with this chat'}
-                </TooltipContent>
-              </Tooltip>
-            </>
-          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => sendAction('toggle-speaker')}
+                aria-label={callState.speakerMuted ? 'Unmute spoken replies' : 'Mute spoken replies'}
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
+                  callState.speakerMuted
+                    ? 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
+                    : 'bg-sky-500/15 text-sky-700 ring-sky-500/30'
+                }`}
+              >
+                {callState.speakerMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {callState.speakerMuted
+                ? 'Replies are silent while the text is open — click to speak them again'
+                : 'Spoken questions are answered aloud — click to read replies silently instead'}
+            </TooltipContent>
+          </Tooltip>
           {/* Jump-to-app stays on the right — it's a window action, not a
-              destination choice. Present on EVERY surface (Skipper card
-              included): the one bridge from hover to the app's side pane. */}
+              destination choice: the one bridge from hover to the app's
+              side pane. */}
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -1127,7 +811,7 @@ export function QuickAskBar() {
 
         {/* The real composer. Submits relay the FULL payload (mentions,
             attachments, search/code/permissions, model/effort) to the app
-            window, which submits into the active chat exactly like an
+            window, which submits into the companion's chat exactly like an
             in-app composer message. */}
         <div className="border-t border-black/5 p-3">
           <ChatInputWithMentions
@@ -1135,98 +819,67 @@ export function QuickAskBar() {
             recentFiles={[]}
             visibleFiles={knowledgeFiles}
             onSubmit={submit}
-            onStop={callCard ? () => sendAction('stop-speaking') : stop}
+            onStop={() => sendAction('stop-speaking')}
             isProcessing={panelProcessing}
             runId={null}
-            placeholder={callCard ? 'Type instead — @ mentions work too…' : 'Ask Rowboat anything…'}
+            placeholder="Type instead — @ mentions work too…"
             focusSignal={focusSignal}
             onSelectionChange={(sel) => {
               selectionRef.current = sel ?? null
             }}
-            isRecording={callCard ? undefined : recording}
-            recordingText={callCard ? undefined : voice.interimText}
-            recordingState={
-              callCard
-                ? undefined
-                : voice.state === 'submitting'
-                  ? 'stopping'
-                  : voice.state === 'connecting'
-                    ? 'connecting'
-                    : 'listening'
-            }
-            audioLevelsRef={voice.audioLevelsRef}
-            onStartRecording={callCard ? undefined : startRecording}
-            onSubmitRecording={callCard ? undefined : submitRecording}
-            onCancelRecording={callCard ? undefined : cancelRecording}
-            voiceAvailable={callCard ? false : voiceAvailable}
+            voiceAvailable={false}
           />
         </div>
       </div>
 
       {/* Tuck handle on the card's mascot-side edge: push the text into the
-          mascot → voice-to-voice. Summoned it STARTS the voice-preset call;
-          on the call card it just tucks (the call keeps going). Dimmed —
-          never hidden — when voice isn't configured, so the feature stays
-          discoverable without dead-end clicks. */}
+          mascot → voice-to-voice. The session keeps going. */}
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
-            onClick={callCard ? () => requestCollapsed(true) : callAvailable ? tuck : undefined}
-            aria-label="Tuck into the mascot — voice-to-voice"
-            aria-disabled={!callCard && !callAvailable}
-            className={`absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-colors ${
-              callCard || callAvailable ? 'hover:bg-neutral-50 hover:text-neutral-900' : 'cursor-default opacity-40'
-            }`}
+            onClick={() => requestCollapsed(true)}
+            aria-label="Tuck the text away"
+            className="absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-colors hover:bg-neutral-50 hover:text-neutral-900"
           >
             <ChevronsRight className="h-3.5 w-3.5" />
           </button>
         </TooltipTrigger>
-        <TooltipContent side="top">
-          {callCard
-            ? 'Tuck the text away — the call keeps going'
-            : callAvailable
-              ? 'Tuck into the mascot — talk instead of type'
-              : 'Voice-to-voice needs voice input & output configured in Settings'}
-        </TooltipContent>
+        <TooltipContent side="top">Tuck the text away — the session keeps going</TooltipContent>
       </Tooltip>
       </div>
       )}
 
       {/* The mascot column — the Skipper's CONSTANT. One mounted node for
-          both Skipper states (text open or folded): identical size, pins,
-          caption slot, and status chip, at identical offsets from the
-          window's bottom-right corner — which the corner-anchored window
-          keeps fixed on screen, so fold/unfold moves NOTHING here; only the
-          card beside it comes and goes. It is the control surface AND the
-          drag handle. Summoned (no call) it stays the inert 124px bobbing
-          silhouette. */}
+          both states (text open or folded): identical size, pins, caption
+          slot, and status chip, at identical offsets from the window's
+          bottom-right corner — which the corner-anchored window keeps fixed
+          on screen, so fold/unfold moves NOTHING here; only the card beside
+          it comes and goes. It is the control surface AND the drag
+          handle. */}
       <div
-        className={`relative flex w-[132px] shrink-0 select-none flex-col items-center ${skipper ? 'cursor-grab' : 'pointer-events-none'}`}
-        style={skipper ? dragRegion : undefined}
-        aria-hidden={skipper ? undefined : true}
-        title={skipper ? 'Drag to move your Skipper' : undefined}
+        className="relative flex w-[132px] shrink-0 cursor-grab select-none flex-col items-center"
+        style={dragRegion}
+        title="Drag to move your Skipper"
       >
-        {skipper && (
-          <style>{`
-            @keyframes listen-ring {
-              0% { transform: scale(0.72); opacity: 0.9; }
-              100% { transform: scale(1.28); opacity: 0; }
-            }
-            @keyframes skipper-pop {
-              0% { opacity: 0; transform: scale(0.5); }
-              100% { opacity: 1; transform: scale(1); }
-            }
-          `}</style>
-        )}
+        <style>{`
+          @keyframes listen-ring {
+            0% { transform: scale(0.72); opacity: 0.9; }
+            100% { transform: scale(1.28); opacity: 0; }
+          }
+          @keyframes skipper-pop {
+            0% { opacity: 0; transform: scale(0.5); }
+            100% { opacity: 1; transform: scale(1); }
+          }
+        `}</style>
         <div
           className="relative -mb-4"
-          style={skipper ? { animation: 'skipper-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' } : undefined}
+          style={{ animation: 'skipper-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}
         >
           {/* Listening halo — rings pulse around the head while the mic
               gate is open, so "press ⌘ and speak" is visibly working in
               both states. */}
-          {skipper && !callState.micMuted && (callState.status === 'listening' || callState.pttLocked) && (
+          {!callState.micMuted && (callState.status === 'listening' || callState.pttLocked) && (
             <>
               <span
                 className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-green-400/90"
@@ -1240,47 +893,37 @@ export function QuickAskBar() {
           )}
           <TalkingHead
             ttsState={
-              skipper
-                ? callState.status === 'thinking' && callState.ttsState === 'idle'
-                  ? 'synthesizing'
-                  : callState.ttsState
-                : processing
-                  ? 'synthesizing'
-                  : 'idle'
+              callState.status === 'thinking' && callState.ttsState === 'idle'
+                ? 'synthesizing'
+                : callState.ttsState
             }
-            getLevel={skipper ? synthLevel : zeroLevel}
-            size={skipper ? 132 : 124}
-            hat={skipper ? 'cowboy' : undefined}
+            getLevel={synthLevel}
+            size={132}
+            hat="cowboy"
             hatOverlay={
-              skipper ? (
-                <SkipperPins
-                  state={callState}
-                  sendAction={sendAction}
-                  textPin={collapsed ? 'expand' : 'collapse'}
-                  onTextPin={() => requestCollapsed(!collapsed)}
-                />
-              ) : undefined
+              <SkipperPins
+                state={callState}
+                sendAction={sendAction}
+                textPin={collapsed ? 'expand' : 'collapse'}
+                onTextPin={() => requestCollapsed(!collapsed)}
+              />
             }
           />
         </div>
-        {skipper && (
-          <>
-            {/* Fixed-height caption + chip slots: present in BOTH states so
-                the head never shifts when a caption appears or the text
-                folds. Both are single-line and CENTERED on the mascot —
-                wider than the 132px column they overflow it symmetrically
-                (the column doesn't clip), which reads as a caption under
-                the head instead of a squeezed left-ragged wrap. */}
-            <div className="flex h-4 items-center">
-              {skipperCaption && (
-                <span className="max-w-[176px] truncate whitespace-nowrap rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{skipperCaption}</span>
-              )}
-            </div>
-            <div className="flex h-6 items-center">
-              <SkipperStatusChip state={callState} activity={heldActivity} />
-            </div>
-          </>
-        )}
+        {/* Fixed-height caption + chip slots: present in BOTH states so the
+            head never shifts when a caption appears or the text folds. Both
+            are single-line and CENTERED on the mascot — wider than the
+            132px column they overflow it symmetrically (the column doesn't
+            clip), which reads as a caption under the head instead of a
+            squeezed left-ragged wrap. */}
+        <div className="flex h-4 items-center">
+          {skipperCaption && (
+            <span className="max-w-[176px] truncate whitespace-nowrap rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{skipperCaption}</span>
+          )}
+        </div>
+        <div className="flex h-6 items-center">
+          <SkipperStatusChip state={callState} activity={heldActivity} />
+        </div>
       </div>
       </div>
       <SonnerToaster theme="light" />

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -492,6 +492,9 @@ export function QuickAskBar() {
   const recordingRef = useRef(false)
   const [voiceAvailable, setVoiceAvailable] = useState(false)
   const [ttsAvailable, setTtsAvailable] = useState(false)
+  // Whether the probe above has answered at all. Until it has, `false` means
+  // "not known yet", never "not configured".
+  const [voiceProbed, setVoiceProbed] = useState(false)
   useEffect(() => {
     Promise.all([
       window.ipc.invoke('voice:getConfig', null),
@@ -506,9 +509,13 @@ export function QuickAskBar() {
         setVoiceAvailable(false)
         setTtsAvailable(false)
       })
+      .finally(() => setVoiceProbed(true))
   }, [])
-  // Tucking starts a voice call — same gate as the call button.
-  const callAvailable = voiceAvailable && ttsAvailable
+  // Tucking starts a voice call — same gate as the call button, but
+  // OPTIMISTIC until this window's probe answers: the app window owns the
+  // authoritative check (and its own text-card fallback), so a summon that
+  // arrives first must relay, not die as a dimmed no-op click.
+  const callAvailable = voiceProbed ? voiceAvailable && ttsAvailable : true
 
   const tuck = useCallback(() => {
     void window.ipc.invoke('quickAsk:tuck', null).catch(() => {})

--- a/apps/x/apps/renderer/src/components/settings/shortcut-settings.tsx
+++ b/apps/x/apps/renderer/src/components/settings/shortcut-settings.tsx
@@ -132,7 +132,7 @@ export function ShortcutSettings() {
   }, [pending, apply, closeModal])
 
   // While the modal is up, main releases the current global chord —
-  // otherwise pressing it would summon the quick-ask bar over the recorder
+  // otherwise pressing it would summon the companion over the recorder
   // instead of showing up as keycaps here.
   useEffect(() => {
     if (!open) return

--- a/apps/x/apps/renderer/src/components/settings/shortcut-settings.tsx
+++ b/apps/x/apps/renderer/src/components/settings/shortcut-settings.tsx
@@ -226,7 +226,7 @@ export function ShortcutSettings() {
       <div>
         <h4 className="text-sm font-medium mb-3">Quick Ask</h4>
         <p className="text-xs text-muted-foreground mb-4">
-          Summon the Quick Ask bar from anywhere — press the shortcut in any app.
+          Summon your Skipper from anywhere — press the shortcut in any app to talk or type; press it again to tuck the text away.
         </p>
         <div className="rounded-lg border border-border p-4">
           <div className="flex items-center justify-between gap-4">

--- a/apps/x/apps/renderer/src/hooks/use-quick-ask-shortcut.ts
+++ b/apps/x/apps/renderer/src/hooks/use-quick-ask-shortcut.ts
@@ -10,7 +10,7 @@ export type QuickAskShortcutState = {
 /**
  * The current global quick-ask chord, live: seeded via quickAsk:getShortcut
  * and updated on every rebind through the quick-ask:shortcut-changed push.
- * Works in any window (app, quick-ask bar) — same preload bridge.
+ * Works in any window (app, companion) — same preload bridge.
  */
 export function useQuickAskShortcut(): QuickAskShortcutState {
   const [state, setState] = useState<QuickAskShortcutState>({

--- a/apps/x/apps/renderer/src/hooks/useVideoMode.ts
+++ b/apps/x/apps/renderer/src/hooks/useVideoMode.ts
@@ -10,6 +10,11 @@ export type ScreenShareState = 'idle' | 'starting' | 'live';
  * AND variance means the content is blocked. Frames that can't be sampled
  * yet report NOT blank, so a slow capture spin-up never false-blocks.
  */
+// Ceiling on acquiring a screen capture (permission check + getDisplayMedia).
+// Generous for a slow first prompt; a hang past this is a denied/ineffective
+// permission, which must fail cleanly instead of wedging the share state.
+const SCREEN_SHARE_START_TIMEOUT_MS = 10_000;
+
 async function screenFrameLooksBlank(stream: MediaStream): Promise<boolean> {
     const video = document.createElement('video');
     video.muted = true;
@@ -323,14 +328,35 @@ export function useVideoMode() {
         // rebuilt binaries (a re-signed app keeps its Settings toggle but a
         // fresh TCC identity) in both directions. Ground truth comes from
         // sampling an actual frame below.
-        await window.ipc.invoke('meeting:checkScreenPermission', null).catch(() => null);
+        //
+        // Both steps are time-boxed: with the permission denied (or its
+        // prompt left unanswered) getDisplayMedia can hang INDEFINITELY —
+        // never resolving, never rejecting — which left screenState stuck at
+        // 'starting' for the rest of the session (every later share request
+        // "succeeded" against it without sharing anything, and a hover
+        // summon awaiting its sticky share never finished).
+        const deadline = new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), SCREEN_SHARE_START_TIMEOUT_MS));
+        await Promise.race([
+            window.ipc.invoke('meeting:checkScreenPermission', null).catch(() => null),
+            deadline,
+        ]);
 
         let stream: MediaStream | null = null;
         try {
-            stream = await navigator.mediaDevices.getDisplayMedia({
+            const capture = navigator.mediaDevices.getDisplayMedia({
                 video: { frameRate: { ideal: 5 } },
                 audio: false,
             });
+            const result = await Promise.race([capture, deadline]);
+            if (result === 'timeout') {
+                console.error('[video] Screen share timed out — Screen Recording permission not effective');
+                // If the capture ever does materialize, nothing must keep
+                // recording behind the user's back.
+                void capture.then((late) => late.getTracks().forEach((t) => t.stop())).catch(() => {});
+                setScreenState('idle');
+                return false;
+            }
+            stream = result;
         } catch (err) {
             console.error('[video] Screen share failed:', err);
             setScreenState('idle');

--- a/apps/x/apps/renderer/src/main.tsx
+++ b/apps/x/apps/renderer/src/main.tsx
@@ -70,7 +70,7 @@ if (window.location.hash === '#meeting-detected') {
     </StrictMode>,
   )
 } else if (window.location.hash === '#quick-ask') {
-  // Global ⌥⇧Space quick-ask bar; same pattern.
+  // The hover companion (global ⌥⇧Space); same pattern.
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <QuickAskBar />

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1281,8 +1281,8 @@ const ipcSchemas = {
     req: z.null(),
     res: z.object({}),
   },
-  // --- Quick-ask bar (global ⌥Space, own always-on-top window) ---
-  // Bar → main: relay a composer submit into the app window's chat.
+  // --- Hover companion (global ⌥⇧Space, own always-on-top window) ---
+  // Companion → main: relay a composer submit into the companion's chat.
   'quickAsk:submit': {
     req: QuickAskSubmitPayload,
     res: z.object({}),
@@ -1292,34 +1292,11 @@ const ipcSchemas = {
     req: QuickAskSubmitPayload,
     res: z.null(),
   },
-  // Bar → main → app window: stop the in-flight turn (the bar composer's
-  // send button becomes Stop while processing, same as in the app).
-  'quickAsk:stop': {
-    req: z.null(),
-    res: z.object({}),
-  },
-  'quick-ask:stop': {
-    req: z.null(),
-    res: z.null(),
-  },
-  // Bar → main: dismiss the bar (Esc).
-  'quickAsk:hide': {
-    req: z.null(),
-    res: z.object({}),
-  },
-  // Main → bar: the window was just summoned. viaShortcut distinguishes the
-  // global chord (⌥⇧Space — hold-to-talk starts capturing immediately) from
-  // programmatic shows (the discoverability toast), which must not touch
-  // the mic.
-  'quick-ask:summoned': {
-    req: z.object({ viaShortcut: z.boolean() }),
-    res: z.null(),
-  },
-  // The companion window's current role: summoned Spotlight bar, pinned
-  // call pill, or hidden. `collapsed` is the pinned pill tucked down to just
-  // the mascot (voice-to-voice). Pushed on every transition; the invoke
-  // covers the load race (the window may finish loading after a transition
-  // fired).
+  // The companion window's current role: `pinned` (the Skipper — the ONE
+  // hover surface) or `hidden`. `collapsed` is the Skipper tucked down to
+  // just the mascot (voice-to-voice). Pushed on every transition; the
+  // invoke covers the load race (the window may finish loading after a
+  // transition fired).
   'quickAsk:getMode': {
     req: z.null(),
     res: z.object({
@@ -1327,7 +1304,7 @@ const ipcSchemas = {
       // quickAsk:modeApplied once that role has PAINTED, and main reveals
       // the window only then (never with the previous role still on screen).
       seq: z.number(),
-      mode: z.enum(['hidden', 'summoned', 'pinned']),
+      mode: z.enum(['hidden', 'pinned']),
       collapsed: z.boolean(),
       // Which surface the pinned role expands to: untuck returns you to the
       // surface you tucked FROM — 'card' (the bar-style text card, for
@@ -1340,7 +1317,7 @@ const ipcSchemas = {
   'quick-ask:mode': {
     req: z.object({
       seq: z.number(),
-      mode: z.enum(['hidden', 'summoned', 'pinned']),
+      mode: z.enum(['hidden', 'pinned']),
       collapsed: z.boolean(),
       surface: z.enum(['card', 'pill']),
     }),
@@ -1390,11 +1367,6 @@ const ipcSchemas = {
   // whether a reply is SPOKEN now follows the question's modality — spoken
   // questions get spoken replies, typed ones stay silent — plus the
   // explicit speaker mute on the Skipper.)
-  // App window → main: open the bar (the discoverability toast's "Try it").
-  'quickAsk:show': {
-    req: z.null(),
-    res: z.object({}),
-  },
   // Bar → main: jump to the conversation in the app — focuses the app
   // window and tells it to show the chat full-view (no middle pane).
   'quickAsk:openChat': {
@@ -1404,42 +1376,6 @@ const ipcSchemas = {
   // Push channel: main → app window for the jump above.
   'quick-ask:open-chat': {
     req: z.null(),
-    res: z.null(),
-  },
-  // Bar → main → app window: the bar's optional toggles. voiceOutput speaks
-  // the answers aloud; screenShare turns on the existing screen capture so
-  // frames ride along with bar submits (the bar owns the share indicator —
-  // no floating pill outside calls).
-  'quickAsk:setOptions': {
-    req: z.object({
-      voiceOutput: z.boolean(),
-      screenShare: z.boolean(),
-    }),
-    res: z.object({}),
-  },
-  // Push channel: main → app window with the toggles above.
-  'quick-ask:set-options': {
-    req: z.object({
-      voiceOutput: z.boolean(),
-      screenShare: z.boolean(),
-    }),
-    res: z.null(),
-  },
-  // App window → main → bar: the ACTUAL state (share can fail on the macOS
-  // permission; the bar must never show a "sharing" badge that lies).
-  'quickAsk:optionsState': {
-    req: z.object({
-      voiceOutput: z.boolean(),
-      screenSharing: z.boolean(),
-    }),
-    res: z.object({}),
-  },
-  // Push channel: main → bar for the state above.
-  'quick-ask:options-state': {
-    req: z.object({
-      voiceOutput: z.boolean(),
-      screenSharing: z.boolean(),
-    }),
     res: z.null(),
   },
   // App window → main → bar: the destination-chat context (see
@@ -1471,29 +1407,6 @@ const ipcSchemas = {
   // Push channel: main → app window for the reset above.
   'quick-ask:new-chat': {
     req: z.null(),
-    res: z.null(),
-  },
-  // App window → main: mirror of the in-flight answer for the bar
-  // (streaming text while processing, final text when done).
-  'quickAsk:state': {
-    req: z.object({
-      processing: z.boolean(),
-      responseText: z.string().nullable(),
-      // What the agent is doing right now ("Reasoning…", "Web search…") —
-      // shown blinking in the bar until the answer starts streaming.
-      statusText: z.string().nullable(),
-    }),
-    res: z.object({}),
-  },
-  // Push channel: main → bar with the latest answer state.
-  'quick-ask:state': {
-    req: z.object({
-      processing: z.boolean(),
-      responseText: z.string().nullable(),
-      // What the agent is doing right now ("Reasoning…", "Web search…") —
-      // shown blinking in the bar until the answer starts streaming.
-      statusText: z.string().nullable(),
-    }),
     res: z.null(),
   },
   // Any window → main: the current global quick-ask chord and whether the

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1323,6 +1323,10 @@ const ipcSchemas = {
   'quickAsk:getMode': {
     req: z.null(),
     res: z.object({
+      // Monotonic per push — the renderer echoes it back over
+      // quickAsk:modeApplied once that role has PAINTED, and main reveals
+      // the window only then (never with the previous role still on screen).
+      seq: z.number(),
       mode: z.enum(['hidden', 'summoned', 'pinned']),
       collapsed: z.boolean(),
       // Which surface the pinned role expands to: untuck returns you to the
@@ -1335,11 +1339,28 @@ const ipcSchemas = {
   },
   'quick-ask:mode': {
     req: z.object({
+      seq: z.number(),
       mode: z.enum(['hidden', 'summoned', 'pinned']),
       collapsed: z.boolean(),
       surface: z.enum(['card', 'pill']),
     }),
     res: z.null(),
+  },
+  // Companion window → main: the role carried by `seq` is on screen (painted)
+  // — main may now show/focus/resize the window for it. Without this ack the
+  // window could be revealed mid-transition: the summoned bar's layout for a
+  // frame (or, on first creation, for the whole page load) before the
+  // Skipper replaced it.
+  'quickAsk:modeApplied': {
+    req: z.object({ seq: z.number() }),
+    res: z.object({}),
+  },
+  // App window → main: the hover relay listener is registered — a summon
+  // that arrived while the app window was (re)loading (or didn't exist: the
+  // user closed it, the shortcut recreated it hidden) is delivered now.
+  'quickAsk:appReady': {
+    req: z.null(),
+    res: z.object({}),
   },
   // Bar → main → app window: tuck the text into the mascot. The app starts
   // the voice-preset call (mascot-only floating surface) — or, if a call is


### PR DESCRIPTION
## Summary

The ⌥⇧Space hover mode ("quick access") had three real bugs, found by driving the dev app over CDP and snapshotting the companion window every ~25 ms:

1. **Old bar flashes before the Skipper.** The first summon created the companion window and `show()`ed it while the page was still loading — `index.html` painted a theme-colored slab, then the renderer's default `summoned` layout (the old text bar), then the Skipper. Re-summons flashed the summoned layout for a frame too (the hidden window keeps that layout; `show()` fired before the re-render).
2. **Hover mode comes up once, then every later chord is dead.** `startHoverCall` held its in-flight guard across the sticky screen share, and `getDisplayMedia` hangs forever when Screen Recording is denied / its prompt is unanswered (the state after every rebuild) — so the guard stayed latched and every later ⌥⇧Space was a silent no-op.
3. **Latent crash:** `QuickAskBar` called `useMemo` after conditional early returns, so a pill ⇄ card switch (camera toggle mid-call) would throw React's hook-count error and blank the window.

## Changes

- **Reveal protocol** (`quick-ask.ts` ⇄ `quick-ask-bar.tsx`, `shared/ipc.ts`): `quick-ask:mode` carries a `seq`; the renderer acks `quickAsk:modeApplied` two frames after committing that role; main orders the window in at opacity 0 and sets opacity 1 / focuses only on the ack. Fold pushes the layout first and shrinks the window on the ack (no squeezed-card frame). Renderer paints nothing until its role is known; `index.html` gives `#quick-ask` / `#screen-pointer` a transparent background from the first paint. Timeouts (600 ms / 6 s while loading) keep a wedged renderer from blocking.
- **Hover flow hardening** (`App.tsx`, `useVideoMode.ts`): guard released right after `startCall`; sticky/`share` screen share is fire-and-forget; `startScreenShare` is time-boxed (10 s) and fails cleanly with the existing permission dialog; a session that fails to start falls back to the text card (never a silent no-op).
- **One flow, every entry point**: chord, tray item, card tuck-handle, toast "Try it", composer call button and the "Share screen" preset all end in `startHoverCall()`. Tray/toast no longer arm hold-to-talk. A summon with the app window closed or still loading recreates it hidden (`initQuickAsk({ ensureAppWindow })`) and re-relays on a `quickAsk:appReady` handshake; closing the app window mid-call unpins the companion. Call-state cache survives fullscreen ⇄ popout (camera calls come back as the pill, no card→pill morph) and is cleared by an explicit idle push at call end.
- Hooks hoisted above the early returns in `QuickAskBar`; `[companion]` mode-transition breadcrumbs in main; settings/toast copy and `VIDEO_MODE.md` updated.

## Verification

- `npm run lint`, `npm run typecheck` clean.
- CDP-driven runtime checks on the dev build: first summon reveals the Skipper ~75 ms after page load with **no** summoned-layout frame (previously ~50–600 ms of the old bar); re-summon reveals ~50 ms after the mode push via the ack (no timeout); fold/unfold ordering correct; end → re-summon works repeatedly (previously dead after the first sticky-share hang); summon with the app window closed recreates it hidden and pins the Skipper in ~1.5 s; text-card fallback and the card's tuck handle → Skipper transition verified.
- Not runtime-tested here: the camera/pill surface (no camera in the test env) and Windows/Linux (`setOpacity` is a no-op on Linux → old behavior there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
