### PR TITLE
Spaces rail redesign: two panes, boards in the tree, Notion-style peek, resize

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -52,7 +52,7 @@ const CHAT_FLOOR = 460
 
 /**
  * Below this content width Split falls back to one surface (CHAT_FLOOR of
- * chat + ~466px of document + the 28px rail edge and divider). Kept low on
+ * chat + ~466px of document + the 10px rail edge and divider). Kept low on
  * purpose — a non-maximized laptop window must still get Split; the doc-width
  * clamp handles the squeeze from here up.
  */
@@ -312,7 +312,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     // ------------------------------------------------------------------
     // Mode: which surface(s) are on screen. Talk = the stream (default),
     // Read = the document, Split = both. Split declines below SPLIT_FLOOR
-    // (600px document + 480px chat + the 28px rail edge).
+    // (600px document + 480px chat + the 10px rail edge).
     // ------------------------------------------------------------------
     const [mode, setMode] = useState<SpaceMode>(() => (selection.kind === 'file' ? 'read' : 'talk'))
     // The discussions/files rail is a plain sticky sidebar (persisted):
@@ -411,7 +411,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
         }).catch(() => {}) // org unreachable — the pane's own first save creates it instead
     }
 
-    /** Auto-hide grace: how long the rail lingers after the cursor leaves. */
+    /** The rail's lock: docked ⇄ edge sliver (the rail peeks on hover by itself). */
     const toggleRailPin = () => {
         const pin = !railPinned
         localStorage.setItem('spaces:railOpen', pin ? '1' : '0')

--- a/apps/x/apps/renderer/src/components/spaces/atoms.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/atoms.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { AtSign, Copy, Loader2, Mail } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
@@ -8,6 +8,7 @@ import {
     Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useMemberNames, useSpaceProfiles } from '@/components/spaces/member-text'
 import { requestComposeInsert } from '@/lib/spaces-compose'
 import { avatarColorClass, initials, orgMonogram } from '@/lib/spaces-presentation'
@@ -424,3 +425,29 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
     )
 }
 
+/**
+ * A single-line label that truncates, with a quick tooltip carrying the full
+ * text — but only when the text is actually clipped, so rows that fit stay
+ * silent on hover. `detail` adds a muted second line (e.g. a blob's size).
+ */
+export function ClippedText({ text, detail, className, side = 'right' }: {
+    text: string
+    detail?: string | null
+    className?: string
+    side?: 'top' | 'right' | 'bottom' | 'left'
+}) {
+    const ref = useRef<HTMLSpanElement | null>(null)
+    const [open, setOpen] = useState(false)
+    const clipped = () => !!ref.current && ref.current.scrollWidth > ref.current.clientWidth
+    return (
+        <Tooltip open={open} onOpenChange={(next) => setOpen(next && (clipped() || !!detail))} delayDuration={300}>
+            <TooltipTrigger asChild>
+                <span ref={ref} className={cn('min-w-0 truncate', className)}>{text}</span>
+            </TooltipTrigger>
+            <TooltipContent side={side} align="start" sideOffset={6} className="max-w-[320px] text-left text-wrap break-words">
+                <div className="font-medium">{text}</div>
+                {detail && <div className="opacity-70">{detail}</div>}
+            </TooltipContent>
+        </Tooltip>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -19,7 +19,7 @@ import {
     type FileTreeNode,
 } from '@/lib/spaces-presentation'
 import { toast } from '@/lib/toast'
-import { MemberAvatar } from '@/components/spaces/atoms'
+import { ClippedText, MemberAvatar } from '@/components/spaces/atoms'
 import { uploadInputFor } from '@/lib/spaces-upload'
 
 // Files: the tree (README first) and the file column — rendered file
@@ -146,7 +146,7 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                                     {open
                                         ? <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
                                         : <Folder className="size-3 shrink-0 text-muted-foreground" />}
-                                    <span className="truncate">{node.name}</span>
+                                    <ClippedText text={node.name} />
                                 </button>
                             </ContextMenuTrigger>
                             <ContextMenuContent>
@@ -243,7 +243,6 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                             }}
                             onDragEnd={() => setDropTarget(null)}
                             onClick={() => onOpenFile(node.path)}
