### PR TITLE
feat(x): vertical-tabs rail in the browser pane, favicons end to end

### DIFF
--- a/apps/x/apps/main/src/browser/view.ts
+++ b/apps/x/apps/main/src/browser/view.ts
@@ -85,6 +85,9 @@ type BrowserTab = {
   view: WebContentsView;
   domReadyAt: number | null;
   loadError: string | null;
+  // Latest page-favicon-updated URL; webContents has no getter for it, so it
+  // must be cached here to survive into snapshotTabState.
+  favicon: string | null;
 };
 
 type CachedSnapshot = {
@@ -465,10 +468,13 @@ export class BrowserViewManager extends EventEmitter {
       this.emitState();
     };
 
-    wc.on('did-start-navigation', (_event, _url, _isInPlace, isMainFrame) => {
+    wc.on('did-start-navigation', (_event, _url, isInPlace, isMainFrame) => {
       if (isMainFrame !== false) {
         tab.domReadyAt = null;
         tab.loadError = null;
+        // A real navigation invalidates the old page's icon; in-page
+        // navigations (hash/pushState) keep it.
+        if (!isInPlace) tab.favicon = null;
       }
       this.invalidateSnapshot(tabId);
       reapplyBounds();
@@ -500,6 +506,12 @@ export class BrowserViewManager extends EventEmitter {
       invalidateAndEmit();
     });
     wc.on('page-title-updated', this.emitState.bind(this));
+    wc.on('page-favicon-updated', (_event, favicons) => {
+      const favicon = favicons[0] ?? null;
+      if (tab.favicon === favicon) return;
+      tab.favicon = favicon;
+      this.emitState();
+    });
 
     this.wireWindowPolicy(wc);
   }
@@ -646,6 +658,7 @@ export class BrowserViewManager extends EventEmitter {
       id: tab.id,
       url: wc.getURL(),
       title: wc.getTitle(),
+      favicon: tab.favicon,
       canGoBack: wc.navigationHistory.canGoBack(),
       canGoForward: wc.navigationHistory.canGoForward(),
       loading: wc.isLoading(),
@@ -696,6 +709,7 @@ export class BrowserViewManager extends EventEmitter {
       view: this.createView(),
       domReadyAt: null,
       loadError: null,
+      favicon: null,
     };
 
     this.wireEvents(tab);

--- a/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowLeft, ArrowRight, Loader2, Plus, RotateCw, X } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Loader2, RotateCw, X } from 'lucide-react'
 
 // Custom element provided by electron-chrome-extensions (injected via the
 // preload script): a row of extension action icons for the given session
@@ -21,7 +21,7 @@ declare module 'react' {
 
 import type { DisplayMediaRequest, DisplayMediaSource, HttpAuthRequest } from '@x/shared/dist/browser-control.js'
 
-import { TabBar } from '@/components/tab-bar'
+import { BrowserTabRail } from '@/components/browser-pane/browser-tab-rail'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -48,6 +48,7 @@ interface BrowserTabState {
   id: string
   url: string
   title: string
+  favicon: string | null
   canGoBack: boolean
   canGoForward: boolean
   loading: boolean
@@ -104,19 +105,6 @@ const hasBlockingOverlay = (doc: Document) => {
     if (!slot || !BLOCKING_OVERLAY_SLOTS.has(slot)) return false
     return isVisibleOverlayElement(el)
   })
-}
-
-const getBrowserTabTitle = (tab: BrowserTabState) => {
-  const title = tab.title.trim()
-  if (title) return title
-  const url = tab.url.trim()
-  if (!url) return 'New tab'
-  try {
-    const parsed = new URL(url)
-    return parsed.hostname || parsed.href
-  } catch {
-    return url.replace(/^https?:\/\//i, '') || 'New tab'
-  }
 }
 
 /**
@@ -310,6 +298,10 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
   const [addressValue, setAddressValue] = useState('')
   const [authQueue, setAuthQueue] = useState<HttpAuthRequest[]>([])
   const [displayMediaQueue, setDisplayMediaQueue] = useState<DisplayMediaRequest[]>([])
+  // The vertical-tabs rail: starts collapsed, opens on an explicit click on
+  // the edge strip, and the choice sticks per machine — the same persisted
+  // pattern as the Spaces rail (see spaces-view.tsx).
+  const [railOpen, setRailOpen] = useState(() => localStorage.getItem('browser:railOpen') === '1')
 
   const activeTabIdRef = useRef<string | null>(null)
   const addressFocusedRef = useRef(false)
@@ -602,6 +594,12 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
     void window.ipc.invoke('browser:closeTab', { tabId })
   }, [])
 
+  const toggleRail = useCallback(() => {
+    const next = !railOpen
+    localStorage.setItem('browser:railOpen', next ? '1' : '0')
+    setRailOpen(next)
+  }, [railOpen])
+
   const handleSubmitAddress = useCallback((e: React.FormEvent) => {
     e.preventDefault()
     const trimmed = addressValue.trim()
@@ -627,115 +625,107 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
   }, [])
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-      <div className="flex h-9 shrink-0 items-stretch border-b border-border bg-sidebar">
-        <TabBar
-          tabs={state.tabs}
-          activeTabId={state.activeTabId ?? ''}
-          getTabTitle={getBrowserTabTitle}
-          getTabId={(tab) => tab.id}
-          onSwitchTab={handleSwitchTab}
-          onCloseTab={handleCloseTab}
-          layout="scroll"
-        />
-        <button
-          type="button"
-          onClick={handleNewTab}
-          className="flex h-9 w-9 shrink-0 items-center justify-center border-l border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          aria-label="New browser tab"
-        >
-          <Plus className="size-4" />
-        </button>
-      </div>
-
-      <div
-        className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-sidebar px-2"
-        style={{ minHeight: CHROME_HEIGHT }}
-      >
-        <button
-          type="button"
-          onClick={handleBack}
-          disabled={!activeTab?.canGoBack}
-          className={cn(
-            'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors',
-            activeTab?.canGoBack ? 'hover:bg-accent hover:text-foreground' : 'opacity-40',
-          )}
-          aria-label="Back"
-        >
-          <ArrowLeft className="size-4" />
-        </button>
-        <button
-          type="button"
-          onClick={handleForward}
-          disabled={!activeTab?.canGoForward}
-          className={cn(
-            'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors',
-            activeTab?.canGoForward ? 'hover:bg-accent hover:text-foreground' : 'opacity-40',
-          )}
-          aria-label="Forward"
-        >
-          <ArrowRight className="size-4" />
-        </button>
-        <button
-          type="button"
-          onClick={handleReload}
-          disabled={!activeTab}
-          className={cn(
-            'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors',
-            activeTab ? 'hover:bg-accent hover:text-foreground' : 'opacity-40',
-          )}
-          aria-label="Reload"
-        >
-          {activeTab?.loading ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <RotateCw className="size-4" />
-          )}
-        </button>
-        <form onSubmit={handleSubmitAddress} className="flex-1 min-w-0">
-          <input
-            type="text"
-            value={addressValue}
-            onChange={(e) => setAddressValue(e.target.value)}
-            onFocus={(e) => {
-              addressFocusedRef.current = true
-              e.currentTarget.select()
-            }}
-            onBlur={() => {
-              addressFocusedRef.current = false
-              setAddressValue(activeTab?.url ?? '')
-            }}
-            placeholder="Enter URL or search..."
-            className={cn(
-              'h-7 w-full rounded-md border border-transparent bg-background px-3 text-sm text-foreground',
-              'placeholder:text-muted-foreground/60',
-              'focus:border-border focus:outline-hidden',
-            )}
-            spellCheck={false}
-            autoCorrect="off"
-            autoCapitalize="off"
-          />
-        </form>
-        <browser-action-list
-          partition="persist:rowboat-browser"
-          alignment="bottom right"
-          className="ml-1 flex shrink-0 items-center"
-        />
-        <button
-          type="button"
-          onClick={onClose}
-          className="ml-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          aria-label="Close browser"
-        >
-          <X className="size-4" />
-        </button>
-      </div>
-
-      <div
-        ref={viewportRef}
-        className="relative min-h-0 min-w-0 flex-1"
-        data-browser-viewport
+    <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+      <BrowserTabRail
+        tabs={state.tabs}
+        activeTabId={state.activeTabId}
+        open={railOpen}
+        onTogglePin={toggleRail}
+        onSwitchTab={handleSwitchTab}
+        onCloseTab={handleCloseTab}
+        onNewTab={handleNewTab}
       />
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div
+          className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-sidebar px-2"
+          style={{ minHeight: CHROME_HEIGHT }}
+        >
+          <button
+            type="button"
+            onClick={handleBack}
+            disabled={!activeTab?.canGoBack}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors',
+              activeTab?.canGoBack ? 'hover:bg-accent hover:text-foreground' : 'opacity-40',
+            )}
+            aria-label="Back"
+          >
+            <ArrowLeft className="size-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleForward}
+            disabled={!activeTab?.canGoForward}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors',
+              activeTab?.canGoForward ? 'hover:bg-accent hover:text-foreground' : 'opacity-40',
+            )}
+            aria-label="Forward"
+          >
+            <ArrowRight className="size-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleReload}
+            disabled={!activeTab}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors',
+              activeTab ? 'hover:bg-accent hover:text-foreground' : 'opacity-40',
+            )}
+            aria-label="Reload"
+          >
+            {activeTab?.loading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <RotateCw className="size-4" />
+            )}
+          </button>
+          <form onSubmit={handleSubmitAddress} className="flex-1 min-w-0">
+            <input
+              type="text"
+              value={addressValue}
+              onChange={(e) => setAddressValue(e.target.value)}
+              onFocus={(e) => {
+                addressFocusedRef.current = true
+                e.currentTarget.select()
+              }}
+              onBlur={() => {
+                addressFocusedRef.current = false
+                setAddressValue(activeTab?.url ?? '')
+              }}
+              placeholder="Enter URL or search..."
+              className={cn(
+                'h-7 w-full rounded-md border border-transparent bg-background px-3 text-sm text-foreground',
+                'placeholder:text-muted-foreground/60',
+                'focus:border-border focus:outline-hidden',
+              )}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+            />
+          </form>
+          <browser-action-list
+            partition="persist:rowboat-browser"
+            alignment="bottom right"
+            className="ml-1 flex shrink-0 items-center"
+          />
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label="Close browser"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div
+          ref={viewportRef}
+          className="relative min-h-0 min-w-0 flex-1"
+          data-browser-viewport
+        />
+      </div>
 
       {activeAuthRequest && (
         <BrowserHttpAuthDialog

--- a/apps/x/apps/renderer/src/components/browser-pane/browser-tab-rail.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/browser-tab-rail.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { Globe, Loader2, PanelLeftClose, Plus, X } from 'lucide-react'
+
+import type { BrowserTabState } from '@x/shared/dist/browser-control.js'
+
+import { cn } from '@/lib/utils'
+
+// The browser's edge rail: vertical tabs, following the Spaces rail pattern
+// (spaces/space-rail.tsx) — a plain sticky sidebar that collapses to a 28px
+// edge strip. Starts collapsed; clicking the strip opens it, the header
+// button collapses it back. No hover behavior — the rail moves only on
+// explicit clicks. Open/closed state lives in BrowserPane (persisted), the
+// same way the Spaces rail's lives in SpacesView.
+
+const RAIL_OPEN_WIDTH = 240
+const RAIL_STRIP_WIDTH = 28
+/** The collapsed strip previews at most this many favicons; the count pill carries the rest. */
+const STRIP_FAVICON_PREVIEW = 6
+
+export const getBrowserTabTitle = (tab: BrowserTabState) => {
+  const title = tab.title.trim()
+  if (title) return title
+  const url = tab.url.trim()
+  if (!url) return 'New tab'
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname || parsed.href
+  } catch {
+    return url.replace(/^https?:\/\//i, '') || 'New tab'
+  }
+}
+
+/**
+ * Favicon slot: spinner while the page loads, the page's icon once reported,
+ * a globe when there is none (or the icon URL failed to fetch).
+ */
+function TabFavicon({ tab, className }: { tab: BrowserTabState; className?: string }) {
+  const [failedSrc, setFailedSrc] = useState<string | null>(null)
+  if (tab.loading) {
+    return <Loader2 className={cn('size-4 shrink-0 animate-spin text-muted-foreground', className)} />
+  }
+  const src = tab.favicon
+  if (src && src !== failedSrc) {
+    return (
+      <img
+        src={src}
+        alt=""
+        className={cn('size-4 shrink-0', className)}
+        onError={() => setFailedSrc(src)}
+      />
+    )
+  }
+  return <Globe className={cn('size-4 shrink-0 text-muted-foreground', className)} />
+}
+
+export function BrowserTabRail({
+  tabs,
+  activeTabId,
+  open,
+  onTogglePin,
+  onSwitchTab,
+  onCloseTab,
+  onNewTab,
+}: {
+  tabs: BrowserTabState[]
+  activeTabId: string | null
+  open: boolean
+  onTogglePin: () => void
+  onSwitchTab: (tabId: string) => void
+  onCloseTab: (tabId: string) => void
+  onNewTab: () => void
+}) {
+  return (
+    <aside
+      style={{ width: open ? RAIL_OPEN_WIDTH : RAIL_STRIP_WIDTH, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
+      className={cn(
+        'relative z-10 shrink-0 min-h-0 overflow-hidden flex flex-col',
+        // Same layering as the Spaces rail: a step lighter than the main
+        // sidebar when open, flush with the canvas when collapsed.
+        open ? 'border-r border-border bg-[var(--rowboat-panel-soft)]' : 'border-r border-border bg-background',
+      )}
+    >
+      {!open ? (
+        // The collapsed edge strip: click to reopen. Deliberately not
+        // hover-triggered — the rail appears only on an explicit act.
+        <button
+          type="button"
+          onClick={onTogglePin}
+          title="Show tabs"
+          className="flex flex-1 flex-col items-center gap-2.5 py-3.5 hover:bg-accent/50"
+        >
+          {tabs.slice(0, STRIP_FAVICON_PREVIEW).map((tab) => (
+            <span
+              key={tab.id}
+              className={cn(
+                'flex size-5 items-center justify-center rounded',
+                tab.id === activeTabId && 'bg-accent ring-1 ring-border',
+              )}
+            >
+              <TabFavicon tab={tab} className="size-[15px]" />
+            </span>
+          ))}
+          <div className="w-px flex-1 bg-border/70" />
+          {tabs.length > 0 && (
+            <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-foreground px-1 text-[9.5px] font-semibold text-background tabular-nums">
+              {tabs.length}
+            </span>
+          )}
+        </button>
+      ) : (
+        // Inner content is fixed at the open width so rows don't reflow mid-slide.
+        <div className="flex h-full w-[240px] flex-col">
+          <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border pl-3 pr-1.5">
+            <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">Tabs</span>
+            <button
+              type="button"
+              onClick={onNewTab}
+              title="New tab"
+              aria-label="New browser tab"
+              className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <Plus className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={onTogglePin}
+              title="Collapse — reopen from the edge strip"
+              className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <PanelLeftClose className="size-3.5" />
+            </button>
+          </div>
+
+          <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-2">
+            {tabs.map((tab) => {
+              const title = getBrowserTabTitle(tab)
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => onSwitchTab(tab.id)}
+                  title={title}
+                  className={cn(
+                    'group/tab flex h-8 w-full shrink-0 items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
+                    tab.id === activeTabId
+                      ? 'bg-accent font-medium text-foreground'
+                      : 'text-foreground/90 hover:bg-accent/50',
+                  )}
+                >
+                  <TabFavicon tab={tab} />
+                  <span className="min-w-0 flex-1 truncate">{title}</span>
+                  {/* Main refuses to close the last tab, so don't offer it (same as the old strip). */}
+                  {tabs.length > 1 && (
+                    <span
+                      role="button"
+                      aria-label="Close tab"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onCloseTab(tab.id)
+                      }}
+                      className="flex shrink-0 items-center justify-center rounded-sm p-0.5 opacity-0 transition-all group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10"
+                    >
+                      <X className="size-3" />
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+            <button
+              type="button"
+              onClick={onNewTab}
+              className="flex h-8 w-full shrink-0 items-center gap-2 rounded-md px-2 text-left text-[13.5px] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            >
+              <Plus className="size-4 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">New tab</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/apps/x/packages/shared/src/browser-control.ts
+++ b/apps/x/packages/shared/src/browser-control.ts
@@ -4,6 +4,8 @@ export const BrowserTabStateSchema = z.object({
   id: z.string(),
   url: z.string(),
   title: z.string(),
+  // Page-declared favicon URL; null until the page reports one.
+  favicon: z.string().nullable(),
   canGoBack: z.boolean(),
   canGoForward: z.boolean(),
   loading: z.boolean(),


### PR DESCRIPTION
## Summary

Replaces the browser pane's horizontal top tab strip with a vertical-tabs sidebar on the left edge, patterned on the Spaces rail (`space-rail.tsx`):

- **Collapsible + sticky**: a 28px edge strip that expands to a 240px rail on an explicit click (no hover behavior), with the same 200ms width transition as Spaces. It's a push-layout flex sibling, so it stays put alongside the web content rather than overlaying it. Starts collapsed by default; the choice persists per machine (`localStorage['browser:railOpen']`).
- **Collapsed strip** previews up to six tab favicons (active one highlighted) plus a tab-count pill; clicking anywhere expands. The expanded header carries new-tab and `PanelLeftClose` collapse buttons; a "New tab" row also sits at the end of the list.
- **Tab actions** (switch, close, new) reuse the existing `browser:*` IPC handlers unchanged; close is hidden when only one tab is open, matching the main process's refusal to close the last tab.
- **Favicons end to end** (previously unimplemented at any layer): `page-favicon-updated` → per-tab cache in `BrowserViewManager` (cleared on real navigations, kept on in-page ones) → `favicon` field on `BrowserTabStateSchema` → rail rendering with spinner-while-loading and globe fallbacks. The IPC channels and agent-facing `BrowserControlResult` reuse the schema, so the field propagates automatically.

The native `WebContentsView` keeps sizing correctly through the rail animation for free — bounds derive from the viewport placeholder div, which the existing `ResizeObserver` already watches.

## Verification

- Full dependency chain rebuilt clean (shared → core → server → client → preload, including the preload bundle that validates IPC schemas).
- Renderer `tsc -b` and main-process `tsc --noEmit` both pass; main bundle builds.
- App boots and runs with the change (verified live via `npm run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)