### PR TITLE
feat(x): sandboxed dev instances — npm run dev:sandbox

### DIFF
--- a/apps/x/DEV_SANDBOX.md
+++ b/apps/x/DEV_SANDBOX.md
@@ -1,0 +1,32 @@
+# Sandboxed dev instances
+
+`npm run dev:sandbox` (at `apps/x`) boots a dev instance that coexists with the
+production app and with other dev instances — including when launched from a
+worktree inside Rowboat code mode.
+
+```bash
+cd apps/x
+npm run dev:sandbox                    # isolated workdir, auto-picked ports
+npm run dev:sandbox -- --seed-config   # first boot: copy ~/.rowboat/config in
+                                       # (minus server.json) so providers work
+npm run dev:sandbox -- --no-deps       # skip the workspace deps build
+```
+
+Each instance gets a workdir at `~/.rowboat-dev/<instance-id>` (id derived from
+the checkout/worktree path, stable across restarts) plus its own Electron
+profile (`<workdir>/.electron-data`) and three free ports. Plain `npm run dev`
+is unchanged: default `~/.rowboat` workdir, ports 3220/3210/5173.
+
+## What makes it work
+
+| Problem | Mechanism |
+|---------|-----------|
+| Code-mode shells leak `ELECTRON_RUN_AS_NODE` (set for the ACP adapter spawn in `core/src/code-mode/acp/agents.ts`), so `electron .` boots as plain Node and crashes at the first `app.` access | `apps/main` start script strips the var (`env -u`); `apps/main/src/node-guard.ts` fails fast with a real error if it still leaks through |
+| rowboat-server refuses a second instance on its port (split-brain guard in `apps/server/src/server.ts`) | `ROWBOAT_SERVER_PORT` env override in `apps/server/src/config.ts` (explicit `opts.port` from tests still wins) |
+| Apps server port was the hardcoded 3210 | `ROWBOAT_APPS_PORT` env override in `core/src/apps/constants.ts`; `appOrigin()` derives from it |
+| Vite port | vite runs with `--port --strictPort`; main already honors `ROWBOAT_DEV_SERVER_URL` (`apps/main/src/dev-server.ts`) |
+| Shared state | `ROWBOAT_WORKDIR` (already supported by core config) + per-instance `userData` set in `apps/main/src/main.ts` when `ROWBOAT_WORKDIR` is set in dev |
+
+Known shared resource left alone: the OAuth loopback server uses a fixed port
+(registered redirect URIs), so two instances can't run an interactive OAuth
+flow at the same moment.

