### PR TITLE
fix(spaces): archived topics are reachable again

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -109,13 +109,16 @@ export function GeneralStream({
         const topic = topicsById.get(topicId)
         if (!topic) return null
         const mark = getTopicLastReadAt(org.id, space.id, topicId)
-        const hasNew = !mark || topic.lastActivityAt > mark
+        // Archived threads never read as unread — consistent with the rail
+        // badge and countSpaceUnread, which both skip archived topics.
+        const hasNew = !topic.archived && (!mark || topic.lastActivityAt > mark)
         // A renamed thread shows its name on the chip; auto-titled ones stay
         // compact. Without the seed prefetch the parent message stands in —
         // the seed's first line IS the parent's, so the comparison holds.
         const named = explicitTitle(topic, threads.byTopic.get(topicId)?.firstMessage?.body ?? message.body)
         return {
             topicId,
+            archived: topic.archived,
             replyCount: Math.max(0, topic.messageCount - 1),
             lastActivityAt: topic.lastActivityAt,
             // Count isn't known without the thread's messages; 1 reads as "has new" on the row.

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -130,6 +130,7 @@ const MESSAGE_PROSE = 'text-sm leading-relaxed [&_p]:my-0.5 [&_h1]:text-base [&_
 
 export interface ThreadRowData {
     topicId: string
+    archived: boolean
     replyCount: number
     lastActivityAt: string
     unreadCount: number
@@ -236,7 +237,10 @@ export function MessageRow({
                     <button
                         type="button"
                         onClick={() => onOpenThread(thread.topicId)}
-                        className="mt-1.5 inline-flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1 text-xs hover:border-foreground/30"
+                        className={cn(
+                            'mt-1.5 inline-flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1 text-xs hover:border-foreground/30',
+                            thread.archived && 'opacity-60',
+                        )}
                     >
                         <MessageSquare className="size-3 text-muted-foreground" />
                         {thread.title && <span className="max-w-48 truncate font-semibold">{thread.title}</span>}
@@ -245,6 +249,7 @@ export function MessageRow({
                         </span>
                         {thread.unreadCount > 0 && <span className="font-semibold text-orange-600">{thread.unreadCount} new</span>}
                         <span className="text-muted-foreground">{formatFeedTime(thread.lastActivityAt)}</span>
+                        {thread.archived && <span className="text-muted-foreground">archived</span>}
                         {thread.workingAgents.length > 0 && (
                             <span className="inline-flex items-center gap-1 text-muted-foreground">
                                 <Bot className="size-3" />

--- a/apps/x/apps/renderer/src/hooks/use-spaces.ts
+++ b/apps/x/apps/renderer/src/hooks/use-spaces.ts
@@ -193,7 +193,10 @@ export function refreshSpaceFeed(orgId: string, spaceId: string): Promise<void> 
     const promise = (async () => {
         try {
             const [topicsRes, historyRes] = await Promise.all([
-                window.ipc.invoke('spaces:listTopics', { orgId, spaceId }),
+                // Archived topics ride along: the rail's Archived tab and the
+                // thread chip under a parent message both need them; every
+                // other consumer filters on t.archived itself.
+                window.ipc.invoke('spaces:listTopics', { orgId, spaceId, includeArchived: true }),
                 window.ipc.invoke('spaces:assetHistory', { orgId, spaceId, limit: 60 }),
             ])
             const next = new Map(feedState)


### PR DESCRIPTION
## Problem

Archiving a topic in Spaces made it vanish with no way back. The Harbor listing endpoint excludes archived topics unless asked (`includeArchived=true`), and the renderer's feed store never asked — so archived topics never reached the client. The rail's **Archived** tab (and its Unarchive action) were already built, but always rendered "No archived topics", and the thread chip under the parent message in the general feed disappeared too.

## Fix

- `use-spaces.ts`: fetch the feed with `includeArchived: true`. Every consumer already filters on `t.archived` itself (rail All/Unread tabs, unread badge, `countSpaceUnread`, `findGeneralTopic`), so nothing else changes behavior.
- `general-stream.tsx`: thread chips for archived threads never read as unread — consistent with the rail badge and sidebar counts, which both skip archived topics.
- `message-row.tsx`: the chip carries the archived flag — dimmed (`opacity-60`, matching the rail's archived rows) with an "archived" label.

## Result

- The Archived tab in the space rail now lists archived topics, with Unarchive in the row menu.
- The thread chip under the original message comes back for archived threads, visibly marked, and opens the thread pane (which already shows the archived badge + Unarchive).
- Replying still revives the topic server-side, unchanged.

`npm run typecheck` and `npm run lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTVSsQMcxuB3GScahWcyTt