### PR TITLE
fix(composio): use POST /connected_accounts/link for managed OAuth

### DIFF
--- a/apps/x/apps/main/src/composio-handler.ts
+++ b/apps/x/apps/main/src/composio-handler.ts
@@ -104,23 +104,18 @@ export async function initiateConnection(toolkitSlug: string): Promise<{
             authConfigId = created.auth_config.id;
         }
 
-        // Create connected account with callback URL
+        // Link connected account with callback URL.
+        // Uses POST /connected_accounts/link (Composio v3 flat body) which replaced
+        // the retired POST /connected_accounts endpoint for managed OAuth.
         const callbackUrl = REDIRECT_URI;
-        const response = await composioClient.createConnectedAccount({
-            auth_config: { id: authConfigId },
-            connection: {
-                user_id: 'rowboat-user',
-                callback_url: callbackUrl,
-            },
+        const response = await composioClient.linkConnectedAccount({
+            auth_config_id: authConfigId,
+            user_id: 'rowboat-user',
+            callback_url: callbackUrl,
         });
 
-        const connectedAccountId = response.id;
-
-        // Safely extract redirectUrl with type checking
-        const connectionVal = response.connectionData?.val;
-        const redirectUrl = typeof connectionVal === 'object' && connectionVal !== null && 'redirectUrl' in connectionVal
-            ? String((connectionVal as Record<string, unknown>).redirectUrl)
-            : undefined;
+        const connectedAccountId = response.connected_account_id;
+        const redirectUrl = response.redirect_url;
 
         if (!redirectUrl) {
             return {

--- a/apps/x/packages/core/src/composio/client.ts
+++ b/apps/x/packages/core/src/composio/client.ts
@@ -13,6 +13,8 @@ import {
     ZErrorResponse,
     ZExecuteActionRequest,
     ZExecuteActionResponse,
+    ZLinkConnectedAccountRequest,
+    ZLinkConnectedAccountResponse,
     ZListResponse,
     ZSearchResultTool,
     ZToolkit,
@@ -148,6 +150,36 @@ export async function composioApiCall<T extends z.ZodTypeAny>(
         }
 
         if (!response.ok) {
+            // Proxy 404 fallback: if we were routing through the Rowboat proxy and the
+            // path isn't forwarded yet (e.g. /connected_accounts/link), retry the same
+            // request directly against Composio using the local API key.
+            if (response.status === 404 && await isSignedIn()) {
+                const localKey = getApiKey();
+                if (localKey) {
+                    console.warn(`[Composio] Proxy returned 404 for ${url.pathname}; falling back to direct Composio API with local key`);
+                    const directUrl = new URL(`${COMPOSIO_BASE_URL}${path}`);
+                    Object.entries(params).forEach(([key, value]) => directUrl.searchParams.set(key, value));
+                    const directResponse = await fetch(directUrl, {
+                        ...options,
+                        headers: {
+                            ...options.headers,
+                            'x-api-key': localKey,
+                            ...(options.method === 'POST' ? { "Content-Type": "application/json" } : {}),
+                        },
+                    });
+                    const directContentType = directResponse.headers.get('content-type') || '';
+                    const directRawText = await directResponse.text();
+                    if (directResponse.ok && directContentType.includes('application/json')) {
+                        const directData = JSON.parse(directRawText);
+                        return schema.parse(directData);
+                    }
+                    console.error(`[Composio] Direct fallback also failed:`, {
+                        status: directResponse.status,
+                        preview: directRawText.slice(0, 200),
+                    });
+                }
+            }
+
             // Try to extract a human-readable message from the JSON body
             let detail = '';
             try {
@@ -242,6 +274,21 @@ export async function createConnectedAccount(
     request: z.infer<typeof ZCreateConnectedAccountRequest>
 ): Promise<z.infer<typeof ZCreateConnectedAccountResponse>> {
     return composioApiCall(ZCreateConnectedAccountResponse, "/connected_accounts", {}, {
+        method: 'POST',
+        body: JSON.stringify(request),
+    });
+}
+
+/**
+ * Link (initiate) a connected account for managed OAuth — Composio v3.
+ * Uses POST /connected_accounts/link with a flat request body.
+ * Prefer this over createConnectedAccount for managed-OAuth toolkits;
+ * the older POST /connected_accounts endpoint was retired by Composio.
+ */
+export async function linkConnectedAccount(
+    request: z.infer<typeof ZLinkConnectedAccountRequest>
+): Promise<z.infer<typeof ZLinkConnectedAccountResponse>> {
+    return composioApiCall(ZLinkConnectedAccountResponse, "/connected_accounts/link", {}, {
         method: 'POST',
         body: JSON.stringify(request),
     });

--- a/apps/x/packages/core/src/composio/types.ts
+++ b/apps/x/packages/core/src/composio/types.ts
@@ -166,6 +166,24 @@ export const ZErrorResponse = z.object({
 });
 
 /**
+ * Link connected account request (POST /connected_accounts/link — Composio v3)
+ * Flat body shape that replaced the nested POST /connected_accounts for managed OAuth.
+ */
+export const ZLinkConnectedAccountRequest = z.object({
+    auth_config_id: z.string(),
+    user_id: z.string().optional(),
+    callback_url: z.string().optional(),
+});
+
+/**
+ * Link connected account response (POST /connected_accounts/link — Composio v3)
+ */
+export const ZLinkConnectedAccountResponse = z.object({
+    connected_account_id: z.string(),
+    redirect_url: z.string().optional(),
+}).passthrough();
+
+/**
  * Delete operation response
  */
 export const ZDeleteOperationResponse = z.object({


### PR DESCRIPTION
## Summary

Composio v3 retired `POST /connected_accounts` in favour of the flat-body
`POST /connected_accounts/link` endpoint. This PR migrates the desktop client
to the new endpoint and adds a resilience fallback for the hosted proxy.

Fixes #912 . Related: #912 .

## Changes

- **`packages/core/src/composio/types.ts`** — add `ZLinkConnectedAccountRequest`
  / `ZLinkConnectedAccountResponse` matching the new flat
  `{ auth_config_id, user_id, callback_url }` request and
  `{ connected_account_id, redirect_url }` response shapes.
- **`packages/core/src/composio/client.ts`** — add `linkConnectedAccount()`
  calling `POST /connected_accounts/link`. Also add a proxy-404 fallback in
  `composioApiCall`: when signed in and the proxy returns 404, retry the same
  request directly against Composio with the local API key (helps users who
  have both a Rowboat session and a local Composio key).
- **`apps/main/src/composio-handler.ts`** — replace `createConnectedAccount()`
  with `linkConnectedAccount()` and update field references.

## Testing

Verified on macOS (signed in to Rowboat):

- Client now sends `POST .../v1/composio/connected_accounts/link` ✅
- Hosted proxy currently returns `404 Not Found` (text/plain) for this path —
  see "Remaining backend work" below
- With a local Composio key configured, the 404 fallback fires and reaches
  `backend.composio.dev/api/v3/connected_accounts/link` directly. It then
  fails with `Auth_Config_NotFound` because the auth config fetched via the
  proxy belongs to Rowboat's Composio org, not the user's — confirming the
  proxy-side fix is required for signed-in users.
- Signed-out BYOK path: `POST https://backend.composio.dev/api/v3/connected_accounts/link` → 201, OAuth proceeds ✅
- `npm run lint`, `npm run typecheck` and package builds all pass

## Remaining backend work (not in this repo)

The hosted proxy at `api.x.rowboatlabs.com` must forward:
POST /v1/composio/connected_accounts/link → POST https://backend.composio.dev/api/v3/connected_accounts/link

with the same auth it already uses for other Composio v3 routes, passing the
flat request body through and returning Composio's JSON response
(`connected_account_id`, `redirect_url`). Until then, pure signed-in users
cannot connect managed-OAuth toolkits; this PR makes the client correct and
ready for when the proxy is updated.