### PR TITLE
Fix: space file links were stripped by both renderers' URL sanitizers

### DIFF
--- a/apps/x/apps/renderer/src/components/rich-markdown-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/rich-markdown-viewer.tsx
@@ -19,6 +19,7 @@ import { EmailBlockExtension, EmailsBlockExtension } from '@/extensions/email-bl
 import { TranscriptBlockExtension } from '@/extensions/transcript-block'
 import { MermaidBlockExtension } from '@/extensions/mermaid-block'
 import { WikiLink } from '@/extensions/wiki-link'
+import { allowRelativeAndAppHrefs } from '@/lib/viewer-links'
 import '@/styles/editor.css'
 
 const BLANK_LINE_MARKER = '\u200B'
@@ -64,6 +65,10 @@ export function RichMarkdownViewer({ content, onToggleTask, onOpenLink }: {
           rel: 'noopener noreferrer',
           target: '_blank',
         },
+        // Only when a link handler is mounted: the default validator drops
+        // relative hrefs (a/b.md) and app:// links at parse time — exactly the
+        // links the handler exists to open.
+        ...(onOpenLink ? { isAllowedUri: allowRelativeAndAppHrefs } : {}),
       }),
       Image.configure({
         inline: false,

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -8,8 +8,10 @@ import {
     decorateMentions,
     parseAssetWireUrl,
     parseBlobAppUrl,
+    parseSpaceFileAppUrl,
     resolveSpaceLink,
     rewriteBlobLinks,
+    rewriteFileLinks,
     type SpaceRefs,
 } from '@/lib/spaces-presentation'
 
@@ -116,8 +118,12 @@ function SpaceAnchor({ href, children, ...rest }: ComponentProps<'a'>) {
         return <BlobLinkCard href={url}>{children}</BlobLinkCard>
     }
     // A relative link in a message is a file link (resolved from the space
-    // root); the contract's canonical asset URL for this space opens the same way.
-    const filePath = resolveSpaceLink(url, '') ?? (refs ? parseAssetWireUrl(url, refs) : null)
+    // root — rewritten pre-parse to app://space-file so Streamdown's URL
+    // hardening doesn't strip it); the contract's canonical asset URL for
+    // this space opens the same way.
+    const filePath = parseSpaceFileAppUrl(url)?.path
+        ?? resolveSpaceLink(url, '')
+        ?? (refs ? parseAssetWireUrl(url, refs) : null)
     if (filePath && openFile) {
         return (
             <button
@@ -143,7 +149,8 @@ export function SpaceMarkdown({ body, className }: { body: string; className?: s
     const memberNames = useMemberNames()
     const text = useMemo(() => {
         const withBlobs = refs ? rewriteBlobLinks(body, refs) : body
-        return decorateMentions(withBlobs, memberNames)
+        const withFiles = refs ? rewriteFileLinks(withBlobs, refs) : withBlobs
+        return decorateMentions(withFiles, memberNames)
     }, [body, refs, memberNames])
     return (
         <div className={cn(className)}>

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.test.ts
@@ -14,10 +14,13 @@ import {
     orgMonogram,
     parseAssetWireUrl,
     parseBlobAppUrl,
+    parseSpaceFileAppUrl,
     resolveMentions,
     resolveSpaceLink,
     rewriteBlobLinks,
+    rewriteFileLinks,
     rewriteRelativeImages,
+    spaceFileAppUrl,
     toggleTaskAt,
 } from './spaces-presentation'
 
@@ -109,6 +112,30 @@ describe('file links — relative markdown resolves against the tree', () => {
         const target = encodeSpaceLinkTarget(path)
         expect(target).not.toMatch(/[ ()]/)
         expect(resolveSpaceLink(target, '')).toBe(path)
+    })
+    it('space-file app URLs round-trip (the render form that survives Streamdown hardening)', () => {
+        const refs = { orgId: 'o1', spaceId: 's1' }
+        const url = spaceFileAppUrl(refs, 'design/notes (v2).md')
+        expect(url.startsWith('app://space-file/o1/s1/')).toBe(true)
+        expect(url).not.toMatch(/[ ()]/)
+        expect(parseSpaceFileAppUrl(url)).toEqual({ orgId: 'o1', spaceId: 's1', path: 'design/notes (v2).md' })
+        expect(parseSpaceFileAppUrl('app://space-blob/o1/s1/abc')).toBeNull()
+        expect(parseSpaceFileAppUrl('https://x.com/a')).toBeNull()
+    })
+    it('rewriteFileLinks: relative links become app://space-file; images, absolute URLs, code stay', () => {
+        const refs = { orgId: 'o1', spaceId: 's1' }
+        expect(rewriteFileLinks('see [sso](decisions/sso.md)', refs))
+            .toBe('see [sso](app://space-file/o1/s1/decisions/sso.md)')
+        expect(rewriteFileLinks('see [n](design%20notes.md)', refs))
+            .toBe('see [n](app://space-file/o1/s1/design%20notes.md)')
+        const untouched = [
+            '![img](shot.png)',
+            '[ext](https://example.com/a)',
+            '[m](mailto:a@b.c)',
+            '`[c](a.md)`',
+            '```\n[c](a.md)\n```',
+        ]
+        for (const body of untouched) expect(rewriteFileLinks(body, refs)).toBe(body)
     })
     it('parses the canonical asset URL for this space only', () => {
         const refs = { orgId: 'o1', orgAddress: 'rowboat.team', spaceId: '01HXAMPZESPACE00000000000A' }

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.ts
@@ -292,6 +292,46 @@ export function parseAssetWireUrl(url: string, refs: SpaceRefs): string | null {
 }
 
 /**
+ * The renderable form of a file link — a render-time-only internal URL (never
+ * persisted). Chat markdown goes through Streamdown, whose harden pass strips
+ * relative hrefs (a bare `a/b.md` isn't parseable as a URL) but passes custom
+ * protocols untouched — so relative links rewrite to this before parsing, and
+ * the anchor component maps it back to the path.
+ */
+export function spaceFileAppUrl(refs: { orgId: string; spaceId: string }, path: string): string {
+    return `app://space-file/${encodeURIComponent(refs.orgId)}/${encodeURIComponent(refs.spaceId)}/${encodeSpaceLinkTarget(path)}`
+}
+
+const SPACE_FILE_APP_URL_RE = /^app:\/\/space-file\/([^/]+)\/([^/]+)\/(.+)$/
+
+export function parseSpaceFileAppUrl(url: string): { orgId: string; spaceId: string; path: string } | null {
+    const m = SPACE_FILE_APP_URL_RE.exec(url)
+    if (!m) return null
+    const path = resolveSpaceLink(`/${m[3]!}`, '')
+    if (!path) return null
+    return { orgId: decodeURIComponent(m[1]!), spaceId: decodeURIComponent(m[2]!), path }
+}
+
+/**
+ * Rewrite relative markdown LINKS (not images) in a message body to their
+ * app://space-file form so they survive Streamdown's URL hardening. Code
+ * regions are cites; absolute URLs and in-page anchors stay literal.
+ */
+export function rewriteFileLinks(body: string, refs: { orgId: string; spaceId: string }): string {
+    const parts = body.split(/(```[\s\S]*?(?:```|$)|`[^`\n]*`)/g)
+    return parts
+        .map((part, i) => {
+            if (i % 2 === 1) return part
+            return part.replace(/(!?)\[([^\]]*)\]\(([^()\s]+)(\s+"[^"]*")?\)/g, (m, bang: string, text: string, target: string, title?: string) => {
+                if (bang) return m
+                const path = resolveSpaceLink(target, '')
+                return path ? `[${text}](${spaceFileAppUrl(refs, path)}${title ?? ''})` : m
+            })
+        })
+        .join('')
+}
+
+/**
  * Rewrite relative image references in a markdown body to renderable URLs
  * (app://space-blob through srcFor). Only references that resolve to a real
  * image asset change; everything else — external URLs, text files, broken

--- a/apps/x/apps/renderer/src/lib/viewer-links.test.ts
+++ b/apps/x/apps/renderer/src/lib/viewer-links.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import { Markdown } from 'tiptap-markdown'
+import { allowRelativeAndAppHrefs } from './viewer-links'
+
+const ok = () => false
+
+describe('allowRelativeAndAppHrefs', () => {
+    it('accepts relative paths and app:// URLs', () => {
+        expect(allowRelativeAndAppHrefs('roadmap.md', { defaultValidate: ok })).toBe(true)
+        expect(allowRelativeAndAppHrefs('decisions/sso.md', { defaultValidate: ok })).toBe(true)
+        expect(allowRelativeAndAppHrefs('../a.md', { defaultValidate: ok })).toBe(true)
+        expect(allowRelativeAndAppHrefs('design%20notes.md', { defaultValidate: ok })).toBe(true)
+        expect(allowRelativeAndAppHrefs(`app://space-blob/o/s/${'a'.repeat(64)}`, { defaultValidate: ok })).toBe(true)
+    })
+    it('still rejects dangerous or scheme-carrying hrefs', () => {
+        expect(allowRelativeAndAppHrefs('javascript:alert(1)', { defaultValidate: ok })).toBe(false)
+        expect(allowRelativeAndAppHrefs('java\nscript:alert(1)', { defaultValidate: ok })).toBe(false)
+        expect(allowRelativeAndAppHrefs('data:text/html,x', { defaultValidate: ok })).toBe(false)
+        expect(allowRelativeAndAppHrefs('//evil.com/x', { defaultValidate: ok })).toBe(false)
+        expect(allowRelativeAndAppHrefs('vbscript:x', { defaultValidate: ok })).toBe(false)
+    })
+    it('defers to the default validator for normal absolute URLs', () => {
+        expect(allowRelativeAndAppHrefs('https://example.com/x', { defaultValidate: (u) => u.startsWith('https:') })).toBe(true)
+    })
+})
+
+// The regression this guards: TipTap's default isAllowedUri drops the link
+// MARK at parse time for hrefs like `decisions/sso.md` and app:// blob links —
+// the file view rendered them as plain text. Mirror the viewer's Link config
+// and prove the marks survive.
+function render(md: string): string {
+    const editor = new Editor({
+        editable: false,
+        extensions: [
+            StarterKit.configure({ heading: { levels: [1, 2, 3] }, link: false }),
+            Link.configure({
+                openOnClick: true,
+                HTMLAttributes: { rel: 'noopener noreferrer', target: '_blank' },
+                isAllowedUri: allowRelativeAndAppHrefs,
+            }),
+            Markdown.configure({ html: true, breaks: true, tightLists: false, transformCopiedText: false, transformPastedText: false }),
+        ],
+        content: md,
+    })
+    const html = editor.getHTML()
+    editor.destroy()
+    return html
+}
+
+describe('RichMarkdownViewer link parsing (relaxed validator)', () => {
+    it('keeps nested relative links', () => {
+        expect(render('see [sso](decisions/sso.md)')).toContain('href="decisions/sso.md"')
+    })
+    it('keeps bare relative and app:// links', () => {
+        expect(render('see [r](roadmap.md)')).toContain('href="roadmap.md"')
+        const hash = 'a'.repeat(64)
+        expect(render(`see [b](app://space-blob/o/s/${hash})`)).toContain(`href="app://space-blob/o/s/${hash}"`)
+    })
+    it('still drops javascript: links (no anchor is produced)', () => {
+        expect(render('see [x](javascript:alert(1))')).not.toContain('href=')
+    })
+})

--- a/apps/x/apps/renderer/src/lib/viewer-links.ts
+++ b/apps/x/apps/renderer/src/lib/viewer-links.ts
@@ -1,0 +1,20 @@
+// Link validation for RichMarkdownViewer when a link handler is mounted.
+//
+// TipTap's default isAllowedUri rejects any href whose first segment is
+// followed by '/', '.', or ':' unless the scheme is allowlisted — which drops
+// the link mark entirely for space-relative paths like `decisions/sso.md` and
+// for app:// blob links. This validator keeps the default (so javascript:,
+// data:, etc. stay blocked), and additionally accepts app:// URLs and
+// scheme-less relative hrefs.
+
+/** Whitespace a browser strips from URLs — remove before scheme sniffing, or `java\nscript:` slips through as "relative". */
+// eslint-disable-next-line no-control-regex
+const URL_WHITESPACE_RE = /[\u0000-\u0020\u00A0\u1680\u2000-\u200B\u2028\u2029\u202F\u205F\u3000\uFEFF]+/g
+
+export function allowRelativeAndAppHrefs(url: string, ctx: { defaultValidate: (url: string) => boolean }): boolean {
+    if (ctx.defaultValidate(url)) return true
+    const cleaned = url.replace(URL_WHITESPACE_RE, '')
+    if (/^app:\/\//i.test(cleaned)) return true
+    // No scheme and not protocol-relative → a relative path, safe to render.
+    return !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(cleaned) && !cleaned.startsWith('//')
+}


### PR DESCRIPTION
Follow-up to #908 (the fix commit was pushed to that branch minutes after it merged, so it needed its own PR).

File links were stored correctly but neither rendered nor clickable, in files and in chat — two independent URL sanitizers stripped them before any click handling ran:

- **Chat (Streamdown)**: the built-in `rehype-harden` pass can't parse a bare relative target (`decisions/sso.md`) into a URL without an origin, so it replaced the anchor with a grey "…[blocked]" span. Custom protocols pass through untouched (why `app://space-blob` attachment cards always worked) — so relative links in message bodies now rewrite at render time (never persisted) to `app://space-file/<org>/<space>/<path>`, which `SpaceAnchor` maps back to the path and opens in the file pane.
- **Files (TipTap)**: the Link extension's default `isAllowedUri` regex rejects any href whose first path segment is followed by `/`, `.`, or `:` unless the scheme is allowlisted — an accidental character-class range (`.-:` covers `/` and digits). Net effect: `roadmap.md` and `../x.md` rendered, but `decisions/sso.md` and `app://space-blob/…` had their link mark dropped at parse time (plain text). When a link handler is mounted, the viewer now uses `allowRelativeAndAppHrefs`: the default validation plus `app://` and scheme-less relative hrefs, with URL whitespace stripped before scheme sniffing so `javascript:`/`data:`/`//host` obfuscations stay blocked. TipTap's own `openOnClick` plugin is inert in read-only editors (verified in source), so there's no double-open.

Regression coverage: a headless editor mirroring the viewer's exact Link config proves nested-relative and `app://` marks survive and `javascript:` produces no anchor; helper tests cover the `app://space-file` round-trip and the message-body rewrite (images, absolute URLs, and code regions untouched).

Renderer suite 340 green; typecheck + lint clean. Client-only, no wire or server changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)