### PR TITLE
feat(x): Phase 7b — child-server mode by default (the flip)

### DIFF
--- a/apps/x/apps/main/bundle.mjs
+++ b/apps/x/apps/main/bundle.mjs
@@ -159,6 +159,19 @@ if (process.platform === 'darwin') {
   }
 }
 
+// Bundle the standalone rowboat-server (spawned as a child with
+// ELECTRON_RUN_AS_NODE in child-server mode). node-pty stays external like
+// in the main bundle and ships from .package/node_modules.
+await esbuild.build({
+  entryPoints: ['../server/dist/standalone.js'],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  outfile: './.package/dist/rowboat-server.cjs',
+  external: ['electron', 'node-pty', 'uiohook-napi', 'bun:sqlite'],
+});
+console.log('✅ rowboat-server bundled to .package/dist/rowboat-server.cjs');
+
 // Bundle the vendored agent-slack CLI into a single self-contained script next
 // to main.cjs. It runs as a child process (process.execPath with
 // ELECTRON_RUN_AS_NODE=1), so it must exist as a real file on disk — it can't

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -110,6 +110,7 @@ function updateSelfCaptureState() {
 }
 import * as composioHandler from '@x/core/dist/composio/flows.js';
 import { oauthConnectBus, composioConnectBus, chatgptStatusBus } from '@x/core/dist/auth/connector-events.js';
+import { subscribeTtsChunks } from '@x/core/dist/voice/tts-bus.js';
 import * as appsIndexer from '@x/core/dist/apps/indexer.js';
 import * as appsServer from '@x/core/dist/apps/server.js';
 import * as appsAgents from '@x/core/dist/apps/agents.js';
