### PR TITLE
feat(x): Phase 7a — child-server mode + reverse-call protocol (flag-gated)

### DIFF
--- a/apps/x/apps/main/forge.config.cjs
+++ b/apps/x/apps/main/forge.config.cjs
@@ -399,6 +399,14 @@ module.exports = {
                 stdio: 'inherit'
             });
 
+            // Build client (TypeScript compilation) - depends on shared;
+            // main imports it for the child-server events bridge
+            console.log('Building client...');
+            execSync('pnpm run build', {
+                cwd: path.join(__dirname, '../../packages/client'),
+                stdio: 'inherit'
+            });
+
             // Build renderer (Vite build) - depends on shared
             console.log('Building renderer...');
             execSync('pnpm run build', {

--- a/apps/x/apps/main/package.json
+++ b/apps/x/apps/main/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@agentclientprotocol/claude-agent-acp": "^0.67.0",
         "@agentclientprotocol/codex-acp": "^1.2.0",
+        "@x/client": "workspace:*",
         "@x/core": "workspace:*",
         "@x/server": "workspace:*",
         "@x/shared": "workspace:*",

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -54,7 +54,7 @@ import type { ISessions, EmitterSessionBus } from '@x/core/dist/runtime/sessions
 import type { ITurnEventBus } from '@x/core/dist/runtime/turns/event-hub.js';
 import container from '@x/core/dist/di/container.js';
 import { forwardRpc, shouldForwardChannel } from './rpc-forwarder.js';
-import { getPairingInfo, rotateKey as rotateServerKey, setLanEnabled as setServerLanEnabled } from './server-host.js';
+import { getPairingInfo, rotateKey as rotateServerKey, setLanEnabled as setServerLanEnabled, bridgeDeltaSubscribe, bridgeDeltaUnsubscribe, childServerMode } from './server-host.js';
 import { testModelConnection, listModelsForProvider, generateOneShot } from '@x/core/dist/models/models.js';
 import { getModelCatalog } from '@x/core/dist/models/catalog.js';
 import { captureProviderConnected, captureProviderDisconnected } from '@x/core/dist/analytics/model-providers.js';
@@ -570,7 +570,7 @@ export function stopWorkspaceWatcher(): void {
 // The one renderer fan-out: send a payload to every live window on a channel.
 // All broadcast feeds (runs, services, sessions, turns, code runs, agent
 // status) go through here.
-function broadcastToWindows(channel: string, payload: unknown): void {
+export function broadcastToWindows(channel: string, payload: unknown): void {
   const windows = BrowserWindow.getAllWindows();
   for (const win of windows) {
     if (!win.isDestroyed() && win.webContents) {
@@ -1446,10 +1446,14 @@ export function setupIpcHandlers() {
     },
     'turns:subscribe': async (event, args) => {
       subscribeTurnDeltas(event.sender, args.turnId);
+      // Child-server mode: deltas arrive over the WS feed, so mirror the
+      // window's interest onto the wire subscription.
+      if (childServerMode()) bridgeDeltaSubscribe(args.turnId);
       return { success: true };
     },
     'turns:unsubscribe': async (event, args) => {
       unsubscribeTurnDeltas(event.sender, args.turnId);
+      if (childServerMode()) bridgeDeltaUnsubscribe(args.turnId);
       return { success: true };
     },
     'sessions:downloadLog': async (event, args) => {

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -27,7 +27,7 @@ import { dirname } from "node:path";
 import { initUpdater } from "./updater.js";
 import { DEV_SERVER_URL } from "./dev-server.js";
 import { stopSkillsWatcher } from "@x/core/dist/runtime/assembly/skills/watcher.js";
-import { init as initAppsServer, shutdown as shutdownAppsServer } from "@x/core/dist/apps/server.js";
+import { shutdown as shutdownAppsServer } from "@x/core/dist/apps/server.js";
 import { registerAppsHostApi } from "@x/core/dist/apps/host-api.js";
 import { setTokenCipher as setGithubTokenCipher } from "@x/core/dist/apps/github-auth.js";
 import { setTokenCipher as setChatGPTTokenCipher } from "@x/core/dist/auth/chatgpt-auth.js";
@@ -37,7 +37,7 @@ import { syncModelProviderPersonProperties } from "@x/core/dist/analytics/model-
 
 import { initConfigs } from "@x/core/dist/config/initConfigs.js";
 import { prepareCoreData, initCoreServices } from "@x/core/dist/boot/services.js";
-import { startServerHost, stopServerHost } from "./server-host.js";
+import { startServerHost, stopServerHost, childServerMode } from "./server-host.js";
 import { getAgentSlackCliStatus } from "@x/core/dist/slack/agent-slack-exec.js";
 import { resolveWorkspacePath } from "@x/core/dist/workspace/workspace.js";
 import started from "electron-squirrel-startup";
@@ -560,7 +560,7 @@ app.whenReady().then(async () => {
   // every app iframe hit connection-refused (blank app) for the first ~10s of
   // each launch. Route registration and the token cipher are synchronous;
   // the listen itself is fire-and-forget.
-  registerAppsHostApi();
+  if (!childServerMode()) registerAppsHostApi();
   // GitHub publish token at rest: encrypt via the OS keychain when available
   // (core stays electron-free; the cipher is injected here).
   setGithubTokenCipher({
@@ -573,9 +573,6 @@ app.whenReady().then(async () => {
     isAvailable: () => safeStorage.isEncryptionAvailable(),
     encrypt: (plain) => safeStorage.encryptString(plain).toString('base64'),
     decrypt: (encrypted) => safeStorage.decryptString(Buffer.from(encrypted, 'base64')),
-  });
-  initAppsServer().catch((error) => {
-    console.error('[Apps] Failed to start:', error);
   });
 
   // Resident app (Granola-style): register as an OS login item once, on the
@@ -654,18 +651,25 @@ app.whenReady().then(async () => {
   // start runs watcher
   startRunsWatcher();
 
-  // One-time data repairs (legacy runs migration, code-session chat
-  // backfill) — shared with the standalone server boot.
-  await prepareCoreData();
+  if (!childServerMode()) {
+    // One-time data repairs (legacy runs migration, code-session chat
+    // backfill) — shared with the standalone server boot.
+    await prepareCoreData();
+  }
   // New runtime: build the in-memory session index (startup scan), then
   // forward the session bus to windows. The renderer window is already up and
   // may have called sessions:list — that handler blocks on
   // markSessionsIndexReady, which must fire even if the scan throws so the
   // list never hangs.
-  try {
-    await container.resolve<ISessions>('sessions').initialize();
-  } finally {
+  if (childServerMode()) {
+    // The child owns the session index; main's in-process gate is moot.
     markSessionsIndexReady();
+  } else {
+    try {
+      await container.resolve<ISessions>('sessions').initialize();
+    } finally {
+      markSessionsIndexReady();
+    }
   }
   startSessionsWatcher();
   startConnectorEventsWatcher();
@@ -715,8 +719,10 @@ app.whenReady().then(async () => {
 
   // Schedulers, sync services, event processor, background agents — the
   // headless-safe half of boot, shared with the standalone rowboat-server
-  // (Phase 6, SEPARATION_PLAN.md).
-  await initCoreServices();
+  // (Phase 6, SEPARATION_PLAN.md). In child-server mode the child runs them.
+  if (!childServerMode()) {
+    await initCoreServices();
+  }
 
   app.on("activate", () => {
     // Reveal the hidden/closed main window (login launches start hidden).

--- a/apps/x/apps/main/src/server-host.ts
+++ b/apps/x/apps/main/src/server-host.ts
@@ -1,5 +1,9 @@
 import os from 'node:os';
-import { app } from 'electron';
+import path from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { app, shell } from 'electron';
+import { createEventsClient, type EventsClient } from '@x/client';
+import { ipc } from '@x/shared';
 import {
   buildPairingPayload,
   createCoreEventSources,
@@ -12,7 +16,117 @@ import {
   type RowboatServer,
 } from '@x/server';
 import { WorkDir } from '@x/core/dist/config/config.js';
-import { onWorkspaceChange, sessionsIndexReady } from './ipc.js';
+import { broadcastToWindows, findMainAppWindow, onWorkspaceChange, sessionsIndexReady } from './ipc.js';
+import { ElectronNotificationService } from './notification/electron-notification-service.js';
+import { ElectronBrowserControlService } from './browser/control-service.js';
+
+// Phase 7a (SEPARATION_PLAN.md): with ROWBOAT_CHILD_SERVER=1, main does not
+// host the transport in-process — it spawns the standalone rowboat-server as
+// a child (ELECTRON_RUN_AS_NODE) and becomes a client: HTTP for calls (the
+// existing forwarder), a WS events bridge for pushes, and Electron-side
+// capability handlers for the server's reverse calls (notifications,
+// open-url, browser-control). Default remains in-process until 7b parity.
+export function childServerMode(): boolean {
+  return process.env.ROWBOAT_CHILD_SERVER === '1';
+}
+
+interface ChildServer {
+  kind: 'child';
+  child: ChildProcess;
+  port: number;
+  key: string;
+  lanEnabled: boolean;
+  events: EventsClient;
+}
+
+const PUSH_CHANNELS = [
+  'turns:events',
+  'sessions:events',
+  'workspace:didChange',
+  'oauth:didConnect',
+  'composio:didConnect',
+  'chatgpt:statusChanged',
+  'terminal:data',
+  'terminal:exit',
+] as const;
+
+async function launchChild(): Promise<ChildServer> {
+  const fs = await import('node:fs/promises');
+  const entry =
+    process.env.ROWBOAT_SERVER_ENTRY ??
+    path.resolve(app.getAppPath(), '../server/dist/standalone.js');
+  const child = spawn(process.execPath, [entry], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  child.on('exit', (code) => {
+    console.error(`[server-host] child rowboat-server exited (code ${code})`);
+  });
+
+  const config = await loadServerConfig(WorkDir);
+  const deadline = Date.now() + 60_000;
+  const port = config.port;
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(1500) });
+      const body = (await res.json()) as { name?: string };
+      if (body.name === 'rowboat-server') break;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline) {
+      child.kill();
+      throw new Error('child rowboat-server did not become healthy within 60s');
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const key = (await fs.readFile(path.join(WorkDir, 'server-key'), 'utf8')).trim();
+
+  const notificationService = new ElectronNotificationService(Date.now());
+  const browserControl = new ElectronBrowserControlService();
+  const events = createEventsClient({
+    baseUrl: `http://127.0.0.1:${port}`,
+    token: key,
+    clientName: 'electron-main',
+    capabilities: {
+      notifications: (payload) => {
+        notificationService.notify(payload as Parameters<ElectronNotificationService['notify']>[0]);
+        return { ok: true };
+      },
+      'open-url': async (payload) => {
+        await shell.openExternal((payload as { url: string }).url);
+        return { ok: true };
+      },
+      'focus-client': () => {
+        const win = findMainAppWindow();
+        if (win) {
+          if (win.isMinimized()) win.restore();
+          win.focus();
+        }
+        return { ok: true };
+      },
+      'browser-control': (payload) => browserControl.execute(payload as never),
+    },
+  });
+  for (const channel of PUSH_CHANNELS) {
+    events.on(channel, (payload) => broadcastToWindows(channel as ipc.SendChannels, payload as never));
+  }
+  return { kind: 'child', child, port, key, lanEnabled: config.lanEnabled, events };
+}
+
+// Renderer turn-delta subscriptions bridge to the child's WS feed.
+const deltaReleases = new Map<string, () => void>();
+export function bridgeDeltaSubscribe(turnId: string): void {
+  const c = current;
+  if (!c || !('events' in c)) return;
+  if (!deltaReleases.has(turnId)) {
+    deltaReleases.set(turnId, c.events.subscribeTurnDeltas(turnId));
+  }
+}
+export function bridgeDeltaUnsubscribe(turnId: string): void {
+  deltaReleases.get(turnId)?.();
+  deltaReleases.delete(turnId);
+}
 
 // Vertical-slice hosting: main runs the rowboat-server transport in-process
 // on its single core instance, so external clients (the phone) and the
@@ -22,10 +136,10 @@ import { onWorkspaceChange, sessionsIndexReady } from './ipc.js';
 // standalone entrypoint instead — this module then shrinks to lifecycle
 // management and everything else survives unchanged.
 
-let current: RowboatServer | null = null;
-let ready: Promise<RowboatServer> | null = null;
+let current: RowboatServer | ChildServer | null = null;
+let ready: Promise<RowboatServer | ChildServer> | null = null;
 
-async function launch(): Promise<RowboatServer> {
+async function launchInProcess(): Promise<RowboatServer> {
   const server = await createRowboatServer({
     workDir: WorkDir,
     handlers: createCoreRpcHandlers({ sessionsIndexReady }),
@@ -43,15 +157,15 @@ async function launch(): Promise<RowboatServer> {
   return server;
 }
 
-export function startServerHost(): Promise<RowboatServer> {
+export function startServerHost(): Promise<RowboatServer | ChildServer> {
   if (!ready) {
-    ready = launch();
+    ready = childServerMode() ? launchChild().then((c) => (current = c)) : launchInProcess();
   }
   return ready;
 }
 
 /** Resolves once the transport is listening — the RPC forwarder awaits this. */
-export function whenServerReady(): Promise<RowboatServer> {
+export function whenServerReady(): Promise<{ port: number; key: string }> {
   return startServerHost();
 }
 
@@ -59,7 +173,13 @@ export async function stopServerHost(): Promise<void> {
   const server = current;
   current = null;
   ready = null;
-  await server?.close();
+  if (!server) return;
+  if ('close' in server) {
+    await server.close();
+  } else {
+    server.events.close();
+    server.child.kill();
+  }
 }
 
 export async function getPairingInfo(): Promise<{

--- a/apps/x/apps/server/src/capabilities.ts
+++ b/apps/x/apps/server/src/capabilities.ts
@@ -1,0 +1,43 @@
+// Reverse calls (RFC Q14): core sometimes needs the CLIENT to do something —
+// show an OS notification, open a browser, drive the embedded browser pane.
+// Clients declare capabilities in their WS hello; the broker routes each
+// request to one capable client and awaits its reply over the socket.
+//
+// The standalone server registers core's DI seams (notification service,
+// url-opener, browser-control) with implementations that call this broker.
+// With no capable client connected, requests fail loudly — by design.
+
+export interface CapabilityRequestOptions {
+  timeoutMs?: number;
+}
+
+export interface CapabilityTransport {
+  /** Send a request to one client advertising `capability`; resolves with its reply. */
+  request(capability: string, payload: unknown, opts?: CapabilityRequestOptions): Promise<unknown>;
+  /** Fire-and-forget to EVERY client advertising `capability` (e.g. notifications). */
+  broadcast(capability: string, payload: unknown): void;
+  hasCapableClient(capability: string): boolean;
+}
+
+let transport: CapabilityTransport | null = null;
+
+export function setCapabilityTransport(next: CapabilityTransport): void {
+  transport = next;
+}
+
+export function capabilityBroker(): CapabilityTransport {
+  return {
+    request(capability, payload, opts) {
+      if (!transport) {
+        return Promise.reject(new Error(`no client connected that provides '${capability}'`));
+      }
+      return transport.request(capability, payload, opts);
+    },
+    broadcast(capability, payload) {
+      transport?.broadcast(capability, payload);
+    },
+    hasCapableClient(capability) {
+      return transport?.hasCapableClient(capability) ?? false;
+    },
+  };
+}

--- a/apps/x/apps/server/src/events-client.test.ts
+++ b/apps/x/apps/server/src/events-client.test.ts
@@ -125,3 +125,61 @@ describe('events client ↔ rowboat-server', () => {
     release();
   });
 });
+
+describe('reverse calls (capability requests)', () => {
+  it('routes a request to a capable client and returns its reply', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-cap-'));
+    const server = await createRowboatServer({
+      workDir: dir,
+      handlers: stubHandlers,
+      events: { subscribeTurnEvents: () => () => {}, subscribeSessionEvents: () => () => {} },
+      resolveWorkspacePath: (rel) => path.join(dir, rel),
+      serverVersion: 'test',
+      port: 0,
+    });
+    const seen: unknown[] = [];
+    const cap = createEventsClient({
+      baseUrl: `http://127.0.0.1:${server.port}`,
+      token: server.key,
+      clientName: 'cap-client',
+      capabilities: {
+        'open-url': async (payload) => {
+          seen.push(payload);
+          return { opened: true };
+        },
+      },
+    });
+    await new Promise<void>((resolve) => {
+      const off = cap.onStatus((s) => {
+        if (s === 'connected') {
+          off();
+          resolve();
+        }
+      });
+    });
+
+    const result = await server.hub.requestCapability('open-url', { url: 'https://example.com' }, { timeoutMs: 5000 });
+    expect(result).toEqual({ opened: true });
+    expect(seen).toEqual([{ url: 'https://example.com' }]);
+
+    // No client advertises this one — must reject, not hang.
+    await expect(server.hub.requestCapability('browser-control', {}, { timeoutMs: 1000 })).rejects.toThrow(/no client/);
+
+    // Handler errors surface as rejections.
+    const failing = createEventsClient({
+      baseUrl: `http://127.0.0.1:${server.port}`,
+      token: server.key,
+      clientName: 'failing',
+      capabilities: { boom: () => { throw new Error('kaput'); } },
+    });
+    await new Promise<void>((resolve) => {
+      const off = failing.onStatus((s) => { if (s === 'connected') { off(); resolve(); } });
+    });
+    await expect(server.hub.requestCapability('boom', {}, { timeoutMs: 5000 })).rejects.toThrow('kaput');
+
+    cap.close();
+    failing.close();
+    await server.close();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/apps/x/apps/server/src/server.ts
+++ b/apps/x/apps/server/src/server.ts
@@ -13,6 +13,7 @@ import { acquireWorkdirLock } from './lock.js';
 import { createRpcRoutes } from './router.js';
 import { createWorkspaceRoutes } from './workspace-route.js';
 import { createWsHub, type WsHub } from './ws-hub.js';
+import { setCapabilityTransport } from './capabilities.js';
 
 // Assembles the transport: HTTP router + workspace files + WS event hub on
 // one node:http server. Deliberately does NOT boot @x/core — the host (today
@@ -170,6 +171,11 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
   const boundPort = typeof address === 'object' && address ? address.port : startPort;
 
   const hub = createWsHub();
+  setCapabilityTransport({
+    request: (capability, payload, opts) => hub.requestCapability(capability, payload, opts),
+    broadcast: (capability, payload) => hub.broadcastCapability(capability, payload),
+    hasCapableClient: (capability) => hub.hasCapableClient(capability),
+  });
   hub.attach(httpServer, {
     serverKey: key,
     serverVersion: opts.serverVersion,

--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -9,6 +9,8 @@ import type { ISessions } from '@x/core/dist/runtime/sessions/index.js';
 import { createCoreEventSources, createCoreRpcHandlers, resolveWorkspacePath } from './core-deps.js';
 import { prepareCoreData, initCoreServices } from '@x/core/dist/boot/services.js';
 import { createRowboatServer } from './server.js';
+import { capabilityBroker } from './capabilities.js';
+import { registerUrlOpener } from '@x/core/dist/auth/url-opener.js';
 
 // Headless rowboat-server: the RFC's end-state entrypoint, where main spawns
 // this as a child process (or it runs on a remote box) and core lives here.
@@ -25,11 +27,24 @@ async function main(): Promise<void> {
   // The workdir lock is acquired by createRowboatServer itself — a live
   // Electron-hosted transport makes this boot fail loudly, as it must.
   await initConfigs();
-  registerNotificationService({ isSupported: () => false, notify: () => {} });
+  // Client capabilities route over the WS as reverse calls (RFC Q14): the
+  // connected client that advertises each capability performs it.
+  const broker = capabilityBroker();
+  registerNotificationService({
+    isSupported: () => broker.hasCapableClient('notifications'),
+    notify: (input) => broker.broadcast('notifications', input),
+  });
   registerBrowserControlService({
-    execute: async () => {
-      throw new Error('browser control is unavailable on a headless server');
+    execute: async (input, ctx) => {
+      void ctx;
+      return (await broker.request('browser-control', input, { timeoutMs: 120_000 })) as never;
     },
+  });
+  registerUrlOpener({
+    open: async (url) => {
+      await broker.request('open-url', { url }, { timeoutMs: 15_000 });
+    },
+    focusClient: () => broker.broadcast('focus-client', {}),
   });
 
   await prepareCoreData();

--- a/apps/x/apps/server/src/ws-hub.ts
+++ b/apps/x/apps/server/src/ws-hub.ts
@@ -44,6 +44,14 @@ const ClientMessage = z.discriminatedUnion('type', [
     topic: z.literal('turn-deltas'),
     turnId: z.string(),
   }),
+  // Reply to a server→client capability request (RFC Q14 reverse calls).
+  z.object({
+    type: z.literal('capability-response'),
+    id: z.string(),
+    ok: z.boolean(),
+    result: z.unknown().optional(),
+    error: z.string().optional(),
+  }),
 ]);
 
 interface Connection {
@@ -51,6 +59,7 @@ interface Connection {
   seq: number;
   helloed: boolean;
   deltaSubs: Set<string>;
+  capabilities: Set<string>;
 }
 
 const HELLO_TIMEOUT_MS = 5000;
@@ -58,6 +67,8 @@ const HELLO_TIMEOUT_MS = 5000;
 // Close codes (4xxx = application-defined).
 export const WS_CLOSE_UNAUTHORIZED = 4401;
 export const WS_CLOSE_NO_HELLO = 4400;
+
+const CAPABILITY_TIMEOUT_MS = 30_000;
 
 export interface WsHub {
   attach(
@@ -75,6 +86,11 @@ export interface WsHub {
   broadcast(channel: PushChannel, payload: unknown): void;
   /** Route one turn-spine event: durable → broadcast, delta → subscribers only. */
   handleTurnEvent(event: TurnBusEvent): void;
+  /** Reverse call: ask one client advertising `capability` to act; await its reply. */
+  requestCapability(capability: string, payload: unknown, opts?: { timeoutMs?: number }): Promise<unknown>;
+  /** Fire-and-forget a capability event to every advertising client. */
+  broadcastCapability(capability: string, payload: unknown): void;
+  hasCapableClient(capability: string): boolean;
   connectionCount(): number;
   close(): void;
 }
@@ -82,6 +98,18 @@ export interface WsHub {
 export function createWsHub(): WsHub {
   const connections = new Set<Connection>();
   let wss: WebSocketServer | null = null;
+  let nextRequestId = 0;
+  const pendingRequests = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }>();
+
+  const capableConnection = (capability: string): Connection | undefined => {
+    // Most recently connected capable client wins (matches "the window the
+    // user is looking at" heuristic well enough for a v1 router).
+    let found: Connection | undefined;
+    for (const conn of connections) {
+      if (conn.helloed && conn.capabilities.has(capability)) found = conn;
+    }
+    return found;
+  };
 
   const send = (conn: Connection, message: Record<string, unknown>) => {
     if (conn.socket.readyState !== WebSocket.OPEN) return;
@@ -139,7 +167,7 @@ export function createWsHub(): WsHub {
     });
 
     wss.on('connection', (socket: WebSocket) => {
-      const conn: Connection = { socket, seq: 0, helloed: false, deltaSubs: new Set() };
+      const conn: Connection = { socket, seq: 0, helloed: false, deltaSubs: new Set(), capabilities: new Set() };
       connections.add(conn);
 
       const helloTimer = setTimeout(() => {
@@ -158,6 +186,7 @@ export function createWsHub(): WsHub {
           case 'hello':
             if (!conn.helloed) {
               conn.helloed = true;
+              for (const cap of parsed.capabilities ?? []) conn.capabilities.add(cap);
               clearTimeout(helloTimer);
               send(conn, {
                 type: 'welcome',
@@ -173,6 +202,16 @@ export function createWsHub(): WsHub {
           case 'unsubscribe':
             conn.deltaSubs.delete(parsed.turnId);
             break;
+          case 'capability-response': {
+            const pending = pendingRequests.get(parsed.id);
+            if (pending) {
+              pendingRequests.delete(parsed.id);
+              clearTimeout(pending.timer);
+              if (parsed.ok) pending.resolve(parsed.result);
+              else pending.reject(new Error(parsed.error ?? 'capability request failed'));
+            }
+            break;
+          }
         }
       });
 
@@ -187,10 +226,37 @@ export function createWsHub(): WsHub {
     });
   };
 
+  const requestCapability: WsHub['requestCapability'] = (capability, payload, opts) => {
+    const conn = capableConnection(capability);
+    if (!conn) {
+      return Promise.reject(new Error(`no client connected that provides '${capability}'`));
+    }
+    const id = `cap-${++nextRequestId}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingRequests.delete(id);
+        reject(new Error(`capability '${capability}' request timed out`));
+      }, opts?.timeoutMs ?? CAPABILITY_TIMEOUT_MS);
+      pendingRequests.set(id, { resolve, reject, timer });
+      send(conn, { type: 'capability-request', id, capability, payload });
+    });
+  };
+
+  const broadcastCapability: WsHub['broadcastCapability'] = (capability, payload) => {
+    for (const conn of connections) {
+      if (conn.helloed && conn.capabilities.has(capability)) {
+        send(conn, { type: 'capability-request', id: `cap-${++nextRequestId}`, capability, payload, fireAndForget: true });
+      }
+    }
+  };
+
   return {
     attach,
     broadcast,
     handleTurnEvent,
+    requestCapability,
+    broadcastCapability,
+    hasCapableClient: (capability) => capableConnection(capability) !== undefined,
     connectionCount: () => connections.size,
     close: () => {
       for (const conn of connections) {

--- a/apps/x/packages/client/src/events.ts
+++ b/apps/x/packages/client/src/events.ts
@@ -21,10 +21,16 @@ export type PushChannel =
 
 interface ServerMessage {
   seq: number;
-  type: 'welcome' | 'event' | 'error';
+  type: 'welcome' | 'event' | 'error' | 'capability-request';
   channel?: PushChannel;
   payload?: unknown;
+  id?: string;
+  capability?: string;
+  fireAndForget?: boolean;
 }
+
+/** Handler for a server→client reverse call (RFC Q14). */
+export type CapabilityHandler = (payload: unknown) => Promise<unknown> | unknown;
 
 export interface EventsClient {
   /** Listen to one push channel. Returns unsubscribe. */
@@ -53,6 +59,11 @@ export function createEventsClient(opts: {
   clientVersion?: string;
   /** Fired on a 4401 close — the server key was rotated; stop reconnecting. */
   onUnauthorized?: () => void;
+  /**
+   * Capabilities this client performs for the server (declared in the hello;
+   * requests arrive as capability-request messages and are answered here).
+   */
+  capabilities?: Record<string, CapabilityHandler>;
 }): EventsClient {
   const wsUrl = `${opts.baseUrl.replace(/\/+$/, '').replace(/^http/, 'ws')}/events`;
 
@@ -109,7 +120,7 @@ export function createEventsClient(opts: {
         type: 'hello',
         v: 1,
         client: { name: opts.clientName, version: opts.clientVersion },
-        capabilities: [],
+        capabilities: Object.keys(opts.capabilities ?? {}),
       });
     };
 
@@ -138,6 +149,24 @@ export function createEventsClient(opts: {
         }
         if (everConnected) fireResync();
         everConnected = true;
+        return;
+      }
+      if (msg.type === 'capability-request' && msg.capability && msg.id) {
+        const handler = opts.capabilities?.[msg.capability];
+        const reply = (ok: boolean, result?: unknown, error?: string) => {
+          if (!msg.fireAndForget) send({ type: 'capability-response', id: msg.id, ok, result, error });
+        };
+        if (!handler) {
+          reply(false, undefined, `capability '${msg.capability}' not provided`);
+          return;
+        }
+        void (async () => {
+          try {
+            reply(true, await handler(msg.payload));
+          } catch (err) {
+            reply(false, undefined, err instanceof Error ? err.message : String(err));
+          }
+        })();
         return;
       }
       if (msg.type === 'event' && msg.channel) {

--- a/apps/x/packages/core/src/boot/services.ts
+++ b/apps/x/packages/core/src/boot/services.ts
@@ -27,6 +27,8 @@ import { init as initChromeSync } from '../knowledge/chrome-extension/server/ser
 import { disconnectGoogleIfScopesStale } from '../auth/oauth-flows.js';
 import { migrateRuns } from '../migrations/runs/migrate.js';
 import { startModelsDevRefresh } from '../models/models-dev.js';
+import { init as initAppsServer } from '../apps/server.js';
+import { registerAppsHostApi } from '../apps/host-api.js';
 
 // The headless-safe half of Rowboat's boot: everything that runs schedulers,
 // sync services, and background agents against the workdir. Extracted from
@@ -99,6 +101,12 @@ export async function initCoreServices(): Promise<void> {
 
   startRetentionSweep();
   startModelsDevRefresh();
+
+  // Rowboat Apps server (per-app origins on 127.0.0.1:3210).
+  registerAppsHostApi();
+  initAppsServer().catch((error) => {
+    console.error('[Apps] Failed to start:', error);
+  });
 
   initChannels().catch((error) => {
     console.error('[Channels] Failed to start mobile channels:', error);

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@agentclientprotocol/codex-acp':
         specifier: ^1.2.0
         version: 1.2.0
+      '@x/client':
+        specifier: workspace:*
+        version: link:../../packages/client
       '@x/core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
Phase 7a of [SEPARATION_PLAN.md](https://github.com/rowboatlabs/rowboat/blob/arch/server-client-separation/apps/x/SEPARATION_PLAN.md): the flip's machinery lands behind `ROWBOAT_CHILD_SERVER=1` (default stays in-process until 7b reaches parity).

**Reverse calls (RFC Q14):** clients declare capabilities in the WS hello; the hub routes `capability-request` to one capable client and awaits `capability-response` (fire-and-forget variant for notifications). The broker backs core's DI seams in the standalone server — notifications, url-opener/focus, browser-control — failing loudly with no capable client.

**Child-server mode:** main spawns `standalone.js` (`ELECTRON_RUN_AS_NODE`), waits for health, and becomes a pure client: HTTP forwarder for calls, WS bridge relaying all push channels to windows, renderer delta subs mirrored onto the wire, Electron capability handlers answering reverse calls. Core boot is skipped in main; the apps server moves into the shared boot module so the child hosts it.

**Verified live under the flag:** child runs every scheduler, main boots core-free, and a real LLM turn completes end-to-end in the child. Reverse-call protocol integration-tested (reply, rejection, error propagation). 19 server tests green; typecheck + lint clean.

**7b before default-on:** sender-scoped handlers (streaming TTS), packaged-build second artifact for the standalone entry, shadow-core-state audit of main's remaining core imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)