### PR TITLE
fix(x): show the actual next meeting in the sidebar

### DIFF
--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -92,6 +92,7 @@ import { extractConferenceLink } from "@/lib/calendar-event"
 import { useBilling } from "@/hooks/useBilling"
 import { useRowboatConfig } from "@/hooks/use-rowboat-config"
 import { toast } from "@/lib/toast"
+import { compareMeetingStarts, formatMeetingTime } from "@/lib/sidebar-meeting-preview"
 import { getBillingPlanData } from "@x/shared/dist/billing.js"
 import { ServiceEvent } from "@x/shared/src/service-events.js"
 import z from "zod"
@@ -556,10 +557,7 @@ export function SidebarContentPanel({
         }))
         const items: UpcomingMeeting[] = []
         for (const r of settled) if (r.status === 'fulfilled' && r.value) items.push(r.value)
-        items.sort((a, b) => {
-          if (a.isAllDay !== b.isAllDay) return a.isAllDay ? -1 : 1
-          return a.start.getTime() - b.start.getTime()
-        })
+        items.sort(compareMeetingStarts)
         if (!cancelled) setMeetings(items.slice(0, 1))
       } catch { /* ignore */ }
     }
@@ -1731,21 +1729,6 @@ function normalizeUpcomingMeeting(raw: RawCalendarEvent, sourcePath: string): Up
     rawStart: raw.start,
     rawEnd: raw.end,
   }
-}
-
-function isSameLocalDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
-}
-
-function formatMeetingTime(event: UpcomingMeeting): string {
-  if (event.isAllDay) return 'All day'
-  const now = new Date()
-  const tomorrow = new Date(now)
-  tomorrow.setDate(tomorrow.getDate() + 1)
-  const time = event.start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-  if (isSameLocalDay(event.start, now)) return time
-  if (isSameLocalDay(event.start, tomorrow)) return `Tmrw ${time}`
-  return event.start.toLocaleDateString([], { month: 'numeric', day: 'numeric' })
 }
 
 function triggerMeetingCapture(event: UpcomingMeeting, openConference: boolean) {

--- a/apps/x/apps/renderer/src/lib/sidebar-meeting-preview.test.ts
+++ b/apps/x/apps/renderer/src/lib/sidebar-meeting-preview.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { compareMeetingStarts, formatMeetingTime } from './sidebar-meeting-preview'
+
+afterEach(() => vi.useRealTimers())
+
+describe('meeting sidebar preview', () => {
+  it('chooses the earliest event instead of prioritizing a later all-day event', () => {
+    const timed = { start: new Date(2026, 7, 31, 9) }
+    const allDay = { start: new Date(2026, 8, 9) }
+
+    expect([allDay, timed].sort(compareMeetingStarts)).toEqual([timed, allDay])
+  })
+
+  it('qualifies future all-day events with their date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 28, 12))
+    const start = new Date(2026, 8, 9)
+    const date = start.toLocaleDateString([], { month: 'numeric', day: 'numeric' })
+
+    expect(formatMeetingTime({ start, isAllDay: true })).toBe(`${date} · All day`)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/sidebar-meeting-preview.ts
+++ b/apps/x/apps/renderer/src/lib/sidebar-meeting-preview.ts
@@ -1,0 +1,23 @@
+export function compareMeetingStarts(a: { start: Date }, b: { start: Date }): number {
+  return a.start.getTime() - b.start.getTime()
+}
+
+function isSameLocalDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+}
+
+export function formatMeetingTime(event: { start: Date; isAllDay: boolean }): string {
+  const now = new Date()
+  const tomorrow = new Date(now)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  if (event.isAllDay) {
+    if (isSameLocalDay(event.start, now)) return 'All day'
+    if (isSameLocalDay(event.start, tomorrow)) return 'Tmrw · All day'
+    const date = event.start.toLocaleDateString([], { month: 'numeric', day: 'numeric' })
+    return `${date} · All day`
+  }
+  const time = event.start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  if (isSameLocalDay(event.start, now)) return time
+  if (isSameLocalDay(event.start, tomorrow)) return `Tmrw ${time}`
+  return event.start.toLocaleDateString([], { month: 'numeric', day: 'numeric' })
+}


### PR DESCRIPTION
## Summary

- sort the sidebar's multi-day upcoming meetings by start time instead of hoisting every all-day event
- qualify future all-day meetings with `Tmrw` or their date
- add a focused regression test for the reported event ordering and subtitle

Fixes #932.

## Testing

- `vitest run src/lib/sidebar-meeting-preview.test.ts` (2 tests passed)
- `eslint src/lib/sidebar-meeting-preview.ts src/lib/sidebar-meeting-preview.test.ts`
- `git diff --cached --check`

## Validation boundary

The full renderer `pnpm run typecheck` currently fails in unchanged Spaces IPC code because the generated shared types do not contain `editedAt` / `spaces:editMessage` used by the current default branch. This change is limited to the Meetings sidebar preview; the Meetings pane and event normalization are unchanged.