### PR TITLE
Done pile for code sessions, and a code-session empty state with a blinking cursor

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1740,6 +1740,10 @@ export function setupIpcHandlers() {
       const manager = container.resolve<CodeModeManager>('codeModeManager');
       return manager.listModelOptions(args.agent);
     },
+    'codeSession:setDone': async (_event, args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      return { session: await service.setDone(args.sessionId, args.done) };
+    },
     'codeSession:delete': async (_event, args) => {
       const service = container.resolve<CodeSessionService>('codeSessionService');
       disposeTerminal(args.sessionId);

--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -1725,3 +1725,18 @@
 @media (prefers-reduced-motion: reduce) {
   .code-working-outline::after { animation: none; }
 }
+
+
+/* Code session empty state: the block cursor after the display line. A
+   stepped blink like a real terminal's — it snaps, never fades. Reduced
+   motion keeps it solid. */
+@keyframes code-cursor-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+.code-cursor-blink {
+  animation: code-cursor-blink 1.06s step-end infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .code-cursor-blink { animation: none; }
+}

--- a/apps/x/apps/renderer/src/components/chat-empty-state.tsx
+++ b/apps/x/apps/renderer/src/components/chat-empty-state.tsx
@@ -8,6 +8,11 @@ interface ChatEmptyStateProps {
   onPickPrompt: (prompt: string) => void
   /** Use a wider column — for the full-screen chat where the narrow column looks cramped. */
   wide?: boolean
+  /**
+   * 'code': the chat is a coding session. One line, no starter cards — the
+   * email/agent/research suggestions don't apply, and the work is the code.
+   */
+  variant?: 'default' | 'code'
 }
 
 const SUGGESTED_ACTIONS: { icon: typeof Mail; title: string; sub: string; prompt: string }[] = [
@@ -24,7 +29,17 @@ const SUGGESTED_ACTIONS: { icon: typeof Mail; title: string; sub: string; prompt
 export function ChatEmptyState({
   onPickPrompt,
   wide = false,
+  variant = 'default',
 }: ChatEmptyStateProps) {
+  if (variant === 'code') {
+    return (
+      <div className={cn('mx-auto flex w-full flex-col py-6', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
+        <div className={cn('font-semibold tracking-tight', wide ? 'text-2xl' : 'text-lg')}>
+          What should we build together?
+        </div>
+      </div>
+    )
+  }
   return (
     <div className={cn('mx-auto flex w-full flex-col gap-5 py-6', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
       <div>

--- a/apps/x/apps/renderer/src/components/chat-empty-state.tsx
+++ b/apps/x/apps/renderer/src/components/chat-empty-state.tsx
@@ -33,7 +33,7 @@ export function ChatEmptyState({
 }: ChatEmptyStateProps) {
   if (variant === 'code') {
     return (
-      <div className={cn('mx-auto flex w-full flex-col py-6', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
+      <div className={cn('mx-auto flex w-full flex-col items-center py-6 text-center', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
         <div className={cn('font-semibold tracking-tight', wide ? 'text-2xl' : 'text-lg')}>
           What should we build together?
         </div>

--- a/apps/x/apps/renderer/src/components/chat-empty-state.tsx
+++ b/apps/x/apps/renderer/src/components/chat-empty-state.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { ArrowRight, BookOpen, Mail, Zap } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -23,33 +22,12 @@ const SUGGESTED_ACTIONS: { icon: typeof Mail; title: string; sub: string; prompt
 ]
 
 const CODE_LINE = 'What should we build together?'
-// The reveal types the line out once when an empty session appears — quick
-// enough to read as a flourish, not a wait.
-const CODE_REVEAL_MS = 650
 
-function prefersReducedMotion(): boolean {
-  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
-// A coding session's empty state: one display line typed out under a block
-// cursor that keeps blinking while the session sits empty — the one detail
+// A coding session's empty state: one display line with a block cursor that
+// keeps blinking after it while the session sits empty — the one detail
 // that says "terminal" without a badge. Clicking it focuses the composer,
 // since a cursor invites typing.
 function CodeEmptyState({ wide }: { wide: boolean }) {
-  const [shown, setShown] = useState(() => (prefersReducedMotion() ? CODE_LINE.length : 0))
-  const done = shown >= CODE_LINE.length
-  useEffect(() => {
-    if (done) return
-    const stepMs = CODE_REVEAL_MS / CODE_LINE.length
-    const timer = setInterval(() => {
-      setShown((n) => {
-        if (n + 1 >= CODE_LINE.length) clearInterval(timer)
-        return Math.min(CODE_LINE.length, n + 1)
-      })
-    }, stepMs)
-    return () => clearInterval(timer)
-  }, [done])
-
   return (
     <div
       className={cn('mx-auto flex w-full flex-col items-center py-6 text-center', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}
@@ -62,13 +40,10 @@ function CodeEmptyState({ wide }: { wide: boolean }) {
           weight of one. Baseline-aligned block cursor, blinking with a
           stepped cycle (a fade would read as loading). */}
       <div className={cn('cursor-default font-normal leading-tight tracking-[-0.01em] text-foreground', wide ? 'text-[30px]' : 'text-xl')}>
-        <span>{CODE_LINE.slice(0, shown)}</span>
+        <span>{CODE_LINE}</span>
         <span
           aria-hidden
-          className={cn(
-            'ml-[0.08em] inline-block h-[0.9em] w-[0.5ch] translate-y-[0.1em] bg-foreground',
-            done && 'code-cursor-blink',
-          )}
+          className="code-cursor-blink ml-[0.08em] inline-block h-[0.9em] w-[0.5ch] translate-y-[0.1em] bg-foreground"
         />
       </div>
     </div>

--- a/apps/x/apps/renderer/src/components/chat-empty-state.tsx
+++ b/apps/x/apps/renderer/src/components/chat-empty-state.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { ArrowRight, BookOpen, Mail, Zap } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -21,6 +22,59 @@ const SUGGESTED_ACTIONS: { icon: typeof Mail; title: string; sub: string; prompt
   { icon: BookOpen, title: 'Research a topic', sub: 'create a local wiki for me', prompt: 'Research [topic] and create a local wiki for me' },
 ]
 
+const CODE_LINE = 'What should we build together?'
+// The reveal types the line out once when an empty session appears — quick
+// enough to read as a flourish, not a wait.
+const CODE_REVEAL_MS = 650
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+// A coding session's empty state: one display line typed out under a block
+// cursor that keeps blinking while the session sits empty — the one detail
+// that says "terminal" without a badge. Clicking it focuses the composer,
+// since a cursor invites typing.
+function CodeEmptyState({ wide }: { wide: boolean }) {
+  const [shown, setShown] = useState(() => (prefersReducedMotion() ? CODE_LINE.length : 0))
+  const done = shown >= CODE_LINE.length
+  useEffect(() => {
+    if (done) return
+    const stepMs = CODE_REVEAL_MS / CODE_LINE.length
+    const timer = setInterval(() => {
+      setShown((n) => {
+        if (n + 1 >= CODE_LINE.length) clearInterval(timer)
+        return Math.min(CODE_LINE.length, n + 1)
+      })
+    }, stepMs)
+    return () => clearInterval(timer)
+  }, [done])
+
+  return (
+    <div
+      className={cn('mx-auto flex w-full flex-col items-center py-6 text-center', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}
+      onClick={(e) => {
+        const root = e.currentTarget.closest<HTMLElement>('[data-chat-sidebar-root]') ?? document
+        root.querySelector<HTMLTextAreaElement>('textarea')?.focus()
+      }}
+    >
+      {/* Regular weight in the system face: the look of a title without the
+          weight of one. Baseline-aligned block cursor, blinking with a
+          stepped cycle (a fade would read as loading). */}
+      <div className={cn('cursor-default font-normal leading-tight tracking-[-0.01em] text-foreground', wide ? 'text-[30px]' : 'text-xl')}>
+        <span>{CODE_LINE.slice(0, shown)}</span>
+        <span
+          aria-hidden
+          className={cn(
+            'ml-[0.08em] inline-block h-[0.9em] w-[0.5ch] translate-y-[0.1em] bg-foreground',
+            done && 'code-cursor-blink',
+          )}
+        />
+      </div>
+    </div>
+  )
+}
+
 /**
  * Empty-state body for the chat surface: greeting and starter action cards.
  * Shown in both the side-pane copilot and full-screen chat; the side pane
@@ -31,17 +85,7 @@ export function ChatEmptyState({
   wide = false,
   variant = 'default',
 }: ChatEmptyStateProps) {
-  if (variant === 'code') {
-    return (
-      <div className={cn('mx-auto flex w-full flex-col items-center py-6 text-center', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
-        {/* A larger, regular-weight display line in the system face — the
-            look of a title, without the weight of one. */}
-        <div className={cn('font-normal leading-tight tracking-[-0.01em] text-foreground', wide ? 'text-[30px]' : 'text-xl')}>
-          What should we build together?
-        </div>
-      </div>
-    )
-  }
+  if (variant === 'code') return <CodeEmptyState wide={wide} />
   return (
     <div className={cn('mx-auto flex w-full flex-col gap-5 py-6', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
       <div>

--- a/apps/x/apps/renderer/src/components/chat-empty-state.tsx
+++ b/apps/x/apps/renderer/src/components/chat-empty-state.tsx
@@ -34,7 +34,7 @@ export function ChatEmptyState({
   if (variant === 'code') {
     return (
       <div className={cn('mx-auto flex w-full flex-col items-center py-6 text-center', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
-        <div className={cn('font-semibold tracking-tight', wide ? 'text-2xl' : 'text-lg')}>
+        <div className={cn('font-normal tracking-tight text-foreground/90', wide ? 'text-2xl' : 'text-lg')}>
           What should we build together?
         </div>
       </div>

--- a/apps/x/apps/renderer/src/components/chat-empty-state.tsx
+++ b/apps/x/apps/renderer/src/components/chat-empty-state.tsx
@@ -34,7 +34,9 @@ export function ChatEmptyState({
   if (variant === 'code') {
     return (
       <div className={cn('mx-auto flex w-full flex-col items-center py-6 text-center', wide ? 'max-w-4xl px-4' : 'max-w-md px-2')}>
-        <div className={cn('font-normal tracking-tight text-foreground/90', wide ? 'text-2xl' : 'text-lg')}>
+        {/* A larger, regular-weight display line in the system face — the
+            look of a title, without the weight of one. */}
+        <div className={cn('font-normal leading-tight tracking-[-0.01em] text-foreground', wide ? 'text-[30px]' : 'text-xl')}>
           What should we build together?
         </div>
       </div>

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -70,6 +70,8 @@ export interface ChatSessionPaneProps {
   onCodePermissionResponse?: (toolCallId: string, requestId: string, decision: PermissionDecision) => void | Promise<void>
   /** Notified when a ComposioConnectCard finishes connecting a toolkit. */
   onComposioConnected?: (toolkitSlug: string) => void
+  /** Empty-state flavour: 'code' for a chat bound to a coding session. */
+  emptyStateVariant?: 'default' | 'code'
 }
 
 export function ChatSessionPane({
@@ -87,6 +89,7 @@ export function ChatSessionPane({
   activeIsReasoning,
   onCodePermissionResponse,
   onComposioConnected,
+  emptyStateVariant = 'default',
 }: ChatSessionPaneProps) {
   // Content-owned tab meta (see lib/tab-meta.ts). Both live instances of a
   // chat (full-screen App pane + side-pane chat) report the same values, so
@@ -143,6 +146,7 @@ export function ChatSessionPane({
           {!tabHasConversation ? (
             <ChatEmptyState
               wide
+              variant={emptyStateVariant}
               onPickPrompt={onPickPrompt}
             />
           ) : (

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -442,6 +442,7 @@ export function ChatSidebar({
                       activeIsReasoning={isReasoning}
                       onCodePermissionResponse={onCodePermissionResponse}
                       onComposioConnected={onComposioConnected}
+                      emptyStateVariant={pinnedToCodeSession ? 'code' : 'default'}
                     />
                   )
                 })}

--- a/apps/x/apps/renderer/src/components/code/code-session-header.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-session-header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { ChevronDown, GitBranch, SlidersHorizontal } from 'lucide-react'
+import { Check, ChevronDown, GitBranch, RotateCcw, SlidersHorizontal } from 'lucide-react'
 import type { CodeSession, CodeSessionStatus, CodeAgentModelOptions } from '@x/shared/src/code-sessions.js'
 import type { ApprovalPolicy, CodingAgent } from '@x/shared/src/code-mode.js'
 import { toast } from 'sonner'
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuRadioGroup,
@@ -87,6 +88,14 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
   }
 
   const worktreeActive = session.worktree && !session.worktree.removedAt
+  const setDone = async (done: boolean) => {
+    try {
+      await window.ipc.invoke('codeSession:setDone', { sessionId: session.id, done })
+      await refreshCodeSessions()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update session')
+    }
+  }
   const models = withDefault(modelOpts.models)
   const efforts = withDefault(modelOpts.efforts)
 
@@ -217,6 +226,13 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>
+          <DropdownMenuSeparator />
+          {/* Done files the session under the rail's Done pile; the chat,
+              worktree and branch stay. Reopen brings it back. */}
+          <DropdownMenuItem onClick={() => void setDone(!session.doneAt)}>
+            {session.doneAt ? <RotateCcw className="size-4" /> : <Check className="size-4" />}
+            {session.doneAt ? 'Reopen' : 'Mark as done'}
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/x/apps/renderer/src/components/code/code-view.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-view.tsx
@@ -152,6 +152,17 @@ export function CodeView({
     await refresh()
   }, [refresh])
 
+  // Done is a flag: nothing on disk changes, and the session stays selected
+  // if it was — the row just moves piles.
+  const handleSetDone = useCallback(async (session: CodeSession, done: boolean) => {
+    try {
+      await window.ipc.invoke('codeSession:setDone', { sessionId: session.id, done })
+      await refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update session')
+    }
+  }, [refresh])
+
   const handleDeleteSession = useCallback(async (session: CodeSession, removeWorktree: boolean) => {
     try {
       await window.ipc.invoke('codeSession:delete', {
@@ -195,6 +206,7 @@ export function CodeView({
           onAddProject={() => void handleAddProject()}
           onRemoveProject={(id) => void handleRemoveProject(id)}
           onNewSession={(projectId, agent) => void handleNewSession(projectId, agent)}
+          onSetDone={(session, done) => void handleSetDone(session, done)}
           onDeleteSession={setDeleteTarget}
         />
       </div>

--- a/apps/x/apps/renderer/src/components/code/session-rail.tsx
+++ b/apps/x/apps/renderer/src/components/code/session-rail.tsx
@@ -1,5 +1,15 @@
-import { useState } from 'react'
-import { ChevronDown, ChevronRight, FolderGit2, FolderPlus, MoreHorizontal, Plus, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  FolderGit2,
+  FolderPlus,
+  MoreHorizontal,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react'
 import type { CodeSession, CodeSessionStatus } from '@x/shared/src/code-sessions.js'
 import type { CodingAgent } from '@x/shared/src/code-mode.js'
 import { cn, compactPath, parentPath } from '@/lib/utils'
@@ -17,6 +27,16 @@ import { projectLabel, type ProjectRow } from './use-code-sessions'
 import { AGENT_LABEL, isAgentReady, type CodeAgentsStatus } from './code-agent-status'
 
 export const CODE_RAIL_WIDTH = 272
+
+// The Done pile shows this many before asking for "Show all" — a display
+// cap, never a deletion policy.
+const DONE_VISIBLE_LIMIT = 25
+const DONE_OPEN_STORAGE_KEY = 'x:code-done-open'
+
+function readDoneOpen(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(DONE_OPEN_STORAGE_KEY) === '1'
+}
 
 // Inline status prefix: a dot plus a word, only when there is something to
 // say. Idle rows carry no prefix so the list stays quiet.
@@ -40,10 +60,113 @@ function StatusPrefix({ status }: { status: CodeSessionStatus }) {
   return null
 }
 
-// Left rail of the Code section: registered projects with their sessions,
-// attention-first. The session that is currently working wears an orbiting
-// outline (see `.code-working-outline` in App.css) so it can be found at a
-// glance even when it is not the selected one.
+// One session row. Active rows show the time and, on hover, a check (mark
+// done) beside the menu; done rows show when they were finished and a
+// reopen arrow instead. Rows keep their looks in either pile — only the
+// heading above them changes.
+function SessionRow({
+  session,
+  status,
+  selected,
+  done,
+  prefix,
+  indent,
+  onSelect,
+  onSetDone,
+  onDelete,
+}: {
+  session: CodeSession
+  status: CodeSessionStatus
+  selected: boolean
+  done: boolean
+  // A project label, for the flat Done pile where rows mix projects.
+  prefix?: string
+  indent: boolean
+  onSelect: () => void
+  onSetDone: (done: boolean) => void
+  onDelete: () => void
+}) {
+  const worktree = session.worktree && !session.worktree.removedAt
+  const when = formatRelativeTime((done && session.doneAt) || session.lastActivityAt || session.createdAt)
+  const ToggleIcon = done ? RotateCcw : Check
+  const toggleLabel = done ? 'Reopen' : 'Mark as done'
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      title={`${session.title}\n${AGENT_LABEL[session.agent] ?? session.agent}${worktree ? ` · ${session.worktree?.branch}` : ''}`}
+      className={cn(
+        'group relative mt-0.5 flex h-8 cursor-pointer items-center gap-2 rounded-lg pl-2 pr-1.5',
+        indent && 'ml-3',
+        selected ? 'bg-accent text-foreground' : 'hover:bg-accent/60',
+        status === 'working' && !done && 'code-working-outline',
+      )}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect()
+        }
+      }}
+    >
+      {!done && <StatusPrefix status={status} />}
+      <span className={cn('min-w-0 flex-1 truncate text-[13px]', selected ? 'font-medium' : 'text-foreground/90')}>
+        {prefix && <span className="text-muted-foreground">{prefix} · </span>}
+        {session.title}
+      </span>
+      <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70 transition-opacity group-hover:opacity-0">
+        {when}
+      </span>
+      {/* Hover actions sit over the time so the row never reflows. */}
+      <div className="absolute right-1 flex items-center opacity-0 transition-opacity group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+              onClick={(e) => { e.stopPropagation(); onSetDone(!done) }}
+              aria-label={toggleLabel}
+            >
+              <ToggleIcon className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{toggleLabel}</TooltipContent>
+        </Tooltip>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 shrink-0 p-0 text-muted-foreground"
+              onClick={(e) => e.stopPropagation()}
+              aria-label="Session actions"
+            >
+              <MoreHorizontal className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
+            <DropdownMenuItem onClick={() => onSetDone(!done)}>
+              <ToggleIcon className="size-4" />
+              {toggleLabel}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onDelete}>
+              <Trash2 className="size-4" />
+              Delete session
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}
+
+// Left rail of the Code section: registered projects with their active
+// sessions, attention-first, and a Done pile pinned to the bottom. The
+// session that is currently working wears an orbiting outline (see
+// `.code-working-outline` in App.css) so it can be found at a glance even
+// when it is not the selected one.
 export function SessionRail({
   projects,
   sessions,
@@ -54,6 +177,7 @@ export function SessionRail({
   onAddProject,
   onRemoveProject,
   onNewSession,
+  onSetDone,
   onDeleteSession,
 }: {
   projects: ProjectRow[]
@@ -67,6 +191,7 @@ export function SessionRail({
   onRemoveProject: (projectId: string) => void
   // No agent = the default (last used, whichever is ready).
   onNewSession: (projectId: string, agent?: CodingAgent) => void
+  onSetDone: (session: CodeSession, done: boolean) => void
   onDeleteSession: (session: CodeSession) => void
 }) {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
@@ -78,6 +203,20 @@ export function SessionRail({
       return next
     })
   }
+  const [doneOpen, setDoneOpen] = useState(readDoneOpen)
+  const [showAllDone, setShowAllDone] = useState(false)
+  useEffect(() => {
+    window.localStorage.setItem(DONE_OPEN_STORAGE_KEY, doneOpen ? '1' : '0')
+  }, [doneOpen])
+
+  const active = sessions.filter((s) => !s.doneAt)
+  // Newest finished first. The store's order is attention-first for the
+  // active list; finished work is a timeline.
+  const done = sessions
+    .filter((s) => s.doneAt)
+    .sort((a, b) => (b.doneAt ?? '').localeCompare(a.doneAt ?? ''))
+  const visibleDone = showAllDone ? done : done.slice(0, DONE_VISIBLE_LIMIT)
+  const labelByProject = new Map(projects.map((row) => [row.project.id, projectLabel(row)]))
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[var(--rowboat-panel-soft)]">
@@ -92,6 +231,8 @@ export function SessionRail({
           <TooltipContent side="bottom">Add a project folder</TooltipContent>
         </Tooltip>
       </div>
+
+      {/* Active work: projects with their sessions. Scrolls on its own. */}
       <div className="min-h-0 flex-1 overflow-auto px-2 py-2">
         {projects.length === 0 && (
           <div className="flex flex-col items-center gap-3 px-3 py-10 text-center">
@@ -107,11 +248,11 @@ export function SessionRail({
         )}
         {projects.map((row) => {
           const { project } = row
-          const label = projectLabel(row)
+          const label = labelByProject.get(project.id) ?? project.name
           // Repo-relative labels are distinctive on their own; only a bare
           // folder name needs its parent to stay tellable-apart.
           const parentHint = row.git.root ? '' : parentPath(project.path)
-          const projectSessions = sessions.filter((s) => s.projectId === project.id)
+          const projectSessions = active.filter((s) => s.projectId === project.id)
           const isCollapsed = collapsed.has(project.id)
           // A collapsed group still surfaces its live sessions — attention
           // must not hide behind a chevron.
@@ -212,63 +353,73 @@ export function SessionRail({
                   New session
                 </button>
               )}
-              {visibleSessions.map((session) => {
-                const status = statusOf(session.id)
-                const selected = selectedSessionId === session.id
-                const worktree = session.worktree && !session.worktree.removedAt
-                const when = formatRelativeTime(session.lastActivityAt ?? session.createdAt)
-                return (
-                  <div
-                    key={session.id}
-                    role="button"
-                    tabIndex={0}
-                    title={`${session.title}\n${AGENT_LABEL[session.agent] ?? session.agent}${worktree ? ` · ${session.worktree?.branch}` : ''}`}
-                    className={cn(
-                      'group relative ml-3 mt-0.5 flex h-8 cursor-pointer items-center gap-2 rounded-lg pl-2 pr-1.5',
-                      selected ? 'bg-accent text-foreground' : 'hover:bg-accent/60',
-                      status === 'working' && 'code-working-outline',
-                    )}
-                    onClick={() => onSelectSession(session.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        onSelectSession(session.id)
-                      }
-                    }}
-                  >
-                    <StatusPrefix status={status} />
-                    <span className={cn('min-w-0 flex-1 truncate text-[13px]', selected ? 'font-medium' : 'text-foreground/90')}>
-                      {session.title}
-                    </span>
-                    <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70 transition-opacity group-hover:opacity-0">
-                      {when}
-                    </span>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="absolute right-1 h-6 w-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label="Session actions"
-                        >
-                          <MoreHorizontal className="size-3.5" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-                        <DropdownMenuItem onClick={() => onDeleteSession(session)}>
-                          <Trash2 className="size-4" />
-                          Delete session
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                )
-              })}
+              {visibleSessions.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  status={statusOf(session.id)}
+                  selected={selectedSessionId === session.id}
+                  done={false}
+                  indent
+                  onSelect={() => onSelectSession(session.id)}
+                  onSetDone={(value) => onSetDone(session, value)}
+                  onDelete={() => onDeleteSession(session)}
+                />
+              ))}
             </div>
           )
         })}
       </div>
+
+      {/* Done: pinned to the bottom edge. Collapsed it is one row; expanded
+          it takes at most a third of the rail with its own scroll, so
+          opening it never pushes active sessions out of view. */}
+      {done.length > 0 && (
+        <div
+          className={cn(
+            'shrink-0 border-t border-border',
+            doneOpen && 'flex max-h-[36%] min-h-0 flex-col',
+          )}
+        >
+          <button
+            type="button"
+            onClick={() => setDoneOpen((v) => !v)}
+            className="flex h-9 w-full shrink-0 items-center gap-1.5 px-2 text-[13px] text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+            aria-expanded={doneOpen}
+          >
+            {doneOpen ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+            <span>Done</span>
+            <span className="tabular-nums text-muted-foreground/70">{done.length}</span>
+          </button>
+          {doneOpen && (
+            <div className="min-h-0 flex-1 overflow-auto px-2 pb-2">
+              {visibleDone.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  status={statusOf(session.id)}
+                  selected={selectedSessionId === session.id}
+                  done
+                  prefix={labelByProject.get(session.projectId)}
+                  indent={false}
+                  onSelect={() => onSelectSession(session.id)}
+                  onSetDone={(value) => onSetDone(session, value)}
+                  onDelete={() => onDeleteSession(session)}
+                />
+              ))}
+              {done.length > DONE_VISIBLE_LIMIT && !showAllDone && (
+                <button
+                  type="button"
+                  onClick={() => setShowAllDone(true)}
+                  className="mt-1 flex h-7 w-full items-center rounded-lg px-2 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                >
+                  Show all {done.length}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -248,6 +248,7 @@ export const RPC_CHANNELS = [
   'codeSession:create',
   'codeSession:list',
   'codeSession:update',
+  'codeSession:setDone',
   'codeSession:delete',
   'codeSession:stop',
   'codeSession:gitStatus',

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -1442,6 +1442,10 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
       const service = container.resolve<CodeSessionService>('codeSessionService');
       return { session: await service.update(args.sessionId, args.patch) };
     },
+    'codeSession:setDone': async (args) => {
+      const service = container.resolve<CodeSessionService>('codeSessionService');
+      return { session: await service.setDone(args.sessionId, args.done) };
+    },
     'codeSession:delete': async (args) => {
       const service = container.resolve<CodeSessionService>('codeSessionService');
       disposeTerminal(args.sessionId);

--- a/apps/x/packages/core/src/code-mode/sessions/service.ts
+++ b/apps/x/packages/core/src/code-mode/sessions/service.ts
@@ -331,8 +331,9 @@ export class CodeSessionService {
     async setDone(sessionId: string, done: boolean): Promise<CodeSession> {
         const session = await this.codeSessionsRepo.get(sessionId);
         if (!session) throw new Error(`Unknown session: ${sessionId}`);
-        const { doneAt: _previous, ...rest } = session;
-        const updated: CodeSession = done ? { ...rest, doneAt: new Date().toISOString() } : rest;
+        const updated: CodeSession = { ...session };
+        if (done) updated.doneAt = new Date().toISOString();
+        else delete updated.doneAt;
         await this.codeSessionsRepo.save(updated);
         return updated;
     }

--- a/apps/x/packages/core/src/code-mode/sessions/service.ts
+++ b/apps/x/packages/core/src/code-mode/sessions/service.ts
@@ -324,6 +324,19 @@ export class CodeSessionService {
         return updated;
     }
 
+    // Done is the user's own verdict on a session (or the natural end of a
+    // merge-back). It touches nothing on disk: worktree, branch and chat all
+    // stay, so reopening is just clearing the flag. Activity clears it too
+    // (status tracker) so a done session that gets a message comes back.
+    async setDone(sessionId: string, done: boolean): Promise<CodeSession> {
+        const session = await this.codeSessionsRepo.get(sessionId);
+        if (!session) throw new Error(`Unknown session: ${sessionId}`);
+        const { doneAt: _previous, ...rest } = session;
+        const updated: CodeSession = done ? { ...rest, doneAt: new Date().toISOString() } : rest;
+        await this.codeSessionsRepo.save(updated);
+        return updated;
+    }
+
     // Stop whatever turn is live on the session's chat. The turn's abort
     // signal unwinds code_agent_run (ACP cancel → grace → force-kill) and
     // cancels any pending approval card.
@@ -349,9 +362,13 @@ export class CodeSessionService {
         }
         const result = await gitService.mergeBack(project.path, session.worktree.branch);
         if (result.ok) {
+            // Merging back is the natural end of a session: file it under
+            // Done as well. Reopen is one click if the user wasn't finished.
+            const now = new Date().toISOString();
             await this.codeSessionsRepo.save({
                 ...session,
-                worktree: { ...session.worktree, mergedAt: new Date().toISOString() },
+                worktree: { ...session.worktree, mergedAt: now },
+                doneAt: session.doneAt ?? now,
             });
         }
         return result;

--- a/apps/x/packages/core/src/code-mode/sessions/status-tracker.ts
+++ b/apps/x/packages/core/src/code-mode/sessions/status-tracker.ts
@@ -142,8 +142,9 @@ export class CodeSessionStatusTracker {
             if (!session) return;
             // A new turn on a done session reopens it — work resumed, so it
             // belongs back in the active list.
-            const { doneAt: _done, ...rest } = session;
-            await this.codeSessionsRepo.save({ ...rest, lastActivityAt: new Date().toISOString() });
+            const reopened = { ...session, lastActivityAt: new Date().toISOString() };
+            delete reopened.doneAt;
+            await this.codeSessionsRepo.save(reopened);
         } catch {
             // Recency sort just stays where it was.
         }

--- a/apps/x/packages/core/src/code-mode/sessions/status-tracker.ts
+++ b/apps/x/packages/core/src/code-mode/sessions/status-tracker.ts
@@ -140,7 +140,10 @@ export class CodeSessionStatusTracker {
         try {
             const session = await this.codeSessionsRepo.get(sessionId);
             if (!session) return;
-            await this.codeSessionsRepo.save({ ...session, lastActivityAt: new Date().toISOString() });
+            // A new turn on a done session reopens it — work resumed, so it
+            // belongs back in the active list.
+            const { doneAt: _done, ...rest } = session;
+            await this.codeSessionsRepo.save({ ...rest, lastActivityAt: new Date().toISOString() });
         } catch {
             // Recency sort just stays where it was.
         }

--- a/apps/x/packages/core/src/home/threads.ts
+++ b/apps/x/packages/core/src/home/threads.ts
@@ -314,6 +314,9 @@ export class HomeThreadsTracker {
             const item = todoKey ? items.get(todoKey) : undefined;
             const code = codeById.get(entry.sessionId);
             const live = this.live.get(entry.sessionId);
+            // Finished work stays out of the deck; a live turn on it means
+            // it is being reopened (the tracker clears the flag as it runs).
+            if (code?.doneAt && !live) continue;
 
             let status: HomeThreadStatus;
             let attention: string | undefined;

--- a/apps/x/packages/shared/src/code-sessions.ts
+++ b/apps/x/packages/shared/src/code-sessions.ts
@@ -63,6 +63,10 @@ export const CodeSession = z.object({
     // The coding agent's own model + reasoning effort (applied to the ACP engine,
     // not the Rowboat-mode LLM). Values come from CODE_AGENT_MODELS /
     // CODE_AGENT_EFFORTS; unset (or 'default') leaves the engine's own default.
+    // Set when the user marks the session done (rail check, menus). Nothing
+    // on disk changes — worktree, branch and chat stay; the rail just files
+    // the session under Done. Cleared by activity (a new turn) or Reopen.
+    doneAt: z.iso.datetime().optional(),
     agentModel: z.string().optional(),
     agentEffort: z.string().optional(),
     createdAt: z.iso.datetime(),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1717,6 +1717,12 @@ export const ipcSchemas = {
     req: z.object({ agent: CodingAgent }),
     res: CodeAgentModelOptions,
   },
+  // Done is a flag, not a lifecycle change: the worktree, branch and chat are
+  // untouched. `done: false` reopens.
+  'codeSession:setDone': {
+    req: z.object({ sessionId: z.string(), done: z.boolean() }),
+    res: z.object({ session: CodeSession }),
+  },
   'codeSession:delete': {
     req: z.object({
       sessionId: z.string(),


### PR DESCRIPTION
## Summary

**Done pile for code sessions.** Finishing a session no longer means deleting it. Mark it done from its row (hover check or `⋯` menu) or from the chat header's menu; it moves to a **Done** pile pinned to the bottom of the rail and nothing else changes — worktree, branch, chat and agent context all stay. Reopen is one click, and any new turn on a done session reopens it on its own (the status tracker clears the flag when it starts working). Merging a worktree back marks the session done as well.

- `CodeSession.doneAt` + `codeSession:setDone` on both hosts (Electron IPC and rowboat-server).
- Rail: the active list and the Done pile scroll independently; the pile opens to at most a third of the rail, shows the last 25 with "Show all" (a display cap, never deletion), and rows carry their project label since the pile spans projects. Open state persists.
- Marking the selected session done keeps it open — nothing jumps.
- Home's deck skips done sessions unless they are live.

**Code-session empty state.** A fresh coding session opens on a single centered line, "What should we build together?", set as a light display heading in the system face, with a block cursor blinking after it (stepped one-second cycle, solid under reduced motion, hidden from screen readers). Clicking the line focuses the composer. The email / background-agent / research starters and the connections card no longer show on code sessions; ordinary chats are unchanged.

## Test plan

- [x] shared, core, renderer, server, main and preload build/typecheck; renderer 373 and core 826 tests pass
- [x] Live in an isolated instance: hover check files the row under "Done 1" with the chat still open; the header menu offers Reopen; reopening clears the flag and the empty pile disappears; the empty state shows the single line with the cursor and a click focuses the composer
- [ ] Reviewer: after pulling, run `npm run dev` (the preload bundles its own copy of the IPC schemas) and make sure no packaged Rowboat.app is running alongside — a second app silently attaches to the first one's server child and reports `unknown channel: codeSession:setDone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHkMjuE9wRuajqtYYkSoRZ
