### PR TITLE
fix: prevent workspace symlink escapes

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -1,6 +1,5 @@
 import { app, BrowserWindow, desktopCapturer, dialog, powerMonitor, protocol, net, shell, session, safeStorage, type Session } from "electron";
 import path from "node:path";
-import fsPromises from "node:fs/promises";
 import os from "node:os";
 import {
   setupIpcHandlers,
@@ -40,7 +39,7 @@ import { initConfigs } from "@x/core/dist/config/initConfigs.js";
 import { prepareCoreData, initCoreServices } from "@x/core/dist/boot/services.js";
 import { startServerHost, stopServerHost, childServerMode, serverHostMode, whenServerReady } from "./server-host.js";
 import { getAgentSlackCliStatus } from "@x/core/dist/slack/agent-slack-exec.js";
-import { resolveWorkspacePath } from "@x/core/dist/workspace/workspace.js";
+import { resolveExistingWorkspacePath } from "@x/core/dist/workspace/workspace.js";
 import started from "electron-squirrel-startup";
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
@@ -205,16 +204,8 @@ function registerAppProtocol() {
             if (range) headers.set("range", range);
             return fetch(`${baseUrl}/workspace/${relPath.split("/").map(encodeURIComponent).join("/")}`, { headers });
           }
-          const absPath = resolveWorkspacePath(relPath);
-          // Parity with the server's /workspace route: `..` is guarded above,
-          // but a symlink inside the workspace can still point out of it —
-          // realpath both sides and require containment.
-          const realRoot = await fsPromises.realpath(resolveWorkspacePath(""));
-          const realTarget = await fsPromises.realpath(absPath);
-          if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
-            return new Response("Forbidden", { status: 403 });
-          }
-          return net.fetch(pathToFileURL(realTarget).toString());
+          const absPath = await resolveExistingWorkspacePath(relPath);
+          return net.fetch(pathToFileURL(absPath).toString());
         } catch {
           return new Response("Forbidden", { status: 403 });
         }

--- a/apps/x/packages/core/src/workspace/workspace.test.ts
+++ b/apps/x/packages/core/src/workspace/workspace.test.ts
@@ -83,3 +83,14 @@ describe("workspace.writeFile etag guard", () => {
     expect(recreated.stat.size).toBe(6);
   });
 });
+
+describe("workspace.readFile path boundary", () => {
+  it("rejects symlinks that resolve outside the workspace", async () => {
+    const workspace = await loadWorkspace();
+    const outsidePath = path.join(tmpDir, "outside.txt");
+    await fs.writeFile(outsidePath, "secret", "utf8");
+    await fs.symlink(outsidePath, path.join(workspaceDir, "link.txt"));
+
+    await expect(workspace.readFile("link.txt", "utf8")).rejects.toThrow("Path outside workspace boundary");
+  });
+});

--- a/apps/x/packages/core/src/workspace/workspace.ts
+++ b/apps/x/packages/core/src/workspace/workspace.ts
@@ -51,6 +51,23 @@ export function resolveWorkspacePath(relPath: string): string {
   return resolved;
 }
 
+function isInsidePath(root: string, target: string): boolean {
+  const rel = path.relative(root, target);
+  return rel === '' || (!!rel && !rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+export async function resolveExistingWorkspacePath(relPath: string): Promise<string> {
+  const resolved = resolveWorkspacePath(relPath);
+  const [realRoot, realTarget] = await Promise.all([
+    fs.realpath(WorkDir),
+    fs.realpath(resolved),
+  ]);
+  if (!isInsidePath(realRoot, realTarget)) {
+    throw new Error('Path outside workspace boundary');
+  }
+  return resolved;
+}
+
 /**
  * Convert absolute path to workspace-relative POSIX path
  * Returns null if path is outside workspace boundary
@@ -189,7 +206,7 @@ export async function readFile(
   relPath: string,
   encoding: z.infer<typeof workspace.Encoding> = 'utf8'
 ): Promise<z.infer<typeof workspace.ReadFileResult>> {
-  const filePath = resolveWorkspacePath(relPath);
+  const filePath = await resolveExistingWorkspacePath(relPath);
   const stats = await fs.lstat(filePath);
 
   let data: string;


### PR DESCRIPTION
Fixes #882

## Summary
- add a realpath boundary check for existing workspace paths before reading them
- reuse the same check in the Electron `app://workspace` protocol handler while preserving remote-workspace proxying
- add regression coverage for a workspace symlink pointing outside the workspace root

## Validation
- `pnpm exec vitest run src/workspace/workspace.test.ts` in `apps/x/packages/core` (3 passed)
- `git diff --check`
- `pnpm run typecheck` and `pnpm run build` in `apps/x/packages/core` are currently blocked after rebasing by pre-existing main-branch errors in `src/spaces/client.ts` (`Routes.editMessage` missing) and `src/terminal/terminal.ts` (`node-pty` unavailable); neither file is changed by this PR

## Risk boundary
- This changes existing-file resolution for workspace reads and the local app protocol only; missing files still fail through the existing filesystem path.
- Remote workspace requests keep using the authenticated server proxy added on main.
- Symlinks that resolve inside the workspace continue to work, while symlinks resolving outside now return the existing forbidden/error path.