### PR TITLE
Spaces: rename topics from the UI

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -7,7 +7,7 @@ import { DayDivider, MessageRow, NewDivider, TypingIndicator, type ThreadRowData
 import type { GeneralState, SpacePresence, ThreadIndex } from '@/hooks/use-space-chat'
 import { ingestGeneralMessage, rememberThread, updateGeneralMessage, usePresenceSender } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
-import { buildThreadSeed, dayKey, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
+import { buildThreadSeed, dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
 import { resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
@@ -96,6 +96,8 @@ export function GeneralStream({
         if (!topic) return null
         const mark = getTopicLastReadAt(org.id, space.id, topicId)
         const hasNew = !mark || topic.lastActivityAt > mark
+        // A renamed thread shows its name on the chip; auto-titled ones stay compact.
+        const named = explicitTitle(topic, threads.byTopic.get(topicId)?.firstMessage?.body)
         return {
             topicId,
             replyCount: Math.max(0, topic.messageCount - 1),
@@ -103,6 +105,7 @@ export function GeneralStream({
             // Count isn't known without the thread's messages; 1 reads as "has new" on the row.
             unreadCount: hasNew && topic.messageCount > 1 ? 1 : 0,
             workingAgents: presence.working.get(topicId) ?? [],
+            title: named ? resolveMentions(named, memberNames) : null,
         }
     }
 

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -130,6 +130,8 @@ export interface ThreadRowData {
     lastActivityAt: string
     unreadCount: number
     workingAgents: string[]
+    /** The topic's explicit name (renamed by someone), mentions already resolved; null while auto-titled. */
+    title?: string | null
 }
 
 export function MessageRow({
@@ -199,7 +201,8 @@ export function MessageRow({
                         className="mt-1.5 inline-flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1 text-xs hover:border-foreground/30"
                     >
                         <MessageSquare className="size-3 text-muted-foreground" />
-                        <span className={cn(thread.unreadCount > 0 ? 'font-bold' : 'font-semibold')}>
+                        {thread.title && <span className="max-w-48 truncate font-semibold">{thread.title}</span>}
+                        <span className={cn(thread.unreadCount > 0 ? 'font-bold' : 'font-semibold', thread.title && 'font-normal text-muted-foreground')}>
                             {thread.replyCount} {thread.replyCount === 1 ? 'reply' : 'replies'}
                         </span>
                         {thread.unreadCount > 0 && <span className="font-semibold text-orange-600">{thread.unreadCount} new</span>}

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,11 +1,16 @@
 import { useMemo, useRef, useState } from 'react'
-import { Bot, FileText, Folder, MessagesSquare, Pin, Plus, Search, Upload } from 'lucide-react'
+import { Archive, ArchiveRestore, Bot, FileText, Folder, MessagesSquare, MoreHorizontal, Pencil, Pin, Plus, Search, Upload } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
+import {
+    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { toast } from '@/lib/toast'
 import { FileTree } from '@/components/spaces/files-tab'
+import { refreshSpaceFeed } from '@/hooks/use-spaces'
 import type { GeneralState, SpacePresence, ThreadIndex } from '@/hooks/use-space-chat'
 import { useMemberNames } from '@/components/spaces/member-text'
-import { isGeneralSeedMessage, stripThreadMarker, threadRefOf } from '@/lib/spaces-conventions'
+import { explicitTitle, isGeneralSeedMessage, stripThreadMarker, threadRefOf } from '@/lib/spaces-conventions'
 import { formatFeedTime, resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt } from '@/lib/spaces-read-state'
 import type { RailSelection } from '@/lib/spaces-selection'
@@ -46,6 +51,22 @@ export function SpaceRail({
     const [creatingFile, setCreatingFile] = useState(false)
     const uploadInputRef = useRef<HTMLInputElement | null>(null)
 
+    // Row-level topic actions. Rename edits inline in the row; the topic event
+    // the server emits updates every other client, the refresh updates this one.
+    const [renaming, setRenaming] = useState<{ topicId: string; value: string } | null>(null)
+    const manageTopic = async (topicId: string, action: spaces.SpacesManageTopicAction) => {
+        try {
+            await window.ipc.invoke('spaces:manageTopic', { orgId, spaceId, topicId, action })
+            await refreshSpaceFeed(orgId, spaceId)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not update the topic', 'error')
+        }
+    }
+    const commitRename = async (topicId: string, title: string) => {
+        setRenaming(null)
+        await manageTopic(topicId, { action: 'retitle', title })
+    }
+
     const generalId = general.topic?.id ?? null
 
     const generalUnread = useMemo(() => {
@@ -81,7 +102,10 @@ export function SpaceRail({
         .filter((t) => (filter === 'unread' ? isUnread(t) : true))
         .map((t) => {
             const info = threads.byTopic.get(t.id)
-            const raw = info?.parentMessageId && info.firstMessage ? stripThreadMarker(info.firstMessage.body).split('\n')[0] ?? t.title : t.title
+            // A renamed topic shows its name; an auto-titled thread keeps
+            // showing its seed text (its derived title is a noisy quote).
+            const named = explicitTitle(t, info?.firstMessage?.body)
+            const raw = named ?? (info?.parentMessageId && info.firstMessage ? stripThreadMarker(info.firstMessage.body).split('\n')[0] ?? t.title : t.title)
             // Titles resolve before the search filter so searching a person's
             // name finds the topics that mention them.
             return { topic: t, title: resolveMentions(raw, memberNames) }
@@ -202,31 +226,75 @@ export function SpaceRail({
                                     const replies = Math.max(0, topic.messageCount - 1)
                                     const files = artifactFiles.get(topic.id)
                                     const working = (presence.working.get(topic.id) ?? []).length > 0
+                                    if (renaming?.topicId === topic.id) {
+                                        return (
+                                            <div key={topic.id} className="rounded-md px-2 py-1.5">
+                                                <input
+                                                    autoFocus
+                                                    value={renaming.value}
+                                                    onChange={(e) => setRenaming({ topicId: topic.id, value: e.target.value })}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === 'Enter' && renaming.value.trim()) void commitRename(topic.id, renaming.value.trim())
+                                                        if (e.key === 'Escape') setRenaming(null)
+                                                    }}
+                                                    onBlur={() => setRenaming(null)}
+                                                    className="w-full rounded-md border border-foreground/30 bg-background px-1.5 py-0.5 text-[13px] leading-snug outline-none"
+                                                    placeholder="Topic name"
+                                                />
+                                            </div>
+                                        )
+                                    }
                                     return (
-                                        <button
-                                            key={topic.id}
-                                            type="button"
-                                            onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
-                                            className={cn(
-                                                'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
-                                                active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
-                                                topic.archived && 'opacity-60',
-                                            )}
-                                        >
-                                            <div className="flex items-center gap-1.5">
-                                                <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
-                                                {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
-                                            </div>
-                                            <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
-                                                <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
-                                                <span>· {formatFeedTime(topic.lastActivityAt)}</span>
-                                                {files && files.size > 0 && (
-                                                    <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
+                                        <div key={topic.id} className="group/topicrow relative">
+                                            <button
+                                                type="button"
+                                                onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
+                                                className={cn(
+                                                    'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
+                                                    active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
+                                                    topic.archived && 'opacity-60',
                                                 )}
-                                                {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
-                                                {topic.archived && <span>· archived</span>}
-                                            </div>
-                                        </button>
+                                            >
+                                                <div className="flex items-center gap-1.5">
+                                                    <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
+                                                    {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
+                                                </div>
+                                                <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
+                                                    <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
+                                                    <span>· {formatFeedTime(topic.lastActivityAt)}</span>
+                                                    {files && files.size > 0 && (
+                                                        <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
+                                                    )}
+                                                    {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
+                                                    {topic.archived && <span>· archived</span>}
+                                                </div>
+                                            </button>
+                                            <DropdownMenu>
+                                                <DropdownMenuTrigger asChild>
+                                                    <button
+                                                        type="button"
+                                                        aria-label="Topic actions"
+                                                        className="absolute right-1 top-1 hidden size-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground group-hover/topicrow:inline-flex data-[state=open]:inline-flex"
+                                                    >
+                                                        <MoreHorizontal className="size-3.5" />
+                                                    </button>
+                                                </DropdownMenuTrigger>
+                                                <DropdownMenuContent align="end">
+                                                    <DropdownMenuItem onClick={() => setRenaming({ topicId: topic.id, value: title })}>
+                                                        <Pencil className="size-3.5 mr-2" /> Rename
+                                                    </DropdownMenuItem>
+                                                    {topic.archived ? (
+                                                        <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'unarchive' })}>
+                                                            <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
+                                                        </DropdownMenuItem>
+                                                    ) : (
+                                                        <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'archive' })}>
+                                                            <Archive className="size-3.5 mr-2" /> Archive
+                                                        </DropdownMenuItem>
+                                                    )}
+                                                </DropdownMenuContent>
+                                            </DropdownMenu>
+                                        </div>
                                     )
                                 })}
                                 {topicRows.length === 0 && (

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -14,7 +14,7 @@ import { MessageRow, NewDivider, TypingIndicator } from '@/components/spaces/mes
 import type { SpacePresence, ThreadInfo } from '@/hooks/use-space-chat'
 import { usePresenceSender } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
-import { artifactsForThread, isContinuation, stripThreadMarker } from '@/lib/spaces-conventions'
+import { artifactsForThread, explicitTitle, isContinuation, stripThreadMarker } from '@/lib/spaces-conventions'
 import { attributionLabel, formatFeedTime, shortId } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
@@ -159,6 +159,17 @@ export function ThreadPane({
         }
     }
 
+    // Inline title editing (window.prompt is a no-op in Electron — the old
+    // Retitle item died silently). null = not editing.
+    const [editingTitle, setEditingTitle] = useState<string | null>(null)
+    const named = topic ? explicitTitle(topic, (threadInfo?.firstMessage ?? messages[0])?.body ?? null) : null
+    const commitTitle = async () => {
+        const title = editingTitle?.trim()
+        setEditingTitle(null)
+        if (!title || title === topic?.title) return
+        await manage({ action: 'retitle', title })
+    }
+
     const openTopicSession = async () => {
         try {
             const { sessionId } = await window.ipc.invoke('spaces:topicSession', { orgId: org.id, spaceId: space.id, topicId })
@@ -208,7 +219,25 @@ export function ThreadPane({
                 )}
                 <span className="pl-1 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topic</span>
                 <span className="truncate text-xs text-muted-foreground">
-                    {isThread ? 'from a message' : <MemberText text={topic?.title ?? ''} />}{groups.length > 0 ? ` · ${groups.length} ${groups.length === 1 ? 'file' : 'files'} changed` : ''}
+                    {editingTitle !== null ? (
+                        <input
+                            autoFocus
+                            value={editingTitle}
+                            onChange={(e) => setEditingTitle(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') void commitTitle()
+                                if (e.key === 'Escape') setEditingTitle(null)
+                            }}
+                            onBlur={() => setEditingTitle(null)}
+                            placeholder="Topic name"
+                            className="w-64 rounded-md border border-foreground/30 bg-background px-1.5 py-0.5 text-xs text-foreground outline-none"
+                        />
+                    ) : (
+                        <>
+                            {isThread ? (named ? <MemberText text={named} /> : 'from a message') : <MemberText text={topic?.title ?? ''} />}
+                            {groups.length > 0 ? ` · ${groups.length} ${groups.length === 1 ? 'file' : 'files'} changed` : ''}
+                        </>
+                    )}
                 </span>
                 <span className="flex-1" />
                 {topic?.archived && <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10.5px] text-muted-foreground">archived</span>}
@@ -217,13 +246,8 @@ export function ThreadPane({
                         <Button variant="ghost" size="icon" className="size-7 text-muted-foreground"><MoreHorizontal className="size-4" /></Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                            onClick={() => {
-                                const title = window.prompt('New title', topic?.title ?? '')
-                                if (title?.trim()) void manage({ action: 'retitle', title: title.trim() })
-                            }}
-                        >
-                            <Pencil className="size-3.5 mr-2" /> Retitle
+                        <DropdownMenuItem onClick={() => setEditingTitle(named ?? topic?.title ?? '')}>
+                            <Pencil className="size-3.5 mr-2" /> Rename
                         </DropdownMenuItem>
                         {topic?.archived ? (
                             <DropdownMenuItem onClick={() => void manage({ action: 'unarchive' })}><ArchiveRestore className="size-3.5 mr-2" /> Unarchive</DropdownMenuItem>

--- a/apps/x/apps/renderer/src/lib/spaces-conventions.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-conventions.test.ts
@@ -4,6 +4,8 @@ import {
     applyReaction,
     artifactsForThread,
     buildThreadSeed,
+    deriveTopicTitle,
+    explicitTitle,
     findGeneralTopic,
     formatDayLabel,
     isContinuation,
@@ -95,6 +97,32 @@ describe('topic-from-message marker', () => {
         expect(stripThreadMarker(seed)).toBe('Standup — Wed. Shipped the copy pass.\nBlocked on SSO.')
         expect(parseThreadMarker('just a message')).toBeNull()
         expect(stripThreadMarker('just a message')).toBe('just a message')
+    })
+})
+
+describe('topic titles — derived vs explicitly renamed', () => {
+    it('deriveTopicTitle mirrors the server: first non-empty line, heading/bullet stripped, capped', () => {
+        expect(deriveTopicTitle('# Ship it\ndetails')).toBe('Ship it')
+        expect(deriveTopicTitle('\n\n- first bullet\nmore')).toBe('first bullet')
+        expect(deriveTopicTitle('   ')).toBe('Untitled')
+        const long = 'x'.repeat(300)
+        expect(deriveTopicTitle(long)).toBe(`${'x'.repeat(255)}…`)
+    })
+
+    it('a topic still wearing its auto-derived title has no explicit name', () => {
+        const seed = buildThreadSeed(msg({ id: '01J9PARENT', body: 'Standup — Wed. Shipped the copy pass.' }))
+        const t = topic({ id: '01J9TOPIC', title: deriveTopicTitle(seed) })
+        expect(explicitTitle(t, seed)).toBeNull()
+        // No first message loaded yet → stay compact rather than guessing.
+        expect(explicitTitle(t, null)).toBeNull()
+    })
+
+    it('a renamed topic surfaces its name — and renaming never touches the message body', () => {
+        const seed = buildThreadSeed(msg({ id: '01J9PARENT', body: 'Standup — Wed. Shipped the copy pass.' }))
+        const renamed = topic({ id: '01J9TOPIC', title: 'SSO rollout' })
+        expect(explicitTitle(renamed, seed)).toBe('SSO rollout')
+        // The seed (the first message) is an input, never an output: unchanged.
+        expect(stripThreadMarker(seed)).toBe('Standup — Wed. Shipped the copy pass.')
     })
 })
 

--- a/apps/x/apps/renderer/src/lib/spaces-conventions.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-conventions.ts
@@ -67,6 +67,36 @@ export function stripThreadMarker(body: string): string {
     return body.replace(MARKER_RE, '').trimEnd()
 }
 
+/**
+ * Mirror of the server's title derivation at topic creation (service.ts
+ * deriveTitle): first non-empty line, markdown heading/bullet prefixes
+ * stripped, 256-capped. Exists so clients can tell an auto-derived title
+ * from an explicit rename — renaming never touches the first message, it
+ * only overwrites the title property, so "was it renamed?" is exactly
+ * "does the title still equal what creation would have derived?".
+ */
+export function deriveTopicTitle(body: string): string {
+    const firstLine = body
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l.length > 0)
+    if (!firstLine) return 'Untitled'
+    const stripped = firstLine.replace(/^#{1,6}\s+/, '').replace(/^[-*]\s+/, '').trim()
+    const title = stripped.length > 0 ? stripped : firstLine
+    return title.length > 256 ? `${title.slice(0, 255)}…` : title
+}
+
+/**
+ * The topic's explicit name — set by a human retitle or an agent's
+ * housekeeping — or null while it still wears its auto-derived title.
+ * Unnamed threads stay compact everywhere (chip shows "N replies", rail
+ * shows the seed text); a real name is worth showing in all those places.
+ */
+export function explicitTitle(topic: spaces.Topic, firstMessageBody: string | null | undefined): string | null {
+    if (!firstMessageBody) return null
+    return topic.title === deriveTopicTitle(firstMessageBody) ? null : topic.title
+}
+
 // ---------------------------------------------------------------------------
 // Artifacts — change-sets made from a topic carry its id at the end of the
 // reason. Two producers only: the Fold gesture and the topic agent's prompt.


### PR DESCRIPTION
The whole retitle stack already existed (contract \`manageTopic\`, server + topic-event fan-out, MCP \`manage_topic\`, IPC) — and the thread pane even shipped a Retitle menu item that was silently dead: it used \`window.prompt\`, which Electron deliberately doesn't implement. This PR makes renaming real and visible.

## What's new

- **Thread pane**: ⋯ → Rename turns the header title into an inline input (Enter saves, Esc cancels).
- **Rail**: topic rows get a hover ⋯ menu with Rename (inline, in place) and Archive/Unarchive.
- **Named threads show their name everywhere**: the rail previously ignored \`topic.title\` for message-born threads (auto-derived titles are noisy quotes), so a rename was invisible there. A client-side mirror of the server's title derivation now distinguishes explicit renames from auto titles — renamed threads show their name in the rail, the thread-pane header, and on the reply chip under the original message in the parent topic; auto-titled threads keep the compact look.

## Guarantees

- Renaming writes only \`Topic.title\` — the first message that started the topic is byte-identical before and after (append-only messages; no mutation path exists).
- Teammates see renames live with zero new wire surface: retitle already emits a \`topic\` event.

Verified: typecheck + lint clean; 322 renderer tests (4 new: derive-mirror + explicit-title semantics, including "renaming never touches the message body").

🤖 Generated with [Claude Code](https://claude.com/claude-code)