### PR TITLE
fix(x): cross-cycle Gmail rate-limit cooldown honoring "Retry after" lockouts

### DIFF
--- a/apps/x/packages/core/src/knowledge/gmail-rate-limit.test.ts
+++ b/apps/x/packages/core/src/knowledge/gmail-rate-limit.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Common } from 'googleapis';
+import {
+    IN_REQUEST_RETRY_FALLBACK_MS,
+    gmailRateLimitCooldownMs,
+    inRequestRetryWaitMs,
+    isRateLimitError,
+    noteGmailRateLimit,
+    rateLimitDeadlineMs,
+    resetGmailRateLimitForTests,
+} from './gmail-rate-limit.js';
+
+const NOW = Date.parse('2026-08-27T01:30:00.000Z');
+
+function gaxiosError(opts: {
+    status?: number;
+    message?: string;
+    headers?: Record<string, string> | Headers;
+    reasons?: string[];
+    dataMessage?: string;
+} = {}): Common.GaxiosError {
+    return {
+        message: opts.message ?? 'Request failed',
+        status: opts.status,
+        config: {},
+        response: {
+            status: opts.status,
+            headers: opts.headers ?? {},
+            data: {
+                error: {
+                    message: opts.dataMessage,
+                    errors: (opts.reasons ?? []).map((reason) => ({ reason })),
+                },
+            },
+        },
+    } as unknown as Common.GaxiosError;
+}
+
+beforeEach(() => {
+    resetGmailRateLimitForTests();
+});
+
+describe('isRateLimitError', () => {
+    it('matches 429 regardless of body', () => {
+        expect(isRateLimitError(gaxiosError({ status: 429 }))).toBe(true);
+    });
+
+    it('matches 403 with a rate-limit reason', () => {
+        expect(isRateLimitError(gaxiosError({ status: 403, reasons: ['userRateLimitExceeded'] }))).toBe(true);
+        expect(isRateLimitError(gaxiosError({ status: 403, reasons: ['rateLimitExceeded'] }))).toBe(true);
+    });
+
+    it('rejects other 403s and non-throttle statuses', () => {
+        expect(isRateLimitError(gaxiosError({ status: 403, reasons: ['insufficientPermissions'] }))).toBe(false);
+        expect(isRateLimitError(gaxiosError({ status: 500 }))).toBe(false);
+    });
+});
+
+describe('rateLimitDeadlineMs', () => {
+    it('reads delta-seconds Retry-After from plain-object headers', () => {
+        const err = gaxiosError({ status: 429, headers: { 'retry-after': '120' } });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(NOW + 120_000);
+    });
+
+    it('reads Retry-After from fetch Headers (gaxios v7 shape)', () => {
+        const err = gaxiosError({ status: 429, headers: new Headers({ 'Retry-After': '15' }) });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(NOW + 15_000);
+    });
+
+    it('reads an HTTP-date Retry-After', () => {
+        const err = gaxiosError({ status: 429, headers: { 'retry-after': 'Thu, 27 Aug 2026 01:35:00 GMT' } });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-27T01:35:00.000Z'));
+    });
+
+    it("reads Gmail's message-embedded deadline when no header exists", () => {
+        const err = gaxiosError({
+            status: 403,
+            reasons: ['userRateLimitExceeded'],
+            message: 'User-rate limit exceeded.  Retry after 2026-08-27T01:41:22.427Z',
+        });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-27T01:41:22.427Z'));
+    });
+
+    it('reads the deadline from the response body message too', () => {
+        const err = gaxiosError({
+            status: 429,
+            dataMessage: 'User-rate limit exceeded. Retry after 2026-08-27T01:45:00.000Z',
+        });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-27T01:45:00.000Z'));
+    });
+
+    it('ignores deadlines in the past and returns null when none is named', () => {
+        const stale = gaxiosError({ status: 429, message: 'Retry after 2026-08-27T01:00:00.000Z' });
+        expect(rateLimitDeadlineMs(stale, NOW)).toBeNull();
+        expect(rateLimitDeadlineMs(gaxiosError({ status: 429 }), NOW)).toBeNull();
+    });
+});
+
+describe('inRequestRetryWaitMs', () => {
+    it('waits out a deadline that fits under the cap', () => {
+        const err = gaxiosError({ status: 429, headers: { 'retry-after': '10' } });
+        expect(inRequestRetryWaitMs(err, NOW)).toBe(10_000);
+    });
+
+    it('returns null (fail fast) when the deadline outlasts the cap', () => {
+        const err = gaxiosError({
+            status: 429,
+            message: 'User-rate limit exceeded. Retry after 2026-08-27T01:41:22.427Z',
+        });
+        expect(inRequestRetryWaitMs(err, NOW)).toBeNull();
+    });
+
+    it('falls back to the short default when no deadline is named', () => {
+        expect(inRequestRetryWaitMs(gaxiosError({ status: 429 }), NOW)).toBe(IN_REQUEST_RETRY_FALLBACK_MS);
+    });
+});
+
+describe('cross-cycle cooldown', () => {
+    it("honors Gmail's own deadline", () => {
+        const deadline = Date.parse('2026-08-27T01:41:22.427Z');
+        const err = gaxiosError({ status: 429, message: `Rate limited. Retry after 2026-08-27T01:41:22.427Z` });
+        expect(noteGmailRateLimit(err, NOW)).toBe(deadline);
+        expect(gmailRateLimitCooldownMs(NOW)).toBe(deadline - NOW);
+        expect(gmailRateLimitCooldownMs(deadline + 1)).toBe(0);
+    });
+
+    it('escalates the default cooldown per strike when no deadline is named', () => {
+        const err = gaxiosError({ status: 429 });
+        expect(noteGmailRateLimit(err, NOW)).toBe(NOW + 60_000);
+        expect(noteGmailRateLimit(err, NOW + 61_000)).toBe(NOW + 61_000 + 120_000);
+        expect(noteGmailRateLimit(err, NOW + 200_000)).toBe(NOW + 200_000 + 240_000);
+    });
+
+    it('caps the escalating default at 15 minutes', () => {
+        const err = gaxiosError({ status: 429 });
+        let t = NOW;
+        for (let i = 0; i < 10; i++) {
+            // Re-strike right after each cooldown ends so the episode persists.
+            t = noteGmailRateLimit(err, t) + 1_000;
+        }
+        expect(noteGmailRateLimit(err, t) - t).toBe(15 * 60_000);
+    });
+
+    it('resets the strike ladder after a quiet spell', () => {
+        const err = gaxiosError({ status: 429 });
+        noteGmailRateLimit(err, NOW);
+        noteGmailRateLimit(err, NOW + 61_000);
+        // > EPISODE_RESET_MS after the last cooldown ended → fresh episode.
+        const later = NOW + 61_000 + 120_000 + 11 * 60_000;
+        expect(noteGmailRateLimit(err, later)).toBe(later + 60_000);
+    });
+
+    it('never shrinks an already-armed cooldown', () => {
+        const far = gaxiosError({ status: 429, message: 'Retry after 2026-08-27T02:00:00.000Z' });
+        const near = gaxiosError({ status: 429, headers: { 'retry-after': '5' } });
+        noteGmailRateLimit(far, NOW);
+        noteGmailRateLimit(near, NOW + 1_000);
+        expect(gmailRateLimitCooldownMs(NOW + 2_000)).toBe(Date.parse('2026-08-27T02:00:00.000Z') - (NOW + 2_000));
+    });
+});

