### PR TITLE
fix(x): polyfill import.meta.url in the packaged rowboat-server bundle

### DIFF
--- a/apps/x/apps/main/bundle.mjs
+++ b/apps/x/apps/main/bundle.mjs
@@ -166,8 +166,14 @@ await esbuild.build({
   entryPoints: ['../server/dist/standalone.js'],
   bundle: true,
   platform: 'node',
+  target: 'node20',
   format: 'cjs',
   outfile: './.package/dist/rowboat-server.cjs',
+  // Same import.meta.url polyfill as main.cjs — core modules resolve asset
+  // paths through it at module init; without the define the CJS bundle sees
+  // undefined and crashes before the server can boot.
+  banner: { js: cjsBanner },
+  define: { 'import.meta.url': '__import_meta_url' },
   external: ['electron', 'node-pty', 'uiohook-napi', 'bun:sqlite'],
 });
 console.log('✅ rowboat-server bundled to .package/dist/rowboat-server.cjs');

--- a/apps/x/apps/main/src/server-host.ts
+++ b/apps/x/apps/main/src/server-host.ts
@@ -207,7 +207,7 @@ async function launchChild(): Promise<ChildServer> {
       ? path.join(__dirname, 'rowboat-server.cjs')
       : path.resolve(app.getAppPath(), '../server/dist/standalone.js'));
   const child = spawn(process.execPath, [entry], {
-    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', ROWBOAT_PARENT_PID: String(process.pid) },
     stdio: ['ignore', 'inherit', 'inherit'],
   });
   child.on('exit', (code) => {

--- a/apps/x/apps/server/src/server.ts
+++ b/apps/x/apps/server/src/server.ts
@@ -206,7 +206,14 @@ export async function createRowboatServer(opts: RowboatServerOptions): Promise<R
     close: async () => {
       for (const unsub of unsubscribers) unsub?.();
       hub.close();
-      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      // close() alone waits for keep-alive sockets that may never end (the
+      // forwarder's fetch pool, idle browser preconnects) — destroy them so
+      // shutdown resolves promptly instead of hanging the process.
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => resolve());
+        httpServer.closeIdleConnections();
+        httpServer.closeAllConnections();
+      });
       await releaseLock();
     },
   };

--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -107,11 +107,27 @@ async function main(): Promise<void> {
   console.log(`[server] rowboat-server listening on http://${server.host}:${server.port} (workdir: ${WorkDir})`);
 
   const shutdown = async () => {
+    // Never let a stuck teardown keep the process alive — exit regardless.
+    setTimeout(() => process.exit(0), 5000).unref();
     await server.close();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown());
   process.on('SIGTERM', () => void shutdown());
+
+  // Child mode: if the parent Electron app dies without managing to kill us
+  // (crash, force-quit), exit rather than run orphaned against its workdir.
+  const parentPid = Number(process.env.ROWBOAT_PARENT_PID ?? '');
+  if (parentPid > 0) {
+    setInterval(() => {
+      try {
+        process.kill(parentPid, 0);
+      } catch {
+        console.error('[server] parent process gone — shutting down');
+        void shutdown();
+      }
+    }, 5000).unref();
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
The packaged app's child server crashed on boot (`TypeError: The "path" argument must be of type string` from core's skills module) — the second esbuild artifact in `bundle.mjs` lacked the `import.meta.url` polyfill that `main.cjs` and the headless build already use. Dev child mode and the AWS headless deploy were unaffected, which is why it survived until the packaged-app test.

Verified: repackaged app spawns the child, `/health` answers, app works normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)