### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -210,6 +210,7 @@ export async function modelConfig() {
             ollama: "",
             "openai-compatible": "",
             openrouter: "",
+            orcarouter: "",
         };
         const defaultBaseUrls: Record<z.infer<typeof Flavor>, string> = {
             "rowboat [free]": "",
@@ -220,6 +221,7 @@ export async function modelConfig() {
             ollama: "http://localhost:11434",
             "openai-compatible": "http://localhost:8080/v1",
             openrouter: "https://openrouter.ai/api/v1",
+            orcarouter: "https://api.orcarouter.ai/v1",
         };
         const defaultModels: Record<z.infer<typeof Flavor>, string> = {
             "rowboat [free]": "google/gemini-3-pro-preview",
@@ -230,6 +232,7 @@ export async function modelConfig() {
             ollama: "llama3.1",
             "openai-compatible": "openai/gpt-5.1",
             openrouter: "openrouter/auto",
+            orcarouter: "orcarouter/auto",
         };
 
         const currentProvider = config?.defaults?.provider;

--- a/apps/cli/src/models/models.ts
+++ b/apps/cli/src/models/models.ts
@@ -19,6 +19,7 @@ export const Flavor = z.enum([
     "openai",
     "openai-compatible",
     "openrouter",
+    "orcarouter",
 ]);
 
 export const Provider = z.object({
@@ -109,6 +110,18 @@ export async function getProvider(name: string = ""): Promise<ProviderV2> {
             providerMap[name] = createOpenRouter({
                 apiKey,
                 baseURL,
+                headers
+            });
+            break;
+        case "orcarouter":
+            // OrcaRouter is an OpenAI-compatible gateway with an
+            // OpenRouter-shaped model namespace; the OpenRouter AI SDK
+            // provider works against its endpoint directly. The service
+            // baseURL is defaulted here because the SDK's own default
+            // points at openrouter.ai, which rejects foreign keys.
+            providerMap[name] = createOpenRouter({
+                apiKey,
+                baseURL: baseURL || "https://api.orcarouter.ai/v1",
                 headers
             });
             break;

--- a/apps/x/apps/renderer/src/components/model-selector.tsx
+++ b/apps/x/apps/renderer/src/components/model-selector.tsx
@@ -26,6 +26,7 @@ export const providerDisplayNames: Record<string, string> = {
   google: 'Gemini',
   ollama: 'Ollama',
   openrouter: 'OpenRouter',
+  orcarouter: 'OrcaRouter',
   aigateway: 'AI Gateway',
   'openai-compatible': 'OpenAI-Compatible',
   rowboat: 'Rowboat',

--- a/apps/x/apps/renderer/src/components/onboarding/provider-icons.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/provider-icons.tsx
@@ -48,6 +48,20 @@ export function OpenRouterIcon({ className }: IconProps) {
   )
 }
 
+export function OrcaRouterIcon({ className }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className={cn("size-5", className)}>
+      <path d="M12 4a8 8 0 0 0-8 8c0 3.3 2 6.1 4.9 7.2" />
+      <path d="M12 4a8 8 0 0 1 8 8c0 3.3-2 6.1-4.9 7.2" />
+      <circle cx="12" cy="12" r="2.6" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="4" r="1.6" fill="currentColor" stroke="none" />
+      <circle cx="20" cy="12" r="1.6" fill="currentColor" stroke="none" />
+      <circle cx="4" cy="12" r="1.6" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="20" r="1.6" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
 export function VercelIcon({ className }: IconProps) {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" className={cn("size-5", className)}>

--- a/apps/x/apps/renderer/src/components/settings/providers-section.tsx
+++ b/apps/x/apps/renderer/src/components/settings/providers-section.tsx
@@ -20,6 +20,7 @@ import {
   OllamaIcon,
   OpenAIIcon,
   OpenRouterIcon,
+  OrcaRouterIcon,
   VercelIcon,
 } from "@/components/onboarding/provider-icons"
 
@@ -29,7 +30,7 @@ import {
 // Providers manage CREDENTIALS only — model choices live in
 // ModelSelectionSection above this section.
 
-type ByokFlavor = "openai" | "anthropic" | "google" | "openrouter" | "aigateway" | "ollama" | "openai-compatible"
+type ByokFlavor = "openai" | "anthropic" | "google" | "openrouter" | "orcarouter" | "aigateway" | "ollama" | "openai-compatible"
 
 interface ProviderMeta {
   id: string
@@ -59,6 +60,7 @@ const BYOK_CATALOG: Array<{ flavor: ByokFlavor; name: string; tagline: string; i
   { flavor: "google", name: "Gemini", tagline: "Google AI Studio", icon: GoogleIcon, needsKey: true, needsEndpoint: false },
   { flavor: "ollama", name: "Ollama", tagline: "Run models locally", icon: OllamaIcon, needsKey: false, needsEndpoint: true },
   { flavor: "openrouter", name: "OpenRouter", tagline: "One key, many models", icon: OpenRouterIcon, needsKey: true, needsEndpoint: false },
+  { flavor: "orcarouter", name: "OrcaRouter", tagline: "AI gateway for models & agents", icon: OrcaRouterIcon, needsKey: true, needsEndpoint: false },
   { flavor: "aigateway", name: "AI Gateway (Vercel)", tagline: "Vercel's AI Gateway", icon: VercelIcon, needsKey: true, needsEndpoint: false },
   { flavor: "openai-compatible", name: "OpenAI-Compatible", tagline: "Custom OpenAI-compatible endpoint", icon: GenericApiIcon, needsKey: true, optionalKey: true, needsEndpoint: true, manualModel: true },
 ]
@@ -67,6 +69,7 @@ const DEFAULT_BASE_URLS: Partial<Record<ByokFlavor, string>> = {
   ollama: "http://localhost:11434",
   "openai-compatible": "http://localhost:1234/v1",
   aigateway: "https://ai-gateway.vercel.sh/v1",
+  orcarouter: "https://api.orcarouter.ai/v1",
 }
 
 function flavorMeta(flavor: string) {

--- a/apps/x/packages/core/src/models/catalog.test.ts
+++ b/apps/x/packages/core/src/models/catalog.test.ts
@@ -212,6 +212,7 @@ describe('getImageModelCatalog', () => {
     serveConfig({
       ollama: { baseURL: 'http://localhost:11434' },
       'openai-compatible': { baseURL: 'http://localhost:1234/v1' },
+      orcarouter: { apiKey: 'sk-orca' },
     });
     mocks.listModelsForProvider.mockResolvedValue(['qwen3', 'gemma3']);
 
@@ -220,6 +221,7 @@ describe('getImageModelCatalog', () => {
     expect(catalog.providers).toEqual([
       { id: 'ollama', flavor: 'ollama', status: 'ok', models: ['qwen3', 'gemma3'] },
       { id: 'openai-compatible', flavor: 'openai-compatible', status: 'ok', models: ['qwen3', 'gemma3'] },
+      { id: 'orcarouter', flavor: 'orcarouter', status: 'ok', models: ['qwen3', 'gemma3'] },
     ]);
     expect(mocks.listImageModelsForProvider).not.toHaveBeenCalled();
   });

--- a/apps/x/packages/core/src/models/catalog.ts
+++ b/apps/x/packages/core/src/models/catalog.ts
@@ -60,6 +60,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
     anthropic: "Anthropic",
     google: "Gemini",
     openrouter: "OpenRouter",
+    orcarouter: "OrcaRouter",
     aigateway: "AI Gateway",
     ollama: "Ollama",
     "openai-compatible": "OpenAI-Compatible",
@@ -80,8 +81,12 @@ export function providerDisplayName(flavor: string): string {
 const MODELS_DEV_FLAVORS = new Set(["openai", "anthropic", "google"]);
 
 // listModelsForProvider builds aigateway's URL from baseURL; apply the
-// service default here so a keyed-but-URL-less config still lists.
+// service default here so a keyed-but-URL-less config still lists. The same
+// applies to orcarouter, whose OpenRouter-shaped SDK provider needs an
+// explicit baseURL to send its key anywhere (it defaults to openrouter.ai
+// otherwise, which rejects foreign keys).
 const AIGATEWAY_DEFAULT_BASE_URL = "https://ai-gateway.vercel.sh/v1";
+const ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1";
 
 // Successful lists are cached until the provider's credentials change or an
 // explicit refresh; failures retry after a short TTL so a temporarily-down
@@ -150,6 +155,9 @@ async function discoverProviders(): Promise<DiscoveredProvider[]> {
         const config = { ...entry };
         if (config.flavor === "aigateway" && !config.baseURL) {
             config.baseURL = AIGATEWAY_DEFAULT_BASE_URL;
+        }
+        if (config.flavor === "orcarouter" && !config.baseURL) {
+            config.baseURL = ORCAROUTER_DEFAULT_BASE_URL;
         }
         discovered.push({ id, flavor: entry.flavor, config });
     }
@@ -293,13 +301,14 @@ export interface ImageCatalogProviderEntry {
 // Flavors generate-image can build an image model for (the gateway plus
 // runtime/tools/domains/image.ts makeBackend's cases). Every one of them
 // lists — the picker only ever offers models a provider reported.
-const IMAGE_FLAVORS = new Set(["rowboat", "openrouter", "google", "openai", "ollama", "openai-compatible"]);
-// …of which these two carry no image-capability metadata anywhere in their
-// listing (Ollama's /api/tags and an OpenAI-compatible /models are bare id
-// lists), so they offer their FULL model list. Picking a non-image model
-// there surfaces the runtime's own readable error — a worse pick than a
-// filtered list, a better one than a free-typed id nothing can check.
-const IMAGE_UNFILTERABLE_FLAVORS = new Set(["ollama", "openai-compatible"]);
+const IMAGE_FLAVORS = new Set(["rowboat", "openrouter", "orcarouter", "google", "openai", "ollama", "openai-compatible"]);
+// …of which these three carry no image-capability metadata anywhere in their
+// listing (Ollama's /api/tags, an OpenAI-compatible /models, and OrcaRouter's
+// /models are bare id lists), so they offer their FULL model list. Picking a
+// non-image model there surfaces the runtime's own readable error — a worse
+// pick than a filtered list, a better one than a free-typed id nothing can
+// check.
+const IMAGE_UNFILTERABLE_FLAVORS = new Set(["ollama", "openai-compatible", "orcarouter"]);
 // Vendors whose image models come from the models.dev catalog's output
 // modalities; their own /models endpoints don't say who generates images.
 const IMAGE_MODELS_DEV_FLAVORS = new Set(["openai", "google"]);

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -23,6 +23,11 @@ import {
 export const Provider = LlmProvider;
 export const ModelConfig = LlmModelConfig;
 
+// OrcaRouter's API base URL. Defaulted for keyed-but-URL-less configs in
+// createProvider and listModelsForProvider (the OpenRouter SDK provider
+// defaults to openrouter.ai, which rejects foreign keys).
+const ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1";
+
 export function createProvider(config: z.infer<typeof Provider>): ProviderV4 {
     const { apiKey, baseURL, headers } = config;
     switch (config.flavor) {
@@ -78,6 +83,20 @@ export function createProvider(config: z.infer<typeof Provider>): ProviderV4 {
             return createOpenRouter({
                 apiKey,
                 baseURL,
+                headers,
+            }) as unknown as ProviderV4;
+        case "orcarouter":
+            // OrcaRouter is an OpenAI-compatible gateway with an
+            // OpenRouter-shaped model namespace; the OpenRouter AI SDK
+            // provider (which routes reasoning/prompt-caching via the same
+            // openrouter providerOptions namespace) works against its
+            // endpoint directly. The service baseURL is defaulted here so a
+            // keyed-but-URL-less config still reaches the right host — the
+            // SDK's own default points at openrouter.ai, which rejects
+            // foreign keys.
+            return createOpenRouter({
+                apiKey,
+                baseURL: baseURL || ORCAROUTER_DEFAULT_BASE_URL,
                 headers,
             }) as unknown as ProviderV4;
         case "rowboat":
@@ -276,6 +295,14 @@ export async function listModelsForProvider(
                 } else {
                     url = "https://openrouter.ai/api/v1/models";
                 }
+                break;
+            case "orcarouter":
+                // Same shape as OpenRouter: the public catalog lists models
+                // even without a key (a false "Connected"), so send the key
+                // when present so a bad key 401s here and the shared throw
+                // below surfaces it. Same OpenAI-shaped { data:[{id}] } list.
+                url = "https://api.orcarouter.ai/v1/models";
+                if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
                 break;
             case "ollama":
                 url = `${(baseURL ?? "http://localhost:11434").replace(/\/$/, "")}/api/tags`;

--- a/apps/x/packages/core/src/models/prompt-caching.test.ts
+++ b/apps/x/packages/core/src/models/prompt-caching.test.ts
@@ -21,6 +21,7 @@ describe("isAnthropicModel", () => {
     it("matches aggregator ids by prefix or claude name", () => {
         expect(isAnthropicModel("rowboat", "anthropic/claude-opus-4.8")).toBe(true);
         expect(isAnthropicModel("openrouter", "anthropic/claude-3.5-sonnet")).toBe(true);
+        expect(isAnthropicModel("orcarouter", "anthropic/claude-3.5-sonnet")).toBe(true);
         expect(isAnthropicModel("aigateway", "claude-sonnet-5")).toBe(true);
     });
 

--- a/apps/x/packages/core/src/models/prompt-caching.ts
+++ b/apps/x/packages/core/src/models/prompt-caching.ts
@@ -27,8 +27,9 @@ const CACHE_CONTROL: Record<string, JsonValue> = {
 };
 
 // Anthropic models arrive three ways: the direct provider (flavor
-// "anthropic", any model id), and aggregators (openrouter, aigateway, the
-// rowboat gateway) that address them as "anthropic/<model>" or "claude-*".
+// "anthropic", any model id), and aggregators (openrouter, orcarouter,
+// aigateway, the rowboat gateway) that address them as "anthropic/<model>"
+// or "claude-*".
 export function isAnthropicModel(flavor: string, modelId: string): boolean {
     if (flavor === "anthropic") {
         return true;

--- a/apps/x/packages/core/src/models/reasoning.test.ts
+++ b/apps/x/packages/core/src/models/reasoning.test.ts
@@ -65,6 +65,9 @@ describe("mapReasoningEffort", () => {
         expect(mapReasoningEffort("openrouter", "openai/o4-mini", "low", true)).toEqual({
             providerOptions: { openrouter: { reasoning: { effort: "low" } } },
         });
+        expect(mapReasoningEffort("orcarouter", "openai/o4-mini", "low", true)).toEqual({
+            providerOptions: { openrouter: { reasoning: { effort: "low" } } },
+        });
         expect(mapReasoningEffort("rowboat", "x/y", "high", false)).toBeUndefined();
     });
 

--- a/apps/x/packages/core/src/models/reasoning.ts
+++ b/apps/x/packages/core/src/models/reasoning.ts
@@ -126,6 +126,7 @@ export function mapReasoningEffort(
             return undefined;
         }
         case "openrouter":
+        case "orcarouter":
         case "rowboat": {
             if (supportsReasoning === false) return undefined;
             return { providerOptions: { openrouter: { reasoning: { effort } } } };

--- a/apps/x/packages/core/src/runtime/tools/domains/image.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/image.ts
@@ -26,7 +26,7 @@ import type { ToolContext } from "../exec-tool.js";
 // BYOK flavors that can build an AI SDK image model. "rowboat" (the
 // signed-in gateway) is the credential-less sixth path; anthropic /
 // aigateway / codex have no image surface here.
-type ImageFlavor = "openrouter" | "google" | "openai" | "ollama" | "openai-compatible" | "rowboat";
+type ImageFlavor = "openrouter" | "orcarouter" | "google" | "openai" | "ollama" | "openai-compatible" | "rowboat";
 
 interface ImageBackend {
     flavor: ImageFlavor;
@@ -54,6 +54,15 @@ function makeBackend(config: z.infer<typeof LlmProvider>): ImageBackend | null {
             return {
                 flavor: "openrouter",
                 makeImageModel: (id) => createOpenRouter({ apiKey, baseURL, headers }).imageModel(id),
+            };
+        case "orcarouter":
+            // Same OpenAI-compatible image surface as OpenRouter (the
+            // gateway fronts an OpenRouter-shaped model namespace). The
+            // SDK's own baseURL default points at openrouter.ai, which
+            // rejects foreign keys — default the service endpoint here.
+            return {
+                flavor: "orcarouter",
+                makeImageModel: (id) => createOpenRouter({ apiKey, baseURL: baseURL || "https://api.orcarouter.ai/v1", headers }).imageModel(id),
             };
         case "google":
             return {
@@ -90,7 +99,7 @@ function makeBackend(config: z.infer<typeof LlmProvider>): ImageBackend | null {
     }
 }
 
-const NO_IMAGE_MODEL_ERROR = "No image model configured. Pick one under model settings → Image model: signed-in users can use the Rowboat gateway; otherwise choose an OpenRouter, Google, OpenAI, Ollama, or OpenAI-compatible provider and one of its image models.";
+const NO_IMAGE_MODEL_ERROR = "No image model configured. Pick one under model settings → Image model: signed-in users can use the Rowboat gateway; otherwise choose an OpenRouter, OrcaRouter, Google, OpenAI, Ollama, or OpenAI-compatible provider and one of its image models.";
 
 type ImageResolution =
     | { ok: true; backend: ImageBackend; model: string }
@@ -135,7 +144,7 @@ async function resolveImageBackend(): Promise<ImageResolution> {
     if (!backend) {
         return {
             ok: false,
-            error: `The configured image model's provider '${selection.provider}' (${entry.flavor}) does not support image generation. Pick an OpenRouter, Google, OpenAI, Ollama, or OpenAI-compatible provider in model settings.`,
+            error: `The configured image model's provider '${selection.provider}' (${entry.flavor}) does not support image generation. Pick an OpenRouter, OrcaRouter, Google, OpenAI, Ollama, or OpenAI-compatible provider in model settings.`,
         };
     }
     return { ok: true, backend, model: selection.model };

--- a/apps/x/packages/shared/src/models.ts
+++ b/apps/x/packages/shared/src/models.ts
@@ -16,7 +16,7 @@ export const LlmProvider = z.object({
   // "rowboat" (signed-in gateway) and "codex" (ChatGPT subscription via
   // "Sign in with ChatGPT") are credential-less flavors: they never appear
   // in models.json's providers map — auth lives in their own token stores.
-  flavor: z.enum(["openai", "anthropic", "google", "openrouter", "aigateway", "ollama", "openai-compatible", "rowboat", "codex"]),
+  flavor: z.enum(["openai", "anthropic", "google", "openrouter", "orcarouter", "aigateway", "ollama", "openai-compatible", "rowboat", "codex"]),
   apiKey: z.string().optional(),
   baseURL: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
## Summary

Rowboat's model settings let users bring their own key/provider — hosted
providers, local runtimes, and aggregators like OpenRouter all show up in
the same provider catalog. This PR adds **OrcaRouter** to that catalog as
a first-class provider, mirroring the existing OpenRouter flavor so a user
can paste an OrcaRouter key and immediately use it for the assistant,
task models, and image generation — no custom-endpoint plumbing.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway
built for both models and agents. Like OpenRouter, it exposes a
provider/model namespace across many models — but it also combines
adaptive routing, automatic failover, zero-markup inference, observability,
guardrails, and agent-tool governance behind the same endpoint. Adding
`orcarouter` as a first-class provider means Rowboat's users can use that
stack directly, without treating OrcaRouter as an anonymous custom base
URL. It also runs gateway-level, zero-trust security for AI agents on the
same endpoint — screening every prompt/response and governing every tool
call on a default-deny basis, with no application code changes.

## Changes

- **`apps/x/packages/shared/src/models.ts`** — add `"orcarouter"` to the
  `LlmProvider.flavor` enum (the provider registry).
- **`apps/x/packages/core/src/models/models.ts`** — `createProvider` maps
  `orcarouter` to the OpenRouter AI SDK provider pointed at
  `https://api.orcarouter.ai/v1` (the SDK's own baseURL default points at
  openrouter.ai, which rejects foreign keys, so the service endpoint is
  defaulted for keyed-but-URL-less configs); `listModelsForProvider`
  lists from `https://api.orcarouter.ai/v1/models`, sending the key when
  present so a bad key surfaces as a 401 rather than a false "Connected".
- **`apps/x/packages/core/src/models/catalog.ts`** — provider display
  name ("OrcaRouter"), image-catalog membership, and the keyed-but-URL-less
  baseURL default (same pattern as AI Gateway).
- **`apps/x/packages/core/src/models/reasoning.ts`** — `orcarouter` maps
  reasoning effort through the same OpenRouter-shaped `reasoning.effort`
  provider option (verified live against the OrcaRouter API).
- **`apps/x/packages/core/src/models/prompt-caching.ts`** — `orcarouter`
  is recognized as an aggregator for Anthropic model ids, so Claude-family
  models get cache breakpoints.
- **`apps/x/packages/core/src/runtime/tools/domains/image.ts`** —
  `orcarouter` can build an image model (the same OpenRouter image surface).
- **Renderer** — `orcarouter` shows in the settings provider catalog
  (tagline "AI gateway for models & agents") with its own icon, and in the
  model picker's display names.
- **CLI** — `orcarouter` flavor with a default base URL and default model
  (`orcarouter/auto`) in the `model-config` interactive flow.
- **Tests** — reasoning, prompt-caching, and catalog coverage for the new
  flavor.

## Verification

- `tsc --noEmit` clean for `apps/x` (shared/core/renderer) and the CLI.
- ESLint clean on `packages/shared` + `packages/core` (renderer is
  excluded from lint per the repo's CI config).
- Vitest: shared 304/304, core models 97/97, renderer 364/364.
- Live (L3): with `ORCAROUTER_API_KEY` set, `listModelsForProvider`
  returned 204 models including `orcarouter/fusion-flash`, `generateText`
  returned `"OK"`, and `testModelConnection` succeeded.

Contact: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
