### PR TITLE
feat(x): Phase 8b — token encryption at rest + OAuth loopback relay

### DIFF
--- a/apps/x/REMOTE_SERVER.md
+++ b/apps/x/REMOTE_SERVER.md
@@ -94,16 +94,19 @@ box (same schema as the desktop writes). Easiest bootstrap: copy your local
 `~/.rowboat/config/models.json` to the box once — or edit models in the
 desktop settings UI while connected remotely; the writes land on the server.
 
-## Known gaps (Phase 8b)
+## Security model (Phase 8b)
 
-- **Token encryption at rest**: headless has no OS keychain — connector
-  tokens fall back to plaintext files in `~/.rowboat`. Mitigate with disk
-  encryption + locked-down box until the file-key cipher lands.
-- **OAuth connect flows**: the loopback redirect lands on the *server's*
-  localhost. Connecting a new provider remotely needs the claim flow (8b);
-  until then, connect providers while running locally, or complete the OAuth
-  redirect in a browser on the server (e.g. via SSH port-forward:
-  `ssh -L <port>:127.0.0.1:<port>` during the flow).
-- **Security model**: bearer token over plain HTTP inside the tailnet.
-  Tailscale encrypts on the wire (WireGuard); do not run this over untrusted
-  networks without it (or a TLS reverse proxy).
+- **Token encryption at rest**: the headless server has no OS keychain, so
+  GitHub/ChatGPT tokens are encrypted with AES-256-GCM under a random key at
+  `~/.rowboat/cipher-key` (0600). Key and data sit on the same disk — an
+  attacker with full workdir access gets both; keep the box locked down and
+  the disk encrypted. Tokens stored earlier by the Electron app (keychain-
+  encrypted) can't be read here — sign in again on the remote server.
+- **OAuth connect flows** work remotely: the server asks the connected
+  desktop (over the WS reverse-call channel) to host the `127.0.0.1`
+  callback listener, so the browser redirect lands on *your* machine and is
+  relayed back to the server. No SSH port-forwarding needed. With no desktop
+  connected, flows fall back to a listener on the server itself.
+- **Transport**: bearer token over plain HTTP inside the tailnet. Tailscale
+  encrypts on the wire (WireGuard); do not run this over untrusted networks
+  without it (or a TLS reverse proxy).

--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -3056,6 +3056,13 @@ export function setupIpcHandlers() {
       await rotateServerKey();
       return { success: true };
     },
+    // Server-only channel: the client's relay listener calls it over HTTP
+    // (see server-host.ts) — it always forwards, this local stub is
+    // unreachable unless forwarding is killed, where the relay can't work
+    // anyway.
+    'oauth:deliverLoopbackCallback': async () => {
+      throw new Error('oauth:deliverLoopbackCallback is served by rowboat-server');
+    },
     // Embedded browser handlers (WebContentsView + navigation)
     ...browserIpcHandlers,
   });

--- a/apps/x/apps/main/src/server-host.ts
+++ b/apps/x/apps/main/src/server-host.ts
@@ -17,6 +17,8 @@ import {
   type RowboatServer,
 } from '@x/server';
 import { WorkDir } from '@x/core/dist/config/config.js';
+import { createRelayAuthServer } from '@x/core/dist/auth/loopback-server.js';
+import type { Server as HttpServer } from 'node:http';
 import { broadcastToWindows, findMainAppWindow, onWorkspaceChange, sessionsIndexReady } from './ipc.js';
 import { ElectronNotificationService } from './notification/electron-notification-service.js';
 import { ElectronBrowserControlService } from './browser/control-service.js';
@@ -80,6 +82,18 @@ const PUSH_CHANNELS = [
   'knowledge:didCommit',
 ] as const;
 
+// OAuth loopback listeners this client hosts on the server's behalf (Phase
+// 8b): the server's `loopback-bind` reverse call binds a local 127.0.0.1
+// listener here — the machine whose browser receives the redirect — and every
+// callback hit is relayed to the server's oauth:deliverLoopbackCallback RPC,
+// which answers with the page to render.
+const relayListeners = new Map<string, HttpServer>();
+
+function closeRelayListeners(): void {
+  for (const server of relayListeners.values()) server.close();
+  relayListeners.clear();
+}
+
 // The client half shared by child and remote modes: WS events relay to
 // renderer windows plus the Electron-side capability handlers for the
 // server's reverse calls.
@@ -118,6 +132,35 @@ function createDesktopEventsClient(baseUrl: string, key: string): EventsClient {
         const p = payload as { type: 'captureTarget' | 'insert'; text?: string };
         if (p.type === 'insert') return textInsertService.insert(p.text ?? '');
         await textInsertService.captureTarget();
+        return { ok: true };
+      },
+      'loopback-bind': async (payload) => {
+        const p = payload as { bindingId: string; port: number; fallback: boolean; callbackPath: string };
+        const { server, port } = await createRelayAuthServer(
+          p.port,
+          async (callbackUrl) => {
+            const res = await fetch(`${baseUrl}/rpc/oauth:deliverLoopbackCallback`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json', authorization: `Bearer ${key}` },
+              body: JSON.stringify({ bindingId: p.bindingId, url: callbackUrl.toString() }),
+            });
+            const body = (await res.json().catch(() => null)) as
+              | { accepted?: boolean; message?: string }
+              | null;
+            if (!res.ok || !body) {
+              return { accepted: false, message: 'Could not reach the Rowboat server to complete sign-in' };
+            }
+            return { accepted: body.accepted === true, message: body.message };
+          },
+          { fallback: p.fallback, callbackPath: p.callbackPath },
+        );
+        relayListeners.set(p.bindingId, server);
+        return { port };
+      },
+      'loopback-close': (payload) => {
+        const p = payload as { bindingId: string };
+        relayListeners.get(p.bindingId)?.close();
+        relayListeners.delete(p.bindingId);
         return { ok: true };
       },
     },
@@ -264,6 +307,7 @@ export async function stopServerHost(): Promise<void> {
   current = null;
   ready = null;
   if (!server) return;
+  closeRelayListeners();
   if ('close' in server) {
     await server.close();
   } else {

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -260,6 +260,9 @@ export const RPC_CHANNELS = [
   'terminal:input',
   'terminal:resize',
   'terminal:dispose',
+
+  // Phase 8b: the loopback-capable client relays OAuth callback hits here.
+  'oauth:deliverLoopbackCallback',
 ] as const satisfies readonly ipc.InvokeChannels[];
 
 export type RpcChannel = (typeof RPC_CHANNELS)[number];

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -1,4 +1,5 @@
 import container from '@x/core/dist/di/container.js';
+import { deliverLoopbackCallback } from './loopback-relay.js';
 import type { ISessions, EmitterSessionBus } from '@x/core/dist/runtime/sessions/index.js';
 import type { ITurnEventBus } from '@x/core/dist/runtime/turns/event-hub.js';
 import * as workspaceCore from '@x/core/dist/workspace/workspace.js';
@@ -1506,6 +1507,11 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
       disposeTerminal(args.id);
       return { success: true };
     },
+
+    // Phase 8b: OAuth loopback relay — the loopback-capable client posts
+    // every callback hit here; the relay settles the owning flow and answers
+    // with the page to render.
+    'oauth:deliverLoopbackCallback': async (args) => deliverLoopbackCallback(args),
 
 
     // Rowboat Apps handlers (spec §13)

--- a/apps/x/apps/server/src/file-cipher.test.ts
+++ b/apps/x/apps/server/src/file-cipher.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createFileCipher } from './file-cipher.js';
+
+describe('file cipher (token encryption at rest)', () => {
+  let workDir: string;
+
+  beforeAll(async () => {
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-cipher-test-'));
+  });
+
+  afterAll(async () => {
+    await fs.rm(workDir, { recursive: true, force: true });
+  });
+
+  it('round-trips and is always available', async () => {
+    const cipher = await createFileCipher(workDir);
+    expect(cipher.isAvailable()).toBe(true);
+    const secret = 'refresh-token-🔑-with-unicode';
+    const encrypted = cipher.encrypt(secret);
+    expect(encrypted).not.toContain(secret);
+    expect(encrypted.startsWith('v1:')).toBe(true);
+    expect(cipher.decrypt(encrypted)).toBe(secret);
+  });
+
+  it('persists the key: a second instance decrypts the first one\'s ciphertext', async () => {
+    const first = await createFileCipher(workDir);
+    const encrypted = first.encrypt('survives-restart');
+    const second = await createFileCipher(workDir);
+    expect(second.decrypt(encrypted)).toBe('survives-restart');
+  });
+
+  it('creates the key file with owner-only permissions', async () => {
+    await createFileCipher(workDir);
+    const stat = await fs.stat(path.join(workDir, 'cipher-key'));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('rejects tampered ciphertext (GCM auth)', async () => {
+    const cipher = await createFileCipher(workDir);
+    const encrypted = cipher.encrypt('integrity');
+    const parts = encrypted.split(':');
+    const data = Buffer.from(parts[3]!, 'base64');
+    data[0]! ^= 0xff;
+    parts[3] = data.toString('base64');
+    expect(() => cipher.decrypt(parts.join(':'))).toThrow();
+    expect(() => cipher.decrypt('not-a-ciphertext')).toThrow();
+  });
+});

--- a/apps/x/apps/server/src/file-cipher.ts
+++ b/apps/x/apps/server/src/file-cipher.ts
@@ -1,0 +1,48 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { TokenCipher } from '@x/core/dist/auth/chatgpt-auth.js';
+
+// Token-at-rest encryption for headless hosts (Phase 8b). The Electron app
+// used safeStorage (OS keychain); a standalone server has no keychain, so the
+// cipher key is a random 32-byte file next to the data it protects —
+// `<workdir>/cipher-key`, mode 0600. This protects tokens from casual reads
+// and backups that miss the key file; an attacker with full workdir access
+// gets both, which matches the keychain-less posture of comparable
+// server daemons. Ciphertext format: v1:<iv>:<tag>:<data>, all base64.
+
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+
+export async function createFileCipher(workDir: string): Promise<TokenCipher> {
+  const keyPath = path.join(workDir, 'cipher-key');
+  let key: Buffer;
+  try {
+    key = Buffer.from((await fs.readFile(keyPath, 'utf8')).trim(), 'base64');
+    if (key.length !== KEY_BYTES) throw new Error(`cipher-key is ${key.length} bytes, expected ${KEY_BYTES}`);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    key = crypto.randomBytes(KEY_BYTES);
+    await fs.mkdir(workDir, { recursive: true });
+    await fs.writeFile(keyPath, key.toString('base64') + '\n', { mode: 0o600 });
+  }
+
+  return {
+    isAvailable: () => true,
+    encrypt: (plain: string): string => {
+      const iv = crypto.randomBytes(IV_BYTES);
+      const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+      const data = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+      return `v1:${iv.toString('base64')}:${cipher.getAuthTag().toString('base64')}:${data.toString('base64')}`;
+    },
+    decrypt: (encrypted: string): string => {
+      const [version, iv, tag, data] = encrypted.split(':');
+      if (version !== 'v1' || !iv || !tag || !data) {
+        throw new Error('Unrecognized ciphertext format');
+      }
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(iv, 'base64'));
+      decipher.setAuthTag(Buffer.from(tag, 'base64'));
+      return Buffer.concat([decipher.update(Buffer.from(data, 'base64')), decipher.final()]).toString('utf8');
+    },
+  };
+}

--- a/apps/x/apps/server/src/loopback-relay.test.ts
+++ b/apps/x/apps/server/src/loopback-relay.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { openLoopback } from '@x/core/dist/auth/loopback-server.js';
+import { installLoopbackRelay, deliverLoopbackCallback } from './loopback-relay.js';
+import type { CapabilityTransport } from './capabilities.js';
+
+// The relay half of Phase 8b: a fake capability transport stands in for the
+// connected desktop client, so no sockets are bound anywhere.
+
+function fakeBroker(overrides: Partial<CapabilityTransport> = {}): CapabilityTransport {
+  return {
+    request: vi.fn(async () => ({ port: 8080 })),
+    broadcast: vi.fn(),
+    hasCapableClient: () => true,
+    ...overrides,
+  };
+}
+
+describe('oauth loopback relay', () => {
+  it('routes openLoopback through the capable client and callbacks through deliver', async () => {
+    const broker = fakeBroker();
+    installLoopbackRelay(broker);
+
+    const received: string[] = [];
+    const handle = await openLoopback(8080, (url) => {
+      received.push(url.searchParams.get('code') ?? '');
+    }, {
+      validateCallback: (url) => (url.searchParams.get('state') === 'live' ? null : 'stale attempt'),
+      onError: undefined,
+    });
+    expect(handle.port).toBe(8080);
+    expect(broker.request).toHaveBeenCalledWith(
+      'loopback-bind',
+      expect.objectContaining({ port: 8080, callbackPath: '/oauth/callback' }),
+      expect.anything(),
+    );
+
+    const bindingId = (broker.request as ReturnType<typeof vi.fn>).mock.calls[0]![1].bindingId as string;
+
+    // Stale state → rejected by the flow's gatekeeper, callback untouched.
+    const stale = await deliverLoopbackCallback({
+      bindingId,
+      url: 'http://localhost:8080/oauth/callback?state=old&code=nope',
+    });
+    expect(stale).toEqual({ accepted: false, message: 'stale attempt' });
+    expect(received).toEqual([]);
+
+    // Live callback → accepted, flow callback ran.
+    const ok = await deliverLoopbackCallback({
+      bindingId,
+      url: 'http://localhost:8080/oauth/callback?state=live&code=abc123',
+    });
+    expect(ok.accepted).toBe(true);
+    expect(received).toEqual(['abc123']);
+
+    // close() broadcasts loopback-close and unregisters the binding.
+    handle.close();
+    expect(broker.broadcast).toHaveBeenCalledWith('loopback-close', { bindingId });
+    const gone = await deliverLoopbackCallback({ bindingId, url: 'http://localhost:8080/oauth/callback?state=live' });
+    expect(gone.accepted).toBe(false);
+  });
+
+  it('surfaces provider errors to the flow onError', async () => {
+    const broker = fakeBroker();
+    installLoopbackRelay(broker);
+    const onError = vi.fn();
+    await openLoopback(8080, () => {}, { onError });
+    const bindingId = (broker.request as ReturnType<typeof vi.fn>).mock.calls[0]![1].bindingId as string;
+
+    const denied = await deliverLoopbackCallback({
+      bindingId,
+      url: 'http://localhost:8080/oauth/callback?error=access_denied',
+    });
+    expect(denied).toEqual({ accepted: false, message: 'Error: access_denied' });
+    expect(onError).toHaveBeenCalledWith('access_denied');
+  });
+
+  it('answers an unknown binding without a live flow', async () => {
+    const res = await deliverLoopbackCallback({ bindingId: 'nope', url: 'http://localhost:8080/oauth/callback' });
+    expect(res.accepted).toBe(false);
+  });
+});

--- a/apps/x/apps/server/src/loopback-relay.ts
+++ b/apps/x/apps/server/src/loopback-relay.ts
@@ -1,0 +1,95 @@
+import crypto from 'node:crypto';
+import { URL } from 'node:url';
+import { registerLoopbackHost } from '@x/core/dist/auth/loopback-server.js';
+import type { capabilityBroker } from './capabilities.js';
+
+// OAuth loopback relay (Phase 8b): with a remote rowboat-server, provider
+// redirects land on 127.0.0.1 of the machine running the BROWSER — the
+// client's. The registered LoopbackHost asks a loopback-capable client (the
+// desktop) over the WS reverse-call channel to bind the port; the client
+// relays every callback hit back via the `oauth:deliverLoopbackCallback` RPC,
+// and this module runs the flow's validate/error/callback logic and answers
+// with what page the client should render. With no capable client connected,
+// the host returns null and core binds locally (child-mode/pre-8b behaviour
+// is only reached when nothing better is available — the desktop client
+// always advertises the capability, so the relay path is the one exercised
+// daily).
+
+interface PendingLoopback {
+  onCallback: (url: URL) => void | Promise<void>;
+  onError?: (error: string) => void;
+  validateCallback?: (url: URL) => string | null;
+}
+
+const pending = new Map<string, PendingLoopback>();
+
+type Broker = ReturnType<typeof capabilityBroker>;
+
+export function installLoopbackRelay(broker: Broker): void {
+  registerLoopbackHost(async (port, onCallback, opts) => {
+    if (!broker.hasCapableClient('loopback-bind')) return null;
+    const bindingId = crypto.randomUUID();
+    const res = (await broker.request(
+      'loopback-bind',
+      {
+        bindingId,
+        port,
+        fallback: opts.fallback === true,
+        callbackPath: opts.callbackPath ?? '/oauth/callback',
+      },
+      { timeoutMs: 15_000 },
+    )) as { port: number };
+    pending.set(bindingId, {
+      onCallback,
+      onError: opts.onError,
+      validateCallback: opts.validateCallback,
+    });
+    return {
+      port: res.port,
+      close: () => {
+        pending.delete(bindingId);
+        broker.broadcast('loopback-close', { bindingId });
+      },
+    };
+  });
+}
+
+/**
+ * RPC handler for `oauth:deliverLoopbackCallback` — mirrors the local
+ * listener's gatekeeper order in loopback-server.ts: validate, provider
+ * error, then the flow callback. The result tells the client which page to
+ * render in the browser tab.
+ */
+export async function deliverLoopbackCallback(args: {
+  bindingId: string;
+  url: string;
+}): Promise<{ accepted: boolean; message?: string }> {
+  const entry = pending.get(args.bindingId);
+  if (!entry) {
+    return { accepted: false, message: 'This sign-in attempt is no longer active. Close this tab and retry from Rowboat.' };
+  }
+  let url: URL;
+  try {
+    url = new URL(args.url);
+  } catch {
+    return { accepted: false, message: 'Malformed callback URL' };
+  }
+  const rejection = entry.validateCallback?.(url) ?? null;
+  if (rejection) {
+    console.warn(`[OAuth] Relay rejected callback (state=${url.searchParams.get('state') ?? '<none>'}): ${rejection}`);
+    return { accepted: false, message: rejection };
+  }
+  const error = url.searchParams.get('error');
+  if (error) {
+    console.warn(`[OAuth] Relay callback carried provider error: ${error}`);
+    entry.onError?.(error);
+    return { accepted: false, message: `Error: ${error}` };
+  }
+  try {
+    await entry.onCallback(url);
+    return { accepted: true };
+  } catch (err) {
+    console.error('[OAuth] Relay callback handling failed:', err);
+    return { accepted: false, message: err instanceof Error ? err.message : 'Callback handling failed' };
+  }
+}

--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -14,6 +14,10 @@ import { prepareCoreData, initCoreServices } from '@x/core/dist/boot/services.js
 import { createRowboatServer } from './server.js';
 import { capabilityBroker } from './capabilities.js';
 import { registerUrlOpener } from '@x/core/dist/auth/url-opener.js';
+import { installLoopbackRelay } from './loopback-relay.js';
+import { createFileCipher } from './file-cipher.js';
+import { setTokenCipher as setChatGPTTokenCipher } from '@x/core/dist/auth/chatgpt-auth.js';
+import { setTokenCipher as setGithubTokenCipher } from '@x/core/dist/apps/github-auth.js';
 
 // Headless rowboat-server: the RFC's end-state entrypoint, where main spawns
 // this as a child process (or it runs on a remote box) and core lives here.
@@ -68,6 +72,15 @@ async function main(): Promise<void> {
     },
     focusClient: () => broker.broadcast('focus-client', {}),
   });
+  // OAuth loopback listeners are hosted by the loopback-capable client (the
+  // machine whose browser gets the redirect); falls back to local binds when
+  // none is connected (Phase 8b).
+  installLoopbackRelay(broker);
+  // Token-at-rest encryption: no OS keychain here — a workdir key file
+  // (cipher-key, 0600) backs AES-256-GCM for the github/chatgpt token stores.
+  const cipher = await createFileCipher(WorkDir);
+  setChatGPTTokenCipher(cipher);
+  setGithubTokenCipher(cipher);
 
   await prepareCoreData();
   const sessions = container.resolve<ISessions>('sessions');

--- a/apps/x/package.json
+++ b/apps/x/package.json
@@ -15,7 +15,7 @@
     "main": "wait-on http://localhost:5173 && cd apps/main && npm run build && npm run start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "npm run shared && npm run client && npm run test:shared && npm run test:core && npm run test:server && npm run test:renderer",
+    "test": "npm run shared && npm run core && npm run client && npm run test:shared && npm run test:core && npm run test:server && npm run test:renderer",
     "test:shared": "cd packages/shared && npm test",
     "test:core": "cd packages/core && npm test",
     "test:server": "cd apps/server && npm test",

--- a/apps/x/packages/core/src/auth/chatgpt-signin.ts
+++ b/apps/x/packages/core/src/auth/chatgpt-signin.ts
@@ -1,6 +1,5 @@
 import { openExternalUrl } from './url-opener.js';
