### PR TITLE
Spaces: one sidebar everywhere — topics with files below, dismissable Split doc

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -5030,6 +5030,9 @@ function App() {
   // which used to live outside this system as a sentinel tab), applying a
   // view can never strand a stale section on screen.
   const applyViewState = useCallback(async (view: ViewState) => {
+    // Whether this navigation ENTERS Spaces (vs a click within it) — read
+    // before closeAllSections resets the flag.
+    const wasSpacesOpen = isSpacesOpen
     closeAllSections()
     switch (view.type) {
       case 'file':
@@ -5099,6 +5102,10 @@ function App() {
         if (!SPACES_ENABLED) return
         if (view.orgId && view.spaceId) setSpaceSelection({ orgId: view.orgId, spaceId: view.spaceId })
         setRailSelection(view.rail ?? { kind: 'general' })
+        // Spaces carries its own conversation surface, so entering it
+        // collapses the assistant chat pane by default; in-space navigation
+        // (topics, files, history within Spaces) leaves it as the user set it.
+        if (!wasSpacesOpen) setIsChatSidebarOpen(false)
         setIsSpacesOpen(true)
         return
       case 'chat':
@@ -5109,7 +5116,7 @@ function App() {
         }
         return
     }
-  }, [closeAllSections, bindChatToRun, handleNewChat])
+  }, [closeAllSections, bindChatToRun, handleNewChat, isSpacesOpen])
   applyViewStateRef.current = applyViewState
 
   const navigateToView = useCallback(async (nextView: ViewState) => {

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -8,7 +8,7 @@ import {
 import { AddOrgDialog, AvatarStack, OrgMonogram } from '@/components/spaces/atoms'
 import { FileColumn, UploadFilesDialog } from '@/components/spaces/files-tab'
 import { GeneralStream } from '@/components/spaces/general-stream'
-import { SpaceRail, type RailList } from '@/components/spaces/space-rail'
+import { SpaceRail } from '@/components/spaces/space-rail'
 import { railKey, type RailSelection } from '@/lib/spaces-selection'
 import { ThreadPane } from '@/components/spaces/thread-pane'
 import { useGeneral, useSpacePresence, useThreadIndex } from '@/hooks/use-space-chat'
@@ -26,9 +26,9 @@ export { AddOrgDialog, OrgMonogram } from '@/components/spaces/atoms'
 
 // Spaces — one surface at a time ("One Surface" layout). A space opens in
 // Talk (the stream); Read shows the document; Split shows both, and declines
-// below SPLIT_FLOOR. One edge rail carries the list the rendered surface
-// needs (topics / files / tabbed in Split): it peeks briefly to teach, opens
-// on hover by pushing the surface over, and pins per surface. Data stays the
+// below SPLIT_FLOOR. One edge rail carries the same sidebar on every surface
+// (topics with the files below them): it peeks briefly to teach, opens on
+// hover by pushing the surface over, and can be pinned. Data stays the
 // v0 contract; general/topic/artifact semantics come from the contract with
 // legacy fallbacks in lib/spaces-conventions.ts.
 
@@ -219,16 +219,11 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // Read = the document, Split = both. Split declines below SPLIT_FLOOR
     // (600px document + 480px chat + the 28px rail edge).
     // ------------------------------------------------------------------
-    const [mode, setModeRaw] = useState<SpaceMode>(() => (selection.kind === 'file' ? 'read' : 'talk'))
-    const [splitList, setSplitList] = useState<RailList>('topics')
+    const [mode, setMode] = useState<SpaceMode>(() => (selection.kind === 'file' ? 'read' : 'talk'))
     const [railHover, setRailHover] = useState(false)
     const [railPeek, setRailPeek] = useState(false)
     const peekTimer = useRef<number | null>(null)
-    const seenRead = useRef(selection.kind === 'file')
-    const [pins, setPins] = useState(() => ({
-        talk: localStorage.getItem('spaces:railPin:talk') === '1',
-        read: localStorage.getItem('spaces:railPin:read') === '1',
-    }))
+    const [railPinned, setRailPinned] = useState(() => localStorage.getItem('spaces:railPin') === '1')
 
     // Width of the pane drives the Split floor and pinnability.
     const paneRef = useRef<HTMLDivElement | null>(null)
@@ -245,8 +240,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // The teach-peek: push the rail open, hold a beat, release — the same
     // motion the cursor makes at the edge. Once the user has hovered or
     // pinned that list themselves, it has done its job and stays quiet.
-    const peekRail = useCallback((list: RailList) => {
-        if (localStorage.getItem(`spaces:railTaught:${list}`) === '1') return
+    const peekRail = useCallback(() => {
+        if (localStorage.getItem('spaces:railTaught') === '1') return
         if (peekTimer.current) window.clearTimeout(peekTimer.current)
         setRailPeek(true)
         peekTimer.current = window.setTimeout(() => setRailPeek(false), 1900)
@@ -255,18 +250,10 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         if (peekTimer.current) window.clearTimeout(peekTimer.current)
     }, [])
     useEffect(() => {
-        peekRail(seenRead.current ? 'files' : 'topics')
+        peekRail()
         // Landing peek only — once per space open.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
-
-    const setMode = useCallback((next: SpaceMode) => {
-        setModeRaw(next)
-        if (next === 'read' && !seenRead.current) {
-            seenRead.current = true
-            peekRail('files')
-        }
-    }, [peekRail])
 
     // Stable listener; requestMode itself re-derives per render (splitFits).
     const requestModeRef = useRef<(next: SpaceMode) => void>(() => {})
@@ -283,10 +270,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
 
     const splitFits = paneWidth >= SPLIT_FLOOR
     // What actually renders: a Split that doesn't fit falls back to the one
-    // surface the selection needs. The rail follows the rendered surface.
+    // surface the selection needs.
     const effMode: SpaceMode = mode === 'split' && !splitFits ? (selection.kind === 'file' ? 'read' : 'talk') : mode
-    const railList: RailList = effMode === 'split' ? splitList : effMode === 'read' ? 'files' : 'topics'
-    const railPinned = mode === 'read' ? pins.read : pins.talk
     const railOpen = railPeek || railHover || railPinned
 
     /** The header buttons and ⌘1/2/3: say why when Split can't render. */
@@ -298,22 +283,20 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
 
     const onRailHover = (hovering: boolean) => {
         setRailHover(hovering)
-        if (hovering) localStorage.setItem(`spaces:railTaught:${railList}`, '1')
+        if (hovering) localStorage.setItem('spaces:railTaught', '1')
     }
     const toggleRailPin = () => {
-        localStorage.setItem(`spaces:railTaught:${railList}`, '1')
-        setPins((p) => {
-            const key = mode === 'read' ? 'read' : 'talk'
-            const next = { ...p, [key]: !p[key] }
-            localStorage.setItem(`spaces:railPin:${key}`, next[key] ? '1' : '0')
-            return next
+        localStorage.setItem('spaces:railTaught', '1')
+        setRailPinned((p) => {
+            localStorage.setItem('spaces:railPin', p ? '0' : '1')
+            return !p
         })
     }
 
     // Selecting is also choreography: a topic opened from Read grows into
-    // Split; a file opened from Talk switches to Read; a file opened from a
-    // topic (an artifact link) opens beside the thread. The rail slides away
-    // once it has been used.
+    // Split; a file opened from Talk (or from a topic's artifact link) opens
+    // beside the conversation in Split. The rail slides away once it has
+    // been used.
     const select = (next: RailSelection) => {
         onSelect(next)
         analytics.spacesTabViewed(next.kind === 'general' ? 'general' : next.kind === 'topic' ? 'topics' : 'files')
@@ -322,8 +305,9 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         if (next.kind === 'topic' && mode === 'read') setMode('split')
         else if (next.kind === 'general' && mode === 'read') setMode('talk')
         else if (next.kind === 'file') {
-            if (next.fromTopicId) { setMode('split'); setSplitList('files') }
-            else if (mode === 'talk') setMode('read')
+            // A file opened while talking keeps the conversation beside it:
+            // Split (effMode falls back to Read below the floor).
+            if (next.fromTopicId || mode === 'talk') setMode('split')
         }
     }
     const openFile = (path: string) => select({ kind: 'file', path })
@@ -335,8 +319,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     useEffect(() => {
         if (prevSelKey.current === selKey) return
         prevSelKey.current = selKey
-        if (selection.kind === 'file' && mode === 'talk') setModeRaw('read')
-        else if (selection.kind !== 'file' && mode === 'read') setModeRaw('talk')
+        if (selection.kind === 'file' && mode === 'talk') setMode('split')
+        else if (selection.kind !== 'file' && mode === 'read') setMode('talk')
     }, [selKey, selection.kind, mode])
 
     // The document pane: an explicitly opened file, else the space's front
@@ -401,6 +385,13 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     const toggleArtifactsRail = () => {
         if (!chatTopicId) return
         setRailPins((prev) => new Map(prev).set(chatTopicId, !artifactsRailOpen))
+    }
+
+    // Split: dismissing the document closes it and returns to Talk, landing
+    // on the conversation that was beside it.
+    const dismissFile = () => {
+        if (selection.kind === 'file') onSelect(chatTopicId ? { kind: 'topic', topicId: chatTopicId } : { kind: 'general' })
+        setMode('talk')
     }
 
     // Crumb for a file opened from a topic.
@@ -494,9 +485,6 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                     onSelect={select}
                     onCreateFile={openFile}
                     onUploadFiles={setUploadFiles}
-                    list={railList}
-                    tabbed={effMode === 'split'}
-                    onPickList={setSplitList}
                     open={railOpen}
                     pinned={railPinned}
                     hint={railPinned ? 'pinned' : railPeek ? 'sliding away' : 'hover · pin to keep'}
@@ -575,8 +563,9 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                                     crumb={selection.kind === 'file' && crumbTopicId && crumbLabel ? {
                                         label: crumbLabel,
                                         // Back to the topic means back to the conversation: Talk.
-                                        onBack: () => { select({ kind: 'topic', topicId: crumbTopicId }); setModeRaw('talk') },
+                                        onBack: () => { select({ kind: 'topic', topicId: crumbTopicId }); setMode('talk') },
                                     } : null}
+                                    onDismiss={effMode === 'split' ? dismissFile : null}
                                 />
                             ) : (
                                 <div className="flex-1 flex items-center justify-center p-8 text-center">

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -134,7 +134,7 @@ interface DraftState {
     conflict: Extract<spaces.ProposeChangeResult, { outcome: 'conflict' }> | null
 }
 
-export function FileColumn({ org, space, path, memberNames, refreshTick, onChanged, crumb }: {
+export function FileColumn({ org, space, path, memberNames, refreshTick, onChanged, crumb, onDismiss }: {
     org: OrgWithSpaces
     space: spaces.Space
     path: string
@@ -143,6 +143,8 @@ export function FileColumn({ org, space, path, memberNames, refreshTick, onChang
     onChanged: () => void
     /** Where the reader came from (a topic) — renders "← <label>" and makes Esc go back there. */
     crumb?: { label: string; onBack: () => void } | null
+    /** Split only: renders an × that closes the document and returns to Talk. */
+    onDismiss?: (() => void) | null
 }) {
     const [asset, setAsset] = useState<spaces.ReadAssetResult | null>(null)
     const [missing, setMissing] = useState(false)
@@ -400,6 +402,16 @@ export function FileColumn({ org, space, path, memberNames, refreshTick, onChang
                             <X className="size-3 mr-1" /> Discard
                         </Button>
                     </>
+                )}
+                {onDismiss && !draft && (
+                    <button
+                        type="button"
+                        title="Close the file — back to Talk"
+                        onClick={onDismiss}
+                        className="inline-flex size-5 shrink-0 items-center justify-center rounded hover:bg-accent hover:text-foreground"
+                    >
+                        <X className="size-3.5" />
+                    </button>
                 )}
             </div>
             <div className="mx-5 border-t border-border" />

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { MemberAvatar } from '@/components/spaces/atoms'
 import { SpaceMarkdown } from '@/components/spaces/space-markdown'
@@ -50,10 +51,13 @@ function ReactionPicker({ onPick, onOpenChange, children }: {
     )
 }
 
-function reactionTitle(group: spaces.ReactionGroup, memberNames: Map<string, string>, selfMemberId?: string): string {
-    const names = group.memberIds.map((id) => (id === selfMemberId ? 'You' : memberNames.get(id) ?? id))
-    return `${names.join(', ')} reacted with ${group.emoji}`
+function joinNames(names: string[]): string {
+    if (names.length <= 1) return names[0] ?? ''
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
 }
+
+/** How many reactor avatars the hover card shows before collapsing to +N. */
+const REACTOR_AVATAR_CAP = 8
 
 function ReactionChips({ message, memberNames, selfMemberId, onReact, onPickerOpenChange }: {
     message: spaces.Message
@@ -68,20 +72,41 @@ function ReactionChips({ message, memberNames, selfMemberId, onReact, onPickerOp
         <div className="mt-1 flex flex-wrap items-center gap-1">
             {groups.map((group) => {
                 const mine = !!selfMemberId && group.memberIds.includes(selfMemberId)
+                const nameOf = (id: string) => (id === selfMemberId ? 'You' : memberNames.get(id) ?? id)
                 return (
-                    <button
-                        key={group.emoji}
-                        type="button"
-                        title={reactionTitle(group, memberNames, selfMemberId)}
-                        onClick={() => onReact(message, group.emoji)}
-                        className={cn(
-                            'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5',
-                            mine ? 'border-foreground/40 bg-accent' : 'border-border bg-background hover:border-foreground/30',
-                        )}
-                    >
-                        <span className="text-[13px] leading-none">{group.emoji}</span>
-                        <span className="text-[11px] font-medium leading-none tabular-nums text-muted-foreground">{group.memberIds.length}</span>
-                    </button>
+                    <HoverCard key={group.emoji} openDelay={250} closeDelay={100}>
+                        <HoverCardTrigger asChild>
+                            <button
+                                type="button"
+                                onClick={() => onReact(message, group.emoji)}
+                                className={cn(
+                                    'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5',
+                                    mine ? 'border-foreground/40 bg-accent' : 'border-border bg-background hover:border-foreground/30',
+                                )}
+                            >
+                                <span className="text-[13px] leading-none">{group.emoji}</span>
+                                <span className="text-[11px] font-medium leading-none tabular-nums text-muted-foreground">{group.memberIds.length}</span>
+                            </button>
+                        </HoverCardTrigger>
+                        <HoverCardContent side="top" className="w-auto max-w-60 p-3">
+                            <div className="flex flex-col items-center gap-1.5 text-center">
+                                <span className="text-2xl leading-none">{group.emoji}</span>
+                                <div className="flex flex-wrap items-center justify-center -space-x-1">
+                                    {group.memberIds.slice(0, REACTOR_AVATAR_CAP).map((id) => (
+                                        <MemberAvatar key={id} id={id} name={nameOf(id)} size="sm" className="ring-2 ring-popover" />
+                                    ))}
+                                    {group.memberIds.length > REACTOR_AVATAR_CAP && (
+                                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-popover">
+                                            +{group.memberIds.length - REACTOR_AVATAR_CAP}
+                                        </span>
+                                    )}
+                                </div>
+                                <p className="text-xs leading-snug text-muted-foreground">
+                                    <span className="font-medium text-foreground">{joinNames(group.memberIds.map(nameOf))}</span> reacted with {group.emoji}
+                                </p>
+                            </div>
+                        </HoverCardContent>
+                    </HoverCard>
                 )
             })}
             <ReactionPicker onPick={(emoji) => onReact(message, emoji)} onOpenChange={onPickerOpenChange}>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -105,6 +105,20 @@ export function SpaceRail({
                 open ? 'bg-muted/20' : 'bg-background',
             )}
         >
+            {/* Always mounted: the rail collapses on mouse-leave while the native
+                file picker is open (the pointer is in the OS dialog), and an input
+                unmounted mid-pick never delivers its change event. */}
+            <input
+                ref={uploadInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                    const files = Array.from(e.target.files ?? [])
+                    if (files.length > 0) onUploadFiles(files)
+                    e.target.value = ''
+                }}
+            />
             {!open ? (
                 // The closed edge: what lives here (topics + files), and how much is unread.
                 <div className="flex flex-1 flex-col items-center gap-2.5 py-3.5">
@@ -229,17 +243,6 @@ export function SpaceRail({
                             <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Files</span>
                             <span className="text-[11px] text-muted-foreground/70">{entries.length}</span>
                             <span className="flex-1" />
-                            <input
-                                ref={uploadInputRef}
-                                type="file"
-                                multiple
-                                className="hidden"
-                                onChange={(e) => {
-                                    const files = Array.from(e.target.files ?? [])
-                                    if (files.length > 0) onUploadFiles(files)
-                                    e.target.value = ''
-                                }}
-                            />
                             <button
                                 type="button"
                                 title="Upload files (or drop them here)"

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -10,17 +10,15 @@ import { formatFeedTime, resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt } from '@/lib/spaces-read-state'
 import type { RailSelection } from '@/lib/spaces-selection'
 
-// The space's edge rail: one collapsible strip that carries the list the
-// current surface needs — topics in Talk, files in Read, both (tabbed) in
-// Split. Collapsed it is a 28px edge; it pushes open to 280px on hover (never
-// floats over content), peeks briefly to teach the gesture, and can be pinned
-// per surface. The surfaces own everything else.
-
-export type RailList = 'topics' | 'files'
+// The space's edge rail: one collapsible strip carrying the same sidebar on
+// every surface — Messages + topics on top, the file tree below. Collapsed it
+// is a 28px edge; it pushes open to 280px on hover (never floats over
+// content), peeks briefly to teach the gesture, and can be pinned. The
+// surfaces own everything else.
 
 export function SpaceRail({
     orgId, spaceId, selfMemberId, general, topics, threads, changeSets, entries, presence, unreadPaths, selection, onSelect, onCreateFile, onUploadFiles,
-    list, tabbed, onPickList, open, pinned, hint, onHoverChange, onTogglePin,
+    open, pinned, hint, onHoverChange, onTogglePin,
 }: {
     orgId: string
     spaceId: string
@@ -37,11 +35,6 @@ export function SpaceRail({
     onCreateFile: (path: string) => void
     /** Picked or dropped files headed for the space's file tree (upload dialog opens in the pane). */
     onUploadFiles: (files: File[]) => void
-    /** Which list the rail carries right now (follows the rendered surface). */
-    list: RailList
-    /** Split: one rail, a Topics/Files switcher instead of a title. */
-    tabbed: boolean
-    onPickList: (list: RailList) => void
     open: boolean
     pinned: boolean
     hint: string
@@ -100,7 +93,7 @@ export function SpaceRail({
     const selectedPath = selection.kind === 'file' ? selection.path : null
 
     const unreadTopics = topics.filter((t) => t.id !== generalId && !t.archived && isUnread(t)).length + (generalUnread > 0 ? 1 : 0)
-    const badge = list === 'topics' ? unreadTopics : unreadPaths.size
+    const badge = unreadTopics + unreadPaths.size
 
     return (
         <aside
@@ -113,11 +106,10 @@ export function SpaceRail({
             )}
         >
             {!open ? (
-                // The closed edge: which list lives here, and how much of it is unread.
+                // The closed edge: what lives here (topics + files), and how much is unread.
                 <div className="flex flex-1 flex-col items-center gap-2.5 py-3.5">
-                    {list === 'topics'
-                        ? <MessagesSquare className="size-[15px] text-muted-foreground" />
-                        : <Folder className="size-[15px] text-muted-foreground" />}
+                    <MessagesSquare className="size-[15px] text-muted-foreground" />
+                    <Folder className="size-[15px] text-muted-foreground" />
                     <div className="w-px flex-1 bg-border/70" />
                     {badge > 0 && (
                         <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-foreground px-1 text-[9.5px] font-semibold text-background tabular-nums">
@@ -129,24 +121,6 @@ export function SpaceRail({
                 // Inner content is fixed at the open width so text doesn't reflow mid-slide.
                 <div className="flex h-full w-[280px] flex-col">
                     <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
-                        {tabbed ? (
-                            <div className="inline-flex items-center rounded-md bg-muted p-0.5 text-[10.5px] font-semibold uppercase tracking-wider">
-                                {(['topics', 'files'] as const).map((l) => (
-                                    <button
-                                        key={l}
-                                        type="button"
-                                        onClick={() => onPickList(l)}
-                                        className={cn('rounded px-2 py-0.5', list === l ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground')}
-                                    >
-                                        {l}
-                                    </button>
-                                ))}
-                            </div>
-                        ) : (
-                            <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
-                                {list === 'topics' ? 'Topics' : 'Files'}
-                            </span>
-                        )}
                         <span className="min-w-0 flex-1 truncate text-right text-[10px] text-muted-foreground/70">{hint}</span>
                         <button
                             type="button"
@@ -161,153 +135,152 @@ export function SpaceRail({
                         </button>
                     </div>
 
-                    {list === 'topics' ? (
-                        <>
-                            <div className="flex flex-col gap-0.5 px-2 pt-2">
-                                <button
-                                    type="button"
-                                    onClick={() => onSelect({ kind: 'general' })}
-                                    className={cn(
-                                        'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
-                                        selection.kind === 'general' ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
-                                    )}
-                                >
-                                    <MessagesSquare className="size-3.5 shrink-0 text-muted-foreground" />
-                                    <span className={cn('flex-1 truncate', generalUnread > 0 && selection.kind !== 'general' && 'font-semibold')}>Messages</span>
-                                    {generalUnread > 0 && selection.kind !== 'general' && (
-                                        <span className="text-[11px] font-semibold tabular-nums">{generalUnread}</span>
-                                    )}
-                                    {(presence.typing.get(generalId ?? '') ?? []).length > 0 && <span className="size-1.5 rounded-full bg-emerald-500" title="someone is typing" />}
-                                </button>
-                            </div>
-
-                            <div className="mt-3 flex items-center gap-2 px-3 pr-2">
-                                <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topics</span>
-                                <span className="text-[11px] text-muted-foreground/70">{topicRows.length}</span>
-                                <span className="flex-1" />
-                                <div className="inline-flex items-center rounded-md bg-muted p-0.5 text-[10.5px]">
-                                    {(['all', 'unread', 'archived'] as const).map((f) => (
-                                        <button
-                                            key={f}
-                                            type="button"
-                                            onClick={() => setFilter(f)}
-                                            className={cn('rounded px-1.5 py-0.5 capitalize', filter === f ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground')}
-                                        >
-                                            {f}
-                                        </button>
-                                    ))}
-                                </div>
-                            </div>
-                            <label className="mx-2 mt-1 flex h-7 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground focus-within:border-foreground/30">
-                                <Search className="size-3" />
-                                <input
-                                    value={query}
-                                    onChange={(e) => setQuery(e.target.value)}
-                                    placeholder="Search topics"
-                                    className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
-                                />
-                            </label>
-                            <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
-                                <div className="flex flex-col gap-0.5">
-                                    {topicRows.map(({ topic, title }) => {
-                                        const active = topic.id === selectedTopicId
-                                        const unread = isUnread(topic)
-                                        const replies = Math.max(0, topic.messageCount - 1)
-                                        const files = artifactFiles.get(topic.id)
-                                        const working = (presence.working.get(topic.id) ?? []).length > 0
-                                        return (
-                                            <button
-                                                key={topic.id}
-                                                type="button"
-                                                onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
-                                                className={cn(
-                                                    'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
-                                                    active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
-                                                    topic.archived && 'opacity-60',
-                                                )}
-                                            >
-                                                <div className="flex items-center gap-1.5">
-                                                    <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
-                                                    {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
-                                                </div>
-                                                <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
-                                                    <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
-                                                    <span>· {formatFeedTime(topic.lastActivityAt)}</span>
-                                                    {files && files.size > 0 && (
-                                                        <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
-                                                    )}
-                                                    {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
-                                                    {topic.archived && <span>· archived</span>}
-                                                </div>
-                                            </button>
-                                        )
-                                    })}
-                                    {topicRows.length === 0 && (
-                                        <div className="px-2 py-2 text-xs text-muted-foreground">
-                                            {q ? 'No topics match.' : filter === 'unread' ? 'Nothing unread.' : filter === 'archived' ? 'No archived topics.' : 'No topics yet — reply to a message to start one.'}
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        </>
-                    ) : (
-                        <>
-                            <div className="flex h-8 shrink-0 items-center gap-2 px-3 pr-2 pt-1">
-                                <span className="text-[11px] text-muted-foreground/70">{entries.length} {entries.length === 1 ? 'file' : 'files'}</span>
-                                <span className="flex-1" />
-                                <input
-                                    ref={uploadInputRef}
-                                    type="file"
-                                    multiple
-                                    className="hidden"
-                                    onChange={(e) => {
-                                        const files = Array.from(e.target.files ?? [])
-                                        if (files.length > 0) onUploadFiles(files)
-                                        e.target.value = ''
-                                    }}
-                                />
-                                <button
-                                    type="button"
-                                    title="Upload files (or drop them here)"
-                                    onClick={() => uploadInputRef.current?.click()}
-                                    className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                                >
-                                    <Upload className="size-3.5" />
-                                </button>
-                                <button
-                                    type="button"
-                                    title="New file"
-                                    onClick={() => setCreatingFile(true)}
-                                    className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                                >
-                                    <Plus className="size-3.5" />
-                                </button>
-                            </div>
-                            <div
-                                className="min-h-0 flex-1 overflow-y-auto px-2 pb-2"
-                                onDragOver={(e) => { if (Array.from(e.dataTransfer.types).includes('Files')) e.preventDefault() }}
-                                onDrop={(e) => {
-                                    if (!Array.from(e.dataTransfer.types).includes('Files')) return
-                                    e.preventDefault()
-                                    const files = Array.from(e.dataTransfer.files)
-                                    if (files.length > 0) onUploadFiles(files)
-                                }}
+                    <div className="flex min-h-0 flex-1 flex-col">
+                        <div className="flex flex-col gap-0.5 px-2 pt-2">
+                            <button
+                                type="button"
+                                onClick={() => onSelect({ kind: 'general' })}
+                                className={cn(
+                                    'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
+                                    selection.kind === 'general' ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
+                                )}
                             >
-                                <FileTree
-                                    entries={entries}
-                                    selectedPath={selectedPath}
-                                    unreadPaths={unreadPaths}
-                                    onOpenFile={(path) => onSelect({ kind: 'file', path })}
-                                    creating={creatingFile}
-                                    onCreateFile={(path) => {
-                                        setCreatingFile(false)
-                                        onCreateFile(path)
-                                    }}
-                                    onCancelCreate={() => setCreatingFile(false)}
-                                />
+                                <MessagesSquare className="size-3.5 shrink-0 text-muted-foreground" />
+                                <span className={cn('flex-1 truncate', generalUnread > 0 && selection.kind !== 'general' && 'font-semibold')}>Messages</span>
+                                {generalUnread > 0 && selection.kind !== 'general' && (
+                                    <span className="text-[11px] font-semibold tabular-nums">{generalUnread}</span>
+                                )}
+                                {(presence.typing.get(generalId ?? '') ?? []).length > 0 && <span className="size-1.5 rounded-full bg-emerald-500" title="someone is typing" />}
+                            </button>
+                        </div>
+
+                        <div className="mt-3 flex items-center gap-2 px-3 pr-2">
+                            <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topics</span>
+                            <span className="text-[11px] text-muted-foreground/70">{topicRows.length}</span>
+                            <span className="flex-1" />
+                            <div className="inline-flex items-center rounded-md bg-muted p-0.5 text-[10.5px]">
+                                {(['all', 'unread', 'archived'] as const).map((f) => (
+                                    <button
+                                        key={f}
+                                        type="button"
+                                        onClick={() => setFilter(f)}
+                                        className={cn('rounded px-1.5 py-0.5 capitalize', filter === f ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground')}
+                                    >
+                                        {f}
+                                    </button>
+                                ))}
                             </div>
-                        </>
-                    )}
+                        </div>
+                        <label className="mx-2 mt-1 flex h-7 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground focus-within:border-foreground/30">
+                            <Search className="size-3" />
+                            <input
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                                placeholder="Search topics"
+                                className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+                            />
+                        </label>
+                        <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+                            <div className="flex flex-col gap-0.5">
+                                {topicRows.map(({ topic, title }) => {
+                                    const active = topic.id === selectedTopicId
+                                    const unread = isUnread(topic)
+                                    const replies = Math.max(0, topic.messageCount - 1)
+                                    const files = artifactFiles.get(topic.id)
+                                    const working = (presence.working.get(topic.id) ?? []).length > 0
+                                    return (
+                                        <button
+                                            key={topic.id}
+                                            type="button"
+                                            onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
+                                            className={cn(
+                                                'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
+                                                active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
+                                                topic.archived && 'opacity-60',
+                                            )}
+                                        >
+                                            <div className="flex items-center gap-1.5">
+                                                <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
+                                                {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
+                                            </div>
+                                            <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
+                                                <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
+                                                <span>· {formatFeedTime(topic.lastActivityAt)}</span>
+                                                {files && files.size > 0 && (
+                                                    <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
+                                                )}
+                                                {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
+                                                {topic.archived && <span>· archived</span>}
+                                            </div>
+                                        </button>
+                                    )
+                                })}
+                                {topicRows.length === 0 && (
+                                    <div className="px-2 py-2 text-xs text-muted-foreground">
+                                        {q ? 'No topics match.' : filter === 'unread' ? 'Nothing unread.' : filter === 'archived' ? 'No archived topics.' : 'No topics yet — reply to a message to start one.'}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="flex max-h-[40%] shrink-0 flex-col border-t border-border">
+                        <div className="flex h-8 shrink-0 items-center gap-2 px-3 pr-2 pt-1">
+                            <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Files</span>
+                            <span className="text-[11px] text-muted-foreground/70">{entries.length}</span>
+                            <span className="flex-1" />
+                            <input
+                                ref={uploadInputRef}
+                                type="file"
+                                multiple
+                                className="hidden"
+                                onChange={(e) => {
+                                    const files = Array.from(e.target.files ?? [])
+                                    if (files.length > 0) onUploadFiles(files)
+                                    e.target.value = ''
+                                }}
+                            />
+                            <button
+                                type="button"
+                                title="Upload files (or drop them here)"
+                                onClick={() => uploadInputRef.current?.click()}
+                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+                            >
+                                <Upload className="size-3.5" />
+                            </button>
+                            <button
+                                type="button"
+                                title="New file"
+                                onClick={() => setCreatingFile(true)}
+                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+                            >
+                                <Plus className="size-3.5" />
+                            </button>
+                        </div>
+                        <div
+                            className="min-h-0 flex-1 overflow-y-auto px-2 pb-2"
+                            onDragOver={(e) => { if (Array.from(e.dataTransfer.types).includes('Files')) e.preventDefault() }}
+                            onDrop={(e) => {
+                                if (!Array.from(e.dataTransfer.types).includes('Files')) return
+                                e.preventDefault()
+                                const files = Array.from(e.dataTransfer.files)
+                                if (files.length > 0) onUploadFiles(files)
+                            }}
+                        >
+                            <FileTree
+                                entries={entries}
+                                selectedPath={selectedPath}
+                                unreadPaths={unreadPaths}
+                                onOpenFile={(path) => onSelect({ kind: 'file', path })}
+                                creating={creatingFile}
+                                onCreateFile={(path) => {
+                                    setCreatingFile(false)
+                                    onCreateFile(path)
+                                }}
+                                onCancelCreate={() => setCreatingFile(false)}
+                            />
+                        </div>
+                    </div>
                 </div>
             )}
         </aside>


### PR DESCRIPTION
## What

- **Removes the Topics/Files tab toggle** from the space rail in Split. The rail now carries one combined sidebar on every surface (Talk, Read, Split): Messages + Topics (filter + search) on top, a **Files** section below it with its own header (count, upload, new file) and the tree.
- **Both lists scroll independently** — topics take the leftover rail height; the files section sizes to content up to 40% of the rail and scrolls past that. Drag-and-drop upload onto the tree still works.
- **Dismiss button on the Split document**: `FileColumn` grew an optional `onDismiss`; in Split an × at the end of the file header closes the document and returns to Talk, landing on the conversation that was beside it (the topic, or Messages). Hidden while a draft is open so a stray click can't drop unsaved edits.
- **Entering Spaces collapses the assistant chat pane by default** — Spaces carries its own conversation surface. Only navigations that *enter* Spaces collapse it; in-space rail clicks (topics, files) leave the pane as the user set it, and the header "Open chat" button reopens it as before.

## Behavior changes

- Opening a file from Talk's sidebar now grows into **Split** (chat stays beside the document) instead of jumping to full-screen Read; it falls back to Read automatically below the Split floor. Read remains reachable via the mode switcher / ⌘2.
- The collapsed 28px edge shows both the topics and folder icons with a combined unread badge.
- Rail pin and teach-peek collapse to a single preference (`spaces:railPin` / `spaces:railTaught`) instead of one per surface — an existing per-surface pin resets once.

## Verification

- `npm run typecheck` and `npm run lint` pass in `apps/x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)