### PR TITLE
feat(spaces): chat improvements — editing, keep-alive panes, media & links, slash commands

### DIFF
--- a/apps/harbor/CONTRACT.md
+++ b/apps/harbor/CONTRACT.md
@@ -147,6 +147,16 @@ team and a Roadboard space (`src/main.ts`).
   `lastActivityAt` and emits no topic event. Re-deleting is an idempotent 200
   no-op. Tombstones take no new reactions (`invalid_request`); removes still
   work so cleanup stays possible. Render-face only, like reactions.
+- **Message editing is an author-only in-place rewrite** (`editMessage` route +
+  the `message_edited` event, 2026-08-26): editor == author, exactly deletion's
+  posture. The new body replaces the old everywhere it lives — messages row AND
+  the stored `message` event (the second sanctioned in-place log rewrite, same
+  reasoning as deletion: the superseded text must not resurface through
+  replay). `Message` carries `editedAt`; clients render an "(edited)" mark.
+  Tombstones refuse (`invalid_request`); an identical body is an idempotent
+  200 no-op — no write, no event. Editing bumps neither `lastActivityAt` nor
+  `messageCount` and emits no topic event. Render-face only, like reactions
+  and deletion — an agent's correction is a new message.
 - **Unknown invite tokens are 404**; `expired`/`revoked` are resolvable states.
 - **MCP face attribution**: acting mode defaults to `agent`; automations
   declare `x-acting-mode: scheduled`; `x-agent-name` carries the display label.

--- a/apps/harbor/packages/protocol/src/api.ts
+++ b/apps/harbor/packages/protocol/src/api.ts
@@ -306,6 +306,25 @@ export const routes = {
     response: z.object({ message: Message }),
   },
   /**
+   * Author-only body rewrite (editor == author, exactly deletion's posture).
+   * The body is replaced everywhere it lives (message row AND the stored
+   * message event — an edit's point is that the old text is gone, replay
+   * included) and a message_edited event goes on the log. Tombstones refuse
+   * (invalid_request); an identical body is a 200 no-op with no event.
+   * Activity is not bumped — editing must not resurface a quiet topic.
+   */
+  editMessage: {
+    method: 'POST',
+    path: '/v1/spaces/:spaceId/messages/:messageId/edit',
+    params: z.object({ spaceId: SpaceId, messageId: MessageId }),
+    request: z.object({
+      body: z.string().min(1).max(65_536),
+      actingMode: ActingMode,
+      agentName: z.string().max(64).optional(),
+    }),
+    response: z.object({ message: Message }),
+  },
+  /**
    * Toggle a reaction (Slack semantics: any member, any message, one per
    * member+emoji). Idempotent — re-adding or re-removing is a 200 no-op with
    * no event. The response carries the message with reactions folded in, so

--- a/apps/harbor/packages/protocol/src/core.ts
+++ b/apps/harbor/packages/protocol/src/core.ts
@@ -122,6 +122,17 @@ export const MessageDeletion = z.object({
 });
 export type MessageDeletion = z.infer<typeof MessageDeletion>;
 
+/** An author's in-place rewrite of a message body — the payload of `message_edited`. */
+export const MessageEdit = z.object({
+  spaceId: SpaceId,
+  topicId: TopicId,
+  messageId: MessageId,
+  body: z.string().min(1).max(65_536),
+  by: Attribution,
+  at: z.iso.datetime(),
+});
+export type MessageEdit = z.infer<typeof MessageEdit>;
+
 export const Message = z.object({
   id: MessageId,
   topicId: TopicId,
@@ -138,6 +149,8 @@ export const Message = z.object({
   offset: StreamOffset,
   /** Set when the author deleted the message (deleter == author, so no separate attribution). */
   deletedAt: z.iso.datetime().optional(),
+  /** Set when the author last edited the body (editor == author, like deletion). */
+  editedAt: z.iso.datetime().optional(),
   /**
    * Folded reactions, groups in first-reacted order. The default keeps pre-
    * reaction payloads (older servers, stored message events) parseable; reads

--- a/apps/harbor/packages/protocol/src/events.ts
+++ b/apps/harbor/packages/protocol/src/events.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ChangeSet } from './changeset.js';
-import { Membership, Message, MessageDeletion, Reaction, Topic } from './core.js';
+import { Membership, Message, MessageDeletion, MessageEdit, Reaction, Topic } from './core.js';
 import { MemberId, SpaceId, StreamOffset, TopicId } from './ids.js';
 
 // Decision 2 (CONTRACT.md): one WebSocket per org, per-space subscriptions,
@@ -35,6 +35,16 @@ export const SpaceEvent = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('message_deleted'),
     deletion: MessageDeletion,
+  }),
+  /**
+   * A message body rewritten by its author. The stored `message` event is
+   * rewritten in place (body + editedAt) — same posture as deletion: the old
+   * text must be unrecoverable, replay included. Live/folding clients apply
+   * this event; an identical-body edit emits nothing.
+   */
+  z.object({
+    type: z.literal('message_edited'),
+    edit: MessageEdit,
   }),
 ]);
 export type SpaceEvent = z.infer<typeof SpaceEvent>;

--- a/apps/harbor/packages/server/src/http.ts
+++ b/apps/harbor/packages/server/src/http.ts
@@ -336,6 +336,13 @@ export function buildHttpApp(deps: {
     return reply(c, routes.deleteMessage.response, { message });
   });
 
+  app.post('/v1/spaces/:spaceId/messages/:messageId/edit', async (c) => {
+    const { spaceId, messageId } = parseWith(routes.editMessage.params, c.req.param());
+    const input = await body(c, routes.editMessage.request);
+    const message = await service.editMessage(actor(c), spaceId, messageId, input);
+    return reply(c, routes.editMessage.response, { message });
+  });
+
   app.post('/v1/spaces/:spaceId/messages/:messageId/reactions', async (c) => {
     const { spaceId, messageId } = parseWith(routes.reactToMessage.params, c.req.param());
     const input = await body(c, routes.reactToMessage.request);

--- a/apps/harbor/packages/server/src/memory-store.ts
+++ b/apps/harbor/packages/server/src/memory-store.ts
@@ -272,6 +272,26 @@ export class MemoryStore implements Store {
     s.messages.set(message.topicId, list);
   }
 
+  async markMessageEdited(spaceId: string, messageId: string, body: string, editedAt: string): Promise<void> {
+    const s = this.must(spaceId);
+    for (const [topicId, list] of s.messages) {
+      const idx = list.findIndex((m) => m.id === messageId);
+      if (idx === -1) continue;
+      const next = [...list];
+      next[idx] = { ...next[idx]!, body, editedAt };
+      s.messages.set(topicId, next);
+      break;
+    }
+    // Rewrite the stored message event too — replay must serve the edit.
+    for (let i = 0; i < s.events.length; i++) {
+      const e = s.events[i]!;
+      if (e.event.type === 'message' && e.event.message.id === messageId) {
+        s.events[i] = { ...e, event: { type: 'message', message: { ...e.event.message, body, editedAt } } };
+        break;
+      }
+    }
+  }
+
   async markMessageDeleted(spaceId: string, messageId: string, deletedAt: string): Promise<void> {
     const s = this.must(spaceId);
     for (const [topicId, list] of s.messages) {

--- a/apps/harbor/packages/server/src/migrations.ts
+++ b/apps/harbor/packages/server/src/migrations.ts
@@ -294,6 +294,14 @@ export const MIGRATIONS: Migration[] = [
       `alter table space_blobs add column if not exists height int`,
     ],
   },
+  {
+    id: '010-message-editing',
+    statements: [
+      // Author-only body rewrites: edited_at is the marker; the body column
+      // and the stored message event are rewritten in place (see editMessage).
+      `alter table messages add column if not exists edited_at text`,
+    ],
+  },
 ];
 
 export async function migrate(db: SqlDb): Promise<void> {

--- a/apps/harbor/packages/server/src/pg-store.ts
+++ b/apps/harbor/packages/server/src/pg-store.ts
@@ -113,6 +113,7 @@ interface MessageRow {
   body: string;
   posted_at: string;
   deleted_at: string | null;
+  edited_at: string | null;
   stream_offset: number;
 }
 
@@ -126,6 +127,7 @@ function rowToMessage(r: MessageRow): Message {
     postedAt: r.posted_at,
     offset: r.stream_offset,
     ...(r.deleted_at !== null ? { deletedAt: r.deleted_at } : {}),
+    ...(r.edited_at !== null ? { editedAt: r.edited_at } : {}),
     // Live reaction state is folded in by the service on reads; rows carry none.
     reactions: [],
   };
@@ -593,6 +595,19 @@ export class PgStore implements Store {
       `insert into messages (id, space_id, topic_id, author, body, posted_at, stream_offset)
        values ($1, $2, $3, $4::jsonb, $5, $6, $7)`,
       [message.id, message.spaceId, message.topicId, JSON.stringify(message.author), message.body, message.postedAt, message.offset],
+    );
+  }
+
+  async markMessageEdited(spaceId: string, messageId: string, body: string, editedAt: string): Promise<void> {
+    await this.sql.query(
+      `update messages set body = $3, edited_at = $4 where space_id = $1 and id = $2`,
+      [spaceId, messageId, body, editedAt],
+    );
+    // Rewrite the stored message event too — replay must serve the edit.
+    await this.sql.query(
+      `update events set event = jsonb_set(jsonb_set(event, '{message,body}', to_jsonb($3::text)), '{message,editedAt}', to_jsonb($4::text))
+       where space_id = $1 and event->>'type' = 'message' and event->'message'->>'id' = $2`,
+      [spaceId, messageId, body, editedAt],
     );
   }
 

--- a/apps/harbor/packages/server/src/service.ts
+++ b/apps/harbor/packages/server/src/service.ts
@@ -75,6 +75,7 @@ type NewTopicMessage = z.infer<Routes['postMessage']['request']>;
 type ManageTopicAction = z.infer<Routes['manageTopic']['request']>;
 type ReactInput = z.infer<Routes['reactToMessage']['request']>;
 type DeleteMessageInput = z.infer<Routes['deleteMessage']['request']>;
+type EditMessageInput = z.infer<Routes['editMessage']['request']>;
 
 export interface OrgInfo {
   name: string;
@@ -974,6 +975,51 @@ export class HarborService {
         deletion: { spaceId, topicId: message.topicId, messageId, by, at },
       });
       return withReactions({ ...message, body: '', deletedAt: at });
+    });
+  }
+
+  /**
+   * Author-only body rewrite (spec §4 posture shared with deletion: the
+   * content plane is role-flat, so editor == author). The body is replaced
+   * everywhere it lives — message row and stored message event — and a
+   * message_edited event narrates. Tombstones refuse; an identical body is
+   * an idempotent 200 no-op with no event. Activity is not bumped.
+   */
+  async editMessage(
+    ctx: ActorCtx,
+    spaceId: string,
+    messageId: string,
+    input: EditMessageInput,
+  ): Promise<Message> {
+    await this.requireMember(ctx, spaceId);
+    this.guardWrite();
+    const by: Attribution = {
+      memberId: ctx.memberId,
+      actingMode: input.actingMode,
+      ...(input.agentName ? { agentName: input.agentName } : {}),
+    };
+
+    return this.store.withSpaceLock(spaceId, async () => {
+      const message = await this.store.getMessage(spaceId, messageId);
+      if (!message) throw new HarborError('not_found', 'no such message');
+      if (message.author.memberId !== ctx.memberId) {
+        throw new HarborError('forbidden', 'only the author can edit a message');
+      }
+      if (message.deletedAt) throw new HarborError('invalid_request', 'cannot edit a deleted message');
+      const withReactions = async (m: Message): Promise<Message> => ({
+        ...m,
+        reactions: foldReactions(await this.store.listReactionsByMessage(spaceId, messageId)),
+      });
+      if (message.body === input.body) return withReactions(message);
+
+      const at = this.now();
+      await this.store.markMessageEdited(spaceId, messageId, input.body, at);
+      const offset = (await this.store.head(spaceId)) + 1;
+      await this.append(spaceId, offset, at, {
+        type: 'message_edited',
+        edit: { spaceId, topicId: message.topicId, messageId, body: input.body, by, at },
+      });
+      return withReactions({ ...message, body: input.body, editedAt: at });
     });
   }
 

--- a/apps/harbor/packages/server/src/store.ts
+++ b/apps/harbor/packages/server/src/store.ts
@@ -166,6 +166,7 @@ export interface Store {
    * included. The message_deleted event itself is appended by the service.
    */
   markMessageDeleted(spaceId: string, messageId: string, deletedAt: string): Promise<void>;
+  markMessageEdited(spaceId: string, messageId: string, body: string, editedAt: string): Promise<void>;
   /** merge_into support: repoints messages; returns how many moved. */
   reassignMessages(spaceId: string, fromTopicId: string, toTopicId: string): Promise<number>;
 

--- a/apps/harbor/packages/server/test/api.test.ts
+++ b/apps/harbor/packages/server/test/api.test.ts
@@ -640,6 +640,89 @@ describe('message deletion', () => {
   });
 });
 
