### PR TITLE
feat(x): Phase 8a — remote server mode + headless distribution

### DIFF
--- a/apps/x/REMOTE_SERVER.md
+++ b/apps/x/REMOTE_SERVER.md
@@ -1,0 +1,109 @@
+# Running rowboat-server on a remote machine
+
+Phase 8 of SEPARATION_PLAN.md: core runs on a remote box, the desktop app is a
+pure client. This documents the validated path — Tailscale for networking (no
+public exposure, no TLS certs), Ubuntu on EC2 as the host.
+
+## 1. Provision the box
+
+- EC2: Ubuntu 24.04 LTS, t3.medium (2 vCPU / 4 GB), 20 GB gp3.
+- Security group: **SSH (22) from your IP only. Nothing else.** All app
+  traffic rides the tailnet, so the server is never exposed publicly — this is
+  what makes `lanEnabled` (a 0.0.0.0 bind) safe below.
+- On the box:
+
+```sh
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up                      # sign in with the same account as your Mac
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs build-essential python3
+tailscale ip -4                        # note the 100.x.y.z address
+```
+
+- On your Mac: install Tailscale (tailscale.com/download), sign in with the
+  same account. `ping <100.x.y.z>` should answer.
+
+## 2. Build and ship the server
+
+On your dev machine, from `apps/x`:
+
+```sh
+npm run deps                            # shared → core → server → client
+cd apps/server && npm run build:headless
+tar -C dist-headless -czf rowboat-server.tgz .
+scp -i <key.pem> rowboat-server.tgz ubuntu@<public-ip>:
+```
+
+On the box:
+
+```sh
+mkdir -p ~/rowboat-server && tar -xzf rowboat-server.tgz -C ~/rowboat-server
+cd ~/rowboat-server && npm install --omit=dev     # compiles node-pty for this host
+mkdir -p ~/.rowboat/config
+echo '{"lanEnabled": true}' > ~/.rowboat/config/server.json
+node rowboat-server.cjs
+```
+
+First boot creates `~/.rowboat` and mints the auth token at
+`~/.rowboat/server-key`. Copy it:
+
+```sh
+cat ~/.rowboat/server-key
+```
+
+For an unattended server, run it under systemd:
+
+```ini
+# /etc/systemd/system/rowboat-server.service
+[Unit]
+Description=rowboat-server
+After=network-online.target tailscaled.service
+
+[Service]
+User=ubuntu
+ExecStart=/usr/bin/node /home/ubuntu/rowboat-server/rowboat-server.cjs
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`sudo systemctl enable --now rowboat-server`
+
+## 3. Point the desktop app at it
+
+```sh
+ROWBOAT_REMOTE_SERVER=http://<100.x.y.z>:3220 \
+ROWBOAT_REMOTE_TOKEN=<contents of server-key> \
+npm run dev          # or open the packaged app with these env vars set
+```
+
+In remote mode main spawns no child server and runs no core: RPC calls,
+the WS event feed, workspace file serving (`app://workspace/...`), and
+reverse-call capabilities (notifications, open-url, browser control…) all
+target the remote box. Notes, sessions, connectors, and the terminal show
+the **server machine's** state — that is the point.
+
+The phone pairs directly with the server the same way (it just needs
+Tailscale, or `lanEnabled` on a shared LAN).
+
+## Configuring the server
+
+LLM provider keys live server-side: `~/.rowboat/config/models.json` on the
+box (same schema as the desktop writes). Easiest bootstrap: copy your local
+`~/.rowboat/config/models.json` to the box once — or edit models in the
+desktop settings UI while connected remotely; the writes land on the server.
+
+## Known gaps (Phase 8b)
+
+- **Token encryption at rest**: headless has no OS keychain — connector
+  tokens fall back to plaintext files in `~/.rowboat`. Mitigate with disk
+  encryption + locked-down box until the file-key cipher lands.
+- **OAuth connect flows**: the loopback redirect lands on the *server's*
+  localhost. Connecting a new provider remotely needs the claim flow (8b);
+  until then, connect providers while running locally, or complete the OAuth
+  redirect in a browser on the server (e.g. via SSH port-forward:
+  `ssh -L <port>:127.0.0.1:<port>` during the flow).
+- **Security model**: bearer token over plain HTTP inside the tailnet.
+  Tailscale encrypts on the wire (WireGuard); do not run this over untrusted
+  networks without it (or a TLS reverse proxy).

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -37,7 +37,7 @@ import { syncModelProviderPersonProperties } from "@x/core/dist/analytics/model-
 
 import { initConfigs } from "@x/core/dist/config/initConfigs.js";
 import { prepareCoreData, initCoreServices } from "@x/core/dist/boot/services.js";
