### PR TITLE
feat(spaces): explicit topics — curation layer over chat, threads stay structure

### DIFF
--- a/apps/harbor/CONTRACT.md
+++ b/apps/harbor/CONTRACT.md
@@ -147,6 +147,27 @@ team and a Roadboard space (`src/main.ts`).
   `lastActivityAt` and emits no topic event. Re-deleting is an idempotent 200
   no-op. Tombstones take no new reactions (`invalid_request`); removes still
   work so cleanup stays possible. Render-face only, like reactions.
+- **Labels are curation; topics are structure** (2026-08-25, `Label` in
+  `core.ts`): a label — presented as a "Topic" in the UI, deliberately NOT the
+  wire word "topic", which already means the thread container — exists only
+  because a member created one, never derived. One label per message
+  (`Message.labelId`, current truth on reads; the copy in a stored `message`
+  event is the at-post snapshot, the reactions pattern); any number of
+  messages across the space may share a label; a thread (the topic anchored
+  on a message) inherits its anchor's label by client-side derivation —
+  nothing is stamped on topics. Five routes: `listLabels` (decorated
+  `LabelListing`: messageCount over live tagged messages + lastActivityAt
+  folding anchored threads' activity in), `createLabel` (get-or-create by
+  case-insensitive name among live labels — concurrent same-name creates land
+  on one label; only real creation emits), `manageLabel`
+  (rename/archive/unarchive; renaming or unarchiving into a live name is
+  `invalid_request`), `setMessageLabel` (any member, set-or-clear, idempotent
+  no-ops; tombstones take no label but clears work; setting an archived label
+  revives it — the archived-topic-reply rule), `listLabelMessages` (the
+  listMessages window semantics, across topics). Two event kinds: `label`
+  (create + any update, full label) and `message_label` (the assignment act,
+  `labelId` null = cleared). Render-face only for now, like reactions — the
+  six MCP tools don't manage labels. Harbor migration 010.
 - **Unknown invite tokens are 404**; `expired`/`revoked` are resolvable states.
 - **MCP face attribution**: acting mode defaults to `agent`; automations
   declare `x-acting-mode: scheduled`; `x-agent-name` carries the display label.

--- a/apps/harbor/packages/protocol/src/api.ts
+++ b/apps/harbor/packages/protocol/src/api.ts
@@ -9,8 +9,8 @@ import {
   ReadAssetResult,
   RestoreAssetResult,
 } from './changeset.js';