--- a/apps/x/apps/main/package.json
+++ b/apps/x/apps/main/package.json
@@ -7,7 +7,7 @@
     "main": ".package/dist/main.cjs",
     "license": "Apache-2.0",
     "scripts": {
-        "start": "electron .",
+        "start": "env -u ELECTRON_RUN_AS_NODE electron .",
         "build": "rm -rf dist && tsc && node bundle.mjs",
         "package": "electron-forge package",
         "make": "electron-forge make"

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -1,3 +1,4 @@
+import "./node-guard.js";
 import { app, BrowserWindow, desktopCapturer, dialog, powerMonitor, protocol, net, shell, session, safeStorage, type Session } from "electron";
 import path from "node:path";
 import fsPromises from "node:fs/promises";
@@ -37,6 +38,7 @@ import { identifyIfSignedIn } from "@x/core/dist/analytics/identify.js";
 import { syncModelProviderPersonProperties } from "@x/core/dist/analytics/model-providers.js";
 
 import { initConfigs } from "@x/core/dist/config/initConfigs.js";
+import { WorkDir } from "@x/core/dist/config/config.js";
 import { prepareCoreData, initCoreServices } from "@x/core/dist/boot/services.js";
 import { startServerHost, stopServerHost, childServerMode, serverHostMode, whenServerReady } from "./server-host.js";
 import { getAgentSlackCliStatus } from "@x/core/dist/slack/agent-slack-exec.js";
@@ -105,6 +107,15 @@ if (app.isPackaged && !app.requestSingleInstanceLock()) {
   console.error('[Main] Another Rowboat instance is already running; exiting this process.');
   app.quit();
   process.exit(0);
+}
+
+// Sandboxed dev instances (ROWBOAT_WORKDIR set, e.g. via `npm run dev:sandbox`)
+// get their own Electron profile too: concurrent instances sharing the default
+// userData dir fight over Chromium's LevelDB locks and each other's
+// localStorage. Must run before 'ready' — session state is created lazily at
+// app ready, so nothing has touched the default profile yet.
+if (!app.isPackaged && process.env.ROWBOAT_WORKDIR) {
+  app.setPath('userData', path.join(WorkDir, '.electron-data'));
 }
 
 // Register as the OS handler for rowboat:// URLs.

--- a/apps/x/apps/main/src/node-guard.ts
+++ b/apps/x/apps/main/src/node-guard.ts
@@ -1,0 +1,25 @@
+// Must stay main.ts's FIRST import — everything below it assumes a real
+// Electron main process, and the crash this guards against happens while the
+// import graph is still evaluating (e.g. ipc.ts touches `app` at module scope).
+//
+// When ELECTRON_RUN_AS_NODE leaks into the environment (any shell spawned by
+// an Electron host inherits it — Rowboat's own code-mode agents are the common
+// case, see core/code-mode/acp/agents.ts), `electron .` boots as plain Node:
+// require('electron') then resolves to the npm stub (a path string) and the
+// first `app.` access dies with a cryptic TypeError deep in the bundle. Fail
+// fast with the actual explanation instead. `process.type` is 'browser' only
+// in a real main process; under ELECTRON_RUN_AS_NODE it is undefined (while
+// process.versions.electron still reports — don't check that).
+const type = (process as { type?: string }).type;
+if (type !== 'browser') {
+    console.error(
+        '[main] fatal: not running inside an Electron main process' +
+        (process.env.ELECTRON_RUN_AS_NODE
+            ? ' — ELECTRON_RUN_AS_NODE leaked in from the parent shell (an Electron-hosted terminal, e.g. code mode). ' +
+              'Launch via `npm run start`/`npm run dev` (which strip it) or unset the variable.'
+            : ` (process.type=${JSON.stringify(type)}).`),
+    );
+    process.exit(1);
+}
+
+export {};

--- a/apps/x/apps/server/src/config.ts
+++ b/apps/x/apps/server/src/config.ts
@@ -16,13 +16,25 @@ function configPath(workDir: string): string {
   return path.join(workDir, 'config', 'server.json');
 }
 
+// Per-instance override for sandboxed dev instances (`npm run dev:sandbox`):
+// lets several rowboat-servers coexist on one machine, each on its own port,
+// without touching the workdir's server.json. Explicit opts.port (tests)
+// still wins over this — see createRowboatServer.
+function envPortOverride(): number | undefined {
+  const port = Number(process.env.ROWBOAT_SERVER_PORT);
+  return Number.isInteger(port) && port > 0 ? port : undefined;
+}
+
 export async function loadServerConfig(workDir: string): Promise<ServerConfig> {
+  let config: ServerConfig;
   try {
     const raw = await fs.readFile(configPath(workDir), 'utf8');
-    return ServerConfig.parse(JSON.parse(raw));
+    config = ServerConfig.parse(JSON.parse(raw));
   } catch {
-    return ServerConfig.parse({});
+    config = ServerConfig.parse({});
   }
+  const envPort = envPortOverride();
+  return envPort === undefined ? config : { ...config, port: envPort };
 }
 
 export async function saveServerConfig(workDir: string, config: ServerConfig): Promise<void> {

--- a/apps/x/package.json
+++ b/apps/x/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "npm run deps && concurrently -k \"npm:renderer\" \"npm:main\"",
+    "dev:sandbox": "node scripts/dev-sandbox.mjs",
     "renderer": "cd apps/renderer && npm run dev",
     "protocol": "cd ../harbor && pnpm install --filter @rowboat/spaces-protocol && cd packages/protocol && npm run build",
     "shared": "npm run protocol && cd packages/shared && npm run build",

--- a/apps/x/packages/core/src/apps/constants.ts
+++ b/apps/x/packages/core/src/apps/constants.ts
@@ -6,7 +6,11 @@ import { WorkDir } from '../config/config.js';
 
 export const APPS_DIR = path.join(WorkDir, 'apps');
 
-export const APPS_PORT = 3210; // reuses the local-sites port (D8)
+// 3210 reuses the local-sites port (D8). ROWBOAT_APPS_PORT is the
+// per-instance override for sandboxed dev instances (`npm run dev:sandbox`) —
+// appOrigin() below derives from this constant, so app URLs follow along.
+const envAppsPort = Number(process.env.ROWBOAT_APPS_PORT);
+export const APPS_PORT = Number.isInteger(envAppsPort) && envAppsPort > 0 ? envAppsPort : 3210;
 export const APPS_HOST_SUFFIX = '.apps.localhost'; // full host: <slug>.apps.localhost:3210
 export const CONTROL_HOST = 'apps.localhost'; // control endpoints only (§6.4)
 

--- a/apps/x/scripts/dev-sandbox.mjs
+++ b/apps/x/scripts/dev-sandbox.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Sandboxed dev instance launcher: boots the app with an isolated workdir and
+// per-instance ports so several dev instances can run at once — alongside the
+// production app, and from inside Rowboat code mode (whose agent shells leak
+// ELECTRON_RUN_AS_NODE; stripped here and in apps/main's start script).
+//
+//   npm run dev:sandbox [-- --seed-config] [--no-deps] [--workdir <path>] [--name <id>]
+//
+//   --seed-config   copy ~/.rowboat/config into the sandbox workdir on first
+//                   boot (minus server.json), so model providers work
+//   --no-deps       skip the workspace deps build (shared/core/server/…)
+//   --workdir       explicit workdir (default ~/.rowboat-dev/<instance-id>)
+//   --name          explicit instance id (default derived from the repo root,
+//                   stable across restarts of the same checkout/worktree)
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
+
+const appsXRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const monorepoRoot = path.resolve(appsXRoot, '..', '..');
+
+const argv = process.argv.slice(2);
+const hasFlag = (name) => argv.includes(name);
+const flagValue = (name) => {
+    const i = argv.indexOf(name);
+    return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+};
+
+const instanceId = flagValue('--name')
+    ?? `${path.basename(monorepoRoot).replace(/[^a-zA-Z0-9._-]+/g, '-')}-${createHash('sha256').update(monorepoRoot).digest('hex').slice(0, 6)}`;
+const workDir = path.resolve(flagValue('--workdir') ?? path.join(os.homedir(), '.rowboat-dev', instanceId));
+
+// Hold each probe server open until all ports are picked, so the trio is
+// guaranteed distinct.
+function openOnFreePort() {
+    return new Promise((resolve, reject) => {
+        const srv = net.createServer();
+        srv.once('error', reject);
+        srv.listen(0, '127.0.0.1', () => resolve(srv));
+    });
+}
+const probes = await Promise.all([openOnFreePort(), openOnFreePort(), openOnFreePort()]);
+const [serverPort, appsPort, vitePort] = probes.map((s) => s.address().port);
+await Promise.all(probes.map((s) => new Promise((r) => s.close(r))));
+
+fs.mkdirSync(workDir, { recursive: true });
+
+const seededConfigDir = path.join(workDir, 'config');
+if (hasFlag('--seed-config')) {
+    const sourceConfigDir = path.join(os.homedir(), '.rowboat', 'config');
+    if (fs.existsSync(seededConfigDir)) {
+        console.log(`[sandbox] config already present in ${seededConfigDir} — not re-seeding`);
+    } else if (!fs.existsSync(sourceConfigDir)) {
+        console.warn(`[sandbox] --seed-config: ${sourceConfigDir} does not exist — skipping`);
+    } else {
+        // server.json stays out: it carries the port/LAN choices of the real
+        // workdir, and the sandbox's port comes from ROWBOAT_SERVER_PORT.
+        fs.cpSync(sourceConfigDir, seededConfigDir, {
+            recursive: true,
+            filter: (src) => path.basename(src) !== 'server.json',
+        });
+        console.log(`[sandbox] seeded config from ${sourceConfigDir}`);
+    }
+}
+
+const env = { ...process.env };
+delete env.ELECTRON_RUN_AS_NODE;
+env.ROWBOAT_WORKDIR = workDir;
+env.ROWBOAT_SERVER_PORT = String(serverPort);
+env.ROWBOAT_APPS_PORT = String(appsPort);
+env.ROWBOAT_DEV_SERVER_URL = `http://localhost:${vitePort}`;
+
+console.log(`[sandbox] instance  ${instanceId}`);
+console.log(`[sandbox] workdir   ${workDir}`);
+console.log(`[sandbox] ports     server=${serverPort} apps=${appsPort} vite=${vitePort}`);
+
+function prefixPipe(stream, label) {
+    readline.createInterface({ input: stream }).on('line', (line) => console.log(`[${label}] ${line}`));
+}
+
+function run(label, args, cwd) {
+    const child = spawn('npm', args, { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    prefixPipe(child.stdout, label);
+    prefixPipe(child.stderr, label);
+    return child;
+}
+
+const waitForExit = (child) => new Promise((resolve) => child.once('exit', resolve));
+
+async function runToCompletion(label, args, cwd) {
+    const code = await waitForExit(run(label, args, cwd));
+    if (code !== 0) {
+        console.error(`[sandbox] ${label} failed with code ${code}`);
+        process.exit(code ?? 1);
+    }
+}
+
+const children = new Set();
+let shuttingDown = false;
+function shutdown(code) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    for (const child of children) child.kill('SIGTERM');
+    process.exitCode = code;
+}
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));
+
+if (!hasFlag('--no-deps')) await runToCompletion('deps', ['run', 'deps'], appsXRoot);
+
+const renderer = run('renderer', ['run', 'dev', '--', '--port', String(vitePort), '--strictPort'], path.join(appsXRoot, 'apps', 'renderer'));
+children.add(renderer);
+renderer.once('exit', (code) => {
+    children.delete(renderer);
+    if (!shuttingDown) {
+        console.error(`[sandbox] renderer exited (code ${code}) — shutting down`);
+        shutdown(code ?? 1);
+    }
+});
+
+// wait-on equivalent for the sandbox's vite port.
+const viteUrl = `http://localhost:${vitePort}`;
+const deadline = Date.now() + 120_000;
+for (;;) {
+    if (shuttingDown) process.exit();
+    try {
+        const res = await fetch(viteUrl);
+        if (res.ok) break;
+    } catch { /* not up yet */ }
+    if (Date.now() > deadline) {
+        console.error(`[sandbox] vite dev server never came up on ${viteUrl}`);
+        shutdown(1);
+        process.exit();
+    }
+    await new Promise((r) => setTimeout(r, 500));
+}
+
+await runToCompletion('main-build', ['run', 'build'], path.join(appsXRoot, 'apps', 'main'));
+
+const main = run('main', ['run', 'start'], path.join(appsXRoot, 'apps', 'main'));
+children.add(main);
+main.once('exit', (code) => {
+    children.delete(main);
+    console.log(`[sandbox] app exited (code ${code})`);
+    shutdown(code ?? 0);
+});


### PR DESCRIPTION
## What

`npm run dev:sandbox` (at `apps/x`) boots a dev instance that coexists with the production app and other dev instances — including when launched from a worktree inside Rowboat code mode. Each instance gets an isolated workdir (`~/.rowboat-dev/<id>`), its own Electron profile, and auto-picked free ports. Plain `npm run dev` is unchanged. Docs in `apps/x/DEV_SANDBOX.md`.

## Why

Running a dev instance from inside code mode failed two ways:
1. Code-mode agent shells inherit `ELECTRON_RUN_AS_NODE=1` (set for the ACP adapter spawn in `core/src/code-mode/acp/agents.ts`), so `electron .` boots as plain Node, `require('electron')` resolves to the npm path-string stub, and the first `app.` access dies with `TypeError: Cannot read properties of undefined (reading 'on')` deep in the bundle.
2. The host app already holds rowboat-server's port 3220, and the split-brain guard makes a second instance fatal (`refusing to start a second instance`); the Apps server's 3210 was a hardcoded constant.

## How

- **`apps/main/src/node-guard.ts`** (new, first import of `main.ts`): fails fast with a clear message when the process isn't a real Electron main process (`process.type !== 'browser'` — `versions.electron` still reports under the leak, verified empirically). The `start` script strips the var with `env -u`. The ACP spawn site is untouched — the var is required there.
- **`ROWBOAT_SERVER_PORT`** override in `apps/server/src/config.ts` (explicit test `opts.port` still wins; split-brain guard intact).
- **`ROWBOAT_APPS_PORT`** override in `core/src/apps/constants.ts`; `appOrigin()` derives from it.
- **Per-instance userData** (`<workdir>/.electron-data`) in `main.ts` when `ROWBOAT_WORKDIR` is set in dev — concurrent instances otherwise fight over Chromium profile locks.
- **`scripts/dev-sandbox.mjs`**: derives a stable instance id from the checkout/worktree path, picks three free ports, optionally seeds `~/.rowboat/config` (minus `server.json`) via `--seed-config`, strips the leaked var, and orchestrates the usual deps → vite → main pipeline (vite pinned with `--port --strictPort`; main already honors `ROWBOAT_DEV_SERVER_URL`).

Known shared resource left alone: the OAuth loopback server's fixed port (registered redirect URIs), so two instances can't run an interactive OAuth flow at the same moment.

## Testing

- With `ELECTRON_RUN_AS_NODE=1` injected, bare `electron .` prints the guard's clear fatal; `npm run dev:sandbox` boots the full app anyway.
- Two sandbox instances ran simultaneously, each answering `/health` as `rowboat-server` on its own port trio with its own workdir/profile; clean SIGTERM teardown, all ports freed.
- All 27 `apps/server` tests pass; full deps + main build and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV11vrsywmfcrvCUQyxvHJ