### PR TITLE
fix(x): rowboat-server hardening (review follow-ups #879–882)

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, desktopCapturer, dialog, protocol, net, shell, session, safeStorage, type Session } from "electron";
 import path from "node:path";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import {
   setupIpcHandlers,
@@ -202,14 +203,24 @@ function registerAppProtocol() {
 
     // Workspace files: app://workspace/<rel-path>
     if (url.host === "workspace") {
-      try {
-        const relPath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
-        if (!relPath) return new Response("Not Found", { status: 404 });
-        const absPath = resolveWorkspacePath(relPath);
-        return net.fetch(pathToFileURL(absPath).toString());
-      } catch {
-        return new Response("Forbidden", { status: 403 });
-      }
+      return (async () => {
+        try {
+          const relPath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+          if (!relPath) return new Response("Not Found", { status: 404 });
+          const absPath = resolveWorkspacePath(relPath);
+          // Parity with the server's /workspace route: `..` is guarded above,
+          // but a symlink inside the workspace can still point out of it —
+          // realpath both sides and require containment.
+          const realRoot = await fsPromises.realpath(resolveWorkspacePath(""));
+          const realTarget = await fsPromises.realpath(absPath);
+          if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
+            return new Response("Forbidden", { status: 403 });
+          }
+          return net.fetch(pathToFileURL(realTarget).toString());
+        } catch {
+          return new Response("Forbidden", { status: 403 });
+        }
+      })();
     }
 
     // Renderer SPA — existing logic

--- a/apps/x/apps/server/src/index.ts
+++ b/apps/x/apps/server/src/index.ts
@@ -1,6 +1,7 @@
 export { createRowboatServer, type EventSources, type RowboatServer, type RowboatServerOptions } from './server.js';
 export { RPC_CHANNELS, isRpcChannel, type RpcChannel, type RpcHandlers } from './channels.js';
 export { createWsHub, type WsHub, type PushChannel, WS_CLOSE_NO_HELLO, WS_CLOSE_UNAUTHORIZED } from './ws-hub.js';
+export { acquireWorkdirLock } from './lock.js';
 export { loadOrCreateServerKey, rotateServerKey, tokenMatches, extractBearer, SERVER_KEY_FILE } from './auth.js';
 export { loadServerConfig, saveServerConfig, ServerConfig, DEFAULT_PORT } from './config.js';
 export { buildPairingPayload, collectPairingUrls, type PairingPayload } from './pairing.js';

--- a/apps/x/apps/server/src/lock.ts
+++ b/apps/x/apps/server/src/lock.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+// One rowboat-server per workdir, whoever hosts it (Electron main in the
+// slice, the standalone entrypoint after the flip). Two hosts on one
+// ~/.rowboat double-run schedulers and split-brain the session index, so the
+// lock is acquired by the transport itself — not by individual entrypoints —
+// and a live holder is a hard error, never a silent fallback.
+
+const LOCK_FILE = 'server.lock';
+
+export async function acquireWorkdirLock(workDir: string): Promise<() => Promise<void>> {
+  const lockPath = path.join(workDir, LOCK_FILE);
+  try {
+    const existing = parseInt(await fs.readFile(lockPath, 'utf8'), 10);
+    if (Number.isFinite(existing) && existing !== process.pid) {
+      try {
+        process.kill(existing, 0); // throws ESRCH if the pid is gone
+        throw new Error(
+          `another rowboat-server host (pid ${existing}) already owns ${workDir} — refusing to split-brain`,
+        );
+      } catch (err) {
+        // ESRCH = no such process (stale lock, take over). EPERM = the pid
+        // exists but belongs to another user — still a live holder.
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'EPERM') {
+          throw new Error(
+            `another rowboat-server host (pid ${existing}) already owns ${workDir} — refusing to split-brain`,
+          );
+        }
+        if (code !== 'ESRCH') throw err;
+      }
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  await fs.mkdir(workDir, { recursive: true });
+  await fs.writeFile(lockPath, String(process.pid));
+  return async () => {
+    // Only remove our own claim (a crashed-then-restarted host may have
+    // re-written it).
+    try {
+      const current = parseInt(await fs.readFile(lockPath, 'utf8'), 10);
+      if (current === process.pid) await fs.rm(lockPath, { force: true });
+    } catch {
+      // already gone
+    }
+  };
+}

--- a/apps/x/apps/server/src/server.test.ts
+++ b/apps/x/apps/server/src/server.test.ts
@@ -284,3 +284,88 @@ describe('rowboat-server transport', () => {
     await fs.rm(tmp, { recursive: true, force: true });
   });
 });
