### PR TITLE
fix(spaces): Split works in real windows — lower floor, doc-width clamp, pin always available

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -37,8 +37,16 @@ export type SpaceSelection = { orgId: string; spaceId: string } | null
 /** Which surface(s) a space shows: the stream, the document, or both. */
 type SpaceMode = 'talk' | 'read' | 'split'
 
-/** Split needs 600px of document + 480px of chat + the 28px rail edge. */
-const SPLIT_FLOOR = 1108
+/** Chat never squeezes below this in Split; the document takes the rest. */
+const CHAT_FLOOR = 460
+
+/**
+ * Below this content width Split falls back to one surface (CHAT_FLOOR of
+ * chat + ~466px of document + the 28px rail edge and divider). Kept low on
+ * purpose — a non-maximized laptop window must still get Split; the doc-width
+ * clamp handles the squeeze from here up.
+ */
+const SPLIT_FLOOR = 960
 
 const MODES: { k: SpaceMode; label: string; Icon: typeof MessageSquare; kb: string }[] = [
     { k: 'talk', label: 'Talk', Icon: MessageSquare, kb: '⌘1' },
@@ -259,24 +267,33 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         }
     }, [peekRail])
 
+    // Stable listener; requestMode itself re-derives per render (splitFits).
+    const requestModeRef = useRef<(next: SpaceMode) => void>(() => {})
     useEffect(() => {
         const onKey = (e: KeyboardEvent) => {
             if ((!e.metaKey && !e.ctrlKey) || e.altKey || e.shiftKey) return
-            if (e.key === '1') { e.preventDefault(); setMode('talk') }
-            else if (e.key === '2') { e.preventDefault(); setMode('read') }
-            else if (e.key === '3') { e.preventDefault(); setMode('split') }
+            if (e.key === '1') { e.preventDefault(); requestModeRef.current('talk') }
+            else if (e.key === '2') { e.preventDefault(); requestModeRef.current('read') }
+            else if (e.key === '3') { e.preventDefault(); requestModeRef.current('split') }
         }
         window.addEventListener('keydown', onKey)
         return () => window.removeEventListener('keydown', onKey)
-    }, [setMode])
+    }, [])
 
     const splitFits = paneWidth >= SPLIT_FLOOR
     // What actually renders: a Split that doesn't fit falls back to the one
     // surface the selection needs. The rail follows the rendered surface.
     const effMode: SpaceMode = mode === 'split' && !splitFits ? (selection.kind === 'file' ? 'read' : 'talk') : mode
     const railList: RailList = effMode === 'split' ? splitList : effMode === 'read' ? 'files' : 'topics'
-    const railPinned = (mode === 'read' ? pins.read : pins.talk) && splitFits
+    const railPinned = mode === 'read' ? pins.read : pins.talk
     const railOpen = railPeek || railHover || railPinned
+
+    /** The header buttons and ⌘1/2/3: say why when Split can't render. */
+    const requestMode = (next: SpaceMode) => {
+        if (next === 'split' && !splitFits) toast('Window is too narrow for Split — it will appear when you widen it')
+        setMode(next)
+    }
+    requestModeRef.current = requestMode
 
     const onRailHover = (hovering: boolean) => {
         setRailHover(hovering)
@@ -342,8 +359,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
             // Doc sits on the right: dragging the divider left grows it.
             const next = dragStart.current.width + (dragStart.current.x - ev.clientX)
             const pane = paneRef.current?.clientWidth ?? window.innerWidth
-            // Keep the chat side at its 480px floor (rail edge + divider ≈ 40px).
-            setDocWidth(Math.min(Math.max(next, 480), Math.max(480, pane - 520)))
+            // Chat keeps its floor; rail edge + divider ≈ 34px.
+            setDocWidth(Math.min(Math.max(next, 420), Math.max(420, pane - CHAT_FLOOR - 34)))
         }
         const onUp = () => {
             window.removeEventListener('mousemove', onMove)
@@ -360,6 +377,9 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     }
     /** Open a file from inside a topic — the file view gets a crumb back to the topic. */
     const openFileFromTopic = (topicId: string) => (path: string) => select({ kind: 'file', path, fromTopicId: topicId })