-import { ActingMode, Member, Message, ReactionEmoji, Space, Topic } from './core.js';
-import { AssetPath, AssetVersion, BlobHash, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
+import { ActingMode, Label, Member, Message, ReactionEmoji, Space, Topic } from './core.js';
+import { AssetPath, AssetVersion, BlobHash, LabelId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
 import {
   AcceptInvite,
   AcceptInviteResult,
@@ -52,6 +52,20 @@ const NewTopicMessage = z.object({
  */
 export const TopicListing = Topic.extend({ firstMessage: Message.nullable() });
 export type TopicListing = z.infer<typeof TopicListing>;
+
+/**
+ * A listLabels entry: the label plus what a sidebar needs without loading any
+ * messages — how many live messages carry it, and when something under it
+ * last moved (the newest of: the label's creation, a tagged message's post,
+ * and the lastActivityAt of any thread anchored on a tagged message —
+ * threads inherit their anchor's label, so their replies count as activity).
+ * Listing decoration only: Label objects inside events stay lean.
+ */
+export const LabelListing = Label.extend({
+  messageCount: z.number().int().nonnegative(),
+  lastActivityAt: z.iso.datetime(),
+});
+export type LabelListing = z.infer<typeof LabelListing>;
 
 export const routes = {
   // --- identity ------------------------------------------------------------
@@ -335,6 +349,83 @@ export const routes = {
       z.object({ action: z.literal('merge_into'), targetTopicId: TopicId }),
     ]),
     response: z.object({ topic: Topic }),
+  },
+
+  // --- labels ("topics" in the UI — see Label in core.ts) -------------------
+  listLabels: {
+    method: 'GET',
+    path: '/v1/spaces/:spaceId/labels',
+    params: z.object({ spaceId: SpaceId }),
+    query: z.object({ includeArchived: z.coerce.boolean().optional() }),
+    response: z.object({ labels: z.array(LabelListing) }),
+  },
+  /**
+   * Get-or-create by name, case-insensitively, among live labels — two people
+   * typing "Launch" concurrently land on ONE label (a create event fires only
+   * when a label is actually made). An archived label never matches; a fresh
+   * one takes the name.
+   */
+  createLabel: {
+    method: 'POST',
+    path: '/v1/spaces/:spaceId/labels',
+    params: z.object({ spaceId: SpaceId }),
+    request: z.object({
+      name: z.string().min(1).max(64),
+      actingMode: ActingMode,
+      agentName: z.string().max(64).optional(),
+    }),
+    response: z.object({ label: Label }),
+  },
+  /**
+   * rename/archive/unarchive. Renaming (and unarchiving) into a name a live
+   * label already holds is invalid_request — merge by re-assigning messages
+   * instead. Archive/unarchive are idempotent 200 no-ops with no event.
+   */
+  manageLabel: {
+    method: 'POST',
+    path: '/v1/spaces/:spaceId/labels/:labelId',
+    params: z.object({ spaceId: SpaceId, labelId: LabelId }),
+    request: z.discriminatedUnion('action', [
+      z.object({ action: z.literal('rename'), name: z.string().min(1).max(64) }),
+      z.object({ action: z.literal('archive') }),
+      z.object({ action: z.literal('unarchive') }),
+    ]),
+    response: z.object({ label: Label }),
+  },
+  /**
+   * Set (or clear — labelId null) the label on a message: any member, any
+   * message, one label per message (a set replaces). Setting an archived
+   * label revives it (a label event narrates), the archived-topic-reply rule.
+   * Idempotent — re-setting what is set / clearing what isn't is a 200 no-op
+   * with no event. Tombstones take no label (clears still work). Returns the
+   * message with the current labelId (and reactions) folded.
+   */
+  setMessageLabel: {
+    method: 'POST',
+    path: '/v1/spaces/:spaceId/messages/:messageId/label',
+    params: z.object({ spaceId: SpaceId, messageId: MessageId }),
+    request: z.object({
+      labelId: LabelId.nullable(),
+      actingMode: ActingMode,
+      agentName: z.string().max(64).optional(),
+    }),
+    response: z.object({ message: Message }),
+  },
+  /**
+   * Every message carrying this label, windowed newest-first exactly like
+   * listMessages (offsets ride the space's one sequence and are the cursor).
+   * The messages span topics — each is rendered where it lives; a thread
+   * anchored on one inherits the label by derivation, client-side.
+   */
+  listLabelMessages: {
+    method: 'GET',
+    path: '/v1/spaces/:spaceId/labels/:labelId/messages',
+    params: z.object({ spaceId: SpaceId, labelId: LabelId }),
+    query: z.object({
+      beforeOffset: z.coerce.number().int().positive().optional(),
+      limit: z.coerce.number().int().positive().max(200).optional(),
+    }),
+    response: z.object({ label: Label, messages: z.array(Message), hasMore: z.boolean() }),
   },
 
   // --- live ----------------------------------------------------------------

--- a/apps/harbor/packages/protocol/src/core.ts
+++ b/apps/harbor/packages/protocol/src/core.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ChangeSetId, MemberId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
+import { ChangeSetId, LabelId, MemberId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
 
 // Core objects shared by both faces. Every act in a space belongs to a member
 // (spec §2, principle 4); attribution carries the acting mode, never a separate
@@ -75,6 +75,43 @@ export const Topic = z.object({
 });
 export type Topic = z.infer<typeof Topic>;
 
+/**
+ * A label (2026-08-25, "topics" in the UI): an explicit, member-created
+ * grouping that messages are assigned to — curation, where Topic is
+ * structure. A label exists only because someone made one (never derived),
+ * any number of messages across the space may carry the same label, and a
+ * thread (the Topic anchored on a message) inherits its anchor's label by
+ * derivation — nothing is stamped on topics. One label per message.
+ *
+ * Deliberately NOT a Topic: the wire name "topic" already means the thread
+ * container. Clients present labels as "Topics" and topics as threads.
+ */
+export const Label = z.object({
+  id: LabelId,
+  spaceId: SpaceId,
+  name: z.string().min(1).max(64),
+  createdBy: Attribution,
+  createdAt: z.iso.datetime(),
+  /** Archived labels keep their assignments but leave the sidebar; assigning one revives it. */
+  archived: z.boolean(),
+});
+export type Label = z.infer<typeof Label>;
+
+/**
+ * One assignment act: a member setting (or clearing — labelId null) the label
+ * on a message. Like Reaction, `topicId` is where the message lived when it
+ * happened; the assignment follows the message by id.
+ */
+export const MessageLabel = z.object({
+  spaceId: SpaceId,
+  topicId: TopicId,
+  messageId: MessageId,
+  labelId: LabelId.nullable(),
+  by: Attribution,
+  at: z.iso.datetime(),
+});
+export type MessageLabel = z.infer<typeof MessageLabel>;
+
 /** The emoji itself ("👍", ZWJ sequences included), rendered verbatim — never a :name:. */
 export const ReactionEmoji = z
   .string()
@@ -138,6 +175,12 @@ export const Message = z.object({
   offset: StreamOffset,
   /** Set when the author deleted the message (deleter == author, so no separate attribution). */
   deletedAt: z.iso.datetime().optional(),
+  /**
+   * The message's label ("topic" in the UI), current truth on reads. The copy
+   * inside a stored `message` event is its at-post snapshot — clients fold
+   * `message_label` events or refetch, the reactions pattern.
+   */
+  labelId: LabelId.optional(),
   /**
    * Folded reactions, groups in first-reacted order. The default keeps pre-
    * reaction payloads (older servers, stored message events) parseable; reads

--- a/apps/harbor/packages/protocol/src/events.ts
+++ b/apps/harbor/packages/protocol/src/events.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ChangeSet } from './changeset.js';
-import { Membership, Message, MessageDeletion, Reaction, Topic } from './core.js';
+import { Label, Membership, Message, MessageDeletion, MessageLabel, Reaction, Topic } from './core.js';
 import { MemberId, SpaceId, StreamOffset, TopicId } from './ids.js';
 
 // Decision 2 (CONTRACT.md): one WebSocket per org, per-space subscriptions,
@@ -36,6 +36,14 @@ export const SpaceEvent = z.discriminatedUnion('type', [
     type: z.literal('message_deleted'),
     deletion: MessageDeletion,
   }),
+  /** Emitted on create and on any update (rename, archive, unarchive); carries the full label. */
+  z.object({ type: z.literal('label'), label: Label }),
+  /**
+   * A label set on (or cleared from — labelId null) a message. Setting what
+   * is already set / clearing what isn't is an idempotent no-op and emits
+   * nothing, like reaction toggles.
+   */
+  z.object({ type: z.literal('message_label'), assignment: MessageLabel }),
 ]);
 export type SpaceEvent = z.infer<typeof SpaceEvent>;
 

--- a/apps/harbor/packages/protocol/src/ids.ts
+++ b/apps/harbor/packages/protocol/src/ids.ts
@@ -15,6 +15,9 @@ export type TopicId = z.infer<typeof TopicId>;
 export const MessageId = Ulid;
 export type MessageId = z.infer<typeof MessageId>;
 
+export const LabelId = Ulid;
+export type LabelId = z.infer<typeof LabelId>;
+
 export const ChangeSetId = Ulid;
 export type ChangeSetId = z.infer<typeof ChangeSetId>;
 

--- a/apps/harbor/packages/server/src/http.ts
+++ b/apps/harbor/packages/server/src/http.ts
@@ -350,5 +350,47 @@ export function buildHttpApp(deps: {
     return reply(c, routes.manageTopic.response, { topic });
   });
 
+  // --- labels ("topics" in the UI) -------------------------------------------
+
+  app.get('/v1/spaces/:spaceId/labels', async (c) => {
+    const { spaceId } = parseWith(routes.listLabels.params, c.req.param());
+    // Same presence-means-true note as listTopics' includeArchived.
+    const q = parseWith(routes.listLabels.query, {
+      ...(c.req.query('includeArchived') !== undefined ? { includeArchived: c.req.query('includeArchived') } : {}),
+    });
+    const labels = await service.listLabels(actor(c), spaceId, q.includeArchived ?? false);
+    return reply(c, routes.listLabels.response, { labels });
+  });
+
+  app.post('/v1/spaces/:spaceId/labels', async (c) => {
+    const { spaceId } = parseWith(routes.createLabel.params, c.req.param());
+    const input = await body(c, routes.createLabel.request);
+    const label = await service.createLabel(actor(c), spaceId, input);
+    return reply(c, routes.createLabel.response, { label });
+  });
+
+  app.post('/v1/spaces/:spaceId/labels/:labelId', async (c) => {
+    const { spaceId, labelId } = parseWith(routes.manageLabel.params, c.req.param());
+    const input = await body(c, routes.manageLabel.request);
+    const label = await service.manageLabel(actor(c), spaceId, labelId, input);
+    return reply(c, routes.manageLabel.response, { label });
+  });
+
+  app.post('/v1/spaces/:spaceId/messages/:messageId/label', async (c) => {
+    const { spaceId, messageId } = parseWith(routes.setMessageLabel.params, c.req.param());
+    const input = await body(c, routes.setMessageLabel.request);
+    const message = await service.setMessageLabel(actor(c), spaceId, messageId, input);
+    return reply(c, routes.setMessageLabel.response, { message });
+  });
+
+  app.get('/v1/spaces/:spaceId/labels/:labelId/messages', async (c) => {
+    const { spaceId, labelId } = parseWith(routes.listLabelMessages.params, c.req.param());
+    const q = parseWith(routes.listLabelMessages.query, {
+      ...(c.req.query('beforeOffset') !== undefined ? { beforeOffset: c.req.query('beforeOffset') } : {}),
+      ...(c.req.query('limit') !== undefined ? { limit: c.req.query('limit') } : {}),
+    });
+    return reply(c, routes.listLabelMessages.response, await service.listLabelMessages(actor(c), spaceId, labelId, q));
+  });
+
   return app;
 }

--- a/apps/harbor/packages/server/src/memory-store.ts
+++ b/apps/harbor/packages/server/src/memory-store.ts
@@ -1,5 +1,6 @@
 import type {
   ChangeSet,
+  Label,
   Member,
   Membership,
   Message,
@@ -19,6 +20,7 @@ interface SpaceState {
   changeSets: ChangeSet[]; // append order == offset order
   changeSetsById: Map<string, ChangeSet>;
   topics: Map<string, Topic>;
+  labels: Map<string, Label>; // labelId → label
   messages: Map<string, Message[]>; // topicId → oldest first
   reactions: Map<string, StoredReaction[]>; // messageId → oldest first
   events: StoredEvent[]; // offsets start at 1; events[i].offset === i + 1
@@ -75,6 +77,7 @@ export class MemoryStore implements Store {
       changeSets: [],
       changeSetsById: new Map(),
       topics: new Map(),
+      labels: new Map(),
       messages: new Map(),
       reactions: new Map(),
       events: [],
@@ -301,6 +304,74 @@ export class MemoryStore implements Store {
     s.messages.set(toTopicId, combined);
     s.messages.delete(fromTopicId);
     return moving.length;
+  }
+
+  async getLabel(spaceId: string, labelId: string): Promise<Label | undefined> {
+    return this.state(spaceId)?.labels.get(labelId);
+  }
+
+  async getLiveLabelByName(spaceId: string, name: string): Promise<Label | undefined> {
+    const wanted = name.trim().toLowerCase();
+    return [...this.must(spaceId).labels.values()].find(
+      (l) => !l.archived && l.name.trim().toLowerCase() === wanted,
+    );
+  }
+
+  async putLabel(label: Label): Promise<void> {
+    this.must(label.spaceId).labels.set(label.id, label);
+  }
+
+  async listLabels(spaceId: string, includeArchived: boolean): Promise<Label[]> {
+    return [...this.must(spaceId).labels.values()]
+      .filter((l) => includeArchived || !l.archived)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+  }
+
+  async labelStats(spaceId: string): Promise<Map<string, { messageCount: number; lastActivityAt: string }>> {
+    const s = this.must(spaceId);
+    const anchoredActivity = new Map<string, string>(); // anchorMessageId → topic lastActivityAt
+    for (const t of s.topics.values()) {
+      if (t.anchorMessageId) anchoredActivity.set(t.anchorMessageId, t.lastActivityAt);
+    }
+    const stats = new Map<string, { messageCount: number; lastActivityAt: string }>();
+    for (const m of [...s.messages.values()].flat()) {
+      if (!m.labelId || m.deletedAt) continue;
+      const threadActivity = anchoredActivity.get(m.id);
+      const activity = threadActivity && threadActivity > m.postedAt ? threadActivity : m.postedAt;
+      const cur = stats.get(m.labelId);
+      stats.set(m.labelId, {
+        messageCount: (cur?.messageCount ?? 0) + 1,
+        lastActivityAt: cur && cur.lastActivityAt > activity ? cur.lastActivityAt : activity,
+      });
+    }
+    return stats;
+  }
+
+  async setMessageLabel(spaceId: string, messageId: string, labelId: string | null): Promise<void> {
+    const s = this.must(spaceId);
+    for (const [topicId, list] of s.messages) {
+      const idx = list.findIndex((m) => m.id === messageId);
+      if (idx === -1) continue;
+      const next = [...list];
+      const { labelId: _dropped, ...rest } = next[idx]!;
+      next[idx] = labelId === null ? rest : { ...rest, labelId };
+      s.messages.set(topicId, next);
+      return;
+    }
+  }
+
+  async listMessagesByLabel(
+    spaceId: string,
+    labelId: string,
+    opts?: { beforeOffset?: number; limit?: number },
+  ): Promise<Message[]> {
+    let list = [...this.must(spaceId).messages.values()]
+      .flat()
+      .filter((m) => m.labelId === labelId)
+      .sort((a, b) => a.offset - b.offset);
+    if (opts?.beforeOffset !== undefined) list = list.filter((m) => m.offset < opts.beforeOffset!);
+    if (opts?.limit !== undefined) list = list.slice(-opts.limit);
+    return list;
   }
 
   async getReaction(

--- a/apps/harbor/packages/server/src/migrations.ts
+++ b/apps/harbor/packages/server/src/migrations.ts
@@ -294,6 +294,28 @@ export const MIGRATIONS: Migration[] = [
       `alter table space_blobs add column if not exists height int`,
     ],
   },
+  {
+    id: '010-labels',
+    statements: [
+      // Labels ("topics" in the UI): explicit member-created groupings, one
+      // per message, assignment on the messages row. `created_by` mirrors the
+      // jsonb Attribution pattern. Live names are unique per space (case-
+      // insensitive) — archiving frees the name; unarchiving into a taken
+      // name is refused in the service, this index is the belt.
+      `create table if not exists labels (
+        id text primary key,
+        space_id text not null,
+        name text not null,
+        created_by jsonb not null,
+        created_at text not null,
+        archived boolean not null
+      )`,
+      `create index if not exists labels_space on labels (space_id)`,
+      `create unique index if not exists labels_live_name on labels (space_id, lower(name)) where archived = false`,
+      `alter table messages add column if not exists label_id text`,
+      `create index if not exists messages_label on messages (space_id, label_id) where label_id is not null`,
+    ],
+  },
 ];
 
 export async function migrate(db: SqlDb): Promise<void> {

--- a/apps/harbor/packages/server/src/pg-store.ts
+++ b/apps/harbor/packages/server/src/pg-store.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type {
   BlobInfo,
   ChangeSet,
+  Label,
   Member,
   Membership,
   Message,
@@ -113,6 +114,7 @@ interface MessageRow {
   body: string;
   posted_at: string;
   deleted_at: string | null;
+  label_id: string | null;
   stream_offset: number;
 }
 
@@ -126,8 +128,29 @@ function rowToMessage(r: MessageRow): Message {
     postedAt: r.posted_at,
     offset: r.stream_offset,
     ...(r.deleted_at !== null ? { deletedAt: r.deleted_at } : {}),
+    ...(r.label_id !== null ? { labelId: r.label_id } : {}),
     // Live reaction state is folded in by the service on reads; rows carry none.
     reactions: [],
+  };
+}
+
+interface LabelRow {
+  id: string;
+  space_id: string;
+  name: string;
+  created_by: Label['createdBy'];
+  created_at: string;
+  archived: boolean;
+}
+
+function rowToLabel(r: LabelRow): Label {
+  return {
+    id: r.id,
+    spaceId: r.space_id,
+    name: r.name,
+    createdBy: r.created_by,
+    createdAt: r.created_at,
+    archived: r.archived,
   };
 }
 
@@ -615,6 +638,85 @@ export class PgStore implements Store {
       [spaceId, fromTopicId, toTopicId],
     );
     return rows.length;
+  }
+
+  // --- labels ----------------------------------------------------------------
+
+  async getLabel(spaceId: string, labelId: string): Promise<Label | undefined> {
+    const rows = await this.sql.query<LabelRow>('select * from labels where space_id = $1 and id = $2', [
+      spaceId,
+      labelId,
+    ]);
+    return rows[0] ? rowToLabel(rows[0]) : undefined;
+  }
+
+  async getLiveLabelByName(spaceId: string, name: string): Promise<Label | undefined> {
+    const rows = await this.sql.query<LabelRow>(
+      'select * from labels where space_id = $1 and archived = false and lower(name) = lower($2)',
+      [spaceId, name.trim()],
+    );
+    return rows[0] ? rowToLabel(rows[0]) : undefined;
+  }
+
+  async putLabel(label: Label): Promise<void> {
+    await this.sql.query(
+      `insert into labels (id, space_id, name, created_by, created_at, archived)
+       values ($1, $2, $3, $4::jsonb, $5, $6)
+       on conflict (id) do update set name = excluded.name, archived = excluded.archived`,
+      [label.id, label.spaceId, label.name, JSON.stringify(label.createdBy), label.createdAt, label.archived],
+    );
+  }
+
+  async listLabels(spaceId: string, includeArchived: boolean): Promise<Label[]> {
+    const rows = await this.sql.query<LabelRow>(
+      `select * from labels where space_id = $1 ${includeArchived ? '' : 'and archived = false'}
+       order by created_at, id`,
+      [spaceId],
+    );
+    return rows.map(rowToLabel);
+  }
+
+  async labelStats(spaceId: string): Promise<Map<string, { messageCount: number; lastActivityAt: string }>> {
+    // Activity = the tagged message's post, or its anchored thread's
+    // lastActivityAt when that is newer (threads inherit their anchor's label).
+    const rows = await this.sql.query<{ label_id: string; message_count: number; last_activity_at: string }>(
+      `select m.label_id, count(*)::int as message_count,
+              max(greatest(m.posted_at, coalesce(t.last_activity_at, m.posted_at))) as last_activity_at
+       from messages m
+       left join topics t on t.space_id = m.space_id and t.anchor_message_id = m.id
+       where m.space_id = $1 and m.label_id is not null and m.deleted_at is null
+       group by m.label_id`,
+      [spaceId],
+    );
+    return new Map(rows.map((r) => [r.label_id, { messageCount: r.message_count, lastActivityAt: r.last_activity_at }]));
+  }
+
+  async setMessageLabel(spaceId: string, messageId: string, labelId: string | null): Promise<void> {
+    await this.sql.query('update messages set label_id = $3 where space_id = $1 and id = $2', [
+      spaceId,
+      messageId,
+      labelId,
+    ]);
+  }
+
+  async listMessagesByLabel(
+    spaceId: string,
+    labelId: string,
+    opts?: { beforeOffset?: number; limit?: number },
+  ): Promise<Message[]> {
+    const params: unknown[] = [spaceId, labelId];
+    let where = 'space_id = $1 and label_id = $2';
+    if (opts?.beforeOffset !== undefined) {
+      params.push(opts.beforeOffset);
+      where += ` and stream_offset < $${params.length}`;
+    }
+    let sql = `select * from messages where ${where} order by stream_offset`;
+    if (opts?.limit !== undefined) {
+      params.push(opts.limit);
+      sql = `select * from (select * from messages where ${where} order by stream_offset desc limit $${params.length}) w order by stream_offset`;
+    }
+    const rows = await this.sql.query<MessageRow>(sql, params);
+    return rows.map(rowToMessage);
   }
 
   // --- reactions -------------------------------------------------------------

--- a/apps/harbor/packages/server/src/service.ts
+++ b/apps/harbor/packages/server/src/service.ts
@@ -12,6 +12,8 @@ import {
   type ConflictRegion,
   type CreateInviteResult,
   type DeleteAssetResult,
+  type Label,
+  type LabelListing,
   type Member,
   type Membership,
   type Message,
@@ -75,6 +77,9 @@ type NewTopicMessage = z.infer<Routes['postMessage']['request']>;
 type ManageTopicAction = z.infer<Routes['manageTopic']['request']>;
 type ReactInput = z.infer<Routes['reactToMessage']['request']>;
 type DeleteMessageInput = z.infer<Routes['deleteMessage']['request']>;
+type CreateLabelInput = z.infer<Routes['createLabel']['request']>;
+type ManageLabelAction = z.infer<Routes['manageLabel']['request']>;
+type SetMessageLabelInput = z.infer<Routes['setMessageLabel']['request']>;
 
 export interface OrgInfo {
   name: string;
@@ -1078,6 +1083,180 @@ export class HarborService {
         }
       }
     });
+  }
+
+  // --- labels ("topics" in the UI) -------------------------------------------
+
+  async listLabels(ctx: ActorCtx, spaceId: string, includeArchived = false): Promise<LabelListing[]> {
+    await this.requireMember(ctx, spaceId);
+    const labels = await this.store.listLabels(spaceId, includeArchived);
+    const stats = await this.store.labelStats(spaceId);
+    return labels.map((label) => {
+      const s = stats.get(label.id);
+      return {
+        ...label,
+        messageCount: s?.messageCount ?? 0,
+        lastActivityAt: s && s.lastActivityAt > label.createdAt ? s.lastActivityAt : label.createdAt,
+      };
+    });
+  }
+
+  /**
+   * Get-or-create by name (case-insensitive, live labels only): concurrent
+   * "Launch" typers land on one label. Only an actual creation writes and
+   * emits a label event — the get path is a pure read.
+   */
+  async createLabel(ctx: ActorCtx, spaceId: string, input: CreateLabelInput): Promise<Label> {
+    await this.requireMember(ctx, spaceId);
+    this.guardWrite();
+    const name = input.name.trim();
+    if (!name) throw new HarborError('invalid_request', 'a label needs a name');
+    const createdBy: Attribution = {
+      memberId: ctx.memberId,
+      actingMode: input.actingMode,
+      ...(input.agentName ? { agentName: input.agentName } : {}),
+    };
+
+    return this.store.withSpaceLock(spaceId, async () => {
+      const existing = await this.store.getLiveLabelByName(spaceId, name);
+      if (existing) return existing;
+      const at = this.now();
+      const label: Label = { id: this.ulid(), spaceId, name, createdBy, createdAt: at, archived: false };
+      await this.store.putLabel(label);
+      const offset = (await this.store.head(spaceId)) + 1;
+      await this.append(spaceId, offset, at, { type: 'label', label });
+      return label;
+    });
+  }
+
+  async manageLabel(ctx: ActorCtx, spaceId: string, labelId: string, action: ManageLabelAction): Promise<Label> {
+    await this.requireMember(ctx, spaceId);
+    this.guardWrite();
+
+    return this.store.withSpaceLock(spaceId, async () => {
+      const label = await this.store.getLabel(spaceId, labelId);
+      if (!label) throw new HarborError('not_found', 'no such label');
+      const at = this.now();
+
+      switch (action.action) {
+        case 'rename': {
+          const name = action.name.trim();
+          if (!name) throw new HarborError('invalid_request', 'a label needs a name');
+          if (name === label.name) return label; // idempotent, no event
+          const taken = await this.store.getLiveLabelByName(spaceId, name);
+          if (taken && taken.id !== label.id) {
+            throw new HarborError('invalid_request', `a label named "${taken.name}" already exists`);
+          }
+          const updated: Label = { ...label, name };
+          await this.store.putLabel(updated);
+          const offset = (await this.store.head(spaceId)) + 1;
+          await this.append(spaceId, offset, at, { type: 'label', label: updated });
+          return updated;
+        }
+        case 'archive':
+        case 'unarchive': {
+          const archived = action.action === 'archive';
+          if (label.archived === archived) return label; // idempotent, no event
+          if (!archived) {
+            // Archiving freed the name; a live label may hold it now.
+            const taken = await this.store.getLiveLabelByName(spaceId, label.name);
+            if (taken) throw new HarborError('invalid_request', `a label named "${taken.name}" already exists`);
+          }
+          const updated: Label = { ...label, archived };
+          await this.store.putLabel(updated);
+          const offset = (await this.store.head(spaceId)) + 1;
+          await this.append(spaceId, offset, at, { type: 'label', label: updated });
+          return updated;
+        }
+      }
+    });
+  }
+
+  /**
+   * Set (or clear — null) the one label on a message: any member, any message
+   * (the content plane is role-flat, the reactions posture). Setting an
+   * archived label revives it — the archived-topic-reply rule — unless a live
+   * label took the name meanwhile. Idempotent no-ops write and emit nothing.
+   */
+  async setMessageLabel(
+    ctx: ActorCtx,
+    spaceId: string,
+    messageId: string,
+    input: SetMessageLabelInput,
+  ): Promise<Message> {
+    await this.requireMember(ctx, spaceId);
+    this.guardWrite();
+    const by: Attribution = {
+      memberId: ctx.memberId,
+      actingMode: input.actingMode,
+      ...(input.agentName ? { agentName: input.agentName } : {}),
+    };
+
+    return this.store.withSpaceLock(spaceId, async () => {
+      const message = await this.store.getMessage(spaceId, messageId);
+      if (!message) throw new HarborError('not_found', 'no such message');
+      if (message.deletedAt && input.labelId !== null) {
+        // Clears stay legal so cleanup stays possible, the tombstone-reaction rule.
+        throw new HarborError('invalid_request', 'cannot label a deleted message');
+      }
+      const withFolds = async (m: Message): Promise<Message> => ({
+        ...m,
+        reactions: foldReactions(await this.store.listReactionsByMessage(spaceId, messageId)),
+      });
+      if ((message.labelId ?? null) === input.labelId) return withFolds(message);
+
+      const at = this.now();
+      let offset = (await this.store.head(spaceId)) + 1;
+      if (input.labelId !== null) {
+        const label = await this.store.getLabel(spaceId, input.labelId);
+        if (!label) throw new HarborError('not_found', 'no such label');
+        if (label.archived) {
+          const taken = await this.store.getLiveLabelByName(spaceId, label.name);
+          if (taken) {
+            throw new HarborError('invalid_request', `this label is archived and "${taken.name}" now names a live one`);
+          }
+          const revived: Label = { ...label, archived: false };
+          await this.store.putLabel(revived);
+          await this.append(spaceId, offset, at, { type: 'label', label: revived });
+          offset += 1;
+        }
+      }
+      await this.store.setMessageLabel(spaceId, messageId, input.labelId);
+      await this.append(spaceId, offset, at, {
+        type: 'message_label',
+        assignment: { spaceId, topicId: message.topicId, messageId, labelId: input.labelId, by, at },
+      });
+      const { labelId: _cleared, ...bare } = message;
+      return withFolds(input.labelId === null ? bare : { ...message, labelId: input.labelId });
+    });
+  }
+
+  async listLabelMessages(
+    ctx: ActorCtx,
+    spaceId: string,
+    labelId: string,
+    opts?: { beforeOffset?: number; limit?: number },
+  ): Promise<{ label: Label; messages: Message[]; hasMore: boolean }> {
+    await this.requireMember(ctx, spaceId);
+    const label = await this.store.getLabel(spaceId, labelId);
+    if (!label) throw new HarborError('not_found', 'no such label');
+    const limit = Math.min(Math.max(opts?.limit ?? MESSAGES_PAGE_DEFAULT, 1), MESSAGES_PAGE_MAX);
+    const window = await this.store.listMessagesByLabel(spaceId, labelId, {
+      ...(opts?.beforeOffset !== undefined ? { beforeOffset: opts.beforeOffset } : {}),
+      limit: limit + 1,
+    });
+    const hasMore = window.length > limit;
+    const messages = hasMore ? window.slice(1) : window;
+    return {
+      label,
+      messages: await Promise.all(
+        messages.map(async (m) => ({
+          ...m,
+          reactions: foldReactions(await this.store.listReactionsByMessage(spaceId, m.id)),
+        })),
+      ),
+      hasMore,
+    };
   }
 
   async searchFeed(

--- a/apps/harbor/packages/server/src/store.ts
+++ b/apps/harbor/packages/server/src/store.ts
@@ -2,6 +2,7 @@ import type {
   Attribution,
   BlobInfo,
   ChangeSet,
+  Label,
   Member,
   Membership,
   Message,
@@ -168,6 +169,24 @@ export interface Store {
   markMessageDeleted(spaceId: string, messageId: string, deletedAt: string): Promise<void>;
   /** merge_into support: repoints messages; returns how many moved. */
   reassignMessages(spaceId: string, fromTopicId: string, toTopicId: string): Promise<number>;
+
+  // labels ("topics" in the UI) — explicit groupings; assignment lives on the
+  // messages row (label_id), current truth on reads like reactions.
+  getLabel(spaceId: string, labelId: string): Promise<Label | undefined>;
+  /** Case-insensitive name match among live (non-archived) labels. */
+  getLiveLabelByName(spaceId: string, name: string): Promise<Label | undefined>;
+  putLabel(label: Label): Promise<void>;
+  listLabels(spaceId: string, includeArchived: boolean): Promise<Label[]>;
+  /**
+   * Per-label sidebar stats over live (non-deleted) tagged messages:
+   * messageCount, and the newest activity among tagged messages' postedAt and
+   * the lastActivityAt of topics anchored on them (threads inherit their
+   * anchor's label). Labels with no tagged messages are absent.
+   */
+  labelStats(spaceId: string): Promise<Map<string, { messageCount: number; lastActivityAt: string }>>;
+  setMessageLabel(spaceId: string, messageId: string, labelId: string | null): Promise<void>;
+  /** Same window semantics as listMessages, across topics: oldest first, newest `limit` below `beforeOffset`. */
+  listMessagesByLabel(spaceId: string, labelId: string, opts?: { beforeOffset?: number; limit?: number }): Promise<Message[]>;
 
   // reactions — per-(member, emoji) toggles on messages
   getReaction(spaceId: string, messageId: string, emoji: string, memberId: string): Promise<StoredReaction | undefined>;

--- a/apps/harbor/packages/server/test/labels.test.ts
+++ b/apps/harbor/packages/server/test/labels.test.ts
@@ -1,0 +1,233 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Label, LabelListing, Message, TopicListing } from '@rowboat/spaces-protocol';
+import { PgStore } from '../src/pg-store.js';
+import { startHarbor, type HarborOptions, type RunningHarbor } from '../src/server.js';
+import type { SqlDb } from '../src/sql.js';
+import { pgliteDb } from './pglite.js';
+import { liveClient, type LiveClient } from './helpers.js';
+
+// Labels ("topics" in the UI, 2026-08-25): explicit member-created groupings.
+// One label per message; a thread inherits its anchor message's label by
+// derivation; the sidebar lists only labels someone made. Runs on both
+// stores, the §11 dual gate.
+
+let harbor: RunningHarbor;
+let sqlDb: SqlDb | undefined;
+let live: LiveClient;
+let spaceId: string;
+let generalId: string;
+let m1: Message;
+let m2: Message;
+let launch: Label;
+
+function api(token: string) {
+  return {
+    async get(path: string) {
+      const res = await fetch(`${harbor.url}${path}`, { headers: { authorization: `Bearer ${token}` } });
+      return { status: res.status, body: (await res.json()) as any };
+    },
+    async post(path: string, body?: unknown) {
+      const res = await fetch(`${harbor.url}${path}`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify(body ?? {}),
+      });
+      return { status: res.status, body: (await res.json()) as any };
+    },
+  };
+}
+
+let ramnique: ReturnType<typeof api>;
+let gagan: ReturnType<typeof api>;
+
+describe.each([['memory'], ['postgres']] as const)('labels (%s store)', (storeKind) => {
+  beforeAll(async () => {
+    const options: HarborOptions = {
+      orgName: 'Label Test Org',
+      seedMembers: [
+        { id: 'ramnique', displayName: 'Ramnique' },
+        { id: 'gagan', displayName: 'Gagan' },
+      ],
+    };
+    if (storeKind === 'postgres') {
+      sqlDb = await pgliteDb();
+      const store = new PgStore(sqlDb);
+      await store.init();
+      options.store = store;
+    }
+    harbor = await startHarbor(options);
+    ramnique = api('dev-ramnique');
+    gagan = api('dev-gagan');
+    const created = await ramnique.post('/v1/spaces', { name: 'Labelled' });
+    spaceId = created.body.space.id;
+    const invite = await ramnique.post('/v1/invites', { spaceId });
+    await gagan.post('/v1/invites/accept', { token: invite.body.token });
+    const topics = await ramnique.get(`/v1/spaces/${spaceId}/topics`);
+    generalId = (topics.body.topics as TopicListing[]).find((t) => t.kind === 'general')!.id;
+    m1 = (await ramnique.post(`/v1/spaces/${spaceId}/messages`, { topicId: generalId, body: 'ship the launch email', actingMode: 'direct' })).body.message;
+    m2 = (await gagan.post(`/v1/spaces/${spaceId}/messages`, { topicId: generalId, body: 'draft is in the doc', actingMode: 'direct' })).body.message;
+    live = await liveClient(harbor, 'dev-ramnique');
+    live.send({ kind: 'subscribe', spaceId, afterOffset: 0 });
+  });
+
+  afterAll(async () => {
+    live.close();
+    await harbor.close();
+    await sqlDb?.close();
+    sqlDb = undefined;
+  });
+
+  it('creates a label and lists it with zero messages', async () => {
+    const res = await ramnique.post(`/v1/spaces/${spaceId}/labels`, { name: 'Launch', actingMode: 'direct' });
+    expect(res.status).toBe(200);
+    launch = res.body.label;
+    expect(launch.name).toBe('Launch');
+    expect(launch.archived).toBe(false);
+    const listed = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    expect((listed.body.labels as LabelListing[]).map((l) => [l.id, l.messageCount])).toEqual([[launch.id, 0]]);
+  });
+
+  it('create is get-or-create, case- and whitespace-insensitively — no duplicate labels', async () => {
+    const again = await gagan.post(`/v1/spaces/${spaceId}/labels`, { name: '  LAUNCH ', actingMode: 'direct' });
+    expect(again.status).toBe(200);
+    expect(again.body.label.id).toBe(launch.id);
+    expect(again.body.label.name).toBe('Launch');
+  });
+
+  it('any member labels any message; reads fold the current labelId in', async () => {
+    const res = await gagan.post(`/v1/spaces/${spaceId}/messages/${m1.id}/label`, { labelId: launch.id, actingMode: 'direct' });
+    expect(res.status).toBe(200);
+    expect(res.body.message.labelId).toBe(launch.id);
+    const read = await ramnique.get(`/v1/spaces/${spaceId}/topics/${generalId}/messages`);
+    const readM1 = (read.body.messages as Message[]).find((m) => m.id === m1.id)!;
+    expect(readM1.labelId).toBe(launch.id);
+    expect((read.body.messages as Message[]).find((m) => m.id === m2.id)!.labelId).toBeUndefined();
+  });
+
+  it('a thread anchored on a labelled message counts as that label\'s activity', async () => {
+    const thread = await ramnique.post(`/v1/spaces/${spaceId}/messages`, {
+      anchorMessageId: m1.id,
+      body: 'ship the launch email\n\n<!-- rowboat:topic parent=msg:x by=y at=z -->',
+      actingMode: 'direct',
+    });
+    expect(thread.status).toBe(200);
+    const reply = await gagan.post(`/v1/spaces/${spaceId}/messages`, { topicId: thread.body.topic.id, body: 'on it', actingMode: 'direct' });
+    expect(reply.status).toBe(200);
+    const listed = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    const row = (listed.body.labels as LabelListing[]).find((l) => l.id === launch.id)!;
+    // Only m1 carries the label — thread replies inherit, they are not tagged rows.
+    expect(row.messageCount).toBe(1);
+    expect(row.lastActivityAt >= reply.body.message.postedAt).toBe(true);
+  });
+
+  it('lists a label\'s messages with the listMessages window semantics', async () => {
+    await ramnique.post(`/v1/spaces/${spaceId}/messages/${m2.id}/label`, { labelId: launch.id, actingMode: 'direct' });
+    const all = await ramnique.get(`/v1/spaces/${spaceId}/labels/${launch.id}/messages`);
+    expect(all.status).toBe(200);
+    expect((all.body.messages as Message[]).map((m) => m.id)).toEqual([m1.id, m2.id]);
+    expect(all.body.hasMore).toBe(false);
+    const newest = await ramnique.get(`/v1/spaces/${spaceId}/labels/${launch.id}/messages?limit=1`);
+    expect((newest.body.messages as Message[]).map((m) => m.id)).toEqual([m2.id]);
+    expect(newest.body.hasMore).toBe(true);
+    const paged = await ramnique.get(`/v1/spaces/${spaceId}/labels/${launch.id}/messages?limit=1&beforeOffset=${m2.offset}`);
+    expect((paged.body.messages as Message[]).map((m) => m.id)).toEqual([m1.id]);
+    expect(paged.body.hasMore).toBe(false);
+  });
+
+  it('one label per message: a set replaces, null clears, and no-ops are idempotent', async () => {
+    const design = (await ramnique.post(`/v1/spaces/${spaceId}/labels`, { name: 'Design', actingMode: 'direct' })).body.label as Label;
+    const moved = await ramnique.post(`/v1/spaces/${spaceId}/messages/${m2.id}/label`, { labelId: design.id, actingMode: 'direct' });
+    expect(moved.body.message.labelId).toBe(design.id);
+    const launchNow = await ramnique.get(`/v1/spaces/${spaceId}/labels/${launch.id}/messages`);
+    expect((launchNow.body.messages as Message[]).map((m) => m.id)).toEqual([m1.id]);
+    // Idempotent re-set, then clear.
+    const again = await ramnique.post(`/v1/spaces/${spaceId}/messages/${m2.id}/label`, { labelId: design.id, actingMode: 'direct' });
+    expect(again.status).toBe(200);
+    const cleared = await ramnique.post(`/v1/spaces/${spaceId}/messages/${m2.id}/label`, { labelId: null, actingMode: 'direct' });
+    expect(cleared.status).toBe(200);
+    expect(cleared.body.message.labelId).toBeUndefined();
+    const designNow = await ramnique.get(`/v1/spaces/${spaceId}/labels/${design.id}/messages`);
+    expect(designNow.body.messages).toEqual([]);
+  });
+
+  it('rename works; renaming into a live name is refused', async () => {
+    const labels = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    const design = (labels.body.labels as LabelListing[]).find((l) => l.name === 'Design')!;
+    const renamed = await ramnique.post(`/v1/spaces/${spaceId}/labels/${design.id}`, { action: 'rename', name: 'Design Sync' });
+    expect(renamed.status).toBe(200);
+    expect(renamed.body.label.name).toBe('Design Sync');
+    const collide = await ramnique.post(`/v1/spaces/${spaceId}/labels/${design.id}`, { action: 'rename', name: 'launch' });
+    expect(collide.status).toBe(400);
+    expect(collide.body.code).toBe('invalid_request');
+  });
+
+  it('archived labels leave the default listing; assigning one revives it', async () => {
+    const labels = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    const design = (labels.body.labels as LabelListing[]).find((l) => l.name === 'Design Sync')!;
+    const archived = await ramnique.post(`/v1/spaces/${spaceId}/labels/${design.id}`, { action: 'archive' });
+    expect(archived.body.label.archived).toBe(true);
+    const defaultList = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    expect((defaultList.body.labels as LabelListing[]).some((l) => l.id === design.id)).toBe(false);
+    const withArchived = await ramnique.get(`/v1/spaces/${spaceId}/labels?includeArchived=1`);
+    expect((withArchived.body.labels as LabelListing[]).some((l) => l.id === design.id)).toBe(true);
+    // Assigning the archived label revives it.
+    const assigned = await gagan.post(`/v1/spaces/${spaceId}/messages/${m2.id}/label`, { labelId: design.id, actingMode: 'direct' });
+    expect(assigned.status).toBe(200);
+    const revived = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    expect((revived.body.labels as LabelListing[]).find((l) => l.id === design.id)?.archived).toBe(false);
+  });
+
+  it('archiving frees the name; unarchiving into a retaken name is refused', async () => {
+    await ramnique.post(`/v1/spaces/${spaceId}/labels/${launch.id}`, { action: 'archive' });
+    const fresh = await ramnique.post(`/v1/spaces/${spaceId}/labels`, { name: 'Launch', actingMode: 'direct' });
+    expect(fresh.body.label.id).not.toBe(launch.id);
+    const stuck = await ramnique.post(`/v1/spaces/${spaceId}/labels/${launch.id}`, { action: 'unarchive' });
+    expect(stuck.status).toBe(400);
+    expect(stuck.body.code).toBe('invalid_request');
+  });
+
+  it('tombstones take no label, and deleted messages leave the stats', async () => {
+    const doomed = (await ramnique.post(`/v1/spaces/${spaceId}/messages`, { topicId: generalId, body: 'oops', actingMode: 'direct' })).body.message as Message;
+    const labels = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    const design = (labels.body.labels as LabelListing[]).find((l) => l.name === 'Design Sync')!;
+    await ramnique.post(`/v1/spaces/${spaceId}/messages/${doomed.id}/label`, { labelId: design.id, actingMode: 'direct' });
+    const before = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    const countBefore = (before.body.labels as LabelListing[]).find((l) => l.id === design.id)!.messageCount;
+    await ramnique.post(`/v1/spaces/${spaceId}/messages/${doomed.id}/delete`, { actingMode: 'direct' });
+    const after = await ramnique.get(`/v1/spaces/${spaceId}/labels`);
+    expect((after.body.labels as LabelListing[]).find((l) => l.id === design.id)!.messageCount).toBe(countBefore - 1);
+    const refused = await ramnique.post(`/v1/spaces/${spaceId}/messages/${doomed.id}/label`, { labelId: design.id, actingMode: 'direct' });
+    expect(refused.status).toBe(400);
+    // Clearing a tombstone's label stays legal (cleanup).
+    const clearOk = await ramnique.post(`/v1/spaces/${spaceId}/messages/${doomed.id}/label`, { labelId: null, actingMode: 'direct' });
+    expect(clearOk.status).toBe(200);
+  });
+
+  it('unknown labels and messages are not_found', async () => {
+    const noLabel = await ramnique.get(`/v1/spaces/${spaceId}/labels/01ARZ3NDEKTSV4RRFFQ69G5FAV/messages`);
+    expect(noLabel.status).toBe(404);
+    const noMessage = await ramnique.post(`/v1/spaces/${spaceId}/messages/01ARZ3NDEKTSV4RRFFQ69G5FAV/label`, { labelId: launch.id, actingMode: 'direct' });
+    expect(noMessage.status).toBe(404);
+  });
+
+  it('label and message_label events ride the space\'s one durable sequence', async () => {
+    await live.until(
+      (frames) =>
+        frames.some((f) => f.kind === 'event' && f.event.type === 'label') &&
+        frames.some((f) => f.kind === 'event' && f.event.type === 'message_label'),
+      'label events on the stream',
+    );
+    const events = live.events().map((f) => f.event);
+    const labelEvents = events.filter((e) => e.type === 'label');
+    const assignments = events.filter((e) => e.type === 'message_label');
+    // Creation events for distinct labels only — the get-or-create path emits nothing.
+    expect(labelEvents.filter((e) => e.type === 'label' && e.label.name === 'Launch' && !e.label.archived).length).toBeGreaterThanOrEqual(1);
+    const first = assignments[0]!;
+    expect(first.type === 'message_label' && first.assignment.messageId).toBe(m1.id);
+    expect(first.type === 'message_label' && first.assignment.labelId).toBe(launch.id);
+    expect(first.type === 'message_label' && first.assignment.by.memberId).toBe('gagan');
+    // Offsets are strictly increasing across every event kind — one sequence.
+    const offsets = live.events().map((f) => f.offset);
+    expect([...offsets].sort((a, b) => a - b)).toEqual(offsets);
+  });
+});

--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -46,6 +46,11 @@ type SpacesHandlers = {
   'spaces:listMessages': InvokeHandler<'spaces:listMessages'>;
   'spaces:postMessage': InvokeHandler<'spaces:postMessage'>;
   'spaces:manageTopic': InvokeHandler<'spaces:manageTopic'>;
+  'spaces:listLabels': InvokeHandler<'spaces:listLabels'>;
+  'spaces:createLabel': InvokeHandler<'spaces:createLabel'>;
+  'spaces:manageLabel': InvokeHandler<'spaces:manageLabel'>;
+  'spaces:setMessageLabel': InvokeHandler<'spaces:setMessageLabel'>;
+  'spaces:listLabelMessages': InvokeHandler<'spaces:listLabelMessages'>;
   'spaces:reactToMessage': InvokeHandler<'spaces:reactToMessage'>;
   'spaces:deleteMessage': InvokeHandler<'spaces:deleteMessage'>;
   'spaces:invokeRowboat': InvokeHandler<'spaces:invokeRowboat'>;
@@ -283,6 +288,31 @@ export const spacesIpcHandlers: SpacesHandlers = {
   'spaces:manageTopic': async (_event, args) => ({
     topic: await orgs.getClient(args.orgId).manageTopic(args.spaceId, args.topicId, args.action),
   }),
+
+  'spaces:listLabels': async (_event, args) => ({
+    labels: await orgs.getClient(args.orgId).listLabels(args.spaceId, args.includeArchived ?? false),
+  }),
+
+  'spaces:createLabel': async (_event, args) => ({
+    label: await orgs.getClient(args.orgId).createLabel(args.spaceId, { name: args.name, actingMode: 'direct' }),
+  }),
+
+  'spaces:manageLabel': async (_event, args) => ({
+    label: await orgs.getClient(args.orgId).manageLabel(args.spaceId, args.labelId, args.action),
+  }),
+
+  'spaces:setMessageLabel': async (_event, args) => ({
+    message: await orgs.getClient(args.orgId).setMessageLabel(args.spaceId, args.messageId, {
+      labelId: args.labelId,
+      actingMode: 'direct',
+    }),
+  }),
+
+  'spaces:listLabelMessages': async (_event, args) =>
+    orgs.getClient(args.orgId).listLabelMessages(args.spaceId, args.labelId, {
+      ...(args.beforeOffset !== undefined ? { beforeOffset: args.beforeOffset } : {}),
+      ...(args.limit !== undefined ? { limit: args.limit } : {}),
+    }),
 
   'spaces:reactToMessage': async (_event, args) => ({
     message: await orgs.getClient(args.orgId).reactToMessage(args.spaceId, args.messageId, {

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -9,6 +9,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { AddOrgDialog, AvatarStack, MemberAvatar, OrgMonogram } from '@/components/spaces/atoms'
 import { FileColumn, TrashDialog, UploadFilesDialog } from '@/components/spaces/files-tab'
 import { GeneralStream } from '@/components/spaces/general-stream'
+import { LabelPane } from '@/components/spaces/label-pane'
 import { SpaceRail } from '@/components/spaces/space-rail'
 import { railKey, type RailSelection } from '@/lib/spaces-selection'
 import { DraftThreadPane, ThreadPane } from '@/components/spaces/thread-pane'
@@ -325,7 +326,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         analytics.spacesTabViewed(next.kind === 'general' ? 'general' : next.kind === 'file' ? 'files' : 'topics')
         setRailHover(false)
         setRailPeek(false)
-        if ((next.kind === 'topic' || next.kind === 'draft') && mode === 'read') setMode('split')
+        if ((next.kind === 'topic' || next.kind === 'draft' || next.kind === 'label') && mode === 'read') setMode('split')
         else if (next.kind === 'general' && mode === 'read') setMode('talk')
         else if (next.kind === 'file') {
             // A file opened while talking keeps the conversation beside it:
@@ -401,7 +402,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // last chat selection sticks until the user picks another.
     const chatContextRef = useRef<string | null>(null)
     if (selection.kind === 'topic') chatContextRef.current = selection.topicId
-    else if (selection.kind === 'general' || selection.kind === 'draft') chatContextRef.current = null
+    else if (selection.kind === 'general' || selection.kind === 'draft' || selection.kind === 'label') chatContextRef.current = null
     else if (selection.kind === 'file' && selection.fromTopicId) chatContextRef.current = selection.fromTopicId
     const chatTopicId = chatContextRef.current
 
@@ -441,7 +442,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         ? crumbInfo?.parentMessageId && crumbInfo.firstMessage
             ? stripThreadMarker(crumbInfo.firstMessage.body).split('\n')[0] ?? crumbTopic.title
             : crumbTopic.title
-        : crumbTopicId ? 'Back to topic' : null
+        : crumbTopicId ? 'Back to thread' : null
     const crumbLabel = crumbLabelRaw === null ? null : resolveMentions(crumbLabelRaw, memberNames)
 
     // Files picked (rail Upload button) or dropped on the tree, awaiting the
@@ -555,9 +556,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                     spaceId={space.id}
                     selfMemberId={org.memberId}
                     general={general}
-                    topics={feed.topics}
-                    threads={threads}
-                    changeSets={feed.changeSets}
+                    labels={feed.labels}
                     entries={entries}
                     draftFolders={draftFolders}
                     presence={presence}
@@ -579,7 +578,23 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                     the document; Split shows both around a draggable divider. */}
                 {effMode !== 'read' && (
                     <div className="flex-1 min-w-0 min-h-0 flex">
-                        {draftParent ? (
+                        {selection.kind === 'label' ? (
+                            <LabelPane
+                                key={selection.labelId}
+                                org={org}
+                                space={space}
+                                labelId={selection.labelId}
+                                labels={feed.labels}
+                                threads={threads}
+                                topics={feed.topics}
+                                presence={presence}
+                                memberNames={memberNames}
+                                refreshTick={refreshTick}
+                                onBack={() => select({ kind: 'general' })}
+                                onOpenThread={(id) => select({ kind: 'topic', topicId: id })}
+                                onStartThread={(m) => select({ kind: 'draft', parentMessageId: m.id })}
+                            />
+                        ) : draftParent ? (
                             <section className="flex-1 min-w-0 min-h-0 flex flex-col">
                                 <DraftThreadPane
                                     key={draftParent.id}
@@ -625,12 +640,14 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                                 general={general}
                                 threads={threads}
                                 topics={feed.topics}
+                                labels={feed.labels}
                                 presence={presence}
                                 members={members}
                                 memberNames={memberNames}
                                 entries={entries}
                                 onOpenThread={(id) => select({ kind: 'topic', topicId: id })}
                                 onStartThread={(m) => select({ kind: 'draft', parentMessageId: m.id })}
+                                onOpenLabel={(id) => select({ kind: 'label', labelId: id })}
                                 onOpenSession={onOpenSession}
                             />
                         )}

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -9,7 +9,7 @@ import {
     buildPendingMessage, failPendingGeneralMessage, ingestGeneralMessage, loadOlderGeneralMessages,
     removeGeneralMessage, resolvePendingGeneralMessage, updateGeneralMessage, usePresenceSender,
 } from '@/hooks/use-space-chat'
-import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { refreshSpaceFeed, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
 import { resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
@@ -19,7 +19,8 @@ import * as analytics from '@/lib/analytics'
 import { containsRowboatAddress } from '@/lib/spaces-mentions'
 
 // Messages — the space's open stream. What people say, in order; a message
-// that gets replies becomes a topic (shown as a row under it here).
+// that gets replies grows a thread (shown as a row under it here), and a
+// message given a topic groups under it in the rail (the label chip).
 
 /** Scroll position per space, so coming back (a topic, a file, the top ‹ ›) lands where you were. */
 const scrollMemory = new Map<string, number>()
@@ -28,13 +29,15 @@ const scrollMemory = new Map<string, number>()
 const RENDER_CAP = 100
 
 export function GeneralStream({
-    org, space, general, threads, topics, presence, members, memberNames, entries = [], onOpenThread, onStartThread, onOpenSession,
+    org, space, general, threads, topics, labels, presence, members, memberNames, entries = [], onOpenThread, onStartThread, onOpenLabel, onOpenSession,
 }: {
     org: OrgWithSpaces
     space: spaces.Space
     general: GeneralState
     threads: ThreadIndex
     topics: spaces.Topic[]
+    /** Explicit topics (labels on the wire) — the picker's options and the chips' names. */
+    labels: spaces.LabelListing[]
     presence: SpacePresence
     members: spaces.Member[]
     memberNames: Map<string, string>
@@ -43,6 +46,8 @@ export function GeneralStream({
     onOpenThread: (topicId: string) => void
     /** Reply on a message with no thread yet — open a draft pane (no topic until first send). */
     onStartThread: (parent: spaces.Message) => void
+    /** Open a topic's grouped view (the rail's Topics). */
+    onOpenLabel: (labelId: string) => void
     onOpenSession?: (sessionId: string) => void
 }) {
     const [seed, setSeed] = useState<{ text: string; nonce: number } | null>(null)
@@ -102,6 +107,39 @@ export function GeneralStream({
     }, [memoryKey])
 
     const topicsById = useMemo(() => new Map(topics.map((t) => [t.id, t])), [topics])
+    const labelsById = useMemo(() => new Map(labels.map((l) => [l.id, l])), [labels])
+    const labelChipFor = (message: spaces.Message) => {
+        if (!message.labelId) return null
+        const l = labelsById.get(message.labelId)
+        return l ? { id: l.id, name: l.name } : null
+    }
+
+    // The topic gesture: set/clear rides the message (the org validates), a
+    // new name is get-or-create on the org so concurrent typers converge.
+    const setLabel = async (message: spaces.Message, labelId: string | null) => {
+        try {
+            const { message: updated } = await window.ipc.invoke('spaces:setMessageLabel', {
+                orgId: org.id, spaceId: space.id, messageId: message.id, labelId,
+            })
+            updateGeneralMessage(org.id, space.id, updated)
+            await refreshSpaceFeed(org.id, space.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not set the topic', 'error')
+        }
+    }
+    const createLabelAndSet = async (message: spaces.Message, name: string) => {
+        try {
+            const { label } = await window.ipc.invoke('spaces:createLabel', { orgId: org.id, spaceId: space.id, name })
+            await setLabel(message, label.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not create the topic', 'error')
+        }
+    }
+    const labeling = {
+        options: labels.filter((l) => !l.archived).map((l) => ({ id: l.id, name: l.name })),
+        onSet: (message: spaces.Message, labelId: string | null) => void setLabel(message, labelId),
+        onCreate: (message: spaces.Message, name: string) => void createLabelAndSet(message, name),
+    }
 
     const threadRowFor = (message: spaces.Message): ThreadRowData | null => {
         const topicId = threads.byParent.get(message.id)
@@ -329,6 +367,9 @@ export function GeneralStream({
                 memberNames={memberNames}
                 continuation={isContinuation(prev, message)}
                 thread={thread}
+                label={labelChipFor(message)}
+                onOpenLabel={onOpenLabel}
+                labeling={labeling}
                 selfMemberId={org.memberId}
                 onOpenThread={onOpenThread}
                 onReplyInThread={replyInThread}
@@ -349,7 +390,7 @@ export function GeneralStream({
         <section className="flex-1 min-w-0 min-h-0 flex flex-col">
             <div className="flex items-center gap-2.5 px-5 h-9 shrink-0">
                 <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Messages</span>
-                <span className="text-xs text-muted-foreground truncate">What the team says, in order. Reply to one to start a topic.</span>
+                <span className="text-xs text-muted-foreground truncate">What the team says, in order. Reply to start a thread; add a topic to group things.</span>
                 <span className="flex-1" />
                 {general.error && <span className="text-xs text-destructive truncate" title={general.error}>messages unavailable</span>}
             </div>

--- a/apps/x/apps/renderer/src/components/spaces/label-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/label-pane.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useRef, useState } from 'react'
+import { Archive, ArchiveRestore, ArrowLeft, Loader2, MoreHorizontal, Pencil, Tag } from 'lucide-react'
+import type { spaces } from '@x/shared'
+import {
+    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { DayDivider, MessageRow, type ThreadRowData } from '@/components/spaces/message-row'
+import type { SpacePresence, ThreadIndex } from '@/hooks/use-space-chat'
+import { updateGeneralMessage } from '@/hooks/use-space-chat'
+import { refreshSpaceFeed, type OrgWithSpaces } from '@/hooks/use-spaces'
+import { dayKey, explicitTitle, formatDayLabel, mergeMessages } from '@/lib/spaces-conventions'
+import { resolveMentions } from '@/lib/spaces-presentation'
+import { getTopicLastReadAt } from '@/lib/spaces-read-state'
+import { toast } from '@/lib/toast'
+
+// A topic's view (a label on the wire): every message someone tagged with it,
+// across the stream, each with its thread chip — the curation layer over the
+// chat. Nothing is posted HERE: messages live in the stream and in threads;
+// this pane groups them. Threads inherit the topic from their anchor message,
+// so opening one from a chip keeps the topic's context.
+
+export function LabelPane({
+    org, space, labelId, labels, threads, topics, presence, memberNames, refreshTick,
+    onBack, onOpenThread, onStartThread,
+}: {
+    org: OrgWithSpaces
+    space: spaces.Space
+    labelId: string
+    /** The feed store's labels — name/archived state stay live between refetches. */
+    labels: spaces.LabelListing[]
+    threads: ThreadIndex
+    topics: spaces.Topic[]
+    presence: SpacePresence
+    memberNames: Map<string, string>
+    refreshTick: number
+    onBack: () => void
+    onOpenThread: (topicId: string) => void
+    /** Reply on a tagged message with no thread yet — same draft flow as the stream. */
+    onStartThread: (parent: spaces.Message) => void
+}) {
+    const [label, setLabel] = useState<spaces.Label | null>(labels.find((l) => l.id === labelId) ?? null)
+    const [messages, setMessages] = useState<spaces.Message[]>([])
+    const [loaded, setLoaded] = useState(false)
+    const [hasMore, setHasMore] = useState(false)
+    const [loadingOlder, setLoadingOlder] = useState(false)
+    // The deepest (oldest) offset any fetch reached — a refetch of the newest
+    // page must not reset hasMore after the reader paged further back.
+    const oldestLoadedRef = useRef<number | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        void window.ipc
+            .invoke('spaces:listLabelMessages', { orgId: org.id, spaceId: space.id, labelId })
+            .then((res) => {
+                if (cancelled) return
+                setLabel(res.label)
+                // A refetch merges — and drops rows whose label moved away.
+                setMessages((prev) => mergeMessages(prev, res.messages).filter((m) => m.labelId === labelId))
+                const windowOldest = res.messages[0]?.offset ?? null
+                if (oldestLoadedRef.current === null || windowOldest === null || windowOldest <= oldestLoadedRef.current) {
+                    oldestLoadedRef.current = windowOldest ?? oldestLoadedRef.current
+                    setHasMore(res.hasMore)
+                }
+                setLoaded(true)
+            })
+            .catch(() => {})
+        return () => {
+            cancelled = true
+        }
+    }, [org.id, space.id, labelId, refreshTick])
+
+    const loadOlder = async () => {
+        const oldest = messages[0]
+        if (!oldest || loadingOlder) return
+        setLoadingOlder(true)
+        try {
+            const res = await window.ipc.invoke('spaces:listLabelMessages', {
+                orgId: org.id, spaceId: space.id, labelId, beforeOffset: oldest.offset,
+            })
+            setMessages((prev) => mergeMessages(prev, res.messages))
+            oldestLoadedRef.current = res.messages[0]?.offset ?? oldestLoadedRef.current
+            setHasMore(res.hasMore)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not load earlier messages', 'error')
+        } finally {
+            setLoadingOlder(false)
+        }
+    }
+
+    const manage = async (action: spaces.SpacesManageLabelAction) => {
+        try {
+            const res = await window.ipc.invoke('spaces:manageLabel', { orgId: org.id, spaceId: space.id, labelId, action })
+            setLabel(res.label)
+            await refreshSpaceFeed(org.id, space.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not update the topic', 'error')
+        }
+    }
+    const [editingName, setEditingName] = useState<string | null>(null)
+    const commitName = async () => {
+        const name = editingName?.trim()
+        setEditingName(null)
+        if (!name || name === label?.name) return
+        await manage({ action: 'rename', name })
+    }
+
+    // The change/remove gesture from inside the view. A removed message drops
+    // out on the spot — the refetch would say the same thing, later.
+    const setMessageLabel = async (message: spaces.Message, nextLabelId: string | null) => {
+        try {
+            const { message: updated } = await window.ipc.invoke('spaces:setMessageLabel', {
+                orgId: org.id, spaceId: space.id, messageId: message.id, labelId: nextLabelId,
+            })
+            setMessages((prev) => (updated.labelId === labelId ? prev.map((m) => (m.id === updated.id ? updated : m)) : prev.filter((m) => m.id !== updated.id)))
+            updateGeneralMessage(org.id, space.id, updated)
+            await refreshSpaceFeed(org.id, space.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not set the topic', 'error')
+        }
+    }
+    const createAndSet = async (message: spaces.Message, name: string) => {
+        try {
+            const { label: created } = await window.ipc.invoke('spaces:createLabel', { orgId: org.id, spaceId: space.id, name })
+            await setMessageLabel(message, created.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not create the topic', 'error')
+        }
+    }
+    const labeling = {
+        options: labels.filter((l) => !l.archived).map((l) => ({ id: l.id, name: l.name })),
+        onSet: (message: spaces.Message, next: string | null) => void setMessageLabel(message, next),
+        onCreate: (message: spaces.Message, name: string) => void createAndSet(message, name),
+    }
+
+    const toggleReaction = async (message: spaces.Message, emoji: string) => {
+        const mine = (message.reactions ?? []).find((g) => g.emoji === emoji)?.memberIds.includes(org.memberId)
+        try {
+            const { message: updated } = await window.ipc.invoke('spaces:reactToMessage', {
+                orgId: org.id, spaceId: space.id, messageId: message.id, emoji, action: mine ? 'remove' : 'add',
+            })
+            setMessages((prev) => prev.map((m) => (m.id === updated.id ? updated : m)))
+            updateGeneralMessage(org.id, space.id, updated)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not react', 'error')
+        }
+    }
+
+    const copyLink = async (message: spaces.Message) => {
+        try {
+            await navigator.clipboard.writeText(`https://${org.address}/s/${space.id}/t/${message.topicId}#${message.id}`)
+            toast('Link copied', 'success')
+        } catch {
+            toast('Could not copy the link', 'error')
+        }
+    }
+
+    const topicsById = new Map(topics.map((t) => [t.id, t]))
+    const threadRowFor = (message: spaces.Message): ThreadRowData | null => {
+        const topicId = threads.byParent.get(message.id)
+        if (!topicId) return null
+        const topic = topicsById.get(topicId)
+        if (!topic) return null
+        const mark = getTopicLastReadAt(org.id, space.id, topicId)
+        const hasNew = !mark || topic.lastActivityAt > mark
+        const named = explicitTitle(topic, threads.byTopic.get(topicId)?.firstMessage?.body ?? message.body)
+        return {
+            topicId,
+            replyCount: Math.max(0, topic.messageCount - 1),
+            lastActivityAt: topic.lastActivityAt,
+            unreadCount: hasNew && topic.messageCount > 1 ? 1 : 0,
+            workingAgents: presence.working.get(topicId) ?? [],
+            title: named ? resolveMentions(named, memberNames) : null,
+        }
+    }
+
+    const visible = messages.filter((m) => !m.deletedAt || threadRowFor(m))
+    const name = label?.name ?? labels.find((l) => l.id === labelId)?.name ?? 'Topic'
+
+    return (
+        <section className="flex-1 min-w-0 min-h-0 flex flex-col">
+            <div className="flex items-center gap-2 border-b border-border px-3 h-11 shrink-0">
+                <button
+                    type="button"
+                    title="Back to Messages"
+                    onClick={onBack}
+                    className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                    <ArrowLeft className="size-3.5" />
+                </button>
+                <Tag className="size-3.5 shrink-0 text-muted-foreground" />
+                {editingName !== null ? (
+                    <input
+                        autoFocus
+                        value={editingName}
+                        onChange={(e) => setEditingName(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') void commitName()
+                            if (e.key === 'Escape') setEditingName(null)
+                        }}
+                        onBlur={() => void commitName()}
+                        className="min-w-0 flex-1 rounded-md border border-foreground/30 bg-background px-1.5 py-0.5 text-[13.5px] font-semibold outline-none"
+                    />
+                ) : (
+                    <h2 className="min-w-0 flex-1 truncate text-[13.5px] font-semibold">{name}</h2>
+                )}
+                <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+                    {visible.length}{hasMore ? '+' : ''} {visible.length === 1 && !hasMore ? 'message' : 'messages'}
+                </span>
+                {label?.archived && <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">archived</span>}
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <button type="button" aria-label="Topic actions" className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground">
+                            <MoreHorizontal className="size-3.5" />
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => setEditingName(name)}>
+                            <Pencil className="size-3.5 mr-2" /> Rename
+                        </DropdownMenuItem>
+                        {label?.archived ? (
+                            <DropdownMenuItem onClick={() => void manage({ action: 'unarchive' })}>
+                                <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
+                            </DropdownMenuItem>
+                        ) : (
+                            <DropdownMenuItem onClick={() => void manage({ action: 'archive' })}>
+                                <Archive className="size-3.5 mr-2" /> Archive
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </div>
+
+            <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
+                {!loaded && (
+                    <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground"><Loader2 className="size-3.5 animate-spin" /> Loading…</div>
+                )}
+                {loaded && visible.length === 0 && (
+                    <div className="px-2 py-6 text-sm text-muted-foreground">
+                        Nothing here yet — add this topic to a message in the stream and it shows up here, thread and all.
+                    </div>
+                )}
+                {hasMore && (
+                    <div className="flex justify-center py-2">
+                        <button
+                            type="button"
+                            onClick={() => void loadOlder()}
+                            disabled={loadingOlder}
+                            className="rounded-md border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground hover:border-foreground/30 hover:text-foreground disabled:opacity-60"
+                        >
+                            {loadingOlder ? 'Loading earlier messages…' : 'Load earlier messages'}
+                        </button>
+                    </div>
+                )}
+                {(() => {
+                    // Tagged messages are sparse — every row keeps its author
+                    // header (no compaction), day dividers keep the timeline.
+                    const rows: React.ReactNode[] = []
+                    let prevDay = ''
+                    for (const message of visible) {
+                        const day = dayKey(message.postedAt)
+                        if (day !== prevDay) {
+                            rows.push(<DayDivider key={`day:${day}`} label={formatDayLabel(message.postedAt)} />)
+                            prevDay = day
+                        }
+                        rows.push(
+                            <MessageRow
+                                key={message.id}
+                                message={message}
+                                memberNames={memberNames}
+                                continuation={false}
+                                thread={threadRowFor(message)}
+                                labeling={labeling}
+                                selfMemberId={org.memberId}
+                                onOpenThread={onOpenThread}
+                                onReplyInThread={(m) => {
+                                    const existing = threads.byParent.get(m.id)
+                                    if (existing) onOpenThread(existing)
+                                    else onStartThread(m)
+                                }}
+                                onCopyLink={(m) => void copyLink(m)}
+                                onReact={(m, emoji) => void toggleReaction(m, emoji)}
+                            />,
+                        )
+                    }
+                    return rows
+                })()}
+            </div>
+            <div className="shrink-0 border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+                Messages are written in the stream — this view groups the ones tagged “{name}”.
+            </div>
+        </section>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Bot, ChevronRight, Link as LinkIcon, Loader2, MessageSquare, MoreHorizontal, SmilePlus, Trash2 } from 'lucide-react'
+import { Bot, ChevronRight, Link as LinkIcon, Loader2, MessageSquare, MoreHorizontal, SmilePlus, Tag, Trash2 } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -7,7 +7,8 @@ import {
     ContextMenuSubContent, ContextMenuSubTrigger, ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import {
-    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSub,
+    DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -126,6 +127,44 @@ function ReactionChips({ message, memberNames, selfMemberId, onReact, onPickerOp
     )
 }
 
+/** The topic gesture (labels on the wire): what a surface passes to offer it. */
+export interface MessageLabeling {
+    /** Live labels for the picker, rail order. */
+    options: { id: string; name: string }[]
+    /** Set (labelId) or clear (null) the message's topic. */
+    onSet: (message: spaces.Message, labelId: string | null) => void
+    /** Create-or-get a topic by name and set it on the message. */
+    onCreate: (message: spaces.Message, name: string) => void
+}
+
+/**
+ * The "New topic…" input inside a menu. Printable keys must not reach the
+ * menu (Radix typeahead would steal them); Enter submits and then closes the
+ * menu by letting a synthetic Escape bubble to the menu content.
+ */
+function NewLabelInput({ onSubmit }: { onSubmit: (name: string) => void }) {
+    const [value, setValue] = useState('')
+    return (
+        <input
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+                if (e.key === 'Escape') return
+                e.stopPropagation()
+                if (e.key === 'Enter' && value.trim()) {
+                    const name = value.trim()
+                    setValue('')
+                    onSubmit(name)
+                    e.currentTarget.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+                }
+            }}
+            placeholder="New topic…"
+            className="mb-0.5 w-full rounded border border-border bg-background px-1.5 py-1 text-xs outline-none placeholder:text-muted-foreground focus:border-foreground/30"
+        />
+    )
+}
+
 const MESSAGE_PROSE = 'text-sm leading-relaxed [&_p]:my-0.5 [&_h1]:text-base [&_h2]:text-[15px] [&_h3]:text-sm [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-semibold [&_h1]:mt-3 [&_h2]:mt-3 [&_h3]:mt-2 [&_h1]:mb-1 [&_h2]:mb-1 [&_h3]:mb-1 [&_ul]:my-1 [&_ol]:my-1'
 
 export interface ThreadRowData {
@@ -139,7 +178,7 @@ export interface ThreadRowData {
 }
 
 export function MessageRow({
-    message, memberNames, continuation, thread, onOpenThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onRetryFailed, onDiscardFailed, dense, selfMemberId,
+    message, memberNames, continuation, thread, label, onOpenLabel, labeling, onOpenThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onRetryFailed, onDiscardFailed, dense, selfMemberId,
 }: {
     message: spaces.Message & { pending?: boolean; failed?: boolean }
     memberNames: Map<string, string>
@@ -148,6 +187,12 @@ export function MessageRow({
     continuation: boolean
     /** Present when a topic was started from this message (general only). */
     thread?: ThreadRowData | null
+    /** The message's topic (a label on the wire), resolved for display; absent = none. */
+    label?: { id: string; name: string } | null
+    /** Open the topic's grouped view. */
+    onOpenLabel?: (labelId: string) => void
+    /** Present = the set/change/remove-topic gesture is offered here. */
+    labeling?: MessageLabeling
     onOpenThread?: (topicId: string) => void
     onReplyInThread?: (message: spaces.Message) => void
     onAskRowboat?: (message: spaces.Message) => void
@@ -173,7 +218,7 @@ export function MessageRow({
     // can act on them either.
     const unconfirmed = !!message.pending || !!message.failed
     const canDelete = !!onDelete && !deleted && !unconfirmed && selfMemberId === message.author.memberId
-    const showActions = !deleted && !unconfirmed && !!(onReplyInThread || onAskRowboat || onCopyLink || onReact || canDelete)
+    const showActions = !deleted && !unconfirmed && !!(onReplyInThread || onAskRowboat || onCopyLink || onReact || labeling || canDelete)
     // While the emoji picker or the ⋯ menu is open the hover-revealed chrome
     // must stay put — unmounting it collapses the popper anchor and the menu
     // would jump to the viewport edge.
@@ -232,6 +277,17 @@ export function MessageRow({
                         onPickerOpenChange={setPickerOpen}
                     />
                 )}
+                {!deleted && !unconfirmed && label && (
+                    <button
+                        type="button"
+                        title={`In topic: ${label.name}`}
+                        onClick={() => onOpenLabel?.(label.id)}
+                        className="mr-1.5 mt-1.5 inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground hover:border-foreground/30 hover:text-foreground"
+                    >
+                        <Tag className="size-3" />
+                        <span className="max-w-40 truncate font-medium">{label.name}</span>
+                    </button>
+                )}
                 {thread && thread.replyCount > 0 && onOpenThread && (
                     <button
                         type="button"
@@ -284,7 +340,7 @@ export function MessageRow({
                     {onReplyInThread && (
                         <button
                             type="button"
-                            title={thread && thread.replyCount > 0 ? 'Open topic' : 'Reply — starts a topic'}
+                            title={thread && thread.replyCount > 0 ? 'Open thread' : 'Reply — starts a thread'}
                             onClick={() => (thread && thread.replyCount > 0 && onOpenThread ? onOpenThread(thread.topicId) : onReplyInThread(message))}
                             className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
                         >
@@ -301,7 +357,7 @@ export function MessageRow({
                             <Bot className="size-3.5" />
                         </button>
                     )}
-                    {(onCopyLink || canDelete) && (
+                    {(onCopyLink || labeling || canDelete) && (
                         <DropdownMenu onOpenChange={setMenuOpen}>
                             <DropdownMenuTrigger asChild>
                                 <button type="button" title="More" className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground">
@@ -309,6 +365,31 @@ export function MessageRow({
                                 </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
+                                {labeling && (
+                                    <DropdownMenuSub>
+                                        <DropdownMenuSubTrigger>
+                                            <Tag className="size-3.5 mr-2" /> {label ? 'Change topic' : 'Add topic'}
+                                        </DropdownMenuSubTrigger>
+                                        <DropdownMenuSubContent className="w-52 p-1.5">
+                                            <NewLabelInput onSubmit={(name) => labeling.onCreate(message, name)} />
+                                            {labeling.options.map((option) => (
+                                                <DropdownMenuItem
+                                                    key={option.id}
+                                                    onClick={() => labeling.onSet(message, option.id)}
+                                                    className={cn(option.id === label?.id && 'bg-accent')}
+                                                >
+                                                    <Tag className="size-3 mr-2 text-muted-foreground" />
+                                                    <span className="truncate">{option.name}</span>
+                                                </DropdownMenuItem>
+                                            ))}
+                                            {label && (
+                                                <DropdownMenuItem onClick={() => labeling.onSet(message, null)}>
+                                                    Remove from “{label.name}”
+                                                </DropdownMenuItem>
+                                            )}
+                                        </DropdownMenuSubContent>
+                                    </DropdownMenuSub>
+                                )}
                                 {onCopyLink && (
                                     <DropdownMenuItem onClick={() => onCopyLink(message)}>
                                         <LinkIcon className="size-3.5 mr-2" /> Copy link
@@ -332,7 +413,7 @@ export function MessageRow({
     // under it kept catching accidental clicks. Tombstones and action-less
     // rows get the plain row.
     if (!showActions) return row
-    const hasTopItems = !!(onReact || onReplyInThread || onAskRowboat || onCopyLink)
+    const hasTopItems = !!(onReact || onReplyInThread || onAskRowboat || onCopyLink || labeling)
     return (
         <ContextMenu>
             <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
@@ -361,13 +442,38 @@ export function MessageRow({
                     <ContextMenuItem
                         onSelect={() => (thread && thread.replyCount > 0 && onOpenThread ? onOpenThread(thread.topicId) : onReplyInThread(message))}
                     >
-                        <MessageSquare className="size-3.5 mr-2" /> {thread && thread.replyCount > 0 ? 'Open topic' : 'Reply — starts a topic'}
+                        <MessageSquare className="size-3.5 mr-2" /> {thread && thread.replyCount > 0 ? 'Open thread' : 'Reply — starts a thread'}
                     </ContextMenuItem>
                 )}
                 {onAskRowboat && (
                     <ContextMenuItem onSelect={() => onAskRowboat(message)}>
                         <Bot className="size-3.5 mr-2" /> Ask @rowboat about this
                     </ContextMenuItem>
+                )}
+                {labeling && (
+                    <ContextMenuSub>
+                        <ContextMenuSubTrigger>
+                            <Tag className="size-3.5 mr-2" /> {label ? 'Change topic' : 'Add topic'}
+                        </ContextMenuSubTrigger>
+                        <ContextMenuSubContent className="w-52 p-1.5">
+                            <NewLabelInput onSubmit={(name) => labeling.onCreate(message, name)} />
+                            {labeling.options.map((option) => (
+                                <ContextMenuItem
+                                    key={option.id}
+                                    onSelect={() => labeling.onSet(message, option.id)}
+                                    className={cn(option.id === label?.id && 'bg-accent')}
+                                >
+                                    <Tag className="size-3 mr-2 text-muted-foreground" />
+                                    <span className="truncate">{option.name}</span>
+                                </ContextMenuItem>
+                            ))}
+                            {label && (
+                                <ContextMenuItem onSelect={() => labeling.onSet(message, null)}>
+                                    Remove from “{label.name}”
+                                </ContextMenuItem>
+                            )}
+                        </ContextMenuSubContent>
+                    </ContextMenuSub>
                 )}
                 {onCopyLink && (
                     <ContextMenuItem onSelect={() => onCopyLink(message)}>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
-import { Archive, ArchiveRestore, Bot, FileText, Folder, FolderPlus, MessagesSquare, MoreHorizontal, Pencil, Pin, Plus, Search, Trash2, Upload } from 'lucide-react'
+import { Archive, ArchiveRestore, Folder, FolderPlus, MessagesSquare, MoreHorizontal, Pencil, Pin, Plus, Search, Tag, Trash2, Upload } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -8,30 +8,29 @@ import {
 import { toast } from '@/lib/toast'
 import { FileTree } from '@/components/spaces/files-tab'
 import { refreshSpaceFeed } from '@/hooks/use-spaces'
-import type { GeneralState, SpacePresence, ThreadIndex } from '@/hooks/use-space-chat'
-import { useMemberNames } from '@/components/spaces/member-text'
-import { explicitTitle, isGeneralSeedMessage, stripThreadMarker, threadRefOf } from '@/lib/spaces-conventions'
-import { formatFeedTime, resolveMentions } from '@/lib/spaces-presentation'
+import type { GeneralState, SpacePresence } from '@/hooks/use-space-chat'
+import { isGeneralSeedMessage } from '@/lib/spaces-conventions'
+import { formatFeedTime } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt } from '@/lib/spaces-read-state'
 import type { RailSelection } from '@/lib/spaces-selection'
 
 // The space's edge rail: one collapsible strip carrying the same sidebar on
-// every surface — Messages + topics on top, the file tree below. Collapsed it
-// is a 28px edge; it pushes open to 280px on hover (never floats over
-// content), peeks briefly to teach the gesture, and can be pinned. The
-// surfaces own everything else.
+// every surface — Messages + Topics on top, the file tree below. Topics here
+// are the explicit labels members created (threads stay in the stream, on
+// their reply chips — never listed here). Collapsed it is a 28px edge; it
+// pushes open to 280px on hover (never floats over content), peeks briefly
+// to teach the gesture, and can be pinned. The surfaces own everything else.
 
 export function SpaceRail({
-    orgId, spaceId, selfMemberId, general, topics, threads, changeSets, entries, draftFolders, presence, unreadPaths, selection, onSelect, onCreateFile, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
+    orgId, spaceId, selfMemberId, general, labels, entries, draftFolders, presence, unreadPaths, selection, onSelect, onCreateFile, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
     open, pinned, hint, onHoverChange, onTogglePin,
 }: {
     orgId: string
     spaceId: string
     selfMemberId: string
     general: GeneralState
-    topics: spaces.Topic[]
-    threads: ThreadIndex
-    changeSets: spaces.ChangeSet[]
+    /** Explicit topics (labels on the wire), listed here; threads are not. */
+    labels: spaces.LabelListing[]
     entries: spaces.SpacesAssetEntry[]
     /** Local-only empty folders — see SpacePane. */
     draftFolders: readonly string[]
@@ -53,25 +52,36 @@ export function SpaceRail({
     onTogglePin: () => void
 }) {
     const [query, setQuery] = useState('')
-    const [filter, setFilter] = useState<'all' | 'unread' | 'archived'>('all')
+    const [filter, setFilter] = useState<'all' | 'archived'>('all')
     const [creatingFile, setCreatingFile] = useState<{ prefix: string } | null>(null)
     const [creatingFolder, setCreatingFolder] = useState(false)
+    const [creatingLabel, setCreatingLabel] = useState(false)
     const uploadInputRef = useRef<HTMLInputElement | null>(null)
 
-    // Row-level topic actions. Rename edits inline in the row; the topic event
-    // the server emits updates every other client, the refresh updates this one.
-    const [renaming, setRenaming] = useState<{ topicId: string; value: string } | null>(null)
-    const manageTopic = async (topicId: string, action: spaces.SpacesManageTopicAction) => {
+    // Row-level topic (label) actions. Rename edits inline in the row; the
+    // label event the org emits updates every other client, the refresh this one.
+    const [renaming, setRenaming] = useState<{ labelId: string; value: string } | null>(null)
+    const manageLabel = async (labelId: string, action: spaces.SpacesManageLabelAction) => {
         try {
-            await window.ipc.invoke('spaces:manageTopic', { orgId, spaceId, topicId, action })
+            await window.ipc.invoke('spaces:manageLabel', { orgId, spaceId, labelId, action })
             await refreshSpaceFeed(orgId, spaceId)
         } catch (err) {
             toast(err instanceof Error ? err.message : 'Could not update the topic', 'error')
         }
     }
-    const commitRename = async (topicId: string, title: string) => {
+    const commitRename = async (labelId: string, name: string) => {
         setRenaming(null)
-        await manageTopic(topicId, { action: 'retitle', title })
+        await manageLabel(labelId, { action: 'rename', name })
+    }
+    const createLabel = async (name: string) => {
+        setCreatingLabel(false)
+        try {
+            const { label } = await window.ipc.invoke('spaces:createLabel', { orgId, spaceId, name })
+            await refreshSpaceFeed(orgId, spaceId)
+            onSelect({ kind: 'label', labelId: label.id })
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not create the topic', 'error')
+        }
     }
 
     const generalId = general.topic?.id ?? null
@@ -83,52 +93,17 @@ export function SpaceRail({
         return general.messages.filter((m, i) => !isGeneralSeedMessage(g, m, i) && (!mark || m.postedAt > mark) && m.author.memberId !== selfMemberId).length
     }, [general, orgId, spaceId, selfMemberId])
 
-    const artifactFiles = useMemo(() => {
-        const counts = new Map<string, Set<string>>()
-        for (const cs of changeSets) {
-            const ref = cs.topicId ?? threadRefOf(cs.reason)
-            if (!ref) continue
-            const set = counts.get(ref) ?? new Set<string>()
-            set.add(cs.assetPath)
-            counts.set(ref, set)
-        }
-        return counts
-    }, [changeSets])
-
-    const isUnread = (t: spaces.Topic) => {
-        const mark = getTopicLastReadAt(orgId, spaceId, t.id)
-        if (mark && t.lastActivityAt <= mark) return false
-        return t.messageCount > 1 || t.createdBy.memberId !== selfMemberId
-    }
-
-    const memberNames = useMemberNames()
     const q = query.trim().toLowerCase()
-    const topicRows = topics
-        .filter((t) => t.id !== generalId)
-        .filter((t) => (filter === 'archived' ? t.archived : !t.archived))
-        .filter((t) => (filter === 'unread' ? isUnread(t) : true))
-        .map((t) => {
-            const info = threads.byTopic.get(t.id)
-            // A renamed topic shows its name; an auto-titled thread keeps
-            // showing its seed text (its derived title is a noisy quote).
-            // Without the seed prefetch the PARENT message (already loaded in
-            // general) stands in — the seed's first line is the parent's.
-            const parentBody = info?.parentMessageId ? general.messages.find((m) => m.id === info.parentMessageId)?.body : undefined
-            const seedBody = info?.firstMessage ? stripThreadMarker(info.firstMessage.body) : parentBody
-            const named = explicitTitle(t, seedBody)
-            const raw = named ?? (info?.parentMessageId && seedBody ? seedBody.split('\n')[0] ?? t.title : t.title)
-            // Titles resolve before the search filter so searching a person's
-            // name finds the topics that mention them.
-            return { topic: t, title: resolveMentions(raw, memberNames) }
-        })
-        .filter((x) => (q ? x.title.toLowerCase().includes(q) : true))
-        .sort((a, b) => b.topic.lastActivityAt.localeCompare(a.topic.lastActivityAt))
+    const labelRows = labels
+        .filter((l) => (filter === 'archived' ? l.archived : !l.archived))
+        .filter((l) => (q ? l.name.toLowerCase().includes(q) : true))
+        .sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt))
 
-    const selectedTopicId = selection.kind === 'topic' ? selection.topicId : null
+    const selectedLabelId = selection.kind === 'label' ? selection.labelId : null
     const selectedPath = selection.kind === 'file' ? selection.path : null
 
-    const unreadTopics = topics.filter((t) => t.id !== generalId && !t.archived && isUnread(t)).length + (generalUnread > 0 ? 1 : 0)
-    const badge = unreadTopics + unreadPaths.size
+    // Threads left the rail, so the collapsed badge is the stream + files.
+    const badge = (generalUnread > 0 ? 1 : 0) + unreadPaths.size
 
     return (
         <aside
@@ -205,10 +180,18 @@ export function SpaceRail({
 
                         <div className="mt-3 flex items-center gap-2 px-3 pr-2">
                             <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topics</span>
-                            <span className="text-[11px] text-muted-foreground/70">{topicRows.length}</span>
+                            <span className="text-[11px] text-muted-foreground/70">{labelRows.length}</span>
                             <span className="flex-1" />
+                            <button
+                                type="button"
+                                title="New topic"
+                                onClick={() => setCreatingLabel(true)}
+                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+                            >
+                                <Plus className="size-3.5" />
+                            </button>
                             <div className="inline-flex items-center rounded-md bg-muted p-0.5 text-[10.5px]">
-                                {(['all', 'unread', 'archived'] as const).map((f) => (
+                                {(['all', 'archived'] as const).map((f) => (
                                     <button
                                         key={f}
                                         type="button"
@@ -231,21 +214,31 @@ export function SpaceRail({
                         </label>
                         <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
                             <div className="flex flex-col gap-0.5">
-                                {topicRows.map(({ topic, title }) => {
-                                    const active = topic.id === selectedTopicId
-                                    const unread = isUnread(topic)
-                                    const replies = Math.max(0, topic.messageCount - 1)
-                                    const files = artifactFiles.get(topic.id)
-                                    const working = (presence.working.get(topic.id) ?? []).length > 0
-                                    if (renaming?.topicId === topic.id) {
+                                {creatingLabel && (
+                                    <div className="rounded-md px-2 py-1.5">
+                                        <input
+                                            autoFocus
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter' && e.currentTarget.value.trim()) void createLabel(e.currentTarget.value.trim())
+                                                if (e.key === 'Escape') setCreatingLabel(false)
+                                            }}
+                                            onBlur={() => setCreatingLabel(false)}
+                                            className="w-full rounded-md border border-foreground/30 bg-background px-1.5 py-0.5 text-[13px] leading-snug outline-none"
+                                            placeholder="Topic name"
+                                        />
+                                    </div>
+                                )}
+                                {labelRows.map((label) => {
+                                    const active = label.id === selectedLabelId
+                                    if (renaming?.labelId === label.id) {
                                         return (
-                                            <div key={topic.id} className="rounded-md px-2 py-1.5">
+                                            <div key={label.id} className="rounded-md px-2 py-1.5">
                                                 <input
                                                     autoFocus
                                                     value={renaming.value}
-                                                    onChange={(e) => setRenaming({ topicId: topic.id, value: e.target.value })}
+                                                    onChange={(e) => setRenaming({ labelId: label.id, value: e.target.value })}
                                                     onKeyDown={(e) => {
-                                                        if (e.key === 'Enter' && renaming.value.trim()) void commitRename(topic.id, renaming.value.trim())
+                                                        if (e.key === 'Enter' && renaming.value.trim()) void commitRename(label.id, renaming.value.trim())
                                                         if (e.key === 'Escape') setRenaming(null)
                                                     }}
                                                     onBlur={() => setRenaming(null)}
@@ -256,28 +249,24 @@ export function SpaceRail({
                                         )
                                     }
                                     return (
-                                        <div key={topic.id} className="group/topicrow relative">
+                                        <div key={label.id} className="group/topicrow relative">
                                             <button
                                                 type="button"
-                                                onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
+                                                onClick={() => onSelect({ kind: 'label', labelId: label.id })}
                                                 className={cn(
                                                     'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
                                                     active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
-                                                    topic.archived && 'opacity-60',
+                                                    label.archived && 'opacity-60',
                                                 )}
                                             >
                                                 <div className="flex items-center gap-1.5">
-                                                    <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
-                                                    {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
+                                                    <Tag className="size-3 shrink-0 text-muted-foreground" />
+                                                    <span className="flex-1 truncate text-[13px] font-normal leading-snug">{label.name}</span>
                                                 </div>
-                                                <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
-                                                    <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
-                                                    <span>· {formatFeedTime(topic.lastActivityAt)}</span>
-                                                    {files && files.size > 0 && (
-                                                        <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
-                                                    )}
-                                                    {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
-                                                    {topic.archived && <span>· archived</span>}
+                                                <div className="flex items-center gap-1.5 truncate pl-[18px] text-[11px] text-muted-foreground">
+                                                    <span>{label.messageCount} {label.messageCount === 1 ? 'message' : 'messages'}</span>
+                                                    <span>· {formatFeedTime(label.lastActivityAt)}</span>
+                                                    {label.archived && <span>· archived</span>}
                                                 </div>
                                             </button>
                                             <DropdownMenu>
@@ -291,15 +280,15 @@ export function SpaceRail({
                                                     </button>
                                                 </DropdownMenuTrigger>
                                                 <DropdownMenuContent align="end">
-                                                    <DropdownMenuItem onClick={() => setRenaming({ topicId: topic.id, value: title })}>
+                                                    <DropdownMenuItem onClick={() => setRenaming({ labelId: label.id, value: label.name })}>
                                                         <Pencil className="size-3.5 mr-2" /> Rename
                                                     </DropdownMenuItem>
-                                                    {topic.archived ? (
-                                                        <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'unarchive' })}>
+                                                    {label.archived ? (
+                                                        <DropdownMenuItem onClick={() => void manageLabel(label.id, { action: 'unarchive' })}>
                                                             <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
                                                         </DropdownMenuItem>
                                                     ) : (
-                                                        <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'archive' })}>
+                                                        <DropdownMenuItem onClick={() => void manageLabel(label.id, { action: 'archive' })}>
                                                             <Archive className="size-3.5 mr-2" /> Archive
                                                         </DropdownMenuItem>
                                                     )}
@@ -308,9 +297,9 @@ export function SpaceRail({
                                         </div>
                                     )
                                 })}
-                                {topicRows.length === 0 && (
+                                {labelRows.length === 0 && !creatingLabel && (
                                     <div className="px-2 py-2 text-xs text-muted-foreground">
-                                        {q ? 'No topics match.' : filter === 'unread' ? 'Nothing unread.' : filter === 'archived' ? 'No archived topics.' : 'No topics yet — reply to a message to start one.'}
+                                        {q ? 'No topics match.' : filter === 'archived' ? 'No archived topics.' : 'No topics yet — add one to a message in the stream, or create one here.'}
                                     </div>
                                 )}
                             </div>

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -238,7 +238,7 @@ export function ThreadPane({
         try {
             const { sessionId } = await window.ipc.invoke('spaces:topicSession', { orgId: org.id, spaceId: space.id, topicId })
             if (sessionId && onOpenSession) onOpenSession(sessionId)
-            else if (!sessionId) toast('No agent session for this topic yet', 'info')
+            else if (!sessionId) toast('No agent session for this thread yet', 'info')
         } catch {
             toast('Could not open the agent session', 'error')
         }
@@ -413,7 +413,7 @@ export function ThreadPane({
                             const own = memberId === org.memberId
                             const label = own ? 'Your Rowboat is working…' : <><MemberName id={memberId} />’s Rowboat is working…</>
                             return own ? (
-                                <button key={memberId} className="flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground" title="Open the agent session for this topic" onClick={() => void openTopicSession()}>
+                                <button key={memberId} className="flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground" title="Open the agent session for this thread" onClick={() => void openTopicSession()}>
                                     <Loader2 className="size-3 animate-spin" />{label}
                                 </button>
                             ) : (
@@ -512,7 +512,7 @@ export function DraftThreadPane({ org, space, parent, members, memberNames, entr
                     <span className="h-px flex-1 bg-border" />
                 </div>
                 <div className="px-2 py-2 text-xs text-muted-foreground">
-                    Nothing here yet — sending a reply is what starts the topic for everyone.
+                    Nothing here yet — sending a reply is what starts the thread for everyone.
                 </div>
             </div>
             <Composer placeholder="Reply…" busy={posting} onSend={post} autoFocus members={members} entries={entries} selfMemberId={org.memberId} />

--- a/apps/x/apps/renderer/src/hooks/use-space-chat.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-chat.ts
@@ -266,6 +266,22 @@ function wireBus(): void {
                     ),
                 })
             }
+        } else if (frame.event.type === 'message_label') {
+            // Fold the topic assignment into the message in place (the feed
+            // store refreshes label counts off the same event on its own tick).
+            const { assignment } = frame.event
+            if (state?.topic && state.messages.some((m) => m.id === assignment.messageId)) {
+                setGeneral(k, {
+                    messages: state.messages.map((m) => {
+                        if (m.id !== assignment.messageId) return m
+                        if (assignment.labelId === null) {
+                            const { labelId: _cleared, ...rest } = m
+                            return rest
+                        }
+                        return { ...m, labelId: assignment.labelId }
+                    }),
+                })
+            }
         } else if (frame.event.type === 'message_deleted') {
             // Tombstone in place — the row stays (threads may anchor to it), the
             // body is gone. Thread panes pick theirs up on the feed-refresh tick.

--- a/apps/x/apps/renderer/src/hooks/use-spaces.ts
+++ b/apps/x/apps/renderer/src/hooks/use-spaces.ts
@@ -153,11 +153,13 @@ export function useSpaceLive(
 export interface SpaceFeedData {
     /** Listing entries — each topic carries its immutable first message. */
     topics: spaces.TopicListing[]
+    /** Explicit labels — the "Topics" the rail shows (wire topics are threads). */
+    labels: spaces.LabelListing[]
     changeSets: spaces.ChangeSet[]
     loaded: boolean
 }
 
-const EMPTY_FEED: SpaceFeedData = { topics: [], changeSets: [], loaded: false }
+const EMPTY_FEED: SpaceFeedData = { topics: [], labels: [], changeSets: [], loaded: false }
 
 let feedState: ReadonlyMap<string, SpaceFeedData> = new Map()
 const feedListeners = new Set<() => void>()
@@ -192,12 +194,15 @@ export function refreshSpaceFeed(orgId: string, spaceId: string): Promise<void> 
     }
     const promise = (async () => {
         try {
-            const [topicsRes, historyRes] = await Promise.all([
+            const [topicsRes, labelsRes, historyRes] = await Promise.all([
                 window.ipc.invoke('spaces:listTopics', { orgId, spaceId }),
+                // A pre-labels org (teammate's stale local Harbor) has no route
+                // — the rail just shows no topics rather than killing the feed.
+                window.ipc.invoke('spaces:listLabels', { orgId, spaceId }).catch(() => ({ labels: [] })),
                 window.ipc.invoke('spaces:assetHistory', { orgId, spaceId, limit: 60 }),
             ])
             const next = new Map(feedState)
-            next.set(key, { topics: topicsRes.topics, changeSets: historyRes.changeSets, loaded: true })
+            next.set(key, { topics: topicsRes.topics, labels: labelsRes.labels, changeSets: historyRes.changeSets, loaded: true })
             feedState = next
             feedRefreshedAt.set(key, Date.now())
             emitFeed()

--- a/apps/x/apps/renderer/src/lib/spaces-selection.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-selection.ts
@@ -1,11 +1,14 @@
-// What's selected inside a space: General (the chat), a topic, or a file.
-// Part of the app's navigation history, so the top ‹ › retrace it.
+// What's selected inside a space: General (the chat), a thread (wire
+// "topic"), a label (UI "Topic"), or a file. Part of the app's navigation
+// history, so the top ‹ › retrace it.
 
 export type RailSelection =
     | { kind: 'general' }
     | { kind: 'topic'; topicId: string }
     /** A reply pane with no topic behind it yet — the topic is created on first send. */
     | { kind: 'draft'; parentMessageId: string }
+    /** An explicit label ("Topic" in the UI) — its tagged messages across the stream. */
+    | { kind: 'label'; labelId: string }
     /** `fromTopicId` = opened from a topic (an artifact link) — the file view shows a crumb back to it. */
     | { kind: 'file'; path: string; fromTopicId?: string }
 
@@ -14,5 +17,6 @@ export function railKey(sel: RailSelection | undefined): string {
     if (!sel || sel.kind === 'general') return 'general'
     if (sel.kind === 'topic') return `topic:${sel.topicId}`
     if (sel.kind === 'draft') return `draft:${sel.parentMessageId}`
+    if (sel.kind === 'label') return `label:${sel.labelId}`
     return `file:${sel.path}`
 }

--- a/apps/x/packages/core/src/spaces/client.test.ts
+++ b/apps/x/packages/core/src/spaces/client.test.ts
@@ -119,6 +119,27 @@ describe('SpacesClient', () => {
     expect(listed.find((t) => t.id === started.topic.id)?.firstMessage?.id).toBe(started.message.id);
   });
 
+  it('label round-trip: create (get-or-create), set on a message, list, clear', async () => {
+    const label = await ramnique.createLabel(spaceId, { name: 'Launch', actingMode: 'direct' });
+    expect((await gagan.createLabel(spaceId, { name: 'launch', actingMode: 'direct' })).id).toBe(label.id);
+
+    const posted = await ramnique.postMessage(spaceId, { body: 'tag me', actingMode: 'direct' });
+    const tagged = await gagan.setMessageLabel(spaceId, posted.message.id, { labelId: label.id, actingMode: 'direct' });
+    expect(tagged.labelId).toBe(label.id);
+
+    const listed = await ramnique.listLabels(spaceId);
+    expect(listed.find((l) => l.id === label.id)?.messageCount).toBe(1);
+    const grouped = await ramnique.listLabelMessages(spaceId, label.id);
+    expect(grouped.messages.map((m) => m.id)).toEqual([posted.message.id]);
+
+    const renamed = await ramnique.manageLabel(spaceId, label.id, { action: 'rename', name: 'Launch week' });
+    expect(renamed.name).toBe('Launch week');
+
+    const cleared = await ramnique.setMessageLabel(spaceId, posted.message.id, { labelId: null, actingMode: 'direct' });
+    expect(cleared.labelId).toBeUndefined();
+    expect((await ramnique.listLabelMessages(spaceId, label.id)).messages).toEqual([]);
+  });
+
   it('messages window newest-first and page back by offset', async () => {
     const started = await ramnique.postMessage(spaceId, { body: 'p1', actingMode: 'direct' });
     for (const body of ['p2', 'p3', 'p4', 'p5']) {

--- a/apps/x/packages/core/src/spaces/client.ts
+++ b/apps/x/packages/core/src/spaces/client.ts
@@ -6,6 +6,8 @@ import {
   type ChangeSet,
   type DeleteAssetResult,
   type CreateInviteResult,
+  type Label,
+  type LabelListing,
   type Member,
   type Message,
   type MoveAssetResult,
@@ -64,6 +66,9 @@ type NewTopicMessage = z.infer<Routes['postMessage']['request']>;
 type ManageTopicAction = z.infer<Routes['manageTopic']['request']>;
 type ReactInput = z.infer<Routes['reactToMessage']['request']>;
 type DeleteMessageInput = z.infer<Routes['deleteMessage']['request']>;
+type CreateLabelInput = z.infer<Routes['createLabel']['request']>;
+type ManageLabelAction = z.infer<Routes['manageLabel']['request']>;
+type SetMessageLabelInput = z.infer<Routes['setMessageLabel']['request']>;
 
 export class SpacesClient {
   private readonly baseUrl: string;
@@ -361,5 +366,57 @@ export class SpacesClient {
         action,
       )
     ).topic;
+  }
+
+  // --- labels ("topics" in the UI) ------------------------------------------
+
+  async listLabels(spaceId: string, includeArchived = false): Promise<LabelListing[]> {
+    const qs = includeArchived ? '?includeArchived=true' : '';
+    return (await this.request('GET', this.space(spaceId, `/labels${qs}`), routes.listLabels.response)).labels;
+  }
+
+  /** Get-or-create by name — the org dedupes case-insensitively among live labels. */
+  async createLabel(spaceId: string, input: CreateLabelInput): Promise<Label> {
+    return (await this.request('POST', this.space(spaceId, '/labels'), routes.createLabel.response, input)).label;
+  }
+
+  async manageLabel(spaceId: string, labelId: string, action: ManageLabelAction): Promise<Label> {
+    return (
+      await this.request(
+        'POST',
+        this.space(spaceId, `/labels/${encodeURIComponent(labelId)}`),
+        routes.manageLabel.response,
+        action,
+      )
+    ).label;
+  }
+
+  /** Set (or clear — labelId null) the one label on a message. Idempotent. */
+  async setMessageLabel(spaceId: string, messageId: string, input: SetMessageLabelInput): Promise<Message> {
+    return (
+      await this.request(
+        'POST',
+        this.space(spaceId, `/messages/${encodeURIComponent(messageId)}/label`),
+        routes.setMessageLabel.response,
+        input,
+      )
+    ).message;
+  }
+
+  /** A label's tagged messages, windowed newest-first like listMessages. */
+  async listLabelMessages(
+    spaceId: string,
+    labelId: string,
+    opts?: { beforeOffset?: number; limit?: number },
+  ): Promise<{ label: Label; messages: Message[]; hasMore: boolean }> {
+    const q = new URLSearchParams();
+    if (opts?.beforeOffset !== undefined) q.set('beforeOffset', String(opts.beforeOffset));
+    if (opts?.limit !== undefined) q.set('limit', String(opts.limit));
+    const qs = q.size > 0 ? `?${q.toString()}` : '';
+    return this.request(
+      'GET',
+      this.space(spaceId, `/labels/${encodeURIComponent(labelId)}/messages${qs}`),
+      routes.listLabelMessages.response,
+    );
   }
 }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -37,6 +37,8 @@ import {
     SpacesOrgSummary,
     type SpacesAssetEntry,
     type SpacesBusEvent,
+    type SpacesLabelMessages,
+    type SpacesManageLabelAction,
     type SpacesManageTopicAction,
     type SpacesPostResult,
     type SpacesProposeInput,
@@ -3659,6 +3661,48 @@ const ipcSchemas = {
       action: z.custom<SpacesManageTopicAction>(),
     }),
     res: z.object({ topic: z.custom<SpacesTypes.Topic>() }),
+  },
+  // Labels — "Topics" in the UI (curation), distinct from wire topics
+  // (threads). One label per message; any member sets or clears; actingMode
+  // is stamped 'direct' by main like postMessage.
+  'spaces:listLabels': {
+    req: z.object({ orgId: z.string(), spaceId: z.string(), includeArchived: z.boolean().optional() }),
+    res: z.object({ labels: z.array(z.custom<SpacesTypes.LabelListing>()) }),
+  },
+  // Get-or-create by name (case-insensitive among live labels) — the org
+  // dedupes concurrent same-name creates.
+  'spaces:createLabel': {
+    req: z.object({ orgId: z.string(), spaceId: z.string(), name: z.string() }),
+    res: z.object({ label: z.custom<SpacesTypes.Label>() }),
+  },
+  'spaces:manageLabel': {
+    req: z.object({
+      orgId: z.string(),
+      spaceId: z.string(),
+      labelId: z.string(),
+      action: z.custom<SpacesManageLabelAction>(),
+    }),
+    res: z.object({ label: z.custom<SpacesTypes.Label>() }),
+  },
+  // labelId null clears. Returns the message with the current labelId folded.
+  'spaces:setMessageLabel': {
+    req: z.object({
+      orgId: z.string(),
+      spaceId: z.string(),
+      messageId: z.string(),
+      labelId: z.string().nullable(),
+    }),
+    res: z.object({ message: z.custom<SpacesTypes.Message>() }),
+  },
+  'spaces:listLabelMessages': {
+    req: z.object({
+      orgId: z.string(),
+      spaceId: z.string(),
+      labelId: z.string(),
+      beforeOffset: z.number().optional(),
+      limit: z.number().optional(),
+    }),
+    res: z.custom<SpacesLabelMessages>(),
   },
   // Slack-style reaction toggle — any member, any message. Idempotent on the
   // org (re-add / re-remove is a no-op); actingMode is stamped 'direct' by

--- a/apps/x/packages/shared/src/spaces.ts
+++ b/apps/x/packages/shared/src/spaces.ts
@@ -8,8 +8,11 @@ import type {
   RestoreAssetResult,
   ConflictRegion,
   CreateInviteResult,
+  Label,
+  LabelListing,
   Member,
   Message,
+  MessageLabel,
   ProposeChangeResult,
   Reaction,
   ReactionGroup,
@@ -37,8 +40,11 @@ export type {
   RestoreAssetResult,
   ConflictRegion,
   CreateInviteResult,
+  Label,
+  LabelListing,
   Member,
   Message,
+  MessageLabel,
   ProposeChangeResult,
   Reaction,
   ReactionGroup,
@@ -91,6 +97,18 @@ export type SpacesManageTopicAction =
   | { action: 'archive' }
   | { action: 'unarchive' }
   | { action: 'merge_into'; targetTopicId: string };
+
+export type SpacesManageLabelAction =
+  | { action: 'rename'; name: string }
+  | { action: 'archive' }
+  | { action: 'unarchive' };
+
+/** listLabelMessages result — a label's tagged messages, windowed like listMessages. */
+export interface SpacesLabelMessages {
+  label: Label;
+  messages: Message[];
+  hasMore: boolean;
+}
 
 /**
  * What the renderer may propose. actingMode is deliberately absent: everything


### PR DESCRIPTION
## What

Adds **explicit topics** to spaces chat, separating curation from structure:

- **Threads stay structure.** Reply chains live on their reply chips in the stream; the rail no longer lists every thread.
- **Topics are deliberate.** A topic exists only because a member created one. Add a topic to a message and the thread anchored on it inherits it; unrelated messages across the stream can share one topic; the rail's Topics section lists only these. **One topic per message.**

## Naming

On the wire the new entity is `Label` — the wire word "topic" already means the thread container, and renaming it would have been a wide breaking change. The UI presents labels as **Topics** and the old topics as **threads**.

## Harbor (contract PR per CONTRACT.md rules)

- **Protocol**: `Label` + `MessageLabel` schemas, `Message.labelId` (current truth on reads; stored `message` events keep the at-post snapshot — the reactions pattern), `label` / `message_label` event kinds, five routes:
  - `listLabels` — decorated `LabelListing` (live tagged-message count + `lastActivityAt` folding anchored threads' reply activity)
  - `createLabel` — **get-or-create by case-insensitive name** among live labels, so concurrent same-name creates converge
  - `manageLabel` — rename/archive/unarchive; renaming or unarchiving into a live name is `invalid_request`
  - `setMessageLabel` — any member, set-or-clear, idempotent no-ops; tombstones take no label (clears still work); assigning an archived label revives it (the archived-thread-reply rule)
  - `listLabelMessages` — the `listMessages` window semantics, across topics
- **Server**: migration `010-labels`, memory + Postgres drivers, service semantics, HTTP face, CONTRACT.md amendment.
- **Tests**: new dual-store suite `test/labels.test.ts` (24 tests). Render-face only for now, like reactions — the six MCP tools don't manage labels.

## apps/x

- Shared types, five `spaces:*` IPC channels, `SpacesClient` methods (+ round-trip test against the real stub), main handlers stamping `actingMode: 'direct'`.
- **Stream**: hover ⋯ and right-click menus gain *Add topic / Change topic* (existing topics + a "New topic…" inline input + *Remove from …*); tagged messages show a tag chip that opens the topic view; live `message_label` events fold in place.
- **Rail**: Topics section lists labels only — name, message count, last activity, create/rename/archive. Empty state teaches the gesture.
- **Topic view** (new `label-pane.tsx`): every message tagged with the topic, day-divided, each with its reply chip — opening a thread keeps the topic's context; inline rename, archive, windowed "load earlier".
- Degrades gracefully against a pre-labels Harbor (the feed survives the missing route; the rail just shows no topics).

## Verification

- Harbor: full suite green — **230 tests / 16 files**, labels suite runs on both memory and PGlite stores.
- apps/x: `npm run deps`, `npm run typecheck` (0 errors), `npm run lint` (clean), core spaces tests green.

## Deliberately out of this slice

MCP face for labels, per-topic unread badges, a `/l/` link-grammar entry, new analytics events. Known edge: starting a draft thread from the topic view on a message outside the stream's loaded window falls back to the stream (same limitation stream drafts already have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)