-import { startServerHost, stopServerHost, childServerMode } from "./server-host.js";
+import { startServerHost, stopServerHost, childServerMode, serverHostMode, whenServerReady } from "./server-host.js";
 import { getAgentSlackCliStatus } from "@x/core/dist/slack/agent-slack-exec.js";
 import { resolveWorkspacePath } from "@x/core/dist/workspace/workspace.js";
 import started from "electron-squirrel-startup";
@@ -189,6 +189,15 @@ function registerAppProtocol() {
         try {
           const relPath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
           if (!relPath) return new Response("Not Found", { status: 404 });
+          // Remote server: the workspace lives on the server's disk — proxy
+          // to its authenticated /workspace route instead of reading locally.
+          if (serverHostMode() === "remote") {
+            const { baseUrl, key } = await whenServerReady();
+            const headers = new Headers({ authorization: `Bearer ${key}` });
+            const range = request.headers.get("range");
+            if (range) headers.set("range", range);
+            return fetch(`${baseUrl}/workspace/${relPath.split("/").map(encodeURIComponent).join("/")}`, { headers });
+          }
           const absPath = resolveWorkspacePath(relPath);
           // Parity with the server's /workspace route: `..` is guarded above,
           // but a symlink inside the workspace can still point out of it —
@@ -646,7 +655,10 @@ app.whenReady().then(async () => {
   // - Changes made via IPC handlers (workspace:writeFile, etc.)
   // - External changes (terminal, git, other editors)
   // Only starts once (guarded in startWorkspaceWatcher)
-  startWorkspaceWatcher();
+  // In child/remote mode the watcher runs inside rowboat-server and its
+  // events arrive over the WS relay — a local watcher would double-fire
+  // (or, remote, watch the wrong machine's disk).
+  if (!childServerMode()) startWorkspaceWatcher();
 
   // start runs watcher
   startRunsWatcher();

--- a/apps/x/apps/main/src/rpc-forwarder.ts
+++ b/apps/x/apps/main/src/rpc-forwarder.ts
@@ -24,7 +24,7 @@ export function shouldForwardChannel(channel: string): boolean {
 
 export async function forwardRpc(channel: string, args: unknown): Promise<unknown> {
   const server = await whenServerReady();
-  const res = await fetch(`http://127.0.0.1:${server.port}/rpc/${channel}`, {
+  const res = await fetch(`${server.baseUrl}/rpc/${channel}`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/apps/x/apps/main/src/server-host.ts
+++ b/apps/x/apps/main/src/server-host.ts
@@ -31,18 +31,39 @@ import { textInsertService } from './text-insert.js';
 // open-url, browser-control). Default remains in-process until 7b parity.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export function childServerMode(): boolean {
+// Phase 8: ROWBOAT_REMOTE_SERVER=<url> (+ ROWBOAT_REMOTE_TOKEN) points the
+// desktop at a rowboat-server on another machine — no child is spawned, no
+// core runs locally. Everything the client does (HTTP calls, WS events,
+// capability handlers, workspace file serving) rides the same paths as
+// child mode, just over the network.
+export type ServerHostMode = 'in-process' | 'child' | 'remote';
+
+export function serverHostMode(): ServerHostMode {
+  if (process.env.ROWBOAT_REMOTE_SERVER) return 'remote';
   const env = process.env.ROWBOAT_CHILD_SERVER;
-  if (env !== undefined) return env !== '0' && env.toLowerCase() !== 'false';
-  return true;
+  if (env !== undefined && (env === '0' || env.toLowerCase() === 'false')) return 'in-process';
+  return 'child';
+}
+
+/** True whenever main is a pure client (child or remote server). */
+export function childServerMode(): boolean {
+  return serverHostMode() !== 'in-process';
 }
 
 interface ChildServer {
   kind: 'child';
   child: ChildProcess;
+  baseUrl: string;
   port: number;
   key: string;
   lanEnabled: boolean;
+  events: EventsClient;
+}
+
+interface RemoteServer {
+  kind: 'remote';
+  baseUrl: string;
+  key: string;
   events: EventsClient;
 }
 
@@ -56,46 +77,17 @@ const PUSH_CHANNELS = [
   'terminal:data',
   'terminal:exit',
   'voice:tts-chunk',
+  'knowledge:didCommit',
 ] as const;
 
-async function launchChild(): Promise<ChildServer> {
-  const fs = await import('node:fs/promises');
-  const entry =
-    process.env.ROWBOAT_SERVER_ENTRY ??
-    (app.isPackaged
-      ? path.join(__dirname, 'rowboat-server.cjs')
-      : path.resolve(app.getAppPath(), '../server/dist/standalone.js'));
-  const child = spawn(process.execPath, [entry], {
-    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
-    stdio: ['ignore', 'inherit', 'inherit'],
-  });
-  child.on('exit', (code) => {
-    console.error(`[server-host] child rowboat-server exited (code ${code})`);
-  });
-
-  const config = await loadServerConfig(WorkDir);
-  const deadline = Date.now() + 60_000;
-  const port = config.port;
-  for (;;) {
-    try {
-      const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(1500) });
-      const body = (await res.json()) as { name?: string };
-      if (body.name === 'rowboat-server') break;
-    } catch {
-      // not up yet
-    }
-    if (Date.now() > deadline) {
-      child.kill();
-      throw new Error('child rowboat-server did not become healthy within 60s');
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  const key = (await fs.readFile(path.join(WorkDir, 'server-key'), 'utf8')).trim();
-
+// The client half shared by child and remote modes: WS events relay to
+// renderer windows plus the Electron-side capability handlers for the
+// server's reverse calls.
+function createDesktopEventsClient(baseUrl: string, key: string): EventsClient {
   const notificationService = new ElectronNotificationService(Date.now());
   const browserControl = new ElectronBrowserControlService();
   const events = createEventsClient({
-    baseUrl: `http://127.0.0.1:${port}`,
+    baseUrl,
     token: key,
     clientName: 'electron-main',
     capabilities: {
@@ -133,7 +125,73 @@ async function launchChild(): Promise<ChildServer> {
   for (const channel of PUSH_CHANNELS) {
     events.on(channel, (payload) => broadcastToWindows(channel as ipc.SendChannels, payload as never));
   }
-  return { kind: 'child', child, port, key, lanEnabled: config.lanEnabled, events };
+  return events;
+}
+
+async function isRowboatServer(baseUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(2500) });
+    const body = (await res.json()) as { name?: string };
+    return body.name === 'rowboat-server';
+  } catch {
+    return false;
+  }
+}
+
+async function connectRemote(): Promise<RemoteServer> {
+  const baseUrl = process.env.ROWBOAT_REMOTE_SERVER!.replace(/\/+$/, '');
+  const key = (process.env.ROWBOAT_REMOTE_TOKEN ?? '').trim();
+  if (!key) {
+    throw new Error('ROWBOAT_REMOTE_SERVER is set but ROWBOAT_REMOTE_TOKEN is missing');
+  }
+  const deadline = Date.now() + 20_000;
+  while (!(await isRowboatServer(baseUrl))) {
+    if (Date.now() > deadline) {
+      throw new Error(`no rowboat-server reachable at ${baseUrl} within 20s`);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  const events = createDesktopEventsClient(baseUrl, key);
+  console.log(`[server-host] connected to remote rowboat-server at ${baseUrl}`);
+  return { kind: 'remote', baseUrl, key, events };
+}
+
+async function launchChild(): Promise<ChildServer> {
+  const fs = await import('node:fs/promises');
+  const entry =
+    process.env.ROWBOAT_SERVER_ENTRY ??
+    (app.isPackaged
+      ? path.join(__dirname, 'rowboat-server.cjs')
+      : path.resolve(app.getAppPath(), '../server/dist/standalone.js'));
+  const child = spawn(process.execPath, [entry], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  child.on('exit', (code) => {
+    console.error(`[server-host] child rowboat-server exited (code ${code})`);
+  });
+
+  const config = await loadServerConfig(WorkDir);
+  const deadline = Date.now() + 60_000;
+  const port = config.port;
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(1500) });
+      const body = (await res.json()) as { name?: string };
+      if (body.name === 'rowboat-server') break;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline) {
+      child.kill();
+      throw new Error('child rowboat-server did not become healthy within 60s');
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const key = (await fs.readFile(path.join(WorkDir, 'server-key'), 'utf8')).trim();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const events = createDesktopEventsClient(baseUrl, key);
+  return { kind: 'child', child, baseUrl, port, key, lanEnabled: config.lanEnabled, events };
 }
 
 // Renderer turn-delta subscriptions bridge to the child's WS feed.
@@ -158,8 +216,10 @@ export function bridgeDeltaUnsubscribe(turnId: string): void {
 // standalone entrypoint instead — this module then shrinks to lifecycle
 // management and everything else survives unchanged.
 
-let current: RowboatServer | ChildServer | null = null;
-let ready: Promise<RowboatServer | ChildServer> | null = null;
+type HostedServer = RowboatServer | ChildServer | RemoteServer;
+
+let current: HostedServer | null = null;
+let ready: Promise<HostedServer> | null = null;
 
 async function launchInProcess(): Promise<RowboatServer> {
   const server = await createRowboatServer({
@@ -179,16 +239,24 @@ async function launchInProcess(): Promise<RowboatServer> {
   return server;
 }
 
-export function startServerHost(): Promise<RowboatServer | ChildServer> {
+export function startServerHost(): Promise<HostedServer> {
   if (!ready) {
-    ready = childServerMode() ? launchChild().then((c) => (current = c)) : launchInProcess();
+    const mode = serverHostMode();
+    ready =
+      mode === 'remote'
+        ? connectRemote().then((c) => (current = c))
+        : mode === 'child'
+          ? launchChild().then((c) => (current = c))
+          : launchInProcess();
   }
   return ready;
 }
 
-/** Resolves once the transport is listening — the RPC forwarder awaits this. */
-export function whenServerReady(): Promise<{ port: number; key: string }> {
-  return startServerHost();
+/** Resolves once the transport is reachable — the RPC forwarder awaits this. */
+export async function whenServerReady(): Promise<{ baseUrl: string; key: string }> {
+  const server = await startServerHost();
+  const baseUrl = 'baseUrl' in server ? server.baseUrl : `http://127.0.0.1:${server.port}`;
+  return { baseUrl, key: server.key };
 }
 
 export async function stopServerHost(): Promise<void> {
@@ -200,7 +268,7 @@ export async function stopServerHost(): Promise<void> {
     await server.close();
   } else {
     server.events.close();
-    server.child.kill();
+    if (server.kind === 'child') server.child.kill();
   }
 }
 
@@ -214,6 +282,17 @@ export async function getPairingInfo(): Promise<{
 }> {
   if (!current) {
     return { running: false, name: os.hostname(), port: null, lanEnabled: false, urls: [], token: null };
+  }
+  if ('kind' in current && current.kind === 'remote') {
+    // Phones pair directly with the remote server, not through this client.
+    return {
+      running: true,
+      name: new URL(current.baseUrl).hostname,
+      port: Number(new URL(current.baseUrl).port) || null,
+      lanEnabled: false,
+      urls: [current.baseUrl],
+      token: current.key,
+    };
   }
   const payload = buildPairingPayload(current.port, current.lanEnabled, current.key);
   return {
@@ -229,6 +308,9 @@ export async function getPairingInfo(): Promise<{
 // Persists the toggle and rebinds the listener (127.0.0.1 ⇄ 0.0.0.0).
 // Connected clients drop and reconnect — acceptable for a settings flip.
 export async function setLanEnabled(enabled: boolean): Promise<void> {
+  if (serverHostMode() === 'remote') {
+    throw new Error('Not available while connected to a remote rowboat-server');
+  }
   const config = await loadServerConfig(WorkDir);
   await saveServerConfig(WorkDir, { ...config, lanEnabled: enabled });
   await stopServerHost();
@@ -237,6 +319,9 @@ export async function setLanEnabled(enabled: boolean): Promise<void> {
 
 /** Mints a new server key, revoking every paired client, then rebinds. */
 export async function rotateKey(): Promise<void> {
+  if (serverHostMode() === 'remote') {
+    throw new Error('Not available while connected to a remote rowboat-server');
+  }
   await stopServerHost();
   await rotateServerKey(WorkDir);
   await startServerHost();

--- a/apps/x/apps/server/.gitignore
+++ b/apps/x/apps/server/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+dist-headless/

--- a/apps/x/apps/server/package.json
+++ b/apps/x/apps/server/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "standalone": "node dist/standalone.js"
+    "standalone": "node dist/standalone.js",
+    "build:headless": "node scripts/build-headless.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.7",
@@ -24,6 +25,7 @@
     "@types/node": "^25.0.3",
     "@types/ws": "^8.18.1",
     "@x/client": "workspace:*",
+    "esbuild": "^0.24.2",
     "vitest": "catalog:"
   }
 }

--- a/apps/x/apps/server/scripts/build-headless.mjs
+++ b/apps/x/apps/server/scripts/build-headless.mjs
@@ -1,0 +1,73 @@
+/**
+ * Builds a self-contained headless distribution of rowboat-server for running
+ * on a plain Node box (Phase 8 — remote validation): no Electron, no pnpm
+ * workspace, no node_modules except node-pty (native, installed on the target
+ * so its binary matches that machine).
+ *
+ * Usage:  npm run build (workspace deps first) → node scripts/build-headless.mjs
+ * Output: dist-headless/  → tar it, scp it, `npm install --omit=dev && node rowboat-server.cjs`
+ */
+
+import * as esbuild from 'esbuild';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '..');
+const out = path.join(root, 'dist-headless');
+
+fs.rmSync(out, { recursive: true, force: true });
+fs.mkdirSync(out, { recursive: true });
+
+// Same shape as apps/main/bundle.mjs's rowboat-server artifact, plus the
+// import.meta.url polyfill (core resolves asset paths through it).
+const cjsBanner = `var __import_meta_url = require('url').pathToFileURL(__filename).href;`;
+await esbuild.build({
+  entryPoints: [path.join(root, 'dist', 'standalone.js')],
+  bundle: true,
+  platform: 'node',
+  target: 'node22',
+  format: 'cjs',
+  outfile: path.join(out, 'rowboat-server.cjs'),
+  banner: { js: cjsBanner },
+  define: { 'import.meta.url': '__import_meta_url' },
+  external: ['electron', 'node-pty', 'uiohook-napi', 'bun:sqlite'],
+});
+
+// node-pty is the one runtime dependency that must be installed on the target
+// machine (native module — the binary has to be compiled for that host).
+const mainPkg = JSON.parse(fs.readFileSync(path.join(root, '..', 'main', 'package.json'), 'utf8'));
+const ptyVersion = mainPkg.dependencies['node-pty'];
+fs.writeFileSync(
+  path.join(out, 'package.json'),
+  JSON.stringify(
+    {
+      name: 'rowboat-server',
+      version: mainPkg.version ?? '0.0.0',
+      private: true,
+      dependencies: { 'node-pty': ptyVersion },
+    },
+    null,
+    2,
+  ),
+);
+
+fs.writeFileSync(
+  path.join(out, 'README.md'),
+  `# rowboat-server (headless)
+
+Requires Node 22+ and build tools for node-pty (\`build-essential python3\` on Debian/Ubuntu).
+
+\`\`\`sh
+npm install --omit=dev
+node rowboat-server.cjs
+\`\`\`
+
+Data lives in ~/.rowboat (override with ROWBOAT_WORKDIR). The pairing token is
+~/.rowboat/server-key; enable non-localhost access by setting
+{"lanEnabled": true} in ~/.rowboat/config/server.json.
+`,
+);
+
+console.log(`✅ headless rowboat-server built in ${out}`);

--- a/apps/x/apps/server/src/server.test.ts
+++ b/apps/x/apps/server/src/server.test.ts
@@ -88,10 +88,12 @@ describe('rowboat-server transport', () => {
   let base: string;
   const turnBus = makeEmitter<TurnBusEvent>();
   const sessionBus = makeEmitter<never>();
+  const knowledgeBus = makeEmitter<void>();
 
   const events: EventSources = {
     subscribeTurnEvents: turnBus.subscribe,
     subscribeSessionEvents: sessionBus.subscribe,
+    subscribeKnowledgeEvents: (listener) => knowledgeBus.subscribe(listener),
   };
 
   beforeAll(async () => {
@@ -228,6 +230,15 @@ describe('rowboat-server transport', () => {
     const probe = connect(`ws://127.0.0.1:${server.port}/events?token=${server.key}`, { hello: true });
     const welcome = await probe.next((m) => m.type === 'welcome');
     expect(welcome.seq).toBe(1);
+    probe.socket.close();
+  });
+
+  it('broadcasts knowledge:didCommit to authenticated clients', async () => {
+    const probe = connect(`ws://127.0.0.1:${server.port}/events`, { token: server.key, hello: true });
+    await probe.next((m) => m.type === 'welcome');
+    knowledgeBus.emit();
+    const msg = await probe.next((m) => m.channel === 'knowledge:didCommit');
+    expect(msg.type).toBe('event');
     probe.socket.close();
   });
 

--- a/apps/x/apps/server/src/server.ts
+++ b/apps/x/apps/server/src/server.ts
@@ -25,6 +25,7 @@ export interface EventSources {
   subscribeTurnEvents(listener: (e: TurnBusEvent) => void): () => void;
   subscribeSessionEvents(listener: (e: SessionBusEvent) => void): () => void;
   subscribeWorkspaceEvents?(listener: (e: z.infer<typeof WorkspaceChangeEvent>) => void): () => void;
+  subscribeKnowledgeEvents?(listener: () => void): () => void;
   subscribeOAuthEvents?(listener: (e: unknown) => void): () => void;
   subscribeComposioEvents?(listener: (e: unknown) => void): () => void;
   subscribeChatgptEvents?(listener: (e: unknown) => void): () => void;
@@ -188,6 +189,7 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
     opts.events.subscribeTurnEvents((e) => hub.handleTurnEvent(e)),
     opts.events.subscribeSessionEvents((e) => hub.broadcast('sessions:events', e)),
     opts.events.subscribeWorkspaceEvents?.((e) => hub.broadcast('workspace:didChange', e)),
+    opts.events.subscribeKnowledgeEvents?.(() => hub.broadcast('knowledge:didCommit', {})),
     opts.events.subscribeOAuthEvents?.((e) => hub.broadcast('oauth:didConnect', e)),
     opts.events.subscribeComposioEvents?.((e) => hub.broadcast('composio:didConnect', e)),
     opts.events.subscribeChatgptEvents?.((e) => hub.broadcast('chatgpt:statusChanged', e)),

--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -9,6 +9,7 @@ import container, {
 } from '@x/core/dist/di/container.js';
 import type { ISessions } from '@x/core/dist/runtime/sessions/index.js';
 import { createCoreEventSources, createCoreRpcHandlers, resolveWorkspacePath } from './core-deps.js';
+import { startWorkspaceWatcher, subscribeWorkspaceEvents, subscribeKnowledgeEvents } from './workspace-watcher.js';
 import { prepareCoreData, initCoreServices } from '@x/core/dist/boot/services.js';
 import { createRowboatServer } from './server.js';
 import { capabilityBroker } from './capabilities.js';
@@ -77,11 +78,15 @@ async function main(): Promise<void> {
   // the Electron host (Phase 6): the standalone server now runs everything.
   await sessionsIndexReady;
   await initCoreServices();
+  // Filesystem change feed lives server-side (Phase 8): clients — local or
+  // remote — get workspace/knowledge pushes over the WS, not from their own
+  // disk.
+  await startWorkspaceWatcher();
 
   const server = await createRowboatServer({
     workDir: WorkDir,
     handlers: createCoreRpcHandlers({ sessionsIndexReady }),
-    events: createCoreEventSources(),
+    events: { ...createCoreEventSources(), subscribeWorkspaceEvents, subscribeKnowledgeEvents },
     resolveWorkspacePath,
     serverVersion: process.env.npm_package_version ?? '0.0.0',
   });

--- a/apps/x/apps/server/src/workspace-watcher.ts
+++ b/apps/x/apps/server/src/workspace-watcher.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs/promises';
+import { z } from 'zod';
+import { watcher as watcherCore, workspace, versionHistory } from '@x/core';
+import { workspace as workspaceShared } from '@x/shared';
+import { invalidateKnowledgeIndex } from '@x/core/dist/knowledge/knowledge_index.js';
+
+// Server-side workspace watcher (Phase 8): the debounced change feed that
+// lived in apps/main/src/ipc.ts, now hosted where core runs. In child and
+// remote modes the Electron client no longer watches the filesystem — it
+// relays `workspace:didChange` / `knowledge:didCommit` from the server's WS
+// feed, so a remote client sees the server machine's workspace, not its own.
+// Logic is a verbatim lift of main's debounce/queue semantics.
+
+type WorkspaceChangeEvent = z.infer<typeof workspaceShared.WorkspaceChangeEvent>;
+
+const workspaceListeners = new Set<(e: WorkspaceChangeEvent) => void>();
+const knowledgeListeners = new Set<() => void>();
+
+const changeQueue = new Set<string>();
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let started = false;
+
+function emitWorkspaceChangeEvent(event: WorkspaceChangeEvent): void {
+  for (const listener of workspaceListeners) listener(event);
+}
+
+function processChangeQueue(): void {
+  if (changeQueue.size === 0) {
+    return;
+  }
+
+  const paths = Array.from(changeQueue);
+  changeQueue.clear();
+
+  if (paths.length === 1) {
+    // For single path, try to determine kind from file stats
+    const relPath = paths[0]!;
+    try {
+      const absPath = workspace.resolveWorkspacePath(relPath);
+      fs.lstat(absPath)
+        .then((stats) => {
+          const kind = stats.isDirectory() ? 'dir' : 'file';
+          emitWorkspaceChangeEvent({ type: 'changed', path: relPath, kind });
+        })
+        .catch(() => {
+          // File no longer exists (edge case), emit without kind
+          emitWorkspaceChangeEvent({ type: 'changed', path: relPath });
+        });
+    } catch {
+      // Invalid path, ignore
+    }
+  } else {
+    // Emit bulkChanged for multiple paths
+    emitWorkspaceChangeEvent({ type: 'bulkChanged', paths });
+  }
+}
+
+function queueChange(relPath: string): void {
+  changeQueue.add(relPath);
+
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+
+  debounceTimer = setTimeout(() => {
+    processChangeQueue();
+    debounceTimer = null;
+  }, 150); // 150ms debounce
+}
+
+function touchesKnowledge(event: WorkspaceChangeEvent): boolean {
+  const hit = (p: string | undefined) => typeof p === 'string' && p.startsWith('knowledge/');
+  switch (event.type) {
+    case 'created':
+    case 'changed':
+    case 'deleted':
+      return hit(event.path);
+    case 'moved':
+      return hit(event.from) || hit(event.to);
+    case 'bulkChanged':
+      return !event.paths || event.paths.some(hit);
+    default:
+      return false;
+  }
+}
+
+function handleWorkspaceChange(event: WorkspaceChangeEvent): void {
+  // Any knowledge-base change drops the cached index so the next read rebuilds.
+  if (touchesKnowledge(event)) invalidateKnowledgeIndex();
+  // Debounce 'changed' events, emit others immediately
+  if (event.type === 'changed' && event.path) {
+    queueChange(event.path);
+  } else {
+    emitWorkspaceChangeEvent(event);
+  }
+}
+
+/** Starts the chokidar watcher and the knowledge-commit feed. Idempotent. */
+export async function startWorkspaceWatcher(): Promise<void> {
+  if (started) return;
+  started = true;
+  versionHistory.onCommit(() => {
+    for (const listener of knowledgeListeners) listener();
+  });
+  await watcherCore.createWorkspaceWatcher(handleWorkspaceChange);
+}
+
+export function subscribeWorkspaceEvents(listener: (e: WorkspaceChangeEvent) => void): () => void {
+  workspaceListeners.add(listener);
+  return () => workspaceListeners.delete(listener);
+}
+
+export function subscribeKnowledgeEvents(listener: () => void): () => void {
+  knowledgeListeners.add(listener);
+  return () => knowledgeListeners.delete(listener);
+}

--- a/apps/x/apps/server/src/ws-hub.ts
+++ b/apps/x/apps/server/src/ws-hub.ts
@@ -19,6 +19,7 @@ export type PushChannel =
   | 'turns:events'
   | 'sessions:events'
   | 'workspace:didChange'
+  | 'knowledge:didCommit'
   | 'oauth:didConnect'
   | 'composio:didConnect'
   | 'chatgpt:statusChanged'

--- a/apps/x/eslint.config.mts
+++ b/apps/x/eslint.config.mts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig([
-  globalIgnores(["**/dist"]),
+  globalIgnores(["**/dist", "**/dist-headless"]),
 
   // node runtime
   {

--- a/apps/x/packages/client/src/events.ts
+++ b/apps/x/packages/client/src/events.ts
@@ -18,7 +18,8 @@ export type PushChannel =
   | 'chatgpt:statusChanged'
   | 'terminal:data'
   | 'terminal:exit'
-  | 'voice:tts-chunk';
+  | 'voice:tts-chunk'
+  | 'knowledge:didCommit';
 
 interface ServerMessage {
   seq: number;

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       '@x/client':
         specifier: workspace:*
         version: link:../../packages/client
+      esbuild:
+        specifier: ^0.24.2
+        version: 0.24.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jsdom@29.1.1)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.2))


### PR DESCRIPTION
Part of the [separation plan](https://github.com/rowboatlabs/rowboat/blob/arch/server-client-separation/apps/x/SEPARATION_PLAN.md) — Phase 8a of remote validation (8b = token encryption at rest + remote OAuth claim flow).

## What
- **Remote server mode**: `ROWBOAT_REMOTE_SERVER=<url>` + `ROWBOAT_REMOTE_TOKEN` make the desktop a pure client of a rowboat-server on another machine — no child spawn, no local core. RPC forwarding, the WS events bridge, reverse-call capabilities, and `app://workspace` media serving (now proxied to the server's authenticated `/workspace` route) all target the remote box.
- **Server-side workspace watcher**: the debounced chokidar feed moves from Electron main into the standalone server; `workspace:didChange` and `knowledge:didCommit` ride the WS relay in child and remote modes. Also fixes `knowledge:didCommit` being dead since the 7b flip (main's versionHistory never commits when core runs in the child).
- **Headless distribution**: `npm run build:headless` in apps/server emits a self-contained `rowboat-server.cjs` + package.json for plain Node 22 on Linux (node-pty compiled on the target).
- **REMOTE_SERVER.md**: EC2 + Tailscale setup, systemd unit, known Phase 8b gaps.

## Verified
- typecheck clean, lint clean, 20 server tests pass (new: knowledge:didCommit broadcast)
- headless bundle boots under plain `node` against an isolated workdir; health OK
- live smoke: dev desktop with `ROWBOAT_REMOTE_SERVER` pointed at the headless server — no child spawned, RPCs round-trip to the remote workdir, WS events client connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)