-                            title={blob ? `${node.name} · ${blob.mime} · ${formatBytes(blob.size)}` : undefined}
                             className={cn(
                                 'flex h-7 w-full items-center gap-1.5 rounded-md pr-7 text-[13px] text-left',
                                 active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
@@ -254,7 +253,11 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                             {!board && blob && (isImageMime(blob.mime)
                                 ? <ImageIcon className="size-3 shrink-0 text-muted-foreground" />
                                 : <FileText className="size-3 shrink-0 text-muted-foreground" />)}
-                            <span className="truncate flex-1">{board ? spaces.whiteboardDisplayName(node.name) : node.name}</span>
+                            <ClippedText
+                                text={board ? spaces.whiteboardDisplayName(node.name) : node.name}
+                                detail={blob ? `${blob.mime} · ${formatBytes(blob.size)}` : null}
+                                className="flex-1"
+                            />
                             {unread && !active && <span className="size-1.5 rounded-full bg-foreground shrink-0" aria-label="updated since you last read" />}
                         </button>
                     </ContextMenuTrigger>

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -139,7 +139,7 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                                     style={pad}
                                     onClick={() => toggle(node.path)}
                                     className={cn(
-                                        'flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-[13px] text-foreground/90 hover:bg-accent/50',
+                                        'flex h-7 w-full items-center gap-1.5 rounded-md pr-7 text-[13px] text-foreground/90 hover:bg-accent/50',
                                         dropTarget === node.path && 'bg-accent ring-1 ring-inset ring-foreground/40',
                                     )}
                                 >
@@ -168,7 +168,7 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                                 <button
                                     type="button"
                                     aria-label="Folder actions"
-                                    className="absolute right-1 top-1 hidden size-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground group-hover/dirrow:inline-flex data-[state=open]:inline-flex"
+                                    className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover/dirrow:opacity-100 data-[state=open]:opacity-100"
                                 >
                                     <MoreHorizontal className="size-3.5" />
                                 </button>
@@ -245,7 +245,7 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                             onClick={() => onOpenFile(node.path)}
                             title={blob ? `${node.name} · ${blob.mime} · ${formatBytes(blob.size)}` : undefined}
                             className={cn(
-                                'flex h-7 w-full items-center gap-1.5 rounded-md pr-2 text-[13px] text-left',
+                                'flex h-7 w-full items-center gap-1.5 rounded-md pr-7 text-[13px] text-left',
                                 active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
                             )}
                         >
@@ -281,7 +281,7 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                             <button
                                 type="button"
                                 aria-label="File actions"
-                                className="absolute right-1 top-1 hidden size-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground group-hover/filerow:inline-flex data-[state=open]:inline-flex"
+                                className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover/filerow:opacity-100 data-[state=open]:opacity-100"
                             >
                                 <MoreHorizontal className="size-3.5" />
                             </button>

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { ArrowLeft, Check, ChevronRight, Clock, Download, Eye, FileText, History, Image as ImageIcon, Loader2, MoreHorizontal, Pencil, Plus, RotateCcw, Trash2, Upload, X } from 'lucide-react'
+import { ArrowLeft, Check, Clock, Download, Eye, FileText, Folder, FolderOpen, History, Image as ImageIcon, Loader2, MoreHorizontal, Pencil, PenTool, Plus, RotateCcw, Trash2, Upload, X } from 'lucide-react'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@/components/ui/context-menu'
-import type { spaces } from '@x/shared'
+import { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -143,7 +143,9 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                                         dropTarget === node.path && 'bg-accent ring-1 ring-inset ring-foreground/40',
                                     )}
                                 >
-                                    <ChevronRight className={cn('size-3 shrink-0 text-muted-foreground transition-transform', open && 'rotate-90')} />
+                                    {open
+                                        ? <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
+                                        : <Folder className="size-3 shrink-0 text-muted-foreground" />}
                                     <span className="truncate">{node.name}</span>
                                 </button>
                             </ContextMenuTrigger>
@@ -186,10 +188,17 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                             </DropdownMenuContent>
                         </DropdownMenu>
                     </div>
-                    {open && node.children.map((child) => renderNode(child, depth + 1))}
-                    {open && empty && (
-                        <div style={{ paddingLeft: `${8 + (depth + 1) * 12}px` }} className="py-0.5 pr-2 text-[11px] italic text-muted-foreground/70">
-                            empty — files added here keep it
+                    {open && (
+                        <div className="relative">
+                            {/* Indent guide: a faint dotted line under the folder's icon
+                                column, spanning its children — nesting reads without carets. */}
+                            <span aria-hidden className="pointer-events-none absolute bottom-1 top-0 border-l border-dotted border-foreground/25" style={{ left: `${8 + depth * 12 + 6}px` }} />
+                            {node.children.map((child) => renderNode(child, depth + 1))}
+                            {empty && (
+                                <div style={{ paddingLeft: `${8 + (depth + 1) * 12}px` }} className="py-0.5 pr-2 text-[11px] italic text-muted-foreground/70">
+                                    empty — files added here keep it
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>
@@ -198,6 +207,9 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
         const active = node.path === selectedPath
         const unread = unreadPaths.has(node.path)
         const blob = node.entry?.blob
+        // A board is a file at whiteboards/<name>.excalidraw — same tree,
+        // pen icon, extension dropped from the label.
+        const board = spaces.isWhiteboardPath(node.path)
         if (renaming?.path === node.path && node.entry) {
             const entry = node.entry
             return (
@@ -238,10 +250,11 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
                             )}
                         >
                             <span className="w-3 shrink-0" />
-                            {blob && (isImageMime(blob.mime)
+                            {board && <PenTool className="size-3 shrink-0 text-muted-foreground" />}
+                            {!board && blob && (isImageMime(blob.mime)
                                 ? <ImageIcon className="size-3 shrink-0 text-muted-foreground" />
                                 : <FileText className="size-3 shrink-0 text-muted-foreground" />)}
-                            <span className="truncate flex-1">{node.name}</span>
+                            <span className="truncate flex-1">{board ? spaces.whiteboardDisplayName(node.name) : node.name}</span>
                             {unread && !active && <span className="size-1.5 rounded-full bg-foreground shrink-0" aria-label="updated since you last read" />}
                         </button>
                     </ContextMenuTrigger>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useRef, useState } from 'react'
-import { Archive, ArchiveRestore, Bell, BellOff, Bot, Check, FileText, Folder, FolderPlus, MessageSquareOff, MessagesSquare, MoreHorizontal, PanelLeftClose, Pencil, PenTool, Plus, Search, Trash2, Upload } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Archive, ArchiveRestore, ArrowLeft, Bell, BellOff, Bot, Check, CornerDownRight, FileText, FolderPlus, MessageSquare, MessageSquareOff, MessagesSquare, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
 import { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -23,19 +23,27 @@ import { getTopicLastReadAt } from '@/lib/spaces-read-state'
 import type { RailSelection } from '@/lib/spaces-selection'
 
 // The space's edge rail: one collapsible strip carrying the same sidebar on
-// every surface — Messages + discussions on top, the file tree below. The
-// Discussions section lists ONLY deliberate topic annotations (annotation
-// model): threads someone gave a goal. Plain reply chains stay behind their
-// chips in the stream — the rail holds intentions, not accidents. It is a
-// plain sticky 280px sidebar (the shell sidebar contracts to the dock while
-// in Spaces, so this is THE sidebar here), collapsible to a 28px edge strip
-// via the header button; clicking the strip reopens it. No hover behavior —
-// the rail moves only on explicit clicks. The surfaces own everything else.
-
-/** Resizable Files section: never shorter than this (header + a couple of rows). */
-const FILES_MIN = 96
-/** Dragging the Files divider always leaves this much for Messages + topics. */
-const TOPICS_FLOOR = 160
+// every surface. Two stacked panes, each with its own scroll — Chat
+// (Messages, then the discussions) on top and Files (the tree; boards are
+// files at whiteboards/<name>.excalidraw and live there with a pen icon)
+// pinned to the bottom. They split the height 60/40 until the divider is
+// dragged (then the Files height sticks, persisted); collapsing either
+// (click its label) hands the whole height to the other. No counts, no
+// filter chips, no search box — ⌘K searches, bold + dot mark unread, and
+// archived discussions get their own view (Chat's ⋯ menu → back row).
+// Each pane's actions sit on its label and appear on hover anywhere in the
+// pane. The Discussions section lists ONLY
+// deliberate topic annotations (annotation model): threads someone gave a
+// goal. Plain reply chains stay behind their chips in the stream — the rail
+// holds intentions, not accidents.
+//
+// Open/close follows Notion. Docked: a 280px sidebar in the flow (the shell
+// sidebar contracts to the dock while in Spaces, so this is THE sidebar
+// here); its header button closes it to a sliver at the edge. Collapsed:
+// hovering the sliver slides the whole rail out as a drawer OVER the
+// surfaces — nothing shifts — and it slides back once the cursor leaves
+// (an open row menu holds it). The drawer's header button is the lock:
+// clicking it docks the rail, the only act that moves the content.
 
 const NOTIFY_CHOICES: { level: NotifyLevel; label: string }[] = [
     { level: 'all', label: 'All messages' },
@@ -43,8 +51,20 @@ const NOTIFY_CHOICES: { level: NotifyLevel; label: string }[] = [
     { level: 'mute', label: 'Muted' },
 ]
 
+type RailSection = 'chat' | 'files'
+/** Collapsed sections persist like the rail's own pin. */
+const COLLAPSED_KEY = 'spaces:railCollapsed'
+/** A dragged Files height persists too (null = the 60/40 default). */
+const FILES_HEIGHT_KEY = 'spaces:filesHeight'
+/** Resizing never leaves Files shorter than this (divider + label + a couple of rows). */
+const FILES_MIN = 96
+/** ...or Chat shorter than this (label + Messages + a discussion). */
+const CHAT_MIN = 120
+/** The collapsed rail: a sliver you hover, not a strip you read. */
+const EDGE_W = 10
+
 export function SpaceRail({
-    orgId, spaceId, selfMemberId, stream, topics, changeSets, entries, draftFolders, presence, unreadPaths, notify, onMenuOpenChange, selection, onSelect, onCreateFile, onCreateBoard, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
+    orgId, spaceId, selfMemberId, stream, topics, changeSets, entries, draftFolders, presence, unreadPaths, notify, selection, onSelect, onCreateFile, onCreateBoard, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
     open, onTogglePin,
 }: {
     orgId: string
@@ -60,12 +80,10 @@ export function SpaceRail({
     unreadPaths: ReadonlySet<string>
     /** The pane's notification-prefs state — shared so the header's space-level changes reflect here live. */
     notify: SpaceNotifyHandle
-    /** A row menu is up — the unpinned rail must not slide away underneath it. */
-    onMenuOpenChange?: (open: boolean) => void
     selection: RailSelection
     onSelect: (selection: RailSelection) => void
     onCreateFile: (path: string) => void
-    /** The "+" in Whiteboards: creates the board asset AND opens it (a taken name just opens). */
+    /** "New board" in the Files menu: creates the board asset AND opens it (a taken name just opens). */
     onCreateBoard: (path: string) => void
     /** Picked or dropped files headed for the space's file tree (upload dialog opens in the pane). */
     onUploadFiles: (files: File[]) => void
@@ -73,51 +91,66 @@ export function SpaceRail({
     onOpenTrash: () => void
     onAddFolder: (path: string) => void
     onRemoveFolder: (path: string) => void
+    /** Docked (in the flow, pushing the surfaces). False = the edge sliver + hover drawer. */
     open: boolean
+    /** The lock: docks a peeked rail, closes a docked one. */
     onTogglePin: () => void
 }) {
-    const [query, setQuery] = useState('')
-    const [filter, setFilter] = useState<'all' | 'unread' | 'archived'>('all')
     const [creatingFile, setCreatingFile] = useState<{ prefix: string } | null>(null)
     const [creatingFolder, setCreatingFolder] = useState(false)
     const [creatingBoard, setCreatingBoard] = useState(false)
+    // Chat shows the live discussions, or — via its ⋯ menu — the archived
+    // ones as a view of their own with a back row.
+    const [chatView, setChatView] = useState<'live' | 'archived'>('live')
     const uploadInputRef = useRef<HTMLInputElement | null>(null)
 
-    // Resizable Files section: null = natural height (grows with the tree,
-    // capped at 40% of the rail) until the divider is dragged; then the
-    // chosen height sticks, persisted like the Split doc width.
+    // Resizable panes: null = the 60/40 default until the divider is dragged;
+    // then the Files height sticks. Dragging up grows Files.
     const [filesHeight, setFilesHeight] = useState<number | null>(() => {
-        const stored = Number(localStorage.getItem('spaces:filesHeight'))
+        const stored = Number(localStorage.getItem(FILES_HEIGHT_KEY))
         return Number.isFinite(stored) && stored >= FILES_MIN ? stored : null
     })
-    const [resizingFiles, setResizingFiles] = useState(false)
-    const filesDrag = useRef<{ y: number; height: number } | null>(null)
-    const railBodyRef = useRef<HTMLDivElement | null>(null)
-    const filesRef = useRef<HTMLDivElement | null>(null)
-    const startFilesResize = (e: React.MouseEvent) => {
+    const [resizing, setResizing] = useState(false)
+    const bodyRef = useRef<HTMLDivElement | null>(null)
+    const filesRef = useRef<HTMLElement | null>(null)
+    const startResize = (e: React.MouseEvent) => {
         e.preventDefault()
-        filesDrag.current = { y: e.clientY, height: filesRef.current?.clientHeight ?? 0 }
-        setResizingFiles(true)
+        const start = { y: e.clientY, height: filesRef.current?.clientHeight ?? 0 }
+        setResizing(true)
         const onMove = (ev: MouseEvent) => {
-            if (!filesDrag.current) return
-            // Files sit at the bottom: dragging the divider up grows them.
-            const next = filesDrag.current.height + (filesDrag.current.y - ev.clientY)
-            const railHeight = railBodyRef.current?.clientHeight ?? window.innerHeight
-            setFilesHeight(Math.min(Math.max(next, FILES_MIN), Math.max(FILES_MIN, railHeight - TOPICS_FLOOR)))
+            const bodyHeight = bodyRef.current?.clientHeight ?? window.innerHeight
+            const next = start.height + (start.y - ev.clientY)
+            setFilesHeight(Math.min(Math.max(next, FILES_MIN), Math.max(FILES_MIN, bodyHeight - CHAT_MIN)))
         }
         const onUp = () => {
             window.removeEventListener('mousemove', onMove)
             window.removeEventListener('mouseup', onUp)
-            filesDrag.current = null
-            setResizingFiles(false)
+            setResizing(false)
             setFilesHeight((h) => {
-                if (h !== null) localStorage.setItem('spaces:filesHeight', String(h))
+                if (h !== null) localStorage.setItem(FILES_HEIGHT_KEY, String(h))
                 return h
             })
         }
         window.addEventListener('mousemove', onMove)
         window.addEventListener('mouseup', onUp)
     }
+
+    const [collapsed, setCollapsed] = useState<ReadonlySet<RailSection>>(() => {
+        try {
+            const raw = localStorage.getItem(COLLAPSED_KEY)
+            return new Set(raw ? (JSON.parse(raw) as RailSection[]) : [])
+        } catch {
+            return new Set()
+        }
+    })
+    const toggleSection = (section: RailSection) =>
+        setCollapsed((prev) => {
+            const next = new Set(prev)
+            if (next.has(section)) next.delete(section)
+            else next.add(section)
+            localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...next]))
+            return next
+        })
 
     // Row-level lifecycle actions. Rename edits inline in the row; the topic
     // event the server emits updates every other client, the refresh updates
@@ -165,29 +198,23 @@ export function SpaceRail({
     }
 
     const memberNames = useMemberNames()
-    const q = query.trim().toLowerCase()
-    const topicRows = topics
-        .filter((t) => (filter === 'archived' ? t.archived : !t.archived))
-        .filter((t) => (filter === 'unread' ? isUnread(t) && effectiveLevel(t.rootMessageId) !== 'mute' : true))
-        // Titles resolve before the search filter so searching a person's
-        // name finds the discussions that mention them.
-        .map((t) => ({ topic: t, title: resolveMentions(t.title, memberNames) }))
-        .filter((x) => (q ? x.title.toLowerCase().includes(q) : true))
-        .sort((a, b) => b.topic.lastActivityAt.localeCompare(a.topic.lastActivityAt))
+    const byActivity = (a: { topic: spaces.TopicListing }, b: { topic: spaces.TopicListing }) => b.topic.lastActivityAt.localeCompare(a.topic.lastActivityAt)
+    const titled = topics.map((t) => ({ topic: t, title: resolveMentions(t.title, memberNames) }))
+    const liveRows = titled.filter((x) => !x.topic.archived).sort(byActivity)
+    const archivedRows = titled.filter((x) => x.topic.archived).sort(byActivity)
+    const archivedView = chatView === 'archived'
+    const topicRows = archivedView ? archivedRows : liveRows
 
     const selectedRootId = selection.kind === 'thread' ? selection.rootMessageId : null
-    const selectedPath = selection.kind === 'file' ? selection.path : null
-    const selectedBoard = selection.kind === 'whiteboard' ? selection.path : null
-
-    // Boards live in the same asset namespace but get their own rail section;
-    // the file tree hides them so one thing appears in one place.
-    const boards = entries.filter((e) => spaces.isWhiteboardPath(e.path) && !e.state)
-    const fileEntries = entries.filter((e) => !spaces.isWhiteboardPath(e.path))
+    // A board is a file in the same tree, so either selection kind highlights its row.
+    const selectedPath = selection.kind === 'file' || selection.kind === 'whiteboard' ? selection.path : null
+    const openEntry = (path: string) => onSelect(spaces.isWhiteboardPath(path) ? { kind: 'whiteboard', path } : { kind: 'file', path })
     const createBoard = (name: string) => {
         setCreatingBoard(false)
         const path = spaces.whiteboardPathForName(name)
         if (path) onCreateBoard(path)
     }
+    const liveFiles = entries.filter((e) => !e.state).length
 
     // The stream mutes under its own key, like any thread.
     const generalBadge = effectiveLevel(STREAM_READ_KEY) === 'mute' ? 0 : generalUnread
@@ -197,15 +224,403 @@ export function SpaceRail({
         topics.filter((t) => !t.archived && isUnread(t) && effectiveLevel(t.rootMessageId) !== 'mute').length + (generalBadge > 0 ? 1 : 0)
     const badge = unreadTopics + unreadPaths.size
 
+    // Peek: with the rail collapsed, hovering the edge slides the drawer out;
+    // leaving slides it back after a beat, unless a row menu is holding it
+    // (menus portal outside the rail, so the cursor "leaves" while using one).
+    const [peek, setPeek] = useState(false)
+    const [menuOpen, setMenuOpen] = useState(false)
+    const asideRef = useRef<HTMLElement | null>(null)
+    const peekTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const clearPeekTimer = () => {
+        if (peekTimer.current) clearTimeout(peekTimer.current)
+        peekTimer.current = null
+    }
+    const scheduleClose = () => {
+        clearPeekTimer()
+        peekTimer.current = setTimeout(() => setPeek(false), 220)
+    }
+    const onEdgeEnter = () => {
+        if (open) return
+        clearPeekTimer()
+        peekTimer.current = setTimeout(() => setPeek(true), 120)
+    }
+    const onEdgeLeave = () => {
+        if (menuOpen) clearPeekTimer()
+        else scheduleClose()
+    }
+    const onMenuOpenChange = (isOpen: boolean) => {
+        setMenuOpen(isOpen)
+        // The menu closed with the cursor already gone: slide back now.
+        if (!isOpen && !open && !asideRef.current?.matches(':hover')) scheduleClose()
+    }
+    useEffect(() => {
+        if (open) setPeek(false)
+    }, [open])
+    useEffect(() => clearPeekTimer, [])
+
+    const chatCollapsed = collapsed.has('chat')
+    const filesCollapsed = collapsed.has('files')
+    const bothOpen = !chatCollapsed && !filesCollapsed
+    // A collapsed pane is just its label; the other takes everything left.
+    // With both open, a dragged Files height wins over the 60/40 default.
+    const chatStyle: React.CSSProperties = chatCollapsed ? { flex: '0 0 auto' } : !bothOpen || filesHeight !== null ? { flex: '1 1 0%' } : { flex: '60 1 0%' }
+    const filesStyle: React.CSSProperties = filesCollapsed
+        ? { flex: '0 0 auto' }
+        : !bothOpen
+            ? { flex: '1 1 0%' }
+            : filesHeight !== null
+                ? { flex: `0 0 ${filesHeight}px`, maxHeight: `calc(100% - ${CHAT_MIN}px)` }
+                : { flex: '40 1 0%' }
+
+    // The rail's content, rendered docked or inside the peek drawer. Fixed at
+    // the open width so text doesn't reflow mid-slide.
+    const body = (
+        <div ref={bodyRef} className={cn('flex h-full min-h-0 w-[280px] flex-col', resizing && 'select-none')}>
+            <section style={chatStyle} className="group/section flex min-h-0 flex-col">
+                <SectionHeader label="Chat" collapsed={chatCollapsed} count={liveRows.length} onToggle={() => toggleSection('chat')}>
+                    <DropdownMenu onOpenChange={onMenuOpenChange}>
+                        <DropdownMenuTrigger asChild>
+                            <button
+                                type="button"
+                                aria-label="Chat options"
+                                className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/section:inline-flex data-[state=open]:inline-flex"
+                            >
+                                <MoreHorizontal className="size-3.5" />
+                            </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            {archivedView ? (
+                                <DropdownMenuItem onClick={() => setChatView('live')}>
+                                    <ArrowLeft className="size-3.5 mr-2" /> Back to chat
+                                </DropdownMenuItem>
+                            ) : (
+                                <DropdownMenuItem onClick={() => setChatView('archived')}>
+                                    <Archive className="size-3.5 mr-2" /> View archived{archivedRows.length > 0 ? ` (${archivedRows.length})` : ''}
+                                </DropdownMenuItem>
+                            )}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                    {/* Docked: close. Peeked: the lock — dock it. Same spot, flipped glyph. */}
+                    <button
+                        type="button"
+                        onClick={() => { setPeek(false); onTogglePin() }}
+                        title={open ? 'Close sidebar' : 'Lock sidebar open'}
+                        className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                    >
+                        {open ? <PanelLeftClose className="size-3.5" /> : <PanelLeftOpen className="size-3.5" />}
+                    </button>
+                </SectionHeader>
+                {!chatCollapsed && (
+                    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2">
+                        {archivedView ? (
+                            <button
+                                type="button"
+                                onClick={() => setChatView('live')}
+                                title="Back to chat"
+                                className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px] text-foreground/90 hover:bg-accent/50"
+                            >
+                                <ArrowLeft className="size-3.5 shrink-0 text-muted-foreground" />
+                                <span className="flex-1 truncate font-medium">Archived</span>
+                                {archivedRows.length > 0 && <span className="text-[11px] tabular-nums text-muted-foreground">{archivedRows.length}</span>}
+                            </button>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={() => onSelect({ kind: 'general' })}
+                                className={cn(
+                                    'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
+                                    selection.kind === 'general' ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
+                                )}
+                            >
+                                <MessageSquare className="size-3.5 shrink-0 text-muted-foreground" />
+                                <span className={cn('flex-1 truncate', generalBadge > 0 && selection.kind !== 'general' && 'font-semibold')}>Messages</span>
+                                {generalBadge > 0 && selection.kind !== 'general' && (
+                                    <span className="text-[11px] font-semibold tabular-nums">{generalBadge}</span>
+                                )}
+                                {(presence.typing.get('') ?? []).length > 0 && <span className="size-1.5 rounded-full bg-[var(--rowboat-success)]" title="someone is typing" />}
+                            </button>
+                        )}
+
+                        {topicRows.map(({ topic, title }) => {
+                            const active = topic.rootMessageId === selectedRootId
+                            const muted = effectiveLevel(topic.rootMessageId) === 'mute'
+                            // Muted topics don't clamor: no bold, no dot,
+                            // greyed like archived (Slack's treatment).
+                            const unread = isUnread(topic) && !muted
+                            const replies = topic.rootMessage?.replyCount ?? 0
+                            const files = artifactFiles.get(topic.rootMessageId)
+                            const working = (presence.working.get(topic.rootMessageId) ?? []).length > 0
+                            if (renaming?.topicId === topic.id) {
+                                return (
+                                    <div key={topic.id} className="flex h-7 items-center rounded-md pl-5 pr-2">
+                                        <input
+                                            autoFocus
+                                            value={renaming.value}
+                                            onChange={(e) => setRenaming({ topicId: topic.id, value: e.target.value })}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter' && renaming.value.trim()) void commitRename(topic.id, renaming.value.trim())
+                                                if (e.key === 'Escape') setRenaming(null)
+                                            }}
+                                            onBlur={() => setRenaming(null)}
+                                            className="w-full rounded-md border border-foreground/30 bg-background px-1.5 py-0.5 text-[13px] leading-snug outline-none"
+                                            placeholder="Discussion goal"
+                                        />
+                                    </div>
+                                )
+                            }
+                            return (
+                                <div key={topic.id} className="group/topicrow relative">
+                                    <ContextMenu onOpenChange={onMenuOpenChange}>
+                                        <ContextMenuTrigger asChild>
+                                            <button
+                                                type="button"
+                                                onClick={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}
+                                                // The row shows only what changes what you do next: unread,
+                                                // a Rowboat at work, muted. Replies, recency and touched files
+                                                // ride the tooltip — the list is already sorted by activity.
+                                                title={[
+                                                    `${replies} ${replies === 1 ? 'reply' : 'replies'}`,
+                                                    formatFeedTime(topic.lastActivityAt),
+                                                    files && files.size > 0 ? `${files.size} ${files.size === 1 ? 'file' : 'files'} changed: ${[...files].join(', ')}` : null,
+                                                ].filter(Boolean).join(' · ')}
+                                                className={cn(
+                                                    // One tree step (12px) in from Messages: these nest under it.
+                                                    'flex h-7 w-full items-center gap-2 rounded-md pl-5 pr-2 text-left',
+                                                    active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
+                                                    (topic.archived || muted) && 'opacity-60',
+                                                )}
+                                            >
+                                                {/* In the Messages icon column: a discussion branches off the stream. */}
+                                                <CornerDownRight className="size-3.5 shrink-0 text-muted-foreground" />
+                                                <span className={cn('min-w-0 flex-1 truncate text-[13px]', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
+                                                {working && <Bot className="size-3 shrink-0 text-muted-foreground" aria-label="a Rowboat is working here" />}
+                                                {muted && <BellOff className="size-3 shrink-0 text-muted-foreground" aria-label="muted" />}
+                                                {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" aria-label="unread" />}
+                                            </button>
+                                        </ContextMenuTrigger>
+                                        <ContextMenuContent>
+                                            <ContextMenuItem onSelect={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}>
+                                                <MessagesSquare className="size-3.5 mr-2" /> Open
+                                            </ContextMenuItem>
+                                            <ContextMenuItem onSelect={() => setRenaming({ topicId: topic.id, value: title })}>
+                                                <Pencil className="size-3.5 mr-2" /> Rename
+                                            </ContextMenuItem>
+                                            <ContextMenuSub>
+                                                <ContextMenuSubTrigger>
+                                                    <Bell className="size-3.5 mr-2" /> Notifications
+                                                </ContextMenuSubTrigger>
+                                            {/* Overrides key on the thread's ROOT message id, never topic.id: the
+                                                watcher (main) and the unread badge both resolve a message to
+                                                `threadRoot ?? id` and look the level up by that. */}
+                                                <ContextMenuSubContent>
+                                                    {NOTIFY_CHOICES.map((c) => (
+                                                        <ContextMenuItem key={c.level} onSelect={() => notify.setTopicLevel(topic.rootMessageId, c.level)}>
+                                                            <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] !== c.level && 'opacity-0')} /> {c.label}
+                                                        </ContextMenuItem>
+                                                    ))}
+                                                    <ContextMenuSeparator />
+                                                    <ContextMenuItem onSelect={() => notify.setTopicLevel(topic.rootMessageId, null)}>
+                                                        <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] && 'opacity-0')} /> Space default
+                                                    </ContextMenuItem>
+                                                </ContextMenuSubContent>
+                                            </ContextMenuSub>
+                                            <ContextMenuSeparator />
+                                            {topic.archived ? (
+                                                <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'unarchive' })}>
+                                                    <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
+                                                </ContextMenuItem>
+                                            ) : (
+                                                <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'archive' })}>
+                                                    <Archive className="size-3.5 mr-2" /> Archive
+                                                </ContextMenuItem>
+                                            )}
+                                            <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'remove' })}>
+                                                <MessageSquareOff className="size-3.5 mr-2" /> Convert back to thread
+                                            </ContextMenuItem>
+                                        </ContextMenuContent>
+                                    </ContextMenu>
+                                    <DropdownMenu onOpenChange={onMenuOpenChange}>
+                                        <DropdownMenuTrigger asChild>
+                                            <button
+                                                type="button"
+                                                aria-label="Discussion actions"
+                                                className="absolute right-1 top-1 hidden size-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground group-hover/topicrow:inline-flex data-[state=open]:inline-flex"
+                                            >
+                                                <MoreHorizontal className="size-3.5" />
+                                            </button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align="end">
+                                            <DropdownMenuItem onClick={() => setRenaming({ topicId: topic.id, value: title })}>
+                                                <Pencil className="size-3.5 mr-2" /> Rename
+                                            </DropdownMenuItem>
+                                            <DropdownMenuSub>
+                                                <DropdownMenuSubTrigger>
+                                                    <Bell className="size-3.5 mr-2" /> Notifications
+                                                </DropdownMenuSubTrigger>
+                                                <DropdownMenuSubContent>
+                                                    {NOTIFY_CHOICES.map((c) => (
+                                                        <DropdownMenuItem key={c.level} onClick={() => notify.setTopicLevel(topic.rootMessageId, c.level)}>
+                                                            <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] !== c.level && 'opacity-0')} /> {c.label}
+                                                        </DropdownMenuItem>
+                                                    ))}
+                                                    <DropdownMenuSeparator />
+                                                    <DropdownMenuItem onClick={() => notify.setTopicLevel(topic.rootMessageId, null)}>
+                                                        <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] && 'opacity-0')} /> Space default
+                                                    </DropdownMenuItem>
+                                                </DropdownMenuSubContent>
+                                            </DropdownMenuSub>
+                                            {topic.archived ? (
+                                                <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'unarchive' })}>
+                                                    <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
+                                                </DropdownMenuItem>
+                                            ) : (
+                                                <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'archive' })}>
+                                                    <Archive className="size-3.5 mr-2" /> Archive
+                                                </DropdownMenuItem>
+                                            )}
+                                            <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'remove' })}>
+                                                <MessageSquareOff className="size-3.5 mr-2" /> Convert back to thread
+                                            </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                    </DropdownMenu>
+                                </div>
+                            )
+                        })}
+                        {topicRows.length === 0 && (
+                            <div className="px-2 py-2 text-xs text-muted-foreground">
+                                {archivedView ? 'Nothing archived.' : 'No discussions yet — give a thread a goal to put it here.'}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </section>
+
+            <section
+                ref={filesRef}
+                style={filesStyle}
+                className="group/section flex min-h-0 flex-col"
+                onDragOver={(e) => { if (Array.from(e.dataTransfer.types).includes('Files')) e.preventDefault() }}
+                onDrop={(e) => {
+                    if (!Array.from(e.dataTransfer.types).includes('Files')) return
+                    e.preventDefault()
+                    const files = Array.from(e.dataTransfer.files)
+                    if (files.length > 0) onUploadFiles(files)
+                }}
+            >
+                {/* The divider: a hairline always, a drag handle while both panes are open. */}
+                <div
+                    onMouseDown={bothOpen ? startResize : undefined}
+                    title={bothOpen ? 'Drag to resize' : undefined}
+                    className={cn(
+                        'h-1.5 shrink-0 border-t border-border transition-colors',
+                        bothOpen && 'cursor-row-resize hover:bg-primary/20',
+                        resizing && 'bg-primary/30',
+                    )}
+                />
+                <SectionHeader label="Files" collapsed={filesCollapsed} count={liveFiles} onToggle={() => toggleSection('files')}>
+                    <DropdownMenu onOpenChange={onMenuOpenChange}>
+                        <DropdownMenuTrigger asChild>
+                            <button
+                                type="button"
+                                aria-label="Add to files"
+                                title="New file, folder, board, or upload"
+                                className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/section:inline-flex data-[state=open]:inline-flex"
+                            >
+                                <Plus className="size-3.5" />
+                            </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => { setCreatingBoard(false); setCreatingFile({ prefix: '' }) }}>
+                                <FileText className="size-3.5 mr-2" /> New file
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => { setCreatingBoard(false); setCreatingFolder(true) }}>
+                                <FolderPlus className="size-3.5 mr-2" /> New folder
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => { setCreatingFile(null); setCreatingFolder(false); setCreatingBoard(true) }}>
+                                <PenTool className="size-3.5 mr-2" /> New board
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => uploadInputRef.current?.click()}>
+                                <Upload className="size-3.5 mr-2" /> Upload files…
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                    <DropdownMenu onOpenChange={onMenuOpenChange}>
+                        <DropdownMenuTrigger asChild>
+                            <button
+                                type="button"
+                                aria-label="Files options"
+                                className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/section:inline-flex data-[state=open]:inline-flex"
+                            >
+                                <MoreHorizontal className="size-3.5" />
+                            </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={onOpenTrash}>
+                                <Trash2 className="size-3.5 mr-2" /> Trash
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </SectionHeader>
+                {!filesCollapsed && (
+                    <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
+                        <FileTree
+                            orgId={orgId}
+                            spaceId={spaceId}
+                            entries={entries}
+                            draftFolders={draftFolders}
+                            selectedPath={selectedPath}
+                            unreadPaths={unreadPaths}
+                            onOpenFile={openEntry}
+                            creating={creatingFile}
+                            onCreateFile={(path) => {
+                                setCreatingFile(null)
+                                onCreateFile(path)
+                            }}
+                            onCancelCreate={() => setCreatingFile(null)}
+                            onStartCreate={(prefix) => setCreatingFile({ prefix })}
+                            creatingFolder={creatingFolder}
+                            onCreateFolder={(path) => {
+                                setCreatingFolder(false)
+                                onAddFolder(path)
+                            }}
+                            onCancelCreateFolder={() => setCreatingFolder(false)}
+                            onRemoveFolder={onRemoveFolder}
+                        />
+                        {creatingBoard && (
+                            <div className="flex items-center gap-1.5 px-1 pt-1">
+                                <PenTool className="size-3 shrink-0 text-muted-foreground" />
+                                <input
+                                    autoFocus
+                                    placeholder="Board name…"
+                                    className="h-7 min-w-0 flex-1 rounded-md border border-transparent bg-[var(--rowboat-wash)] px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground focus:border-border"
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') createBoard(e.currentTarget.value)
+                                        else if (e.key === 'Escape') setCreatingBoard(false)
+                                    }}
+                                    onBlur={(e) => (e.currentTarget.value.trim() ? createBoard(e.currentTarget.value) : setCreatingBoard(false))}
+                                />
+                            </div>
+                        )}
+                    </div>
+                )}
+            </section>
+        </div>
+    )
+
     return (
         <aside
-            style={{ width: open ? 280 : 28, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
+            ref={asideRef}
+            onMouseEnter={onEdgeEnter}
+            onMouseLeave={onEdgeLeave}
+            style={{ width: open ? 280 : EDGE_W, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
             className={cn(
-                'relative z-10 shrink-0 min-h-0 overflow-hidden flex flex-col',
+                'relative flex min-h-0 shrink-0 flex-col border-r border-border',
                 // A step lighter than the main sidebar so the two rails read as
                 // distinct layers; at this subtle a shift the hairline to the
                 // canvas earns its place.
-                open ? 'border-r border-border bg-[var(--rowboat-panel-soft)]' : 'border-r border-border bg-background',
+                open ? 'z-10 overflow-hidden bg-[var(--rowboat-panel-soft)]' : 'overflow-visible bg-background',
+                // The drawer rides over the surfaces' own sticky layers (z-20).
+                !open && (peek ? 'z-30' : 'z-10'),
             )}
         >
             {/* Always mounted: an input unmounted mid-pick (the rail toggled
@@ -222,376 +637,61 @@ export function SpaceRail({
                     e.target.value = ''
                 }}
             />
-            {!open ? (
-                // The collapsed edge strip: click to reopen. Deliberately not
-                // hover-triggered — the rail appears only on an explicit act.
-                <button
-                    type="button"
-                    onClick={onTogglePin}
-                    title="Show discussions & files"
-                    className="flex flex-1 flex-col items-center gap-2.5 py-3.5 hover:bg-accent/50"
-                >
-                    <MessagesSquare className="size-[15px] text-muted-foreground" />
-                    <Folder className="size-[15px] text-muted-foreground" />
-                    <div className="w-px flex-1 bg-border/70" />
-                    {badge > 0 && (
-                        <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-foreground px-1 text-[9.5px] font-semibold text-background tabular-nums">
-                            {badge}
-                        </span>
-                    )}
-                </button>
-            ) : (
-                // Inner content is fixed at the open width so text doesn't reflow mid-slide.
-                <div ref={railBodyRef} className="flex h-full w-[280px] flex-col">
-                    <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
-                        <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">Discussions &amp; files</span>
-                        <button
-                            type="button"
-                            onClick={onTogglePin}
-                            title="Collapse — reopen from the edge strip"
-                            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-                        >
-                            <PanelLeftClose className="size-3.5" />
-                        </button>
+            {open ? body : (
+                <>
+                    {/* The edge sliver: hover slides the drawer out. It says one
+                        thing at rest — a dot when something here is unread. */}
+                    <div aria-hidden className={cn('relative flex-1 transition-colors', peek ? 'bg-accent/60' : 'hover:bg-accent/60')}>
+                        {badge > 0 && <span className="absolute left-1/2 top-3 size-1 -translate-x-1/2 rounded-full bg-foreground" />}
                     </div>
-
-                    <div className="flex min-h-0 flex-1 flex-col">
-                        <div className="flex flex-col gap-0.5 px-2 pt-2">
-                            <button
-                                type="button"
-                                onClick={() => onSelect({ kind: 'general' })}
-                                className={cn(
-                                    'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
-                                    selection.kind === 'general' ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
-                                )}
-                            >
-                                <MessagesSquare className="size-3.5 shrink-0 text-muted-foreground" />
-                                <span className={cn('flex-1 truncate', generalBadge > 0 && selection.kind !== 'general' && 'font-semibold')}>Messages</span>
-                                {generalBadge > 0 && selection.kind !== 'general' && (
-                                    <span className="text-[11px] font-semibold tabular-nums">{generalBadge}</span>
-                                )}
-                                {(presence.typing.get('') ?? []).length > 0 && <span className="size-1.5 rounded-full bg-[var(--rowboat-success)]" title="someone is typing" />}
-                            </button>
-                        </div>
-
-                        <div className="mt-3 flex items-center gap-2 px-3 pr-2">
-                            <span className="text-[13px] text-muted-foreground">Discussions</span>
-                            <span className="text-[11px] text-muted-foreground/70">{topicRows.length}</span>
-                            <span className="flex-1" />
-                            <div className="inline-flex items-center rounded-md bg-muted p-0.5 text-[10.5px]">
-                                {(['all', 'unread', 'archived'] as const).map((f) => (
-                                    <button
-                                        key={f}
-                                        type="button"
-                                        onClick={() => setFilter(f)}
-                                        className={cn('rounded px-1.5 py-0.5 capitalize', filter === f ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground')}
-                                    >
-                                        {f}
-                                    </button>
-                                ))}
-                            </div>
-                        </div>
-                        <label className="mx-2 mt-1 flex h-7 items-center gap-1.5 rounded-md border border-transparent bg-[var(--rowboat-wash)] px-2 text-xs text-muted-foreground focus-within:border-border">
-                            <Search className="size-3" />
-                            <input
-                                value={query}
-                                onChange={(e) => setQuery(e.target.value)}
-                                placeholder="Search discussions"
-                                className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
-                            />
-                        </label>
-                        <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
-                            <div className="flex flex-col gap-0.5">
-                                {topicRows.map(({ topic, title }) => {
-                                    const active = topic.rootMessageId === selectedRootId
-                                    const muted = effectiveLevel(topic.rootMessageId) === 'mute'
-                                    // Muted topics don't clamor: no bold, no dot,
-                                    // greyed like archived (Slack's treatment).
-                                    const unread = isUnread(topic) && !muted
-                                    const replies = topic.rootMessage?.replyCount ?? 0
-                                    const files = artifactFiles.get(topic.rootMessageId)
-                                    const working = (presence.working.get(topic.rootMessageId) ?? []).length > 0
-                                    if (renaming?.topicId === topic.id) {
-                                        return (
-                                            <div key={topic.id} className="rounded-md px-2 py-1.5">
-                                                <input
-                                                    autoFocus
-                                                    value={renaming.value}
-                                                    onChange={(e) => setRenaming({ topicId: topic.id, value: e.target.value })}
-                                                    onKeyDown={(e) => {
-                                                        if (e.key === 'Enter' && renaming.value.trim()) void commitRename(topic.id, renaming.value.trim())
-                                                        if (e.key === 'Escape') setRenaming(null)
-                                                    }}
-                                                    onBlur={() => setRenaming(null)}
-                                                    className="w-full rounded-md border border-foreground/30 bg-background px-1.5 py-0.5 text-[13px] leading-snug outline-none"
-                                                    placeholder="Discussion goal"
-                                                />
-                                            </div>
-                                        )
-                                    }
-                                    return (
-                                        <div key={topic.id} className="group/topicrow relative">
-                                            <ContextMenu onOpenChange={onMenuOpenChange}>
-                                                <ContextMenuTrigger asChild>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}
-                                                        className={cn(
-                                                            'flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left',
-                                                            active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
-                                                            (topic.archived || muted) && 'opacity-60',
-                                                        )}
-                                                    >
-                                                        <div className="flex items-center gap-1.5">
-                                                            <span className={cn('flex-1 truncate text-[13px] leading-snug', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
-                                                            {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" />}
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5 truncate text-[11px] text-muted-foreground">
-                                                            <span>{replies} {replies === 1 ? 'reply' : 'replies'}</span>
-                                                            <span>· {formatFeedTime(topic.lastActivityAt)}</span>
-                                                            {files && files.size > 0 && (
-                                                                <span className="inline-flex items-center gap-0.5" title={`Files changed here: ${[...files].join(', ')}`}><FileText className="size-2.5" />{files.size}</span>
-                                                            )}
-                                                            {working && <Bot className="size-2.5" aria-label="a Rowboat is working here" />}
-                                                            {muted && <BellOff className="size-2.5" aria-label="muted" />}
-                                                            {topic.archived && <span>· archived</span>}
-                                                        </div>
-                                                    </button>
-                                                </ContextMenuTrigger>
-                                                <ContextMenuContent>
-                                                    <ContextMenuItem onSelect={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}>
-                                                        <MessagesSquare className="size-3.5 mr-2" /> Open
-                                                    </ContextMenuItem>
-                                                    <ContextMenuItem onSelect={() => setRenaming({ topicId: topic.id, value: title })}>
-                                                        <Pencil className="size-3.5 mr-2" /> Rename
-                                                    </ContextMenuItem>
-                                                    <ContextMenuSub>
-                                                        <ContextMenuSubTrigger>
-                                                            <Bell className="size-3.5 mr-2" /> Notifications
-                                                        </ContextMenuSubTrigger>
-                                                    {/* Overrides key on the thread's ROOT message id, never topic.id: the
-                                                        watcher (main) and the unread badge both resolve a message to
-                                                        `threadRoot ?? id` and look the level up by that. */}
-                                                        <ContextMenuSubContent>
-                                                            {NOTIFY_CHOICES.map((c) => (
-                                                                <ContextMenuItem key={c.level} onSelect={() => notify.setTopicLevel(topic.rootMessageId, c.level)}>
-                                                                    <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] !== c.level && 'opacity-0')} /> {c.label}
-                                                                </ContextMenuItem>
-                                                            ))}
-                                                            <ContextMenuSeparator />
-                                                            <ContextMenuItem onSelect={() => notify.setTopicLevel(topic.rootMessageId, null)}>
-                                                                <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] && 'opacity-0')} /> Space default
-                                                            </ContextMenuItem>
-                                                        </ContextMenuSubContent>
-                                                    </ContextMenuSub>
-                                                    <ContextMenuSeparator />
-                                                    {topic.archived ? (
-                                                        <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'unarchive' })}>
-                                                            <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
-                                                        </ContextMenuItem>
-                                                    ) : (
-                                                        <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'archive' })}>
-                                                            <Archive className="size-3.5 mr-2" /> Archive
-                                                        </ContextMenuItem>
-                                                    )}
-                                                    <ContextMenuItem onSelect={() => void manageTopic(topic.id, { action: 'remove' })}>
-                                                        <MessageSquareOff className="size-3.5 mr-2" /> Convert back to thread
-                                                    </ContextMenuItem>
-                                                </ContextMenuContent>
-                                            </ContextMenu>
-                                            <DropdownMenu onOpenChange={onMenuOpenChange}>
-                                                <DropdownMenuTrigger asChild>
-                                                    <button
-                                                        type="button"
-                                                        aria-label="Discussion actions"
-                                                        className="absolute right-1 top-1 hidden size-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground group-hover/topicrow:inline-flex data-[state=open]:inline-flex"
-                                                    >
-                                                        <MoreHorizontal className="size-3.5" />
-                                                    </button>
-                                                </DropdownMenuTrigger>
-                                                <DropdownMenuContent align="end">
-                                                    <DropdownMenuItem onClick={() => setRenaming({ topicId: topic.id, value: title })}>
-                                                        <Pencil className="size-3.5 mr-2" /> Rename
-                                                    </DropdownMenuItem>
-                                                    <DropdownMenuSub>
-                                                        <DropdownMenuSubTrigger>
-                                                            <Bell className="size-3.5 mr-2" /> Notifications
-                                                        </DropdownMenuSubTrigger>
-                                                        <DropdownMenuSubContent>
-                                                            {NOTIFY_CHOICES.map((c) => (
-                                                                <DropdownMenuItem key={c.level} onClick={() => notify.setTopicLevel(topic.rootMessageId, c.level)}>
-                                                                    <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] !== c.level && 'opacity-0')} /> {c.label}
-                                                                </DropdownMenuItem>
-                                                            ))}
-                                                            <DropdownMenuSeparator />
-                                                            <DropdownMenuItem onClick={() => notify.setTopicLevel(topic.rootMessageId, null)}>
-                                                                <Check className={cn('size-3.5 mr-2', notify.topics[topic.rootMessageId] && 'opacity-0')} /> Space default
-                                                            </DropdownMenuItem>
-                                                        </DropdownMenuSubContent>
-                                                    </DropdownMenuSub>
-                                                    {topic.archived ? (
-                                                        <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'unarchive' })}>
-                                                            <ArchiveRestore className="size-3.5 mr-2" /> Unarchive
-                                                        </DropdownMenuItem>
-                                                    ) : (
-                                                        <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'archive' })}>
-                                                            <Archive className="size-3.5 mr-2" /> Archive
-                                                        </DropdownMenuItem>
-                                                    )}
-                                                    <DropdownMenuItem onClick={() => void manageTopic(topic.id, { action: 'remove' })}>
-                                                        <MessageSquareOff className="size-3.5 mr-2" /> Convert back to thread
-                                                    </DropdownMenuItem>
-                                                </DropdownMenuContent>
-                                            </DropdownMenu>
-                                        </div>
-                                    )
-                                })}
-                                {topicRows.length === 0 && (
-                                    <div className="px-2 py-2 text-xs text-muted-foreground">
-                                        {q ? 'No discussions match.' : filter === 'unread' ? 'Nothing unread.' : filter === 'archived' ? 'No archived discussions.' : 'No discussions yet — give a thread a goal to put it here.'}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="shrink-0 border-t border-border">
-                        <div className="flex h-8 items-center gap-2 px-3 pr-2 pt-1">
-                            <span className="text-[13px] text-muted-foreground">Whiteboards</span>
-                            <span className="text-[11px] text-muted-foreground/70">{boards.length}</span>
-                            <span className="flex-1" />
-                            <button
-                                type="button"
-                                title="New whiteboard"
-                                onClick={() => setCreatingBoard(true)}
-                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <Plus className="size-3.5" />
-                            </button>
-                        </div>
-                        <div className="max-h-36 overflow-y-auto px-2 pb-2">
-                            <div className="flex flex-col gap-0.5">
-                                {creatingBoard && (
-                                    <input
-                                        autoFocus
-                                        placeholder="Board name…"
-                                        className="h-7 rounded-md border border-transparent bg-[var(--rowboat-wash)] px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground focus:border-border"
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') createBoard(e.currentTarget.value)
-                                            else if (e.key === 'Escape') setCreatingBoard(false)
-                                        }}
-                                        onBlur={(e) => (e.currentTarget.value.trim() ? createBoard(e.currentTarget.value) : setCreatingBoard(false))}
-                                    />
-                                )}
-                                {boards.map((b) => (
-                                    <button
-                                        key={b.path}
-                                        type="button"
-                                        onClick={() => onSelect({ kind: 'whiteboard', path: b.path })}
-                                        className={cn(
-                                            'flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px]',
-                                            b.path === selectedBoard ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
-                                        )}
-                                    >
-                                        <PenTool className="size-3.5 shrink-0 text-muted-foreground" />
-                                        <span className="flex-1 truncate">{spaces.whiteboardDisplayName(b.path)}</span>
-                                    </button>
-                                ))}
-                                {boards.length === 0 && !creatingBoard && (
-                                    <div className="px-2 py-1 text-xs text-muted-foreground">Draw together — boards sync live for everyone here.</div>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div
-                        ref={filesRef}
-                        // maxHeight backstops a persisted height against a shorter window.
-                        style={filesHeight !== null ? { height: filesHeight, maxHeight: '75%' } : undefined}
-                        className={cn('flex shrink-0 flex-col', filesHeight === null && 'max-h-[40%]')}
-                    >
+                    {/* The drawer: the same rail, sliding out over the surfaces from
+                        the edge — nothing underneath moves. The outer box clips on
+                        the left so the slide never shows over the shell dock, and is
+                        wide enough to leave the shadow alone. Inert while hidden so
+                        its rows never catch focus. */}
+                    <div className="pointer-events-none absolute inset-y-0 left-0 w-[330px] overflow-hidden">
                         <div
-                            onMouseDown={startFilesResize}
-                            title="Drag to resize the files pane"
+                            inert={!peek}
                             className={cn(
-                                'h-1.5 shrink-0 cursor-row-resize border-t border-border transition-colors hover:bg-primary/20',
-                                resizingFiles && 'bg-primary/30',
+                                'absolute bottom-1.5 left-0 top-1.5 w-[280px] overflow-hidden rounded-r-xl border border-border bg-[var(--rowboat-panel-soft)] shadow-2xl transition-transform duration-200 ease-[cubic-bezier(0.2,0,0,1)]',
+                                peek ? 'pointer-events-auto translate-x-0' : '-translate-x-full',
                             )}
-                        />
-                        <div className="flex h-8 shrink-0 items-center gap-2 px-3 pr-2 pt-1">
-                            <span className="text-[13px] text-muted-foreground">Files</span>
-                            <span className="text-[11px] text-muted-foreground/70">{fileEntries.length}</span>
-                            <span className="flex-1" />
-                            <button
-                                type="button"
-                                title="Upload files (or drop them here)"
-                                onClick={() => uploadInputRef.current?.click()}
-                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <Upload className="size-3.5" />
-                            </button>
-                            <button
-                                type="button"
-                                title="New file"
-                                onClick={() => setCreatingFile({ prefix: '' })}
-                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <Plus className="size-3.5" />
-                            </button>
-                            <button
-                                type="button"
-                                title="New folder (folders are path prefixes — it becomes real when a file lands in it)"
-                                onClick={() => setCreatingFolder(true)}
-                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <FolderPlus className="size-3.5" />
-                            </button>
-                            <button
-                                type="button"
-                                title="Trash — deleted files, restorable"
-                                onClick={onOpenTrash}
-                                className="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <Trash2 className="size-3.5" />
-                            </button>
-                        </div>
-                        <div
-                            className="min-h-0 flex-1 overflow-y-auto px-2 pb-2"
-                            onDragOver={(e) => { if (Array.from(e.dataTransfer.types).includes('Files')) e.preventDefault() }}
-                            onDrop={(e) => {
-                                if (!Array.from(e.dataTransfer.types).includes('Files')) return
-                                e.preventDefault()
-                                const files = Array.from(e.dataTransfer.files)
-                                if (files.length > 0) onUploadFiles(files)
-                            }}
                         >
-                            <FileTree
-                                orgId={orgId}
-                                spaceId={spaceId}
-                                entries={fileEntries}
-                                draftFolders={draftFolders}
-                                selectedPath={selectedPath}
-                                unreadPaths={unreadPaths}
-                                onOpenFile={(path) => onSelect({ kind: 'file', path })}
-                                creating={creatingFile}
-                                onCreateFile={(path) => {
-                                    setCreatingFile(null)
-                                    onCreateFile(path)
-                                }}
-                                onCancelCreate={() => setCreatingFile(null)}
-                                onStartCreate={(prefix) => setCreatingFile({ prefix })}
-                                creatingFolder={creatingFolder}
-                                onCreateFolder={(path) => {
-                                    setCreatingFolder(false)
-                                    onAddFolder(path)
-                                }}
-                                onCancelCreateFolder={() => setCreatingFolder(false)}
-                                onRemoveFolder={onRemoveFolder}
-                            />
+                            {body}
                         </div>
                     </div>
-                </div>
+                </>
             )}
         </aside>
