### PR TITLE
feat(x): add shared secondary sidebar for email and spaces

### DIFF
--- a/apps/x/apps/renderer/src/components/email-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/email-rail.test.tsx
@@ -92,10 +92,14 @@ describe('EmailRail', () => {
     expect(screen.getByText('Drafts').closest('button')?.className).toContain('font-medium')
   })
 
-  it('collapses to an edge strip that reopens on click', () => {
-    const { onTogglePin } = renderRail({ open: false })
-    expect(screen.queryByText('All mail')).toBeNull()
-    fireEvent.click(screen.getByTitle('Show mail filters'))
+  it('collapsed: the rows wait inert in the hover drawer', () => {
+    renderRail({ open: false })
+    expect(screen.getByText('All mail').closest('[inert]')).toBeTruthy()
+  })
+
+  it('docked: the header button reports the collapse', () => {
+    const { onTogglePin } = renderRail()
+    fireEvent.click(screen.getByTitle('Close sidebar'))
     expect(onTogglePin).toHaveBeenCalled()
   })
 })

--- a/apps/x/apps/renderer/src/components/email-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/email-rail.test.tsx
@@ -18,6 +18,7 @@ function renderRail(overrides: Partial<Parameters<typeof EmailRail>[0]> = {}) {
       categoryCounts={COUNTS}
       labels={BUILTIN_LABELS}
       draftCount={0}
+      replyReadyCount={0}
       open
       onTogglePin={onTogglePin}
       onSelect={onSelect}
@@ -30,7 +31,7 @@ function renderRail(overrides: Partial<Parameters<typeof EmailRail>[0]> = {}) {
 describe('EmailRail', () => {
   it('renders the fixed views and one row per non-empty category', () => {
     renderRail()
-    for (const label of ['All mail', 'Important', 'Everything else', 'Drafts']) {
+    for (const label of ['All mail', 'Important', 'Reply ready', 'Everything else', 'Drafts']) {
       expect(screen.getByText(label)).toBeTruthy()
     }
     // Registry display names, pill order: News before Direct, Uncategorized last.
@@ -51,6 +52,20 @@ describe('EmailRail', () => {
     expect(onSelect).toHaveBeenLastCalledWith({ kind: 'other' })
     fireEvent.click(screen.getByText('All mail'))
     expect(onSelect).toHaveBeenLastCalledWith({ kind: 'all' })
+  })
+
+  it('shows the Reply ready count and reports its selection', () => {
+    const { onSelect } = renderRail({ replyReadyCount: 4 })
+    const row = screen.getByText('Reply ready').closest('button')
+    expect(row?.textContent).toContain('4')
+    fireEvent.click(screen.getByText('Reply ready'))
+    expect(onSelect).toHaveBeenLastCalledWith({ kind: 'reply-ready' })
+  })
+
+  it('marks Reply ready active only in that inbox filter', () => {
+    renderRail({ inboxFilter: 'reply-ready', replyReadyCount: 2 })
+    expect(screen.getByText('Reply ready').closest('button')?.className).toContain('font-medium')
+    expect(screen.getByText('Important').closest('button')?.className).not.toContain('font-medium')
   })
 
   it('selects a category, and clicking the active category clears it', () => {

--- a/apps/x/apps/renderer/src/components/email-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/email-rail.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BUILTIN_LABELS } from '@/lib/email-labels'
+import { EmailRail, type EmailRailSelection } from './email-rail'
+
+afterEach(cleanup)
+
+const COUNTS = { newsletter: 5, correspondence: 2, unclassified: 3 }
+
+function renderRail(overrides: Partial<Parameters<typeof EmailRail>[0]> = {}) {
+  const onSelect = vi.fn<(sel: EmailRailSelection) => void>()
+  const onTogglePin = vi.fn()
+  render(
+    <EmailRail
+      view="inbox"
+      inboxFilter="all"
+      otherCategory={null}
+      categoryCounts={COUNTS}
+      labels={BUILTIN_LABELS}
+      draftCount={0}
+      open
+      onTogglePin={onTogglePin}
+      onSelect={onSelect}
+      {...overrides}
+    />,
+  )
+  return { onSelect, onTogglePin }
+}
+
+describe('EmailRail', () => {
+  it('renders the fixed views and one row per non-empty category', () => {
+    renderRail()
+    for (const label of ['All mail', 'Important', 'Everything else', 'Drafts']) {
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+    // Registry display names, pill order: News before Direct, Uncategorized last.
+    expect(screen.getByText('News')).toBeTruthy()
+    expect(screen.getByText('Direct')).toBeTruthy()
+    expect(screen.getByText('Uncategorized')).toBeTruthy()
+    // Everything-else total = sum of the section's category counts.
+    expect(screen.getByText('10')).toBeTruthy()
+  })
+
+  it('reports selections for the fixed views', () => {
+    const { onSelect } = renderRail()
+    fireEvent.click(screen.getByText('Important'))
+    expect(onSelect).toHaveBeenLastCalledWith({ kind: 'important' })
+    fireEvent.click(screen.getByText('Drafts'))
+    expect(onSelect).toHaveBeenLastCalledWith({ kind: 'drafts' })
+    fireEvent.click(screen.getByText('Everything else'))
+    expect(onSelect).toHaveBeenLastCalledWith({ kind: 'other' })
+    fireEvent.click(screen.getByText('All mail'))
+    expect(onSelect).toHaveBeenLastCalledWith({ kind: 'all' })
+  })
+
+  it('selects a category, and clicking the active category clears it', () => {
+    const { onSelect } = renderRail()
+    fireEvent.click(screen.getByText('News'))
+    expect(onSelect).toHaveBeenLastCalledWith({ kind: 'other', category: 'newsletter' })
+
+    cleanup()
+    const second = renderRail({ inboxFilter: 'other', otherCategory: 'newsletter' })
+    fireEvent.click(screen.getByText('News'))
+    expect(second.onSelect).toHaveBeenLastCalledWith({ kind: 'other', category: null })
+  })
+
+  it('marks the active row', () => {
+    renderRail({ inboxFilter: 'important' })
+    const important = screen.getByText('Important').closest('button')
+    const allMail = screen.getByText('All mail').closest('button')
+    expect(important?.className).toContain('font-medium')
+    expect(allMail?.className).not.toContain('font-medium')
+  })
+
+  it('highlights Drafts when the drafts view is open', () => {
+    renderRail({ view: 'drafts' })
+    expect(screen.getByText('Drafts').closest('button')?.className).toContain('font-medium')
+  })
+
+  it('collapses to an edge strip that reopens on click', () => {
+    const { onTogglePin } = renderRail({ open: false })
+    expect(screen.queryByText('All mail')).toBeNull()
+    fireEvent.click(screen.getByTitle('Show mail filters'))
+    expect(onTogglePin).toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/components/email-rail.tsx
+++ b/apps/x/apps/renderer/src/components/email-rail.tsx
@@ -1,4 +1,4 @@
-import { Inbox, Mail, PanelLeftClose, PenLine, Star, Tag } from 'lucide-react'
+import { Inbox, Mail, PanelLeftClose, PenLine, Sparkles, Star, Tag } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/email-labels'
 
@@ -13,20 +13,23 @@ import { labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/ema
 export type EmailRailSelection =
     | { kind: 'all' }
     | { kind: 'important' }
+    | { kind: 'reply-ready' }
     | { kind: 'other'; category?: string | null }
     | { kind: 'drafts' }
 
 export function EmailRail({
-    view, inboxFilter, otherCategory, categoryCounts, labels, draftCount, open, onTogglePin, onSelect,
+    view, inboxFilter, otherCategory, categoryCounts, labels, draftCount, replyReadyCount, open, onTogglePin, onSelect,
 }: {
     view: 'inbox' | 'drafts'
-    inboxFilter: 'all' | 'important' | 'other'
+    inboxFilter: 'all' | 'important' | 'reply-ready' | 'other'
     otherCategory: string | null
     /** Whole-'other'-section counts from the last backend response (pre-filter). */
     categoryCounts: Record<string, number>
     labels: EmailLabelInfo[]
     /** Drafts are fetched lazily — 0 until the Drafts view first loads. */
     draftCount: number
+    /** Threads with a classifier-drafted reply, across the loaded sections. */
+    replyReadyCount: number
     open: boolean
     onTogglePin: () => void
     onSelect: (selection: EmailRailSelection) => void
@@ -109,6 +112,12 @@ export function EmailRail({
                                 <Star className="size-3.5 shrink-0 text-muted-foreground" />,
                                 'Important', null,
                                 () => onSelect({ kind: 'important' }),
+                            )}
+                            {viewRow(
+                                inInbox && inboxFilter === 'reply-ready',
+                                <Sparkles className="size-3.5 shrink-0 text-muted-foreground" />,
+                                'Reply ready', replyReadyCount,
+                                () => onSelect({ kind: 'reply-ready' }),
                             )}
                             {viewRow(
                                 inInbox && inboxFilter === 'other' && !otherCategory,

--- a/apps/x/apps/renderer/src/components/email-rail.tsx
+++ b/apps/x/apps/renderer/src/components/email-rail.tsx
@@ -1,14 +1,14 @@
-import { Inbox, Mail, PanelLeftClose, PenLine, Sparkles, Star, Tag } from 'lucide-react'
+import { Inbox, Mail, PanelLeftClose, PanelLeftOpen, PenLine, Sparkles, Star, Tag } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { SecondaryRail, type SecondaryRailContext } from '@/components/secondary-rail'
 import { labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/email-labels'
 
-// The email section's edge rail: quick subsetting of the inbox. Modeled on the
-// Spaces rail — a plain 280px sidebar collapsible to a 28px edge strip via the
-// header button; clicking the strip reopens it. No hover behavior — the rail
-// moves only on explicit clicks. Fixed views on top (All mail / Important /
-// Everything else / Drafts), then one row per category with mail in it; a
-// category click narrows Everything else the same way the pills do (the two
-// stay in sync — both read the same filter state).
+// The email section's rail: quick subsetting of the inbox, on the same
+// SecondaryRail shell as the Spaces rail (docked + drag-resize, collapsed
+// sliver, hover peek drawer). Fixed views on top (All mail / Important /
+// Reply ready / Everything else / Drafts), then one row per category with
+// mail in it; a category click narrows Everything else the same way the
+// pills do (the two stay in sync — both read the same filter state).
 
 export type EmailRailSelection =
     | { kind: 'all' }
@@ -61,112 +61,93 @@ export function EmailRail({
         </button>
     )
 
-    return (
-        <aside
-            style={{ width: open ? 280 : 28, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
-            className={cn(
-                'relative z-10 shrink-0 min-h-0 overflow-hidden flex flex-col',
-                // A step lighter than the main sidebar so the two rails read as
-                // distinct layers (same treatment as the Spaces rail).
-                open ? 'border-r border-border bg-[var(--rowboat-panel-soft)]' : 'border-r border-border bg-background',
-            )}
-        >
-            {!open ? (
-                // The collapsed edge strip: click to reopen. Deliberately not
-                // hover-triggered — the rail appears only on an explicit act.
+    const renderBody = ({ togglePin }: SecondaryRailContext) => (
+        <div className="flex h-full min-h-0 flex-col">
+            <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
+                <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">Mail</span>
+                {/* Docked: close. Peeked: the lock — dock it. Same spot, flipped glyph. */}
                 <button
                     type="button"
-                    onClick={onTogglePin}
-                    title="Show mail filters"
-                    className="flex flex-1 flex-col items-center gap-2.5 py-3.5 hover:bg-accent/50"
+                    onClick={togglePin}
+                    title={open ? 'Close sidebar' : 'Lock sidebar open'}
+                    className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
                 >
-                    <Mail className="size-[15px] text-muted-foreground" />
-                    <Tag className="size-[15px] text-muted-foreground" />
-                    <div className="w-px flex-1 bg-border/70" />
+                    {open ? <PanelLeftClose className="size-3.5" /> : <PanelLeftOpen className="size-3.5" />}
                 </button>
-            ) : (
-                // Inner content is fixed at the open width so text doesn't reflow mid-slide.
-                <div className="flex h-full w-[280px] flex-col">
-                    <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
-                        <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">Mail</span>
-                        <button
-                            type="button"
-                            onClick={onTogglePin}
-                            title="Collapse — reopen from the edge strip"
-                            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-                        >
-                            <PanelLeftClose className="size-3.5" />
-                        </button>
-                    </div>
+            </div>
 
-                    <div className="flex min-h-0 flex-1 flex-col">
-                        <div className="flex flex-col gap-0.5 px-2 pt-2">
-                            {viewRow(
-                                inInbox && inboxFilter === 'all',
-                                <Mail className="size-3.5 shrink-0 text-muted-foreground" />,
-                                'All mail', null,
-                                () => onSelect({ kind: 'all' }),
-                            )}
-                            {viewRow(
-                                inInbox && inboxFilter === 'important',
-                                <Star className="size-3.5 shrink-0 text-muted-foreground" />,
-                                'Important', null,
-                                () => onSelect({ kind: 'important' }),
-                            )}
-                            {viewRow(
-                                inInbox && inboxFilter === 'reply-ready',
-                                <Sparkles className="size-3.5 shrink-0 text-muted-foreground" />,
-                                'Reply ready', replyReadyCount,
-                                () => onSelect({ kind: 'reply-ready' }),
-                            )}
-                            {viewRow(
-                                inInbox && inboxFilter === 'other' && !otherCategory,
-                                <Inbox className="size-3.5 shrink-0 text-muted-foreground" />,
-                                'Everything else', otherTotal,
-                                () => onSelect({ kind: 'other' }),
-                            )}
-                            {viewRow(
-                                view === 'drafts',
-                                <PenLine className="size-3.5 shrink-0 text-muted-foreground" />,
-                                'Drafts', draftCount,
-                                () => onSelect({ kind: 'drafts' }),
-                            )}
-                        </div>
-
-                        {categories.length > 0 && (
-                            <>
-                                <div className="mt-3 flex items-center gap-2 px-3 pr-2">
-                                    <span className="text-[13px] text-muted-foreground">Categories</span>
-                                    <span className="text-[11px] text-muted-foreground/70">{categories.length}</span>
-                                </div>
-                                <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
-                                    <div className="flex flex-col gap-0.5">
-                                        {categories.map((cat) => {
-                                            const active = inInbox && otherCategory === cat
-                                            return (
-                                                <button
-                                                    key={cat}
-                                                    type="button"
-                                                    // Clicking the active category clears it back to all of Everything else.
-                                                    onClick={() => onSelect({ kind: 'other', category: active ? null : cat })}
-                                                    className={cn(
-                                                        'flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px]',
-                                                        active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
-                                                    )}
-                                                >
-                                                    <Tag className="size-3.5 shrink-0 text-muted-foreground" />
-                                                    <span className="flex-1 truncate">{labelNameFor(labels, cat)}</span>
-                                                    <span className="text-[11px] tabular-nums text-muted-foreground">{categoryCounts[cat]}</span>
-                                                </button>
-                                            )
-                                        })}
-                                    </div>
-                                </div>
-                            </>
-                        )}
-                    </div>
+            <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex flex-col gap-0.5 px-2 pt-2">
+                    {viewRow(
+                        inInbox && inboxFilter === 'all',
+                        <Mail className="size-3.5 shrink-0 text-muted-foreground" />,
+                        'All mail', null,
+                        () => onSelect({ kind: 'all' }),
+                    )}
+                    {viewRow(
+                        inInbox && inboxFilter === 'important',
+                        <Star className="size-3.5 shrink-0 text-muted-foreground" />,
+                        'Important', null,
+                        () => onSelect({ kind: 'important' }),
+                    )}
+                    {viewRow(
+                        inInbox && inboxFilter === 'reply-ready',
+                        <Sparkles className="size-3.5 shrink-0 text-muted-foreground" />,
+                        'Reply ready', replyReadyCount,
+                        () => onSelect({ kind: 'reply-ready' }),
+                    )}
+                    {viewRow(
+                        inInbox && inboxFilter === 'other' && !otherCategory,
+                        <Inbox className="size-3.5 shrink-0 text-muted-foreground" />,
+                        'Everything else', otherTotal,
+                        () => onSelect({ kind: 'other' }),
+                    )}
+                    {viewRow(
+                        view === 'drafts',
+                        <PenLine className="size-3.5 shrink-0 text-muted-foreground" />,
+                        'Drafts', draftCount,
+                        () => onSelect({ kind: 'drafts' }),
+                    )}
                 </div>
-            )}
-        </aside>
+
+                {categories.length > 0 && (
+                    <>
+                        <div className="mt-3 flex items-center gap-2 px-3 pr-2">
+                            <span className="text-[13px] text-muted-foreground">Categories</span>
+                            <span className="text-[11px] text-muted-foreground/70">{categories.length}</span>
+                        </div>
+                        <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+                            <div className="flex flex-col gap-0.5">
+                                {categories.map((cat) => {
+                                    const active = inInbox && otherCategory === cat
+                                    return (
+                                        <button
+                                            key={cat}
+                                            type="button"
+                                            // Clicking the active category clears it back to all of Everything else.
+                                            onClick={() => onSelect({ kind: 'other', category: active ? null : cat })}
+                                            className={cn(
+                                                'flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px]',
+                                                active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
+                                            )}
+                                        >
+                                            <Tag className="size-3.5 shrink-0 text-muted-foreground" />
+                                            <span className="flex-1 truncate">{labelNameFor(labels, cat)}</span>
+                                            <span className="text-[11px] tabular-nums text-muted-foreground">{categoryCounts[cat]}</span>
+                                        </button>
+                                    )
+                                })}
+                            </div>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    )
+
+    return (
+        <SecondaryRail open={open} onTogglePin={onTogglePin} widthStorageKey="email:railWidth">
+            {renderBody}
+        </SecondaryRail>
     )
 }

--- a/apps/x/apps/renderer/src/components/email-rail.tsx
+++ b/apps/x/apps/renderer/src/components/email-rail.tsx
@@ -1,0 +1,163 @@
+import { Inbox, Mail, PanelLeftClose, PenLine, Star, Tag } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/email-labels'
+
+// The email section's edge rail: quick subsetting of the inbox. Modeled on the
+// Spaces rail — a plain 280px sidebar collapsible to a 28px edge strip via the
+// header button; clicking the strip reopens it. No hover behavior — the rail
+// moves only on explicit clicks. Fixed views on top (All mail / Important /
+// Everything else / Drafts), then one row per category with mail in it; a
+// category click narrows Everything else the same way the pills do (the two
+// stay in sync — both read the same filter state).
+
+export type EmailRailSelection =
+    | { kind: 'all' }
+    | { kind: 'important' }
+    | { kind: 'other'; category?: string | null }
+    | { kind: 'drafts' }
+
+export function EmailRail({
+    view, inboxFilter, otherCategory, categoryCounts, labels, draftCount, open, onTogglePin, onSelect,
+}: {
+    view: 'inbox' | 'drafts'
+    inboxFilter: 'all' | 'important' | 'other'
+    otherCategory: string | null
+    /** Whole-'other'-section counts from the last backend response (pre-filter). */
+    categoryCounts: Record<string, number>
+    labels: EmailLabelInfo[]
+    /** Drafts are fetched lazily — 0 until the Drafts view first loads. */
+    draftCount: number
+    open: boolean
+    onTogglePin: () => void
+    onSelect: (selection: EmailRailSelection) => void
+}) {
+    const categories = orderedCategoryIds(labels, categoryCounts)
+    const otherTotal = Object.values(categoryCounts).reduce((sum, n) => sum + n, 0)
+    const inInbox = view === 'inbox'
+
+    const viewRow = (
+        active: boolean,
+        icon: React.ReactNode,
+        label: string,
+        count: number | null,
+        select: () => void,
+    ) => (
+        <button
+            type="button"
+            onClick={select}
+            className={cn(
+                'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
+                active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
+            )}
+        >
+            {icon}
+            <span className="flex-1 truncate">{label}</span>
+            {count !== null && count > 0 && (
+                <span className="text-[11px] tabular-nums text-muted-foreground">{count}</span>
+            )}
+        </button>
+    )
+
+    return (
+        <aside
+            style={{ width: open ? 280 : 28, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
+            className={cn(
+                'relative z-10 shrink-0 min-h-0 overflow-hidden flex flex-col',
+                // A step lighter than the main sidebar so the two rails read as
+                // distinct layers (same treatment as the Spaces rail).
+                open ? 'border-r border-border bg-[var(--rowboat-panel-soft)]' : 'border-r border-border bg-background',
+            )}
+        >
+            {!open ? (
+                // The collapsed edge strip: click to reopen. Deliberately not
+                // hover-triggered — the rail appears only on an explicit act.
+                <button
+                    type="button"
+                    onClick={onTogglePin}
+                    title="Show mail filters"
+                    className="flex flex-1 flex-col items-center gap-2.5 py-3.5 hover:bg-accent/50"
+                >
+                    <Mail className="size-[15px] text-muted-foreground" />
+                    <Tag className="size-[15px] text-muted-foreground" />
+                    <div className="w-px flex-1 bg-border/70" />
+                </button>
+            ) : (
+                // Inner content is fixed at the open width so text doesn't reflow mid-slide.
+                <div className="flex h-full w-[280px] flex-col">
+                    <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
+                        <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">Mail</span>
+                        <button
+                            type="button"
+                            onClick={onTogglePin}
+                            title="Collapse — reopen from the edge strip"
+                            className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                        >
+                            <PanelLeftClose className="size-3.5" />
+                        </button>
+                    </div>
+
+                    <div className="flex min-h-0 flex-1 flex-col">
+                        <div className="flex flex-col gap-0.5 px-2 pt-2">
+                            {viewRow(
+                                inInbox && inboxFilter === 'all',
+                                <Mail className="size-3.5 shrink-0 text-muted-foreground" />,
+                                'All mail', null,
+                                () => onSelect({ kind: 'all' }),
+                            )}
+                            {viewRow(
+                                inInbox && inboxFilter === 'important',
+                                <Star className="size-3.5 shrink-0 text-muted-foreground" />,
+                                'Important', null,
+                                () => onSelect({ kind: 'important' }),
+                            )}
+                            {viewRow(
+                                inInbox && inboxFilter === 'other' && !otherCategory,
+                                <Inbox className="size-3.5 shrink-0 text-muted-foreground" />,
+                                'Everything else', otherTotal,
+                                () => onSelect({ kind: 'other' }),
+                            )}
+                            {viewRow(
+                                view === 'drafts',
+                                <PenLine className="size-3.5 shrink-0 text-muted-foreground" />,
+                                'Drafts', draftCount,
+                                () => onSelect({ kind: 'drafts' }),
+                            )}
+                        </div>
+
+                        {categories.length > 0 && (
+                            <>
+                                <div className="mt-3 flex items-center gap-2 px-3 pr-2">
+                                    <span className="text-[13px] text-muted-foreground">Categories</span>
+                                    <span className="text-[11px] text-muted-foreground/70">{categories.length}</span>
+                                </div>
+                                <div className="mt-1 flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+                                    <div className="flex flex-col gap-0.5">
+                                        {categories.map((cat) => {
+                                            const active = inInbox && otherCategory === cat
+                                            return (
+                                                <button
+                                                    key={cat}
+                                                    type="button"
+                                                    // Clicking the active category clears it back to all of Everything else.
+                                                    onClick={() => onSelect({ kind: 'other', category: active ? null : cat })}
+                                                    className={cn(
+                                                        'flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px]',
+                                                        active ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50',
+                                                    )}
+                                                >
+                                                    <Tag className="size-3.5 shrink-0 text-muted-foreground" />
+                                                    <span className="flex-1 truncate">{labelNameFor(labels, cat)}</span>
+                                                    <span className="text-[11px] tabular-nums text-muted-foreground">{categoryCounts[cat]}</span>
+                                                </button>
+                                            )
+                                        })}
+                                    </div>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                </div>
+            )}
+        </aside>
+    )
+}

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils'
 import { toast } from '@/lib/toast'
 import * as analytics from '@/lib/analytics'
 import { prepareEmailHtml, splitPlainTextQuote, stripQuotedReplyText, QUOTED_CLASS } from '@/lib/email-quotes'
+import { BUILTIN_LABELS, labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/email-labels'
+import { EmailRail, type EmailRailSelection } from '@/components/email-rail'
 import { useTheme } from '@/contexts/theme-context'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { Button } from '@/components/ui/button'
@@ -147,46 +149,9 @@ function withDateDividers(threads: GmailThread[], renderThread: (thread: GmailTh
   return out
 }
 
-// The label set (chips, filter pills, correction dropdown) comes from the
-// backend label registry: built-ins (display names follow Superhuman's Auto
-// Label vocabulary — Marketing / Pitch / News / Calendar) plus any labels the
-// user defined in their agent instructions. This static copy of the built-ins
-// is the fallback used until the registry loads, and for ids the registry no
-// longer knows (a custom label the user later removed).
+// The label set (chips, filter pills, rail rows, correction dropdown) lives in
+// lib/email-labels — shared with the filter rail.
 type EmailCategory = string
-
-interface EmailLabelInfo {
-  id: string
-  name: string
-  kind: 'builtin' | 'custom'
-}
-
-const BUILTIN_LABELS: EmailLabelInfo[] = [
-  { id: 'correspondence', name: 'Direct', kind: 'builtin' },
-  { id: 'meeting', name: 'Calendar', kind: 'builtin' },
-  { id: 'notification', name: 'Notification', kind: 'builtin' },
-  { id: 'newsletter', name: 'News', kind: 'builtin' },
-  { id: 'promotion', name: 'Marketing', kind: 'builtin' },
-  { id: 'cold_outreach', name: 'Pitch', kind: 'builtin' },
-  { id: 'receipt', name: 'Receipt', kind: 'builtin' },
-]
-
-// Pill order in the "Everything else" filter row: noise first (that's what
-// gets bulk-archived), then the rest of the built-ins; custom labels are
-// appended in registry order at render time. 'unclassified' (threads the
-// classifier hasn't reached yet) is always last and unarchivable.
-const BUILTIN_PILL_ORDER = ['newsletter', 'promotion', 'notification', 'cold_outreach', 'receipt', 'meeting', 'correspondence']
-
-// Fallback for ids the registry doesn't know: "portfolio_updates" → "Portfolio updates".
-function prettifyLabelId(id: string): string {
-  const words = id.replace(/_/g, ' ').trim()
-  return words ? words[0].toUpperCase() + words.slice(1) : id
-}
-
-function labelNameFor(labels: EmailLabelInfo[], category: string): string {
-  if (category === 'unclassified') return 'Uncategorized'
-  return labels.find((l) => l.id === category)?.name ?? prettifyLabelId(category)
-}
 
 // The user sent the latest message and someone else is in the conversation —
 // the ball is in their court. Derived from the messages on every render (never
@@ -2742,12 +2707,39 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
   const closeCompose = useCallback(() => setComposeOpen(false), [])
   // Inbox vs Drafts. Drafts are fetched live (they're not in the inbox cache).
   const [view, setView] = useState<'inbox' | 'drafts'>('inbox')
+  // Which inbox sections the rail shows: both, Important only, or Everything
+  // else only. Purely a render subset — both sections stay loaded either way.
+  const [inboxFilter, setInboxFilter] = useState<'all' | 'important' | 'other'>('all')
+  // Filter rail collapse, persisted like the Spaces rail.
+  const [railOpen, setRailOpen] = useState(() => localStorage.getItem('email:railOpen') !== '0')
+  const toggleRail = useCallback(() => {
+    setRailOpen((prev) => {
+      localStorage.setItem('email:railOpen', prev ? '0' : '1')
+      return !prev
+    })
+  }, [])
   // Category filter for "Everything else" (null = all) + whole-section counts
   // from the last backend response, which drive the filter pills.
   const [otherCategory, setOtherCategory] = useState<string | null>(null)
   const otherCategoryRef = useRef<string | null>(null)
   otherCategoryRef.current = otherCategory
   const [categoryCounts, setCategoryCounts] = useState<Record<string, number>>({})
+  // Rail clicks map onto the existing view/filter state — the list re-subsets
+  // immediately (category changes refetch via the otherCategory effect below).
+  const selectRail = useCallback((sel: EmailRailSelection) => {
+    if (sel.kind === 'drafts') {
+      setView('drafts')
+      return
+    }
+    setView('inbox')
+    if (sel.kind === 'other') {
+      setInboxFilter('other')
+      setOtherCategory(sel.category ?? null)
+      return
+    }
+    setInboxFilter(sel.kind)
+    setOtherCategory(null)
+  }, [])
   const [bulkArchiving, setBulkArchiving] = useState(false)
   const [drafts, setDrafts] = useState<GmailThread[]>(() => persistedDrafts ?? [])
   const [draftsLoading, setDraftsLoading] = useState(false)
@@ -3400,9 +3392,23 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
   const visibleList = useMemo<GmailThread[]>(() => {
     if (query.trim()) return searchResults
     if (view === 'drafts') return visibleDrafts
-    if (other.threads.length > 0) return [...visibleNeedsYou, ...visibleWaiting, ...visibleOther]
-    return [...visibleNeedsYou, ...visibleWaiting]
-  }, [query, searchResults, view, visibleDrafts, visibleNeedsYou, visibleWaiting, visibleOther, other.threads.length])
+    const importantRows = inboxFilter === 'other' ? [] : [...visibleNeedsYou, ...visibleWaiting]
+    const otherRows = inboxFilter === 'important' || other.threads.length === 0 ? [] : visibleOther
+    return [...importantRows, ...otherRows]
+  }, [query, searchResults, view, inboxFilter, visibleDrafts, visibleNeedsYou, visibleWaiting, visibleOther, other.threads.length])
+
+  // Narrowing to a different rail subset re-anchors the j/k cursor at the top
+  // (same posture as switching between inbox / search / drafts). Skipped on
+  // mount so a deep-linked thread's focus isn't clobbered.
+  const inboxFilterMounted = useRef(false)
+  useEffect(() => {
+    if (!inboxFilterMounted.current) {
+      inboxFilterMounted.current = true
+      return
+    }
+    lastFocusedIndexRef.current = 0
+    setFocusedThreadId(null)
+  }, [inboxFilter])
 
   // Keep the cursor valid as the list changes: switching between inbox,
   // search, and drafts resets it; if the focused row vanished (archived,
@@ -3714,6 +3720,17 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
 
   return (
     <div className="gmail-shell" ref={rootRef}>
+      <EmailRail
+        view={view}
+        inboxFilter={inboxFilter}
+        otherCategory={otherCategory}
+        categoryCounts={categoryCounts}
+        labels={emailLabels}
+        draftCount={drafts.length}
+        open={railOpen}
+        onTogglePin={toggleRail}
+        onSelect={selectRail}
+      />
       <div className="gmail-main">
         <div className="gmail-topbar">
           <div className="gmail-search">
@@ -3819,7 +3836,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
           <div className="gmail-empty-state">Could not load mail: {error}</div>
         ) : hasAny ? (
           <div className="gmail-list" aria-label="Recent emails">
-            {visibleNeedsYou.length > 0 ? (
+            {inboxFilter !== 'other' && (visibleNeedsYou.length > 0 ? (
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Needs you</span>
@@ -3831,8 +3848,8 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
               </section>
             ) : important.hasReachedEnd && !important.loadingPage ? (
               <div className="gmail-caughtup">You’re caught up — nothing needs a reply.</div>
-            ) : null}
-            {visibleWaiting.length > 0 && (
+            ) : null)}
+            {inboxFilter !== 'other' && visibleWaiting.length > 0 && (
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Waiting on them</span>
@@ -3845,7 +3862,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
             )}
             {/* Pages of "Important" feed both sections above, so the sentinel
                 lives after them rather than inside either one. */}
-            {important.threads.length > 0 && !important.hasReachedEnd && (
+            {inboxFilter !== 'other' && important.threads.length > 0 && !important.hasReachedEnd && (
               <SectionSentinel
                 disabled={important.loadingPage || important.hasReachedEnd}
                 onIntersect={() => loadNextPage('important')}
@@ -3856,7 +3873,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
                 loaded the section never unmounts: silent live reloads reset
                 Important to page 1 (hasReachedEnd → false), and gating the
                 render on it made this whole section vanish on every sync. */}
-            {(other.threads.length > 0 || otherCategory !== null) && (
+            {inboxFilter !== 'important' && (other.threads.length > 0 || otherCategory !== null || inboxFilter === 'other') && (
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Everything else</span>
@@ -3866,13 +3883,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
                 </div>
                 {Object.keys(categoryCounts).length > 0 && (
                   <div className="gmail-category-pills">
-                    {[
-                      ...BUILTIN_PILL_ORDER,
-                      ...emailLabels.filter((l) => l.kind === 'custom').map((l) => l.id),
-                      // Stale custom ids still present in counts render too.
-                      ...Object.keys(categoryCounts).filter((c) => c !== 'unclassified' && !BUILTIN_PILL_ORDER.includes(c) && !emailLabels.some((l) => l.id === c)),
-                      'unclassified',
-                    ].filter((c) => (categoryCounts[c] ?? 0) > 0).map((cat) => (
+                    {orderedCategoryIds(emailLabels, categoryCounts).map((cat) => (
                       <button
                         key={cat}
                         type="button"
@@ -3896,9 +3907,11 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
                     )}
                   </div>
                 )}
-                {other.threads.length === 0 && otherCategory !== null && !other.loadingPage && (
+                {other.threads.length === 0 && !other.loadingPage && (otherCategory !== null ? (
                   <div className="gmail-caughtup">Nothing filed as {labelNameFor(emailLabels, otherCategory).toLowerCase()}.</div>
-                )}
+                ) : inboxFilter === 'other' ? (
+                  <div className="gmail-caughtup">Nothing here yet.</div>
+                ) : null)}
                 {visibleOther.map((t) => renderRow(t, 'other'))}
                 {!other.hasReachedEnd && (
                   <SectionSentinel

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -3760,19 +3760,9 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
               </button>
             )}
           </div>
+          {/* Inbox vs Drafts moved to the filter rail — the topbar keeps only
+              the icon actions. */}
           <div className="gmail-topbar-actions">
-            <div className="flex items-center rounded-md border border-border p-0.5 text-xs font-medium">
-              <button
-                type="button"
-                className={cn('rounded px-2.5 py-1 transition-colors', view === 'inbox' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground')}
-                onClick={() => setView('inbox')}
-              >Inbox</button>
-              <button
-                type="button"
-                className={cn('rounded px-2.5 py-1 transition-colors', view === 'drafts' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground')}
-                onClick={() => setView('drafts')}
-              >Drafts{drafts.length > 0 ? ` (${drafts.length})` : ''}</button>
-            </div>
             <button
               type="button"
               className="gmail-icon-button"

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -10,6 +10,7 @@ import { toast } from '@/lib/toast'
 import * as analytics from '@/lib/analytics'
 import { prepareEmailHtml, splitPlainTextQuote, stripQuotedReplyText, QUOTED_CLASS } from '@/lib/email-quotes'
 import { BUILTIN_LABELS, labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/email-labels'
+import { replyReadyThreads } from '@/lib/email-reply-ready'
 import { EmailRail, type EmailRailSelection } from '@/components/email-rail'
 import { useTheme } from '@/contexts/theme-context'
 import { SettingsDialog } from '@/components/settings-dialog'
@@ -2707,9 +2708,11 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
   const closeCompose = useCallback(() => setComposeOpen(false), [])
   // Inbox vs Drafts. Drafts are fetched live (they're not in the inbox cache).
   const [view, setView] = useState<'inbox' | 'drafts'>('inbox')
-  // Which inbox sections the rail shows: both, Important only, or Everything
-  // else only. Purely a render subset — both sections stay loaded either way.
-  const [inboxFilter, setInboxFilter] = useState<'all' | 'important' | 'other'>('all')
+  // Which inbox sections the rail shows: both, Important only, Reply ready
+  // (threads with a classifier-drafted reply, across both sections), or
+  // Everything else only. Purely a render subset — both sections stay loaded
+  // either way.
+  const [inboxFilter, setInboxFilter] = useState<'all' | 'important' | 'reply-ready' | 'other'>('all')
   // Filter rail collapse, persisted like the Spaces rail.
   const [railOpen, setRailOpen] = useState(() => localStorage.getItem('email:railOpen') !== '0')
   const toggleRail = useCallback(() => {
@@ -3372,6 +3375,24 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
     [visibleImportant, selfEmail],
   )
 
+  // "Reply ready" spans both loaded sections. The rail count ignores the
+  // search box (like the drafts count); the visible list respects it. Both
+  // recompute whenever the watcher reloads a section, so a draft appearing,
+  // being sent, or vanishing after re-classification updates them in place.
+  const replyReadyCount = useMemo(
+    () => replyReadyThreads(important.threads, other.threads).length,
+    [important.threads, other.threads],
+  )
+  const visibleReplyReady = useMemo(
+    () => replyReadyThreads(visibleImportant, visibleOther),
+    [visibleImportant, visibleOther],
+  )
+  // Row actions (category correction) need each thread's home section.
+  const importantThreadIds = useMemo(
+    () => new Set(important.threads.map((t) => t.threadId)),
+    [important.threads],
+  )
+
   // ── Keyboard shortcuts (Superhuman-style) ───────────────────────────────────
   // EmailView only mounts while the email tab is open, so these are naturally
   // scoped to that view. Single-letter keys stay inert while typing in any
@@ -3392,10 +3413,11 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
   const visibleList = useMemo<GmailThread[]>(() => {
     if (query.trim()) return searchResults
     if (view === 'drafts') return visibleDrafts
+    if (inboxFilter === 'reply-ready') return visibleReplyReady
     const importantRows = inboxFilter === 'other' ? [] : [...visibleNeedsYou, ...visibleWaiting]
     const otherRows = inboxFilter === 'important' || other.threads.length === 0 ? [] : visibleOther
     return [...importantRows, ...otherRows]
-  }, [query, searchResults, view, inboxFilter, visibleDrafts, visibleNeedsYou, visibleWaiting, visibleOther, other.threads.length])
+  }, [query, searchResults, view, inboxFilter, visibleDrafts, visibleReplyReady, visibleNeedsYou, visibleWaiting, visibleOther, other.threads.length])
 
   // Narrowing to a different rail subset re-anchors the j/k cursor at the top
   // (same posture as switching between inbox / search / drafts). Skipped on
@@ -3727,6 +3749,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
         categoryCounts={categoryCounts}
         labels={emailLabels}
         draftCount={drafts.length}
+        replyReadyCount={replyReadyCount}
         open={railOpen}
         onTogglePin={toggleRail}
         onSelect={selectRail}
@@ -3826,7 +3849,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
           <div className="gmail-empty-state">Could not load mail: {error}</div>
         ) : hasAny ? (
           <div className="gmail-list" aria-label="Recent emails">
-            {inboxFilter !== 'other' && (visibleNeedsYou.length > 0 ? (
+            {(inboxFilter === 'all' || inboxFilter === 'important') && (visibleNeedsYou.length > 0 ? (
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Needs you</span>
@@ -3839,7 +3862,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
             ) : important.hasReachedEnd && !important.loadingPage ? (
               <div className="gmail-caughtup">You’re caught up — nothing needs a reply.</div>
             ) : null)}
-            {inboxFilter !== 'other' && visibleWaiting.length > 0 && (
+            {(inboxFilter === 'all' || inboxFilter === 'important') && visibleWaiting.length > 0 && (
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Waiting on them</span>
@@ -3852,7 +3875,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
             )}
             {/* Pages of "Important" feed both sections above, so the sentinel
                 lives after them rather than inside either one. */}
-            {inboxFilter !== 'other' && important.threads.length > 0 && !important.hasReachedEnd && (
+            {(inboxFilter === 'all' || inboxFilter === 'important') && important.threads.length > 0 && !important.hasReachedEnd && (
               <SectionSentinel
                 disabled={important.loadingPage || important.hasReachedEnd}
                 onIntersect={() => loadNextPage('important')}
@@ -3863,7 +3886,27 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
                 loaded the section never unmounts: silent live reloads reset
                 Important to page 1 (hasReachedEnd → false), and gating the
                 render on it made this whole section vanish on every sync. */}
-            {inboxFilter !== 'important' && (other.threads.length > 0 || otherCategory !== null || inboxFilter === 'other') && (
+            {inboxFilter === 'reply-ready' && (
+              <section className="gmail-section">
+                <div className="gmail-list-header">
+                  <span>Reply ready</span>
+                  <span>{visibleReplyReady.length} thread{visibleReplyReady.length === 1 ? '' : 's'}</span>
+                </div>
+                {visibleReplyReady.length === 0 && !important.loadingPage && !other.loadingPage && (
+                  <div className="gmail-caughtup">No drafted replies right now.</div>
+                )}
+                {withDateDividers(visibleReplyReady, (t) => renderRow(t, importantThreadIds.has(t.threadId) ? 'important' : 'other'))}
+                {/* Deeper pages of either section may hold more drafted replies. */}
+                {(!important.hasReachedEnd || !other.hasReachedEnd) && (
+                  <SectionSentinel
+                    disabled={important.loadingPage || other.loadingPage}
+                    onIntersect={() => loadNextPage(important.hasReachedEnd ? 'other' : 'important')}
+                    loading={important.loadingPage || other.loadingPage}
+                  />
+                )}
+              </section>
+            )}
+            {(inboxFilter === 'all' || inboxFilter === 'other') && (other.threads.length > 0 || otherCategory !== null || inboxFilter === 'other') && (
               <section className="gmail-section">
                 <div className="gmail-list-header">
                   <span>Everything else</span>

--- a/apps/x/apps/renderer/src/components/secondary-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/secondary-rail.test.tsx
@@ -1,0 +1,66 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SecondaryRail } from './secondary-rail'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+function renderRail(open: boolean) {
+  const onTogglePin = vi.fn()
+  render(
+    <SecondaryRail open={open} onTogglePin={onTogglePin} widthStorageKey="test:railWidth">
+      {({ togglePin }) => (
+        <div>
+          <button type="button" onClick={togglePin}>pin</button>
+          <span>rail content</span>
+        </div>
+      )}
+    </SecondaryRail>,
+  )
+  return { onTogglePin }
+}
+
+const aside = () => screen.getByText('rail content').closest('aside') as HTMLElement
+const drawer = () => screen.getByText('rail content').closest('[inert]')
+
+describe('SecondaryRail', () => {
+  it('docked: renders interactive content with a width-resize handle', () => {
+    renderRail(true)
+    expect(drawer()).toBeNull()
+    expect(screen.getByTitle('Drag to resize')).toBeTruthy()
+  })
+
+  it('docked: the context togglePin reports to the parent', () => {
+    const { onTogglePin } = renderRail(true)
+    fireEvent.click(screen.getByText('pin'))
+    expect(onTogglePin).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapsed: content waits inert in the drawer, no resize handle', () => {
+    renderRail(false)
+    expect(drawer()).toBeTruthy()
+    expect(screen.queryByTitle('Drag to resize')).toBeNull()
+  })
+
+  it('collapsed: hovering peeks the drawer open; leaving slides it back', () => {
+    vi.useFakeTimers()
+    renderRail(false)
+    fireEvent.mouseEnter(aside())
+    act(() => { vi.advanceTimersByTime(150) })
+    expect(drawer()).toBeNull()
+    fireEvent.mouseLeave(aside())
+    act(() => { vi.advanceTimersByTime(250) })
+    expect(drawer()).toBeTruthy()
+  })
+
+  it('peeked: togglePin is the lock — it reaches the parent', () => {
+    vi.useFakeTimers()
+    const { onTogglePin } = renderRail(false)
+    fireEvent.mouseEnter(aside())
+    act(() => { vi.advanceTimersByTime(150) })
+    fireEvent.click(screen.getByText('pin'))
+    expect(onTogglePin).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/x/apps/renderer/src/components/secondary-rail.tsx
+++ b/apps/x/apps/renderer/src/components/secondary-rail.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+// The shared shell for a section's secondary sidebar (Spaces' rail, Email's
+// filter rail): everything about BEING a rail, nothing about what's in one.
+//
+// Open/close follows Notion. Docked: a sidebar in the flow (280px until its
+// right edge is dragged; persisted per surface via widthStorageKey); the
+// domain's header button closes it to a sliver at the edge. Collapsed:
+// hovering the sliver slides the whole rail out as a drawer OVER the
+// content — nothing shifts — and it slides back once the cursor leaves (an
+// open row menu holds it, reported through the context's onMenuOpenChange
+// since menus portal outside the rail). The drawer's header button is the
+// lock: clicking it docks the rail, the only act that moves the content.
+//
+// The parent owns the docked/collapsed choice (open/onTogglePin) and its
+// persistence; the shell owns width, peek, and the chrome. Domain content
+// renders through a children function so its header can host the
+// close/lock button (ctx.togglePin) and its menus can hold the drawer.
+
+/** The collapsed rail: a sliver you hover, not a strip you read. */
+const EDGE_W = 10
+/** Docked width: 280 until the right edge is dragged (persisted), within these. */
+const WIDTH_DEFAULT = 280
+const WIDTH_MIN = 220
+const WIDTH_MAX = 480
+
+export interface SecondaryRailContext {
+    /** Docked: close. Peeked: the lock — dock it. Clears the peek first. */
+    togglePin: () => void
+    /** Row menus portal outside the rail — report open/close so the peeked
+     *  drawer holds while one is up. */
+    onMenuOpenChange: (open: boolean) => void
+}
+
+export function SecondaryRail({ open, onTogglePin, widthStorageKey, edgeDot = false, persistent, children }: {
+    /** Docked (in the flow, pushing the content). False = the edge sliver + hover drawer. */
+    open: boolean
+    /** The lock: docks a peeked rail, closes a docked one. */
+    onTogglePin: () => void
+    /** localStorage key for the dragged width (e.g. 'spaces:railWidth'). */
+    widthStorageKey: string
+    /** Show the sliver's "something here is unread" dot. */
+    edgeDot?: boolean
+    /** Rendered directly in the <aside>, mounted in BOTH modes — for hidden
+     *  inputs that must survive the dock/collapse remount of the body. */
+    persistent?: ReactNode
+    children: (ctx: SecondaryRailContext) => ReactNode
+}) {
+    // Docked width: drag the rail's right edge. The drawer uses the same width.
+    const [width, setWidth] = useState<number>(() => {
+        const stored = Number(localStorage.getItem(widthStorageKey))
+        return Number.isFinite(stored) && stored >= WIDTH_MIN && stored <= WIDTH_MAX ? stored : WIDTH_DEFAULT
+    })
+    const [resizingWidth, setResizingWidth] = useState(false)
+    const startWidthResize = (e: React.MouseEvent) => {
+        e.preventDefault()
+        const start = { x: e.clientX, width }
+        setResizingWidth(true)
+        const onMove = (ev: MouseEvent) => {
+            setWidth(Math.min(WIDTH_MAX, Math.max(WIDTH_MIN, start.width + (ev.clientX - start.x))))
+        }
+        const onUp = () => {
+            window.removeEventListener('mousemove', onMove)
+            window.removeEventListener('mouseup', onUp)
+            setResizingWidth(false)
+            setWidth((w) => {
+                localStorage.setItem(widthStorageKey, String(w))
+                return w
+            })
+        }
+        window.addEventListener('mousemove', onMove)
+        window.addEventListener('mouseup', onUp)
+    }
+
+    // Peek: with the rail collapsed, hovering the edge slides the drawer out;
+    // leaving slides it back after a beat, unless a row menu is holding it
+    // (menus portal outside the rail, so the cursor "leaves" while using one).
+    const [peek, setPeek] = useState(false)
+    const [menuOpen, setMenuOpen] = useState(false)
+    const asideRef = useRef<HTMLElement | null>(null)
+    const peekTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const clearPeekTimer = () => {
+        if (peekTimer.current) clearTimeout(peekTimer.current)
+        peekTimer.current = null
+    }
+    const scheduleClose = () => {
+        clearPeekTimer()
+        peekTimer.current = setTimeout(() => setPeek(false), 220)
+    }
+    const onEdgeEnter = () => {
+        if (open) return
+        clearPeekTimer()
+        peekTimer.current = setTimeout(() => setPeek(true), 120)
+    }
+    const onEdgeLeave = () => {
+        if (menuOpen) clearPeekTimer()
+        else scheduleClose()
+    }
+    const onMenuOpenChange = (isOpen: boolean) => {
+        setMenuOpen(isOpen)
+        // The menu closed with the cursor already gone: slide back now.
+        if (!isOpen && !open && !asideRef.current?.matches(':hover')) scheduleClose()
+    }
+    useEffect(() => {
+        if (open) setPeek(false)
+    }, [open])
+    useEffect(() => clearPeekTimer, [])
+
+    const togglePin = () => {
+        setPeek(false)
+        onTogglePin()
+    }
+
+    // The rail's content, rendered docked or inside the peek drawer. Fixed at
+    // the open width so text doesn't reflow mid-slide. The ctx handlers run
+    // on user events only — never during the children() call itself — so the
+    // ref reads inside them are safe.
+    // eslint-disable-next-line react-hooks/refs
+    const content = children({ togglePin, onMenuOpenChange })
+    const body = (
+        <div style={{ width }} className={cn('flex h-full min-h-0 flex-col', resizingWidth && 'select-none')}>
+            {content}
+        </div>
+    )
+
+    return (
+        <aside
+            ref={asideRef}
+            onMouseEnter={onEdgeEnter}
+            onMouseLeave={onEdgeLeave}
+            // No slide while the edge is being dragged — the width must track the cursor.
+            style={{ width: open ? width : EDGE_W, transition: resizingWidth ? undefined : 'width 200ms cubic-bezier(0.2,0,0,1)' }}
+            className={cn(
+                'relative flex min-h-0 shrink-0 flex-col border-r border-border',
+                // A step lighter than the main sidebar so the two rails read as
+                // distinct layers; at this subtle a shift the hairline to the
+                // canvas earns its place.
+                open ? 'z-10 overflow-hidden bg-[var(--rowboat-panel-soft)]' : 'overflow-visible bg-background',
+                // The drawer rides over the content's own sticky layers (z-20).
+                !open && (peek ? 'z-30' : 'z-10'),
+            )}
+        >
+            {persistent}
+            {open ? (
+                <>
+                    {body}
+                    {/* Docked: drag the right edge to resize. */}
+                    <div
+                        onMouseDown={startWidthResize}
+                        title="Drag to resize"
+                        className={cn(
+                            'absolute inset-y-0 -right-px z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/20',
+                            resizingWidth && 'bg-primary/30',
+                        )}
+                    />
+                </>
+            ) : (
+                <>
+                    {/* The edge sliver: hover slides the drawer out. It says one
+                        thing at rest — a dot when something here is unread. */}
+                    <div aria-hidden className={cn('relative flex-1 transition-colors', peek ? 'bg-accent/60' : 'hover:bg-accent/60')}>
+                        {edgeDot && <span className="absolute left-1/2 top-3 size-1 -translate-x-1/2 rounded-full bg-foreground" />}
+                    </div>
+                    {/* The drawer: the same rail, sliding out over the content from
+                        the edge — nothing underneath moves. The outer box clips on
+                        the left so the slide never shows over the shell dock, and is
+                        wide enough to leave the shadow alone. Inert while hidden so
+                        its rows never catch focus. */}
+                    <div style={{ width: width + 50 }} className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden">
+                        <div
+                            inert={!peek}
+                            style={{ width }}
+                            className={cn(
+                                'absolute bottom-1.5 left-0 top-1.5 overflow-hidden rounded-r-xl border border-border bg-[var(--rowboat-panel-soft)] shadow-2xl transition-transform duration-200 ease-[cubic-bezier(0.2,0,0,1)]',
+                                peek ? 'pointer-events-auto translate-x-0' : '-translate-x-full',
+                            )}
+                        >
+                            {body}
+                        </div>
+                    </div>
+                </>
+            )}
+        </aside>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useMemo, useRef, useState, type ReactNode } from 'react'
 import { Archive, ArchiveRestore, ArrowLeft, Bell, BellOff, Bot, Check, CornerDownRight, FileText, FolderPlus, MessageSquare, MessageSquareOff, MessagesSquare, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
 import { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/context-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { toast } from '@/lib/toast'
+import { SecondaryRail, type SecondaryRailContext } from '@/components/secondary-rail'
 import { FileTree } from '@/components/spaces/files-tab'
 import { refreshSpaceFeed } from '@/hooks/use-spaces'
 import type { NotifyLevel, SpaceNotifyHandle } from '@/hooks/use-spaces-notify'
@@ -38,14 +39,11 @@ import type { RailSelection } from '@/lib/spaces-selection'
 // goal. Plain reply chains stay behind their chips in the stream — the rail
 // holds intentions, not accidents.
 //
-// Open/close follows Notion. Docked: a sidebar in the flow (280px until its
-// right edge is dragged; the shell sidebar contracts to the dock while in
-// Spaces, so this is THE sidebar here); its header button closes it to a
-// sliver at the edge. Collapsed:
-// hovering the sliver slides the whole rail out as a drawer OVER the
-// surfaces — nothing shifts — and it slides back once the cursor leaves
-// (an open row menu holds it). The drawer's header button is the lock:
-// clicking it docks the rail, the only act that moves the content.
+// The rail chrome (docked width + drag-resize, the collapsed sliver, the
+// hover peek drawer) is the shared SecondaryRail shell — Email's filter
+// rail uses the same one. This file owns only what's IN the rail. The
+// shell sidebar contracts to the dock while in Spaces, so this is THE
+// sidebar here.
 
 const NOTIFY_CHOICES: { level: NotifyLevel; label: string }[] = [
     { level: 'all', label: 'All messages' },
@@ -62,13 +60,6 @@ const FILES_HEIGHT_KEY = 'spaces:filesHeight'
 const FILES_MIN = 96
 /** ...or Chat shorter than this (label + Messages + a discussion). */
 const CHAT_MIN = 120
-/** The collapsed rail: a sliver you hover, not a strip you read. */
-const EDGE_W = 10
-/** Docked width: 280 until the right edge is dragged (persisted), within these. */
-const WIDTH_KEY = 'spaces:railWidth'
-const WIDTH_DEFAULT = 280
-const WIDTH_MIN = 220
-const WIDTH_MAX = 480
 
 export function SpaceRail({
     orgId, spaceId, selfMemberId, stream, topics, changeSets, entries, draftFolders, presence, unreadPaths, notify, selection, onSelect, onCreateFile, onCreateBoard, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
@@ -118,31 +109,6 @@ export function SpaceRail({
         return Number.isFinite(stored) && stored >= FILES_MIN ? stored : null
     })
     const [resizing, setResizing] = useState(false)
-    // Docked width: drag the rail's right edge. The drawer uses the same width.
-    const [width, setWidth] = useState<number>(() => {
-        const stored = Number(localStorage.getItem(WIDTH_KEY))
-        return Number.isFinite(stored) && stored >= WIDTH_MIN && stored <= WIDTH_MAX ? stored : WIDTH_DEFAULT
-    })
-    const [resizingWidth, setResizingWidth] = useState(false)
-    const startWidthResize = (e: React.MouseEvent) => {
-        e.preventDefault()
-        const start = { x: e.clientX, width }
-        setResizingWidth(true)
-        const onMove = (ev: MouseEvent) => {
-            setWidth(Math.min(WIDTH_MAX, Math.max(WIDTH_MIN, start.width + (ev.clientX - start.x))))
-        }
-        const onUp = () => {
-            window.removeEventListener('mousemove', onMove)
-            window.removeEventListener('mouseup', onUp)
-            setResizingWidth(false)
-            setWidth((w) => {
-                localStorage.setItem(WIDTH_KEY, String(w))
-                return w
-            })
-        }
-        window.addEventListener('mousemove', onMove)
-        window.addEventListener('mouseup', onUp)
-    }
     const bodyRef = useRef<HTMLDivElement | null>(null)
     const filesRef = useRef<HTMLElement | null>(null)
     const startResize = (e: React.MouseEvent) => {
@@ -256,40 +222,6 @@ export function SpaceRail({
         topics.filter((t) => !t.archived && isUnread(t) && effectiveLevel(t.rootMessageId) !== 'mute').length + (generalBadge > 0 ? 1 : 0)
     const badge = unreadTopics + unreadPaths.size
 
-    // Peek: with the rail collapsed, hovering the edge slides the drawer out;
-    // leaving slides it back after a beat, unless a row menu is holding it
-    // (menus portal outside the rail, so the cursor "leaves" while using one).
-    const [peek, setPeek] = useState(false)
-    const [menuOpen, setMenuOpen] = useState(false)
-    const asideRef = useRef<HTMLElement | null>(null)
-    const peekTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-    const clearPeekTimer = () => {
-        if (peekTimer.current) clearTimeout(peekTimer.current)
-        peekTimer.current = null
-    }
-    const scheduleClose = () => {
-        clearPeekTimer()
-        peekTimer.current = setTimeout(() => setPeek(false), 220)
-    }
-    const onEdgeEnter = () => {
-        if (open) return
-        clearPeekTimer()
-        peekTimer.current = setTimeout(() => setPeek(true), 120)
-    }
-    const onEdgeLeave = () => {
-        if (menuOpen) clearPeekTimer()
-        else scheduleClose()
-    }
-    const onMenuOpenChange = (isOpen: boolean) => {
-        setMenuOpen(isOpen)
-        // The menu closed with the cursor already gone: slide back now.
-        if (!isOpen && !open && !asideRef.current?.matches(':hover')) scheduleClose()
-    }
-    useEffect(() => {
-        if (open) setPeek(false)
-    }, [open])
-    useEffect(() => clearPeekTimer, [])
-
     const chatCollapsed = collapsed.has('chat')
     const filesCollapsed = collapsed.has('files')
     const bothOpen = !chatCollapsed && !filesCollapsed
@@ -304,10 +236,10 @@ export function SpaceRail({
                 ? { flex: `0 0 ${filesHeight}px`, maxHeight: `calc(100% - ${CHAT_MIN}px)` }
                 : { flex: '40 1 0%' }
 
-    // The rail's content, rendered docked or inside the peek drawer. Fixed at
-    // the open width so text doesn't reflow mid-slide.
-    const body = (
-        <div ref={bodyRef} style={{ width }} className={cn('flex h-full min-h-0 flex-col', (resizing || resizingWidth) && 'select-none')}>
+    // The rail's content — the shell renders it docked or inside the peek
+    // drawer at the fixed open width.
+    const renderBody = ({ togglePin, onMenuOpenChange }: SecondaryRailContext) => (
+        <div ref={bodyRef} className={cn('flex h-full min-h-0 flex-col', resizing && 'select-none')}>
             <section style={chatStyle} className="group/section flex min-h-0 flex-col">
                 <SectionHeader label="Chat" collapsed={chatCollapsed} count={liveRows.length} onToggle={() => toggleSection('chat')}>
                     <DropdownMenu onOpenChange={onMenuOpenChange}>
@@ -335,7 +267,7 @@ export function SpaceRail({
                     {/* Docked: close. Peeked: the lock — dock it. Same spot, flipped glyph. */}
                     <button
                         type="button"
-                        onClick={() => { setPeek(false); onTogglePin() }}
+                        onClick={togglePin}
                         title={open ? 'Close sidebar' : 'Lock sidebar open'}
                         className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
                     >
@@ -650,76 +582,30 @@ export function SpaceRail({
     )
 
     return (
-        <aside
-            ref={asideRef}
-            onMouseEnter={onEdgeEnter}
-            onMouseLeave={onEdgeLeave}
-            // No slide while the edge is being dragged — the width must track the cursor.
-            style={{ width: open ? width : EDGE_W, transition: resizingWidth ? undefined : 'width 200ms cubic-bezier(0.2,0,0,1)' }}
-            className={cn(
-                'relative flex min-h-0 shrink-0 flex-col border-r border-border',
-                // A step lighter than the main sidebar so the two rails read as
-                // distinct layers; at this subtle a shift the hairline to the
-                // canvas earns its place.
-                open ? 'z-10 overflow-hidden bg-[var(--rowboat-panel-soft)]' : 'overflow-visible bg-background',
-                // The drawer rides over the surfaces' own sticky layers (z-20).
-                !open && (peek ? 'z-30' : 'z-10'),
-            )}
+        <SecondaryRail
+            open={open}
+            onTogglePin={onTogglePin}
+            widthStorageKey="spaces:railWidth"
+            edgeDot={badge > 0}
+            persistent={
+                // Always mounted: an input unmounted mid-pick (the rail toggled
+                // closed while the OS file dialog is up) never delivers its
+                // change event.
+                <input
+                    ref={uploadInputRef}
+                    type="file"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => {
+                        const files = Array.from(e.target.files ?? [])
+                        if (files.length > 0) onUploadFiles(files)
+                        e.target.value = ''
+                    }}
+                />
+            }
         >
-            {/* Always mounted: an input unmounted mid-pick (the rail toggled
-                closed while the OS file dialog is up) never delivers its
-                change event. */}
-            <input
-                ref={uploadInputRef}
-                type="file"
-                multiple
-                className="hidden"
-                onChange={(e) => {
-                    const files = Array.from(e.target.files ?? [])
-                    if (files.length > 0) onUploadFiles(files)
-                    e.target.value = ''
-                }}
-            />
-            {open ? (
-                <>
-                    {body}
-                    {/* Docked: drag the right edge to resize. */}
-                    <div
-                        onMouseDown={startWidthResize}
-                        title="Drag to resize"
-                        className={cn(
-                            'absolute inset-y-0 -right-px z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/20',
-                            resizingWidth && 'bg-primary/30',
-                        )}
-                    />
-                </>
-            ) : (
-                <>
-                    {/* The edge sliver: hover slides the drawer out. It says one
-                        thing at rest — a dot when something here is unread. */}
-                    <div aria-hidden className={cn('relative flex-1 transition-colors', peek ? 'bg-accent/60' : 'hover:bg-accent/60')}>
-                        {badge > 0 && <span className="absolute left-1/2 top-3 size-1 -translate-x-1/2 rounded-full bg-foreground" />}
-                    </div>
-                    {/* The drawer: the same rail, sliding out over the surfaces from
-                        the edge — nothing underneath moves. The outer box clips on
-                        the left so the slide never shows over the shell dock, and is
-                        wide enough to leave the shadow alone. Inert while hidden so
-                        its rows never catch focus. */}
-                    <div style={{ width: width + 50 }} className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden">
-                        <div
-                            inert={!peek}
-                            style={{ width }}
-                            className={cn(
-                                'absolute bottom-1.5 left-0 top-1.5 overflow-hidden rounded-r-xl border border-border bg-[var(--rowboat-panel-soft)] shadow-2xl transition-transform duration-200 ease-[cubic-bezier(0.2,0,0,1)]',
-                                peek ? 'pointer-events-auto translate-x-0' : '-translate-x-full',
-                            )}
-                        >
-                            {body}
-                        </div>
-                    </div>
-                </>
-            )}
-        </aside>
+            {renderBody}
+        </SecondaryRail>
     )
 }
 

--- a/apps/x/apps/renderer/src/lib/email-labels.test.ts
+++ b/apps/x/apps/renderer/src/lib/email-labels.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { BUILTIN_LABELS, labelNameFor, orderedCategoryIds, prettifyLabelId } from './email-labels'
+
+describe('labelNameFor', () => {
+  it('maps unclassified to Uncategorized', () => {
+    expect(labelNameFor(BUILTIN_LABELS, 'unclassified')).toBe('Uncategorized')
+  })
+
+  it('uses the registry name when known', () => {
+    expect(labelNameFor(BUILTIN_LABELS, 'newsletter')).toBe('News')
+  })
+
+  it('prettifies unknown ids', () => {
+    expect(labelNameFor(BUILTIN_LABELS, 'portfolio_updates')).toBe('Portfolio updates')
+    expect(prettifyLabelId('cold_outreach')).toBe('Cold outreach')
+  })
+})
+
+describe('orderedCategoryIds', () => {
+  it('orders builtins first, then custom, then stale ids, then unclassified — dropping empty ones', () => {
+    const labels = [...BUILTIN_LABELS, { id: 'investor', name: 'Investor', kind: 'custom' as const }]
+    const counts = {
+      correspondence: 2,
+      newsletter: 5,
+      investor: 1,
+      removed_label: 3, // stale id no longer in the registry
+      unclassified: 4,
+      receipt: 0, // empty categories don't render
+    }
+    expect(orderedCategoryIds(labels, counts)).toEqual([
+      'newsletter', 'correspondence', 'investor', 'removed_label', 'unclassified',
+    ])
+  })
+
+  it('returns nothing when there are no counts', () => {
+    expect(orderedCategoryIds(BUILTIN_LABELS, {})).toEqual([])
+  })
+})

--- a/apps/x/apps/renderer/src/lib/email-labels.ts
+++ b/apps/x/apps/renderer/src/lib/email-labels.ts
@@ -1,0 +1,53 @@
+// The email label set (chips, filter pills, rail rows, correction dropdown)
+// comes from the backend label registry: built-ins (display names follow
+// Superhuman's Auto Label vocabulary — Marketing / Pitch / News / Calendar)
+// plus any labels the user defined in their agent instructions. The static
+// copy of the built-ins is the fallback used until the registry loads, and
+// for ids the registry no longer knows (a custom label the user later
+// removed). Shared between the email view and its filter rail.
+
+export interface EmailLabelInfo {
+  id: string
+  name: string
+  kind: 'builtin' | 'custom'
+}
+
+export const BUILTIN_LABELS: EmailLabelInfo[] = [
+  { id: 'correspondence', name: 'Direct', kind: 'builtin' },
+  { id: 'meeting', name: 'Calendar', kind: 'builtin' },
+  { id: 'notification', name: 'Notification', kind: 'builtin' },
+  { id: 'newsletter', name: 'News', kind: 'builtin' },
+  { id: 'promotion', name: 'Marketing', kind: 'builtin' },
+  { id: 'cold_outreach', name: 'Pitch', kind: 'builtin' },
+  { id: 'receipt', name: 'Receipt', kind: 'builtin' },
+]
+
+// Category order in the "Everything else" filter row and the rail's Categories
+// section: noise first (that's what gets bulk-archived), then the rest of the
+// built-ins; custom labels are appended in registry order at render time.
+// 'unclassified' (threads the classifier hasn't reached yet) is always last
+// and unarchivable.
+export const BUILTIN_PILL_ORDER = ['newsletter', 'promotion', 'notification', 'cold_outreach', 'receipt', 'meeting', 'correspondence']
+
+// Fallback for ids the registry doesn't know: "portfolio_updates" → "Portfolio updates".
+export function prettifyLabelId(id: string): string {
+  const words = id.replace(/_/g, ' ').trim()
+  return words ? words[0].toUpperCase() + words.slice(1) : id
+}
+
+export function labelNameFor(labels: EmailLabelInfo[], category: string): string {
+  if (category === 'unclassified') return 'Uncategorized'
+  return labels.find((l) => l.id === category)?.name ?? prettifyLabelId(category)
+}
+
+/** Categories with mail in them, in display order: built-ins, custom labels,
+ *  stale ids still present in counts, then 'unclassified'. */
+export function orderedCategoryIds(labels: EmailLabelInfo[], counts: Record<string, number>): string[] {
+  return [
+    ...BUILTIN_PILL_ORDER,
+    ...labels.filter((l) => l.kind === 'custom').map((l) => l.id),
+    // Stale custom ids still present in counts render too.
+    ...Object.keys(counts).filter((c) => c !== 'unclassified' && !BUILTIN_PILL_ORDER.includes(c) && !labels.some((l) => l.id === c)),
+    'unclassified',
+  ].filter((c) => (counts[c] ?? 0) > 0)
+}

--- a/apps/x/apps/renderer/src/lib/email-reply-ready.test.ts
+++ b/apps/x/apps/renderer/src/lib/email-reply-ready.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { blocks } from '@x/shared'
+import { isReplyReady, replyReadyThreads } from './email-reply-ready'
+
+// Only the fields the helpers read — the rest of the thread shape is inert here.
+function thread(threadId: string, over: Partial<blocks.GmailThread> = {}): blocks.GmailThread {
+  return { threadId, ...over } as blocks.GmailThread
+}
+
+describe('isReplyReady', () => {
+  it('is true exactly when the thread carries a drafted reply', () => {
+    expect(isReplyReady(thread('a', { draft_response: 'Sounds good — Thursday works.' }))).toBe(true)
+    expect(isReplyReady(thread('b'))).toBe(false)
+    expect(isReplyReady(thread('c', { draft_response: undefined }))).toBe(false)
+  })
+})
+
+describe('replyReadyThreads', () => {
+  it('keeps only reply-ready threads across lists, newest first', () => {
+    const important = [
+      thread('old', { draft_response: 'hi', date: '2026-09-01T10:00:00Z' }),
+      thread('none', { date: '2026-09-03T10:00:00Z' }),
+    ]
+    const other = [thread('new', { draft_response: 'hello', date: '2026-09-02T10:00:00Z' })]
+    expect(replyReadyThreads(important, other).map((t) => t.threadId)).toEqual(['new', 'old'])
+  })
+
+  it('dedupes a thread appearing in both sections mid-flip', () => {
+    const a = thread('dup', { draft_response: 'x', date: '2026-09-01T10:00:00Z' })
+    expect(replyReadyThreads([a], [a])).toHaveLength(1)
+  })
+
+  it('tolerates missing dates', () => {
+    const rows = replyReadyThreads([
+      thread('undated', { draft_response: 'x' }),
+      thread('dated', { draft_response: 'y', date: '2026-09-01T10:00:00Z' }),
+    ])
+    expect(rows.map((t) => t.threadId)).toEqual(['dated', 'undated'])
+  })
+})

--- a/apps/x/apps/renderer/src/lib/email-reply-ready.ts
+++ b/apps/x/apps/renderer/src/lib/email-reply-ready.ts
@@ -1,0 +1,24 @@
+import type { blocks } from '@x/shared'
+
+// "Reply ready" means the thread carries a classifier-drafted reply
+// (thread.draft_response, written during sync and refreshed whenever the
+// thread changes) — the same condition behind the row chip. This is a view
+// over the loaded sections, not a stored status: send or receive a message
+// and the re-classified snapshot decides again whether a draft belongs.
+
+export function isReplyReady(thread: blocks.GmailThread): boolean {
+  return Boolean(thread.draft_response)
+}
+
+/** Reply-ready threads from the given lists, deduped by threadId (a thread
+ *  mid-flip between sections must not render twice), newest first. */
+export function replyReadyThreads(...lists: blocks.GmailThread[][]): blocks.GmailThread[] {
+  const seen = new Set<string>()
+  const out: blocks.GmailThread[] = []
+  for (const thread of lists.flat()) {
+    if (!isReplyReady(thread) || seen.has(thread.threadId)) continue
+    seen.add(thread.threadId)
+    out.push(thread)
+  }
+  return out.sort((a, b) => (Date.parse(b.date ?? '') || 0) - (Date.parse(a.date ?? '') || 0))
+}


### PR DESCRIPTION
Extracts the Spaces rail's shell into a shared `SecondaryRail` component (`components/secondary-rail.tsx`) and builds a new Email filter sidebar on it, so both sections use the same secondary-sidebar chrome and interactions: docked width with right-edge drag-resize (persisted per surface), a collapsed edge sliver, and the hover peek drawer with lock-to-dock. Spaces was migrated with no user-visible change; domain content renders through a small context (`togglePin`, `onMenuOpenChange`).

**Email sidebar filters**
- **All mail** — the combined Needs you / Waiting on them / Everything else view.
- **Important** — just the important sections.
- **Reply ready** — threads with a classifier-drafted reply (`thread.draft_response`, the condition behind the existing row chip; re-decided on every sync re-classification), across both sections with a count.
- **Everything else** — with its total count.
- **Drafts** — with a count once loaded.
- **Categories** — one row per non-empty category (built-ins, custom labels, Uncategorized) with counts, kept in sync with the in-list category pills via the same filter state.

The now-redundant topbar Inbox | Drafts toggle is removed; `g→i` / `g→d` still switch views and the rail reflects them. Search, thread selection, j/k navigation, and collapse persistence are preserved. No backend/IPC changes.

**Validation:** renderer typecheck and eslint pass on all touched code; full renderer test suite passes (396 tests / 41 files), including behavior-level tests for the shared rail (docked vs collapsed, hover-peek, inert drawer, toggle wiring), the Email rail rows/selection/counts, and the category/reply-ready helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)