+
+describe('hardening guards', () => {
+  const noEvents: EventSources = {
+    subscribeTurnEvents: () => () => {},
+    subscribeSessionEvents: () => () => {},
+  };
+  const stub = stubHandlers({});
+
+  async function makeServer(workDir: string, port = 0) {
+    return createRowboatServer({
+      workDir,
+      handlers: stub,
+      events: noEvents,
+      resolveWorkspacePath: (rel) => {
+        if (rel.includes('..') || path.isAbsolute(rel)) throw new Error('traversal');
+        return path.join(workDir, rel);
+      },
+      serverVersion: 'test',
+      port,
+    });
+  }
+
+  it('rejects requests with a foreign Host header (DNS rebinding)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-host-'));
+    const server = await makeServer(dir);
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest(
+        {
+          host: '127.0.0.1',
+          port: server.port,
+          path: '/health',
+          headers: { host: 'evil.example.com', authorization: `Bearer ${server.key}` },
+        },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(status).toBe(403);
+    // Legit local host still works.
+    const ok = await fetch(`http://127.0.0.1:${server.port}/health`);
+    expect(ok.status).toBe(200);
+    await server.close();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('refuses to serve a symlink that escapes the workspace', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-symlink-'));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-outside-'));
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'top secret');
+    await fs.symlink(path.join(outside, 'secret.txt'), path.join(dir, 'escape.txt'));
+    await fs.writeFile(path.join(dir, 'fine.txt'), 'fine');
+    const server = await makeServer(dir);
+    const authed = { headers: { authorization: `Bearer ${server.key}` } };
+
+    const escape = await fetch(`http://127.0.0.1:${server.port}/workspace/escape.txt`, authed);
+    expect(escape.status).toBe(403);
+    const fine = await fetch(`http://127.0.0.1:${server.port}/workspace/fine.txt`, authed);
+    expect(fine.status).toBe(200);
+
+    await server.close();
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(outside, { recursive: true, force: true });
+  });
+
+  it('refuses a workdir whose lock is held by a live foreign process', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-lock-'));
+    await fs.writeFile(path.join(dir, 'server.lock'), '1'); // pid 1 is always alive
+    await expect(makeServer(dir)).rejects.toThrow(/refusing to split-brain/);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('fails loudly when the port is held by another rowboat-server', async () => {
+    const dirA = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-portA-'));
+    const dirB = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-portB-'));
+    const a = await makeServer(dirA);
+    await expect(makeServer(dirB, a.port)).rejects.toThrow(/refusing to start a second instance/);
+    await a.close();
+    await fs.rm(dirA, { recursive: true, force: true });
+    await fs.rm(dirB, { recursive: true, force: true });
+  });
+});

--- a/apps/x/apps/server/src/server.ts
+++ b/apps/x/apps/server/src/server.ts
@@ -1,4 +1,5 @@
 import type { Server as HttpServer } from 'node:http';
+import os from 'node:os';
 import { createAdaptorServer } from '@hono/node-server';
 import { Hono } from 'hono';
 import type { TurnBusEvent } from '@x/shared/dist/turns.js';
@@ -8,6 +9,7 @@ import { z } from 'zod';
 import { extractBearer, loadOrCreateServerKey, tokenMatches } from './auth.js';
 import type { RpcHandlers } from './channels.js';
 import { loadServerConfig } from './config.js';
+import { acquireWorkdirLock } from './lock.js';
 import { createRpcRoutes } from './router.js';
 import { createWorkspaceRoutes } from './workspace-route.js';
 import { createWsHub, type WsHub } from './ws-hub.js';
@@ -63,14 +65,57 @@ function listenOnce(server: HttpServer, host: string, port: number): Promise<voi
   });
 }
 
