### PR TITLE
chore(x): bump @agentclientprotocol/sdk to 1.4.0 in core

### DIFF
--- a/apps/x/packages/core/package.json
+++ b/apps/x/packages/core/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.67.0",
     "@agentclientprotocol/codex-acp": "^1.2.0",
-    "@agentclientprotocol/sdk": "^1.3.0",
+    "@agentclientprotocol/sdk": "^1.4.0",
     "@ai-sdk/anthropic": "^4.0.12",
     "@ai-sdk/google": "^4.0.12",
     "@ai-sdk/openai": "^4.0.11",

--- a/apps/x/pnpm-lock.yaml
+++ b/apps/x/pnpm-lock.yaml
@@ -608,8 +608,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@agentclientprotocol/sdk':
-        specifier: ^1.3.0
-        version: 1.3.0(zod@4.2.1)
+        specifier: ^1.4.0
+        version: 1.4.0(zod@4.2.1)
       '@ai-sdk/anthropic':
         specifier: ^4.0.12
         version: 4.0.12(zod@4.2.1)
@@ -797,6 +797,11 @@ packages:
 
   '@agentclientprotocol/sdk@1.3.0':
     resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@1.4.0':
+    resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -11813,13 +11818,13 @@ snapshots:
       vscode-jsonrpc: 8.2.0
       zod: 4.4.3
 
-  '@agentclientprotocol/sdk@1.3.0(zod@4.2.1)':
-    dependencies:
-      zod: 4.2.1
-
   '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
+
+  '@agentclientprotocol/sdk@1.4.0(zod@4.2.1)':
+    dependencies:
+      zod: 4.2.1
 
   '@ai-sdk/anthropic@4.0.12(zod@4.2.1)':
     dependencies:
@@ -16531,9 +16536,7 @@ snapshots:
       metro-runtime: 0.84.5
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
## Summary

Bumps `@agentclientprotocol/sdk` in `packages/core` from `^1.3.0` to `^1.4.0`. Groundwork for slash commands and session resume in Code mode.

- Additive over 1.3.0: `session/set_model`, `session/delete`, and the next-edit-suggestion methods. The two removed exports (`OutboundStream`, `OutboundSubscription`) are not used here.
- The Claude Code and Codex adapters keep their own 1.3.0 pin, so pnpm holds both copies; they only meet over JSON-RPC, and the protocol version is unchanged (1).
- Only `package.json` and the lockfile change.

## Test plan

- [x] Live handshake against the installed `claude-agent-acp` and `codex-acp` adapters with the 1.4.0 client: protocol version 1 negotiated on both; both advertise the `list` / `resume` / `close` / `delete` session capabilities (Claude also `fork`); both push `available_commands_update` right after `session/new`; `listSessions` answers
- [x] core builds; 826 core tests pass; server and main typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHkMjuE9wRuajqtYYkSoRZ
