### PR TITLE
feat(x): Connect-to-server settings UI

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -54,7 +54,7 @@ import type { ISessions, EmitterSessionBus } from '@x/core/dist/runtime/sessions
 import type { ITurnEventBus } from '@x/core/dist/runtime/turns/event-hub.js';
 import container from '@x/core/dist/di/container.js';
 import { forwardRpc, shouldForwardChannel } from './rpc-forwarder.js';
-import { getPairingInfo, rotateKey as rotateServerKey, setLanEnabled as setServerLanEnabled, bridgeDeltaSubscribe, bridgeDeltaUnsubscribe, childServerMode } from './server-host.js';
+import { getPairingInfo, rotateKey as rotateServerKey, setLanEnabled as setServerLanEnabled, bridgeDeltaSubscribe, bridgeDeltaUnsubscribe, childServerMode, getConnectionInfo, connectRemoteServer, disconnectRemoteServer } from './server-host.js';
 import { testModelConnection, listModelsForProvider, generateOneShot } from '@x/core/dist/models/models.js';
 import { getModelCatalog } from '@x/core/dist/models/catalog.js';
 import { captureProviderConnected, captureProviderDisconnected } from '@x/core/dist/analytics/model-providers.js';
@@ -577,6 +577,13 @@ export function broadcastToWindows(channel: string, payload: unknown): void {
     if (!win.isDestroyed() && win.webContents) {
       win.webContents.send(channel, payload);
     }
+  }
+}
+
+/** Reload every window — used after switching servers, so all renderer state refetches. */
+export function broadcastReload(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed() && win.webContents) win.webContents.reload();
   }
 }
 