+
+    // A persisted width from a wider window must not crush the chat side.
+    const docWidthEff = Math.max(420, Math.min(docWidth, paneWidth - CHAT_FLOOR - 34))
 
     const here = presence.here.filter((id) => members.some((m) => m.id === id))
 
@@ -426,7 +446,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                             key={k}
                             type="button"
                             title={`${label} ${kb}`}
-                            onClick={() => setMode(k)}
+                            onClick={() => requestMode(k)}
                             className={cn(
                                 'inline-flex h-6 items-center gap-1.5 rounded px-2 text-xs',
                                 mode === k ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
@@ -472,7 +492,6 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                     onPickList={setSplitList}
                     open={railOpen}
                     pinned={railPinned}
-                    canPin={splitFits}
                     hint={railPinned ? 'pinned' : railPeek ? 'sliding away' : 'hover · pin to keep'}
                     onHoverChange={onRailHover}
                     onTogglePin={toggleRailPin}
@@ -533,7 +552,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                 )}
                 {effMode !== 'talk' && (
                     <aside
-                        style={effMode === 'split' ? { width: docWidth } : undefined}
+                        style={effMode === 'split' ? { width: docWidthEff } : undefined}
                         className={cn('min-w-0 min-h-0 flex', effMode === 'split' ? 'shrink-0' : 'flex-1 justify-center')}
                     >
                         <div className={cn('flex min-w-0 min-h-0 flex-1', effMode !== 'split' && 'mx-auto max-w-[880px]')}>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -20,7 +20,7 @@ export type RailList = 'topics' | 'files'
 
 export function SpaceRail({
     orgId, spaceId, selfMemberId, general, topics, threads, changeSets, entries, presence, unreadPaths, selection, onSelect, onCreateFile,
-    list, tabbed, onPickList, open, pinned, canPin, hint, onHoverChange, onTogglePin,
+    list, tabbed, onPickList, open, pinned, hint, onHoverChange, onTogglePin,
 }: {
     orgId: string
     spaceId: string
@@ -42,7 +42,6 @@ export function SpaceRail({
     onPickList: (list: RailList) => void
     open: boolean
     pinned: boolean
-    canPin: boolean
     hint: string
     onHoverChange: (hovering: boolean) => void
     onTogglePin: () => void
@@ -149,8 +148,7 @@ export function SpaceRail({
                         <button
                             type="button"
                             onClick={onTogglePin}
-                            disabled={!canPin}
-                            title={canPin ? (pinned ? 'Unpin — collapse when the mouse leaves' : 'Pin this rail open') : 'Window too narrow to pin the rail'}
+                            title={pinned ? 'Unpin — collapse when the mouse leaves' : 'Pin this rail open'}
                             className={cn(
                                 'flex size-6 shrink-0 items-center justify-center rounded-md border disabled:opacity-40',
                                 pinned ? 'border-foreground bg-foreground text-background' : 'border-border bg-background text-muted-foreground hover:text-foreground',


### PR DESCRIPTION
Dogfood day-one finding (Ramnique): in a non-maximized window, picking **Split** rendered nothing on the right and the rail's **pin** button was disabled everywhere.

Root cause: the layout shipped with the design prototype's constants — a 1108px content-width floor below which Split silently falls back to one surface, and a pin gate tied to the same check. Real laptop windows sit under 1108 constantly, and the failure had zero feedback.

- `SPLIT_FLOOR` → **960** (460px chat + ~466px doc + rail edge/divider). Above the floor, the squeeze is handled properly: the persisted document width is clamped so chat always keeps its 460px floor.
- Picking Split below the floor now explains itself with a toast instead of doing nothing.
- Pinning the rail no longer depends on window width.

Typecheck + lint green; renderer suite 312 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)