### PR TITLE
feat(x): Phase 5 — code-mode & terminal to rowboat-server (23 channels)

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -78,7 +78,7 @@ import { HomeThreadsTracker } from '@x/core/dist/home/threads.js';
 import type { CodeModeManager } from '@x/core/dist/code-mode/acp/manager.js';
 import * as codeGit from '@x/core/dist/code-mode/git/service.js';
 import { readProjectDir, readProjectFile } from '@x/core/dist/code-mode/projects/fs.js';
-import { ensureTerminal, writeTerminal, resizeTerminal, disposeTerminal } from './terminal.js';
+import { ensureTerminal, writeTerminal, resizeTerminal, disposeTerminal, subscribeTerminalEvents } from '@x/core/dist/terminal/terminal.js';
 import type { CodeSession } from '@x/shared/dist/code-sessions.js';
 import { invalidateCopilotInstructionsCache } from '@x/core/dist/runtime/assembly/copilot/instructions.js';
 import { triggerSync as triggerGranolaSync } from '@x/core/dist/knowledge/granola/sync.js';
@@ -590,6 +590,13 @@ function emitServiceEvent(event: z.infer<typeof ServiceEvent>): void {
 
 // Connector state pushes now originate in core (oauth-flows/composio/chatgpt
 // buses); this watcher relays them to renderer windows.
+let terminalEventsWatcher = false;
+export function startTerminalEventsWatcher(): void {
+  if (terminalEventsWatcher) return;
+  terminalEventsWatcher = true;
+  subscribeTerminalEvents((e) => broadcastToWindows(e.channel, e.payload));
+}
+
 let connectorEventsWatcher = false;
 export function startConnectorEventsWatcher(): void {
   if (connectorEventsWatcher) return;

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import {
   setupIpcHandlers,
   startConnectorEventsWatcher,
+  startTerminalEventsWatcher,
   findMainAppWindow,
   startRunsWatcher, startSessionsWatcher, startTurnEventsWatcher, markSessionsIndexReady, startRetentionSweep,
   startCodeRunFeedWatcher,
@@ -20,7 +21,7 @@ import {
   stopServicesWatcher,
   stopWorkspaceWatcher
 } from "./ipc.js";
-import { disposeAllTerminals } from "./terminal.js";
+import { disposeAllTerminals } from "@x/core/dist/terminal/terminal.js";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname } from "node:path";
 import { initUpdater } from "./updater.js";
@@ -714,6 +715,7 @@ app.whenReady().then(async () => {
   }
   startSessionsWatcher();
   startConnectorEventsWatcher();
+  startTerminalEventsWatcher();
   // Daily auto-delete of old chats & task transcripts (delayed first run).
   startRetentionSweep();
   // Turn event spine: durable events of every turn (session, headless,

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -230,6 +230,32 @@ export const RPC_CHANNELS = [
   'bg-task:create',
   'bg-task:delete',
   'bg-task:stop',
+  // Phase 5 (SEPARATION_PLAN.md): code-mode & terminal — the PTY lives with
+  // core now (RFC Q13: the terminal shows the machine core runs on).
+  // codeMode:provisionEngine stays client-local (sender-scoped progress).
+  'codeRun:resolvePermission',
+  'codeMode:getConfig',
+  'codeMode:setConfig',
+  'codeMode:checkAgentStatus',
+  'codeMode:listModelOptions',
+  'codeProject:add',
+  'codeProject:remove',
+  'codeProject:list',
+  'codeSession:create',
+  'codeSession:list',
+  'codeSession:update',
+  'codeSession:delete',
+  'codeSession:stop',
+  'codeSession:gitStatus',
+  'codeSession:fileDiff',
+  'codeSession:readdir',
+  'codeSession:readFile',
+  'codeSession:mergeBack',
+  'codeSession:cleanupWorktree',
+  'terminal:ensure',
+  'terminal:input',
+  'terminal:resize',
+  'terminal:dispose',
 ] as const satisfies readonly ipc.InvokeChannels[];
 
 export type RpcChannel = (typeof RPC_CHANNELS)[number];

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -106,6 +106,27 @@ import { classifySchedule, processRowboatInstruction } from '@x/core/dist/knowle
 import { summarizeMeeting } from '@x/core/dist/knowledge/summarize_meeting.js';
 import { runLiveNoteAgent } from '@x/core/dist/knowledge/live-note/runner.js';
 import { runBackgroundTask } from '@x/core/dist/background-tasks/runner.js';
+import type { ICodeModeConfigRepo } from '@x/core/dist/code-mode/repo.js';
+import type { CodePermissionRegistry } from '@x/core/dist/code-mode/acp/permission-registry.js';
+import { checkCodeModeAgentStatus } from '@x/core/dist/code-mode/status.js';
+import type { ICodeProjectsRepo } from '@x/core/dist/code-mode/projects/repo.js';
+import type { ICodeSessionsRepo } from '@x/core/dist/code-mode/sessions/repo.js';
+import type { CodeSessionService } from '@x/core/dist/code-mode/sessions/service.js';
+import type { CodeSessionStatusTracker } from '@x/core/dist/code-mode/sessions/status-tracker.js';
+import type { CodeModeManager } from '@x/core/dist/code-mode/acp/manager.js';
+import * as codeGit from '@x/core/dist/code-mode/git/service.js';
+import { readProjectDir, readProjectFile } from '@x/core/dist/code-mode/projects/fs.js';
+import type { CodeSession } from '@x/shared/dist/code-sessions.js';
+import { ensureTerminal, writeTerminal, resizeTerminal, disposeTerminal, subscribeTerminalEvents } from '@x/core/dist/terminal/terminal.js';
+
+async function requireCodeSession(sessionId: string): Promise<CodeSession> {
+  const repo = container.resolve<ICodeSessionsRepo>('codeSessionsRepo');
+  const session = await repo.get(sessionId);
+  if (!session) {
+    throw new Error(`Unknown code session: ${sessionId}`);
+  }
+  return session;
+}
 
 // Process-local caches mirrored from apps/main/src/ipc.ts — memoization only,
 // no cross-process invariants (each host keeps its own).
@@ -1327,6 +1348,141 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
         return { success: false, error: err instanceof Error ? err.message : String(err) };
       }
     },
+    // ── Phase 5: code-mode & terminal (verbatim lifts) ──
+    'codeRun:resolvePermission': async (args) => {
+      const registry = container.resolve<CodePermissionRegistry>('codePermissionRegistry');
+      registry.resolve(args.requestId, args.decision);
+      return { success: true };
+    },
+    'codeMode:getConfig': async () => {
+      const repo = container.resolve<ICodeModeConfigRepo>('codeModeConfigRepo');
+      const config = await repo.getConfig();
+      return { enabled: config.enabled, approvalPolicy: config.approvalPolicy, defaultProjectId: config.defaultProjectId };
+    },
+    'codeMode:setConfig': async (args) => {
+      const repo = container.resolve<ICodeModeConfigRepo>('codeModeConfigRepo');
+      await repo.setConfig({ enabled: args.enabled, approvalPolicy: args.approvalPolicy, defaultProjectId: args.defaultProjectId });
+      invalidateCopilotInstructionsCache();
+      return { success: true };
+    },
+    'codeMode:checkAgentStatus': async () => {
+      return await checkCodeModeAgentStatus();
+    },
+    'codeMode:listModelOptions': async (args) => {
+      const manager = container.resolve<CodeModeManager>('codeModeManager');
+      return manager.listModelOptions(args.agent);
+    },
+    'codeProject:add': async (args) => {
+      const repo = container.resolve<ICodeProjectsRepo>('codeProjectsRepo');
+      const project = await repo.add(args.path);
+      const git = await codeGit.repoInfo(project.path);
+      return { project, git };
+    },
+    'codeProject:remove': async (args) => {
+      const repo = container.resolve<ICodeProjectsRepo>('codeProjectsRepo');
+      await repo.remove(args.projectId);
+      return { success: true };
+    },
+    'codeProject:list': async () => {
+      const repo = container.resolve<ICodeProjectsRepo>('codeProjectsRepo');
+      const projects = await repo.list();
+      return {
+        projects: await Promise.all(projects.map(async (project) => ({
+          project,
+          git: await codeGit.repoInfo(project.path),
+        }))),
+      };
+    },
+    'codeSession:create': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      const session = await service.create(args);
+      capture('code_session_created', { agent: session.agent });
+      return { session };
+    },
+    'codeSession:list': async () => {
+      const repo = container.resolve<ICodeSessionsRepo>('codeSessionsRepo');
+      const tracker = container.resolve<CodeSessionStatusTracker>('codeSessionStatusTracker');
+      return { sessions: await repo.list(), statuses: tracker.getStatuses() };
+    },
+    'codeSession:update': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      return { session: await service.update(args.sessionId, args.patch) };
+    },
+    'codeSession:delete': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      disposeTerminal(args.sessionId);
+      await service.delete(args.sessionId, {
+        removeWorktree: args.removeWorktree,
+        deleteBranch: args.deleteBranch,
+      });
+      return { success: true };
+    },
+    'codeSession:stop': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      await service.stop(args.sessionId);
+      return { success: true };
+    },
+    'codeSession:gitStatus': async (args) => {
+      const session = await requireCodeSession(args.sessionId);
+      const info = await codeGit.repoInfo(session.cwd);
+      if (!info.isGitRepo) {
+        return { isRepo: false, branch: null, hasCommits: false, files: [] };
+      }
+      let files = await codeGit.status(session.cwd);
+      if (session.worktree && !session.worktree.removedAt && session.worktree.baseBranch) {
+        const branchFiles = await codeGit.changedSinceBase(session.cwd, session.worktree.baseBranch);
+        const byPath = new Map(branchFiles.map((file) => [file.path, file]));
+        for (const file of files) {
+          if (!byPath.has(file.path)) byPath.set(file.path, file);
+        }
+        files = [...byPath.values()];
+      }
+      return { isRepo: true, branch: info.branch, hasCommits: info.hasCommits, files };
+    },
+    'codeSession:fileDiff': async (args) => {
+      const session = await requireCodeSession(args.sessionId);
+      return codeGit.fileDiff(session.cwd, args.path, {
+        baseRef: session.worktree && !session.worktree.removedAt ? session.worktree.baseBranch : null,
+      });
+    },
+    'codeSession:readdir': async (args) => {
+      const session = await requireCodeSession(args.sessionId);
+      return { entries: await readProjectDir(session.cwd, args.relPath) };
+    },
+    'codeSession:readFile': async (args) => {
+      const session = await requireCodeSession(args.sessionId);
+      return readProjectFile(session.cwd, args.relPath);
+    },
+    'codeSession:mergeBack': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      return service.mergeBack(args.sessionId);
+    },
+    'codeSession:cleanupWorktree': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      try {
+        await service.cleanupWorktree(args.sessionId, args.deleteBranch);
+        return { success: true };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to clean up worktree';
+        return { success: false, error: message };
+      }
+    },
+    'terminal:ensure': async (args) => {
+      return ensureTerminal(args.id, args.cwd, args.cols, args.rows);
+    },
+    'terminal:input': async (args) => {
+      writeTerminal(args.id, args.data);
+      return { success: true };
+    },
+    'terminal:resize': async (args) => {
+      resizeTerminal(args.id, args.cols, args.rows);
+      return { success: true };
+    },
+    'terminal:dispose': async (args) => {
+      disposeTerminal(args.id);
+      return { success: true };
+    },
+
 
     // Rowboat Apps handlers (spec §13)
 
@@ -1345,6 +1501,7 @@ export function createCoreEventSources(): EventSources {
     subscribeOAuthEvents: (listener) => oauthConnectBus.subscribe(listener),
     subscribeComposioEvents: (listener) => composioConnectBus.subscribe(listener),
     subscribeChatgptEvents: (listener) => chatgptStatusBus.subscribe(listener),
+    subscribeTerminalEvents: (listener) => subscribeTerminalEvents(listener),
   };
 }
 

--- a/apps/x/apps/server/src/server.ts
+++ b/apps/x/apps/server/src/server.ts
@@ -27,6 +27,7 @@ export interface EventSources {
   subscribeOAuthEvents?(listener: (e: unknown) => void): () => void;
   subscribeComposioEvents?(listener: (e: unknown) => void): () => void;
   subscribeChatgptEvents?(listener: (e: unknown) => void): () => void;
+  subscribeTerminalEvents?(listener: (e: { channel: 'terminal:data' | 'terminal:exit'; payload: unknown }) => void): () => void;
 }
 
 export interface RowboatServerOptions {
@@ -183,6 +184,7 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
     opts.events.subscribeOAuthEvents?.((e) => hub.broadcast('oauth:didConnect', e)),
     opts.events.subscribeComposioEvents?.((e) => hub.broadcast('composio:didConnect', e)),
     opts.events.subscribeChatgptEvents?.((e) => hub.broadcast('chatgpt:statusChanged', e)),
+    opts.events.subscribeTerminalEvents?.((e) => hub.broadcast(e.channel, e.payload)),
   ];
 
   return {

--- a/apps/x/apps/server/src/ws-hub.ts
+++ b/apps/x/apps/server/src/ws-hub.ts
@@ -21,7 +21,9 @@ export type PushChannel =
   | 'workspace:didChange'
   | 'oauth:didConnect'
   | 'composio:didConnect'
-  | 'chatgpt:statusChanged';
+  | 'chatgpt:statusChanged'
+  | 'terminal:data'
+  | 'terminal:exit';
 
 const ClientMessage = z.discriminatedUnion('type', [
   z.object({

--- a/apps/x/packages/client/src/events.ts
+++ b/apps/x/packages/client/src/events.ts
@@ -15,7 +15,9 @@ export type PushChannel =
   | 'workspace:didChange'
   | 'oauth:didConnect'
   | 'composio:didConnect'
-  | 'chatgpt:statusChanged';
+  | 'chatgpt:statusChanged'
+  | 'terminal:data'
+  | 'terminal:exit';
 
 interface ServerMessage {
   seq: number;

--- a/apps/x/packages/core/package.json
+++ b/apps/x/packages/core/package.json
@@ -42,6 +42,7 @@
     "isomorphic-git": "^1.29.0",
     "mammoth": "^1.11.0",
     "node-html-markdown": "^2.0.0",
+    "node-pty": "^1.1.0",
     "ollama-ai-provider-v2": "^4.0.1",
     "openid-client": "^6.8.1",
     "papaparse": "^5.5.3",

--- a/apps/x/packages/core/src/terminal/terminal.ts
+++ b/apps/x/packages/core/src/terminal/terminal.ts
@@ -1,4 +1,3 @@
-import { BrowserWindow } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -21,12 +20,21 @@ interface TerminalEntry {
 
 const terminals = new Map<string, TerminalEntry>();
 
+// PTY output fan-out is host-agnostic: Electron main relays to its windows,
+// rowboat-server relays to WS clients (broadcast-to-all, per RFC Q12/Q13).
+export type TerminalEvent =
+  | { channel: 'terminal:data'; payload: { id: string; data: string } }
+  | { channel: 'terminal:exit'; payload: { id: string; exitCode: number } };
+
+const terminalListeners = new Set<(e: TerminalEvent) => void>();
+export function subscribeTerminalEvents(listener: (e: TerminalEvent) => void): () => void {
+  terminalListeners.add(listener);
+  return () => terminalListeners.delete(listener);
+}
+
 function broadcast(channel: 'terminal:data' | 'terminal:exit', payload: unknown): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed() && win.webContents) {
-      win.webContents.send(channel, payload);
-    }
-  }
+  const event = { channel, payload } as TerminalEvent;
+  for (const l of terminalListeners) l(event);
 }
 
 // pnpm extracts node-pty's prebuilt macOS spawn-helper without its executable

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -676,6 +676,9 @@ importers:
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       ollama-ai-provider-v2:
         specifier: ^4.0.1
         version: 4.0.1(ai@7.0.22(zod@4.2.1))(zod@4.2.1)
@@ -1075,10 +1078,6 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
@@ -1097,10 +1096,6 @@ packages:
 
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
@@ -1143,12 +1138,6 @@ packages:
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
@@ -1198,10 +1187,6 @@ packages:
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.29.7':
@@ -9346,10 +9331,6 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   posthog-js@1.332.0:
     resolution: {integrity: sha512-w3+sL+IFK4mpfFmgTW7On8cR+z34pre+SOewx+eHZQSYF9RYqXsLIhrxagWbQKkowPd4tCwUHrkS1+VHsjnPqA==}
 
@@ -12005,21 +11986,19 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
-
   '@babel/compat-data@7.29.7': {}
 
   '@babel/core@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -12049,19 +12028,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/helper-compilation-targets@7.27.2':
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -12121,15 +12092,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -12180,8 +12142,6 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
-
   '@babel/helper-validator-option@7.29.7': {}
 
   '@babel/helper-wrap-function@7.29.7':
@@ -12194,8 +12154,8 @@ snapshots:
 
   '@babel/helpers@7.28.4':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.28.5':
     dependencies:
@@ -19330,9 +19290,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.5
 
   fetch-blob@3.2.0:
     dependencies:
@@ -22179,12 +22139,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   posthog-js@1.332.0:
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -23655,8 +23609,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
@@ -24048,9 +24002,9 @@ snapshots:
   vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
       rollup: 4.54.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -24064,9 +24018,9 @@ snapshots:
   vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
       rollup: 4.54.0
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
Phase 5 of [SEPARATION_PLAN.md](https://github.com/rowboatlabs/rowboat/blob/arch/server-client-separation/apps/x/SEPARATION_PLAN.md) — the RFC Q13 move. **226 of 356 channels on the frontier.**

**The PTY lives with core now**: `terminal.ts` moves from main into `@x/core` (`terminal/terminal.ts`); its window broadcast becomes `subscribeTerminalEvents`, relayed by main to windows and by the WS hub to network clients (new push channels `terminal:data`/`terminal:exit`, broadcast-to-all per Q12). `node-pty` becomes a core dependency (still external to the esbuild bundle).

**Migrated:** `codeMode:` config/status/model-options · `codeProject:` add/remove/list · `codeSession:` create/list/update/delete/stop/gitStatus/fileDiff/readdir/readFile/mergeBack/cleanupWorktree · `codeRun:resolvePermission` · `terminal:` ensure/input/resize/dispose. `codeMode:provisionEngine` stays client-local (sender-scoped progress stream).

**Verified live — terminal over the wire**: PTY spawned via `terminal:ensure` (HTTP), `echo hello-p5` typed via `terminal:input`, output received on the WS `terminal:data` feed, disposed cleanly. Code-mode channels answering. 18 server + 717 core + 288 renderer tests green; full typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)