### PR TITLE
fix(x): harden the Gmail rate-limit cooldown after v0.9.1 field reports

### DIFF
--- a/apps/x/packages/core/src/knowledge/agent_notes.ts
+++ b/apps/x/packages/core/src/knowledge/agent_notes.ts
@@ -7,6 +7,7 @@ import { getErrorDetails } from '../application/lib/errors.js';
 import { serviceLogger } from '../services/service_logger.js';
 import { loadUserConfig, updateUserEmail } from '../config/user_config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
+import { gmailRateLimitCooldownMs } from './gmail-rate-limit.js';
 import {
     loadAgentNotesState,
     saveAgentNotesState,
@@ -190,11 +191,23 @@ function extractConversationMessages(runFilePath: string): { role: string; text:
 
 // --- User email resolution ---
 
+// The processing loop ticks every 10s; until the profile fetch succeeds once
+// (it persists into user config and is never needed again) each tick would
+// re-hit Gmail — during a rate-limit lockout that both burned quota and kept
+// re-arming the cooldown. Attempt at most every 15 minutes, never during a
+// lockout.
+let lastProfileAttemptAt = 0;
+const PROFILE_RETRY_MS = 15 * 60_000;
+
 async function ensureUserEmail(): Promise<string | null> {
     const existing = loadUserConfig();
     if (existing?.email) {
         return existing.email;
     }
+
+    if (gmailRateLimitCooldownMs() > 0) return null;
+    if (Date.now() - lastProfileAttemptAt < PROFILE_RETRY_MS) return null;
+    lastProfileAttemptAt = Date.now();
 
     // Try direct Google OAuth (covers both BYOK and rowboat modes)
     try {

--- a/apps/x/packages/core/src/knowledge/classify_thread.ts
+++ b/apps/x/packages/core/src/knowledge/classify_thread.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { z } from 'zod';
 import type { OAuth2Client } from 'google-auth-library';
 import { GoogleClientFactory } from './google-client-factory.js';
+import { noteGmailSuccess } from './gmail-rate-limit.js';
 import { WorkDir } from '../config/config.js';
 import { createLanguageModel } from '../models/models.js';
 import { generateObjectSafe } from '../models/structured.js';
@@ -88,14 +89,25 @@ function formatCalendar(events: CalendarSlice[]): string {
 }
 
 let cachedUserEmail: string | null = null;
+// Negative cache: agent_notes' 10s loop and the email view's status poll both
+// funnel here; without it a failing getProfile was re-attempted on every poll.
+let lastUserEmailAttemptAt = 0;
+const USER_EMAIL_RETRY_MS = 60_000;
 
 export async function getUserEmail(auth: OAuth2Client): Promise<string | null> {
     if (cachedUserEmail) return cachedUserEmail;
+    if (Date.now() - lastUserEmailAttemptAt < USER_EMAIL_RETRY_MS) return null;
+    lastUserEmailAttemptAt = Date.now();
     try {
         const gmailClient = GoogleClientFactory.gmailClient(auth);
         const res = await gmailClient.users.getProfile({ userId: 'me' });
         if (res.data.emailAddress) {
             cachedUserEmail = res.data.emailAddress.toLowerCase();
+            // Deliberately NOT gated on the rate-limit cooldown: this
+            // 1-quota-unit call is the designated recovery probe — its
+            // success proves Gmail is healthy again and ends a stale
+            // cooldown early.
+            noteGmailSuccess();
             return cachedUserEmail;
         }
     } catch (err) {

--- a/apps/x/packages/core/src/knowledge/gmail-rate-limit.test.ts
+++ b/apps/x/packages/core/src/knowledge/gmail-rate-limit.test.ts
@@ -2,10 +2,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import type { Common } from 'googleapis';
 import {
     IN_REQUEST_RETRY_FALLBACK_MS,
+    gmailCooldownInfo,
+    gmailQuotaTight,
     gmailRateLimitCooldownMs,
     inRequestRetryWaitMs,
     isRateLimitError,
     noteGmailRateLimit,
+    noteGmailSuccess,
     rateLimitDeadlineMs,
     resetGmailRateLimitForTests,
 } from './gmail-rate-limit.js';
@@ -18,6 +21,7 @@ function gaxiosError(opts: {
     headers?: Record<string, string> | Headers;
     reasons?: string[];
     dataMessage?: string;
+    dataRaw?: string;
 } = {}): Common.GaxiosError {
     return {
         message: opts.message ?? 'Request failed',
@@ -26,7 +30,7 @@ function gaxiosError(opts: {
         response: {
             status: opts.status,
             headers: opts.headers ?? {},
-            data: {
+            data: opts.dataRaw ?? {
                 error: {
                     message: opts.dataMessage,
                     errors: (opts.reasons ?? []).map((reason) => ({ reason })),
@@ -156,5 +160,80 @@ describe('cross-cycle cooldown', () => {
         noteGmailRateLimit(far, NOW);
         noteGmailRateLimit(near, NOW + 1_000);
         expect(gmailRateLimitCooldownMs(NOW + 2_000)).toBe(Date.parse('2026-08-27T02:00:00.000Z') - (NOW + 2_000));
+    });
+});
+
+describe('deadline format tolerance', () => {
+    it('parses a space-separated timestamp with a UTC suffix', () => {
+        const err = gaxiosError({ status: 429, message: 'User-rate limit exceeded. Retry after 2026-08-31 17:26:00 UTC' });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-31T17:26:00Z'));
+    });
+
+    it('assumes UTC when the timestamp names no zone', () => {
+        const err = gaxiosError({ status: 429, message: 'Retry after 2026-08-31T17:26:00.500' });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-31T17:26:00.500Z'));
+    });
+
+    it('parses an offset without a colon', () => {
+        const err = gaxiosError({ status: 429, message: 'Retry after 2026-08-31T22:56:00+0530' });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-31T22:56:00+05:30'));
+    });
+
+    it('reads the deadline from a raw string response body', () => {
+        const err = gaxiosError({ status: 429, dataRaw: 'User-rate limit exceeded.  Retry after 2026-08-31T17:26:00.000Z' });
+        expect(rateLimitDeadlineMs(err, NOW)).toBe(Date.parse('2026-08-31T17:26:00.000Z'));
+    });
+});
+
+describe('no-slide and recovery semantics', () => {
+    const bare = () => gaxiosError({ status: 429 });
+
+    it('a no-deadline failure never extends an active cooldown', () => {
+        expect(noteGmailRateLimit(bare(), NOW)).toBe(NOW + 60_000);
+        expect(noteGmailRateLimit(bare(), NOW + 30_000)).toBe(NOW + 60_000);
+        expect(gmailRateLimitCooldownMs(NOW + 30_000)).toBe(30_000);
+        // ...and it did not burn a strike: the next episode escalates to 2m.
+        expect(noteGmailRateLimit(bare(), NOW + 61_000)).toBe(NOW + 61_000 + 120_000);
+    });
+
+    it("a Gmail-named deadline may extend an active cooldown — it is Gmail's word", () => {
+        noteGmailRateLimit(bare(), NOW);
+        const err = gaxiosError({ status: 429, message: 'Retry after 2026-08-27T01:40:00.000Z' });
+        expect(noteGmailRateLimit(err, NOW + 30_000)).toBe(Date.parse('2026-08-27T01:40:00.000Z'));
+        expect(gmailCooldownInfo(NOW + 31_000)?.source).toBe('gmail');
+    });
+
+    it('an earlier Gmail deadline never shortens a later active one', () => {
+        const far = gaxiosError({ status: 429, message: 'Retry after 2026-08-27T02:00:00.000Z' });
+        const near = gaxiosError({ status: 429, message: 'Retry after 2026-08-27T01:32:00.000Z' });
+        noteGmailRateLimit(far, NOW);
+        expect(noteGmailRateLimit(near, NOW + 1_000)).toBe(Date.parse('2026-08-27T02:00:00.000Z'));
+    });
+
+    it('noteGmailSuccess clears the cooldown and resets the ladder', () => {
+        const err = gaxiosError({ status: 429, message: 'Retry after 2026-08-27T02:00:00.000Z' });
+        noteGmailRateLimit(err, NOW);
+        noteGmailSuccess();
+        expect(gmailRateLimitCooldownMs(NOW + 1_000)).toBe(0);
+        expect(noteGmailRateLimit(bare(), NOW + 2_000)).toBe(NOW + 2_000 + 60_000);
+    });
+});
+
+describe('gmailQuotaTight', () => {
+    it('is false when nothing was ever armed', () => {
+        expect(gmailQuotaTight(NOW)).toBe(false);
+    });
+
+    it('covers the active cooldown and a 60s grace after it', () => {
+        noteGmailRateLimit(gaxiosError({ status: 429 }), NOW);
+        expect(gmailQuotaTight(NOW + 30_000)).toBe(true);
+        expect(gmailQuotaTight(NOW + 60_000 + 30_000)).toBe(true);
+        expect(gmailQuotaTight(NOW + 60_000 + 61_000)).toBe(false);
+    });
+
+    it('ends immediately on a successful probe', () => {
+        noteGmailRateLimit(gaxiosError({ status: 429 }), NOW);
+        noteGmailSuccess();
+        expect(gmailQuotaTight(NOW + 1_000)).toBe(false);
     });
 });

--- a/apps/x/packages/core/src/knowledge/gmail-rate-limit.ts
+++ b/apps/x/packages/core/src/knowledge/gmail-rate-limit.ts
@@ -2,24 +2,38 @@ import type { Common } from 'googleapis';
 
 /**
  * Gmail rate-limit detection and the cross-cycle cooldown (the follow-up
- * deferred by #869).
+ * deferred by #869, hardened after the first field reports on v0.9.1).
  *
- * Two layers use this module:
+ * Three layers use this module:
  *   - GoogleClientFactory.gmailClient()'s retry hooks classify errors
  *     (isRateLimitError), size the single in-request retry
  *     (inRequestRetryWaitMs), and arm the cooldown (noteGmailRateLimit)
  *     whenever a throttled request is about to fail through to the caller.
  *   - The background loops (sync_gmail's 30s tick, gmail_sent_contacts'
- *     refresh) consult gmailRateLimitCooldownMs() and stand down while it is
- *     positive, instead of re-tripping the quota every tick.
+ *     refresh, agent_notes' email backfill) consult gmailRateLimitCooldownMs()
+ *     and stand down while it is positive; the heavy maintenance passes
+ *     (inbox prune, classify sweep, timer backfill) also honor
+ *     gmailQuotaTight(), which extends the pause through a short grace after
+ *     the lockout ends so the first pass back is the lean core sync only.
+ *   - getUserEmail (classify_thread.ts) doubles as a cheap recovery probe:
+ *     its 1-quota-unit getProfile is allowed through during a lockout (at
+ *     most once a minute) and calls noteGmailSuccess() on success, ending a
+ *     stale cooldown the moment Gmail actually recovers.
  *
- * Gmail's flood-control errors ("User-rate limit exceeded. Retry after
- * 2026-08-27T20:08:37.427Z") put the deadline in the error MESSAGE, not a
- * Retry-After header, and it is routinely minutes away — far beyond what an
- * in-request retry may wait. Honoring it requires state that outlives the
- * request, hence this process-wide singleton. Deliberately not persisted to
- * disk: lockouts are minutes long, restarts are rare mid-lockout, and a stale
- * on-disk deadline would silently pause sync after a crash.
+ * Cooldown policy, learned the hard way:
+ *   - A deadline Gmail names (Retry-After header, or the "Retry after
+ *     <timestamp>" embedded in the error message) is always honored, and may
+ *     extend an active cooldown — it is Gmail's own word.
+ *   - Our no-deadline fallback NEVER extends an active cooldown. v0.9.1 let
+ *     it, and un-gated callers failing during a lockout kept sliding the
+ *     promised resume time forward ("next attempt at 5:25" → 5:31 → …).
+ *   - The fallback escalates per EPISODE (a new cooldown armed from an
+ *     expired state), not per failing request — concurrent callers used to
+ *     each count a strike and jump the ladder straight to its cap.
+ *
+ * The state is a process-wide in-memory singleton, deliberately not
+ * persisted: lockouts are minutes long, restarts are rare mid-lockout, and a
+ * stale on-disk deadline would silently pause sync after a crash.
  *
  * User-initiated actions (send, archive, mark read) do NOT consult the
  * cooldown — one interactive request can't sustain the limit, and an explicit
@@ -33,15 +47,21 @@ export const IN_REQUEST_RETRY_CAP_MS = 30_000;
 /** In-request retry wait when Gmail names no deadline at all. */
 export const IN_REQUEST_RETRY_FALLBACK_MS = 2_000;
 
-// No-deadline cooldowns escalate per strike: 1m, 2m, 4m, ... capped at 15m.
+// No-deadline cooldowns escalate per episode: 1m, 2m, 4m, ... capped at 15m.
 // A quiet EPISODE_RESET_MS after a cooldown ends starts the ladder over.
 const NO_DEADLINE_BASE_COOLDOWN_MS = 60_000;
 const NO_DEADLINE_MAX_COOLDOWN_MS = 15 * 60_000;
 const EPISODE_RESET_MS = 10 * 60_000;
 // Sanity clamp on Gmail-supplied deadlines (clock skew, malformed dates).
 const DEADLINE_CAP_MS = 6 * 60 * 60_000;
+// After a cooldown expires, heavy maintenance passes stay paused this long so
+// the first pass back doesn't re-trip the quota with a full burst.
+const POST_COOLDOWN_GRACE_MS = 60_000;
+
+export type GmailCooldownSource = 'gmail' | 'default';
 
 let cooldownUntil = 0;
+let cooldownSource: GmailCooldownSource = 'default';
 let strikes = 0;
 
 /** 429 anywhere, or Gmail's alternate 403-with-rate-limit-reason form. */
@@ -64,10 +84,32 @@ function headerValue(err: Common.GaxiosError, name: string): string | null {
 }
 
 /**
+ * "Retry after <timestamp>" parsed out of free text. Gmail's flood-control
+ * message has been observed as ISO-with-T ("2026-08-31T17:26:00.123Z") but
+ * this also accepts a space separator, a UTC/GMT/offset suffix, and no zone
+ * at all (Gmail timestamps are UTC, so a missing zone normalizes to Z —
+ * Date.parse would otherwise read a bare timestamp as LOCAL time).
+ */
+function parseRetryAfterTimestamp(text: string, now: number): number | null {
+    const match = /retry\s*after\s+['"]?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?)\s*(Z|UTC|GMT|[+-]\d{2}:?\d{2})?/i.exec(text);
+    if (!match) return null;
+    const base = match[1].replace(' ', 'T');
+    const zoneRaw = match[2]?.toUpperCase();
+    let zone: string;
+    if (!zoneRaw || zoneRaw === 'Z' || zoneRaw === 'UTC' || zoneRaw === 'GMT') {
+        zone = 'Z';
+    } else {
+        zone = zoneRaw.includes(':') ? zoneRaw : `${zoneRaw.slice(0, 3)}:${zoneRaw.slice(3)}`;
+    }
+    const asDate = Date.parse(base + zone);
+    return Number.isFinite(asDate) && asDate > now ? asDate : null;
+}
+
+/**
  * Epoch-ms deadline after which Gmail says a throttled request may be retried,
  * or null when the error names none. Checks the Retry-After header (delta
- * seconds or HTTP-date) first, then the "Retry after <ISO timestamp>" Gmail
- * embeds in the error message.
+ * seconds or HTTP-date) first, then the "Retry after <timestamp>" Gmail
+ * embeds in the error message and/or response body.
  */
 export function rateLimitDeadlineMs(err: Common.GaxiosError, now: number = Date.now()): number | null {
     const header = headerValue(err, 'retry-after');
@@ -78,14 +120,11 @@ export function rateLimitDeadlineMs(err: Common.GaxiosError, now: number = Date.
         if (Number.isFinite(asDate) && asDate > now) return asDate;
     }
 
-    const data = err.response?.data as { error?: { message?: string } } | undefined;
-    const message = `${err.message ?? ''} ${data?.error?.message ?? ''}`;
-    const match = /retry after\s+(\d{4}-\d{2}-\d{2}T[0-9:.]+Z?)/i.exec(message);
-    if (match) {
-        const asDate = Date.parse(match[1]);
-        if (Number.isFinite(asDate) && asDate > now) return asDate;
-    }
-    return null;
+    const data = err.response?.data as unknown;
+    const dataMessage = typeof data === 'string'
+        ? data
+        : (data as { error?: { message?: string } } | undefined)?.error?.message ?? '';
+    return parseRetryAfterTimestamp(`${err.message ?? ''}\n${dataMessage}`, now);
 }
 
 /**
@@ -102,18 +141,38 @@ export function inRequestRetryWaitMs(err: Common.GaxiosError, now: number = Date
 
 /**
  * Arm (or extend) the cross-cycle cooldown for a rate-limit error that is
- * failing through to its caller. Uses Gmail's own deadline when it names one;
- * otherwise escalates a default per strike. Returns the cooldown end (epoch ms).
+ * failing through to its caller. A Gmail-named deadline is always honored
+ * (never shortened, clamped for sanity); without one, a fresh cooldown is
+ * armed from the per-episode ladder — but an active cooldown is never
+ * extended by our own guesses. Returns the cooldown end (epoch ms).
  */
 export function noteGmailRateLimit(err: Common.GaxiosError, now: number = Date.now()): number {
+    const deadline = rateLimitDeadlineMs(err, now);
+    if (deadline !== null) {
+        const until = Math.min(deadline, now + DEADLINE_CAP_MS);
+        if (until > cooldownUntil) {
+            cooldownUntil = until;
+            cooldownSource = 'gmail';
+        }
+        return cooldownUntil;
+    }
+
+    if (cooldownUntil > now) return cooldownUntil;
+
     if (now - cooldownUntil > EPISODE_RESET_MS) strikes = 0;
     strikes += 1;
-    const deadline = rateLimitDeadlineMs(err, now);
-    const until = deadline !== null
-        ? Math.min(deadline, now + DEADLINE_CAP_MS)
-        : now + Math.min(NO_DEADLINE_BASE_COOLDOWN_MS * 2 ** (strikes - 1), NO_DEADLINE_MAX_COOLDOWN_MS);
-    cooldownUntil = Math.max(cooldownUntil, until);
+    cooldownUntil = now + Math.min(NO_DEADLINE_BASE_COOLDOWN_MS * 2 ** (strikes - 1), NO_DEADLINE_MAX_COOLDOWN_MS);
+    cooldownSource = 'default';
     return cooldownUntil;
+}
+
+/**
+ * A Gmail request went through: quota is provably healthy. Ends any cooldown
+ * (a stale default one, or Gmail relenting early) and resets the ladder.
+ */
+export function noteGmailSuccess(): void {
+    cooldownUntil = 0;
+    strikes = 0;
 }
 
 /** Milliseconds until Gmail may be called again; 0 when no cooldown is active. */
@@ -121,7 +180,25 @@ export function gmailRateLimitCooldownMs(now: number = Date.now()): number {
     return Math.max(0, cooldownUntil - now);
 }
 
+/** Active-cooldown details for logging/notices, or null when none is active. */
+export function gmailCooldownInfo(now: number = Date.now()): { remainingMs: number; until: number; source: GmailCooldownSource } | null {
+    if (cooldownUntil <= now) return null;
+    return { remainingMs: cooldownUntil - now, until: cooldownUntil, source: cooldownSource };
+}
+
+/**
+ * Whether heavy, deferrable Gmail work (inbox prune, classify sweep, timer
+ * backfill) should stand down: an active cooldown, or the short grace right
+ * after one — so the first pass back is the lean core sync, not a burst that
+ * immediately re-trips the quota. noteGmailSuccess() ends the grace early.
+ */
+export function gmailQuotaTight(now: number = Date.now()): boolean {
+    if (cooldownUntil > now) return true;
+    return cooldownUntil > 0 && now - cooldownUntil < POST_COOLDOWN_GRACE_MS;
+}
+
 export function resetGmailRateLimitForTests(): void {
     cooldownUntil = 0;
+    cooldownSource = 'default';
     strikes = 0;
 }

--- a/apps/x/packages/core/src/knowledge/google-client-factory.ts
+++ b/apps/x/packages/core/src/knowledge/google-client-factory.ts
@@ -2,6 +2,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { google, gmail_v1 } from 'googleapis';
 import {
     IN_REQUEST_RETRY_FALLBACK_MS,
+    gmailCooldownInfo,
     inRequestRetryWaitMs,
     isRateLimitError,
     noteGmailRateLimit,
@@ -360,7 +361,8 @@ export class GoogleClientFactory {
                     const attempt = err.config.retryConfig?.currentRetryAttempt ?? 0;
                     if (attempt < 1 && inRequestRetryWaitMs(err) !== null) return true;
                     const until = noteGmailRateLimit(err);
-                    console.warn(`[Gmail] rate limited — cooling down until ${new Date(until).toISOString()}`);
+                    const source = gmailCooldownInfo()?.source === 'gmail' ? "Gmail's stated deadline" : 'default backoff';
+                    console.warn(`[Gmail] rate limited — cooling down until ${new Date(until).toISOString()} (${source})`);
                     return false;
                 },
                 retryBackoff: (err) => {

--- a/apps/x/packages/core/src/knowledge/sync_gmail.ts
+++ b/apps/x/packages/core/src/knowledge/sync_gmail.ts
@@ -5,7 +5,7 @@ import { OAuth2Client } from 'google-auth-library';
 import { WorkDir } from '../config/config.js';
 import { getMaxEmails } from '../config/gmail_sync_config.js';
 import { GoogleClientFactory } from './google-client-factory.js';
-import { gmailRateLimitCooldownMs } from './gmail-rate-limit.js';
+import { gmailCooldownInfo, gmailQuotaTight, gmailRateLimitCooldownMs } from './gmail-rate-limit.js';
 import { serviceLogger, type ServiceRunContext } from '../services/service_logger.js';
 import { limitEventItems } from './limit_event_items.js';
 import { formatTimestampForModel } from '@x/shared/dist/time.js';
@@ -902,7 +902,7 @@ async function backfillMissingRecentThreads(
     lookbackDays: number,
     opts: { force?: boolean } = {},
 ): Promise<SyncedThread[]> {
-    if (!opts.force && !shouldRunRecentBackfill(stateFile)) return [];
+    if (!opts.force && (gmailQuotaTight() || !shouldRunRecentBackfill(stateFile))) return [];
 
     const gmailClient = GoogleClientFactory.gmailClient(auth);
     const recentThreads = await listRecentNonDeletedThreadIds(gmailClient, lookbackDays);
@@ -1385,11 +1385,15 @@ async function sweepUnclassifiedMarkdown(auth: OAuth2Client, llmBudget: number =
 // run_complete would wrongly clear the sidebar's red failed state (any
 // non-error outcome clears it) while Gmail is still locked out.
 let lastCooldownNoticeUntil = 0;
+// True after a failed pass until the next successful one (drives the
+// recovery event in performSync).
+let syncDegraded = false;
 async function logRateLimitCooldownNotice(cooldownMs: number): Promise<void> {
     const until = Date.now() + cooldownMs;
     if (Math.abs(until - lastCooldownNoticeUntil) < 5_000) return;
     lastCooldownNoticeUntil = until;
     const at = new Date(until).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const info = gmailCooldownInfo();
     try {
         await serviceLogger.log({
             type: 'progress',
@@ -1397,6 +1401,11 @@ async function logRateLimitCooldownNotice(cooldownMs: number): Promise<void> {
             runId: 'gmail_rate_limit_notice',
             level: 'warn',
             message: `Rate limited by Gmail — next sync attempt at ${at}`,
+            // Which cooldown fired matters when reading field reports: 'gmail'
+            // means we honored a deadline Gmail named; 'default' means the
+            // error carried none (or we failed to parse it) and the fallback
+            // ladder chose the wait.
+            details: { source: info?.source ?? 'default', until: new Date(until).toISOString() },
         });
     } catch {
         // Best-effort: the caller's console log still records the skip.
@@ -1479,16 +1488,40 @@ async function performSync() {
             await publishGmailSyncEvent(backfilled);
         }
 
-        // Keep inbox_lists/ in lock-step with Gmail's INBOX label —
-        // remove cache files for threads that were archived/trashed elsewhere.
-        await pruneInboxCache(auth);
+        // Quota-tight (a cooldown armed mid-pass, or the grace right after a
+        // lockout): skip the heavy maintenance passes so the first passes back
+        // are the lean core sync, not a burst that re-trips the limit.
+        if (!gmailQuotaTight()) {
+            // Keep inbox_lists/ in lock-step with Gmail's INBOX label —
+            // remove cache files for threads that were archived/trashed elsewhere.
+            await pruneInboxCache(auth);
 
-        // Backfill classification verdicts onto any markdown the main sync
-        // paths missed — the knowledge graph holds unstamped files forever.
-        await sweepUnclassifiedMarkdown(auth);
+            // Backfill classification verdicts onto any markdown the main sync
+            // paths missed — the knowledge graph holds unstamped files forever.
+            await sweepUnclassifiedMarkdown(auth);
+        }
+
+        // A pass succeeded after one or more failed ones: emit a run so the
+        // sidebar's red "failed" state clears. Quiet successful ticks emit no
+        // events by design, so without this the red state lingered until new
+        // mail happened to arrive.
+        if (syncDegraded) {
+            syncDegraded = false;
+            const run = await serviceLogger.startRun({ service: 'gmail', message: 'Syncing Gmail', trigger: 'timer' });
+            await serviceLogger.log({
+                type: 'run_complete',
+                service: run.service,
+                runId: run.runId,
+                level: 'info',
+                message: 'Gmail sync recovered',
+                durationMs: Date.now() - run.startedAt,
+                outcome: 'ok',
+            });
+        }
 
         console.log("Sync completed.");
     } catch (error) {
+        syncDegraded = true;
         console.error("Error during sync:", error);
     }
 }


### PR DESCRIPTION
Follow-up to #926, driven by a throttled user's report on v0.9.1: the cooldown held (no more per-minute hammering, syncs resumed and succeeded), but the degraded cycle remained — the promised resume time kept sliding forward ("next attempt at 5:25" → 5:31), every wait was exactly 15 minutes (our fallback cap, suggesting Gmail's stated deadline wasn't being honored), and each resume re-tripped the limit with a full maintenance burst.

## Root causes found

1. **Sliding resume time**: Gmail consumers not gated by the cooldown (inbox prune, classify sweep, pollers) kept failing during a lockout, and every no-deadline failure re-armed the cooldown at `now + 15m` — pushing the deadline out indefinitely.
2. **Ladder pinned at the 15m cap**: strikes counted per failing request, so a handful of concurrent failures in the first burst maxed the 1m→15m escalation immediately.
3. **A hidden 10s hammer**: `agent_notes`' processing loop runs every 10 seconds (a leftover "(for testing)" interval) and re-called `getProfile` on **every tick** until one succeeded — during a fresh-connect lockout, 6 failing calls a minute, each one re-arming the cooldown. This is the un-gated poller behind the slide.
4. **Burst on re-entry**: the first pass after a lockout ran the full backfill + whole-inbox prune + classify sweep in one shot, re-earning the limit.

## Fixes

- **No-slide rule** (`gmail-rate-limit.ts`): a deadline Gmail names may always extend an active cooldown — it's Gmail's own word — but the no-deadline fallback can never extend one. The promised resume time can only move when Gmail moves it.
- **Per-episode strikes**: the ladder escalates only when arming from an expired state; concurrent failures within one lockout no longer burn strikes. First no-deadline lockout waits 1 minute again, not 15.
- **Deadline parsing hardened**: accepts space-separated timestamps, `UTC`/`GMT`/offset suffixes, a missing zone (assumed UTC — `Date.parse` would otherwise read it as local time), and raw string response bodies, alongside the classic ISO-with-`Z` form. Covers every documented shape of Gmail's "Retry after" text, since the field report's exact string wasn't recoverable.
- **Recovery probe**: `getUserEmail`'s 1-quota-unit `getProfile` stays un-gated (at most once a minute via a negative cache) and its success calls `noteGmailSuccess()`, clearing a stale cooldown the moment Gmail actually recovers and resetting the ladder. Over-waiting is now bounded by the probe cadence, not the cap.
- **`agent_notes` gated**: profile fetch at most every 15 minutes, never during a lockout (the result persists to user config after one success, so this only affects the fresh-connect window).
- **Gentle re-entry**: new `gmailQuotaTight()` — active cooldown plus a 60-second grace after it, ended early by a successful probe — stands down the inbox prune, classify sweep, and timer backfill, so the first pass back is the lean core sync.
- **Recovery event** (pre-existing gap, tester finding): a one-time "Gmail sync recovered" run is emitted on the first successful pass after any failure, so the sidebar's red "failed" state clears even when recovery is quiet (applies to network errors too).
- **Diagnosability**: the console warning and the yellow feed notice now record whether the wait came from a parsed Gmail deadline (`source: gmail`) or the fallback ladder (`source: default`), with the exact ISO deadline in the notice's `details` — the next field report's `services.jsonl` will say exactly which path fired instead of leaving us inferring from screenshot arithmetic.

## Out of scope (unchanged from #926)

- Full-sync checkpointing (skipping already-fetched threads on a resumed pass) — real semantic edge cases; the quota-tight gating should make it unnecessary. Revisit if field reports still show re-tripping.
- Outlook `graphFetch` parity.

## Test plan

- [x] 28 unit tests (11 new): no-slide, Gmail-deadline-extends-active, earlier-deadline-never-shortens, success-clears-and-resets, per-episode escalation + cap + quiet-spell reset, quota-tight window + grace + early end, and all four new deadline formats.
- [x] `npm run deps`, `npm run lint`, `npm run typecheck` pass; full knowledge suite green (110 tests / 9 files).
- [ ] Prerelease to the reporting user: expect honored (non-15m-uniform) waits, a resume time that never slides, no re-trip on re-entry, and the red state clearing after recovery. The notice `details.source` in their `services.jsonl` confirms whether Gmail's deadlines are being parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV11vrsywmfcrvCUQyxvHJ