-import type { Server } from 'http';
-import { createAuthServer } from './loopback-server.js';
+import { openLoopback, type LoopbackHandle } from './loopback-server.js';
 import * as oauthClient from '../auth/oauth-client.js';
 import { exchangeChatGPTCode, getChatGPTStatus } from '../auth/chatgpt-auth.js';
 import { applyCodexInitialSelection } from '../models/chatgpt-selection.js';
@@ -103,7 +102,7 @@ function startAttempt(): ActiveAttempt {
   });
 
   let settled = false;
-  let server: Server | null = null;
+  let server: LoopbackHandle | null = null;
   let timeoutHandle: NodeJS.Timeout | null = null;
   let serverClosed: Promise<void> | null = null;
 
@@ -118,16 +117,9 @@ function startAttempt(): ActiveAttempt {
     if (serverClosed) return serverClosed;
     const s = server;
     server = null;
-    serverClosed = !s
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          s.close(() => resolve());
-          s.closeIdleConnections();
-          // Preconnect sockets that never carried a request survive
-          // closeIdleConnections; destroy stragglers once the in-flight
-          // response has flushed.
-          setTimeout(() => s.closeAllConnections(), 5000).unref();
-        });
+    // Idle-connection cleanup and delayed straggler destruction live inside
+    // the handle's close() (loopback-server's patched close).
+    serverClosed = !s ? Promise.resolve() : Promise.resolve(s.close()).then(() => undefined);
     return serverClosed;
   };
 
