### PR TITLE
Spaces: tint only the mention chip, not the whole row (Slack-style)

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -213,22 +213,12 @@ function MessageRowImpl({
     const canQuote = !!onQuoteReply && !deleted && !unconfirmed && !!messageText
     const canForward = !!onForward && !deleted && !unconfirmed
 
-    // A ping: the wire body addresses you (@<yourId>) or everyone (@here).
-    // Discord treatment — amber wash + left accent bar, no layout shift.
-    const pingsMe =
-        !deleted &&
-        !!selfMemberId &&
-        message.author.memberId !== selfMemberId &&
-        new RegExp(`@(?:${selfMemberId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}|here)(?![\\w.-])`).test(message.body)
-
     const row = (
         <div
             data-mid={message.id}
             className={cn(
                 'group/msg relative flex items-start gap-3 px-3 hover:bg-accent',
                 continuation ? 'py-0.5' : 'py-1.5',
-                // A message that pings you carries the dialect's "needs you" wash.
-                pingsMe && 'bg-[var(--stream-you-wash)] shadow-[inset_3px_0_0] shadow-[var(--stream-you-ink)]',
             )}
         >
             {continuation ? (

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -9,7 +9,7 @@ import { ZoomableImage } from '@/components/image-lightbox'
 import { isTrustedDomain, linkDomain, trustDomain } from '@/lib/trusted-domains'
 import { toast } from '@/lib/toast'
 import { MemberProfilePopover } from '@/components/spaces/atoms'
-import { useMemberNames } from '@/components/spaces/member-text'
+import { useMemberNames, useSpaceProfiles } from '@/components/spaces/member-text'
 import {
     decorateMentions,
     imageDimsFromUrl,
@@ -415,20 +415,35 @@ const spaceComponents: StreamdownComponents = {
     },
     a: SpaceAnchor,
     // decorateMentions renders "@name" as **bold**; the stream dialect shows
-    // those as tinted mention chips (broadcasts get the amber "needs you"
-    // wash). A chip naming a real member also opens their profile on click.
+    // those as tinted mention chips. Slack treatment: only the chip is
+    // tinted, never the row — amber when it addresses you (@you, @here),
+    // blue for anyone else. A chip naming a real member opens their profile.
     strong: MentionStrong,
 }
 
 function MentionStrong({ children, ...props }: ComponentProps<'strong'>) {
     const names = useMemberNames()
+    const { selfId } = useSpaceProfiles()
     const label = plainLabel(children)
     if (!label?.startsWith('@')) return <strong {...props}>{children}</strong>
 
     const broadcast = /^@(here|channel|everyone)$/i.test(label)
+    // The label carries the display name (decorateMentions), so the id comes
+    // from a reverse lookup; an unmatched name still renders as a chip.
+    const name = label.slice(1)
+    let memberId: string | null = null
+    if (!broadcast) {
+        for (const [id, display] of names) {
+            if (display === name) {
+                memberId = id
+                break
+            }
+        }
+    }
+    const addressesMe = broadcast || (!!selfId && memberId === selfId)
     const chip = cn(
         'rounded-[4px] px-[3px] py-px font-medium',
-        broadcast
+        addressesMe
             ? 'bg-[var(--stream-you-wash)] text-[var(--stream-you-ink)]'
             : 'bg-[var(--stream-mention-wash)] text-[var(--stream-link)]',
     )
@@ -439,16 +454,6 @@ function MentionStrong({ children, ...props }: ComponentProps<'strong'>) {
                 {children}
             </strong>
         )
-    }
-    // The label carries the display name (decorateMentions), so the id comes
-    // from a reverse lookup; an unmatched name still renders as a chip.
-    const name = label.slice(1)
-    let memberId: string | null = null
-    for (const [id, display] of names) {
-        if (display === name) {
-            memberId = id
-            break
-        }
     }
     if (!memberId) {
         return (


### PR DESCRIPTION
## What

Quick UI fix for Spaces chat mentions, matching Slack.

- **Row wash removed.** A message that pinged you (`@you` or `@here`) painted the whole row amber with a left accent bar. That's gone; the inline chip is now the only signal.
- **Chip colour follows Slack's rule.** Amber when the mention addresses you (`@you`, `@here`), blue for anyone else. Previously only `@here` was amber and every person mention was blue.

## Files

- `apps/renderer/src/components/spaces/message-row.tsx`: drop the `pingsMe` computation and the row-level `--stream-you-wash` class.
- `apps/renderer/src/components/spaces/space-markdown.tsx`: `MentionStrong` reads the viewer's id from `useSpaceProfiles` and picks the amber wash when the resolved member is self (or the label is a broadcast).

## Verified

- `tsc --noEmit` clean on the renderer.
- Visual check is via hot reload in the running app (not automated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdKK6pfaNc4cBZqZBf1USA