--- a/apps/x/packages/core/src/knowledge/gmail-rate-limit.ts
+++ b/apps/x/packages/core/src/knowledge/gmail-rate-limit.ts
@@ -1,0 +1,127 @@
+import type { Common } from 'googleapis';
+
+/**
+ * Gmail rate-limit detection and the cross-cycle cooldown (the follow-up
+ * deferred by #869).
+ *
+ * Two layers use this module:
+ *   - GoogleClientFactory.gmailClient()'s retry hooks classify errors
+ *     (isRateLimitError), size the single in-request retry
+ *     (inRequestRetryWaitMs), and arm the cooldown (noteGmailRateLimit)
+ *     whenever a throttled request is about to fail through to the caller.
+ *   - The background loops (sync_gmail's 30s tick, gmail_sent_contacts'
+ *     refresh) consult gmailRateLimitCooldownMs() and stand down while it is
+ *     positive, instead of re-tripping the quota every tick.
+ *
+ * Gmail's flood-control errors ("User-rate limit exceeded. Retry after
+ * 2026-08-27T20:08:37.427Z") put the deadline in the error MESSAGE, not a
+ * Retry-After header, and it is routinely minutes away — far beyond what an
+ * in-request retry may wait. Honoring it requires state that outlives the
+ * request, hence this process-wide singleton. Deliberately not persisted to
+ * disk: lockouts are minutes long, restarts are rare mid-lockout, and a stale
+ * on-disk deadline would silently pause sync after a crash.
+ *
+ * User-initiated actions (send, archive, mark read) do NOT consult the
+ * cooldown — one interactive request can't sustain the limit, and an explicit
+ * error beats a silent no-op.
+ */
+
+const RATE_LIMIT_REASONS = new Set(['rateLimitExceeded', 'userRateLimitExceeded']);
+
+/** Longest an in-request retry may wait; beyond this, fail fast and cool down. */
+export const IN_REQUEST_RETRY_CAP_MS = 30_000;
+/** In-request retry wait when Gmail names no deadline at all. */
+export const IN_REQUEST_RETRY_FALLBACK_MS = 2_000;
+
+// No-deadline cooldowns escalate per strike: 1m, 2m, 4m, ... capped at 15m.
+// A quiet EPISODE_RESET_MS after a cooldown ends starts the ladder over.
+const NO_DEADLINE_BASE_COOLDOWN_MS = 60_000;
+const NO_DEADLINE_MAX_COOLDOWN_MS = 15 * 60_000;
+const EPISODE_RESET_MS = 10 * 60_000;
+// Sanity clamp on Gmail-supplied deadlines (clock skew, malformed dates).
+const DEADLINE_CAP_MS = 6 * 60 * 60_000;
+
+let cooldownUntil = 0;
+let strikes = 0;
+
+/** 429 anywhere, or Gmail's alternate 403-with-rate-limit-reason form. */
+export function isRateLimitError(err: Common.GaxiosError): boolean {
+    const status = err.response?.status ?? err.status;
+    if (status === 429) return true;
+    if (status !== 403) return false;
+    const data = err.response?.data as { error?: { errors?: { reason?: string }[] } } | undefined;
+    return (data?.error?.errors ?? []).some((e) => e.reason !== undefined && RATE_LIMIT_REASONS.has(e.reason));
+}
+
+/** Tolerates both fetch Headers (gaxios v7) and plain-object headers. */
+function headerValue(err: Common.GaxiosError, name: string): string | null {
+    const headers = err.response?.headers as unknown;
+    if (!headers) return null;
+    if (typeof (headers as Headers).get === 'function') return (headers as Headers).get(name);
+    const record = headers as Record<string, string | string[] | undefined>;
+    const raw = record[name] ?? record[name.toLowerCase()];
+    return (Array.isArray(raw) ? raw[0] : raw) ?? null;
+}
+
+/**
+ * Epoch-ms deadline after which Gmail says a throttled request may be retried,
+ * or null when the error names none. Checks the Retry-After header (delta
+ * seconds or HTTP-date) first, then the "Retry after <ISO timestamp>" Gmail
+ * embeds in the error message.
+ */
+export function rateLimitDeadlineMs(err: Common.GaxiosError, now: number = Date.now()): number | null {
+    const header = headerValue(err, 'retry-after');
+    if (header) {
+        const seconds = Number(header);
+        if (Number.isFinite(seconds) && seconds > 0) return now + seconds * 1000;
+        const asDate = Date.parse(header);
+        if (Number.isFinite(asDate) && asDate > now) return asDate;
+    }
+
+    const data = err.response?.data as { error?: { message?: string } } | undefined;
+    const message = `${err.message ?? ''} ${data?.error?.message ?? ''}`;
+    const match = /retry after\s+(\d{4}-\d{2}-\d{2}T[0-9:.]+Z?)/i.exec(message);
+    if (match) {
+        const asDate = Date.parse(match[1]);
+        if (Number.isFinite(asDate) && asDate > now) return asDate;
+    }
+    return null;
+}
+
+/**
+ * How long the single in-request retry should wait, or null when the deadline
+ * outlasts IN_REQUEST_RETRY_CAP_MS — then retrying in-request is pointless
+ * (and burns another quota-counted call): fail fast and cool down instead.
+ */
+export function inRequestRetryWaitMs(err: Common.GaxiosError, now: number = Date.now()): number | null {
+    const deadline = rateLimitDeadlineMs(err, now);
+    if (deadline === null) return IN_REQUEST_RETRY_FALLBACK_MS;
+    const wait = deadline - now;
+    return wait <= IN_REQUEST_RETRY_CAP_MS ? Math.max(wait, 1_000) : null;
+}
+
+/**
+ * Arm (or extend) the cross-cycle cooldown for a rate-limit error that is
+ * failing through to its caller. Uses Gmail's own deadline when it names one;
+ * otherwise escalates a default per strike. Returns the cooldown end (epoch ms).
+ */
+export function noteGmailRateLimit(err: Common.GaxiosError, now: number = Date.now()): number {
+    if (now - cooldownUntil > EPISODE_RESET_MS) strikes = 0;
+    strikes += 1;
+    const deadline = rateLimitDeadlineMs(err, now);
+    const until = deadline !== null
+        ? Math.min(deadline, now + DEADLINE_CAP_MS)
+        : now + Math.min(NO_DEADLINE_BASE_COOLDOWN_MS * 2 ** (strikes - 1), NO_DEADLINE_MAX_COOLDOWN_MS);
+    cooldownUntil = Math.max(cooldownUntil, until);
+    return cooldownUntil;
+}
+
+/** Milliseconds until Gmail may be called again; 0 when no cooldown is active. */
+export function gmailRateLimitCooldownMs(now: number = Date.now()): number {
+    return Math.max(0, cooldownUntil - now);
+}
+
+export function resetGmailRateLimitForTests(): void {
+    cooldownUntil = 0;
+    strikes = 0;
+}