@@ -185,9 +177,9 @@ function startAttempt(): ActiveAttempt {
       // Bind the loopback server FIRST so a busy port fails fast, before any
       // browser tab opens. Fixed port — createAuthServer's no-fallback error
       // message tells the user to free the port.
-      let boundServer: Server;
+      let boundServer: LoopbackHandle;
       try {
-        ({ server: boundServer } = await createAuthServer(CHATGPT_CALLBACK_PORT, onCallback, {
+        boundServer = await openLoopback(CHATGPT_CALLBACK_PORT, onCallback, {
           callbackPath: CHATGPT_CALLBACK_PATH,
           onError: (error) => {
             void finish({
@@ -210,7 +202,7 @@ function startAttempt(): ActiveAttempt {
             }
             return null;
           },
-        }));
+        });
       } catch (error) {
         void finish({
           signedIn: false,
@@ -222,8 +214,7 @@ function startAttempt(): ActiveAttempt {
       if (settled) {
         // Cancelled while the bind was in flight — release the port we just
         // grabbed (finish() already ran with no server to close).
-        boundServer.closeAllConnections();
-        boundServer.close();
+        void boundServer.close();
         return;
       }
       server = boundServer;

--- a/apps/x/packages/core/src/auth/loopback-server.test.ts
+++ b/apps/x/packages/core/src/auth/loopback-server.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRelayAuthServer } from './loopback-server.js';
+
+// Regression: createAuthServer rebuilds its CallbackHandlingOpts — dropping
+// `relay` there made the client-side relay listener render a success page
+// without ever forwarding the callback, leaving the server's flow hanging.
+
+describe('createRelayAuthServer', () => {
+  it('forwards callback hits to the relay and renders its verdict', async () => {
+    const relay = vi.fn(async (url: URL) => ({
+      accepted: url.searchParams.get('code') === 'good',
+      message: 'nope',
+    }));
+    const { server, port } = await createRelayAuthServer(18099, relay, { callbackPath: '/oauth/callback' });
+    try {
+      const ok = await fetch(`http://127.0.0.1:${port}/oauth/callback?code=good&state=s1`);
+      expect(await ok.text()).toContain('Authorization Successful');
+      expect(relay).toHaveBeenCalledTimes(1);
+      expect(relay.mock.calls[0]![0].searchParams.get('state')).toBe('s1');
+
+      const bad = await fetch(`http://127.0.0.1:${port}/oauth/callback?code=bad`);
+      expect(await bad.text()).toContain('nope');
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/apps/x/packages/core/src/auth/loopback-server.ts
+++ b/apps/x/packages/core/src/auth/loopback-server.ts
@@ -32,6 +32,34 @@ interface CallbackHandlingOpts {
    * without disturbing the live flow.
    */
   validateCallback?: (url: URL) => string | null;
+  /**
+   * Relay mode (remote-server client): every hit on callbackPath is shipped
+   * verbatim to the machine that owns the flow, which runs the validate /
+   * error / callback logic itself and answers with what page to render.
+   * When set, validateCallback/onError/onCallback are bypassed locally.
+   */
+  relay?: (url: URL) => Promise<{ accepted: boolean; message?: string }>;
+}
+
+function renderSuccessPage(res: import('http').ServerResponse): void {
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Authorization Successful</title>
+        <style>
+          body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
+          .success { color: #2e7d32; }
+        </style>
+      </head>
+      <body>
+        <h1 class="success">Authorization Successful</h1>
+        <p>You can close this window.</p>
+        <script>setTimeout(() => window.close(), 2000);</script>
+      </body>
+    </html>
+  `);
 }
 
 function renderErrorPage(res: import('http').ServerResponse, message: string): void {
@@ -78,6 +106,20 @@ function tryBindPort(
       const url = new URL(req.url, `http://localhost:${port}`);
 
       if (url.pathname === opts.callbackPath) {
+        if (opts.relay) {
+          opts
+            .relay(url)
+            .then((r) => {
+              if (r.accepted) renderSuccessPage(res);
+              else renderErrorPage(res, r.message ?? 'Sign-in failed');
+            })
+            .catch((err: unknown) => {
+              console.error('[OAuth] Callback relay failed:', err);
+              renderErrorPage(res, err instanceof Error ? err.message : 'Callback relay failed');
+            });
+          return;
+        }
+
         // Gatekeeper first: stale/foreign requests must not reach onError or
         // onCallback (a stale tab's redirect must never settle a live flow).
         const rejection = opts.validateCallback?.(url) ?? null;
@@ -107,24 +149,7 @@ function tryBindPort(
         // the handler failed hides the failure from the user and leaves the
         // app-side flow spinning with no visible cause.
         Promise.resolve(onCallback(url)).then(() => {
-          res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end(`
-            <!DOCTYPE html>
-            <html>
-              <head>
-                <title>Authorization Successful</title>
-                <style>
-                  body { font-family: Arial, sans-serif; text-align: center; padding: 50px; }
-                  .success { color: #2e7d32; }
-                </style>
-              </head>
-              <body>
-                <h1 class="success">Authorization Successful</h1>
-                <p>You can close this window.</p>
-                <script>setTimeout(() => window.close(), 2000);</script>
-              </body>
-            </html>
-          `);
+          renderSuccessPage(res);
         }).catch((err: unknown) => {
           console.error('[OAuth] Callback handling failed:', err);
           renderErrorPage(res, err instanceof Error ? err.message : 'Callback handling failed');
@@ -260,3 +285,65 @@ export async function createAuthServer(
   throw new Error(`No available port found in range ${port}–${limit}.`);
 }
 
+
+// ============================================================================
+// Loopback host seam (Phase 8b — SEPARATION_PLAN.md)
+// ============================================================================
+//
+// OAuth redirects land on 127.0.0.1 of whatever machine runs the BROWSER —
+// which, with a remote rowboat-server, is the client's machine, not this one.
+// A registered LoopbackHost lets the standalone server delegate "listen on
+// loopback port N and hand me the callback" to a connected client over the
+// WS reverse-call channel. Flows call openLoopback() instead of
+// createAuthServer(); with no host registered (Electron in-process mode,
+// tests) or no capable client connected, it binds locally — the pre-8b
+// behaviour, byte for byte.
+
+export interface LoopbackHandle {
+  port: number;
+  /** Resolves (when a promise) once the listener has released the port. */
+  close(): void | Promise<void>;
+}
+
+export type LoopbackHost = (
+  port: number,
+  onCallback: (callbackUrl: URL) => void | Promise<void>,
+  opts: { fallback?: boolean } & Partial<Omit<CallbackHandlingOpts, 'relay'>>,
+) => Promise<LoopbackHandle | null>;
+
+let loopbackHost: LoopbackHost | null = null;
+
+export function registerLoopbackHost(host: LoopbackHost): void {
+  loopbackHost = host;
+}
+
+/** What every OAuth flow calls: delegates to the registered host, falls back to a local bind. */
+export async function openLoopback(
+  port: number,
+  onCallback: (callbackUrl: URL) => void | Promise<void>,
+  opts: { fallback?: boolean } & Partial<Omit<CallbackHandlingOpts, 'relay'>> = {},
+): Promise<LoopbackHandle> {
+  if (loopbackHost) {
+    const handle = await loopbackHost(port, onCallback, opts);
+    if (handle) return handle;
+  }
+  const { server, port: boundPort } = await createAuthServer(port, onCallback, opts);
+  return {
+    port: boundPort,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+/**
+ * The client half of the relay: a real local listener whose every callback
+ * hit is shipped verbatim to the flow's owner (the server), which answers
+ * with what page to render. Used by the desktop app when it receives a
+ * `loopback-bind` reverse call.
+ */
+export async function createRelayAuthServer(
+  port: number,
+  relay: (callbackUrl: URL) => Promise<{ accepted: boolean; message?: string }>,
+  opts: { fallback?: boolean; callbackPath?: string } = {},
+): Promise<AuthServerResult> {
+  return createAuthServer(port, () => {}, { ...opts, relay });
+}

--- a/apps/x/packages/core/src/auth/loopback-server.ts
+++ b/apps/x/packages/core/src/auth/loopback-server.ts
@@ -257,6 +257,7 @@ export async function createAuthServer(
     callbackPath: opts.callbackPath ?? OAUTH_CALLBACK_PATH,
     onError: opts.onError,
     validateCallback: opts.validateCallback,
+    relay: opts.relay,
   };
   const limit = fallback ? port + PORT_RANGE_SIZE - 1 : port;
 

--- a/apps/x/packages/core/src/auth/oauth-flows.ts
+++ b/apps/x/packages/core/src/auth/oauth-flows.ts
@@ -1,5 +1,4 @@
-import type { Server } from 'http';
-import { createAuthServer } from './loopback-server.js';
+import { openLoopback, type LoopbackHandle } from './loopback-server.js';
 import { DEFAULT_CALLBACK_PORT } from '../auth/client-repo.js';
 import * as oauthClient from '../auth/oauth-client.js';
 import type { Configuration } from '../auth/oauth-client.js';
@@ -92,7 +91,7 @@ const activeFlows = new Map<string, {
 interface ActiveOAuthFlow {
   provider: string;
   state: string;
-  server: Server;
+  server: LoopbackHandle;
   cleanupTimeout: NodeJS.Timeout;
 }
 
@@ -243,8 +242,8 @@ export async function resolveStartPort(
   const registeredPort = await clientRepo.getRegisteredPort(provider);
   try {
     // Probe — fixed-port (no fallback) so we know whether the exact registered port is free
-    const probe = await createAuthServer(registeredPort, () => { /* probe */ });
-    probe.server.close();
+    const probe = await openLoopback(registeredPort, () => { /* probe */ });
+    await probe.close();
     console.log(`[OAuth] ${provider}: registered port ${registeredPort} still available`);
     return registeredPort;
   } catch {
@@ -319,7 +318,7 @@ export async function connectProvider(provider: string, credentials?: { clientId
     let state = '';
     let callbackHandled = false;
 
-    const { server, port: boundPort } = await createAuthServer(
+    const server = await openLoopback(
       startPort,
       async (callbackUrl) => {
         // Guard against duplicate callbacks (browser may send multiple
@@ -467,6 +466,8 @@ export async function connectProvider(provider: string, credentials?: { clientId
         },
       },
     );
+
+    const boundPort = server.port;
 
     // Server is bound. Any throw between here and `activeFlow = ...` would
     // leak the port — `cancelActiveFlow` only closes it once activeFlow is set.

--- a/apps/x/packages/core/src/composio/flows.ts
+++ b/apps/x/packages/core/src/composio/flows.ts
@@ -1,6 +1,6 @@
 import { openExternalUrl } from '../auth/url-opener.js';
 import { composioConnectBus } from '../auth/connector-events.js';
-import { createAuthServer } from '../auth/loopback-server.js';
+import { openLoopback } from '../auth/loopback-server.js';
 import * as composioClient from '../composio/client.js';
 import { composioAccountsRepo } from '../composio/repo.js';
 import { invalidateCopilotInstructionsCache } from '../runtime/assembly/copilot/instructions.js';
@@ -16,7 +16,7 @@ const activeFlows = new Map<string, {
     toolkitSlug: string;
     connectedAccountId: string;
     authConfigId: string;
-    server: import('http').Server;
+    server: import('../auth/loopback-server.js').LoopbackHandle;
     timeout: NodeJS.Timeout;
 }>();
 
@@ -145,7 +145,7 @@ export async function initiateConnection(toolkitSlug: string): Promise<{
         // Set up callback server
         const timeoutRef: { current: NodeJS.Timeout | null } = { current: null };
         let callbackHandled = false;
-        const { server } = await createAuthServer(8081, async () => {
+        const server = await openLoopback(8081, async () => {
             // Guard against duplicate callbacks (browser may send multiple requests)
             if (callbackHandled) return;
             callbackHandled = true;

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3418,6 +3418,20 @@ export const ipcSchemas = {
       success: z.literal(true),
     }),
   },
+  // OAuth loopback relay (Phase 8b): a loopback-capable client hosting the
+  // 127.0.0.1 callback listener for a remote server ships each callback hit
+  // here; the response says which page to render in the browser tab. Called
+  // by the client's relay listener, never by the renderer.
+  'oauth:deliverLoopbackCallback': {
+    req: z.object({
+      bindingId: z.string(),
+      url: z.string(),
+    }),
+    res: z.object({
+      accepted: z.boolean(),
+      message: z.string().optional(),
+    }),
+  },
 } as const;
 
 // ============================================================================


### PR DESCRIPTION
Part of the [separation plan](https://github.com/rowboatlabs/rowboat/blob/arch/server-client-separation/apps/x/SEPARATION_PLAN.md) — closes the two Phase 8 gaps documented in REMOTE_SERVER.md. With this, everything needed for the remote validation (Phase 8's exit criteria) is in place.

## Token encryption at rest
Headless hosts have no OS keychain. The standalone server now encrypts the GitHub/ChatGPT token stores with AES-256-GCM under a random 32-byte key at `<workdir>/cipher-key` (0600), replacing the plaintext fallback. Same-disk key caveat documented in REMOTE_SERVER.md.

## OAuth loopback relay
OAuth redirects land on `127.0.0.1` of the machine running the **browser** — with a remote server, that's the client. New seam in core (`openLoopback()` in `auth/loopback-server.ts`): a registered LoopbackHost lets the standalone server delegate the callback listener to a loopback-capable client via reverse calls (`loopback-bind`/`loopback-close`); the client relays each callback hit through the new `oauth:deliverLoopbackCallback` RPC, and the server runs the flow's validate/error/callback logic and answers with the page to render. All flows migrated (BYOK providers incl. DCR port probing, Composio, ChatGPT sign-in). No host registered or no capable client → local bind, byte-for-byte the old behaviour.

## Verified
- 1328 tests pass across all packages (8 new: cipher round-trip/persistence/perms/tamper, relay bind–deliver–close, provider-error, stale-state gatekeeping)
- typecheck + lint clean
- live: headless bundle boots with the cipher key created 0600; `oauth:deliverLoopbackCallback` answers end-to-end over HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)