+    )
+}
+
+/**
+ * A pane's label: click collapses the pane. The count shows only while
+ * collapsed — that is the one moment a number says something the rows
+ * can't. `children` are the pane's actions, right-aligned (hover-revealed
+ * ones key off group/section, which the PANE carries — hovering anywhere in
+ * it shows them).
+ */
+function SectionHeader({ label, collapsed, count, onToggle, children }: {
+    label: string
+    collapsed: boolean
+    count: number
+    onToggle: () => void
+    children?: ReactNode
+}) {
+    return (
+        <div className="flex h-8 shrink-0 items-center gap-1 pl-3 pr-1.5">
+            <button
+                type="button"
+                onClick={onToggle}
+                title={collapsed ? `Show ${label.toLowerCase()}` : `Hide ${label.toLowerCase()}`}
+                className="flex h-full min-w-0 flex-1 items-center gap-1.5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground hover:text-foreground"
+            >
+                <span className="truncate">{label}</span>
+                {collapsed && count > 0 && <span className="font-normal tabular-nums">{count}</span>}
+            </button>
+            {children}
+        </div>
     )
 }

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -10,6 +10,7 @@ import {
     ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuSub,
     ContextMenuSubContent, ContextMenuSubTrigger, ContextMenuTrigger,
 } from '@/components/ui/context-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { toast } from '@/lib/toast'
 import { FileTree } from '@/components/spaces/files-tab'
 import { refreshSpaceFeed } from '@/hooks/use-spaces'