+// DNS-rebinding guard: a hostile page can point its own domain at 127.0.0.1
+// and fetch with the browser happily sending that domain as Host. Bearer auth
+// already stops it reading anything, but rejecting foreign Hosts outright is
+// cheap defense-in-depth. The set is the machine's own names and addresses.
+export function buildAllowedHosts(): Set<string> {
+  const hosts = new Set(['localhost', '127.0.0.1', '[::1]', '::1', os.hostname().toLowerCase()]);
+  for (const infos of Object.values(os.networkInterfaces())) {
+    for (const info of infos ?? []) {
+      hosts.add(info.family === 'IPv6' ? `[${info.address.toLowerCase()}]` : info.address);
+    }
+  }
+  return hosts;
+}
+
+export function hostAllowed(hostHeader: string | undefined, allowed: Set<string>): boolean {
+  if (!hostHeader) return false;
+  // Strip the port: "name:3220" or "[::1]:3220".
+  const host = hostHeader.replace(/:\d+$/, '').toLowerCase();
+  return allowed.has(host);
+}
+
+/** Is the process answering on this port another rowboat-server? */
+async function isRowboatServer(port: number): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 1500);
+    const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
+    clearTimeout(timer);
+    const body = (await res.json().catch(() => null)) as { name?: string } | null;
+    return body?.name === 'rowboat-server';
+  } catch {
+    return false;
+  }
+}
+
 export async function createRowboatServer(opts: RowboatServerOptions): Promise<RowboatServer> {
   const config = await loadServerConfig(opts.workDir);
   const key = await loadOrCreateServerKey(opts.workDir);
   const host = opts.host ?? (config.lanEnabled ? '0.0.0.0' : '127.0.0.1');
   const startPort = opts.port ?? config.port;
 
+  // Whoever hosts the transport owns core for this workdir — a second host is
+  // a split-brain, not a peer. Held until close().
+  const releaseLock = await acquireWorkdirLock(opts.workDir);
+
+  const allowedHosts = buildAllowedHosts();
   const app = new Hono();
   app.use('*', async (c, next) => {
+    if (!hostAllowed(c.req.header('host'), allowedHosts)) {
+      return c.json({ error: { code: 'forbidden', message: 'unrecognized Host header' } }, 403);
+    }
     await next();
     c.header('x-rowboat-api-version', '0');
   });
@@ -94,14 +139,28 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
 
   const httpServer = createAdaptorServer({ fetch: app.fetch }) as HttpServer;
 
-  for (let attempt = 0; ; attempt++) {
-    try {
-      await listenOnce(httpServer, host, startPort + attempt);
-      break;
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'EADDRINUSE' || attempt >= PORT_FALLBACK_ATTEMPTS - 1) throw err;
+  try {
+    for (let attempt = 0; ; attempt++) {
+      const tryPort = startPort + attempt;
+      try {
+        await listenOnce(httpServer, host, tryPort);
+        break;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== 'EADDRINUSE' || attempt >= PORT_FALLBACK_ATTEMPTS - 1) throw err;
+        // Colliding with another rowboat-server means two hosts are live —
+        // that must fail loudly, never quietly bind one port over.
+        if (tryPort !== 0 && (await isRowboatServer(tryPort))) {
+          throw new Error(
+            `another rowboat-server is already listening on port ${tryPort} — refusing to start a second instance`,
+          );
+        }
+        console.warn(`[server] port ${tryPort} is taken by another app; trying ${tryPort + 1}`);
+      }
     }
+  } catch (err) {
+    await releaseLock();
+    throw err;
   }
   const address = httpServer.address();
   const boundPort = typeof address === 'object' && address ? address.port : startPort;
@@ -111,6 +170,7 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
     serverKey: key,
     serverVersion: opts.serverVersion,
     helloTimeoutMs: opts.helloTimeoutMs,
+    allowedHosts,
   });
 
   const unsubscribers = [
@@ -129,6 +189,7 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
       for (const unsub of unsubscribers) unsub?.();
       hub.close();
       await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      await releaseLock();
     },
   };
 }

--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import process from 'node:process';
 import { WorkDir } from '@x/core/dist/config/config.js';
 import { initConfigs } from '@x/core/dist/config/initConfigs.js';
@@ -25,36 +23,9 @@ import { createRowboatServer } from './server.js';
 // schedulers, knowledge sync (gmail/calendar/granola/fireflies), event
 // processor, live-note + bg-task agents.
 
