### PR TITLE
fix(x): reclaim crash-orphaned turns instead of queueing behind them forever

### DIFF
--- a/apps/x/packages/core/src/runtime/sessions/api.ts
+++ b/apps/x/packages/core/src/runtime/sessions/api.ts
@@ -13,6 +13,15 @@ import type {
 } from "@x/shared/dist/turns.js";
 import type { Turn } from "../turns/api.js";
 
+/**
+ * The cancel reason sendOrQueueMessage records when it reclaims a
+ * crash-orphaned turn (idle in the log, no live advance — nothing will ever
+ * settle it). Consumers that narrate turn endings (e.g. the spaces topic
+ * watchdog) match on it to tell a reclaim apart from a person pressing Stop.
+ */
+export const RECLAIMED_TURN_REASON =
+    "interrupted: the app quit or crashed while this turn was running";
+
 // Per-message configuration; it lands on the turn (sessions store none).
 export interface SendMessageConfig {
     agent: z.infer<typeof RequestedAgent>;

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -1251,11 +1251,15 @@ describe("pending queue (sendOrQueueMessage, steering, promotion)", () => {
 
     it("queues while the latest turn is non-terminal and mirrors the queue on the bus", async () => {
         const { sessions, fake, bus } = makeSessions();
+        // Hold the advance open: the turn is genuinely live (an idle log with
+        // no live advance would instead be reclaimed as crash-orphaned).
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>(() => undefined),
+        });
         const sessionId = await sessions.createSession();
-        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+        await sessions.sendMessage(sessionId, user("one"), {
             agent: { agentId: "copilot" },
         });
-        void turnId; // default log stays idle (non-terminal)
 
         const result = await sessions.sendOrQueueMessage(sessionId, user("two"), {
             agent: { agentId: "copilot" },
@@ -1272,8 +1276,69 @@ describe("pending queue (sendOrQueueMessage, steering, promotion)", () => {
         });
     });
 
+    it("reclaims a crash-orphaned turn: cancels it and starts the new turn", async () => {
+        const { sessions, fake } = makeSessions();
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        // The advance settled without a terminal event ever landing in the
+        // log — exactly what a dead process leaves behind: an idle log and
+        // no live advance.
+        await flush();
+
+        fake.script = ({ turnId: t, input }) => {
+            if (input?.type === "cancel") {
+                fake.setLog(t, [
+                    ...turnLog(t, sessionId, "idle"),
+                    { type: "turn_cancelled", turnId: t, ts: TS, reason: input.reason, usage: {} },
+                ]);
+                return { outcome: { status: "cancelled", usage: {} } };
+            }
+            return { outcome: completedOutcome() };
+        };
+        const result = await sessions.sendOrQueueMessage(sessionId, user("two"), {
+            agent: { agentId: "copilot" },
+        });
+
+        expect(result).toMatchObject({ queued: false });
+        const cancel = fake.advanceCalls.find((c) => c.input?.type === "cancel");
+        expect(cancel).toMatchObject({
+            turnId,
+            input: { type: "cancel", reason: expect.stringContaining("interrupted") },
+        });
+        // The new turn chains onto the cancelled ghost; nothing stays queued.
+        expect(fake.createTurnInputs).toHaveLength(2);
+        expect(fake.createTurnInputs[1]).toMatchObject({
+            input: user("two"),
+            context: { previousTurnId: turnId },
+        });
+        expect(sessions.listQueued(sessionId)).toEqual([]);
+    });
+
+    it("does not reclaim a suspended turn — permission/async-tool waits still queue", async () => {
+        const { sessions, fake } = makeSessions();
+        const sessionId = await sessions.createSession();
+        const { turnId } = await sessions.sendMessage(sessionId, user("one"), {
+            agent: { agentId: "copilot" },
+        });
+        await flush();
+        fake.setLog(turnId, turnLog(turnId, sessionId, "suspended"));
+
+        const result = await sessions.sendOrQueueMessage(sessionId, user("two"), {
+            agent: { agentId: "copilot" },
+        });
+
+        expect(result).toMatchObject({ queued: true });
+        expect(fake.advanceCalls.filter((c) => c.input?.type === "cancel")).toHaveLength(0);
+        expect(fake.createTurnInputs).toHaveLength(1);
+    });
+
     it("hands the pending queue to every session advance as a steer source", async () => {
         const { sessions, fake } = makeSessions();
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>(() => undefined),
+        });
         const sessionId = await sessions.createSession();
         await sessions.sendMessage(sessionId, user("one"), {
             agent: { agentId: "copilot" },

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -234,10 +234,33 @@ export class SessionsImpl implements ISessions {
         return this.sessionRepo.withLock(sessionId, async () => {
             const events = await this.sessionRepo.read(sessionId);
             const state = reduceSession(events);
-            const latestTurnState = await this.latestTurnState(state);
-            const status = latestTurnState
+            let latestTurnState = await this.latestTurnState(state);
+            let status = latestTurnState
                 ? deriveTurnStatus(latestTurnState)
                 : "none";
+            // An "idle" turn with no live advance in this process is a turn
+            // NOTHING is running: the process driving it died (or its advance
+            // rejected as infrastructure) before a terminal event was written.
+            // It will never settle, so deliver-ASAP must not park messages
+            // behind it forever — cancel it (the §22 fast-path: no live
+            // dependencies, never re-issues a model call) and deliver this
+            // message as a fresh turn. A suspended turn is different: it is
+            // parked on a permission or async tool and legitimately waits
+            // with no advance, so it still queues.
+            if (
+                status === "idle" &&
+                state.latestTurnId &&
+                !this.active.has(state.latestTurnId)
+            ) {
+                await this.abortOrCancel(
+                    state.latestTurnId,
+                    "interrupted: the app quit or crashed while this turn was running",
+                );
+                latestTurnState = await this.latestTurnState(state);
+                status = latestTurnState
+                    ? deriveTurnStatus(latestTurnState)
+                    : "none";
+            }
             const settled =
                 status === "none" ||
                 status === "completed" ||

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -37,6 +37,7 @@ import { carriesSkillsForward } from "../assembly/traits.js";
 import type { IClock } from "../turns/clock.js";
 import {
     type ISessions,
+    RECLAIMED_TURN_REASON,
     type SendMessageConfig,
     TurnNotSettledError,
 } from "./api.js";
@@ -252,10 +253,7 @@ export class SessionsImpl implements ISessions {
                 state.latestTurnId &&
                 !this.active.has(state.latestTurnId)
             ) {
-                await this.abortOrCancel(
-                    state.latestTurnId,
-                    "interrupted: the app quit or crashed while this turn was running",
-                );
+                await this.abortOrCancel(state.latestTurnId, RECLAIMED_TURN_REASON);
                 latestTurnState = await this.latestTurnState(state);
                 status = latestTurnState
                     ? deriveTurnStatus(latestTurnState)

--- a/apps/x/packages/core/src/spaces/topic-agent.test.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildInvocationMessage, describeTurnError, finalAssistantText, isTopicReceiptCall } from './topic-agent.js';
+import { RECLAIMED_TURN_REASON } from '../runtime/sessions/api.js';
+import { backstopBody, buildInvocationMessage, describeTurnError, finalAssistantText, isTopicReceiptCall } from './topic-agent.js';
 
 const input = {
     orgId: 'org-1',
@@ -93,5 +94,26 @@ describe('describeTurnError', () => {
         expect(describeTurnError('429 Too Many Requests')).toMatch(/rate-limited/);
         expect(describeTurnError('tool foo exploded')).toBe('tool foo exploded');
         expect(describeTurnError(undefined)).toBe('unknown error');
+    });
+});
+
+describe('backstopBody', () => {
+    it('tells a reclaimed crash-orphaned turn apart from a person pressing Stop', () => {
+        expect(backstopBody({ type: 'turn_cancelled', reason: RECLAIMED_TURN_REASON })).toBe(
+            '⚠️ An earlier Rowboat run here was interrupted — picking up your latest message now.',
+        );
+        expect(backstopBody({ type: 'turn_cancelled' })).toBe(
+            "⚠️ Rowboat's run was stopped before it finished.",
+        );
+        expect(backstopBody({ type: 'turn_cancelled', reason: 'user asked' })).toBe(
+            "⚠️ Rowboat's run was stopped before it finished.",
+        );
+    });
+
+    it('keeps the failed and no-receipt wordings', () => {
+        expect(backstopBody({ type: 'turn_failed', error: '401' })).toMatch(/isn't signed in/);
+        expect(backstopBody({ type: 'turn_completed' })).toBe(
+            'Rowboat finished without posting a receipt or leaving a note.',
+        );
     });
 });

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { ITurnEventBus } from '../runtime/turns/event-hub.js';
-import type { ISessions } from '../runtime/sessions/api.js';
+import { type ISessions, RECLAIMED_TURN_REASON } from '../runtime/sessions/api.js';
 import type { TurnBusEvent } from '@x/shared/dist/turns.js';
 import { WorkDir } from '../config/config.js';
 import { getClient, getLive, spacesMcpServerNameFor } from './orgs.js';
@@ -249,22 +249,38 @@ function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
 
+/**
+ * The backstop receipt's wording (pure; tested). A cancelled turn is usually a
+ * person pressing Stop — except a reclaim: sendOrQueueMessage cancelling a
+ * crash-orphaned turn because a NEW mention just arrived. That one must not
+ * read as the new run failing; the new turn posts its own receipt right after.
+ */
+export function backstopBody(event: {
+  type: string;
+  error?: string;
+  reason?: string;
+  output?: unknown;
+}): string {
+  if (event.type === 'turn_failed') {
+    return `⚠️ Rowboat couldn't complete this — ${describeTurnError(event.error)}`;
+  }
+  if (event.type === 'turn_cancelled') {
+    return event.reason === RECLAIMED_TURN_REASON
+      ? '⚠️ An earlier Rowboat run here was interrupted — picking up your latest message now.'
+      : `⚠️ Rowboat's run was stopped before it finished.`;
+  }
+  const text = finalAssistantText(event.output);
+  return text
+    ? `Rowboat finished without posting a receipt. Its final note: "${truncate(text, 300)}"`
+    : 'Rowboat finished without posting a receipt or leaving a note.';
+}
+
 /** Never go dark: the turn ended without posting its receipt — post one for it. */
 async function postBackstop(
   watch: TopicWatch,
-  event: { type: string; error?: string; output?: unknown },
+  event: { type: string; error?: string; reason?: string; output?: unknown },
 ): Promise<void> {
-  let body: string;
-  if (event.type === 'turn_failed') {
-    body = `⚠️ Rowboat couldn't complete this — ${describeTurnError(event.error)}`;
-  } else if (event.type === 'turn_cancelled') {
-    body = `⚠️ Rowboat's run was stopped before it finished.`;
-  } else {
-    const text = finalAssistantText(event.output);
-    body = text
-      ? `Rowboat finished without posting a receipt. Its final note: "${truncate(text, 300)}"`
-      : 'Rowboat finished without posting a receipt or leaving a note.';
-  }
+  const body = backstopBody(event);
   await getClient(watch.orgId).postMessage(watch.spaceId, {
     topicId: watch.topicId,
     body,


### PR DESCRIPTION
## The bug

A turn interrupted by an app quit or crash never gets its terminal event written, so its log derives `idle` forever. `sendOrQueueMessage` (the deliver-ASAP path used by the chat composer and spaces `@rowboat` invocations) saw "not settled" and parked every subsequent message in the **ephemeral** pending queue behind a turn that no process was running. Nothing ever settled it, the queue evaporated on the next quit, and no error surfaced anywhere.

Found in the wild: a dev-server restart mid-turn wedged a space topic's agent session — every `@rowboat` mention after that silently went nowhere (no receipt, no working chip, no toast) until the stuck session was found and stopped by hand. With `npm run dev` restarting main constantly, this is easy to hit; the packaged app hits it on crash or force-quit mid-turn.

## The fix

In `sendOrQueueMessage`, under the session lock it already holds: if the latest turn derives **`idle`** and `this.active` has **no live advance** for it, that combination is only possible when the process driving the turn died (or its advance rejected as infrastructure) — reclaim it:

- cancel the ghost through the existing `abortOrCancel` → `advanceWithInput({type: 'cancel'})` path — the §22 cancel fast-path, which needs no live dependencies and never re-issues a model call (it's exactly what pressing Stop does), with reason `"interrupted: the app quit or crashed while this turn was running"` recorded on the `turn_cancelled` event;
- re-derive, then deliver the new message as a fresh turn chained onto the cancelled one.

**Suspended turns are explicitly not reclaimed**: a turn parked on a permission prompt or async tool legitimately sits with no live advance, and messages still queue behind it to steer the resuming advance, as before.

## Scope and safety

- `sendMessage` (the strict variant used by the todo runner, channels bridge, code sessions) is untouched — it already surfaces `TurnNotSettledError` instead of queueing silently.
- Both the check and the cancel run under the same session lock that turn-starting uses (`startTurnLocked` registers the advance before the lock releases), so a genuinely live turn can't be misread as dead.
- If pending entries exist when the ghost is cancelled, the cancel's settle hook promotes the queue head under the lock after this call, preserving arrival order.
- Startup behavior is unchanged: no automatic resume (which would re-issue interrupted model calls) — reclaim happens only when a new message actually arrives, and it cancels rather than resumes.
- Known pre-existing caveat, unchanged by this PR: dev builds skip `requestSingleInstanceLock`, so a dev and a packaged instance sharing `~/.rowboat` could each see the other's turns as orphaned — but two instances already conflict on the session files themselves.

## Receipt wording on reclaim

The spaces topic watchdog's never-go-dark receipt for a cancelled turn ("Rowboat's run was stopped before it finished") landed right after the mention that triggered a reclaim — reading like the *new* run failed. The reclaim reason is now a shared constant (`RECLAIMED_TURN_REASON` in `runtime/sessions/api.ts`); the backstop matches on it and posts "⚠️ An earlier Rowboat run here was interrupted — picking up your latest message now." instead. A person pressing Stop keeps the old wording. (`backstopBody` extracted as a pure, tested helper.)

## Testing

- New: reclaim cancels the orphan with the interruption reason and starts the new turn chained onto it; suspended turns still queue with no cancel issued.
- Adjusted two existing tests that used an idle-log-with-no-advance as a stand-in for "running" — they now hold the advance genuinely open (`pending` script), matching what the real runtime produces.
- Full core suite: 764 passed; the one failure (`spaces/client.test.ts` blob round-trip, 404) fails identically on clean main — pre-existing, unrelated.
- `npm run deps`, `npm run typecheck`, `npm run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