+describe('message editing', () => {
+  let spaceId: string;
+  let topicId: string;
+
+  const edit = (who: ReturnType<typeof api>, messageId: string, body: string) =>
+    who.post(`/v1/spaces/${spaceId}/messages/${messageId}/edit`, { body, actingMode: 'direct' });
+
+  beforeAll(async () => {
+    const r = await ramnique.post('/v1/spaces', { name: 'Editing' });
+    spaceId = r.body.space.id;
+    const inv = await ramnique.post('/v1/invites', { spaceId });
+    await gagan.post('/v1/invites/accept', { token: inv.body.token });
+  });
+
+  it('the author rewrites a body; reads and replay serve the new text', async () => {
+    const posted = await ramnique.post(`/v1/spaces/${spaceId}/messages`, {
+      body: 'teh quick fix',
+      actingMode: 'direct',
+    });
+    const messageId = posted.body.message.id;
+    topicId = posted.body.topic.id;
+
+    const r = await edit(ramnique, messageId, 'the quick fix');
+    expect(r.status).toBe(200);
+    expect(r.body.message.body).toBe('the quick fix');
+    expect(r.body.message.editedAt).toBeTruthy();
+
+    // Reads carry the rewrite; counts and activity are untouched.
+    const msgs = await gagan.get(`/v1/spaces/${spaceId}/topics/${topicId}/messages`);
+    const m = msgs.body.messages.find((x: any) => x.id === messageId);
+    expect(m.body).toBe('the quick fix');
+    expect(m.editedAt).toBe(r.body.message.editedAt);
+
+    // Replay rewrite: catch-up gets the REWRITTEN message event plus the edit event.
+    const live = await liveClient(harbor, 'dev-gagan');
+    live.send({ kind: 'subscribe', spaceId, afterOffset: 0 });
+    await live.until(
+      (frames) => frames.some((f) => f.kind === 'event' && f.event.type === 'message_edited'),
+      'replayed edit',
+    );
+    const replayed = live.events().find((f) => f.event.type === 'message' && f.event.message.id === messageId)!;
+    expect(replayed.event).toMatchObject({
+      type: 'message',
+      message: { id: messageId, body: 'the quick fix', editedAt: r.body.message.editedAt },
+    });
+    expect(live.events().find((f) => f.event.type === 'message_edited')!.event).toMatchObject({
+      type: 'message_edited',
+      edit: { messageId, topicId, body: 'the quick fix', by: { memberId: 'ramnique', actingMode: 'direct' } },
+    });
+    live.close();
+  });
+
+  it('only the author edits; tombstones and unknown messages refuse', async () => {
+    const posted = await ramnique.post(`/v1/spaces/${spaceId}/messages`, { topicId, body: 'mine', actingMode: 'direct' });
+    const messageId = posted.body.message.id;
+    expect((await edit(gagan, messageId, 'hijack')).status).toBe(403);
+    expect((await edit(ramnique, '01ARZ3NDEKTSV4RRFFQ69G5FAV', 'ghost')).status).toBe(404);
+    await ramnique.post(`/v1/spaces/${spaceId}/messages/${messageId}/delete`, { actingMode: 'direct' });
+    expect((await edit(ramnique, messageId, 'necromancy')).status).toBe(400);
+  });
+
+  it('an identical body is an idempotent no-op: no event', async () => {
+    const posted = await ramnique.post(`/v1/spaces/${spaceId}/messages`, { topicId, body: 'stable', actingMode: 'direct' });
+    const messageId = posted.body.message.id;
+
+    const live = await liveClient(harbor, 'dev-ramnique');
+    live.send({ kind: 'subscribe', spaceId });
+    await live.until((frames) => frames.some((f) => f.kind === 'subscribed'), 'subscribed');
+
+    const same = await edit(ramnique, messageId, 'stable');
+    expect(same.status).toBe(200);
+    expect(same.body.message.editedAt).toBeUndefined();
+
+    await edit(ramnique, messageId, 'stable, now edited');
+    await live.until(
+      (frames) => frames.some((f) => f.kind === 'event' && f.event.type === 'message_edited'),
+      'edit event',
+    );
+    expect(live.events().filter((f) => f.event.type === 'message_edited')).toHaveLength(1);
+    live.close();
+  });
+});
+
 describe('read-only limit (spec §4: never lockout)', () => {
   it('writes pause, reads keep working', async () => {
     const r = await ramnique.post('/v1/spaces', { name: 'Limits' });

--- a/apps/harbor/packages/server/test/migrations.test.ts
+++ b/apps/harbor/packages/server/test/migrations.test.ts
@@ -9,7 +9,8 @@ import { pgliteDb } from './pglite.js';
 // runner implicitly via PgStore.init().
 
 describe('schema migrations', () => {
-  it('applies all migrations to a fresh database and records them', async () => {
+  // The full ladder on PGlite takes seconds; the default 5s got too snug.
+  it('applies all migrations to a fresh database and records them', { timeout: 20_000 }, async () => {
     const db = await pgliteDb();
     await migrate(db);
     const applied = await db.query<{ id: string }>('select id from schema_migrations order by id');

--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -48,6 +48,7 @@ type SpacesHandlers = {
   'spaces:manageTopic': InvokeHandler<'spaces:manageTopic'>;
   'spaces:reactToMessage': InvokeHandler<'spaces:reactToMessage'>;
   'spaces:deleteMessage': InvokeHandler<'spaces:deleteMessage'>;
+  'spaces:editMessage': InvokeHandler<'spaces:editMessage'>;
   'spaces:invokeRowboat': InvokeHandler<'spaces:invokeRowboat'>;
   'spaces:topicSession': InvokeHandler<'spaces:topicSession'>;
   'spaces:subscribeSpace': InvokeHandler<'spaces:subscribeSpace'>;
@@ -294,6 +295,13 @@ export const spacesIpcHandlers: SpacesHandlers = {
 
   'spaces:deleteMessage': async (_event, args) => ({
     message: await orgs.getClient(args.orgId).deleteMessage(args.spaceId, args.messageId, {
+      actingMode: 'direct',
+    }),
+  }),
+
+  'spaces:editMessage': async (_event, args) => ({
+    message: await orgs.getClient(args.orgId).editMessage(args.spaceId, args.messageId, {
+      body: args.body,
       actingMode: 'direct',
     }),
   }),

--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -8,6 +8,7 @@ import * as spacesOAuth from '@x/core/dist/spaces/oauth.js';
 import { syncSpaceMentionWatch } from '@x/core/dist/spaces/mention-watch.js';
 import { invokeTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
+import { fetchLinkPreview } from './link-preview.js';
 
 type IPCChannels = ipc.IPCChannels;
 
@@ -38,6 +39,7 @@ type SpacesHandlers = {
   'spaces:uploadBlob': InvokeHandler<'spaces:uploadBlob'>;
   'spaces:saveBlob': InvokeHandler<'spaces:saveBlob'>;
   'spaces:saveImageUrl': InvokeHandler<'spaces:saveImageUrl'>;
+  'spaces:linkPreview': InvokeHandler<'spaces:linkPreview'>;
   'spaces:readAsset': InvokeHandler<'spaces:readAsset'>;
   'spaces:proposeChange': InvokeHandler<'spaces:proposeChange'>;
   'spaces:assetHistory': InvokeHandler<'spaces:assetHistory'>;
@@ -236,6 +238,8 @@ export const spacesIpcHandlers: SpacesHandlers = {
     await fs.writeFile(result.filePath, Buffer.from(await res.arrayBuffer()));
     return { saved: true, path: result.filePath };
   },
+
+  'spaces:linkPreview': async (_event, args) => ({ preview: await fetchLinkPreview(args.url) }),
 
   'spaces:readAsset': async (_event, args) =>
     orgs.getClient(args.orgId).readAsset(args.spaceId, args.path, args.version),

--- a/apps/x/apps/main/src/spaces/link-preview.ts
+++ b/apps/x/apps/main/src/spaces/link-preview.ts
@@ -1,0 +1,142 @@
+// OpenGraph unfurling for link cards in Spaces chat. Main fetches because
+// the renderer can't cross-origin; the renderer decides WHICH links to
+// unfurl (trusted domains only — this module never phones anywhere on its
+// own). Failures are nulls, never errors: a card is decoration.
+
+export interface LinkPreview {
+  url: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  siteName?: string;
+}
+
+const FETCH_TIMEOUT_MS = 8_000;
+/** Read at most this much of the page — og tags live in <head>. */
+const MAX_HTML_BYTES = 512 * 1024;
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const CACHE_MAX = 200;
+
+const cache = new Map<string, { at: number; preview: LinkPreview | null }>();
+
+function cacheGet(url: string): { preview: LinkPreview | null } | null {
+  const hit = cache.get(url);
+  if (!hit) return null;
+  if (Date.now() - hit.at > CACHE_TTL_MS) {
+    cache.delete(url);
+    return null;
+  }
+  return hit;
+}
+
+function cachePut(url: string, preview: LinkPreview | null) {
+  // Insertion-ordered Map: evict the oldest entry once full.
+  if (cache.size >= CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(url, { at: Date.now(), preview });
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec: string) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+/** content of the first matching <meta property|name=... content=...> — attribute order varies in the wild. */
+function metaContent(html: string, key: string): string | null {
+  const attr = `(?:property|name)\\s*=\\s*["']${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']`;
+  const m =
+    new RegExp(`<meta\\s[^>]*${attr}[^>]*?content\\s*=\\s*["']([^"']*)["'][^>]*>`, 'i').exec(html) ??
+    new RegExp(`<meta\\s[^>]*?content\\s*=\\s*["']([^"']*)["'][^>]*${attr}[^>]*>`, 'i').exec(html);
+  const value = m?.[1] ? decodeEntities(m[1]).trim() : '';
+  return value.length > 0 ? value : null;
+}
+
+function clip(text: string | null, max: number): string | undefined {
+  if (!text) return undefined;
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+async function readCapped(res: Response): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return '';
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (total < MAX_HTML_BYTES) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  void reader.cancel().catch(() => {});
+  return new TextDecoder('utf-8', { fatal: false }).decode(Buffer.concat(chunks));
+}
+
+export async function fetchLinkPreview(rawUrl: string): Promise<LinkPreview | null> {
+  let target: URL;
+  try {
+    target = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (target.protocol !== 'https:') return null;
+  const cached = cacheGet(target.href);
+  if (cached) return cached.preview;
+
+  let preview: LinkPreview | null = null;
+  try {
+    const res = await fetch(target.href, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: {
+        accept: 'text/html,application/xhtml+xml',
+        // Some sites refuse UA-less requests outright.
+        'user-agent': 'Mozilla/5.0 (compatible; Rowboat/1.0; link-preview)',
+      },
+    });
+    const type = res.headers.get('content-type') ?? '';
+    if (res.ok && /text\/html|application\/xhtml/i.test(type)) {
+      const html = await readCapped(res);
+      const title =
+        metaContent(html, 'og:title') ??
+        metaContent(html, 'twitter:title') ??
+        (() => {
+          const t = /<title[^>]*>([^<]*)<\/title>/i.exec(html)?.[1];
+          return t ? decodeEntities(t).trim() || null : null;
+        })();
+      const description = metaContent(html, 'og:description') ?? metaContent(html, 'twitter:description') ?? metaContent(html, 'description');
+      const image = metaContent(html, 'og:image') ?? metaContent(html, 'twitter:image');
+      // Redirects may have landed elsewhere; resolve relative images there.
+      const base = res.url || target.href;
+      let imageUrl: string | undefined;
+      if (image) {
+        try {
+          const abs = new URL(image, base);
+          if (abs.protocol === 'https:') imageUrl = abs.href;
+        } catch {
+          // unusable image address — card renders without one
+        }
+      }
+      if (title || description) {
+        preview = {
+          url: target.href,
+          title: clip(title, 200),
+          description: clip(description, 300),
+          imageUrl,
+          siteName: clip(metaContent(html, 'og:site_name'), 100),
+        };
+      }
+    }
+  } catch {
+    preview = null;
+  }
+  cachePut(target.href, preview);
+  return preview;
+}

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -832,6 +832,12 @@ function App() {
   const [isBgTasksOpen, setIsBgTasksOpen] = useState(false)
   const [isAppsOpen, setIsAppsOpen] = useState(false)
   const [isSpacesOpen, setIsSpacesOpen] = useState(false)
+  // Spaces keeps its view mounted after the first open (hidden, not torn
+  // down) — reopening must be instant, not a full remount of the pane.
+  const [spacesEverOpened, setSpacesEverOpened] = useState(false)
+  useEffect(() => {
+    if (isSpacesOpen) setSpacesEverOpened(true)
+  }, [isSpacesOpen])
   // The space open in the Spaces view (org + space); the sidebar highlights it.
   const [spaceSelection, setSpaceSelection] = useState<SpaceSelection>(null)
   // What's selected inside the open space (general / topic / file) — part of the history.
@@ -6847,6 +6853,26 @@ function App() {
                 })()}
               </ContentHeader>
 
+              {/* Spaces stays mounted once opened (Slack-style keep-alive):
+                  hiding instead of unmounting makes reopening instant. The
+                  active flag gates presence + read marks while hidden. */}
+              {(isSpacesOpen || spacesEverOpened) && (
+                <div className={isSpacesOpen && !isBrowserOpen ? 'flex-1 min-h-0 flex flex-col overflow-hidden' : 'hidden'}>
+                  <SpacesView
+                    active={isSpacesOpen && !isBrowserOpen}
+                    selection={spaceSelection}
+                    onSelect={setSpaceSelection}
+                    railSelection={railSelection}
+                    onRailSelect={(rail) => {
+                      // In-space navigation is real navigation: each selection is a history entry,
+                      // so the top ‹ › retrace general → topic → file.
+                      if (spaceSelection) void navigateToView({ type: 'spaces', orgId: spaceSelection.orgId, spaceId: spaceSelection.spaceId, rail })
+                      else setRailSelection(rail)
+                    }}
+                    onOpenSession={(sessionId) => void navigateToView({ type: 'chat', runId: sessionId })}
+                  />
+                </div>
+              )}
               {isBrowserOpen ? (
                 <BrowserPane
                   onClose={handleCloseBrowser}
@@ -7027,20 +7053,8 @@ function App() {
                   />
                 </div>
               ) : isSpacesOpen ? (
-                <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-                  <SpacesView
-                    selection={spaceSelection}
-                    onSelect={setSpaceSelection}
-                    railSelection={railSelection}
-                    onRailSelect={(rail) => {
-                      // In-space navigation is real navigation: each selection is a history entry,
-                      // so the top ‹ › retrace general → topic → file.
-                      if (spaceSelection) void navigateToView({ type: 'spaces', orgId: spaceSelection.orgId, spaceId: spaceSelection.spaceId, rail })
-                      else setRailSelection(rail)
-                    }}
-                    onOpenSession={(sessionId) => void navigateToView({ type: 'chat', runId: sessionId })}
-                  />
-                </div>
+                // Rendered by the keep-alive container above the chain.
+                null
               ) : isEmailOpen ? (
                 <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
                   <EmailView initialThreadId={emailInitialThreadId} threadIdVersion={emailThreadIdVersion} initialSearchQuery={emailInitialSearchQuery} searchQueryVersion={emailSearchQueryVersion} onOpenNote={openNoteFromEmail} />

--- a/apps/x/apps/renderer/src/components/image-lightbox.tsx
+++ b/apps/x/apps/renderer/src/components/image-lightbox.tsx
@@ -1,5 +1,114 @@
+import { useRef, useState } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { Download, ExternalLink, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const ZOOM_MAX = 8
+/** What a click on the fitted image zooms to. */
+const CLICK_ZOOM = 2.5
+
+/** Translate clamp: the scaled image must always overlap its fitted box. */
+function clampPan(value: number, extent: number, scale: number) {
+  const max = ((scale - 1) * extent) / 2
+  return Math.min(max, Math.max(-max, value))
+}
+
+/**
+ * Zoomable image for lightboxes: scroll (or pinch) zooms toward the cursor,
+ * click toggles fit ⇄ 2.5×, drag pans while zoomed. State lives here, so
+ * closing the viewer (which unmounts it) resets the zoom.
+ */
+export function ZoomableImage({ src, alt, className, onError }: {
+  src: string
+  alt: string
+  className?: string
+  onError?: () => void
+}) {
+  const ref = useRef<HTMLImageElement | null>(null)
+  const [zoom, setZoom] = useState({ s: 1, x: 0, y: 0 })
+  const drag = useRef<{ id: number; startX: number; startY: number; x: number; y: number; moved: boolean } | null>(null)
+  // A drag that actually moved must not fire the click toggle on release.
+  const suppressClick = useRef(false)
+  const [dragging, setDragging] = useState(false)
+
+  /** Rescale around the cursor: the image point under it stays put. */
+  const rescale = (z: { s: number; x: number; y: number }, nextScale: number, clientX: number, clientY: number) => {
+    const s = Math.min(ZOOM_MAX, Math.max(1, nextScale))
+    if (s === 1) return { s: 1, x: 0, y: 0 }
+    const el = ref.current
+    if (!el) return { ...z, s }
+    const r = el.getBoundingClientRect()
+    // Scaling is centre-origin, so the transformed rect's centre is the
+    // untransformed centre + the translate.
+    const px = clientX - (r.left + r.width / 2 - z.x)
+    const py = clientY - (r.top + r.height / 2 - z.y)
+    const k = s / z.s
+    const w = r.width / z.s
+    const h = r.height / z.s
+    return { s, x: clampPan(px - k * (px - z.x), w, s), y: clampPan(py - k * (py - z.y), h, s) }
+  }
+
+  const onWheel = (e: React.WheelEvent) => {
+    const factor = Math.exp(-e.deltaY * 0.002)
+    setZoom((z) => rescale(z, z.s * factor, e.clientX, e.clientY))
+  }
+  const onClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (suppressClick.current) {
+      suppressClick.current = false
+      return
+    }
+    setZoom((z) => rescale(z, z.s > 1 ? 1 : CLICK_ZOOM, e.clientX, e.clientY))
+  }
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (zoom.s <= 1 || e.button !== 0) return
+    e.currentTarget.setPointerCapture(e.pointerId)
+    drag.current = { id: e.pointerId, startX: e.clientX, startY: e.clientY, x: zoom.x, y: zoom.y, moved: false }
+    setDragging(true)
+  }
+  const onPointerMove = (e: React.PointerEvent) => {
+    const d = drag.current
+    if (!d || e.pointerId !== d.id) return
+    const dx = e.clientX - d.startX
+    const dy = e.clientY - d.startY
+    if (Math.abs(dx) + Math.abs(dy) > 4) d.moved = true
+    setZoom((z) => {
+      const el = ref.current
+      if (!el) return z
+      const r = el.getBoundingClientRect()
+      return { ...z, x: clampPan(d.x + dx, r.width / z.s, z.s), y: clampPan(d.y + dy, r.height / z.s, z.s) }
+    })
+  }
+  const onPointerEnd = (e: React.PointerEvent) => {
+    const d = drag.current
+    if (!d || e.pointerId !== d.id) return
+    suppressClick.current = d.moved
+    drag.current = null
+    setDragging(false)
+  }
+
+  return (
+    <img
+      ref={ref}
+      src={src}
+      alt={alt}
+      draggable={false}
+      onError={onError}
+      onWheel={onWheel}
+      onClick={onClick}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerEnd}
+      onPointerCancel={onPointerEnd}
+      style={{ transform: `translate(${zoom.x}px, ${zoom.y}px) scale(${zoom.s})`, willChange: 'transform' }}
+      className={cn(
+        'touch-none select-none',
+        zoom.s === 1 ? 'cursor-zoom-in' : dragging ? 'cursor-grabbing' : 'cursor-grab',
+        className,
+      )}
+    />
+  )
+}
 
 /** Semi-transparent control overlaid on an image (inline hover row, lightbox). */
 export function ImageOverlayButton({
@@ -58,10 +167,9 @@ export function ImageLightbox({
           className="fixed inset-0 z-50 flex items-center justify-center outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
         >
           <DialogPrimitive.Title className="sr-only">{name}</DialogPrimitive.Title>
-          <img
+          <ZoomableImage
             src={src}
             alt={name}
-            onClick={(e) => e.stopPropagation()}
             onError={onError}
             className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain"
           />

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -8,7 +8,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { AddOrgDialog, OrgMonogram, type SpaceSelection } from '@/components/spaces-view'
 import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
-import { useSpacesUnreadCounts } from '@/hooks/use-space-chat'
+import { prefetchGeneral, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
 import { toast } from '@/lib/toast'
 
 // The sidebar's SPACES section (design: "App shell scope planning"): every
@@ -179,7 +179,14 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
                 const count = unread.get(`${org.id}/${space.id}`) ?? 0
                 return (
                     <SidebarMenuItem key={space.id}>
-                        <SidebarMenuButton isActive={active} onClick={() => onOpenSpace(org.id, space.id)} className="pl-4">
+                        <SidebarMenuButton
+                            isActive={active}
+                            onClick={() => onOpenSpace(org.id, space.id)}
+                            // Hover = intent: warm the cached tail + start the
+                            // refresh, so the click paints instantly.
+                            onMouseEnter={() => prefetchGeneral(org.id, space.id)}
+                            className="pl-4"
+                        >
                             <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
                             {count > 0 && (
                                 <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Check, ChevronDown, Columns2, FileText, FolderOpen, Link as LinkIcon, Loader2, MessageSquare, MoreHorizontal, Plus } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { Button } from '@/components/ui/button'
@@ -9,6 +9,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { AddOrgDialog, AvatarStack, MemberAvatar, OrgMonogram } from '@/components/spaces/atoms'
 import { FileColumn, TrashDialog, UploadFilesDialog } from '@/components/spaces/files-tab'
 import { GeneralStream } from '@/components/spaces/general-stream'
+import { SelectionCopy } from '@/components/spaces/selection-copy'
 import { SpaceRail } from '@/components/spaces/space-rail'
 import { railKey, type RailSelection } from '@/lib/spaces-selection'
 import { DraftThreadPane, ThreadPane } from '@/components/spaces/thread-pane'
@@ -61,13 +62,19 @@ const MODES: { k: SpaceMode; label: string; Icon: typeof MessageSquare; kb: stri
 // Root view: the selected space (the org/space list lives in the app sidebar)
 // ---------------------------------------------------------------------------
 
-export function SpacesView({ selection, onSelect, railSelection, onRailSelect, onOpenSession }: {
+export function SpacesView({ selection, onSelect, railSelection, onRailSelect, onOpenSession, active = true }: {
     selection: SpaceSelection
     onSelect: (selection: SpaceSelection) => void
     /** What's selected inside the space (general / a topic / a file) — part of the app's history. */
     railSelection: RailSelection
     onRailSelect: (selection: RailSelection) => void
     onOpenSession?: (sessionId: string) => void
+    /**
+     * False while the view is kept mounted but hidden (the app shows another
+     * section). Gates presence and read marks — a hidden pane must not report
+     * "viewing" or mark arriving messages read.
+     */
+    active?: boolean
 }) {
     const { orgs, loading, refresh } = useSpacesOrgs()
     const [addOrgOpen, setAddOrgOpen] = useState(false)
@@ -105,6 +112,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
                 selection={railSelection}
                 onSelect={onRailSelect}
                 onOpenSession={onOpenSession}
+                active={active}
             />
         )
     }
@@ -146,12 +154,14 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
 // One space: header across the top, then the space rail | the selected thing
 // ---------------------------------------------------------------------------
 
-function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
+function SpacePane({ org, space, selection, onSelect, onOpenSession, active = true }: {
     org: OrgWithSpaces
     space: spaces.Space
     selection: RailSelection
     onSelect: (selection: RailSelection) => void
     onOpenSession?: (sessionId: string) => void
+    /** False while the Spaces view is kept mounted but hidden. */
+    active?: boolean
 }) {
     const [members, setMembers] = useState<spaces.Member[]>([])
     const [entries, setEntries] = useState<spaces.SpacesAssetEntry[]>([])
@@ -243,10 +253,14 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // (600px document + 480px chat + the 28px rail edge).
     // ------------------------------------------------------------------
     const [mode, setMode] = useState<SpaceMode>(() => (selection.kind === 'file' ? 'read' : 'talk'))
+    // The topics/files rail has two modes, persisted: PINNED (default) — a
+    // plain sidebar, always open; or AUTO-HIDE — a collapsed edge that opens
+    // on hover and lingers a few seconds after the cursor leaves, so moving
+    // to the stream and back doesn't slam it shut mid-thought. (The first
+    // design closed the instant the cursor left — too twitchy to use.)
+    const [railPinned, setRailPinned] = useState(() => localStorage.getItem('spaces:railOpen') !== '0')
     const [railHover, setRailHover] = useState(false)
-    const [railPeek, setRailPeek] = useState(false)
-    const peekTimer = useRef<number | null>(null)
-    const [railPinned, setRailPinned] = useState(() => localStorage.getItem('spaces:railPin') === '1')
+    const railCloseTimer = useRef<number | null>(null)
 
     // Width of the pane drives the Split floor and pinnability.
     const paneRef = useRef<HTMLDivElement | null>(null)
@@ -258,24 +272,6 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         ro.observe(el)
         setPaneWidth(el.clientWidth)
         return () => ro.disconnect()
-    }, [])
-
-    // The teach-peek: push the rail open, hold a beat, release — the same
-    // motion the cursor makes at the edge. Once the user has hovered or
-    // pinned that list themselves, it has done its job and stays quiet.
-    const peekRail = useCallback(() => {
-        if (localStorage.getItem('spaces:railTaught') === '1') return
-        if (peekTimer.current) window.clearTimeout(peekTimer.current)
-        setRailPeek(true)
-        peekTimer.current = window.setTimeout(() => setRailPeek(false), 1900)
-    }, [])
-    useEffect(() => () => {
-        if (peekTimer.current) window.clearTimeout(peekTimer.current)
-    }, [])
-    useEffect(() => {
-        peekRail()
-        // Landing peek only — once per space open.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // Stable listener; requestMode itself re-derives per render (splitFits).
@@ -295,7 +291,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     // What actually renders: a Split that doesn't fit falls back to the one
     // surface the selection needs.
     const effMode: SpaceMode = mode === 'split' && !splitFits ? (selection.kind === 'file' ? 'read' : 'talk') : mode
-    const railOpen = railPeek || railHover || railPinned
+    const railOpen = railPinned || railHover
 
     /** The header buttons and ⌘1/2/3: say why when Split can't render. */
     const requestMode = (next: SpaceMode) => {
@@ -304,27 +300,39 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
     }
     requestModeRef.current = requestMode
 
+    /** Auto-hide grace: how long the rail lingers after the cursor leaves. */
+    const RAIL_LINGER_MS = 3_500
+    const clearRailTimer = () => {
+        if (railCloseTimer.current) {
+            window.clearTimeout(railCloseTimer.current)
+            railCloseTimer.current = null
+        }
+    }
+    useEffect(() => clearRailTimer, [])
     const onRailHover = (hovering: boolean) => {
-        setRailHover(hovering)
-        if (hovering) localStorage.setItem('spaces:railTaught', '1')
+        clearRailTimer()
+        if (hovering) setRailHover(true)
+        else railCloseTimer.current = window.setTimeout(() => setRailHover(false), RAIL_LINGER_MS)
     }
     const toggleRailPin = () => {
-        localStorage.setItem('spaces:railTaught', '1')
-        setRailPinned((p) => {
-            localStorage.setItem('spaces:railPin', p ? '0' : '1')
-            return !p
-        })
+        const pin = !railPinned
+        localStorage.setItem('spaces:railOpen', pin ? '1' : '0')
+        setRailPinned(pin)
+        // Unpinning closes NOW (the cursor is on the button, inside the rail —
+        // without this the hover hold keeps it open and the click reads as dead).
+        if (!pin) {
+            clearRailTimer()
+            setRailHover(false)
+        }
     }
 
     // Selecting is also choreography: a topic opened from Read grows into
     // Split; a file opened from Talk (or from a topic's artifact link) opens
-    // beside the conversation in Split. The rail slides away once it has
-    // been used.
+    // beside the conversation in Split. The rail stays where it is — it is a
+    // sidebar, not a flyout.
     const select = (next: RailSelection) => {
         onSelect(next)
         analytics.spacesTabViewed(next.kind === 'general' ? 'general' : next.kind === 'file' ? 'files' : 'topics')
-        setRailHover(false)
-        setRailPeek(false)
         if ((next.kind === 'topic' || next.kind === 'draft') && mode === 'read') setMode('split')
         else if (next.kind === 'general' && mode === 'read') setMode('talk')
         else if (next.kind === 'file') {
@@ -455,6 +463,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
         <SpaceRefsProvider refs={{ orgId: org.id, orgAddress: org.address, spaceId: space.id }}>
         <SpaceNavProvider onOpenFile={openFile}>
         <div className="flex-1 min-h-0 flex flex-col">
+            {/* One per pane — covers the stream and thread panes alike. */}
+            {active && <SelectionCopy />}
             <header className="flex items-center gap-3 px-4 h-12 shrink-0 border-b border-border">
                 <OrgMonogram org={org} />
                 <h1 className="text-[15px] font-semibold truncate">{space.name}</h1>
@@ -571,71 +581,74 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession }: {
                     onRemoveFolder={removeFolder}
                     open={railOpen}
                     pinned={railPinned}
-                    hint={railPinned ? 'pinned' : railPeek ? 'sliding away' : 'hover · pin to keep'}
                     onHoverChange={onRailHover}
                     onTogglePin={toggleRailPin}
                 />
                 {/* The surfaces. Talk = the stream or an open topic; Read =
-                    the document; Split shows both around a draggable divider. */}
-                {effMode !== 'read' && (
-                    <div className="flex-1 min-w-0 min-h-0 flex">
-                        {draftParent ? (
-                            <section className="flex-1 min-w-0 min-h-0 flex flex-col">
-                                <DraftThreadPane
-                                    key={draftParent.id}
-                                    org={org}
-                                    space={space}
-                                    parent={draftParent}
-                                    members={members}
-                                    memberNames={memberNames}
-                                    entries={entries}
-                                    onBack={() => select({ kind: 'general' })}
-                                    onCreated={(topicId) => select({ kind: 'topic', topicId })}
-                                />
-                            </section>
-                        ) : chatTopicId ? (
-                            <section className="flex-1 min-w-0 min-h-0 flex flex-col">
-                                <ThreadPane
-                                    key={chatTopicId}
-                                    org={org}
-                                    space={space}
-                                    topicId={chatTopicId}
-                                    threadInfo={selectedInfo}
-                                    topic={selectedTopic}
-                                    changeSets={feed.changeSets}
-                                    entries={entries}
-                                    presence={presence}
-                                    members={members}
-                                    memberNames={memberNames}
-                                    refreshTick={refreshTick}
-                                    anchorChange={selectedAnchor}
-                                    showBack
-                                    onBack={() => select({ kind: 'general' })}
-                                    onOpenFile={openFileFromTopic(chatTopicId)}
-                                    onOpenSession={onOpenSession}
-                                    artifactsRailOpen={artifactsRailOpen}
-                                    onToggleArtifactsRail={toggleArtifactsRail}
-                                    onFolding={setFolding}
-                                />
-                            </section>
-                        ) : (
-                            <GeneralStream
+                    the document; Split shows both around a draggable divider.
+                    The stream is the expensive surface, so it never unmounts
+                    while the space is open — a topic, a draft, or read mode
+                    HIDE it (keep-alive), and closing them is instant. */}
+                <div className={cn('flex-1 min-w-0 min-h-0', effMode === 'read' ? 'hidden' : 'flex')}>
+                    {draftParent ? (
+                        <section className="flex-1 min-w-0 min-h-0 flex flex-col">
+                            <DraftThreadPane
+                                key={draftParent.id}
                                 org={org}
                                 space={space}
-                                general={general}
-                                threads={threads}
-                                topics={feed.topics}
-                                presence={presence}
+                                parent={draftParent}
                                 members={members}
                                 memberNames={memberNames}
                                 entries={entries}
-                                onOpenThread={(id) => select({ kind: 'topic', topicId: id })}
-                                onStartThread={(m) => select({ kind: 'draft', parentMessageId: m.id })}
-                                onOpenSession={onOpenSession}
+                                onBack={() => select({ kind: 'general' })}
+                                onCreated={(topicId) => select({ kind: 'topic', topicId })}
                             />
-                        )}
+                        </section>
+                    ) : chatTopicId ? (
+                        <section className="flex-1 min-w-0 min-h-0 flex flex-col">
+                            <ThreadPane
+                                key={chatTopicId}
+                                org={org}
+                                space={space}
+                                topicId={chatTopicId}
+                                threadInfo={selectedInfo}
+                                topic={selectedTopic}
+                                changeSets={feed.changeSets}
+                                entries={entries}
+                                presence={presence}
+                                members={members}
+                                memberNames={memberNames}
+                                refreshTick={refreshTick}
+                                anchorChange={selectedAnchor}
+                                showBack
+                                onBack={() => select({ kind: 'general' })}
+                                onOpenFile={openFileFromTopic(chatTopicId)}
+                                onOpenSession={onOpenSession}
+                                artifactsRailOpen={artifactsRailOpen}
+                                onToggleArtifactsRail={toggleArtifactsRail}
+                                onFolding={setFolding}
+                                visible={active && effMode !== 'read'}
+                            />
+                        </section>
+                    ) : null}
+                    <div className={cn('flex-1 min-w-0 min-h-0', draftParent || chatTopicId ? 'hidden' : 'flex')}>
+                        <GeneralStream
+                            org={org}
+                            space={space}
+                            general={general}
+                            threads={threads}
+                            topics={feed.topics}
+                            presence={presence}
+                            members={members}
+                            memberNames={memberNames}
+                            entries={entries}
+                            onOpenThread={(id) => select({ kind: 'topic', topicId: id })}
+                            onStartThread={(m) => select({ kind: 'draft', parentMessageId: m.id })}
+                            onOpenSession={onOpenSession}
+                            visible={active && effMode !== 'read' && !draftParent && !chatTopicId}
+                        />
                     </div>
-                )}
+                </div>
                 {effMode === 'split' && (
                     <div
                         onMouseDown={startDocResize}

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -354,10 +354,14 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
         else if (selection.kind !== 'file' && mode === 'read') setMode('talk')
     }, [selKey, selection.kind, mode])
 
-    // The document pane: an explicitly opened file, else the space's front
-    // page (README.md), else the first file there is.
+    // The last dismissed file — Read/Split and the header chip reopen it.
+    const [lastDoc, setLastDoc] = useState<{ path: string; fromTopicId?: string } | null>(null)
+
+    // The document pane: an explicitly opened file, else the one that was
+    // just dismissed, else the space's front page (README.md), else the
+    // first file there is.
     const defaultDocPath = entries.some((e) => e.path === 'README.md') ? 'README.md' : (entries[0]?.path ?? null)
-    const centerPath = selection.kind === 'file' ? selection.path : defaultDocPath
+    const centerPath = selection.kind === 'file' ? selection.path : (lastDoc?.path ?? defaultDocPath)
 
     // Resizable Split divider: drag it; the document width persists.
     const [docWidth, setDocWidth] = useState<number>(() => {
@@ -435,10 +439,18 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     }
 
     // Split: dismissing the document closes it and returns to Talk, landing
-    // on the conversation that was beside it.
+    // on the conversation that was beside it. The dismissed file is remembered
+    // (lastDoc) so it can be reopened — from the header chip, or by
+    // re-entering Read/Split (which prefer it over the README default).
     const dismissFile = () => {
-        if (selection.kind === 'file') onSelect(chatTopicId ? { kind: 'topic', topicId: chatTopicId } : { kind: 'general' })
+        if (selection.kind === 'file') {
+            setLastDoc({ path: selection.path, fromTopicId: selection.fromTopicId })
+            onSelect(chatTopicId ? { kind: 'topic', topicId: chatTopicId } : { kind: 'general' })
+        }
         setMode('talk')
+    }
+    const reopenDoc = () => {
+        if (lastDoc) select({ kind: 'file', path: lastDoc.path, fromTopicId: lastDoc.fromTopicId })
     }
 
     // Crumb for a file opened from a topic.
@@ -527,6 +539,18 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                     </span>
                 )}
                 <div className="flex-1" />
+                {effMode === 'talk' && selection.kind !== 'file' && lastDoc && entries.some((e) => e.path === lastDoc.path) && (
+                    <button
+                        type="button"
+                        onClick={reopenDoc}
+                        title={`Reopen ${lastDoc.path} beside the conversation`}
+                        className="inline-flex h-6 max-w-[14rem] items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                    >
+                        <FileText className="size-3 shrink-0" />
+                        <span className="truncate font-mono text-[11px]">{lastDoc.path.split('/').pop()}</span>
+                        <Columns2 className="size-3 shrink-0" />
+                    </button>
+                )}
                 <div className="inline-flex items-center rounded-md bg-muted p-0.5">
                     {MODES.map(({ k, label, Icon, kb }) => (
                         <button

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -65,7 +65,7 @@ interface MentionCandidate {
 // "/" so typing into a folder ("@design/sc…") keeps the file query alive.
 const MENTION_RE = /(^|[\s([{])@([\w./-]*)$/
 
-export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, members = [], entries = [], selfMemberId }: {
+export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, members = [], entries = [], selfMemberId, draftKey }: {
     placeholder: string
     onSend: (body: string, agent?: AgentOptions) => Promise<void>
     busy: boolean
@@ -79,8 +79,23 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
     /** Space files — the same @ autocomplete offers them; picking one links it. */
     entries?: spaces.SpacesAssetEntry[]
     selfMemberId?: string
+    /**
+     * Persist the unsent text under this key (per install, like read marks) —
+     * switching spaces or restarting the app hands the draft back. Sending
+     * clears it. Attachments are not persisted; they re-upload on return.
+     */
+    draftKey?: string
 }) {
-    const [draft, setDraft] = useState('')
+    const [draft, setDraft] = useState(() => (draftKey ? window.localStorage.getItem(`spaces:draft:${draftKey}`) ?? '' : ''))
+    useEffect(() => {
+        if (!draftKey) return
+        try {
+            if (draft) window.localStorage.setItem(`spaces:draft:${draftKey}`, draft)
+            else window.localStorage.removeItem(`spaces:draft:${draftKey}`)
+        } catch {
+            // Quota/private mode: the draft just doesn't persist.
+        }
+    }, [draftKey, draft])
     const [appliedSeed, setAppliedSeed] = useState<number | null>(null)
     const ref = useRef<HTMLTextAreaElement | null>(null)
 

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -65,7 +65,24 @@ interface MentionCandidate {
 // "/" so typing into a folder ("@design/sc…") keeps the file query alive.
 const MENTION_RE = /(^|[\s([{])@([\w./-]*)$/
 
-export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, members = [], entries = [], selfMemberId, draftKey }: {
+/** A pane-provided slash command; `args` absent = picking it runs immediately. */
+export interface SlashCommand {
+    name: string
+    /** Argument placeholder shown in the menu, e.g. '<file>'. */
+    args?: string
+    hint: string
+    run: (args: string) => void | Promise<void>
+}
+
+type CommandEntry = Omit<SlashCommand, 'run'> & { run?: SlashCommand['run'] }
+
+/** Built into the composer itself: /ask rewrites to an @rowboat message and sends. */
+const ASK_COMMAND: CommandEntry = { name: 'ask', args: '<question>', hint: 'Ask your Rowboat — same as @rowboat' }
+
+/** A draft that IS a command: "/name" or "/name args". */
+const COMMAND_RE = /^\/([a-zA-Z]+)(?:\s+([\s\S]*))?$/
+
+export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, members = [], entries = [], selfMemberId, draftKey, commands = [] }: {
     placeholder: string
     onSend: (body: string, agent?: AgentOptions) => Promise<void>
     busy: boolean
@@ -85,6 +102,8 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
      * clears it. Attachments are not persisted; they re-upload on return.
      */
     draftKey?: string
+    /** Surface-specific slash commands (a "/" draft opens the menu; /ask is built in). */
+    commands?: SlashCommand[]
 }) {
     const [draft, setDraft] = useState(() => (draftKey ? window.localStorage.getItem(`spaces:draft:${draftKey}`) ?? '' : ''))
     useEffect(() => {
@@ -282,6 +301,45 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
     }
     const showMentions = mentionOpen && !!mentionMatch && candidates.length > 0
 
+    // --- slash commands ------------------------------------------------------
+    // "/name" (no space yet) filters the menu; "/name args" pins the matched
+    // command's usage hint above the box; Enter runs it via send().
+    const allCommands: CommandEntry[] = [ASK_COMMAND, ...commands]
+    const cmdMenuMatch = /^\/([a-zA-Z]*)$/.exec(draft)
+    const cmdQuery = cmdMenuMatch?.[1]?.toLowerCase() ?? null
+    const cmdCandidates = cmdQuery !== null ? allCommands.filter((c) => c.name.startsWith(cmdQuery)) : []
+    const [cmdIndex, setCmdIndex] = useState(0)
+    const [cmdDismissed, setCmdDismissed] = useState(false)
+    const [lastCmdQuery, setLastCmdQuery] = useState<string | null>(null)
+    if (cmdQuery !== lastCmdQuery) {
+        setLastCmdQuery(cmdQuery)
+        setCmdIndex(0)
+        setCmdDismissed(false)
+    }
+    const showCommands = !showMentions && !cmdDismissed && cmdCandidates.length > 0
+    const activeCommand = (() => {
+        const m = /^\/([a-zA-Z]+)\s/.exec(draft)
+        return m ? allCommands.find((c) => c.name === m[1]!.toLowerCase()) ?? null : null
+    })()
+
+    const pickCommand = (c: CommandEntry) => {
+        if (c.args) {
+            // Complete to "/name " — the person types the argument, Enter runs.
+            const next = `/${c.name} `
+            setDraft(next)
+            requestAnimationFrame(() => {
+                const el = ref.current
+                if (!el) return
+                el.focus()
+                el.setSelectionRange(next.length, next.length)
+                setCaret(next.length)
+            })
+        } else {
+            setDraft('')
+            if (c.run) void c.run('')
+        }
+    }
+
     const insertAt = (start: number, end: number, text: string) => {
         const next = `${draft.slice(0, start)}${text}${draft.slice(end)}`
         setDraft(next)
@@ -305,6 +363,36 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
         else insertAt(mentionMatch.start, caret, `@${c.label} `)
     }
 
+    // Markdown formatting shortcuts (⌘B bold, ⌘I italic, ⌘E code, ⌘⇧X
+    // strikethrough): wrap the selection — or an empty caret — in the marker;
+    // fired again on an already-wrapped selection, unwrap (toggle).
+    const wrapSelection = (marker: string) => {
+        const el = ref.current
+        if (!el) return
+        const start = el.selectionStart ?? 0
+        const end = el.selectionEnd ?? start
+        const selected = draft.slice(start, end)
+        const before = draft.slice(0, start)
+        const after = draft.slice(end)
+        const place = (next: string, selStart: number, selEnd: number) => {
+            setDraft(next)
+            requestAnimationFrame(() => {
+                el.focus()
+                el.setSelectionRange(selStart, selEnd)
+                setCaret(selEnd)
+            })
+        }
+        if (before.endsWith(marker) && after.startsWith(marker)) {
+            place(`${before.slice(0, -marker.length)}${selected}${after.slice(marker.length)}`, start - marker.length, end - marker.length)
+        } else if (selected.startsWith(marker) && selected.endsWith(marker) && selected.length >= marker.length * 2) {
+            const inner = selected.slice(marker.length, selected.length - marker.length)
+            place(`${before}${inner}${after}`, start, start + inner.length)
+        } else {
+            // Empty caret lands between the markers, ready to type.
+            place(`${before}${marker}${selected}${marker}${after}`, start + marker.length, end + marker.length)
+        }
+    }
+
     const insertRowboatChip = () => {
         const el = ref.current
         const mention = '@rowboat '
@@ -321,10 +409,32 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
 
     // --- send ----------------------------------------------------------------
     const mentioned = containsRowboatAddress(draft)
-    const send = async () => {
+    const send = async (textOverride?: string) => {
         if (busy || uploading) return
+        const raw = (textOverride ?? draft).trim()
+        // A command draft executes instead of posting. Unknown names fall
+        // through and send as literal text — "/shrug" is somebody's message.
+        if (textOverride === undefined) {
+            const m = COMMAND_RE.exec(raw)
+            const found = m ? allCommands.find((c) => c.name === m[1]!.toLowerCase()) : undefined
+            if (m && found) {
+                const args = (m[2] ?? '').trim()
+                if (!args && found.args) {
+                    toast(`Usage: /${found.name} ${found.args}`, 'info')
+                    return
+                }
+                if (found.run) {
+                    setDraft('')
+                    await found.run(args)
+                    return
+                }
+                // Built-in /ask: rewrite and send through the normal path.
+                await send(`@rowboat ${args}`)
+                return
+            }
+        }
         const ready = attachments.filter((a) => a.status === 'done' && a.hash)
-        const text = encodeMentions(draft.trim(), members)
+        const text = encodeMentions(raw, members)
         // Each attachment lands on the wire as a canonical blob link: images as
         // markdown images (renderers show them inline), the rest as plain links
         // (rendered as download cards). ?name= keeps the display filename;
@@ -341,7 +451,9 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
         // row under the text instead of flowing inline after it.
         const body = [text, attachmentLines.join('\n')].filter(Boolean).join('\n\n')
         if (!body) return
-        const agent: AgentOptions | undefined = mentioned
+        // From the text actually going out — an /ask rewrite mentions @rowboat
+        // even though the draft it came from didn't.
+        const agent: AgentOptions | undefined = containsRowboatAddress(raw)
             ? {
                   ...(model ? { model: { provider: model.provider, model: model.model, ...(model.effort ? { effort: model.effort } : {}) } } : {}),
                   permissionMode,
@@ -367,6 +479,30 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
                 {dragOver && (
                     <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-xl border-2 border-dashed border-foreground/40 bg-background/90 text-sm text-muted-foreground">
                         Drop to attach
+                    </div>
+                )}
+                {showCommands && (
+                    <div className="absolute bottom-full left-0 right-0 z-20 mb-1.5 overflow-hidden rounded-xl border border-border bg-background p-1.5 shadow-sm">
+                        {cmdCandidates.map((c, i) => (
+                            <button
+                                key={c.name}
+                                type="button"
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => pickCommand(c)}
+                                className={cn('flex w-full items-baseline gap-2.5 rounded-lg px-3 py-2 text-left', i === cmdIndex ? 'bg-accent' : 'hover:bg-accent/60')}
+                            >
+                                <span className="shrink-0 font-mono text-sm font-medium">/{c.name}</span>
+                                {c.args && <span className="shrink-0 font-mono text-xs text-muted-foreground">{c.args}</span>}
+                                <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{c.hint}</span>
+                            </button>
+                        ))}
+                        <div className="px-3 pb-1 pt-1.5 text-[11px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
+                    </div>
+                )}
+                {!showCommands && activeCommand && !showMentions && (
+                    <div className="absolute bottom-full left-0 right-0 z-20 mb-1.5 rounded-xl border border-border bg-background px-3 py-2 text-xs text-muted-foreground shadow-sm">
+                        <span className="font-mono text-sm font-medium text-foreground">/{activeCommand.name}</span>
+                        {activeCommand.args && <span className="font-mono text-sm"> {activeCommand.args}</span>} — {activeCommand.hint} · ↵ to run
                     </div>
                 )}
                 {showMentions && (
@@ -447,6 +583,29 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
                     }}
                     onSelect={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
                     onKeyDown={(e) => {
+                        if (showCommands) {
+                            if (e.key === 'ArrowDown') {
+                                e.preventDefault()
+                                setCmdIndex((i) => (i + 1) % cmdCandidates.length)
+                                return
+                            }
+                            if (e.key === 'ArrowUp') {
+                                e.preventDefault()
+                                setCmdIndex((i) => (i - 1 + cmdCandidates.length) % cmdCandidates.length)
+                                return
+                            }
+                            if (e.key === 'Enter' || e.key === 'Tab') {
+                                e.preventDefault()
+                                const c = cmdCandidates[cmdIndex]
+                                if (c) pickCommand(c)
+                                return
+                            }
+                            if (e.key === 'Escape') {
+                                e.preventDefault()
+                                setCmdDismissed(true)
+                                return
+                            }
+                        }
                         if (showMentions) {
                             if (e.key === 'ArrowDown') {
                                 e.preventDefault()
@@ -467,6 +626,17 @@ export function Composer({ placeholder, onSend, busy, autoFocus, onType, seed, m
                             if (e.key === 'Escape') {
                                 e.preventDefault()
                                 setMentionOpen(false)
+                                return
+                            }
+                        }
+                        if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+                            const key = e.key.toLowerCase()
+                            const marker = e.shiftKey
+                                ? key === 'x' ? '~~' : null
+                                : key === 'b' ? '**' : key === 'i' ? '*' : key === 'e' ? '`' : null
+                            if (marker) {
+                                e.preventDefault()
+                                wrapSelection(marker)
                                 return
                             }
                         }

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { ArrowLeft, Check, ChevronRight, Clock, Download, FileText, History, Image as ImageIcon, Loader2, MoreHorizontal, Pencil, Plus, RotateCcw, Trash2, Upload, X } from 'lucide-react'
+import { ArrowLeft, Check, ChevronRight, Clock, Download, Eye, FileText, History, Image as ImageIcon, Loader2, MoreHorizontal, Pencil, Plus, RotateCcw, Trash2, Upload, X } from 'lucide-react'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@/components/ui/context-menu'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -130,18 +131,35 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
             return (
                 <div key={node.path}>
                     <div className="group/dirrow relative" {...dirDragProps(node.path)}>
-                        <button
-                            type="button"
-                            style={pad}
-                            onClick={() => toggle(node.path)}
-                            className={cn(
-                                'flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-[13px] text-foreground/90 hover:bg-accent/50',
-                                dropTarget === node.path && 'bg-accent ring-1 ring-inset ring-foreground/40',
-                            )}
-                        >
-                            <ChevronRight className={cn('size-3 shrink-0 text-muted-foreground transition-transform', open && 'rotate-90')} />
-                            <span className="truncate">{node.name}</span>
-                        </button>
+                        <ContextMenu>
+                            <ContextMenuTrigger asChild>
+                                <button
+                                    type="button"
+                                    style={pad}
+                                    onClick={() => toggle(node.path)}
+                                    className={cn(
+                                        'flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-[13px] text-foreground/90 hover:bg-accent/50',
+                                        dropTarget === node.path && 'bg-accent ring-1 ring-inset ring-foreground/40',
+                                    )}
+                                >
+                                    <ChevronRight className={cn('size-3 shrink-0 text-muted-foreground transition-transform', open && 'rotate-90')} />
+                                    <span className="truncate">{node.name}</span>
+                                </button>
+                            </ContextMenuTrigger>
+                            <ContextMenuContent>
+                                <ContextMenuItem onSelect={() => onStartCreate?.(`${node.path}/`)}>
+                                    <Plus className="size-3.5 mr-2" /> New file
+                                </ContextMenuItem>
+                                {empty && onRemoveFolder && (
+                                    <>
+                                        <ContextMenuSeparator />
+                                        <ContextMenuItem onSelect={() => onRemoveFolder(node.path)}>
+                                            <Trash2 className="size-3.5 mr-2" /> Remove folder
+                                        </ContextMenuItem>
+                                    </>
+                                )}
+                            </ContextMenuContent>
+                        </ContextMenu>
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                                 <button
@@ -200,29 +218,49 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
         }
         return (
             <div key={node.path} className="group/filerow relative">
-                <button
-                    type="button"
-                    style={pad}
-                    draggable
-                    onDragStart={(e) => {
-                        e.dataTransfer.setData(ASSET_DRAG_MIME, node.path)
-                        e.dataTransfer.effectAllowed = 'move'
-                    }}
-                    onDragEnd={() => setDropTarget(null)}
-                    onClick={() => onOpenFile(node.path)}
-                    title={blob ? `${node.name} · ${blob.mime} · ${formatBytes(blob.size)}` : undefined}
-                    className={cn(
-                        'flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-[13px] text-left',
-                        active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
-                    )}
-                >
-                    <span className="w-3 shrink-0" />
-                    {blob && (isImageMime(blob.mime)
-                        ? <ImageIcon className="size-3 shrink-0 text-muted-foreground" />
-                        : <FileText className="size-3 shrink-0 text-muted-foreground" />)}
-                    <span className="truncate flex-1">{node.name}</span>
-                    {unread && !active && <span className="size-1.5 rounded-full bg-foreground shrink-0" aria-label="updated since you last read" />}
-                </button>
+                <ContextMenu>
+                    <ContextMenuTrigger asChild>
+                        <button
+                            type="button"
+                            style={pad}
+                            draggable
+                            onDragStart={(e) => {
+                                e.dataTransfer.setData(ASSET_DRAG_MIME, node.path)
+                                e.dataTransfer.effectAllowed = 'move'
+                            }}
+                            onDragEnd={() => setDropTarget(null)}
+                            onClick={() => onOpenFile(node.path)}
+                            title={blob ? `${node.name} · ${blob.mime} · ${formatBytes(blob.size)}` : undefined}
+                            className={cn(
+                                'flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-[13px] text-left',
+                                active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
+                            )}
+                        >
+                            <span className="w-3 shrink-0" />
+                            {blob && (isImageMime(blob.mime)
+                                ? <ImageIcon className="size-3 shrink-0 text-muted-foreground" />
+                                : <FileText className="size-3 shrink-0 text-muted-foreground" />)}
+                            <span className="truncate flex-1">{node.name}</span>
+                            {unread && !active && <span className="size-1.5 rounded-full bg-foreground shrink-0" aria-label="updated since you last read" />}
+                        </button>
+                    </ContextMenuTrigger>
+                    <ContextMenuContent>
+                        <ContextMenuItem onSelect={() => onOpenFile(node.path)}>
+                            <Eye className="size-3.5 mr-2" /> Open
+                        </ContextMenuItem>
+                        {node.entry && (
+                            <>
+                                <ContextMenuItem onSelect={() => setRenaming({ path: node.path, value: node.path })}>
+                                    <Pencil className="size-3.5 mr-2" /> Rename / move
+                                </ContextMenuItem>
+                                <ContextMenuSeparator />
+                                <ContextMenuItem onSelect={() => setDeleting(node.entry!)}>
+                                    <Trash2 className="size-3.5 mr-2" /> Delete…
+                                </ContextMenuItem>
+                            </>
+                        )}
+                    </ContextMenuContent>
+                </ContextMenu>
                 {node.entry && (
                     <DropdownMenu>
                         <DropdownMenuTrigger asChild>

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Bot, Loader2 } from 'lucide-react'
+import { startTransition, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { ArrowDown, Bot, Loader2 } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { Composer, type AgentOptions } from '@/components/spaces/composer'
 import { MemberName } from '@/components/spaces/member-text'
@@ -10,7 +10,7 @@ import {
     removeGeneralMessage, resolvePendingGeneralMessage, updateGeneralMessage, usePresenceSender,
 } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
-import { dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
+import { applyReaction, dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
 import { resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
@@ -21,14 +21,14 @@ import { containsRowboatAddress } from '@/lib/spaces-mentions'
 // Messages — the space's open stream. What people say, in order; a message
 // that gets replies becomes a topic (shown as a row under it here).
 
-/** Scroll position per space, so coming back (a topic, a file, the top ‹ ›) lands where you were. */
-const scrollMemory = new Map<string, number>()
+/** The first frame renders a short tail — markdown is the paint cost; the full window follows right after. */
+const FIRST_PAINT_CAP = 16
 
-/** How many messages render at first; the data is local, so expanding is instant. */
+/** The steady-state window; the data is local, so expanding is instant. */
 const RENDER_CAP = 100
 
 export function GeneralStream({
-    org, space, general, threads, topics, presence, members, memberNames, entries = [], onOpenThread, onStartThread, onOpenSession,
+    org, space, general, threads, topics, presence, members, memberNames, entries = [], onOpenThread, onStartThread, onOpenSession, visible = true,
 }: {
     org: OrgWithSpaces
     space: spaces.Space
@@ -44,12 +44,18 @@ export function GeneralStream({
     /** Reply on a message with no thread yet — open a draft pane (no topic until first send). */
     onStartThread: (parent: spaces.Message) => void
     onOpenSession?: (sessionId: string) => void
+    /**
+     * The keep-alive flag: the stream stays MOUNTED while a topic, a file, or
+     * another app section covers it, and this goes false. Hidden means no
+     * presence lease, no read marks — the reader isn't actually looking.
+     */
+    visible?: boolean
 }) {
     const [seed, setSeed] = useState<{ text: string; nonce: number } | null>(null)
     const scrollRef = useRef<HTMLDivElement | null>(null)
     const bottomRef = useRef<HTMLDivElement | null>(null)
     const generalId = general.topic?.id ?? null
-    const { onType } = usePresenceSender(org.id, space.id, generalId ?? undefined)
+    const { onType } = usePresenceSender(org.id, space.id, generalId ?? undefined, visible)
 
     // Agents invoked straight from the stream hold their working lease on the
     // stream's own topic — surface it here, typing-indicator position.
@@ -65,41 +71,74 @@ export function GeneralStream({
         }
     }
 
-    // "New" divider: snapshot the read mark when general opens; mark read from then on.
+    // "New" divider: snapshot the read mark when general opens; mark read from
+    // then on — but only while actually on screen. A kept-alive hidden stream
+    // must not mark messages read as they arrive; the flip back to visible
+    // re-runs this and marks the catch-up read.
     const [newSince] = useState<string | null>(() => (generalId ? getTopicLastReadAt(org.id, space.id, generalId) : null))
     useEffect(() => {
-        if (!generalId || !general.ready) return
+        if (!visible || !generalId || !general.ready) return
         markTopicRead(org.id, space.id, generalId)
-    }, [org.id, space.id, generalId, general.ready, general.messages.length])
+    }, [org.id, space.id, generalId, general.ready, general.messages.length, visible])
 
-    // First paint: restore the remembered position (or start at the bottom).
-    // After that: keep the tail in view when new messages land, unless the
-    // reader scrolled up. Remember the position on the way out.
+    // First paint: start at the bottom — the newest messages, always. After
+    // that: keep the tail in view when new messages land, unless the reader
+    // scrolled up.
     const memoryKey = `${org.id}/${space.id}`
     const restoredRef = useRef(false)
     const lastScrollTopRef = useRef<number | null>(null)
+    // Only a scroll the READER made may turn follow-mode off. The browser
+    // fires scroll events of its own: scroll anchoring compensates when a
+    // lazy image finishes and its tile row wraps taller, and that event lands
+    // mid-stream — indistinguishable from a reader scroll by position alone.
+    // So track intent: wheel/touch stamps a time, a pointer held down (the
+    // scrollbar, a text-selection drag) counts for as long as it's down.
+    const userScrollAtRef = useRef(0)
+    const pointerDownRef = useRef(false)
+    useEffect(() => {
+        const up = () => {
+            pointerDownRef.current = false
+        }
+        window.addEventListener('pointerup', up)
+        window.addEventListener('pointercancel', up)
+        return () => {
+            window.removeEventListener('pointerup', up)
+            window.removeEventListener('pointercancel', up)
+        }
+    }, [])
     // Layout effect: the anchor lands before paint — no flash of the top.
     useLayoutEffect(() => {
         const el = scrollRef.current
         if (!el || !general.ready) return
         if (!restoredRef.current) {
             restoredRef.current = true
-            const saved = scrollMemory.get(memoryKey)
-            // A saved position is never the bottom (bottom deletes it) — mark
-            // follow-mode off NOW, before the scroll event lands, so the tail
-            // pin can't yank a restored position down meanwhile.
-            if (saved !== undefined) lastScrollTopRef.current = saved
-            el.scrollTop = saved ?? el.scrollHeight
+            el.scrollTop = el.scrollHeight
             return
         }
         const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160
         if (nearBottom) bottomRef.current?.scrollIntoView({ block: 'end' })
-    }, [general.ready, general.messages.length, presence.typing, workingHere.length, memoryKey])
-    useEffect(() => {
-        return () => {
-            if (lastScrollTopRef.current !== null) scrollMemory.set(memoryKey, lastScrollTopRef.current)
-        }
-    }, [memoryKey])
+    }, [general.ready, general.messages.length, presence.typing, workingHere.length])
+    // The "jump to latest" pill: shown once the reader is meaningfully away
+    // from the tail, with a count of messages that arrived below since they
+    // left it. lastSeen tracks the newest offset that was ever on screen at
+    // the bottom (updated by the scroll events the pins fire).
+    const [awayFromBottom, setAwayFromBottom] = useState(false)
+    const lastSeenOffsetRef = useRef(-1)
+    const jumpToLatest = () => {
+        const el = scrollRef.current
+        if (el) el.scrollTop = el.scrollHeight
+    }
+    // Coming back from hidden (keep-alive): display:none dropped the scroll
+    // geometry, so put it back before paint — the remembered spot if the
+    // reader had scrolled up, else the bottom (following).
+    const wasVisibleRef = useRef(visible)
+    useLayoutEffect(() => {
+        const was = wasVisibleRef.current
+        wasVisibleRef.current = visible
+        const el = scrollRef.current
+        if (!el || !visible || was || !restoredRef.current) return
+        el.scrollTop = lastScrollTopRef.current ?? el.scrollHeight
+    }, [visible])
 
     const topicsById = useMemo(() => new Map(topics.map((t) => [t.id, t])), [topics])
 
@@ -170,9 +209,15 @@ export function GeneralStream({
     }
 
     // Toggle: add when the viewer isn't in the group yet, remove when they are.
+    // Optimistic — the chip moves the instant it's clicked; the org's answer
+    // replaces it right behind, and a failure puts the old state back.
     const toggleReaction = async (message: spaces.Message, emoji: string) => {
         const mine = (message.reactions ?? []).find((g) => g.emoji === emoji)?.memberIds.includes(org.memberId)
         const action = mine ? 'remove' : 'add'
+        updateGeneralMessage(org.id, space.id, {
+            ...message,
+            reactions: applyReaction(message.reactions, { emoji, memberId: org.memberId, action: action === 'add' ? 'added' : 'removed' }),
+        })
         try {
             const { message: updated } = await window.ipc.invoke('spaces:reactToMessage', {
                 orgId: org.id, spaceId: space.id, messageId: message.id, emoji, action,
@@ -180,6 +225,7 @@ export function GeneralStream({
             updateGeneralMessage(org.id, space.id, updated)
             analytics.spacesReactionToggled({ action })
         } catch (err) {
+            updateGeneralMessage(org.id, space.id, message)
             toast(err instanceof Error ? err.message : 'Could not react', 'error')
         }
     }
@@ -190,6 +236,21 @@ export function GeneralStream({
             toast('Link copied', 'success')
         } catch {
             toast('Could not copy the link', 'error')
+        }
+    }
+
+    // Optimistic rewrite, same shape as reactions: the new body renders on
+    // save; the org's answer (or a failure revert) reconciles right behind.
+    const editMessage = async (message: spaces.Message, body: string) => {
+        updateGeneralMessage(org.id, space.id, { ...message, body, editedAt: new Date().toISOString() })
+        try {
+            const { message: updated } = await window.ipc.invoke('spaces:editMessage', {
+                orgId: org.id, spaceId: space.id, messageId: message.id, body,
+            })
+            updateGeneralMessage(org.id, space.id, updated)
+        } catch (err) {
+            updateGeneralMessage(org.id, space.id, message)
+            toast(err instanceof Error ? err.message : 'Could not edit', 'error')
         }
     }
 
@@ -213,8 +274,20 @@ export function GeneralStream({
         () => general.messages.filter((m, i) => !(general.topic && isGeneralSeedMessage(general.topic, m, i))),
         [general.messages, general.topic],
     )
-    const [renderCap, setRenderCap] = useState(RENDER_CAP)
-    useEffect(() => setRenderCap(RENDER_CAP), [memoryKey])
+    const [renderCap, setRenderCap] = useState(FIRST_PAINT_CAP)
+    useEffect(() => setRenderCap(FIRST_PAINT_CAP), [memoryKey])
+    // The short tail is on screen — widen to the full window right after, as
+    // a TRANSITION: React time-slices the ~70 extra markdown rows instead of
+    // blocking input for one long commit. The rows prepend above the
+    // viewport; the tail pin below keeps the bottom in view, so the reader
+    // never sees the reflow.
+    useEffect(() => {
+        if (!general.ready) return
+        const raf = requestAnimationFrame(() => {
+            startTransition(() => setRenderCap((c) => Math.max(c, RENDER_CAP)))
+        })
+        return () => cancelAnimationFrame(raf)
+    }, [general.ready, memoryKey])
     const hiddenCount = Math.max(0, streamMessages.length - renderCap)
     const visibleMessages = hiddenCount > 0 ? streamMessages.slice(hiddenCount) : streamMessages
 
@@ -336,6 +409,7 @@ export function GeneralStream({
                 onCopyLink={(m) => void copyLink(m)}
                 onReact={(m, emoji) => void toggleReaction(m, emoji)}
                 onDelete={(m) => void deleteMessage(m)}
+                onEdit={(m, body) => void editMessage(m, body)}
                 onRetryFailed={retryFailed}
                 onDiscardFailed={discardFailed}
             />,
@@ -353,15 +427,47 @@ export function GeneralStream({
                 <span className="flex-1" />
                 {general.error && <span className="text-xs text-destructive truncate" title={general.error}>messages unavailable</span>}
             </div>
+            <div className="relative flex-1 min-h-0 flex flex-col">
             <div
                 ref={scrollRef}
                 className="flex-1 min-h-0 overflow-y-auto px-3 pb-1"
+                onWheel={() => {
+                    userScrollAtRef.current = performance.now()
+                }}
+                onTouchMove={() => {
+                    userScrollAtRef.current = performance.now()
+                }}
+                onPointerDown={() => {
+                    pointerDownRef.current = true
+                }}
                 onScroll={(e) => {
                     const el = e.currentTarget
-                    // At the bottom = "follow the tail"; remember that as "no saved position".
-                    lastScrollTopRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 8 ? null : el.scrollTop
-                    if (lastScrollTopRef.current === null) scrollMemory.delete(memoryKey)
-                    if (el.scrollTop < 80) loadEarlier()
+                    const fromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+                    const userScroll = pointerDownRef.current || performance.now() - userScrollAtRef.current < 250
+                    setAwayFromBottom(fromBottom > 200)
+                    if (fromBottom < 8) {
+                        // At the bottom = "follow the tail" — and everything
+                        // settled so far counts as seen.
+                        for (let i = general.messages.length - 1; i >= 0; i--) {
+                            const m = general.messages[i]!
+                            if (m.pending || m.failed) continue
+                            lastSeenOffsetRef.current = Math.max(lastSeenOffsetRef.current, m.offset)
+                            break
+                        }
+                        lastScrollTopRef.current = null
+                    } else if (userScroll || lastScrollTopRef.current !== null) {
+                        lastScrollTopRef.current = el.scrollTop
+                    } else if (!pendingRestoreRef.current) {
+                        // A scroll the reader didn't make, while following the
+                        // tail — anchoring's compensation for a late layout.
+                        // Re-pin the bottom; never let it unfollow.
+                        el.scrollTop = el.scrollHeight
+                    }
+                    // No auto-backfill off the first short-tail frame: on a tall
+                    // viewport its initial bottom pin can land under the 80px
+                    // line and this would fire before the cap lifts to the full
+                    // window — wait for that lift instead.
+                    if (el.scrollTop < 80 && renderCap >= RENDER_CAP) loadEarlier()
                 }}
             >
                 {/* One measurable child — the tail pin observes its size. */}
@@ -392,9 +498,26 @@ export function GeneralStream({
                 <div ref={bottomRef} />
                 </div>
             </div>
+            {awayFromBottom && (() => {
+                const unseen = streamMessages.filter(
+                    (m) => m.offset > lastSeenOffsetRef.current && !m.pending && !m.failed && m.author.memberId !== org.memberId,
+                ).length
+                return (
+                    <button
+                        type="button"
+                        onClick={jumpToLatest}
+                        className="absolute bottom-3 left-1/2 z-20 inline-flex -translate-x-1/2 animate-in fade-in slide-in-from-bottom-2 items-center gap-1.5 rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium shadow-md hover:bg-accent"
+                    >
+                        {unseen > 0 ? `${unseen} new ${unseen === 1 ? 'message' : 'messages'}` : 'Latest'}
+                        <ArrowDown className="size-3" />
+                    </button>
+                )
+            })()}
+            </div>
             <Composer
                 placeholder={`Message ${space.name} — @rowboat to ask your agent`}
                 busy={!generalId}
+                draftKey={memoryKey}
                 onSend={post}
                 onType={onType}
                 seed={seed}

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -1,10 +1,11 @@
 import { startTransition, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { ArrowDown, Bot, Loader2 } from 'lucide-react'
+import { ArrowDown, Bot, Loader2, ShieldAlert } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { Composer, type AgentOptions } from '@/components/spaces/composer'
 import { MemberName } from '@/components/spaces/member-text'
 import { DayDivider, MessageRow, NewDivider, TypingIndicator, type ThreadRowData } from '@/components/spaces/message-row'
 import type { GeneralState, SpacePresence, ThreadIndex } from '@/hooks/use-space-chat'
+import { useTopicAgentPermissionWait } from '@/hooks/use-topic-agent-permission'
 import {
     buildPendingMessage, failPendingGeneralMessage, ingestGeneralMessage, loadOlderGeneralMessages,
     removeGeneralMessage, resolvePendingGeneralMessage, updateGeneralMessage, usePresenceSender,
@@ -12,7 +13,7 @@ import {
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { applyReaction, dayKey, explicitTitle, formatDayLabel, isContinuation, isGeneralSeedMessage } from '@/lib/spaces-conventions'
 import { resolveMentions } from '@/lib/spaces-presentation'
-import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
+import { getTopicLastReadAt, markRead, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
 import { toast } from '@/lib/toast'
 import * as analytics from '@/lib/analytics'
@@ -26,6 +27,11 @@ const FIRST_PAINT_CAP = 16
 
 /** The steady-state window; the data is local, so expanding is instant. */
 const RENDER_CAP = 100
+
+/** How long the New line lingers once the reader has caught up with it. */
+const NEW_LINGER_MS = 5_000
+/** Clear delay after the fade starts — must outlast the divider's duration-700. */
+const NEW_FADE_MS = 800
 
 export function GeneralStream({
     org, space, general, threads, topics, presence, members, memberNames, entries = [], onOpenThread, onStartThread, onOpenSession, visible = true,
@@ -60,6 +66,11 @@ export function GeneralStream({
     // Agents invoked straight from the stream hold their working lease on the
     // stream's own topic — surface it here, typing-indicator position.
     const workingHere = presence.working.get(generalId ?? '') ?? []
+    // Your own agent, blocked mid-turn on a tool permission: surface it here
+    // instead of letting it idle behind a "working…" spinner (or silence).
+    const permissionWait = useTopicAgentPermissionWait(org.id, space.id, generalId, visible)
+    // While blocked, the amber pill replaces the own-agent spinner.
+    const spinningHere = permissionWait.length > 0 ? workingHere.filter((id) => id !== org.memberId) : workingHere
     const openStreamSession = async () => {
         if (!generalId) return
         try {
@@ -75,7 +86,19 @@ export function GeneralStream({
     // then on — but only while actually on screen. A kept-alive hidden stream
     // must not mark messages read as they arrive; the flip back to visible
     // re-runs this and marks the catch-up read.
-    const [newSince] = useState<string | null>(() => (generalId ? getTopicLastReadAt(org.id, space.id, generalId) : null))
+    const [newSince, setNewSince] = useState<string | null>(() => (generalId ? getTopicLastReadAt(org.id, space.id, generalId) : null))
+    const [newFading, setNewFading] = useState(false)
+    // Each return to the stream re-arms the line at the catch-up point: the
+    // read mark as it stood while hidden. Declared BEFORE the mark-read
+    // effect below — same flip, and the snapshot must win the race.
+    const newArmedVisibleRef = useRef(visible)
+    useEffect(() => {
+        const was = newArmedVisibleRef.current
+        newArmedVisibleRef.current = visible
+        if (!visible || was || !generalId) return
+        setNewFading(false)
+        setNewSince(getTopicLastReadAt(org.id, space.id, generalId))
+    }, [visible, org.id, space.id, generalId])
     useEffect(() => {
         if (!visible || !generalId || !general.ready) return
         markTopicRead(org.id, space.id, generalId)
@@ -117,7 +140,7 @@ export function GeneralStream({
         }
         const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160
         if (nearBottom) bottomRef.current?.scrollIntoView({ block: 'end' })
-    }, [general.ready, general.messages.length, presence.typing, workingHere.length])
+    }, [general.ready, general.messages.length, presence.typing, workingHere.length, permissionWait.length])
     // The "jump to latest" pill: shown once the reader is meaningfully away
     // from the tail, with a count of messages that arrived below since they
     // left it. lastSeen tracks the newest offset that was ever on screen at
@@ -128,6 +151,23 @@ export function GeneralStream({
         const el = scrollRef.current
         if (el) el.scrollTop = el.scrollHeight
     }
+    // Once the reader is with the new messages (on screen, at the tail) the
+    // line has done its job: linger a beat, fade, drop. Keep-alive means no
+    // remount ever resets it — without this it would sit in history forever.
+    const hasNewLine = !!newSince && general.messages.some((m) => m.postedAt > newSince && m.author.memberId !== org.memberId)
+    useEffect(() => {
+        if (!visible || !general.ready || awayFromBottom || !hasNewLine || newFading) return
+        const t = window.setTimeout(() => setNewFading(true), NEW_LINGER_MS)
+        return () => window.clearTimeout(t)
+    }, [visible, general.ready, awayFromBottom, hasNewLine, newFading])
+    useEffect(() => {
+        if (!newFading) return
+        const t = window.setTimeout(() => {
+            setNewSince(null)
+            setNewFading(false)
+        }, NEW_FADE_MS)
+        return () => window.clearTimeout(t)
+    }, [newFading])
     // Coming back from hidden (keep-alive): display:none dropped the scroll
     // geometry, so put it back before paint — the remembered spot if the
     // reader had scrolled up, else the bottom (following).
@@ -391,7 +431,7 @@ export function GeneralStream({
             prev = undefined
         }
         if (!newShown && newSince && message.postedAt > newSince && message.author.memberId !== org.memberId) {
-            rows.push(<NewDivider key="new" />)
+            rows.push(<NewDivider key="new" fading={newFading} />)
             newShown = true
             prev = undefined
         }
@@ -479,9 +519,24 @@ export function GeneralStream({
                     <div className="px-2 py-6 text-sm text-muted-foreground">Nothing here yet — say hello, or @rowboat to ask your agent.</div>
                 )}
                 {rows}
-                {workingHere.length > 0 && (
+                {/* Your agent is stopped, not working — it wants an answer. */}
+                {permissionWait.length > 0 && (
                     <div className="flex flex-wrap items-center gap-2 pl-10 pt-1">
-                        {workingHere.map((memberId) => {
+                        <button
+                            type="button"
+                            onClick={() => void openStreamSession()}
+                            title="Open the agent session to review the request"
+                            className="flex items-center gap-1.5 rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 hover:bg-amber-500/20 dark:text-amber-400"
+                        >
+                            <ShieldAlert className="size-3" />
+                            Your Rowboat needs permission — {permissionWait[0]}
+                            {permissionWait.length > 1 ? ` +${permissionWait.length - 1} more` : ''} · Review
+                        </button>
+                    </div>
+                )}
+                {spinningHere.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-2 pl-10 pt-1">
+                        {spinningHere.map((memberId) => {
                             const own = memberId === org.memberId
                             const label = own ? 'Your Rowboat is working…' : <><MemberName id={memberId} />’s Rowboat is working…</>
                             return own ? (
@@ -524,6 +579,31 @@ export function GeneralStream({
                 members={members}
                 entries={entries}
                 selfMemberId={org.memberId}
+                commands={[
+                    {
+                        name: 'invite',
+                        hint: 'Copy an invite link to this space',
+                        run: async () => {
+                            try {
+                                const result = await window.ipc.invoke('spaces:createInvite', { orgId: org.id, spaceId: space.id })
+                                await navigator.clipboard.writeText(result.link)
+                                toast('Invite link copied to clipboard', 'success')
+                            } catch (err) {
+                                toast(err instanceof Error ? err.message : 'Could not create an invite', 'error')
+                            }
+                        },
+                    },
+                    {
+                        name: 'read',
+                        hint: 'Mark everything in this space read',
+                        run: () => {
+                            markRead(org.id, space.id)
+                            if (general.topic) markTopicRead(org.id, space.id, general.topic.id)
+                            for (const t of topics) markTopicRead(org.id, space.id, t.id)
+                            toast('Marked read', 'success')
+                        },
+                    },
+                ]}
             />
         </section>
     )

--- a/apps/x/apps/renderer/src/components/spaces/link-preview-card.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/link-preview-card.tsx
@@ -1,0 +1,57 @@
+import { useMemo, useState } from 'react'
+import { useLinkPreview } from '@/hooks/use-link-preview'
+import { isDirectImageUrl } from '@/components/spaces/space-markdown'
+import { isTrustedDomain, linkDomain } from '@/lib/trusted-domains'
+
+// Discord-style unfurl under a message: site, title, description, thumbnail.
+// Only links on TRUSTED domains unfurl — a preview is a silent network
+// request, and the trust gate on clicks would mean nothing if every posted
+// URL got fetched anyway. One card per message (the first qualifying link).
+
+/** The message's first https link worth a card — skips image tiles and untrusted domains. */
+function firstPreviewUrl(body: string): string | null {
+    const m = /https:\/\/[^\s<>)"'\]]+/.exec(body)
+    if (!m) return null
+    const url = m[0].replace(/[.,;:!?]+$/, '')
+    if (isDirectImageUrl(url)) return null
+    const domain = linkDomain(url)
+    return domain && isTrustedDomain(domain) ? url : null
+}
+
+export function MessageLinkPreview({ body }: { body: string }) {
+    const url = useMemo(() => firstPreviewUrl(body), [body])
+    const preview = useLinkPreview(url)
+    const [imageFailed, setImageFailed] = useState(false)
+    if (!url || !preview) return null
+    const open = () => window.open(preview.url)
+    return (
+        <div className="mt-1 flex max-w-md items-start gap-3 rounded-lg border-l-4 border-l-blue-500/70 bg-muted/40 py-2 pl-3 pr-3">
+            <div className="min-w-0 flex-1">
+                {preview.siteName && <div className="text-[11px] text-muted-foreground">{preview.siteName}</div>}
+                {preview.title && (
+                    <button
+                        type="button"
+                        onClick={open}
+                        title={preview.url}
+                        className="block max-w-full truncate text-left text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                        {preview.title}
+                    </button>
+                )}
+                {preview.description && (
+                    <div className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">{preview.description}</div>
+                )}
+            </div>
+            {preview.imageUrl && !imageFailed && (
+                <img
+                    src={preview.imageUrl}
+                    alt=""
+                    loading="lazy"
+                    onError={() => setImageFailed(true)}
+                    onClick={open}
+                    className="size-16 shrink-0 cursor-pointer rounded-md border border-border object-cover"
+                />
+            )}
+        </div>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Bot, ChevronRight, Link as LinkIcon, Loader2, MessageSquare, MoreHorizontal, SmilePlus, Trash2 } from 'lucide-react'
+import { memo, useState } from 'react'
+import { Bot, ChevronRight, Copy, Link as LinkIcon, Loader2, MessageSquare, MoreHorizontal, Pencil, SmilePlus, Trash2 } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -11,9 +11,11 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Textarea } from '@/components/ui/textarea'
 import { MemberAvatar } from '@/components/spaces/atoms'
 import { SpaceMarkdown } from '@/components/spaces/space-markdown'
-import { formatFeedTime } from '@/lib/spaces-presentation'
+import { formatFeedTime, formatFullTimestamp, resolveMentions } from '@/lib/spaces-presentation'
+import { toast } from '@/lib/toast'
 
 // One message in a stream (general or a thread). Consecutive messages by the
 // same author compact to a time gutter; hover reveals the action bar.
@@ -44,7 +46,7 @@ function ReactionPicker({ onPick, onOpenChange, children }: {
                                 setBoth(false)
                                 onPick(emoji)
                             }}
-                            className="inline-flex size-7 items-center justify-center rounded-md text-base hover:bg-accent"
+                            className="inline-flex size-7 items-center justify-center rounded-md text-base transition-transform duration-100 hover:bg-accent hover:scale-125 active:scale-95"
                         >
                             {emoji}
                         </button>
@@ -80,15 +82,17 @@ function ReactionChips({ message, memberNames, selfMemberId, onReact, onPickerOp
                 return (
                     <HoverCard key={group.emoji} openDelay={250} closeDelay={100}>
                         <HoverCardTrigger asChild>
+                            {/* The chip zooms in when the group appears; the emoji
+                                re-pops (keyed remount) every time the count moves. */}
                             <button
                                 type="button"
                                 onClick={() => onReact(message, group.emoji)}
                                 className={cn(
-                                    'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5',
+                                    'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 transition-all duration-150 animate-in fade-in-0 zoom-in-50 active:scale-90',
                                     mine ? 'border-foreground/40 bg-accent' : 'border-border bg-background hover:border-foreground/30',
                                 )}
                             >
-                                <span className="text-[13px] leading-none">{group.emoji}</span>
+                                <span key={group.memberIds.length} className="text-[13px] leading-none animate-in zoom-in-50 duration-300">{group.emoji}</span>
                                 <span className="text-[11px] font-medium leading-none tabular-nums text-muted-foreground">{group.memberIds.length}</span>
                             </button>
                         </HoverCardTrigger>
@@ -138,8 +142,8 @@ export interface ThreadRowData {
     title?: string | null
 }
 
-export function MessageRow({
-    message, memberNames, continuation, thread, onOpenThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onRetryFailed, onDiscardFailed, dense, selfMemberId,
+function MessageRowImpl({
+    message, memberNames, continuation, thread, onOpenThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onRetryFailed, onDiscardFailed, dense, selfMemberId,
 }: {
     message: spaces.Message & { pending?: boolean; failed?: boolean }
     memberNames: Map<string, string>
@@ -156,6 +160,8 @@ export function MessageRow({
     onReact?: (message: spaces.Message, emoji: string) => void
     /** Deletes the message — only offered on the viewer's own (the org enforces it too). */
     onDelete?: (message: spaces.Message) => void
+    /** Rewrites the body — only offered on the viewer's own text messages. */
+    onEdit?: (message: spaces.Message, body: string) => void
     /** A failed optimistic send: try it again / drop the row. */
     onRetryFailed?: (message: spaces.Message) => void
     onDiscardFailed?: (message: spaces.Message) => void
@@ -173,6 +179,14 @@ export function MessageRow({
     // can act on them either.
     const unconfirmed = !!message.pending || !!message.failed
     const canDelete = !!onDelete && !deleted && !unconfirmed && selfMemberId === message.author.memberId
+    const canEdit = !!onEdit && !deleted && !unconfirmed && selfMemberId === message.author.memberId
+    // The inline editor: null = not editing; a string = the draft body.
+    const [editDraft, setEditDraft] = useState<string | null>(null)
+    const commitEdit = () => {
+        const text = (editDraft ?? '').trim()
+        setEditDraft(null)
+        if (text && text !== message.body) onEdit!(message, text)
+    }
     const showActions = !deleted && !unconfirmed && !!(onReplyInThread || onAskRowboat || onCopyLink || onReact || canDelete)
     // While the emoji picker or the ⋯ menu is open the hover-revealed chrome
     // must stay put — unmounting it collapses the popper anchor and the menu
@@ -180,10 +194,23 @@ export function MessageRow({
     const [pickerOpen, setPickerOpen] = useState(false)
     const [menuOpen, setMenuOpen] = useState(false)
 
+    // What "Copy message" copies: mentions resolved to names, image embeds
+    // dropped — their app:// addresses mean nothing outside the app. Empty
+    // (image-only message, tombstone) hides the item.
+    const messageText = deleted || unconfirmed ? '' : resolveMentions(message.body, memberNames).replace(/!\[[^\]]*\]\([^)]*\)/g, '').trim()
+    // The selection as it stood when the context menu opened (opening keeps it).
+    const [selectionText, setSelectionText] = useState('')
+    const copyToClipboard = (text: string) => {
+        void navigator.clipboard.writeText(text).then(
+            () => toast('Copied', 'success'),
+            () => toast('Could not copy', 'error'),
+        )
+    }
+
     const row = (
         <div className={cn('group/msg relative flex items-start gap-2.5 rounded-lg px-2 hover:bg-accent/40', continuation ? 'py-0.5' : 'py-1.5')}>
             {continuation ? (
-                <span className={cn('shrink-0 pt-1 text-right text-[10px] leading-5 text-muted-foreground/0 group-hover/msg:text-muted-foreground', gutter)}>
+                <span title={formatFullTimestamp(message.postedAt)} className={cn('shrink-0 pt-1 text-right text-[10px] leading-5 text-muted-foreground/0 group-hover/msg:text-muted-foreground', gutter)}>
                     {formatFeedTime(message.postedAt).replace(/^Yesterday /, '')}
                 </span>
             ) : (
@@ -198,14 +225,39 @@ export function MessageRow({
                                 via {message.author.agentName ?? 'agent'}{message.author.actingMode === 'scheduled' ? ', scheduled' : ''}
                             </span>
                         )}
-                        <span className="text-muted-foreground">{formatFeedTime(message.postedAt)}</span>
+                        <span title={formatFullTimestamp(message.postedAt)} className="text-muted-foreground">{formatFeedTime(message.postedAt)}</span>
                     </div>
                 )}
-                {deleted ? (
+                {editDraft !== null ? (
+                    <div className="mt-1">
+                        <Textarea
+                            autoFocus
+                            value={editDraft}
+                            onChange={(e) => setEditDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' && !e.shiftKey) {
+                                    e.preventDefault()
+                                    commitEdit()
+                                } else if (e.key === 'Escape') {
+                                    setEditDraft(null)
+                                }
+                            }}
+                            className="min-h-16 text-sm"
+                        />
+                        <div className="mt-1 flex items-center gap-2 text-xs">
+                            <button type="button" onClick={commitEdit} className="rounded-md bg-foreground px-2 py-0.5 font-medium text-background hover:opacity-90">Save</button>
+                            <button type="button" onClick={() => setEditDraft(null)} className="text-muted-foreground hover:text-foreground">Cancel</button>
+                            <span className="text-muted-foreground/70">Enter to save · Esc to cancel</span>
+                        </div>
+                    </div>
+                ) : deleted ? (
                     <div className="text-sm italic leading-relaxed text-muted-foreground">This message was deleted</div>
                 ) : (
                     <div className={cn(MESSAGE_PROSE, message.pending && 'opacity-60')}>
                         <SpaceMarkdown body={message.body} />
+                        {message.editedAt && (
+                            <span title={formatFullTimestamp(message.editedAt)} className="text-[10.5px] text-muted-foreground/70">(edited)</span>
+                        )}
                     </div>
                 )}
                 {message.failed && (
@@ -233,10 +285,13 @@ export function MessageRow({
                     />
                 )}
                 {thread && thread.replyCount > 0 && onOpenThread && (
+                    // A full-width row, not a snug chip: opening the thread is
+                    // the most common follow-up and deserves a target the size
+                    // of the message itself.
                     <button
                         type="button"
                         onClick={() => onOpenThread(thread.topicId)}
-                        className="mt-1.5 inline-flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1 text-xs hover:border-foreground/30"
+                        className="group/thread mt-1.5 flex w-full max-w-2xl items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5 text-left text-xs transition-colors hover:border-foreground/30 hover:bg-accent/40"
                     >
                         <MessageSquare className="size-3 text-muted-foreground" />
                         {thread.title && <span className="max-w-48 truncate font-semibold">{thread.title}</span>}
@@ -244,7 +299,7 @@ export function MessageRow({
                             {thread.replyCount} {thread.replyCount === 1 ? 'reply' : 'replies'}
                         </span>
                         {thread.unreadCount > 0 && <span className="font-semibold text-orange-600">{thread.unreadCount} new</span>}
-                        <span className="text-muted-foreground">{formatFeedTime(thread.lastActivityAt)}</span>
+                        <span title={formatFullTimestamp(thread.lastActivityAt)} className="text-muted-foreground">{formatFeedTime(thread.lastActivityAt)}</span>
                         {thread.workingAgents.length > 0 && (
                             <span className="inline-flex items-center gap-1 text-muted-foreground">
                                 <Bot className="size-3" />
@@ -255,7 +310,12 @@ export function MessageRow({
                                     : `${thread.workingAgents.length} agents working…`}
                             </span>
                         )}
-                        {thread.unreadCount > 0 ? <span className="size-1.5 rounded-full bg-foreground" /> : <ChevronRight className="size-3 text-muted-foreground" />}
+                        <span className="flex-1" />
+                        {thread.unreadCount > 0 ? (
+                            <span className="size-1.5 rounded-full bg-foreground" />
+                        ) : (
+                            <ChevronRight className="size-3 text-muted-foreground transition-transform group-hover/thread:translate-x-0.5" />
+                        )}
                     </button>
                 )}
                 {thread && thread.replyCount === 0 && thread.workingAgents.length > 0 && onOpenThread && (
@@ -282,13 +342,16 @@ export function MessageRow({
                         </ReactionPicker>
                     )}
                     {onReplyInThread && (
+                        // Labelled, not icon-only: replying is THE core action
+                        // and a bare glyph made people hunt for it.
                         <button
                             type="button"
                             title={thread && thread.replyCount > 0 ? 'Open topic' : 'Reply — starts a topic'}
                             onClick={() => (thread && thread.replyCount > 0 && onOpenThread ? onOpenThread(thread.topicId) : onReplyInThread(message))}
-                            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                            className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
                         >
                             <MessageSquare className="size-3.5" />
+                            {thread && thread.replyCount > 0 ? 'Open' : 'Reply'}
                         </button>
                     )}
                     {onAskRowboat && (
@@ -301,7 +364,7 @@ export function MessageRow({
                             <Bot className="size-3.5" />
                         </button>
                     )}
-                    {(onCopyLink || canDelete) && (
+                    {(onCopyLink || canDelete || canEdit) && (
                         <DropdownMenu onOpenChange={setMenuOpen}>
                             <DropdownMenuTrigger asChild>
                                 <button type="button" title="More" className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground">
@@ -309,6 +372,16 @@ export function MessageRow({
                                 </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
+                                {canEdit && (
+                                    <DropdownMenuItem onClick={() => setEditDraft(message.body)}>
+                                        <Pencil className="size-3.5 mr-2" /> Edit message
+                                    </DropdownMenuItem>
+                                )}
+                                {messageText && (
+                                    <DropdownMenuItem onClick={() => copyToClipboard(messageText)}>
+                                        <Copy className="size-3.5 mr-2" /> Copy message
+                                    </DropdownMenuItem>
+                                )}
                                 {onCopyLink && (
                                     <DropdownMenuItem onClick={() => onCopyLink(message)}>
                                         <LinkIcon className="size-3.5 mr-2" /> Copy link
@@ -332,11 +405,16 @@ export function MessageRow({
     // under it kept catching accidental clicks. Tombstones and action-less
     // rows get the plain row.
     if (!showActions) return row
-    const hasTopItems = !!(onReact || onReplyInThread || onAskRowboat || onCopyLink)
+    const hasTopItems = !!(onReact || onReplyInThread || onAskRowboat || onCopyLink || messageText)
     return (
-        <ContextMenu>
+        <ContextMenu onOpenChange={(open) => { if (open) setSelectionText(window.getSelection()?.toString().trim() ?? '') }}>
             <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
             <ContextMenuContent className="w-56">
+                {selectionText && (
+                    <ContextMenuItem onSelect={() => copyToClipboard(selectionText)}>
+                        <Copy className="size-3.5 mr-2" /> Copy
+                    </ContextMenuItem>
+                )}
                 {onReact && (
                     <ContextMenuSub>
                         <ContextMenuSubTrigger>
@@ -369,6 +447,16 @@ export function MessageRow({
                         <Bot className="size-3.5 mr-2" /> Ask @rowboat about this
                     </ContextMenuItem>
                 )}
+                {canEdit && (
+                    <ContextMenuItem onSelect={() => setEditDraft(message.body)}>
+                        <Pencil className="size-3.5 mr-2" /> Edit message
+                    </ContextMenuItem>
+                )}
+                {messageText && (
+                    <ContextMenuItem onSelect={() => copyToClipboard(messageText)}>
+                        <Copy className="size-3.5 mr-2" /> Copy message
+                    </ContextMenuItem>
+                )}
                 {onCopyLink && (
                     <ContextMenuItem onSelect={() => onCopyLink(message)}>
                         <LinkIcon className="size-3.5 mr-2" /> Copy link
@@ -386,6 +474,38 @@ export function MessageRow({
         </ContextMenu>
     )
 }
+
+type MessageRowProps = Parameters<typeof MessageRowImpl>[0]
+
+function threadRowEqual(a: ThreadRowData | null | undefined, b: ThreadRowData | null | undefined): boolean {
+    if (!a || !b) return !a === !b
+    return (
+        a.topicId === b.topicId &&
+        a.replyCount === b.replyCount &&
+        a.lastActivityAt === b.lastActivityAt &&
+        a.unreadCount === b.unreadCount &&
+        a.title === b.title &&
+        a.workingAgents.length === b.workingAgents.length &&
+        a.workingAgents.every((id, i) => id === b.workingAgents[i])
+    )
+}
+
+/**
+ * Memoized by DATA, deliberately ignoring the handler props: the stream
+ * recreates its closures every render (presence frames, visibility flips),
+ * and comparing them would make the memo worthless. Safe because everything
+ * a handler reads is either per-pane-stable (org, space) or flows through a
+ * compared prop — a thread index change reaches the row as a new `thread`
+ * object, which re-renders it with fresh closures.
+ */
+export const MessageRow = memo(MessageRowImpl, (prev: MessageRowProps, next: MessageRowProps) =>
+    prev.message === next.message &&
+    prev.continuation === next.continuation &&
+    prev.selfMemberId === next.selfMemberId &&
+    prev.dense === next.dense &&
+    prev.memberNames === next.memberNames &&
+    threadRowEqual(prev.thread, next.thread),
+)
 
 export function DayDivider({ label }: { label: string }) {
     return (

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -13,6 +13,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/h
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
 import { MemberAvatar } from '@/components/spaces/atoms'
+import { MessageLinkPreview } from '@/components/spaces/link-preview-card'
 import { SpaceMarkdown } from '@/components/spaces/space-markdown'
 import { formatFeedTime, formatFullTimestamp, resolveMentions } from '@/lib/spaces-presentation'
 import { toast } from '@/lib/toast'
@@ -258,6 +259,7 @@ function MessageRowImpl({
                         {message.editedAt && (
                             <span title={formatFullTimestamp(message.editedAt)} className="text-[10.5px] text-muted-foreground/70">(edited)</span>
                         )}
+                        <MessageLinkPreview body={message.body} />
                     </div>
                 )}
                 {message.failed && (
@@ -517,9 +519,10 @@ export function DayDivider({ label }: { label: string }) {
     )
 }
 
-export function NewDivider() {
+/** The line has been seen: fade over 700ms; the pane drops it after. */
+export function NewDivider({ fading = false }: { fading?: boolean }) {
     return (
-        <div className="flex items-center gap-2.5 px-2 py-1">
+        <div className={cn('flex items-center gap-2.5 px-2 py-1 transition-opacity duration-700', fading && 'opacity-0')}>
             <span className="h-px flex-1 bg-orange-500" />
             <span className="text-[10.5px] font-semibold uppercase tracking-wider text-orange-600">New</span>
         </div>

--- a/apps/x/apps/renderer/src/components/spaces/selection-copy.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/selection-copy.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from 'react'
+import { Copy } from 'lucide-react'
+import { toast } from '@/lib/toast'
+
+// A floating Copy chip over selected message text. The app replaces the
+// browser's right-click menu with its own, so a plain selection needs its own
+// copy affordance (Ctrl+C still works; this is the mouse path). One instance
+// per space pane — it scopes itself to message rows by ancestry.
+
+export function SelectionCopy() {
+    const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
+    const textRef = useRef('')
+    const chipRef = useRef<HTMLButtonElement | null>(null)
+
+    useEffect(() => {
+        const readSelection = () => {
+            const sel = window.getSelection()
+            if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null
+            const text = sel.toString()
+            if (!text.trim()) return null
+            const range = sel.getRangeAt(0)
+            const node = range.commonAncestorContainer
+            const el = node instanceof Element ? node : node.parentElement
+            // Message text only — not the composer, not file panes.
+            if (!el?.closest('[class~="group/msg"]')) return null
+            const rect = range.getBoundingClientRect()
+            if (rect.width === 0 && rect.height === 0) return null
+            return { text, rect }
+        }
+        // Appear when a drag-select finishes — not while the drag is running,
+        // and not on a right-button release (the context menu owns that).
+        const onMouseUp = (e: MouseEvent) => {
+            if (e.button !== 0) return
+            // The selection settles after mouseup — read it a tick later.
+            window.setTimeout(() => {
+                const s = readSelection()
+                if (!s) return
+                textRef.current = s.text
+                setPos({ x: s.rect.left + s.rect.width / 2, y: s.rect.top })
+            }, 0)
+        }
+        const onMouseDown = (e: MouseEvent) => {
+            if (chipRef.current?.contains(e.target as Node)) return
+            setPos(null)
+        }
+        const onSelectionChange = () => {
+            const sel = window.getSelection()
+            if (!sel || sel.isCollapsed) setPos(null)
+        }
+        // Scrolling moves the selection under the fixed chip — hide, don't track.
+        const onScroll = () => setPos(null)
+        document.addEventListener('mouseup', onMouseUp)
+        document.addEventListener('mousedown', onMouseDown)
+        document.addEventListener('selectionchange', onSelectionChange)
+        document.addEventListener('scroll', onScroll, true)
+        return () => {
+            document.removeEventListener('mouseup', onMouseUp)
+            document.removeEventListener('mousedown', onMouseDown)
+            document.removeEventListener('selectionchange', onSelectionChange)
+            document.removeEventListener('scroll', onScroll, true)
+        }
+    }, [])
+
+    if (!pos) return null
+    return (
+        <button
+            ref={chipRef}
+            type="button"
+            style={{ position: 'fixed', left: pos.x, top: Math.max(8, pos.y - 36) }}
+            // Without this the mousedown collapses the selection before click lands.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+                void navigator.clipboard.writeText(textRef.current).then(
+                    () => toast('Copied', 'success'),
+                    () => toast('Could not copy', 'error'),
+                )
+                setPos(null)
+            }}
+            className="z-50 -translate-x-1/2 inline-flex items-center gap-1.5 rounded-md border border-border bg-popover px-2 py-1 text-xs font-medium text-foreground shadow-md hover:bg-accent"
+        >
+            <Copy className="size-3" /> Copy
+        </button>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -1,8 +1,12 @@
 import { createContext, memo, useContext, useMemo, useState, type ComponentProps, type CSSProperties, type ReactNode } from 'react'
 import { Streamdown } from 'streamdown'
-import { FileDown, FileText, Loader2 } from 'lucide-react'
+import { Eye, FileDown, FilePlus2, FileText, Loader2 } from 'lucide-react'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { ZoomableImage } from '@/components/image-lightbox'
+import { isTrustedDomain, linkDomain, trustDomain } from '@/lib/trusted-domains'
 import { toast } from '@/lib/toast'
 import { useMemberNames } from '@/components/spaces/member-text'
 import {
@@ -94,8 +98,9 @@ function BlobLinkCard({ href, children }: { href: string; children?: ReactNode }
 
 /**
  * Discord-style viewer: the image large on a dimmed backdrop. Esc or a click
- * outside closes; the row under the image carries the source-specific action
- * (download for blobs, open-original for external links).
+ * outside closes; scroll zooms, click toggles fit ⇄ zoomed, drag pans. The
+ * row under the image carries the source-specific action (download for
+ * blobs, open-original for external links).
  */
 function ImageLightbox({ src, alt, open, onOpenChange, children }: {
     src: string
@@ -111,7 +116,7 @@ function ImageLightbox({ src, alt, open, onOpenChange, children }: {
                 className="flex w-auto max-w-[92vw] flex-col items-center border-none bg-transparent p-0 shadow-none outline-none sm:max-w-[92vw]"
             >
                 <DialogTitle className="sr-only">{alt || 'Image'}</DialogTitle>
-                <img src={src} alt={alt} className="max-h-[82vh] max-w-[92vw] rounded-lg object-contain" />
+                <ZoomableImage src={src} alt={alt} className="max-h-[82vh] max-w-[92vw] rounded-lg object-contain" />
                 {children && <div className="flex items-center gap-3 self-start text-xs">{children}</div>}
             </DialogContent>
         </Dialog>
@@ -137,8 +142,73 @@ function tileStyle(dims: { width: number; height: number } | null): CSSPropertie
     return { width: Math.round(Math.min(TILE_MAX_W, (TILE_H * dims.width) / dims.height)), height: TILE_H }
 }
 
+/**
+ * Promote a chat image into the space's files — the record. The bytes are
+ * already in the org's blob store; saving is one proposeChange referencing
+ * the hash. baseVersion 0 = create: an occupied path fails with the server's
+ * conflict error rather than silently overwriting someone's file.
+ */
+function SaveToSpaceDialog({ src, onClose }: { src: string; onClose: () => void }) {
+    const parsed = parseBlobAppUrl(src)
+    const suggested = (() => {
+        try {
+            return new URL(src).searchParams.get('name') ?? ''
+        } catch {
+            return ''
+        }
+    })()
+    const [path, setPath] = useState(suggested || (parsed ? `image-${parsed.hash.slice(0, 8)}.png` : ''))
+    const [saving, setSaving] = useState(false)
+    if (!parsed) return null
+    const save = async () => {
+        const cleaned = path.split('/').filter((s) => s && s !== '.' && s !== '..').join('/')
+        if (!cleaned || saving) return
+        setSaving(true)
+        try {
+            await window.ipc.invoke('spaces:proposeChange', {
+                orgId: parsed.orgId,
+                spaceId: parsed.spaceId,
+                input: { assetPath: cleaned, baseVersion: 0, blob: parsed.hash, reason: 'saved from chat' },
+            })
+            toast('Saved to space files', 'success')
+            onClose()
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not save to space files', 'error')
+        } finally {
+            setSaving(false)
+        }
+    }
+    return (
+        <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+            <DialogContent className="sm:max-w-md">
+                <DialogTitle>Save to space files</DialogTitle>
+                <div className="text-sm text-muted-foreground">
+                    The image becomes a file in this space — in the file tree for everyone, versioned like any other file.
+                </div>
+                <input
+                    autoFocus
+                    value={path}
+                    onChange={(e) => setPath(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') void save()
+                    }}
+                    placeholder="folder/name.png"
+                    className="w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs outline-none focus:border-foreground/30"
+                />
+                <div className="flex justify-end gap-2">
+                    <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+                    <Button size="sm" disabled={saving} onClick={() => void save()}>
+                        {saving ? <Loader2 className="mr-1 size-3.5 animate-spin" /> : null} Save
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
 export function BlobImage({ src, alt }: { src: string; alt: string }) {
     const [open, setOpen] = useState(false)
+    const [saveOpen, setSaveOpen] = useState(false)
     const [saving, setSaving] = useState(false)
     const [loaded, setLoaded] = useState(false)
     const parsed = parseBlobAppUrl(src)
@@ -174,22 +244,49 @@ export function BlobImage({ src, alt }: { src: string; alt: string }) {
     }
     return (
         <>
-            <img
-                src={src}
-                alt={alt}
-                loading="lazy"
-                onClick={() => setOpen(true)}
-                onLoad={() => setLoaded(true)}
-                style={style}
-                className={cn(TILE_CLASS, !style && 'h-60 max-w-[360px]', dims && !loaded && 'animate-pulse')}
-            />
+            <ContextMenu>
+                <ContextMenuTrigger asChild>
+                    <img
+                        src={src}
+                        alt={alt}
+                        loading="lazy"
+                        onClick={() => setOpen(true)}
+                        // The row has its own context menu — the image's wins here.
+                        onContextMenu={(e) => e.stopPropagation()}
+                        onLoad={() => setLoaded(true)}
+                        style={style}
+                        className={cn(TILE_CLASS, !style && 'h-60 max-w-[360px]', dims && !loaded && 'animate-pulse')}
+                    />
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                    <ContextMenuItem onSelect={() => setOpen(true)}>
+                        <Eye className="size-3.5 mr-2" /> View
+                    </ContextMenuItem>
+                    {parsed && (
+                        <>
+                            <ContextMenuItem onSelect={() => setSaveOpen(true)}>
+                                <FilePlus2 className="size-3.5 mr-2" /> Save to space files…
+                            </ContextMenuItem>
+                            <ContextMenuItem onSelect={() => void save()}>
+                                <FileDown className="size-3.5 mr-2" /> Download…
+                            </ContextMenuItem>
+                        </>
+                    )}
+                </ContextMenuContent>
+            </ContextMenu>
             <ImageLightbox src={src} alt={alt} open={open} onOpenChange={setOpen}>
                 {parsed && (
-                    <button type="button" onClick={() => void save()} className="text-white/80 hover:text-white hover:underline">
-                        {saving ? 'Saving…' : 'Download'}
-                    </button>
+                    <>
+                        <button type="button" onClick={() => void save()} className="text-white/80 hover:text-white hover:underline">
+                            {saving ? 'Saving…' : 'Download'}
+                        </button>
+                        <button type="button" onClick={() => setSaveOpen(true)} className="text-white/80 hover:text-white hover:underline">
+                            Save to space files
+                        </button>
+                    </>
                 )}
             </ImageLightbox>
+            {saveOpen && <SaveToSpaceDialog src={src} onClose={() => setSaveOpen(false)} />}
         </>
     )
 }
@@ -232,11 +329,7 @@ function ExternalImage({ src, alt }: { src: string; alt: string }) {
         }
     }
     if (failed) {
-        return (
-            <a href={src} target="_blank" rel="noreferrer">
-                {alt || src}
-            </a>
-        )
+        return <ExternalLink href={src}>{alt || src}</ExternalLink>
     }
     return (
         <>
@@ -261,6 +354,54 @@ function ExternalImage({ src, alt }: { src: string; alt: string }) {
     )
 }
 
+/**
+ * An external link: blue, clickable — and gated. The first click on a domain
+ * shows the full destination and offers to trust the domain (stored locally);
+ * links to trusted domains open straight in the system browser.
+ */
+function ExternalLink({ href, children }: { href: string; children?: ReactNode }) {
+    const [confirming, setConfirming] = useState(false)
+    const domain = linkDomain(href)
+    // Only http(s) leaves the app; anything else renders inert.
+    if (!domain) return <span>{children}</span>
+    const open = () => window.open(href) // main routes this to the system browser
+    return (
+        <>
+            <a
+                href={href}
+                title={href}
+                onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    if (isTrustedDomain(domain)) open()
+                    else setConfirming(true)
+                }}
+                className="cursor-pointer break-words text-blue-600 underline underline-offset-2 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+                {children}
+            </a>
+            {confirming && (
+                <Dialog open onOpenChange={(o) => { if (!o) setConfirming(false) }}>
+                    <DialogContent className="sm:max-w-md">
+                        <DialogTitle>Leaving Rowboat</DialogTitle>
+                        <div className="text-sm text-muted-foreground">
+                            This link opens in your browser:
+                            <div className="mt-2 max-h-24 overflow-y-auto break-all rounded-md bg-muted px-2 py-1.5 font-mono text-xs text-foreground">{href}</div>
+                        </div>
+                        <div className="flex flex-wrap justify-end gap-2">
+                            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>Cancel</Button>
+                            <Button variant="outline" size="sm" onClick={() => { trustDomain(domain); setConfirming(false); open() }}>
+                                Trust {domain}
+                            </Button>
+                            <Button size="sm" onClick={() => { setConfirming(false); open() }}>Open link</Button>
+                        </div>
+                    </DialogContent>
+                </Dialog>
+            )}
+        </>
+    )
+}
+
 type StreamdownComponents = NonNullable<ComponentProps<typeof Streamdown>['components']>
 
 const spaceComponents: StreamdownComponents = {
@@ -274,7 +415,7 @@ const spaceComponents: StreamdownComponents = {
     a: SpaceAnchor,
 }
 
-function SpaceAnchor({ href, children, ...rest }: ComponentProps<'a'>) {
+function SpaceAnchor({ href, children }: ComponentProps<'a'>) {
     const refs = useContext(SpaceRefsContext)
     const openFile = useContext(SpaceNavContext)
     const url = typeof href === 'string' ? href : ''
@@ -307,11 +448,7 @@ function SpaceAnchor({ href, children, ...rest }: ComponentProps<'a'>) {
             </button>
         )
     }
-    return (
-        <a href={url} target="_blank" rel="noreferrer" {...rest}>
-            {children}
-        </a>
-    )
+    return <ExternalLink href={url}>{children}</ExternalLink>
 }
 
 // Memoized: a stream re-renders on every presence/typing frame, and markdown

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, type ComponentProps, type CSSProperties, type ReactNode } from 'react'
+import { createContext, memo, useContext, useMemo, useState, type ComponentProps, type CSSProperties, type ReactNode } from 'react'
 import { Streamdown } from 'streamdown'
 import { FileDown, FileText, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -314,7 +314,10 @@ function SpaceAnchor({ href, children, ...rest }: ComponentProps<'a'>) {
     )
 }
 
-export function SpaceMarkdown({ body, className }: { body: string; className?: string }) {
+// Memoized: a stream re-renders on every presence/typing frame, and markdown
+// is by far the heaviest thing in a row — same body, same refs, same names
+// (both contexts still cut through the memo) means the row's markdown stands.
+export const SpaceMarkdown = memo(function SpaceMarkdown({ body, className }: { body: string; className?: string }) {
     const refs = useContext(SpaceRefsContext)
     const memberNames = useMemberNames()
     const text = useMemo(() => {
@@ -329,4 +332,4 @@ export function SpaceMarkdown({ body, className }: { body: string; className?: s
             <Streamdown components={spaceComponents}>{text}</Streamdown>
         </div>
     )
-}
+})

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { toast } from '@/lib/toast'
 import { FileTree } from '@/components/spaces/files-tab'
 import { refreshSpaceFeed } from '@/hooks/use-spaces'
@@ -21,6 +22,11 @@ import type { RailSelection } from '@/lib/spaces-selection'
 // that opens on hover and lingers a few seconds after the cursor leaves
 // (instant close was too twitchy). The header button flips the mode; a click
 // on the closed edge pins it back open. The surfaces own everything else.
+
+/** Resizable Files section: never shorter than this (header + a couple of rows). */
+const FILES_MIN = 96
+/** Dragging the Files divider always leaves this much for Messages + topics. */
+const TOPICS_FLOOR = 160
 
 export function SpaceRail({
     orgId, spaceId, selfMemberId, general, topics, threads, changeSets, entries, draftFolders, presence, unreadPaths, selection, onSelect, onCreateFile, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
@@ -57,6 +63,42 @@ export function SpaceRail({
     const [creatingFile, setCreatingFile] = useState<{ prefix: string } | null>(null)
     const [creatingFolder, setCreatingFolder] = useState(false)
     const uploadInputRef = useRef<HTMLInputElement | null>(null)
+
+    // Resizable Files section: null = natural height (grows with the tree,
+    // capped at 40% of the rail) until the divider is dragged; then the
+    // chosen height sticks, persisted like the Split doc width.
+    const [filesHeight, setFilesHeight] = useState<number | null>(() => {
+        const stored = Number(localStorage.getItem('spaces:filesHeight'))
+        return Number.isFinite(stored) && stored >= FILES_MIN ? stored : null
+    })
+    const [resizingFiles, setResizingFiles] = useState(false)
+    const filesDrag = useRef<{ y: number; height: number } | null>(null)
+    const railBodyRef = useRef<HTMLDivElement | null>(null)
+    const filesRef = useRef<HTMLDivElement | null>(null)
+    const startFilesResize = (e: React.MouseEvent) => {
+        e.preventDefault()
+        filesDrag.current = { y: e.clientY, height: filesRef.current?.clientHeight ?? 0 }
+        setResizingFiles(true)
+        const onMove = (ev: MouseEvent) => {
+            if (!filesDrag.current) return
+            // Files sit at the bottom: dragging the divider up grows them.
+            const next = filesDrag.current.height + (filesDrag.current.y - ev.clientY)
+            const railHeight = railBodyRef.current?.clientHeight ?? window.innerHeight
+            setFilesHeight(Math.min(Math.max(next, FILES_MIN), Math.max(FILES_MIN, railHeight - TOPICS_FLOOR)))
+        }
+        const onUp = () => {
+            window.removeEventListener('mousemove', onMove)
+            window.removeEventListener('mouseup', onUp)
+            filesDrag.current = null
+            setResizingFiles(false)
+            setFilesHeight((h) => {
+                if (h !== null) localStorage.setItem('spaces:filesHeight', String(h))
+                return h
+            })
+        }
+        window.addEventListener('mousemove', onMove)
+        window.addEventListener('mouseup', onUp)
+    }
 
     // Row-level topic actions. Rename edits inline in the row; the topic event
     // the server emits updates every other client, the refresh updates this one.
@@ -174,7 +216,7 @@ export function SpaceRail({
                 </button>
             ) : (
                 // Inner content is fixed at the open width so text doesn't reflow mid-slide.
-                <div className="flex h-full w-[280px] flex-col">
+                <div ref={railBodyRef} className="flex h-full w-[280px] flex-col">
                     <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
                         <span className="min-w-0 flex-1 truncate text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topics &amp; files</span>
                         <button
@@ -265,29 +307,51 @@ export function SpaceRail({
                                     }
                                     return (
                                         <div key={topic.id} className="group/topicrow relative">
-                                            <button
-                                                type="button"
-                                                onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
-                                                className={cn(
-                                                    'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
-                                                    active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
-                                                    topic.archived && 'opacity-60',
-                                                )}
-                                            >
-                                                <div className="flex items-center gap-1.5">
-                                                    <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
-                                                    {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
-                                                </div>
-                                                <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
-                                                    <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
-                                                    <span>· {formatFeedTime(topic.lastActivityAt)}</span>
-                                                    {files && files.size > 0 && (
-                                                        <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
+                                            <ContextMenu>
+                                                <ContextMenuTrigger asChild>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => onSelect({ kind: 'topic', topicId: topic.id })}
+                                                        className={cn(
+                                                            'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
+                                                            active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
+                                                            topic.archived && 'opacity-60',
+                                                        )}
+                                                    >
+                                                        <div className="flex items-center gap-1.5">
+                                                            <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
+                                                            {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
+                                                        </div>
+                                                        <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
+                                                            <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
+                                                            <span>· {formatFeedTime(topic.lastActivityAt)}</span>
+                                                            {files && files.size > 0 && (
+                                                                <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
+                                                            )}
+                                                            {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
+                                                            {topic.archived && <span>· archived</span>}
+                                                        </div>
+                                                    </button>
+                                                </ContextMenuTrigger>
+                                                <ContextMenuContent>
+                                                    <ContextMenuItem onSelect={() => onSelect({ kind: 'topic', topicId: topic.id })}>
+                                                        <MessagesSquare className="size-3.5 mr-2" /> Open
+                                                    </ContextMenuItem>
+                                                    <ContextMenuItem onSelect={() => setRenaming({ topicId: topic.id, value: title })}>
+                                                        <Pencil className="size-3.5 mr-2" /> Rename
+                                                    </ContextMenuItem>
+                                                    <ContextMenuSeparator />
+                                                    {topic.archived ? (
+                                                        <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'unarchive' })}>
+                                                            <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
+                                                        </ContextMenuItem>
+                                                    ) : (
+                                                        <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'archive' })}>
+                                                            <Archive className="size-3.5 mr-2" /> Archive
+                                                        </ContextMenuItem>
                                                     )}
-                                                    {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
-                                                    {topic.archived && <span>· archived</span>}
-                                                </div>
-                                            </button>
+                                                </ContextMenuContent>
+                                            </ContextMenu>
                                             <DropdownMenu>
                                                 <DropdownMenuTrigger asChild>
                                                     <button
@@ -325,7 +389,20 @@ export function SpaceRail({
                         </div>
                     </div>
 
-                    <div className="flex max-h-[40%] shrink-0 flex-col border-t border-border">
+                    <div
+                        ref={filesRef}
+                        // maxHeight backstops a persisted height against a shorter window.
+                        style={filesHeight !== null ? { height: filesHeight, maxHeight: '75%' } : undefined}
+                        className={cn('flex shrink-0 flex-col', filesHeight === null && 'max-h-[40%]')}
+                    >
+                        <div
+                            onMouseDown={startFilesResize}
+                            title="Drag to resize the files pane"
+                            className={cn(
+                                'h-1.5 shrink-0 cursor-row-resize border-t border-border transition-colors hover:bg-primary/20',
+                                resizingFiles && 'bg-primary/30',
+                            )}
+                        />
                         <div className="flex h-8 shrink-0 items-center gap-2 px-3 pr-2 pt-1">
                             <span className="text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Files</span>
                             <span className="text-[11px] text-muted-foreground/70">{entries.length}</span>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
-import { Archive, ArchiveRestore, Bot, FileText, Folder, FolderPlus, MessagesSquare, MoreHorizontal, Pencil, Pin, Plus, Search, Trash2, Upload } from 'lucide-react'
+import { Archive, ArchiveRestore, Bot, FileText, Folder, FolderPlus, MessagesSquare, MoreHorizontal, PanelLeftClose, Pencil, Pin, Plus, Search, Trash2, Upload } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -16,14 +16,15 @@ import { getTopicLastReadAt } from '@/lib/spaces-read-state'
 import type { RailSelection } from '@/lib/spaces-selection'
 
 // The space's edge rail: one collapsible strip carrying the same sidebar on
-// every surface — Messages + topics on top, the file tree below. Collapsed it
-// is a 28px edge; it pushes open to 280px on hover (never floats over
-// content), peeks briefly to teach the gesture, and can be pinned. The
-// surfaces own everything else.
+// every surface — Messages + topics on top, the file tree below. Two modes:
+// PINNED (default) it is a plain 280px sidebar; unpinned it is a 28px edge
+// that opens on hover and lingers a few seconds after the cursor leaves
+// (instant close was too twitchy). The header button flips the mode; a click
+// on the closed edge pins it back open. The surfaces own everything else.
 
 export function SpaceRail({
     orgId, spaceId, selfMemberId, general, topics, threads, changeSets, entries, draftFolders, presence, unreadPaths, selection, onSelect, onCreateFile, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
-    open, pinned, hint, onHoverChange, onTogglePin,
+    open, pinned, onHoverChange, onTogglePin,
 }: {
     orgId: string
     spaceId: string
@@ -48,7 +49,6 @@ export function SpaceRail({
     onRemoveFolder: (path: string) => void
     open: boolean
     pinned: boolean
-    hint: string
     onHoverChange: (hovering: boolean) => void
     onTogglePin: () => void
 }) {
@@ -140,9 +140,9 @@ export function SpaceRail({
                 open ? 'bg-muted/20' : 'bg-background',
             )}
         >
-            {/* Always mounted: the rail collapses on mouse-leave while the native
-                file picker is open (the pointer is in the OS dialog), and an input
-                unmounted mid-pick never delivers its change event. */}
+            {/* Always mounted: an input unmounted mid-pick (the rail toggled
+                closed while the OS file dialog is up) never delivers its
+                change event. */}
             <input
                 ref={uploadInputRef}
                 type="file"
@@ -155,8 +155,14 @@ export function SpaceRail({
                 }}
             />
             {!open ? (
-                // The closed edge: what lives here (topics + files), and how much is unread.
-                <div className="flex flex-1 flex-col items-center gap-2.5 py-3.5">
+                // The closed edge: hovering opens the rail; a click pins it
+                // (the strong signal — and the only path on touch screens).
+                <button
+                    type="button"
+                    onClick={onTogglePin}
+                    title="Show topics & files"
+                    className="flex flex-1 flex-col items-center gap-2.5 py-3.5 hover:bg-accent/50"
+                >
                     <MessagesSquare className="size-[15px] text-muted-foreground" />
                     <Folder className="size-[15px] text-muted-foreground" />
                     <div className="w-px flex-1 bg-border/70" />
@@ -165,22 +171,24 @@ export function SpaceRail({
                             {badge}
                         </span>
                     )}
-                </div>
+                </button>
             ) : (
                 // Inner content is fixed at the open width so text doesn't reflow mid-slide.
                 <div className="flex h-full w-[280px] flex-col">
                     <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
-                        <span className="min-w-0 flex-1 truncate text-right text-[10px] text-muted-foreground/70">{hint}</span>
+                        <span className="min-w-0 flex-1 truncate text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topics &amp; files</span>
                         <button
                             type="button"
                             onClick={onTogglePin}
-                            title={pinned ? 'Unpin — collapse when the mouse leaves' : 'Pin this rail open'}
+                            title={pinned ? 'Auto-hide — opens on hover, slides away a moment after the cursor leaves' : 'Keep open'}
                             className={cn(
-                                'flex size-6 shrink-0 items-center justify-center rounded-md border disabled:opacity-40',
-                                pinned ? 'border-foreground bg-foreground text-background' : 'border-border bg-background text-muted-foreground hover:text-foreground',
+                                'flex size-6 shrink-0 items-center justify-center rounded-md',
+                                pinned
+                                    ? 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                                    : 'border border-border bg-background text-muted-foreground hover:text-foreground',
                             )}
                         >
-                            <Pin className="size-3" />
+                            {pinned ? <PanelLeftClose className="size-3.5" /> : <Pin className="size-3" />}
                         </button>
                     </div>
 

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -14,7 +14,7 @@ import { MessageRow, NewDivider, TypingIndicator } from '@/components/spaces/mes
 import type { ChatMessage, SpacePresence, ThreadInfo } from '@/hooks/use-space-chat'
 import { buildPendingMessage, rememberThread, usePresenceSender } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
-import { artifactsForThread, buildThreadSeed, explicitTitle, isContinuation, mergeMessages, parseThreadMarker, stripThreadMarker } from '@/lib/spaces-conventions'
+import { applyReaction, artifactsForThread, buildThreadSeed, explicitTitle, isContinuation, mergeMessages, parseThreadMarker, stripThreadMarker } from '@/lib/spaces-conventions'
 import { attributionLabel, formatFeedTime, shortId } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
@@ -28,7 +28,7 @@ import { containsRowboatAddress } from '@/lib/spaces-mentions'
 
 export function ThreadPane({
     org, space, topicId, threadInfo, topic: topicFromList, changeSets, entries, presence, members, memberNames, refreshTick,
-    anchorChange, showBack, onBack, onOpenFile, onOpenSession, artifactsRailOpen, onToggleArtifactsRail, onFolding,
+    anchorChange, showBack, onBack, onOpenFile, onOpenSession, artifactsRailOpen, onToggleArtifactsRail, onFolding, visible = true,
 }: {
     org: OrgWithSpaces
     space: spaces.Space
@@ -52,6 +52,8 @@ export function ThreadPane({
     onToggleArtifactsRail: () => void
     /** Lets a parent (the rail) share the fold-busy state. */
     onFolding?: (busy: boolean) => void
+    /** False while kept mounted but off screen (read mode, hidden Spaces view) — no presence, no read marks. */
+    visible?: boolean
 }) {
     const [topic, setTopic] = useState<spaces.Topic | null>(topicFromList ?? null)
     const [messages, setMessages] = useState<ChatMessage[]>([])
@@ -63,7 +65,25 @@ export function ThreadPane({
     const oldestLoadedRef = useRef<number | null>(null)
     const [folding, setFolding] = useState(false)
     const bottomRef = useRef<HTMLDivElement | null>(null)
-    const { onType } = usePresenceSender(org.id, space.id, topicId)
+    const { onType } = usePresenceSender(org.id, space.id, topicId, visible)
+    // A ref, not an effect dep: visibility flips must not refetch the thread.
+    const visibleRef = useRef(visible)
+    visibleRef.current = visible
+
+    // Esc goes back to Messages. Not from a field (typing must keep its Esc
+    // semantics — and a drafted reply must not vanish), and not when an
+    // overlay already claimed the key (Radix prevents default on those).
+    useEffect(() => {
+        if (!visible) return
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key !== 'Escape' || e.defaultPrevented) return
+            const t = e.target as HTMLElement | null
+            if (t?.closest('input, textarea, [contenteditable="true"], [role="dialog"], [role="menu"]')) return
+            onBack()
+        }
+        window.addEventListener('keydown', onKey)
+        return () => window.removeEventListener('keydown', onKey)
+    }, [visible, onBack])
 
     const [newSince] = useState<string | null>(() => getTopicLastReadAt(org.id, space.id, topicId))
 
@@ -89,13 +109,18 @@ export function ThreadPane({
                     setHasMore(res.hasMore)
                 }
                 setLoaded(true)
-                markTopicRead(org.id, space.id, topicId)
+                if (visibleRef.current) markTopicRead(org.id, space.id, topicId)
             })
             .catch(() => {})
         return () => {
             cancelled = true
         }
     }, [org.id, space.id, topicId, refreshTick])
+    // Refetches that landed while hidden left the topic unread on purpose —
+    // becoming visible again is the moment the reader actually sees them.
+    useEffect(() => {
+        if (visible && loaded) markTopicRead(org.id, space.id, topicId)
+    }, [visible, loaded, org.id, space.id, topicId])
 
     const loadOlderReplies = async () => {
         const oldest = messages.find((m) => !m.pending && !m.failed)
@@ -187,9 +212,13 @@ export function ThreadPane({
     }
 
     // Toggle: add when the viewer isn't in the group yet, remove when they are.
+    // Optimistic like general's — the chip moves on click, the org reconciles.
     const toggleReaction = async (message: spaces.Message, emoji: string) => {
         const mine = (message.reactions ?? []).find((g) => g.emoji === emoji)?.memberIds.includes(org.memberId)
         const action = mine ? 'remove' : 'add'
+        setMessages((prev) => prev.map((m) => (
+            m.id === message.id ? { ...m, reactions: applyReaction(m.reactions, { emoji, memberId: org.memberId, action: action === 'add' ? 'added' : 'removed' }) } : m
+        )))
         try {
             const { message: updated } = await window.ipc.invoke('spaces:reactToMessage', {
                 orgId: org.id, spaceId: space.id, messageId: message.id, emoji, action,
@@ -197,7 +226,22 @@ export function ThreadPane({
             setMessages((prev) => prev.map((m) => (m.id === updated.id ? updated : m)))
             analytics.spacesReactionToggled({ action })
         } catch (err) {
+            setMessages((prev) => prev.map((m) => (m.id === message.id ? message : m)))
             toast(err instanceof Error ? err.message : 'Could not react', 'error')
+        }
+    }
+
+    // Optimistic rewrite, mirroring general's.
+    const editMessage = async (message: spaces.Message, body: string) => {
+        setMessages((prev) => prev.map((m) => (m.id === message.id ? { ...m, body, editedAt: new Date().toISOString() } : m)))
+        try {
+            const { message: updated } = await window.ipc.invoke('spaces:editMessage', {
+                orgId: org.id, spaceId: space.id, messageId: message.id, body,
+            })
+            setMessages((prev) => prev.map((m) => (m.id === updated.id ? updated : m)))
+        } catch (err) {
+            setMessages((prev) => prev.map((m) => (m.id === message.id ? message : m)))
+            toast(err instanceof Error ? err.message : 'Could not edit', 'error')
         }
     }
 
@@ -265,6 +309,7 @@ export function ThreadPane({
                 selfMemberId={org.memberId}
                 onReact={(m, emoji) => void toggleReaction(m, emoji)}
                 onDelete={(m) => void deleteMessage(m)}
+                onEdit={(m, body) => void editMessage(m, body)}
                 onRetryFailed={retryFailed}
                 onDiscardFailed={discardFailed}
                 dense
@@ -426,7 +471,7 @@ export function ThreadPane({
                 <div ref={bottomRef} />
             </div>
 
-            <Composer placeholder="Reply…" busy={false} onSend={post} onType={onType} autoFocus members={members} entries={entries} selfMemberId={org.memberId} />
+            <Composer placeholder="Reply…" busy={false} onSend={post} onType={onType} autoFocus members={members} entries={entries} selfMemberId={org.memberId} draftKey={`${org.id}/${space.id}/${topicId}`} />
 
         </div>
     )
@@ -515,7 +560,7 @@ export function DraftThreadPane({ org, space, parent, members, memberNames, entr
                     Nothing here yet — sending a reply is what starts the topic for everyone.
                 </div>
             </div>
-            <Composer placeholder="Reply…" busy={posting} onSend={post} autoFocus members={members} entries={entries} selfMemberId={org.memberId} />
+            <Composer placeholder="Reply…" busy={posting} onSend={post} autoFocus members={members} entries={entries} selfMemberId={org.memberId} draftKey={`${org.id}/${space.id}/draft:${parent.id}`} />
         </div>
     )
 }

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Anchor, Archive, ArchiveRestore, ArrowLeft, Bot, Loader2, MoreHorizontal, Pencil, X } from 'lucide-react'
+import { Anchor, Archive, ArchiveRestore, ArrowLeft, Bot, Loader2, MoreHorizontal, Pencil, ShieldAlert, X } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { Button } from '@/components/ui/button'
 import {
@@ -13,6 +13,7 @@ import { SpaceMarkdown } from '@/components/spaces/space-markdown'
 import { MessageRow, NewDivider, TypingIndicator } from '@/components/spaces/message-row'
 import type { ChatMessage, SpacePresence, ThreadInfo } from '@/hooks/use-space-chat'
 import { buildPendingMessage, rememberThread, usePresenceSender } from '@/hooks/use-space-chat'
+import { useTopicAgentPermissionWait } from '@/hooks/use-topic-agent-permission'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { applyReaction, artifactsForThread, buildThreadSeed, explicitTitle, isContinuation, mergeMessages, parseThreadMarker, stripThreadMarker } from '@/lib/spaces-conventions'
 import { attributionLabel, formatFeedTime, shortId } from '@/lib/spaces-presentation'
@@ -25,6 +26,11 @@ import { containsRowboatAddress } from '@/lib/spaces-mentions'
 // A thread (or any topic): the parent on top, the artifacts it produced,
 // the replies, a reply composer. In general it sits on the right; on the
 // Topics tab it is the centre column and the artifacts expand into a rail.
+
+/** How long the New line lingers once the reader has caught up with it. */
+const NEW_LINGER_MS = 5_000
+/** Clear delay after the fade starts — must outlast the divider's duration-700. */
+const NEW_FADE_MS = 800
 
 export function ThreadPane({
     org, space, topicId, threadInfo, topic: topicFromList, changeSets, entries, presence, members, memberNames, refreshTick,
@@ -85,7 +91,19 @@ export function ThreadPane({
         return () => window.removeEventListener('keydown', onKey)
     }, [visible, onBack])
 
-    const [newSince] = useState<string | null>(() => getTopicLastReadAt(org.id, space.id, topicId))
+    const [newSince, setNewSince] = useState<string | null>(() => getTopicLastReadAt(org.id, space.id, topicId))
+    const [newFading, setNewFading] = useState(false)
+    // Each return to the topic re-arms the line at the catch-up point: the
+    // read mark as it stood while hidden. Declared BEFORE the visible
+    // mark-read effect below — same flip, and the snapshot must win the race.
+    const newArmedVisibleRef = useRef(visible)
+    useEffect(() => {
+        const was = newArmedVisibleRef.current
+        newArmedVisibleRef.current = visible
+        if (!visible || was) return
+        setNewFading(false)
+        setNewSince(getTopicLastReadAt(org.id, space.id, topicId))
+    }, [visible, org.id, space.id, topicId])
 
     useEffect(() => {
         let cancelled = false
@@ -141,9 +159,14 @@ export function ThreadPane({
     }
 
     const workingAgents = presence.working.get(topicId) ?? []
+    // Your own agent, blocked mid-turn on a tool permission: surface it here
+    // instead of letting it idle behind a "working…" spinner (or silence).
+    const permissionWait = useTopicAgentPermissionWait(org.id, space.id, topicId, visible)
+    // While blocked, the amber pill replaces the own-agent spinner.
+    const spinningAgents = permissionWait.length > 0 ? workingAgents.filter((id) => id !== org.memberId) : workingAgents
     useEffect(() => {
         bottomRef.current?.scrollIntoView({ block: 'end' })
-    }, [messages.length, workingAgents.length])
+    }, [messages.length, workingAgents.length, permissionWait.length])
 
     const groups = useMemo(() => artifactsForThread(changeSets, topicId), [changeSets, topicId])
 
@@ -155,6 +178,23 @@ export function ThreadPane({
     // Display metadata (who said the parent, when) rides in the seed's marker.
     const marker = threadInfo?.marker ?? (parent ? parseThreadMarker(parent.body) : null)
     const replies = messages.filter((m) => m.id !== parent?.id)
+
+    // Once the reader has caught up (this pane pins to the bottom, so visible
+    // = with the new messages) the line lingers a beat, fades, drops.
+    const hasNewLine = !!newSince && replies.some((m) => !m.deletedAt && m.postedAt > newSince && m.author.memberId !== org.memberId)
+    useEffect(() => {
+        if (!visible || !loaded || !hasNewLine || newFading) return
+        const t = window.setTimeout(() => setNewFading(true), NEW_LINGER_MS)
+        return () => window.clearTimeout(t)
+    }, [visible, loaded, hasNewLine, newFading])
+    useEffect(() => {
+        if (!newFading) return
+        const t = window.setTimeout(() => {
+            setNewSince(null)
+            setNewFading(false)
+        }, NEW_FADE_MS)
+        return () => window.clearTimeout(t)
+    }, [newFading])
 
     // Echo a just-posted reply into the pane — the live event that would
     // otherwise render it may be seconds away, or never come at all when the
@@ -296,7 +336,7 @@ export function ThreadPane({
     let newShown = false
     for (const message of visibleReplies) {
         if (!newShown && newSince && message.postedAt > newSince && message.author.memberId !== org.memberId) {
-            rows.push(<NewDivider key="new" />)
+            rows.push(<NewDivider key="new" fading={newFading} />)
             newShown = true
             prev = undefined
         }
@@ -327,9 +367,12 @@ export function ThreadPane({
         <div className="flex h-full min-h-0 flex-col bg-background">
             <div className="flex h-9 shrink-0 items-center gap-1.5 border-b border-border pl-2 pr-2">
                 {showBack && (
-                    <Button variant="ghost" size="icon" className="size-7 text-muted-foreground" onClick={onBack} aria-label="Back to messages">
-                        <ArrowLeft className="size-4" />
-                    </Button>
+                    <>
+                        <Button variant="ghost" size="xs" className="gap-1 bg-primary/10 px-2 font-semibold text-primary hover:bg-primary/15 hover:text-primary" onClick={onBack} title="Back to Messages (Esc)" aria-label="Back to messages">
+                            <ArrowLeft className="size-3.5" /> Messages
+                        </Button>
+                        <span className="h-4 w-px shrink-0 bg-border" />
+                    </>
                 )}
                 <span className="pl-1 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topic</span>
                 <span className="truncate text-xs text-muted-foreground">
@@ -451,10 +494,25 @@ export function ThreadPane({
                 </div>
                 {rows}
 
-                {/* Typing-indicator position: below the last message, where eyes rest. */}
-                {workingAgents.length > 0 && (
+                {/* Your agent is stopped, not working — it wants an answer. */}
+                {permissionWait.length > 0 && (
                     <div className="flex flex-wrap items-center gap-2 pl-10 pt-1">
-                        {workingAgents.map((memberId) => {
+                        <button
+                            type="button"
+                            onClick={() => void openTopicSession()}
+                            title="Open the agent session to review the request"
+                            className="flex items-center gap-1.5 rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 hover:bg-amber-500/20 dark:text-amber-400"
+                        >
+                            <ShieldAlert className="size-3" />
+                            Your Rowboat needs permission — {permissionWait[0]}
+                            {permissionWait.length > 1 ? ` +${permissionWait.length - 1} more` : ''} · Review
+                        </button>
+                    </div>
+                )}
+                {/* Typing-indicator position: below the last message, where eyes rest. */}
+                {spinningAgents.length > 0 && (
+                    <div className="flex flex-wrap items-center gap-2 pl-10 pt-1">
+                        {spinningAgents.map((memberId) => {
                             const own = memberId === org.memberId
                             const label = own ? 'Your Rowboat is working…' : <><MemberName id={memberId} />’s Rowboat is working…</>
                             return own ? (
@@ -471,7 +529,47 @@ export function ThreadPane({
                 <div ref={bottomRef} />
             </div>
 
-            <Composer placeholder="Reply…" busy={false} onSend={post} onType={onType} autoFocus members={members} entries={entries} selfMemberId={org.memberId} draftKey={`${org.id}/${space.id}/${topicId}`} />
+            <Composer
+                placeholder="Reply…"
+                busy={false}
+                onSend={post}
+                onType={onType}
+                autoFocus
+                members={members}
+                entries={entries}
+                selfMemberId={org.memberId}
+                draftKey={`${org.id}/${space.id}/${topicId}`}
+                commands={[
+                    {
+                        name: 'fold',
+                        args: '<file>',
+                        hint: 'Ask your Rowboat to fold this topic into a file',
+                        run: (args) => void fold(args),
+                    },
+                    {
+                        name: 'rename',
+                        args: '<title>',
+                        hint: 'Rename this topic',
+                        run: (args) => void manage({ action: 'retitle', title: args }),
+                    },
+                    topic?.archived
+                        ? { name: 'unarchive', hint: 'Unarchive this topic', run: () => void manage({ action: 'unarchive' }) }
+                        : { name: 'archive', hint: 'Archive this topic — it leaves the rail until unarchived', run: () => void manage({ action: 'archive' }) },
+                    {
+                        name: 'invite',
+                        hint: 'Copy an invite link to this space',
+                        run: async () => {
+                            try {
+                                const result = await window.ipc.invoke('spaces:createInvite', { orgId: org.id, spaceId: space.id })
+                                await navigator.clipboard.writeText(result.link)
+                                toast('Invite link copied to clipboard', 'success')
+                            } catch (err) {
+                                toast(err instanceof Error ? err.message : 'Could not create an invite', 'error')
+                            }
+                        },
+                    },
+                ]}
+            />
 
         </div>
     )
@@ -532,9 +630,10 @@ export function DraftThreadPane({ org, space, parent, members, memberNames, entr
     return (
         <div className="flex h-full min-h-0 flex-col bg-background">
             <div className="flex h-9 shrink-0 items-center gap-1.5 border-b border-border pl-2 pr-2">
-                <Button variant="ghost" size="icon" className="size-7 text-muted-foreground" onClick={onBack} aria-label="Back to messages">
-                    <ArrowLeft className="size-4" />
+                <Button variant="ghost" size="xs" className="gap-1 bg-primary/10 px-2 font-semibold text-primary hover:bg-primary/15 hover:text-primary" onClick={onBack} title="Back to Messages" aria-label="Back to messages">
+                    <ArrowLeft className="size-3.5" /> Messages
                 </Button>
+                <span className="h-4 w-px shrink-0 bg-border" />
                 <span className="pl-1 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">Topic</span>
                 <span className="truncate text-xs text-muted-foreground">new — created when you send</span>
                 <span className="flex-1" />

--- a/apps/x/apps/renderer/src/hooks/use-link-preview.ts
+++ b/apps/x/apps/renderer/src/hooks/use-link-preview.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+
+export interface LinkPreviewData {
+    url: string
+    title?: string
+    description?: string
+    imageUrl?: string
+    siteName?: string
+}
+
+// Session-lived cache: one fetch per URL no matter how many rows show it
+// (the stream re-renders constantly; the IPC + page fetch must not).
+const cache = new Map<string, Promise<LinkPreviewData | null>>()
+
+function fetchPreview(url: string): Promise<LinkPreviewData | null> {
+    let hit = cache.get(url)
+    if (!hit) {
+        hit = window.ipc
+            .invoke('spaces:linkPreview', { url })
+            .then((res) => res.preview)
+            .catch(() => null)
+        cache.set(url, hit)
+    }
+    return hit
+}
+
+/** OpenGraph card data for a URL — null while loading or when there is none. */
+export function useLinkPreview(url: string | null): LinkPreviewData | null {
+    // The url rides along with its result; a mismatch (url changed, fetch
+    // still in flight) reads as "no preview yet" without an in-effect reset.
+    const [state, setState] = useState<{ url: string; preview: LinkPreviewData | null } | null>(null)
+    useEffect(() => {
+        if (!url) return
+        let cancelled = false
+        void fetchPreview(url).then((preview) => {
+            if (!cancelled) setState({ url, preview })
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [url])
+    return url && state?.url === url ? state.preview : null
+}

--- a/apps/x/apps/renderer/src/hooks/use-space-chat.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-chat.ts
@@ -75,7 +75,88 @@ function setGeneral(k: string, patch: Partial<GeneralState>): void {
     const next = new Map(generalState)
     next.set(k, { ...(generalState.get(k) ?? EMPTY_GENERAL), ...patch })
     generalState = next
+    persistGeneral(k)
     emitGeneral()
+}
+
+// ---------------------------------------------------------------------------
+// Cold-open cache — the tail of general, persisted per install (localStorage,
+// like the read marks). Opening a space paints the cached tail immediately;
+// the network fetch still runs and merges over it, so the paint is stale for
+// a round trip at most.
+// ---------------------------------------------------------------------------
+
+const CACHE_VERSION = 1
+/** Enough settled rows to fill the first screen well past the render cap. */
+const CACHE_TAIL = 60
+
+function cacheKey(k: string): string {
+    return `spaces:general:${k}`
+}
+
+interface GeneralCache {
+    v: number
+    topic: spaces.Topic
+    messages: spaces.Message[]
+    hasMore: boolean
+}
+
+function persistGeneral(k: string): void {
+    const state = generalState.get(k)
+    if (!state?.ready || !state.topic || state.error) return
+    const settled = state.messages.filter((m) => !m.pending && !m.failed)
+    if (settled.length === 0) return
+    const tail = settled.slice(-CACHE_TAIL)
+    const payload: GeneralCache = { v: CACHE_VERSION, topic: state.topic, messages: tail, hasMore: state.hasMore || tail.length < settled.length }
+    try {
+        window.localStorage.setItem(cacheKey(k), JSON.stringify(payload))
+    } catch {
+        // Best-effort (quota, private mode) — cold opens just fetch.
+    }
+}
+
+/** Keys painted from the cache and not yet confirmed by the org. */
+const generalCacheOnly = new Set<string>()
+
+/**
+ * Seed module state from the persisted cache. Render-safe on purpose: it
+ * swaps the snapshot WITHOUT notifying listeners, so useGeneral can call it
+ * during render and the space's very first frame already holds messages —
+ * no loading commit at all. Already-mounted subscribers catch up on the next
+ * emit (the network fetch right behind it). Idempotent once state exists.
+ */
+function hydrateGeneral(k: string): void {
+    if (generalState.has(k)) return
+    try {
+        const raw = window.localStorage.getItem(cacheKey(k))
+        if (!raw) return
+        const cached = JSON.parse(raw) as GeneralCache
+        if (cached.v !== CACHE_VERSION || !cached.topic || !Array.isArray(cached.messages)) return
+        generalCacheOnly.add(k)
+        const next = new Map(generalState)
+        next.set(k, { ...EMPTY_GENERAL, topic: cached.topic, messages: cached.messages, hasMore: cached.hasMore, ready: true })
+        generalState = next
+    } catch {
+        // A corrupt entry paints nothing; the fetch rebuilds it.
+    }
+}
+
+/**
+ * Warm a space's chat before it opens (the sidebar calls this on hover):
+ * hydrate the cached tail into module state and start the network refresh,
+ * so the click that follows finds everything already in. Never seeds — a
+ * hover must not post anything; seeding stays with the real open.
+ */
+export function prefetchGeneral(orgId: string, spaceId: string): void {
+    const k = key(orgId, spaceId)
+    hydrateGeneral(k)
+    const feed = getSpaceFeed(orgId, spaceId)
+    if (!feed.loaded) return
+    const found = findGeneralTopic(feed.topics)
+    const current = generalState.get(k)
+    if (found && (current?.topic?.id !== found.id || !current.ready || generalCacheOnly.has(k))) {
+        void loadGeneralMessages(orgId, spaceId, found)
+    }
 }
 
 async function loadGeneralMessages(orgId: string, spaceId: string, topic: spaces.Topic): Promise<void> {
@@ -95,13 +176,19 @@ async function loadGeneralMessages(orgId: string, spaceId: string, topic: spaces
             (m) => (m.pending || m.failed) && !res.messages.some((r) => r.author.memberId === m.author.memberId && r.body === m.body),
         )
         const reachesDeeper = (settled[0]?.offset ?? Infinity) < (res.messages[0]?.offset ?? Infinity)
+        generalCacheOnly.delete(k)
         setGeneral(k, {
             topic: res.topic,
             messages: [...mergeMessages(settled, res.messages), ...carried],
             hasMore: reachesDeeper && sameTopic ? prev.hasMore : res.hasMore,
             ready: true,
+            // A fresh page clears an old failure (the merge would keep it).
+            error: undefined,
         })
     } catch (err) {
+        // The attempt settled either way — a cached paint with an error badge
+        // behaves like today's error state; the reconnect resync retries.
+        generalCacheOnly.delete(k)
         setGeneral(k, { topic, ready: true, error: err instanceof Error ? err.message : String(err) })
     } finally {
         generalLoading.delete(k)
@@ -196,12 +283,15 @@ export function removeGeneralMessage(orgId: string, spaceId: string, messageId: 
 /** Find general in the feed store's topics; seed it when the space has none. */
 async function ensureGeneral(orgId: string, spaceId: string): Promise<void> {
     const k = key(orgId, spaceId)
+    // Paint the cached tail first — it needs no feed, so a cold open shows
+    // messages while topics are still on the wire.
+    hydrateGeneral(k)
     const feed = getSpaceFeed(orgId, spaceId)
     if (!feed.loaded) return
     const found = findGeneralTopic(feed.topics)
     const current = generalState.get(k)
     if (found) {
-        if (current?.topic?.id !== found.id || !current.ready) await loadGeneralMessages(orgId, spaceId, found)
+        if (current?.topic?.id !== found.id || !current.ready || generalCacheOnly.has(k)) await loadGeneralMessages(orgId, spaceId, found)
         else if (current.topic && (current.topic.title !== found.title || current.topic.archived !== found.archived)) setGeneral(k, { topic: found })
         return
     }
@@ -255,14 +345,30 @@ function wireBus(): void {
             }
         } else if (frame.event.type === 'reaction') {
             // Fold the toggle into the message in place (thread panes refetch on
-            // their own tick; general keeps its messages live here).
+            // their own tick; general keeps its messages live here). The
+            // viewer's own toggles are EXCLUDED: those reconcile through their
+            // HTTP response, and this echo can arrive seconds later — folding
+            // it would resurrect a reaction the optimistic remove just cleared.
             const { reaction, action } = frame.event
+            const selfId = getSpacesOrgs().find((o) => o.id === event.orgId)?.memberId
+            if (reaction.by.memberId === selfId) return
             if (state?.topic && state.messages.some((m) => m.id === reaction.messageId)) {
                 setGeneral(k, {
                     messages: state.messages.map((m) =>
                         m.id === reaction.messageId
                             ? { ...m, reactions: applyReaction(m.reactions, { emoji: reaction.emoji, memberId: reaction.by.memberId, action }) }
                             : m,
+                    ),
+                })
+            }
+        } else if (frame.event.type === 'message_edited') {
+            // Rewrite in place. Own edits are NOT excluded (unlike reactions):
+            // the fold is idempotent — re-applying the same body is harmless.
+            const { edit } = frame.event
+            if (state?.topic && state.messages.some((m) => m.id === edit.messageId)) {
+                setGeneral(k, {
+                    messages: state.messages.map((m) =>
+                        m.id === edit.messageId ? { ...m, body: edit.body, editedAt: edit.at } : m,
                     ),
                 })
             }
@@ -294,6 +400,10 @@ const watched = new Set<string>()
 /** General for one space: its topic and live messages. Seeds general on first open. */
 export function useGeneral(orgId: string, spaceId: string): GeneralState {
     const feed = useSpaceFeed(orgId, spaceId)
+    // Before the snapshot read, not in an effect: a space with a persisted
+    // tail must paint messages in its FIRST frame (the Slack feel). The call
+    // is idempotent and never emits, so it is safe during render.
+    hydrateGeneral(key(orgId, spaceId))
     const state = useSyncExternalStore(
         (l) => {
             generalListeners.add(l)
@@ -512,11 +622,12 @@ export function useSpacePresence(orgId: string, spaceId: string, selfMemberId: s
 }
 
 /**
- * Human presence sender: `viewing` while mounted (renewed every 20s), `typing`
- * at most every 4s while `onType()` keeps being called, `idle` on unmount or
+ * Human presence sender: `viewing` while mounted AND active (renewed every
+ * 20s), `typing` at most every 4s while `onType()` keeps being called, `idle`
+ * on unmount, on going inactive (a kept-alive pane hidden off screen), or
  * after 6s without typing (falls back to viewing).
  */
-export function usePresenceSender(orgId: string, spaceId: string, topicId?: string): { onType: () => void } {
+export function usePresenceSender(orgId: string, spaceId: string, topicId?: string, active = true): { onType: () => void } {
     const lastTypingRef = useRef(0)
     const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -528,6 +639,7 @@ export function usePresenceSender(orgId: string, spaceId: string, topicId?: stri
     )
 
     useEffect(() => {
+        if (!active) return
         send('viewing')
         const timer = setInterval(() => send('viewing'), 20_000)
         return () => {
@@ -535,7 +647,7 @@ export function usePresenceSender(orgId: string, spaceId: string, topicId?: stri
             if (idleTimerRef.current) clearTimeout(idleTimerRef.current)
             send('idle')
         }
-    }, [send])
+    }, [send, active])
 
     const onType = useCallback(() => {
         const now = Date.now()

--- a/apps/x/apps/renderer/src/hooks/use-topic-agent-permission.ts
+++ b/apps/x/apps/renderer/src/hooks/use-topic-agent-permission.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react'
+import { outstandingPermissions, reduceTurn } from '@x/shared/src/turns.js'
+import type { SessionLatestTurnStatus } from '@x/shared/src/sessions.js'
+import { ipcSessionsClient } from '@/lib/session-chat/client'
+import { subscribeSessionFeed } from '@/lib/session-chat/feed'
+
+// A topic's own-agent session can suspend mid-turn waiting for a tool
+// permission — invisible from the space (the working lease keeps spinning,
+// or expires, and the agent just idles). This watches the session index for
+// the topic's session and, when its latest turn is suspended, fetches the
+// turn to see whether permissions (not async tools) are what it waits on.
+
+/** Tool names the topic's agent is blocked on, oldest first ([] = not blocked). */
+export function useTopicAgentPermissionWait(
+    orgId: string,
+    spaceId: string,
+    topicId: string | null,
+    /** Gate for kept-alive hidden panes — no watching while off screen. */
+    enabled: boolean,
+): string[] {
+    const [sessionId, setSessionId] = useState<string | null>(null)
+    const [tools, setTools] = useState<string[]>([])
+
+    useEffect(() => {
+        let cancelled = false
+        setSessionId(null)
+        if (!topicId || !enabled) return
+        void window.ipc
+            .invoke('spaces:topicSession', { orgId, spaceId, topicId })
+            .then((res) => {
+                if (!cancelled) setSessionId(res.sessionId ?? null)
+            })
+            .catch(() => {})
+        return () => {
+            cancelled = true
+        }
+    }, [orgId, spaceId, topicId, enabled])
+
+    useEffect(() => {
+        setTools([])
+        if (!sessionId || !enabled) return
+        let cancelled = false
+        const check = (turnId: string | undefined, status: SessionLatestTurnStatus) => {
+            // "suspended" covers async tools too — only a fetched turn can say
+            // whether an unresolved permission is what holds it.
+            if (status !== 'suspended' || !turnId) {
+                setTools([])
+                return
+            }
+            void ipcSessionsClient
+                .getTurn(turnId)
+                .then(({ events }) => {
+                    if (cancelled) return
+                    setTools(outstandingPermissions(reduceTurn(events)).map((tc) => tc.toolName))
+                })
+                .catch(() => {})
+        }
+        void ipcSessionsClient
+            .list()
+            .then(({ sessions }) => {
+                if (cancelled) return
+                const entry = sessions.find((s) => s.sessionId === sessionId)
+                if (entry) check(entry.latestTurnId, entry.latestTurnStatus)
+            })
+            .catch(() => {})
+        const off = subscribeSessionFeed((event) => {
+            if (event.kind !== 'index-changed' || event.sessionId !== sessionId) return
+            if (!event.entry) setTools([])
+            else check(event.entry.latestTurnId, event.entry.latestTurnStatus)
+        })
+        return () => {
+            cancelled = true
+            off()
+        }
+    }, [sessionId, enabled])
+
+    return tools
+}

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.ts
@@ -59,16 +59,53 @@ export function attributionLabel(a: Attribution, members: Map<string, string>): 
 // Time — the feed shows clock time for today, "Yesterday 17:20", else "Aug 12"
 // ---------------------------------------------------------------------------
 
+// toLocale*String builds a fresh Intl.DateTimeFormat on every call — the
+// single hottest thing in a feed render (every row, every commit). Build the
+// two formats once; cache results per (timestamp, current day) since the
+// label only changes when the calendar day rolls over.
+const CLOCK_FORMAT = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
+const DAY_FORMAT = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' })
+const feedTimeCache = new Map<string, string>()
+
 export function formatFeedTime(iso: string, now: Date = new Date()): string {
+    const nowDay = now.toDateString()
+    const cacheKey = `${iso}|${nowDay}`
+    const hit = feedTimeCache.get(cacheKey)
+    if (hit !== undefined) return hit
     const date = new Date(iso)
     if (Number.isNaN(date.getTime())) return ''
-    const clock = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })
-    if (date.toDateString() === now.toDateString()) return clock
-    const yesterday = new Date(now)
-    yesterday.setDate(now.getDate() - 1)
-    if (date.toDateString() === yesterday.toDateString()) return `Yesterday ${clock}`
-    const day = date.toLocaleDateString([], { month: 'short', day: 'numeric' })
-    return date.getFullYear() === now.getFullYear() ? day : `${day}, ${date.getFullYear()}`
+    const clock = CLOCK_FORMAT.format(date)
+    let label: string
+    if (date.toDateString() === nowDay) {
+        label = clock
+    } else {
+        const yesterday = new Date(now)
+        yesterday.setDate(now.getDate() - 1)
+        if (date.toDateString() === yesterday.toDateString()) {
+            label = `Yesterday ${clock}`
+        } else {
+            const day = DAY_FORMAT.format(date)
+            label = date.getFullYear() === now.getFullYear() ? day : `${day}, ${date.getFullYear()}`
+        }
+    }
+    if (feedTimeCache.size > 4096) feedTimeCache.clear()
+    feedTimeCache.set(cacheKey, label)
+    return label
+}
+
+/** The hover tooltip behind a compact feed time: the full date and clock. */
+const FULL_TIME_FORMAT = new Intl.DateTimeFormat(undefined, { dateStyle: 'full', timeStyle: 'short' })
+const fullTimeCache = new Map<string, string>()
+
+export function formatFullTimestamp(iso: string): string {
+    const hit = fullTimeCache.get(iso)
+    if (hit !== undefined) return hit
+    const date = new Date(iso)
+    if (Number.isNaN(date.getTime())) return ''
+    const label = FULL_TIME_FORMAT.format(date)
+    if (fullTimeCache.size > 4096) fullTimeCache.clear()
+    fullTimeCache.set(iso, label)
+    return label
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/x/apps/renderer/src/lib/trusted-domains.ts
+++ b/apps/x/apps/renderer/src/lib/trusted-domains.ts
@@ -1,0 +1,35 @@
+// Trusted domains for external links in Spaces chat: first click on a domain
+// asks (the full URL shown), "trust" remembers the hostname locally so later
+// links there open straight away. Local only — this is a per-machine
+// convenience list, never synced through the org.
+
+const KEY = 'spaces:trustedDomains'
+
+function load(): string[] {
+    try {
+        const parsed: unknown = JSON.parse(localStorage.getItem(KEY) ?? '[]')
+        return Array.isArray(parsed) ? parsed.filter((d): d is string => typeof d === 'string') : []
+    } catch {
+        return []
+    }
+}
+
+/** Hostname a link would take the user to — null for anything but http(s). */
+export function linkDomain(url: string): string | null {
+    try {
+        const u = new URL(url)
+        return u.protocol === 'https:' || u.protocol === 'http:' ? u.hostname.toLowerCase() : null
+    } catch {
+        return null
+    }
+}
+
+export function isTrustedDomain(domain: string): boolean {
+    return load().includes(domain.toLowerCase())
+}
+
+export function trustDomain(domain: string): void {
+    const d = domain.toLowerCase()
+    const list = load()
+    if (!list.includes(d)) localStorage.setItem(KEY, JSON.stringify([...list, d]))
+}

--- a/apps/x/packages/core/src/spaces/client.ts
+++ b/apps/x/packages/core/src/spaces/client.ts
@@ -64,6 +64,7 @@ type NewTopicMessage = z.infer<Routes['postMessage']['request']>;
 type ManageTopicAction = z.infer<Routes['manageTopic']['request']>;
 type ReactInput = z.infer<Routes['reactToMessage']['request']>;
 type DeleteMessageInput = z.infer<Routes['deleteMessage']['request']>;
+type EditMessageInput = z.infer<Routes['editMessage']['request']>;
 
 export class SpacesClient {
   private readonly baseUrl: string;
@@ -335,6 +336,18 @@ export class SpacesClient {
         'POST',
         this.space(spaceId, `/messages/${encodeURIComponent(messageId)}/delete`),
         routes.deleteMessage.response,
+        input,
+      )
+    ).message;
+  }
+
+  /** Author-only body rewrite (identical body = no-op). Returns the edited message. */
+  async editMessage(spaceId: string, messageId: string, input: EditMessageInput): Promise<Message> {
+    return (
+      await this.request(
+        'POST',
+        this.space(spaceId, `/messages/${encodeURIComponent(messageId)}/edit`),
+        routes.editMessage.response,
         input,
       )
     ).message;

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3760,6 +3760,23 @@ const ipcSchemas = {
     req: z.object({ url: z.string() }),
     res: z.object({ saved: z.boolean(), path: z.string().optional() }),
   },
+  // OpenGraph metadata for a link card. Main fetches the page — the renderer
+  // can't (CORS) — with a size cap and timeout. null preview = nothing
+  // usable (not html, too slow, no tags). https only.
+  'spaces:linkPreview': {
+    req: z.object({ url: z.string() }),
+    res: z.object({
+      preview: z
+        .object({
+          url: z.string(),
+          title: z.string().optional(),
+          description: z.string().optional(),
+          imageUrl: z.string().optional(),
+          siteName: z.string().optional(),
+        })
+        .nullable(),
+    }),
+  },
   // Live: renderer subscribes per space; frames arrive on 'spaces:events'
   // wrapped with their orgId. Offset resume mirrors the turn-event spine.
   'spaces:subscribeSpace': {

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3683,6 +3683,17 @@ const ipcSchemas = {
     }),
     res: z.object({ message: z.custom<SpacesTypes.Message>() }),
   },
+  // Author-only body rewrite — the org enforces caller == author; identical
+  // bodies no-op. Returns the message with editedAt set.
+  'spaces:editMessage': {
+    req: z.object({
+      orgId: z.string(),
+      spaceId: z.string(),
+      messageId: z.string(),
+      body: z.string(),
+    }),
+    res: z.object({ message: z.custom<SpacesTypes.Message>() }),
+  },
   // @rowboat in a topic (spec §8): the renderer detected an addressed message
   // it just posted; main routes it into the topic's session (creating one on
   // first use — the queue/steer machinery handles the rest). messageId is the


### PR DESCRIPTION
## What

A batch of Spaces chat improvements across Harbor and the desktop app.

### Message editing (end-to-end)
- **Harbor**: new `editMessage` route + `message_edited` event. Author-only, exactly deletion's posture: the new body replaces the old everywhere it lives (message row **and** the stored `message` event — the old text must not resurface through replay). Tombstones refuse; an identical body is an idempotent 200 no-op with no write and no event. Editing bumps neither `lastActivityAt` nor `messageCount`. `Message` gains `editedAt`. Covered by API + migration tests; CONTRACT.md updated.
- **apps/x**: inline editor on your own messages (Enter to save, Esc to cancel) with an "(edited)" mark, wired through a new `spaces:editMessage` IPC handler and `SpacesClient.editMessage`.

### Keep-alive panes
- The Spaces view stays mounted once opened (hidden, not torn down), so reopening from the sidebar is instant.
- Within a space, the general stream — the expensive surface — never unmounts while the space is open; topics, drafts, and read mode hide it instead.
- A new `active`/`visible` flag gates presence and read marks so a hidden pane never reports "viewing" or marks arriving messages read.
- Hovering a space in the sidebar prefetches its general stream, so the click paints instantly.

### Rail rework
The topics/files rail is now either **pinned** (default — a plain sidebar) or **auto-hide** with a ~3.5s linger after the cursor leaves, replacing the teach-peek flyout that closed the instant the cursor left. Unpinning closes immediately so the click doesn't read as dead.

### Composer drafts
Unsent composer text persists per space/topic in localStorage — switching spaces or restarting the app hands the draft back; sending clears it.

### Selection copy
The app replaces the browser context menu, so plain text selection had no mouse-path copy. Added a floating Copy chip over selected message text, plus "copy message" (mentions resolved, image embeds dropped) and "copy selection" in the message context menu.

### Polish
Full timestamps on hover, a labelled Reply/Open action instead of a bare glyph, full-width thread rows, and reaction pop animations.

## Testing
- Harbor API tests cover edit semantics (author-only, tombstone refusal, idempotent no-op, replay rewrite) and the migration.
- UI changes verified in the running app.

---

## Round 2

### Navigation
- Topic panes lead with a bold **← Messages** chip (primary-tinted, with the Esc shortcut in its tooltip) and a breadcrumb divider before the topic title — the only way back to the stream used to be an unlabeled gray arrow.
- The rail's Files section is resizable: its top border is a drag handle and the height persists; untouched, it keeps the old grow-up-to-40% behavior.
- Dismissing the Split document (the ✕) now remembers the file — a header chip reopens it beside the conversation, and ⌘2/⌘3 prefer it over the README default.

### New-messages line
The orange **New** divider was snapshotted once at mount, and keep-alive panes meant it never cleared (it even resurfaced mid-conversation). It now re-arms at the true catch-up point each time a pane becomes visible, and fades out a few seconds after the reader has caught up — the stream gates the countdown on follow-mode; topic panes pin to the bottom so visibility is enough.

### Agent visibility
When an invoked Rowboat suspends mid-turn waiting on a tool permission, the topic/stream shows an amber **"Your Rowboat needs permission — \<tool\> · Review"** pill (click opens the agent session) instead of an indefinite "working…" spinner. A new hook watches the session-index feed for the topic's deterministic session and fetches the turn to distinguish permission waits from async-tool suspensions. Own-agent only by construction — session state is local.

### Links
- External links render blue/underlined and clickable. First click on a domain shows the full destination URL with **Cancel / Trust \<domain\> / Open link** — trusted hostnames live in a local list (`localStorage`), never synced through the org. Only http(s) leaves the app.
- Discord-style OpenGraph preview cards under messages (site, title, description, thumbnail) — for **trusted domains only**, since a preview is a silent network request and the trust gate should mean something. New `spaces:linkPreview` IPC: main fetches (https-only, 8s timeout, 512KB read cap, entity decoding, 30-min cache), the renderer caches one fetch per URL per session.

### Media
- **Lightbox zoom**, shared by the spaces and assistant-chat viewers: wheel/pinch zooms toward the cursor, click toggles fit ⇄ 2.5×, drag pans with the pan clamped so the image can't be lost; state resets on close.
- **Save to space files** on chat images — from the lightbox action row or the image's new right-click menu. One `proposeChange` referencing the already-uploaded blob hash (no byte re-upload), `baseVersion: 0` so an occupied path conflicts instead of silently overwriting.

### Composer
- Markdown formatting shortcuts: ⌘B / ⌘I / ⌘E / ⌘⇧X wrap the selection (or an empty caret) in the markers, and toggle-unwrap when already applied.
- **Interactive slash commands**: `/` opens a filtered menu styled like the composer itself (↑↓, ↵/⇥, click); argument commands complete to `/name ` with a pinned usage hint; unknown `/words` send as literal text. `/ask` is built in (rewrites to `@rowboat` and honors the agent-options strip); surfaces contribute `/fold <file>`, `/rename <title>`, `/archive` ⇄ `/unarchive`, `/invite`, `/read`.

### Context menus
Right-click on rail topic rows (Open / Rename / Archive), file rows (Open / Rename-move / Delete…), and folder rows (New file / Remove folder), mirroring the hover ⋯ menus.

### Merge with main
Merged `main` in; the one conflict (thread rows in `message-row.tsx`) composes this branch's full-width row styling with #922's archived-topic dimming and label.

## Testing (round 2)
- Full workspace typecheck and lint pass (the only remaining lint errors in touched files pre-date the branch).
- Renderer-only features verified via hot reload; the link-preview IPC and permission-wait path need a dev-main restart to exercise.