-const LOCK_FILE = 'server.lock';
-
-async function acquireLock(workDir: string): Promise<() => Promise<void>> {
-  const lockPath = path.join(workDir, LOCK_FILE);
-  try {
-    const existing = parseInt(await fs.readFile(lockPath, 'utf8'), 10);
-    if (Number.isFinite(existing)) {
-      try {
-        process.kill(existing, 0); // throws if the pid is gone
-        throw new Error(
-          `another rowboat-server (pid ${existing}) already owns ${workDir} — refusing to split-brain`,
-        );
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
-        // stale lock from a dead process — take over
-      }
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-  }
-  await fs.mkdir(workDir, { recursive: true });
-  await fs.writeFile(lockPath, String(process.pid));
-  return async () => {
-    await fs.rm(lockPath, { force: true });
-  };
-}
-
 async function main(): Promise<void> {
-  const releaseLock = await acquireLock(WorkDir);
-
+  // The workdir lock is acquired by createRowboatServer itself — a live
+  // Electron-hosted transport makes this boot fail loudly, as it must.
   await initConfigs();
   registerNotificationService({ isSupported: () => false, notify: () => {} });
   registerBrowserControlService({
@@ -80,7 +51,6 @@ async function main(): Promise<void> {
 
   const shutdown = async () => {
     await server.close();
-    await releaseLock();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown());

--- a/apps/x/apps/server/src/workspace-route.ts
+++ b/apps/x/apps/server/src/workspace-route.ts
@@ -39,9 +39,17 @@ export function createWorkspaceRoutes(resolveWorkspacePath: (relPath: string) =>
     }
 
     try {
-      const stats = await fs.stat(absPath);
+      // resolveWorkspacePath guards `..` traversal but not a symlink inside
+      // the workspace pointing out of it — realpath both sides and require
+      // containment before touching the file.
+      const realRoot = await fs.realpath(resolveWorkspacePath(''));
+      const realTarget = await fs.realpath(absPath);
+      if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
+        return c.text('Forbidden', 403);
+      }
+      const stats = await fs.stat(realTarget);
       if (!stats.isFile()) return c.text('Not Found', 404);
-      const data = await fs.readFile(absPath);
+      const data = await fs.readFile(realTarget);
       const type = CONTENT_TYPES[path.extname(absPath).toLowerCase()] ?? 'application/octet-stream';
       return c.body(new Uint8Array(data), 200, {
         'Content-Type': type,

--- a/apps/x/apps/server/src/ws-hub.ts
+++ b/apps/x/apps/server/src/ws-hub.ts
@@ -54,7 +54,14 @@ export const WS_CLOSE_NO_HELLO = 4400;
 export interface WsHub {
   attach(
     server: HttpServer,
-    opts: { path?: string; serverKey: string; serverVersion: string; helloTimeoutMs?: number },
+    opts: {
+      path?: string;
+      serverKey: string;
+      serverVersion: string;
+      helloTimeoutMs?: number;
+      /** When set, upgrades with a foreign Host header are refused (DNS-rebinding guard). */
+      allowedHosts?: Set<string>;
+    },
   ): void;
   /** Broadcast a push-channel event to every fully-connected client. */
   broadcast(channel: PushChannel, payload: unknown): void;
@@ -101,6 +108,13 @@ export function createWsHub(): WsHub {
       if (url.pathname !== wsPath) {
         socket.destroy();
         return;
+      }
+      if (opts.allowedHosts) {
+        const hostHeader = request.headers.host?.replace(/:\d+$/, '').toLowerCase();
+        if (!hostHeader || !opts.allowedHosts.has(hostHeader)) {
+          socket.destroy();
+          return;
+        }
       }
       const token = extractBearer(request.headers.authorization, url.searchParams.get('token'));
       if (!token || !tokenMatches(token, opts.serverKey)) {

--- a/apps/x/packages/client/src/events.ts
+++ b/apps/x/packages/client/src/events.ts
@@ -81,9 +81,19 @@ export function createEventsClient(opts: {
     if (closed) return;
     setStatus('connecting');
     lastSeq = 0;
-    // React Native's WebSocket accepts a headers option; browsers don't.
-    // The ?token= fallback works everywhere, so use it unconditionally.
-    const ws = new WebSocket(`${wsUrl}?token=${encodeURIComponent(opts.token)}`);
+    // React Native's WebSocket accepts a headers option — use it so the
+    // token stays out of URLs (and any log that captures them). Browsers and
+    // Node's undici WebSocket can't set headers, so they fall back to
+    // ?token=, which the server accepts for exactly this reason.
+    const isReactNative =
+      typeof navigator !== 'undefined' && (navigator as { product?: string }).product === 'ReactNative';
+    const ws = isReactNative
+      ? new (WebSocket as unknown as new (
+          url: string,
+          protocols: string[] | null,
+          options: { headers: Record<string, string> },
+        ) => WebSocket)(wsUrl, null, { headers: { authorization: `Bearer ${opts.token}` } })
+      : new WebSocket(`${wsUrl}?token=${encodeURIComponent(opts.token)}`);
     socket = ws;
 
     ws.onopen = () => {


### PR DESCRIPTION
First follow-up on the `arch/server-client-separation` integration branch, closing the four non-blocking findings from the #758 review:

- **Fixes #879** — the workdir lock now lives in `createRowboatServer` itself, so the Electron-hosted transport and the standalone entrypoint contend for the same `server.lock` (EPERM on the pid probe counts as a live holder). An `EADDRINUSE` on the configured port probes the occupant's `/health`: another rowboat-server is a hard startup error instead of a silent port+1 fallback.
- **Fixes #880** — @x/client sends the WS token as an `Authorization` header on React Native; `?token=` remains only for clients that can't set headers (browser/undici).
- **Fixes #881** — every HTTP request and WS upgrade validates `Host` against the machine's own names/addresses; foreign hosts get 403 (DNS-rebinding defense-in-depth).
- **Fixes #882** — `GET /workspace/{path}` and the `app://workspace` protocol realpath the target and require workspace containment, closing the symlink escape (server route and Electron handler in parity).

Four new tests cover the guards (foreign Host 403, symlink 403, foreign-pid lock refusal, loud port collision); all suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)