--- a/apps/x/packages/core/src/knowledge/gmail_sent_contacts.ts
+++ b/apps/x/packages/core/src/knowledge/gmail_sent_contacts.ts
@@ -5,6 +5,7 @@ import { gmail_v1 as gmail } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
+import { gmailRateLimitCooldownMs } from './gmail-rate-limit.js';
 import { getUserEmail } from './classify_thread.js';
 import { isAutomatedAddress } from './contact_filters.js';
 
@@ -302,6 +303,8 @@ async function performSync(): Promise<void> {
 
 function ensureFresh(): void {
     if (pendingSync) return;
+    // Don't spend quota on a background refresh during a rate-limit lockout.
+    if (gmailRateLimitCooldownMs() > 0) return;
     if (Date.now() - lastRefreshAt < REFRESH_INTERVAL_MS) return;
     pendingSync = performSync()
         .catch((err) => {

--- a/apps/x/packages/core/src/knowledge/google-client-factory.ts
+++ b/apps/x/packages/core/src/knowledge/google-client-factory.ts
@@ -1,5 +1,11 @@
 import { OAuth2Client } from 'google-auth-library';
-import { google, gmail_v1, type Common } from 'googleapis';
+import { google, gmail_v1 } from 'googleapis';
+import {
+    IN_REQUEST_RETRY_FALLBACK_MS,
+    inRequestRetryWaitMs,
+    isRateLimitError,
+    noteGmailRateLimit,
+} from './gmail-rate-limit.js';
 import container from '../di/container.js';
 import { IOAuthRepo } from '../auth/repo.js';
 import { IClientRegistrationRepo } from '../auth/client-repo.js';
@@ -14,23 +20,6 @@ import {
 } from '../auth/google-backend-oauth.js';
 
 type Mode = 'byok' | 'rowboat';
-
-const RATE_LIMIT_REASONS = new Set(['rateLimitExceeded', 'userRateLimitExceeded']);
-
-/** 429 anywhere, or Gmail's alternate 403-with-rate-limit-reason form. */
-function isRateLimitError(err: Common.GaxiosError): boolean {
-    const status = err.response?.status ?? err.status;
-    if (status === 429) return true;
-    if (status !== 403) return false;
-    const data = err.response?.data as { error?: { errors?: { reason?: string }[] } } | undefined;
-    return (data?.error?.errors ?? []).some((e) => e.reason !== undefined && RATE_LIMIT_REASONS.has(e.reason));
-}
-
-/** Retry-After in ms, capped at 30s; 2s when the header is absent/unparsable. */
-function rateLimitDelayMs(err: Common.GaxiosError): number {
-    const seconds = Number(err.response?.headers?.get('retry-after'));
-    return Number.isFinite(seconds) && seconds > 0 ? Math.min(seconds, 30) * 1000 : 2000;
-}
 
 /**
  * Factory for creating and managing Google OAuth2Client instances.
@@ -349,11 +338,16 @@ export class GoogleClientFactory {
     /**
      * Gmail API client with rate-limit retry — parity with Outlook's
      * graphFetch (outlook-client-factory.ts): one retry per request on a
-     * throttled response, waiting out Retry-After capped at 30s (2s when the
-     * header is absent). gaxios' stock retry can't express this — its delay
-     * formula never reads Retry-After, and its default method list excludes
-     * POST, which modify/trash/send all use — so both hooks are custom. A
-     * request still throttled after the retry fails like any other error.
+     * throttled response, waiting out the deadline Gmail names (Retry-After
+     * header or the "Retry after <timestamp>" in the error message) when it
+     * fits under the in-request cap. gaxios' stock retry can't express this —
+     * its delay formula never reads Retry-After, and its default method list
+     * excludes POST, which modify/trash/send all use — so both hooks are
+     * custom.
+     *
+     * A request that will fail anyway — retry spent, or the deadline outlasts
+     * the cap — arms the cross-cycle cooldown (gmail-rate-limit.ts) on its way
+     * out, so the background sync loops stop re-tripping the quota every tick.
      */
     static gmailClient(auth: OAuth2Client): gmail_v1.Gmail {
         return google.gmail({
@@ -361,10 +355,16 @@ export class GoogleClientFactory {
             auth,
             retryConfig: {
                 retry: 1,
-                shouldRetry: (err) =>
-                    (err.config.retryConfig?.currentRetryAttempt ?? 0) < 1 && isRateLimitError(err),
+                shouldRetry: (err) => {
+                    if (!isRateLimitError(err)) return false;
+                    const attempt = err.config.retryConfig?.currentRetryAttempt ?? 0;
+                    if (attempt < 1 && inRequestRetryWaitMs(err) !== null) return true;
+                    const until = noteGmailRateLimit(err);
+                    console.warn(`[Gmail] rate limited — cooling down until ${new Date(until).toISOString()}`);
+                    return false;
+                },
                 retryBackoff: (err) => {
-                    const waitMs = rateLimitDelayMs(err);
+                    const waitMs = inRequestRetryWaitMs(err) ?? IN_REQUEST_RETRY_FALLBACK_MS;
                     console.warn(`[Gmail] rate limited — retrying after ${waitMs}ms`);
                     return new Promise((resolve) => setTimeout(resolve, waitMs));
                 },

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -5,6 +5,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
 import { getMaxEmails } from '../config/gmail_sync_config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
+import { gmailRateLimitCooldownMs } from './gmail-rate-limit.js';
 import { serviceLogger, type ServiceRunContext } from '../services/service_logger.js';
 import { limitEventItems } from './limit_event_items.js';
 import { formatTimestampForModel } from '@x/shared/dist/time.js';
@@ -1378,6 +1379,30 @@ async function sweepUnclassifiedMarkdown(auth: OAuth2Client, llmBudget: number =
     }
 }
 
+// One Sync Activity notice per rate-limit episode, deduped on the lockout
+// deadline — without it the cooldown silences the feed mid-lockout, which
+// reads as sync having given up. A progress event on a synthetic run: a
+// run_complete would wrongly clear the sidebar's red failed state (any
+// non-error outcome clears it) while Gmail is still locked out.
+let lastCooldownNoticeUntil = 0;
+async function logRateLimitCooldownNotice(cooldownMs: number): Promise<void> {
+    const until = Date.now() + cooldownMs;
+    if (Math.abs(until - lastCooldownNoticeUntil) < 5_000) return;
+    lastCooldownNoticeUntil = until;
+    const at = new Date(until).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    try {
+        await serviceLogger.log({
+            type: 'progress',
+            service: 'gmail',
+            runId: 'gmail_rate_limit_notice',
+            level: 'warn',
+            message: `Rate limited by Gmail — next sync attempt at ${at}`,
+        });
+    } catch {
+        // Best-effort: the caller's console log still records the skip.
+    }
+}
+
 async function performSync() {
     const LOOKBACK_DAYS = 7; // Default to 1 week
     const ATTACHMENTS_DIR = path.join(SYNC_DIR, 'attachments');
@@ -1386,6 +1411,16 @@ async function performSync() {
     // Ensure directories exist
     if (!fs.existsSync(SYNC_DIR)) fs.mkdirSync(SYNC_DIR, { recursive: true });
     if (!fs.existsSync(ATTACHMENTS_DIR)) fs.mkdirSync(ATTACHMENTS_DIR, { recursive: true });
+
+    // Stand down while Gmail's rate-limit lockout is active — every pass
+    // attempted before the deadline fails anyway, and its partial progress
+    // is exactly what kept the quota permanently tripped.
+    const cooldownMs = gmailRateLimitCooldownMs();
+    if (cooldownMs > 0) {
+        console.log(`[Gmail] rate-limit cooldown active — skipping sync for another ${Math.ceil(cooldownMs / 1000)}s`);
+        await logRateLimitCooldownNotice(cooldownMs);
+        return;
+    }
 
     try {
         const auth = await GoogleClientFactory.getClient();
@@ -2068,9 +2103,14 @@ export async function init() {
             console.error("Error in main loop:", error);
         }
 
-        // Sleep for N minutes before next check (can be interrupted by triggerSync)
-        console.log(`Sleeping for ${SYNC_INTERVAL_MS / 1000} seconds...`);
-        await interruptibleSleep(SYNC_INTERVAL_MS);
+        // Sleep before the next check (can be interrupted by triggerSync).
+        // An active rate-limit cooldown stretches the sleep to Gmail's own
+        // deadline; performSync guards again in case a trigger wakes us early.
+        const cooldownMs = gmailRateLimitCooldownMs();
+        if (cooldownMs > 0) await logRateLimitCooldownNotice(cooldownMs);
+        const sleepMs = Math.max(SYNC_INTERVAL_MS, cooldownMs > 0 ? cooldownMs + 1_000 : 0);
+        console.log(`Sleeping for ${Math.round(sleepMs / 1000)} seconds...`);
+        await interruptibleSleep(sleepMs);
     }
 }
 


### PR DESCRIPTION
The follow-up deferred by #869 ("Cross-cycle rate-limit cooldown honoring Gmail's 'Retry after <timestamp>' lockouts"), prompted by the Discord report that the aggressive retry loop is back on 0.8.9.

## The problem

When Gmail rate-limits, the sync loop keeps retrying on its fixed 30s tick with no backoff. Each failed pass saves no state, redoes the same listing/fetch burst from scratch, and its partial progress re-arms the very quota that killed the previous pass — so one rate-limit event becomes a permanent lockout ("Syncing Gmail → Gmail sync error → Gmail sync failed" every minute, all night). #869's in-request retry can't help: it waits at most 30s (2s when no `Retry-After` header is present), and Gmail's flood-control errors put the deadline in the error **message** ("User-rate limit exceeded. Retry after 2026-08-27T…Z"), routinely minutes away — nothing ever read it.

## The fix

**New `gmail-rate-limit.ts`** — one module owning rate-limit handling:
- Detection (moved from the client factory) plus deadline parsing: `Retry-After` header (delta-seconds or HTTP-date) and the message-embedded ISO timestamp.
- A process-wide cooldown: armed whenever a throttled request fails through to its caller, using Gmail's own deadline when it names one (clamped to 6h); otherwise a per-strike escalating default (1m → 2m → 4m … capped at 15m, ladder reset after a 10-minute quiet spell). Never shrinks. In-memory by design — lockouts are minutes long, and a stale on-disk deadline would silently pause sync after a crash.

**`gmailClient()` retry hooks** now size the single in-request retry from the parsed deadline — a deadline within 30s is waited out precisely; one beyond the cap fails fast instead of burning a doomed 2s retry — and arm the cooldown on the way out. All 18 Gmail call sites go through the factory, so every consumer's failures feed it.

**The loops honor it:** `performSync` stands down while the cooldown is active (also covering `triggerSync` wakes, the inbox prune, and the classify sweep), and `init()` stretches its sleep to Gmail's deadline instead of ticking every 30s through a lockout. `gmail_sent_contacts`' background refresh stands down too. User-initiated actions (send, archive, mark read) deliberately do **not** consult the cooldown — one interactive request can't sustain the limit, and an explicit error beats a silent no-op.

**Visibility:** one Sync Activity entry per lockout episode — "Rate limited by Gmail — next sync attempt at HH:MM" — deduped on the deadline, so the feed shows the failure once plus the pause instead of a failing triplet every minute. Shaped as a warn-level `progress` event on a synthetic run: a `run_complete` would wrongly clear the sidebar's red failed state (any non-error outcome clears it) while Gmail is still locked out.

## Out of scope (follow-ups)

- Checkpointing full-sync/backfill progress so a failed pass doesn't restart from scratch after the cooldown.
- Outlook parity (its `graphFetch` retry has the same in-request-only shape).
- Persistent "last synced at" status UI.

## Test plan

- [x] 17 unit tests (`gmail-rate-limit.test.ts`): both `Retry-After` header forms, message-embedded deadlines (header-absent Gmail form from the report), past/absent deadlines, fail-fast vs in-request wait, deadline honoring, strike escalation + cap + episode reset, never-shrinking cooldowns.
- [x] `npm run deps`, `npm run lint`, `npm run typecheck` pass; existing `google-client-factory` and `sync_gmail` suites still green.
- [ ] Fake-429 harness: local server returning 429 with a far "Retry after" → one cooldown log, one feed notice, stretched sleep, auto-resume after the deadline; manual sync during lockout skips without a duplicate notice.
- [ ] Prerelease confirmation from the affected user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)