@@ -3055,6 +3062,19 @@ export function setupIpcHandlers() {
     'server:rotateKey': async () => {
       await rotateServerKey();
       return { success: true };
+    },
+    'server:getConnection': async () => getConnectionInfo(),
+    'server:connectRemote': async (_event, args) => {
+      const result = await connectRemoteServer(args.url, args.token);
+      // The renderer's caches all describe the old server — reload every
+      // window once the reply has been delivered.
+      if (result.success) setTimeout(() => broadcastReload(), 400);
+      return result;
+    },
+    'server:disconnectRemote': async () => {
+      const result = await disconnectRemoteServer();
+      if (result.success) setTimeout(() => broadcastReload(), 400);
+      return result;
     },
     // Server-only channel: the client's relay listener calls it over HTTP
     // (see server-host.ts) — it always forwards, this local stub is

--- a/apps/x/apps/main/src/server-host.ts
+++ b/apps/x/apps/main/src/server-host.ts
@@ -1,5 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { app, shell } from 'electron';
@@ -40,8 +42,45 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // child mode, just over the network.
 export type ServerHostMode = 'in-process' | 'child' | 'remote';
 
+// A remote connection saved from the Settings UI. Env vars stay the
+// power-user override and always win; the saved config makes remote mode
+// reachable without a terminal. Read synchronously once — serverHostMode()
+// gates decisions during main's boot, before any async init has run.
+const clientConfigPath = path.join(WorkDir, 'config', 'client.json');
+let savedRemote: { url: string; token: string } | null | undefined;
+
+function loadSavedRemote(): { url: string; token: string } | null {
+  if (savedRemote !== undefined) return savedRemote;
+  savedRemote = null;
+  try {
+    const raw = JSON.parse(fsSync.readFileSync(clientConfigPath, 'utf8')) as {
+      remoteServer?: { url?: string; token?: string };
+    };
+    if (raw.remoteServer?.url && raw.remoteServer.token) {
+      savedRemote = { url: raw.remoteServer.url, token: raw.remoteServer.token };
+    }
+  } catch {
+    // no config yet — local mode
+  }
+  return savedRemote;
+}
+
+/** Where the client should connect, or null for a local child. */
+function remoteTarget(): { baseUrl: string; key: string; fromEnv: boolean } | null {
+  if (process.env.ROWBOAT_REMOTE_SERVER) {
+    return {
+      baseUrl: process.env.ROWBOAT_REMOTE_SERVER.replace(/\/+$/, ''),
+      key: (process.env.ROWBOAT_REMOTE_TOKEN ?? '').trim(),
+      fromEnv: true,
+    };
+  }
+  const saved = loadSavedRemote();
+  if (saved) return { baseUrl: saved.url, key: saved.token, fromEnv: false };
+  return null;
+}
+
 export function serverHostMode(): ServerHostMode {
-  if (process.env.ROWBOAT_REMOTE_SERVER) return 'remote';
+  if (remoteTarget()) return 'remote';
   const env = process.env.ROWBOAT_CHILD_SERVER;
   if (env !== undefined && (env === '0' || env.toLowerCase() === 'false')) return 'in-process';
   return 'child';
@@ -182,10 +221,11 @@ async function isRowboatServer(baseUrl: string): Promise<boolean> {
 }
 
 async function connectRemote(): Promise<RemoteServer> {
-  const baseUrl = process.env.ROWBOAT_REMOTE_SERVER!.replace(/\/+$/, '');
-  const key = (process.env.ROWBOAT_REMOTE_TOKEN ?? '').trim();
+  const target = remoteTarget();
+  if (!target) throw new Error('no remote server configured');
+  const { baseUrl, key } = target;
   if (!key) {
-    throw new Error('ROWBOAT_REMOTE_SERVER is set but ROWBOAT_REMOTE_TOKEN is missing');
+    throw new Error('remote server configured without an access token');
   }
   const deadline = Date.now() + 20_000;
   while (!(await isRowboatServer(baseUrl))) {
@@ -359,6 +399,83 @@ export async function setLanEnabled(enabled: boolean): Promise<void> {
   await saveServerConfig(WorkDir, { ...config, lanEnabled: enabled });
   await stopServerHost();
   await startServerHost();
+}
+
+// ============================================================================
+// Remote connection management (Settings → Connect to server)
+// ============================================================================
+
+export function getConnectionInfo(): { mode: ServerHostMode; url: string | null; fromEnv: boolean } {
+  const target = remoteTarget();
+  return {
+    mode: serverHostMode(),
+    url: target?.baseUrl ?? null,
+    fromEnv: target?.fromEnv ?? false,
+  };
+}
+
+async function saveClientConfig(remote: { url: string; token: string } | null): Promise<void> {
+  let existing: Record<string, unknown> = {};
+  try {
+    existing = JSON.parse(await fs.readFile(clientConfigPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    // fresh file
+  }
+  if (remote) existing.remoteServer = remote;
+  else delete existing.remoteServer;
+  await fs.mkdir(path.dirname(clientConfigPath), { recursive: true });
+  await fs.writeFile(clientConfigPath, JSON.stringify(existing, null, 2) + '\n', { mode: 0o600 });
+}
+
+/**
+ * Validate the address + token against a live server, persist them, and
+ * switch the running app over (the local child, if any, is stopped).
+ */
+export async function connectRemoteServer(url: string, token: string): Promise<{ success: boolean; error?: string }> {
+  if (process.env.ROWBOAT_REMOTE_SERVER) {
+    return { success: false, error: 'The server address is set by environment variables — unset them to manage it here.' };
+  }
+  if (serverHostMode() === 'in-process') {
+    return { success: false, error: 'Not available while ROWBOAT_CHILD_SERVER=0 is set.' };
+  }
+  const baseUrl = url.trim().replace(/\/+$/, '');
+  const key = token.trim();
+  if (!/^https?:\/\//.test(baseUrl)) {
+    return { success: false, error: 'Enter a full address like http://100.x.y.z:3220' };
+  }
+  if (!key) return { success: false, error: 'Enter the server’s access code' };
+  if (!(await isRowboatServer(baseUrl))) {
+    return { success: false, error: 'No Rowboat server answered at that address' };
+  }
+  try {
+    const res = await fetch(`${baseUrl}/rpc/sessions:list`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+      body: '{}',
+      signal: AbortSignal.timeout(8000),
+    });
+    if (res.status === 401) return { success: false, error: 'The server rejected that access code' };
+    if (!res.ok) return { success: false, error: `The server answered with an error (${res.status})` };
+  } catch {
+    return { success: false, error: 'Could not reach the server to verify the access code' };
+  }
+  await saveClientConfig({ url: baseUrl, token: key });
+  savedRemote = { url: baseUrl, token: key };
+  await stopServerHost();
+  await startServerHost();
+  return { success: true };
+}
+
+/** Back to local: forget the saved server and spawn the local child again. */
+export async function disconnectRemoteServer(): Promise<{ success: boolean; error?: string }> {
+  if (process.env.ROWBOAT_REMOTE_SERVER) {
+    return { success: false, error: 'The server address is set by environment variables — unset them to manage it here.' };
+  }
+  await saveClientConfig(null);
+  savedRemote = null;
+  await stopServerHost();
+  await startServerHost();
+  return { success: true };
 }
 
 /** Mints a new server key, revoking every paired client, then rebinds. */

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -29,6 +29,7 @@ import { AccountSettings } from "@/components/settings/account-settings"
 import { ConnectedAccountsSettings } from "@/components/settings/connected-accounts-settings"
 import { MobileChannelsSettings } from "@/components/settings/mobile-channels-settings"
 import { PhonePairingSettings } from "@/components/settings/phone-pairing-settings"
+import { RemoteServerSettings } from "@/components/settings/remote-server-settings"
 import type { ApprovalPolicy } from "@x/shared/src/code-mode.js"
 import { DEFAULT_TURN_LIMITS_SETTINGS } from "@x/shared/src/turn-limits.js"
 import type { ipc as ipcShared } from "@x/shared"
@@ -2104,7 +2105,14 @@ export function SettingsDialog({ children, defaultTab = "account", open: control
               ) : activeTab === "mobile" ? (
                 <MobileChannelsSettings dialogOpen={open} />
               ) : activeTab === "phone" ? (
-                <PhonePairingSettings dialogOpen={open} />
+                <div className="space-y-6">
+                  <PhonePairingSettings dialogOpen={open} />
+                  <Separator />
+                  <div className="space-y-2">
+                    <h4 className="text-sm font-semibold">Connect to a server</h4>
+                    <RemoteServerSettings dialogOpen={open} />
+                  </div>
+                </div>
               ) : activeTab === "models" ? (
                 // ONE model-selection surface for signed-in and BYOK alike:
                 // the Assistant model + per-task overrides, then provider

--- a/apps/x/apps/renderer/src/components/settings/remote-server-settings.tsx
+++ b/apps/x/apps/renderer/src/components/settings/remote-server-settings.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { toast } from "sonner"
+
+type ConnectionInfo = {
+  mode: "in-process" | "child" | "remote"
+  url: string | null
+  fromEnv: boolean
+}
+
+// Settings → Connect to server: point this desktop at a rowboat-server on
+// another machine (address + access code from that machine's
+// ~/.rowboat/server-key), or go back to running everything locally. On a
+// successful switch main reloads every window, so this component only has to
+// deliver the toast before the reload lands.
+export function RemoteServerSettings({ dialogOpen }: { dialogOpen: boolean }) {
+  const [info, setInfo] = useState<ConnectionInfo | null>(null)
+  const [url, setUrl] = useState("")
+  const [token, setToken] = useState("")
+  const [busy, setBusy] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      setInfo(await window.ipc.invoke("server:getConnection", null))
+    } catch {
+      toast.error("Failed to load connection state")
+    }
+  }, [])
+
+  useEffect(() => {
+    if (dialogOpen) void refresh()
+  }, [dialogOpen, refresh])
+
+  if (!info) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        Loading...
+      </div>
+    )
+  }
+
+  const handleConnect = async () => {
+    setBusy(true)
+    try {
+      const result = await window.ipc.invoke("server:connectRemote", { url, token })
+      if (result.success) {
+        toast.success("Connected — reloading…")
+      } else {
+        toast.error(result.error ?? "Could not connect")
+        setBusy(false)
+      }
+    } catch {
+      toast.error("Could not connect")
+      setBusy(false)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    setBusy(true)
+    try {
+      const result = await window.ipc.invoke("server:disconnectRemote", null)
+      if (result.success) {
+        toast.success("Back to this Mac — reloading…")
+      } else {
+        toast.error(result.error ?? "Could not disconnect")
+        setBusy(false)
+      }
+    } catch {
+      toast.error("Could not disconnect")
+      setBusy(false)
+    }
+  }
+
+  if (info.fromEnv) {
+    return (
+      <div className="space-y-2">
+        <div className="text-sm">
+          Connected to <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{info.url}</code>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          This connection is set by environment variables (ROWBOAT_REMOTE_SERVER), so it
+          can&apos;t be changed here. Relaunch the app without them to manage it from Settings.
+        </p>
+      </div>
+    )
+  }
+
+  if (info.mode === "remote") {
+    return (
+      <div className="space-y-3">
+        <div className="text-sm">
+          Connected to <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{info.url}</code>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Your chats, notes, and connectors live on that machine. Disconnect to go back
+          to running everything on this Mac.
+        </p>
+        <Button variant="outline" size="sm" disabled={busy} onClick={handleDisconnect}>
+          {busy ? "Disconnecting…" : "Disconnect — use this Mac"}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Run Rowboat against a server on another machine. Enter its address and the
+        access code from <code className="font-mono">~/.rowboat/server-key</code> on that
+        machine. Everything — chats, notes, connectors — will live there.
+      </p>
+      <div className="space-y-2">
+        <Input
+          placeholder="http://100.x.y.z:3220"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="font-mono text-xs"
+        />
+        <Input
+          placeholder="Access code"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          className="font-mono text-xs"
+        />
+      </div>
+      <Button size="sm" disabled={busy || !url.trim() || !token.trim()} onClick={handleConnect}>
+        {busy ? "Connecting…" : "Connect"}
+      </Button>
+    </div>
+  )
+}

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3418,6 +3418,25 @@ export const ipcSchemas = {
       success: z.literal(true),
     }),
   },
+  // Remote-server connection (client-local, never forwarded): where this
+  // desktop's client points — the local child by default, or a remote
+  // rowboat-server saved from Settings. Env vars override and lock the UI.
+  'server:getConnection': {
+    req: z.null(),
+    res: z.object({
+      mode: z.enum(['in-process', 'child', 'remote']),
+      url: z.string().nullable(),
+      fromEnv: z.boolean(),
+    }),
+  },
+  'server:connectRemote': {
+    req: z.object({ url: z.string(), token: z.string() }),
+    res: z.object({ success: z.boolean(), error: z.string().optional() }),
+  },
+  'server:disconnectRemote': {
+    req: z.null(),
+    res: z.object({ success: z.boolean(), error: z.string().optional() }),
+  },
   // OAuth loopback relay (Phase 8b): a loopback-capable client hosting the
   // 127.0.0.1 callback listener for a remote server ships each callback hit
   // here; the response says which page to render in the browser tab. Called


### PR DESCRIPTION
Closes the 'remote is env-var only' gap: Settings → Phone → **Connect to a server** — address + access code, validated live (health probe + authed RPC; wrong code → clear error, nothing switches), saved to `~/.rowboat/config/client.json`, app switches live and reloads windows. Disconnect reverses. Env vars still win and lock the section.

Verified live against the AWS box via the UI (including wrong-code and unreachable-address paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)