### PR TITLE
fix(search): don't crash grep on a literal query with regex metacharacters

### DIFF
--- a/apps/x/packages/core/src/filesystem/files.grep.test.ts
+++ b/apps/x/packages/core/src/filesystem/files.grep.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { WorkDir } from "../config/config.js";
+import { grep } from "./files.js";
+
+// grep() resolves paths under WorkDir, so write the fixtures there.
+const dir = path.join(WorkDir, "grep-test");
+
+beforeAll(async () => {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "note.md"), "We shipped the C++ parser\nBudget (est.) is $4k\nplain ascii line\n");
+});
+
+afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe("grep pattern handling", () => {
+    it("still honors a valid regex", async () => {
+        const { matches } = await grep({ pattern: "C\\+\\+", searchPath: "grep-test" });
+        expect(matches.map((m) => m.line)).toEqual([1]);
+    });
+
+    it("matches literal text with regex metacharacters instead of throwing", async () => {
+        // "C++" is an invalid regex (nothing to repeat); before the fix this
+        // rejected the whole call. It should now match the literal line.
+        const { matches } = await grep({ pattern: "C++", searchPath: "grep-test" });
+        expect(matches.map((m) => m.line)).toEqual([1]);
+    });
+
+    it("matches an unbalanced-paren query as a literal", async () => {
+        const { matches } = await grep({ pattern: "(est.)", searchPath: "grep-test" });
+        expect(matches.map((m) => m.line)).toEqual([2]);
+    });
+});

--- a/apps/x/packages/core/src/filesystem/files.ts
+++ b/apps/x/packages/core/src/filesystem/files.ts
@@ -14,6 +14,10 @@ export { computeEtag, EtagMismatchError, isEtagMismatchError };
 
 export type FileOperation = 'read' | 'list' | 'search' | 'write' | 'delete';
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export type ResolvedFilePath = {
   originalPath: string;
   resolvedPath: string;
@@ -650,7 +654,16 @@ export async function grep({
     })
     : [path.basename(root.resolvedPath)];
   const baseDir = stats.isDirectory() ? root.resolvedPath : path.dirname(root.resolvedPath);
-  const regex = new RegExp(pattern, 'i');
+  // The pattern is a regex, but the assistant routinely passes literal text
+  // that happens to contain regex metacharacters ("C++", "cost (est.)"). An
+  // invalid pattern used to throw here and fail the whole tool call; fall back
+  // to matching it as a literal so those searches return results instead.
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern, 'i');
+  } catch {
+    regex = new RegExp(escapeRegExp(pattern), 'i');
+  }
   const matches: Array<{ file: string; resolvedPath: string; line: number; content: string; before?: string[]; after?: string[] }> = [];
 
   // Matched "lines" in synced data (email HTML, base64 blobs) can be

--- a/apps/x/packages/core/src/search/search.ts
+++ b/apps/x/packages/core/src/search/search.ts
@@ -172,8 +172,11 @@ async function searchChats(query: string, limit: number, sessions: ChatSessionMe
 function grepFiles(query: string, dir: string, includeGlob: string): Promise<Array<{ file: string; line: string }>> {
   return new Promise((resolve, reject) => {
     execFile(
+      // -F: the search bar takes literal text, not a regex — this matches the
+      // literal preview scan below and stops a query like "C++" or "cost()"
+      // from being read as a (mis)pattern. -e / -- guard a query starting "-".
       'grep',
-      ['-ril', '--include=' + includeGlob, query, dir],
+      ['-rilF', '--include=' + includeGlob, '-e', query, '--', dir],
       { maxBuffer: 1024 * 1024 },
       (error, stdout) => {
         if (error) {


### PR DESCRIPTION
## What

The knowledge grep tool (`filesystem/files.ts`) compiled the caller's pattern as a regex *outside* the per-file `try` block:

```ts
const regex = new RegExp(pattern, 'i');   // throws here
...
try { /* read + match */ } catch { }      // too late to help
```

The assistant calls this tool with whatever string it decides to search for. When that string isn't a valid regex — `C++`, `(draft)`, `[WIP]`, an unbalanced paren — `new RegExp` throws before any file is read, and the whole tool call fails. From the user's side, the assistant just can't find something that's sitting in their notes.

## Fix

Compile the pattern inside a `try` and fall back to an escaped-literal match on failure. Valid regex patterns behave exactly as before; literal queries with metacharacters now match instead of crashing.

The UI search bar (`search/search.ts`) had the same class of bug, passing the query straight to `grep` as a basic regex. Switched that call to `grep -F` (and `-e` / `--` to guard a leading `-`), which also lines it up with the literal `.includes` preview it already does.

## Repro (before this PR)

Ask the assistant to find notes mentioning `C++`:

```
new RegExp("C++")  →  SyntaxError: Invalid regular expression: nothing to repeat
```

## Tests

Added `filesystem/files.grep.test.ts` covering a valid regex, a metacharacter literal (`C++`), and an unbalanced-paren query (`(est.)`). Full `packages/core` suite passes.
