### PR TITLE
feat(x): @here mentions in spaces — notify everyone online, Slack-style

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowUp, Bot, FileText, Globe, Loader2, Paperclip, ShieldCheck, Terminal, X as XIcon } from 'lucide-react'
+import { ArrowUp, Bot, FileText, Globe, Loader2, Megaphone, Paperclip, ShieldCheck, Terminal, X as XIcon } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { Textarea } from '@/components/ui/textarea'
@@ -12,7 +12,8 @@ import { blobAppUrl, blobWireUrl, encodeMentions, formatBytes, isImageMime } fro
 import { toast } from '@/lib/toast'
 
 // The space composer. A plain message box — Enter sends, Shift+Enter breaks a
-// line — with two things layered on: `@` autocompletes members and @rowboat,
+// line — with two things layered on: `@` autocompletes members, @here (notify
+// everyone online) and @rowboat,
 // and the moment the draft addresses @rowboat, a strip of agent options
 // (model · permissions · search · terminal) appears; they ride along with the
 // invocation for that one turn. The message itself always goes to the team.
@@ -52,6 +53,7 @@ interface MentionCandidate {
     label: string
     hint?: string
     isAgent?: boolean
+    isBroadcast?: boolean
 }
 
 const MENTION_RE = /(^|[\s([{])@([\w.-]*)$/
@@ -196,6 +198,7 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
         const q = mentionMatch.query
         const list: MentionCandidate[] = []
         if ('rowboat'.startsWith(q)) list.push({ id: 'rowboat', label: 'rowboat', hint: 'your agent — acts only when asked', isAgent: true })
+        if ('here'.startsWith(q)) list.push({ id: 'here', label: 'here', hint: 'notify everyone online', isBroadcast: true })
         for (const m of members) {
             const hay = `${m.id} ${m.displayName}`.toLowerCase()
             if (!q || hay.includes(q)) list.push({ id: m.id, label: m.displayName, ...(m.id === selfMemberId ? { hint: 'you' } : {}) })
@@ -303,6 +306,8 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
                             >
                                 {c.isAgent ? (
                                     <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background"><Bot className="size-3.5" /></span>
+                                ) : c.isBroadcast ? (
+                                    <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><Megaphone className="size-3.5" /></span>
                                 ) : (
                                     <MemberAvatar id={c.id} name={c.label} size="sm" className="size-6 text-[10px]" />
                                 )}

--- a/apps/x/apps/renderer/src/lib/spaces-mentions.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-mentions.ts
@@ -1,3 +1,3 @@
 // Mention detection lives in @x/shared (one scanner for the renderer and for
 // main's mention notifications); this module keeps the renderer's import path.
-export { containsMemberAddress, containsRowboatAddress, mentionsMember, stripNonAddressRegions, type MentionIdentity } from '@x/shared/dist/spaces.js'
+export { containsHereAddress, containsMemberAddress, containsRowboatAddress, mentionsMember, stripNonAddressRegions, type MentionIdentity } from '@x/shared/dist/spaces.js'

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.test.ts
@@ -94,6 +94,14 @@ describe('mentions — compose names, wire ids', () => {
         expect(encodeMentions('@rowboat go', [{ id: '01HIMPOSTOR', displayName: 'rowboat' }])).toBe('@rowboat go')
     })
 
+    it('@here stays literal on the wire and decorates like a mention', () => {
+        expect(encodeMentions('@here standup in 5', members)).toBe('@here standup in 5')
+        expect(encodeMentions('@here go', [{ id: '01HIMPOSTOR', displayName: 'here' }])).toBe('@here go')
+        const names = new Map(members.map((m) => [m.id, m.displayName]))
+        expect(decorateMentions('@here standup in 5', names)).toBe('**@here** standup in 5')
+        expect(resolveMentions('`@here` in code stays', names)).toBe('`@here` in code stays')
+    })
+
     it('round-trips: encoded wire body decorates back to the name', () => {
         const names = new Map(members.map((m) => [m.id, m.displayName]))
         expect(decorateMentions(encodeMentions('hey @Ramnique Singh', members), names))

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.ts
@@ -205,52 +205,21 @@ export function formatBytes(size: number): string {
     return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${unit}`
 }
 
-/**
- * The one walker that turns wire member addresses ("@<memberId>") into
- * people. Code regions stay literal (same address-vs-cite line the trigger
- * logic draws); unknown ids pass through untouched; @rowboat keeps its
- * handle. Every mention-rendering path goes through here — fix it once.
- */
-function mapMentions(body: string, memberNames: ReadonlyMap<string, string>, wrap: (handle: string) => string): string {
-    const parts = body.split(/(```[\s\S]*?(?:```|$)|`[^`\n]*`)/g)
-    return parts
-        .map((part, i) => {
-            if (i % 2 === 1) return part // a code region — cite, not address
-            return part.replace(/(^|[\s([{])@([A-Za-z0-9][\w.-]*)/g, (match, pre: string, id: string) => {
-                if (id.toLowerCase() === 'rowboat') return `${pre}${wrap('@rowboat')}`
-                const name = memberNames.get(id)
-                return name ? `${pre}${wrap(`@${name}`)}` : match
-            })
-        })
-        .join('')
-}
-
-/**
- * For markdown surfaces (message bodies): "@<memberId>" becomes
- * "**@Display Name**" so the pipeline sets it off in bold.
- */
-export function decorateMentions(body: string, memberNames: ReadonlyMap<string, string>): string {
-    return mapMentions(body, memberNames, (h) => `**${h}**`)
-}
-
-/**
- * For plain-text surfaces (topic titles, crumbs, reasons): same resolution,
- * no markup — safe for search haystacks and tooltips too.
- */
-export function resolveMentions(body: string, memberNames: ReadonlyMap<string, string>): string {
-    return mapMentions(body, memberNames, (h) => h)
-}
+// The wire-address → person walker lives in @x/shared (main's notification
+// text resolves through the same code); re-exported to keep the renderer's
+// import path.
+export { decorateMentions, resolveMentions } from '@x/shared/dist/spaces.js'
 
 /**
  * The inverse, for the composer: people type/pick "@Display Name" but the wire
  * address is "@<memberId>" (that's what mention notifications and agent
  * invocation scan for). Longest name first so "Ramnique Singh" wins over a
  * teammate named "Ramnique"; case-insensitive; code regions stay literal.
- * A member named "rowboat" never captures the agent's address.
+ * A member named "rowboat" or "here" never captures those addresses.
  */
 export function encodeMentions(body: string, members: readonly { id: string; displayName: string }[]): string {
     const ordered = members
-        .filter((m) => m.displayName && m.displayName !== m.id && m.displayName.toLowerCase() !== 'rowboat')
+        .filter((m) => m.displayName && m.displayName !== m.id && !['rowboat', 'here'].includes(m.displayName.toLowerCase()))
         .sort((a, b) => b.displayName.length - a.displayName.length)
     if (ordered.length === 0) return body
     const parts = body.split(/(```[\s\S]*?(?:```|$)|`[^`\n]*`)/g)

--- a/apps/x/packages/core/src/spaces/mention-watch.test.ts
+++ b/apps/x/packages/core/src/spaces/mention-watch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { resolveMentions } from '@x/shared/dist/spaces.js';
 import { buildMentionNotify, buildMissedSummaryNotify, isMissedArrival, mentionExcerpt, mentionLink } from './mention-watch.js';
 
 describe('isMissedArrival', () => {
@@ -22,22 +23,35 @@ describe('mentionExcerpt', () => {
         expect(mentionExcerpt('@arjun can you look?\n```js\nsecret()\n```\n> old quote\n**soon**')).toBe('@arjun can you look? soon');
         expect(mentionExcerpt('x'.repeat(200))).toHaveLength(140);
     });
+    it('resolved wire bodies show people, not member ids', () => {
+        const names = new Map([['01M0KTADMQSQ35V1M2WH15XNTY', 'Arjun']]);
+        expect(mentionExcerpt(resolveMentions('@here ping @01M0KTADMQSQ35V1M2WH15XNTY', names)))
+            .toBe('@here ping @Arjun');
+    });
 });
 
 describe('notification payloads', () => {
     it('builds a background-only mention notification with a topic deep link', () => {
-        const n = buildMentionNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', topicId: 't1', authorName: 'Harsh', body: '@arjun ping' });
+        const n = buildMentionNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', topicId: 't1', authorName: 'Harsh', body: '@arjun ping', kind: 'you' });
         expect(n.title).toBe('Harsh mentioned you · Roadboard');
         expect(n.message).toBe('@arjun ping');
         expect(n.link).toContain('topicId=t1');
         expect(n.onlyWhenBackground).toBe(true);
     });
+    it('titles an @here hit as mentioning everyone', () => {
+        const n = buildMentionNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', topicId: 't1', authorName: 'Harsh', body: '@here standup', kind: 'here' });
+        expect(n.title).toBe('Harsh mentioned everyone · Roadboard');
+    });
     it('summarises missed mentions, landing on the sole topic when there is one', () => {
-        const one = buildMissedSummaryNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', count: 1, soleTopicId: 't1' });
+        const one = buildMissedSummaryNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', youCount: 1, hereCount: 0, soleTopicId: 't1' });
         expect(one.message).toBe('1 mention of you');
         expect(one.link).toContain('topicId=t1');
-        const many = buildMissedSummaryNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', count: 3 });
+        const many = buildMissedSummaryNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', youCount: 3, hereCount: 0 });
         expect(many.message).toBe('3 mentions of you');
         expect(many.link).not.toContain('topicId');
+    });
+    it('counts @here separately in the missed summary', () => {
+        expect(buildMissedSummaryNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', youCount: 0, hereCount: 2 }).message).toBe('2 @here');
+        expect(buildMissedSummaryNotify({ orgId: 'o1', spaceId: 's1', spaceName: 'Roadboard', youCount: 2, hereCount: 1 }).message).toBe('2 mentions of you · 1 @here');
     });
 });

--- a/apps/x/packages/core/src/spaces/mention-watch.ts
+++ b/apps/x/packages/core/src/spaces/mention-watch.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { mentionsMember, type MentionIdentity } from '@x/shared/dist/spaces.js';
+import { containsHereAddress, mentionsMember, resolveMentions, type MentionIdentity } from '@x/shared/dist/spaces.js';
 import type { Member, ServerFrame } from '@rowboat/spaces-protocol';
 import { notifyIfEnabled } from '../application/notification/notifier.js';
 import type { NotifyInput } from '../application/notification/service.js';
@@ -10,9 +10,10 @@ import { getClient, getLive, listOrgs } from './orgs.js';
 // Space mention notifications: main-side watcher that subscribes to EVERY
 // space of every org (independent of what's on screen), scans incoming
 // messages for a mention of me — by display name (what the composer types;
-// member ids are opaque IdP subjects) or by id (agent-written, older
-// messages) — and notifies, suppressed while the app is focused
-// (onlyWhenBackground) and gated by the 'space_mention' category.
+// member ids are opaque IdP subjects), by id (agent-written, older
+// messages), or via @here (everyone online, Slack-style) — and notifies,
+// suppressed while the app is focused (onlyWhenBackground) and gated by the
+// 'space_mention' category.
 //
 // Offsets are persisted per space so a relaunch replays what arrived while
 // the app was closed: fresh mentions notify individually, older ones fold
@@ -41,6 +42,8 @@ export interface MentionHit {
   topicId: string;
   authorName: string;
   body: string;
+  /** 'you' = addressed me by name/id; 'here' = @here, addressed everyone online. */
+  kind: 'you' | 'here';
 }
 
 export function isMissedArrival(postedAt: string, now: number = Date.now()): boolean {
@@ -66,7 +69,7 @@ export function mentionExcerpt(body: string, max = 140): string {
 
 export function buildMentionNotify(hit: MentionHit): NotifyInput {
   return {
-    title: `${hit.authorName} mentioned you · ${hit.spaceName}`,
+    title: `${hit.authorName} ${hit.kind === 'here' ? 'mentioned everyone' : 'mentioned you'} · ${hit.spaceName}`,
     message: mentionExcerpt(hit.body),
     link: mentionLink(hit.orgId, hit.spaceId, hit.topicId),
     onlyWhenBackground: true,
@@ -77,13 +80,19 @@ export function buildMissedSummaryNotify(input: {
   orgId: string;
   spaceId: string;
   spaceName: string;
-  count: number;
+  /** Missed mentions that addressed me by name/id. */
+  youCount: number;
+  /** Missed @here mentions — surfaced on coming back online. */
+  hereCount: number;
   /** When every missed mention sits in one topic, click lands there. */
   soleTopicId?: string;
 }): NotifyInput {
+  const parts: string[] = [];
+  if (input.youCount > 0) parts.push(`${input.youCount} ${input.youCount === 1 ? 'mention' : 'mentions'} of you`);
+  if (input.hereCount > 0) parts.push(`${input.hereCount} @here`);
   return {
     title: `While you were away · ${input.spaceName}`,
-    message: `${input.count} ${input.count === 1 ? 'mention' : 'mentions'} of you`,
+    message: parts.join(' · '),
     link: mentionLink(input.orgId, input.spaceId, input.soleTopicId),
     onlyWhenBackground: true,
     // The summary IS the replay burst — never drop it to the startup grace.
@@ -124,7 +133,8 @@ interface SpaceSub {
 }
 
 interface MissedBucket {
-  count: number;
+  youCount: number;
+  hereCount: number;
   topicIds: Set<string>;
   spaceName: string;
   timer: ReturnType<typeof setTimeout>;
@@ -159,16 +169,17 @@ function authorName(k: string, memberId: string): string {
   return memberNames.get(k)?.get(memberId) ?? memberId;
 }
 
-function queueMissed(k: string, orgId: string, spaceId: string, spaceName: string, topicId: string): void {
+function queueMissed(k: string, orgId: string, spaceId: string, spaceName: string, topicId: string, kind: MentionHit['kind']): void {
   const existing = missed.get(k);
   if (existing) {
-    existing.count += 1;
+    existing[kind === 'here' ? 'hereCount' : 'youCount'] += 1;
     existing.topicIds.add(topicId);
     existing.timer.refresh();
     return;
   }
   const bucket: MissedBucket = {
-    count: 1,
+    youCount: kind === 'here' ? 0 : 1,
+    hereCount: kind === 'here' ? 1 : 0,
     topicIds: new Set([topicId]),
     spaceName,
     timer: setTimeout(() => {
@@ -177,7 +188,8 @@ function queueMissed(k: string, orgId: string, spaceId: string, spaceName: strin
         orgId,
         spaceId,
         spaceName: bucket.spaceName,
-        count: bucket.count,
+        youCount: bucket.youCount,
+        hereCount: bucket.hereCount,
         ...(bucket.topicIds.size === 1 ? { soleTopicId: [...bucket.topicIds][0] } : {}),
       }));
     }, MISSED_DEBOUNCE_MS),
@@ -193,11 +205,17 @@ function makeHandler(orgId: string, spaceId: string, spaceName: string, me: Ment
     if (frame.event.type !== 'message') return;
     const message = frame.event.message;
     if (message.author.memberId === me.id) return;
-    // People type the NAME (ids are opaque); agent-written mentions may carry the id.
-    if (!mentionsMember(message.body, me)) return;
+    // People type the NAME (ids are opaque); agent-written mentions may carry
+    // the id. A direct mention outranks @here when both appear.
+    const kind: MentionHit['kind'] | null = mentionsMember(message.body, me)
+      ? 'you'
+      : containsHereAddress(message.body)
+        ? 'here'
+        : null;
+    if (!kind) return;
 
     if (isMissedArrival(message.postedAt)) {
-      queueMissed(k, orgId, spaceId, spaceName, message.topicId);
+      queueMissed(k, orgId, spaceId, spaceName, message.topicId, kind);
       return;
     }
     const cooldownKey = `${k}/${message.topicId}`;
@@ -210,7 +228,9 @@ function makeHandler(orgId: string, spaceId: string, spaceName: string, me: Ment
       spaceName,
       topicId: message.topicId,
       authorName: authorName(k, message.author.memberId),
-      body: message.body,
+      // The wire carries "@<memberId>" addresses — show people, not ids.
+      body: resolveMentions(message.body, memberNames.get(k) ?? new Map()),
+      kind,
     }));
   };
 }

--- a/apps/x/packages/shared/src/spaces.test.ts
+++ b/apps/x/packages/shared/src/spaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { containsRowboatAddress, mentionsMember, stripNonAddressRegions } from './spaces.js';
+import { containsHereAddress, containsRowboatAddress, mentionsMember, stripNonAddressRegions } from './spaces.js';
 
 const arjun = { id: '01M0F8S2MC8HYMF4MYWM61MR7B', displayName: 'Arjun Kumar' };
 
@@ -36,5 +36,21 @@ describe('mentionsMember', () => {
   it('leaves @rowboat alone', () => {
     expect(containsRowboatAddress('@rowboat summarise this')).toBe(true);
     expect(containsRowboatAddress('email@rowboat.com')).toBe(false);
+  });
+});
+
+describe('containsHereAddress', () => {
+  it('matches a genuine @here address, any case', () => {
+    expect(containsHereAddress('@here standup in 5')).toBe(true);
+    expect(containsHereAddress('heads up @HERE.')).toBe(true);
+    expect(containsHereAddress('(@here) deploy going out')).toBe(true);
+  });
+
+  it('ignores longer handles, cites, code, and emails', () => {
+    expect(containsHereAddress('@hereabouts is a word')).toBe(false);
+    expect(containsHereAddress('> @here said someone else')).toBe(false);
+    expect(containsHereAddress('use `@here` sparingly')).toBe(false);
+    expect(containsHereAddress('mail me@here.com')).toBe(false);
+    expect(containsHereAddress('come here now')).toBe(false);
   });
 });

--- a/apps/x/packages/shared/src/spaces.ts
+++ b/apps/x/packages/shared/src/spaces.ts
@@ -153,3 +153,51 @@ export function mentionsMember(body: string, member: MentionIdentity): boolean {
 export function containsRowboatAddress(body: string): boolean {
   return containsMemberAddress(body, 'rowboat');
 }
+
+/**
+ * The @here address — everyone in the space whose app is online, Slack-style.
+ * There is no server fan-out: every member's client scans incoming messages
+ * itself (mention-watch), so "online" is exactly "the app is running to see
+ * this arrive"; whoever was away catches it in the missed-replay summary.
+ */
+export function containsHereAddress(body: string): boolean {
+  return containsMemberAddress(body, 'here');
+}
+
+/**
+ * The one walker that turns wire member addresses ("@<memberId>") into
+ * people. Code regions stay literal (same address-vs-cite line the trigger
+ * logic draws); unknown ids pass through untouched; @rowboat and @here keep
+ * their handles. Every mention-rendering path — renderer surfaces AND main's
+ * notification text — goes through here. Fix it once.
+ */
+function mapMentions(body: string, memberNames: ReadonlyMap<string, string>, wrap: (handle: string) => string): string {
+  const parts = body.split(/(```[\s\S]*?(?:```|$)|`[^`\n]*`)/g);
+  return parts
+    .map((part, i) => {
+      if (i % 2 === 1) return part; // a code region — cite, not address
+      return part.replace(/(^|[\s([{])@([A-Za-z0-9][\w.-]*)/g, (match, pre: string, id: string) => {
+        if (id.toLowerCase() === 'rowboat') return `${pre}${wrap('@rowboat')}`;
+        if (id.toLowerCase() === 'here') return `${pre}${wrap('@here')}`;
+        const name = memberNames.get(id);
+        return name ? `${pre}${wrap(`@${name}`)}` : match;
+      });
+    })
+    .join('');
+}
+
+/**
+ * For markdown surfaces (message bodies): "@<memberId>" becomes
+ * "**@Display Name**" so the pipeline sets it off in bold.
+ */
+export function decorateMentions(body: string, memberNames: ReadonlyMap<string, string>): string {
+  return mapMentions(body, memberNames, (h) => `**${h}**`);
+}
+
+/**
+ * For plain-text surfaces (topic titles, crumbs, reasons, notification
+ * bodies): same resolution, no markup — safe for search haystacks too.
+ */
+export function resolveMentions(body: string, memberNames: ReadonlyMap<string, string>): string {
+  return mapMentions(body, memberNames, (h) => h);
+}


### PR DESCRIPTION
## What

Typing `@here` in a space message now notifies every member of that space (except the author), like Slack's `@here`.

## How it works

There's no server fan-out — each member's app already runs a main-process watcher (`mention-watch.ts`) that scans every incoming message for mentions of itself. `@here` is simply treated as "this mentions me" by every client:

- **Online members** (app running, even backgrounded) get an immediate notification titled "*X* mentioned everyone · *Space*", behind the same `space_mention` settings gate, focus suppression, and per-topic cooldown as personal mentions.
- **Members who were offline** catch it on relaunch: the missed-replay summary now itemizes both kinds — "2 mentions of you · 1 @here".
- A direct mention of you outranks `@here` when a message has both.
- The composer's `@` autocomplete offers **here** ("notify everyone online") with a megaphone icon; `@here` renders bold in messages like other mentions. The shared scanner's address-vs-cite rules apply, so code fences, quotes, "hereabouts", and `me@here.com` never trigger it. A member who names themselves "here" can't hijack the address (same guard `@rowboat` has).
- `@here` does **not** invoke anyone's `@rowboat` agent — it's purely a people notification.

## Also: notifications no longer leak wire addresses

Notification text was built from the raw wire body, so it showed `@01M0KTAD…` member ids instead of names (a pre-existing gap `@here` made visible, since you now get notified about messages mentioning other people). The wire-address → person walker moved from the renderer into `@x/shared` (renderer re-exports it, all call sites untouched), and `mention-watch` resolves bodies through it before notifying.

## Testing

- `npm run deps`, `npm run typecheck`, `npm run lint` all clean
- Shared/core/renderer mention suites pass (32 tests), including new cases for `@here` matching, notification wording, missed-summary counts, wire encoding, and the id → name resolution fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)