@@ -37,9 +38,10 @@ import type { RailSelection } from '@/lib/spaces-selection'
 // goal. Plain reply chains stay behind their chips in the stream — the rail
 // holds intentions, not accidents.
 //
-// Open/close follows Notion. Docked: a 280px sidebar in the flow (the shell
-// sidebar contracts to the dock while in Spaces, so this is THE sidebar
-// here); its header button closes it to a sliver at the edge. Collapsed:
+// Open/close follows Notion. Docked: a sidebar in the flow (280px until its
+// right edge is dragged; the shell sidebar contracts to the dock while in
+// Spaces, so this is THE sidebar here); its header button closes it to a
+// sliver at the edge. Collapsed:
 // hovering the sliver slides the whole rail out as a drawer OVER the
 // surfaces — nothing shifts — and it slides back once the cursor leaves
 // (an open row menu holds it). The drawer's header button is the lock:
@@ -62,6 +64,11 @@ const FILES_MIN = 96
 const CHAT_MIN = 120
 /** The collapsed rail: a sliver you hover, not a strip you read. */
 const EDGE_W = 10
+/** Docked width: 280 until the right edge is dragged (persisted), within these. */
+const WIDTH_KEY = 'spaces:railWidth'
+const WIDTH_DEFAULT = 280
+const WIDTH_MIN = 220
+const WIDTH_MAX = 480
 
 export function SpaceRail({
     orgId, spaceId, selfMemberId, stream, topics, changeSets, entries, draftFolders, presence, unreadPaths, notify, selection, onSelect, onCreateFile, onCreateBoard, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
@@ -111,6 +118,31 @@ export function SpaceRail({
         return Number.isFinite(stored) && stored >= FILES_MIN ? stored : null
     })
     const [resizing, setResizing] = useState(false)
+    // Docked width: drag the rail's right edge. The drawer uses the same width.
+    const [width, setWidth] = useState<number>(() => {
+        const stored = Number(localStorage.getItem(WIDTH_KEY))
+        return Number.isFinite(stored) && stored >= WIDTH_MIN && stored <= WIDTH_MAX ? stored : WIDTH_DEFAULT
+    })
+    const [resizingWidth, setResizingWidth] = useState(false)
+    const startWidthResize = (e: React.MouseEvent) => {
+        e.preventDefault()
+        const start = { x: e.clientX, width }
+        setResizingWidth(true)
+        const onMove = (ev: MouseEvent) => {
+            setWidth(Math.min(WIDTH_MAX, Math.max(WIDTH_MIN, start.width + (ev.clientX - start.x))))
+        }
+        const onUp = () => {
+            window.removeEventListener('mousemove', onMove)
+            window.removeEventListener('mouseup', onUp)
+            setResizingWidth(false)
+            setWidth((w) => {
+                localStorage.setItem(WIDTH_KEY, String(w))
+                return w
+            })
+        }
+        window.addEventListener('mousemove', onMove)
+        window.addEventListener('mouseup', onUp)
+    }
     const bodyRef = useRef<HTMLDivElement | null>(null)
     const filesRef = useRef<HTMLElement | null>(null)
     const startResize = (e: React.MouseEvent) => {
@@ -275,7 +307,7 @@ export function SpaceRail({
     // The rail's content, rendered docked or inside the peek drawer. Fixed at
     // the open width so text doesn't reflow mid-slide.
     const body = (
-        <div ref={bodyRef} className={cn('flex h-full min-h-0 w-[280px] flex-col', resizing && 'select-none')}>
+        <div ref={bodyRef} style={{ width }} className={cn('flex h-full min-h-0 flex-col', (resizing || resizingWidth) && 'select-none')}>
             <section style={chatStyle} className="group/section flex min-h-0 flex-col">
                 <SectionHeader label="Chat" collapsed={chatCollapsed} count={liveRows.length} onToggle={() => toggleSection('chat')}>
                     <DropdownMenu onOpenChange={onMenuOpenChange}>
@@ -371,34 +403,43 @@ export function SpaceRail({
                             return (
                                 <div key={topic.id} className="group/topicrow relative">
                                     <ContextMenu onOpenChange={onMenuOpenChange}>
-                                        <ContextMenuTrigger asChild>
-                                            <button
-                                                type="button"
-                                                onClick={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}
-                                                // The row shows only what changes what you do next: unread,
-                                                // a Rowboat at work, muted. Replies, recency and touched files
-                                                // ride the tooltip — the list is already sorted by activity.
-                                                title={[
-                                                    `${replies} ${replies === 1 ? 'reply' : 'replies'}`,
-                                                    formatFeedTime(topic.lastActivityAt),
-                                                    files && files.size > 0 ? `${files.size} ${files.size === 1 ? 'file' : 'files'} changed: ${[...files].join(', ')}` : null,
-                                                ].filter(Boolean).join(' · ')}
-                                                className={cn(
-                                                    // One tree step (12px) in from Messages: these nest under it.
-                                                    // pr-7 keeps the title and indicators clear of the ⋯ slot.
-                                                    'flex h-7 w-full items-center gap-2 rounded-md pl-5 pr-7 text-left',
-                                                    active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
-                                                    (topic.archived || muted) && 'opacity-60',
-                                                )}
-                                            >
-                                                {/* In the Messages icon column: a discussion branches off the stream. */}
-                                                <CornerDownRight className="size-3.5 shrink-0 text-muted-foreground" />
-                                                <span className={cn('min-w-0 flex-1 truncate text-[13px]', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
-                                                {working && <Bot className="size-3 shrink-0 text-muted-foreground" aria-label="a Rowboat is working here" />}
-                                                {muted && <BellOff className="size-3 shrink-0 text-muted-foreground" aria-label="muted" />}
-                                                {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" aria-label="unread" />}
-                                            </button>
-                                        </ContextMenuTrigger>
+                                        {/* Both triggers are slots on the one button: tooltip outside so the
+                                            context menu's right-click reaches the element unchanged. */}
+                                        <Tooltip delayDuration={400}>
+                                            <TooltipTrigger asChild>
+                                                <ContextMenuTrigger asChild>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}
+                                                        // The row shows only what changes what you do next: unread,
+                                                        // a Rowboat at work, muted. The full title, replies, recency
+                                                        // and touched files ride the tooltip — the list is already
+                                                        // sorted by activity.
+                                                        className={cn(
+                                                            // One tree step (12px) in from Messages: these nest under it.
+                                                            // pr-7 keeps the title and indicators clear of the ⋯ slot.
+                                                            'flex h-7 w-full items-center gap-2 rounded-md pl-5 pr-7 text-left',
+                                                            active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
+                                                            (topic.archived || muted) && 'opacity-60',
+                                                        )}
+                                                    >
+                                                        {/* In the Messages icon column: a discussion branches off the stream. */}
+                                                        <CornerDownRight className="size-3.5 shrink-0 text-muted-foreground" />
+                                                        <span className={cn('min-w-0 flex-1 truncate text-[13px]', unread ? 'font-semibold' : 'font-normal')}>{title}</span>
+                                                        {working && <Bot className="size-3 shrink-0 text-muted-foreground" aria-label="a Rowboat is working here" />}
+                                                        {muted && <BellOff className="size-3 shrink-0 text-muted-foreground" aria-label="muted" />}
+                                                        {unread && !active && <span className="size-1.5 shrink-0 rounded-full bg-foreground" aria-label="unread" />}
+                                                    </button>
+                                                </ContextMenuTrigger>
+                                            </TooltipTrigger>
+                                            <TooltipContent side="right" align="start" sideOffset={6} className="max-w-[320px] text-left text-wrap break-words">
+                                                <div className="font-medium">{title}</div>
+                                                <div className="opacity-70">
+                                                    {replies} {replies === 1 ? 'reply' : 'replies'} · {formatFeedTime(topic.lastActivityAt)}
+                                                    {files && files.size > 0 && ` · ${files.size} ${files.size === 1 ? 'file' : 'files'} changed: ${[...files].join(', ')}`}
+                                                </div>
+                                            </TooltipContent>
+                                        </Tooltip>
                                         <ContextMenuContent>
                                             <ContextMenuItem onSelect={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}>
                                                 <MessagesSquare className="size-3.5 mr-2" /> Open
@@ -613,7 +654,8 @@ export function SpaceRail({
             ref={asideRef}
             onMouseEnter={onEdgeEnter}
             onMouseLeave={onEdgeLeave}
-            style={{ width: open ? 280 : EDGE_W, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
+            // No slide while the edge is being dragged — the width must track the cursor.
+            style={{ width: open ? width : EDGE_W, transition: resizingWidth ? undefined : 'width 200ms cubic-bezier(0.2,0,0,1)' }}
             className={cn(
                 'relative flex min-h-0 shrink-0 flex-col border-r border-border',
                 // A step lighter than the main sidebar so the two rails read as
@@ -638,7 +680,20 @@ export function SpaceRail({
                     e.target.value = ''
                 }}
             />
-            {open ? body : (
+            {open ? (
+                <>
+                    {body}
+                    {/* Docked: drag the right edge to resize. */}
+                    <div
+                        onMouseDown={startWidthResize}
+                        title="Drag to resize"
+                        className={cn(
+                            'absolute inset-y-0 -right-px z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/20',
+                            resizingWidth && 'bg-primary/30',
+                        )}
+                    />
+                </>
+            ) : (
                 <>
                     {/* The edge sliver: hover slides the drawer out. It says one
                         thing at rest — a dot when something here is unread. */}
@@ -650,11 +705,12 @@ export function SpaceRail({
                         the left so the slide never shows over the shell dock, and is
                         wide enough to leave the shadow alone. Inert while hidden so
                         its rows never catch focus. */}
-                    <div className="pointer-events-none absolute inset-y-0 left-0 w-[330px] overflow-hidden">
+                    <div style={{ width: width + 50 }} className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden">
                         <div
                             inert={!peek}
+                            style={{ width }}
                             className={cn(
-                                'absolute bottom-1.5 left-0 top-1.5 w-[280px] overflow-hidden rounded-r-xl border border-border bg-[var(--rowboat-panel-soft)] shadow-2xl transition-transform duration-200 ease-[cubic-bezier(0.2,0,0,1)]',
+                                'absolute bottom-1.5 left-0 top-1.5 overflow-hidden rounded-r-xl border border-border bg-[var(--rowboat-panel-soft)] shadow-2xl transition-transform duration-200 ease-[cubic-bezier(0.2,0,0,1)]',
                                 peek ? 'pointer-events-auto translate-x-0' : '-translate-x-full',
                             )}
                         >

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -283,7 +283,7 @@ export function SpaceRail({
                             <button
                                 type="button"
                                 aria-label="Chat options"
-                                className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/section:inline-flex data-[state=open]:inline-flex"
+                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/section:opacity-100 data-[state=open]:opacity-100"
                             >
                                 <MoreHorizontal className="size-3.5" />
                             </button>
@@ -385,7 +385,8 @@ export function SpaceRail({
                                                 ].filter(Boolean).join(' · ')}
                                                 className={cn(
                                                     // One tree step (12px) in from Messages: these nest under it.
-                                                    'flex h-7 w-full items-center gap-2 rounded-md pl-5 pr-2 text-left',
+                                                    // pr-7 keeps the title and indicators clear of the ⋯ slot.
+                                                    'flex h-7 w-full items-center gap-2 rounded-md pl-5 pr-7 text-left',
                                                     active ? 'bg-accent text-foreground' : 'hover:bg-accent/50',
                                                     (topic.archived || muted) && 'opacity-60',
                                                 )}
@@ -444,7 +445,7 @@ export function SpaceRail({
                                             <button
                                                 type="button"
                                                 aria-label="Discussion actions"
-                                                className="absolute right-1 top-1 hidden size-5 items-center justify-center rounded text-muted-foreground hover:bg-background hover:text-foreground group-hover/topicrow:inline-flex data-[state=open]:inline-flex"
+                                                className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover/topicrow:opacity-100 data-[state=open]:opacity-100"
                                             >
                                                 <MoreHorizontal className="size-3.5" />
                                             </button>
@@ -524,7 +525,7 @@ export function SpaceRail({
                                 type="button"
                                 aria-label="Add to files"
                                 title="New file, folder, board, or upload"
-                                className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/section:inline-flex data-[state=open]:inline-flex"
+                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/section:opacity-100 data-[state=open]:opacity-100"
                             >
                                 <Plus className="size-3.5" />
                             </button>
@@ -549,7 +550,7 @@ export function SpaceRail({
                             <button
                                 type="button"
                                 aria-label="Files options"
-                                className="hidden size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground group-hover/section:inline-flex data-[state=open]:inline-flex"
+                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/section:opacity-100 data-[state=open]:opacity-100"
                             >
                                 <MoreHorizontal className="size-3.5" />
                             </button>


### PR DESCRIPTION
## What

A simplification pass on the Spaces sidebar, iterated live against the running app. Three commits, squash-friendly.

**Two panes, Chat and Files.** Each has its own scroll. Files is pinned to the bottom; the split is 60/40 until you drag the divider, and the dragged height persists. Clicking a pane's label collapses it and the other pane takes the full height. Pane actions (Chat `⋯`, Files `+` and `⋯`) appear on hover anywhere in the pane. Gone: the "Discussions & files" title, the three counts, the All/Unread/Archived chips, the in-rail search box (⌘K already searches), the Whiteboards section, and the always-visible four-icon toolbar.

**Chat.** Messages first, then discussions as one-line rows: a `↳` in the icon column plus the title, indented one tree step under Messages. Only indicators that change what you do next stay on the row (unread bold + dot, bot glyph while a Rowboat works, muted bell). A quick tooltip carries the full title, replies, recency, and files touched. Archived discussions are a separate view reached from the Chat `⋯` menu ("View archived"), with a back row at the top.

**Files.** Whiteboards fold into the tree as `whiteboards/<name>.excalidraw` with a pen icon and their bare name; the view already routed file-shaped selections under that path to the board pane, so this is rail-only. Folder icons (closed/open) are the disclosure, no carets, and open folders drop a faint dotted indent guide down their icon column. `+` holds New file / New folder / New board / Upload; `⋯` holds Trash. File and folder names pop a tooltip with the full name only when clipped (uploads add type and size).

**Open/close, Notion-style.** Docked is unchanged. Closed is a 10px sliver with a single dot when something is unread. Hovering the sliver slides the whole rail out as a floating drawer over the content (nothing shifts); it slides back after the cursor leaves, and an open row menu holds it. The header button flips from `«` (close) to `»` (lock open); locking is the only act that moves the content. Clicking the sliver does nothing.

**Docked resize.** Drag the rail's right edge between 220 and 480px; persisted, and the peek drawer uses the same width.

**Row menus.** The hover `⋯` on discussion, file and folder rows stays in layout and fades instead of toggling `display`, and rows reserve its slot. This fixes the `⋯` overlapping the unread dot and long titles, and a closing menu flashing at the window's top-left (Radix lost the popper anchor when the trigger left layout mid-exit).

## Files

- `apps/renderer/src/components/spaces/space-rail.tsx`: the rewrite.
- `apps/renderer/src/components/spaces/files-tab.tsx`: folder icons, dotted guides, board rows, clipped-name tooltips, menu slot.
- `apps/renderer/src/components/spaces/atoms.tsx`: new `ClippedText` (truncating label, tooltip only when clipped).
- `apps/renderer/src/components/spaces-view.tsx`: comment updates only.

## Not in this PR

File unread dots still clear only via "Mark all read" or `/read`; opening a file does not mark it read. Follow-up.

## Verified

- `tsc --noEmit` clean on the renderer.
- Iterated visually via hot reload in the app; not covered by automated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdKK6pfaNc4cBZqZBf1USA
