### PR TITLE
Reply starts a topic only when the first reply is sent

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -10,7 +10,7 @@ import { FileColumn, TrashDialog, UploadFilesDialog } from '@/components/spaces/
 import { GeneralStream } from '@/components/spaces/general-stream'
 import { SpaceRail } from '@/components/spaces/space-rail'
 import { railKey, type RailSelection } from '@/lib/spaces-selection'
-import { ThreadPane } from '@/components/spaces/thread-pane'
+import { DraftThreadPane, ThreadPane } from '@/components/spaces/thread-pane'
 import { useGeneral, useSpacePresence, useThreadIndex } from '@/hooks/use-space-chat'
 import { useSpaceFeed, useSpaceLastReadAt, useSpaceLive, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { SpaceMembersProvider } from '@/components/spaces/member-text'
@@ -321,10 +321,10 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // been used.
     const select = (next: RailSelection) => {
         onSelect(next)
-        analytics.spacesTabViewed(next.kind === 'general' ? 'general' : next.kind === 'topic' ? 'topics' : 'files')
+        analytics.spacesTabViewed(next.kind === 'general' ? 'general' : next.kind === 'file' ? 'files' : 'topics')
         setRailHover(false)
         setRailPeek(false)
-        if (next.kind === 'topic' && mode === 'read') setMode('split')
+        if ((next.kind === 'topic' || next.kind === 'draft') && mode === 'read') setMode('split')
         else if (next.kind === 'general' && mode === 'read') setMode('talk')
         else if (next.kind === 'file') {
             // A file opened while talking keeps the conversation beside it:
@@ -395,9 +395,20 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // last chat selection sticks until the user picks another.
     const chatContextRef = useRef<string | null>(null)
     if (selection.kind === 'topic') chatContextRef.current = selection.topicId
-    else if (selection.kind === 'general') chatContextRef.current = null
-    else if (selection.fromTopicId) chatContextRef.current = selection.fromTopicId
+    else if (selection.kind === 'general' || selection.kind === 'draft') chatContextRef.current = null
+    else if (selection.kind === 'file' && selection.fromTopicId) chatContextRef.current = selection.fromTopicId
     const chatTopicId = chatContextRef.current
+
+    // Draft thread: the reply pane before any topic exists. The parent lives
+    // in the general stream; a stale draft (relaunch, deep link) falls back.
+    const draftParent = selection.kind === 'draft'
+        ? general.messages.find((m) => m.id === selection.parentMessageId) ?? null
+        : null
+    const draftMissing = selection.kind === 'draft' && general.ready && !draftParent
+    useEffect(() => {
+        if (draftMissing) onSelect({ kind: 'general' })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draftMissing])
 
     const selectedTopic = chatTopicId ? feed.topics.find((t) => t.id === chatTopicId) : undefined
     const selectedInfo = chatTopicId ? threads.byTopic.get(chatTopicId) : undefined
@@ -523,7 +534,21 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                     the document; Split shows both around a draggable divider. */}
                 {effMode !== 'read' && (
                     <div className="flex-1 min-w-0 min-h-0 flex">
-                        {chatTopicId ? (
+                        {draftParent ? (
+                            <section className="flex-1 min-w-0 min-h-0 flex flex-col">
+                                <DraftThreadPane
+                                    key={draftParent.id}
+                                    org={org}
+                                    space={space}
+                                    parent={draftParent}
+                                    members={members}
+                                    memberNames={memberNames}
+                                    entries={entries}
+                                    onBack={() => select({ kind: 'general' })}
+                                    onCreated={(topicId) => select({ kind: 'topic', topicId })}
+                                />
+                            </section>
+                        ) : chatTopicId ? (
                             <section className="flex-1 min-w-0 min-h-0 flex flex-col">
                                 <ThreadPane
                                     key={chatTopicId}
@@ -560,6 +585,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                                 memberNames={memberNames}
                                 entries={entries}
                                 onOpenThread={(id) => select({ kind: 'topic', topicId: id })}
+                                onStartThread={(m) => select({ kind: 'draft', parentMessageId: m.id })}
                                 onOpenSession={onOpenSession}
                             />
                         )}

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -5,9 +5,9 @@ import { Composer, type AgentOptions } from '@/components/spaces/composer'
 import { MemberName } from '@/components/spaces/member-text'
 import { DayDivider, MessageRow, NewDivider, TypingIndicator, type ThreadRowData } from '@/components/spaces/message-row'
 import type { GeneralState, SpacePresence, ThreadIndex } from '@/hooks/use-space-chat'
-import { ingestGeneralMessage, rememberThread, updateGeneralMessage, usePresenceSender } from '@/hooks/use-space-chat'
+import { ingestGeneralMessage, updateGeneralMessage, usePresenceSender } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
-import { buildThreadSeed, dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
+import { dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
 import { resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
@@ -22,7 +22,7 @@ import { containsRowboatAddress } from '@/lib/spaces-mentions'
 const scrollMemory = new Map<string, number>()
 
 export function GeneralStream({
-    org, space, general, threads, topics, presence, members, memberNames, entries = [], onOpenThread, onOpenSession,
+    org, space, general, threads, topics, presence, members, memberNames, entries = [], onOpenThread, onStartThread, onOpenSession,
 }: {
     org: OrgWithSpaces
     space: spaces.Space
@@ -35,6 +35,8 @@ export function GeneralStream({
     /** The space's files — the composer's @ typeahead offers them as links. */
     entries?: spaces.SpacesAssetEntry[]
     onOpenThread: (topicId: string) => void
+    /** Reply on a message with no thread yet — open a draft pane (no topic until first send). */
+    onStartThread: (parent: spaces.Message) => void
     onOpenSession?: (sessionId: string) => void
 }) {
     const [posting, setPosting] = useState(false)
@@ -130,18 +132,13 @@ export function GeneralStream({
         }
     }
 
-    const replyInThread = async (parent: spaces.Message) => {
-        try {
-            // anchorMessageId is the contract linkage; the seed's marker stays for
-            // teammates on pre-contract builds to parse.
-            const result = await window.ipc.invoke('spaces:postMessage', { orgId: org.id, spaceId: space.id, body: buildThreadSeed(parent), anchorMessageId: parent.id })
-            rememberThread(org.id, space.id, result.topic, result.message)
-            markTopicRead(org.id, space.id, result.topic.id)
-            analytics.spacesTopicStarted()
-            onOpenThread(result.topic.id)
-        } catch (err) {
-            toast(err instanceof Error ? err.message : 'Could not start the topic', 'error')
-        }
+    // Reply creates NOTHING: an existing thread opens (even a 0-reply one left
+    // by an older build), otherwise a draft pane — the topic is created only
+    // when the first reply is actually sent (DraftThreadPane).
+    const replyInThread = (parent: spaces.Message) => {
+        const existing = threads.byParent.get(parent.id)
+        if (existing) onOpenThread(existing)
+        else onStartThread(parent)
     }
 
     const askRowboat = (message: spaces.Message) => {
@@ -202,7 +199,7 @@ export function GeneralStream({
                 thread={threadRowFor(message)}
                 selfMemberId={org.memberId}
                 onOpenThread={onOpenThread}
-                onReplyInThread={(m) => void replyInThread(m)}
+                onReplyInThread={replyInThread}
                 onAskRowboat={askRowboat}
                 onCopyLink={(m) => void copyLink(m)}
                 onReact={(m, emoji) => void toggleReaction(m, emoji)}

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -12,9 +12,9 @@ import { MemberName, MemberText } from '@/components/spaces/member-text'
 import { SpaceMarkdown } from '@/components/spaces/space-markdown'
 import { MessageRow, NewDivider, TypingIndicator } from '@/components/spaces/message-row'
 import type { SpacePresence, ThreadInfo } from '@/hooks/use-space-chat'
-import { usePresenceSender } from '@/hooks/use-space-chat'
+import { rememberThread, usePresenceSender } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
-import { artifactsForThread, explicitTitle, isContinuation, stripThreadMarker } from '@/lib/spaces-conventions'
+import { artifactsForThread, buildThreadSeed, explicitTitle, isContinuation, stripThreadMarker } from '@/lib/spaces-conventions'
 import { attributionLabel, formatFeedTime, shortId } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
@@ -353,4 +353,88 @@ export function ThreadPane({
 
 function ParentBody({ body }: { body: string }) {
     return <SpaceMarkdown body={body} />
+}
+
+// ---------------------------------------------------------------------------
+// Draft thread — Reply opened a pane, but nothing exists yet. The topic (seed
+// message + the reply) is created only when the first reply is actually SENT;
+// clicking Reply and walking away leaves no trace in anyone's space.
+// ---------------------------------------------------------------------------
+
+export function DraftThreadPane({ org, space, parent, members, memberNames, entries, onBack, onCreated }: {
+    org: OrgWithSpaces
+    space: spaces.Space
+    /** The general message being replied to. */
+    parent: spaces.Message
+    members: spaces.Member[]
+    memberNames: Map<string, string>
+    entries: spaces.SpacesAssetEntry[]
+    onBack: () => void
+    /** The first reply landed — the pane should be swapped for the real topic. */
+    onCreated: (topicId: string) => void
+}) {
+    const [posting, setPosting] = useState(false)
+    // If the seed landed but the reply failed, a retry must reuse the topic —
+    // never mint a second one on the same parent.
+    const seededRef = useRef<{ topic: spaces.Topic; message: spaces.Message } | null>(null)
+
+    const post = async (body: string, agent?: AgentOptions) => {
+        setPosting(true)
+        try {
+            if (!seededRef.current) {
+                seededRef.current = await window.ipc.invoke('spaces:postMessage', {
+                    orgId: org.id, spaceId: space.id, body: buildThreadSeed(parent), anchorMessageId: parent.id,
+                })
+                rememberThread(org.id, space.id, seededRef.current.topic, seededRef.current.message)
+                analytics.spacesTopicStarted()
+            }
+            const seeded = seededRef.current
+            const result = await window.ipc.invoke('spaces:postMessage', { orgId: org.id, spaceId: space.id, topicId: seeded.topic.id, body })
+            markTopicRead(org.id, space.id, seeded.topic.id)
+            analytics.spacesMessagePosted({ kind: 'topic', mentionsRowboat: containsRowboatAddress(body) })
+            maybeInvokeRowboat(org, space, result.topic, result.message.id, body, agent)
+            onCreated(seeded.topic.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not post', 'error')
+            throw err
+        } finally {
+            setPosting(false)
+        }
+    }
+
+    const authorName = memberNames.get(parent.author.memberId) ?? parent.author.memberId
+    return (
+        <div className="flex h-full min-h-0 flex-col bg-background">
+            <div className="flex h-9 shrink-0 items-center gap-1.5 border-b border-border pl-2 pr-2">
+                <Button variant="ghost" size="icon" className="size-7 text-muted-foreground" onClick={onBack} aria-label="Back to messages">
+                    <ArrowLeft className="size-4" />
+                </Button>
+                <span className="pl-1 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topic</span>
+                <span className="truncate text-xs text-muted-foreground">new — created when you send</span>
+                <span className="flex-1" />
+            </div>
+            <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2">
+                <div className="flex items-start gap-2.5 rounded-lg border border-border bg-muted/30 px-3 py-2">
+                    <MemberAvatar id={parent.author.memberId} name={authorName} size="md" className="mt-0.5" />
+                    <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-1.5 text-xs">
+                            <span className="font-semibold">{authorName}</span>
+                            <span className="text-muted-foreground">{formatFeedTime(parent.postedAt)} · in Messages</span>
+                        </div>
+                        <div className="text-sm leading-relaxed [&_p]:my-0.5">
+                            <ParentBody body={parent.body} />
+                        </div>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2 px-1 pb-1 pt-3">
+                    <span className="text-[11px] font-medium text-muted-foreground">0 replies</span>
+                    <span className="h-px flex-1 bg-border" />
+                </div>
+                <div className="px-2 py-2 text-xs text-muted-foreground">
+                    Nothing here yet — sending a reply is what starts the topic for everyone.
+                </div>
+            </div>
+            <Composer placeholder="Reply…" busy={posting} onSend={post} autoFocus members={members} entries={entries} selfMemberId={org.memberId} />
+        </div>
+    )
 }

--- a/apps/x/apps/renderer/src/lib/spaces-selection.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-selection.ts
@@ -4,6 +4,8 @@
 export type RailSelection =
     | { kind: 'general' }
     | { kind: 'topic'; topicId: string }
+    /** A reply pane with no topic behind it yet — the topic is created on first send. */
+    | { kind: 'draft'; parentMessageId: string }
     /** `fromTopicId` = opened from a topic (an artifact link) — the file view shows a crumb back to it. */
     | { kind: 'file'; path: string; fromTopicId?: string }
 
@@ -11,5 +13,6 @@ export type RailSelection =
 export function railKey(sel: RailSelection | undefined): string {
     if (!sel || sel.kind === 'general') return 'general'
     if (sel.kind === 'topic') return `topic:${sel.topicId}`
+    if (sel.kind === 'draft') return `draft:${sel.parentMessageId}`
     return `file:${sel.path}`
 }


### PR DESCRIPTION
Verified bug: clicking Reply immediately posted the thread seed — the server created the topic on the spot, so the act of clicking alone left a durable empty topic ("0 replies") in every member's rail and a topic-created event in the log, even if you never typed anything.

Now Reply opens a **draft pane** — the parent message plus a composer, backed by nothing. Only when the first reply is actually sent does the client post the seed (which creates the topic) and then the reply, and the pane swaps over to the real topic. Closing or abandoning the draft creates nothing.

Details:
- New `RailSelection` kind `draft` keyed by the parent message; Split/Talk choreography matches topics, and a stale draft (relaunch, deep link, parent missing) falls back to Messages.
- Reply on a message that already has a thread — including a 0-reply topic left behind by an older build — opens the existing topic instead of drafting a duplicate.
- If the seed lands but the reply post fails, retrying reuses the already-created topic (no double topic on the same parent).
- @rowboat invocation (with the per-turn agent options strip), read marks, thread-index remembering, and analytics all moved to the send path unchanged.

Client-only; no protocol/server changes. Renderer suite green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)