### PR TITLE
fix(x): enable multilingual voice transcription

### DIFF
--- a/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
+++ b/apps/x/apps/renderer/src/hooks/useMeetingTranscription.ts
@@ -17,7 +17,7 @@ const DEEPGRAM_PARAMS = new URLSearchParams({
     interim_results: 'true',
     smart_format: 'true',
     punctuate: 'true',
-    language: 'en',
+    language: 'multi',
 });
 const DEEPGRAM_LISTEN_URL = `wss://api.deepgram.com/v1/listen?${DEEPGRAM_PARAMS.toString()}`;
 

--- a/apps/x/apps/renderer/src/hooks/useVoiceMode.ts
+++ b/apps/x/apps/renderer/src/hooks/useVoiceMode.ts
@@ -16,7 +16,7 @@ const DEEPGRAM_PARAMS = new URLSearchParams({
     interim_results: 'true',
     smart_format: 'true',
     punctuate: 'true',
-    language: 'en',
+    language: 'multi',
     endpointing: '100',
     no_delay: 'true',
 });

--- a/apps/x/packages/core/src/voice/voice.ts
+++ b/apps/x/packages/core/src/voice/voice.ts
@@ -154,7 +154,7 @@ const ASR_PARAMS = new URLSearchParams({
     model: 'nova-3',
     smart_format: 'true',
     punctuate: 'true',
-    language: 'en',
+    language: 'multi',
 });
 
 const ASR_WS_CHUNK_BYTES = 32 * 1024;


### PR DESCRIPTION
## Summary

- use Deepgram Nova-3 multilingual mode for live voice input
- apply the same language mode to meeting and batch/tool transcription paths
- preserve all existing endpointing, diarization, and audio settings

Fixes #871.

## Validation

- `tsc -p packages/shared/tsconfig.build.json`
- `tsc -p packages/core/tsconfig.build.json`
- `tsc -b apps/renderer`
- ESLint passed for `useMeetingTranscription.ts` and `voice.ts`
- a focused source assertion verified all three Nova-3 request configs use `language=multi` and no longer use `language=en`

## Boundaries

No live Deepgram request or microphone capture was run locally. A full lint of `useVoiceMode.ts` remains blocked by the two existing errors at lines 152 and 167 on current `main`; this change only touches its language parameter at line 19. The unrelated screenshot-paste note in #871 is not addressed here.