@@ -603,6 +604,7 @@ export function startConnectorEventsWatcher(): void {
   oauthConnectBus.subscribe((event) => broadcastToWindows('oauth:didConnect', event));
   composioConnectBus.subscribe((event) => broadcastToWindows('composio:didConnect', event));
   chatgptStatusBus.subscribe((event) => broadcastToWindows('chatgpt:statusChanged', event));
+  subscribeTtsChunks((event) => broadcastToWindows('voice:tts-chunk', event));
 }
 
 async function requireCodeSession(sessionId: string): Promise<CodeSession> {

--- a/apps/x/apps/main/src/server-host.ts
+++ b/apps/x/apps/main/src/server-host.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { app, shell } from 'electron';
 import { createEventsClient, type EventsClient } from '@x/client';
@@ -19,6 +20,8 @@ import { WorkDir } from '@x/core/dist/config/config.js';
 import { broadcastToWindows, findMainAppWindow, onWorkspaceChange, sessionsIndexReady } from './ipc.js';
 import { ElectronNotificationService } from './notification/electron-notification-service.js';
 import { ElectronBrowserControlService } from './browser/control-service.js';
+import { screenPointerService } from './screen-pointer.js';
+import { textInsertService } from './text-insert.js';
 
 // Phase 7a (SEPARATION_PLAN.md): with ROWBOAT_CHILD_SERVER=1, main does not
 // host the transport in-process — it spawns the standalone rowboat-server as
@@ -26,8 +29,12 @@ import { ElectronBrowserControlService } from './browser/control-service.js';
 // existing forwarder), a WS events bridge for pushes, and Electron-side
 // capability handlers for the server's reverse calls (notifications,
 // open-url, browser-control). Default remains in-process until 7b parity.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export function childServerMode(): boolean {
-  return process.env.ROWBOAT_CHILD_SERVER === '1';
+  const env = process.env.ROWBOAT_CHILD_SERVER;
+  if (env !== undefined) return env !== '0' && env.toLowerCase() !== 'false';
+  return true;
 }
 
 interface ChildServer {
@@ -48,13 +55,16 @@ const PUSH_CHANNELS = [
   'chatgpt:statusChanged',
   'terminal:data',
   'terminal:exit',
+  'voice:tts-chunk',
 ] as const;
 
 async function launchChild(): Promise<ChildServer> {
   const fs = await import('node:fs/promises');
   const entry =
     process.env.ROWBOAT_SERVER_ENTRY ??
-    path.resolve(app.getAppPath(), '../server/dist/standalone.js');
+    (app.isPackaged
+      ? path.join(__dirname, 'rowboat-server.cjs')
+      : path.resolve(app.getAppPath(), '../server/dist/standalone.js'));
   const child = spawn(process.execPath, [entry], {
     env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
     stdio: ['ignore', 'inherit', 'inherit'],
@@ -106,6 +116,18 @@ async function launchChild(): Promise<ChildServer> {
         return { ok: true };
       },
       'browser-control': (payload) => browserControl.execute(payload as never),
+      'screen-pointer': async (payload) => {
+        const p = payload as { type: 'point' | 'hide'; target?: never };
+        if (p.type === 'point') return screenPointerService.point(p.target as never);
+        await screenPointerService.hide();
+        return { success: true };
+      },
+      'text-insert': async (payload) => {
+        const p = payload as { type: 'captureTarget' | 'insert'; text?: string };
+        if (p.type === 'insert') return textInsertService.insert(p.text ?? '');
+        await textInsertService.captureTarget();
+        return { ok: true };
+      },
     },
   });
   for (const channel of PUSH_CHANNELS) {

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -230,6 +230,10 @@ export const RPC_CHANNELS = [
   'bg-task:create',
   'bg-task:delete',
   'bg-task:stop',
+  // Phase 7b: streaming TTS runs server-side; chunks fan out on the
+  // voice:tts-chunk push channel (renderers filter by requestId).
+  'voice:synthesizeStreamStart',
+  'voice:synthesizeStreamCancel',
   // Phase 5 (SEPARATION_PLAN.md): code-mode & terminal — the PTY lives with
   // core now (RFC Q13: the terminal shows the machine core runs on).
   // codeMode:provisionEngine stays client-local (sender-scoped progress).

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -20,6 +20,7 @@ import { loadRetentionSettings } from '@x/core/dist/config/retention.js';
 import type { IAgentScheduleRepo } from '@x/core/dist/agent-schedule/repo.js';
 import type { IAgentScheduleStateRepo } from '@x/core/dist/agent-schedule/state-repo.js';
 import * as voice from '@x/core/dist/voice/voice.js';
+import { publishTtsChunk, subscribeTtsChunks } from '@x/core/dist/voice/tts-bus.js';
 import { fetchLiveNote, listLiveNotes, setLiveNote, setLiveNoteActive, deleteLiveNote } from '@x/core/dist/knowledge/live-note/fileops.js';
 import { runningItemKeys } from '@x/core/dist/todo/runner.js';
 import { getSessionIndex as getTodoSessionIndex } from '@x/core/dist/todo/session-index.js';
@@ -130,6 +131,7 @@ async function requireCodeSession(sessionId: string): Promise<CodeSession> {
 
 // Process-local caches mirrored from apps/main/src/ipc.ts — memoization only,
 // no cross-process invariants (each host keeps its own).
+const activeTtsStreams = new Map<string, AbortController>();
 const appInstallPreviews = new Map<string, Awaited<ReturnType<typeof appsInstaller.previewInstall>>>();
 let lastAppsFingerprint: string | null = null;
 import type { RpcHandlers } from './channels.js';
@@ -1243,6 +1245,28 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
     'inline-task:process': async (args) => {
       return await processRowboatInstruction(args.instruction, args.noteContent, args.notePath);
     },
+    'voice:synthesizeStreamStart': async (args) => {
+      const { requestId, text } = args;
+      const controller = new AbortController();
+      activeTtsStreams.set(requestId, controller);
+      void voice
+        .synthesizeSpeechStream(
+          text,
+          (chunk: Buffer) => publishTtsChunk({ requestId, chunkBase64: chunk.toString('base64'), done: false }),
+          controller.signal,
+        )
+        .then(() => publishTtsChunk({ requestId, done: true }))
+        .catch((err: unknown) => {
+          publishTtsChunk({ requestId, done: true, error: err instanceof Error ? err.message : String(err) });
+        })
+        .finally(() => activeTtsStreams.delete(requestId));
+      return { ok: true };
+    },
+    'voice:synthesizeStreamCancel': async (args) => {
+      activeTtsStreams.get(args.requestId)?.abort();
+      activeTtsStreams.delete(args.requestId);
+      return {};
+    },
     'voice:synthesize': async (args) => {
       return voice.synthesizeSpeech(args.text);
     },
@@ -1502,6 +1526,7 @@ export function createCoreEventSources(): EventSources {
     subscribeComposioEvents: (listener) => composioConnectBus.subscribe(listener),
     subscribeChatgptEvents: (listener) => chatgptStatusBus.subscribe(listener),
     subscribeTerminalEvents: (listener) => subscribeTerminalEvents(listener),
+    subscribeTtsChunks: (listener) => subscribeTtsChunks(listener),
   };
 }
 

--- a/apps/x/apps/server/src/server.ts
+++ b/apps/x/apps/server/src/server.ts
@@ -29,6 +29,7 @@ export interface EventSources {
   subscribeComposioEvents?(listener: (e: unknown) => void): () => void;
   subscribeChatgptEvents?(listener: (e: unknown) => void): () => void;
   subscribeTerminalEvents?(listener: (e: { channel: 'terminal:data' | 'terminal:exit'; payload: unknown }) => void): () => void;
+  subscribeTtsChunks?(listener: (e: unknown) => void): () => void;
 }
 
 export interface RowboatServerOptions {
@@ -191,6 +192,7 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
     opts.events.subscribeComposioEvents?.((e) => hub.broadcast('composio:didConnect', e)),
     opts.events.subscribeChatgptEvents?.((e) => hub.broadcast('chatgpt:statusChanged', e)),
     opts.events.subscribeTerminalEvents?.((e) => hub.broadcast(e.channel, e.payload)),
+    opts.events.subscribeTtsChunks?.((e) => hub.broadcast('voice:tts-chunk', e)),
   ];
 
   return {

--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -4,6 +4,8 @@ import { initConfigs } from '@x/core/dist/config/initConfigs.js';
 import container, {
   registerBrowserControlService,
   registerNotificationService,
+  registerScreenPointerService,
+  registerTextInsertService,
 } from '@x/core/dist/di/container.js';
 import type { ISessions } from '@x/core/dist/runtime/sessions/index.js';
 import { createCoreEventSources, createCoreRpcHandlers, resolveWorkspacePath } from './core-deps.js';
@@ -39,6 +41,25 @@ async function main(): Promise<void> {
       void ctx;
       return (await broker.request('browser-control', input, { timeoutMs: 120_000 })) as never;
     },
+  });
+  registerScreenPointerService({
+    // Sync share-state can't round-trip the socket — approximate with
+    // "a pointer-capable client is connected"; point() itself reports the
+    // truthful result from the client.
+    isShareActive: () => broker.hasCapableClient('screen-pointer'),
+    point: async (target) =>
+      (await broker.request('screen-pointer', { type: 'point', target }, { timeoutMs: 15_000 })) as never,
+    hide: async () => {
+      await broker.request('screen-pointer', { type: 'hide' }, { timeoutMs: 15_000 }).catch(() => {});
+    },
+  });
+  registerTextInsertService({
+    isSupported: () => broker.hasCapableClient('text-insert'),
+    captureTarget: async () => {
+      await broker.request('text-insert', { type: 'captureTarget' }, { timeoutMs: 15_000 }).catch(() => {});
+    },
+    insert: async (text) =>
+      (await broker.request('text-insert', { type: 'insert', text }, { timeoutMs: 30_000 })) as never,
   });
   registerUrlOpener({
     open: async (url) => {

--- a/apps/x/apps/server/src/ws-hub.ts
+++ b/apps/x/apps/server/src/ws-hub.ts
@@ -23,7 +23,8 @@ export type PushChannel =
   | 'composio:didConnect'
   | 'chatgpt:statusChanged'
   | 'terminal:data'
-  | 'terminal:exit';
+  | 'terminal:exit'
+  | 'voice:tts-chunk';
 
 const ClientMessage = z.discriminatedUnion('type', [
   z.object({

--- a/apps/x/packages/client/src/events.ts
+++ b/apps/x/packages/client/src/events.ts
@@ -17,7 +17,8 @@ export type PushChannel =
   | 'composio:didConnect'
   | 'chatgpt:statusChanged'
   | 'terminal:data'
-  | 'terminal:exit';
+  | 'terminal:exit'
+  | 'voice:tts-chunk';
 
 interface ServerMessage {
   seq: number;

--- a/apps/x/packages/core/src/voice/tts-bus.ts
+++ b/apps/x/packages/core/src/voice/tts-bus.ts
@@ -1,0 +1,19 @@
+// TTS chunk fan-out: the synthesize-stream handler publishes base64 MP3
+// chunks here; Electron main relays them to windows, the WS hub to network
+// clients. Renderers filter by requestId.
+
+export type TtsChunkEvent = {
+  requestId: string;
+  chunkBase64?: string;
+  done: boolean;
+  error?: string;
+};
+
+const listeners = new Set<(e: TtsChunkEvent) => void>();
+export function subscribeTtsChunks(listener: (e: TtsChunkEvent) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+export function publishTtsChunk(event: TtsChunkEvent): void {
+  for (const l of listeners) l(event);
+}


### PR DESCRIPTION
Phase 7b of [SEPARATION_PLAN.md](https://github.com/rowboatlabs/rowboat/blob/arch/server-client-separation/apps/x/SEPARATION_PLAN.md): **the flip is on by default** — Electron spawns the standalone rowboat-server and runs as a pure client. `ROWBOAT_CHILD_SERVER=0` remains as the kill switch for one release cycle.

**Parity work:**
- **Streaming TTS server-side** — `voice:synthesizeStreamStart/Cancel` are RPC channels; chunks fan out on the `voice:tts-chunk` push channel via a core bus (main→windows in both modes, hub→network clients).
- **screen-pointer & text-insert as reverse calls** — broker-backed DI impls in the standalone server; Electron advertises/answers the capabilities.
- **Packaged builds ship the server** as a second esbuild artifact (`rowboat-server.cjs`, node-pty external); dev spawns `apps/server/dist/standalone.js`.

**Carried to Phase 8:** token encryption at rest (child has no safeStorage; core's existing plaintext fallback applies — same file, same machine).

**Verified live, no flag:** child spawns and owns core, real LLM turn completes end-to-end, TTS RPC answers, kill switch still boots in-process. 19 server tests green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)