### PR TITLE
fix(harbor): run the asset_search backfill on the deployment boot path

### DIFF
--- a/apps/harbor/packages/server/src/deployment.ts
+++ b/apps/harbor/packages/server/src/deployment.ts
@@ -73,6 +73,11 @@ interface OrgRuntime {
 
 export async function startHarborDeployment(options: DeploymentOptions): Promise<RunningDeployment> {
   await migrate(options.db);
+  // Derived-index repair rides boot on BOTH boot paths (this one and the
+  // single-org PgStore.init()): fill asset_search rows the migrations can't
+  // (extraction is TypeScript). Org-agnostic and idempotent — one pass covers
+  // every org; per-org runtimes below deliberately never run init().
+  await new PgStore(options.db).backfillAssetSearch();
   const directory = new OrgDirectory(options.db);
   const hub = new SpaceHub();
   const runtimes = new Map<string, OrgRuntime>();

--- a/apps/harbor/packages/server/test/multi-org.test.ts
+++ b/apps/harbor/packages/server/test/multi-org.test.ts
@@ -100,6 +100,37 @@ describe('multi-org deployment', () => {
     expect(atBeta.body.code).toBe('not_a_member');
   });
 
+  it('deployment boot backfills asset_search — the path single-org init() covers, on the fleet', async () => {
+    const ram = await as.mint({ sub: 'sub-ram' });
+    const spaceId = (await http('acme.test', ram).get('/v1/spaces')).body.spaces[0].id;
+    await http('acme.test', ram).post(`/v1/spaces/${spaceId}/changes`, {
+      assetPath: 'notes/relics.md',
+      baseVersion: 0,
+      newContent: 'the amphora survives the reboot',
+      actingMode: 'direct',
+    });
+
+    // Simulate pre-012 data: the asset exists, its search row does not.
+    await db.query('delete from asset_search', []);
+    expect(
+      (await http('acme.test', ram).get(`/v1/spaces/${spaceId}/search?q=amphora`)).body.assets,
+    ).toEqual([]);
+
+    // A fresh deployment over the same database — the fleet's restart.
+    const dep2 = await startHarborDeployment({ db, apexDomain: 'spaces.test', issuer: as.issuer });
+    try {
+      const url = dep2.url;
+      const res = await fetch(`${url}/v1/spaces/${spaceId}/search?q=amphora`, {
+        headers: { 'x-forwarded-host': 'acme.test', authorization: `Bearer ${ram}` },
+      });
+      const body = (await res.json()) as { assets: Array<{ path: string; snippet?: string }> };
+      expect(body.assets.map((a) => a.path)).toEqual(['notes/relics.md']);
+      expect(body.assets[0]!.snippet).toContain('amphora');
+    } finally {
+      await dep2.close();
+    }
+  });
+
   it("an org's invite token is not_found at another org", async () => {
     const ram = await as.mint({ sub: 'sub-ram' });
     const spaceId = (await http('acme.test', ram).get('/v1/spaces')).body.spaces[0].id;


### PR DESCRIPTION
## What broke

After deploying #946 to the fleet: migration 012 applied (message/topic tsvector columns present and populated) but `asset_search` stayed empty.

## Why

The asset backfill can't live in the SQL migration (extraction is TypeScript — excalidraw parsing etc.), so #946 hung it on `PgStore.init()`. But the fleet boots through `startHarborDeployment`, which calls `migrate(db)` directly and builds per-org stores **without** `init()` — so the boot repair never ran there. Only the single-org `main.ts` path was covered. New asset commits indexed fine (the `putAssetVersion` hook is on every `PgStore`); only pre-existing assets were left behind.

## Fix

One call after `migrate()` in the deployment path — the backfill is org-agnostic and idempotent by design, so a single pass covers every org. Comment on both boot paths now names the invariant.

## Verification

New regression test in `multi-org.test.ts`: commit an asset through the deployment face, delete its `asset_search` rows (simulating pre-012 data), boot a **second deployment over the same database**, and find the asset by content through the wire. Full harbor suite green (the one `api.test.ts` rail-sorting failure seen in CI-style full runs is a pre-existing timestamp-tie flake — passes on re-run, unrelated to this change).

## Deploy note

Next fleet deploy picks this up automatically — the backfill runs on boot and fills every live asset missing its row. Nothing manual needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUGHMxsjmBNAvv5w6FzFtY