### PR TITLE
feat(x): Auto model selection — backend-recommended model, resolved per run

### DIFF
--- a/apps/x/apps/renderer/src/components/model-selector.tsx
+++ b/apps/x/apps/renderer/src/components/model-selector.tsx
@@ -12,6 +12,8 @@ import {
   CommandList,
 } from '@/components/ui/command'
 import { useModels, type ModelPickerGroup, type ModelRef, type ModelSelection } from '@/hooks/use-models'
+import { useRowboatConfig } from '@/hooks/use-rowboat-config'
+import { AUTO_MODEL_ID, isAutoModel } from '@x/shared/dist/models.js'
 import { cn } from '@/lib/utils'
 
 export type { ModelRef, ModelSelection } from '@/hooks/use-models'
@@ -69,6 +71,8 @@ function pointInTriangle(p: Point, a: Point, b: Point, c: Point): boolean {
 }
 
 function getModelDisplayName(model: string) {
+  // The Auto sentinel is a selection, not a model id — never show it raw.
+  if (isAutoModel(model)) return 'Auto'
   return model.split('/').pop() || model
 }
 
@@ -222,10 +226,19 @@ export function ModelSelector({
   lockedModel = null,
   effortSelectable = false,
 }: ModelSelectorProps) {
-  const { groups: catalogGroups, reasoningByKey, defaultModel: catalogDefault, catalogByProvider, refresh } = useModels()
+  const { groups: catalogGroups, reasoningByKey, defaultModel: catalogDefault, defaultIsAuto, catalogByProvider, refresh } = useModels()
   const allGroups = groupsProp ?? catalogGroups
   // The chat default has no standing in a caller-supplied model space.
   const defaultModel = groupsProp ? null : catalogDefault
+
+  // Providers offering an "Auto (recommended)" row: those with a backend
+  // recommendation to resolve against (chat catalog only — Auto has no
+  // meaning in static/caller-supplied model spaces). Local/custom flavors
+  // never have recommendations, so they never show the row.
+  const modelRecommendations = useRowboatConfig()?.modelRecommendations
+  const autoEligible = useCallback((g: ModelPickerGroup) =>
+    !staticOptions && !groupsProp && Boolean(modelRecommendations?.[g.flavor]),
+  [staticOptions, groupsProp, modelRecommendations])
 
   // inheritDefault is defaultOption with placeholder styling — one sentinel
   // code path, not two.
@@ -374,10 +387,12 @@ export function ModelSelector({
       (o.label ?? o.id).toLowerCase().includes(queryValue) || o.id.toLowerCase().includes(queryValue))
   }, [staticOptions, queryValue])
   const staticLabelFor = (id: string) => staticOptions?.find((o) => o.id === id)?.label ?? id
-  // Nothing matches anywhere → "No models match".
+  // Nothing matches anywhere → "No models match". Auto rows count: a query
+  // of "auto" with no matching model id still has rows on screen.
   const anyModelRowVisible = staticVisible
     ? staticVisible.length > 0
     : standaloneVisible
+      || ('auto'.includes(queryValue) && groups.some((g) => autoEligible(g)))
       || groups.some((g) =>
         groupMatchesFilter(g) ? g.models.length > 0
           : g.models.some((m) => m.toLowerCase().includes(queryValue)))
@@ -559,6 +574,28 @@ export function ModelSelector({
     </CommandItem>
   )
 
+  // Searching still surfaces the row by name.
+  const autoRowMatchesQuery = !queryValue || 'auto'.includes(queryValue)
+
+  // The "Auto" row: commits the provider-scoped sentinel, which the runtime
+  // resolves to the current backend recommendation per run. Secondary text
+  // shows what Auto resolves to right now when we know it (the app default
+  // is an Auto selection on this provider); otherwise just "Recommended".
+  const renderAutoItem = (g: ModelPickerGroup) => {
+    if (!autoEligible(g) || !autoRowMatchesQuery) return null
+    const key = `${g.id}/${AUTO_MODEL_ID}`
+    const resolved = defaultIsAuto && defaultModel?.provider === g.id ? defaultModel.model : null
+    return (
+      <CommandItem key={key} value={key} onSelect={() => select({ provider: g.id, model: AUTO_MODEL_ID })}>
+        <Check className={cn('size-3.5 shrink-0', selectedKey === key ? 'opacity-100' : 'opacity-0')} />
+        <span className="truncate">Auto</span>
+        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+          {resolved ?? 'Recommended'}
+        </span>
+      </CommandItem>
+    )
+  }
+
   const renderErrorItem = (g: ModelPickerGroup) => (
     <CommandItem
       key={`__retry__:${g.id}`}
@@ -630,7 +667,7 @@ export function ModelSelector({
                 <span className="flex min-w-0 items-center gap-2">
                   <span className={cn('truncate', !value && sentinelMuted && 'text-muted-foreground')}>
                     {value
-                      ? (staticOptions ? staticLabelFor(value.model) : value.model)
+                      ? (staticOptions ? staticLabelFor(value.model) : isAutoModel(value.model) ? 'Auto' : value.model)
                       : (sentinel?.label || defaultModel?.model || 'Select a model')}
                   </span>
                   {renderEffortBadge()}
@@ -653,7 +690,11 @@ export function ModelSelector({
                 <span className="min-w-0 truncate text-foreground/80">
                   {staticOptions
                     ? (value ? staticLabelFor(value.model) : (sentinel?.label ?? 'Model'))
-                    : getModelDisplayName(value?.model || defaultModel?.model || 'Model')}
+                    : !value && defaultIsAuto && defaultModel
+                      // Following an Auto default: name what actually runs,
+                      // marked as Auto so it doesn't read as a pinned pick.
+                      ? `Auto · ${getModelDisplayName(defaultModel.model)}`
+                      : getModelDisplayName(value?.model || defaultModel?.model || 'Model')}
                 </span>
                 {renderEffortBadge()}
                 <ChevronDown className="h-3 w-3 shrink-0" />
@@ -742,6 +783,7 @@ export function ModelSelector({
                     <CommandList className="max-h-80 flex-1" onScroll={() => setSub(null)}>
                       <CommandGroup>
                         {renderSentinelItem()}
+                        {renderAutoItem(activeGroup)}
                         {standaloneDefault && standaloneDefault.provider === activeGroup.id &&
                           renderModelItem(standaloneDefault.provider, standaloneDefault.model)}
                         {activeGroup.models.map((m) => renderModelItem(activeGroup.id, m))}
@@ -790,9 +832,11 @@ export function ModelSelector({
                       // the header) regardless of the filter and don't count
                       // toward "No models match".
                       const showError = g.status === 'error'
-                      if (visibleModels.length === 0 && !showError) return null
+                      const autoRow = renderAutoItem(g)
+                      if (visibleModels.length === 0 && !showError && !autoRow) return null
                       return (
                         <CommandGroup key={g.id} heading={providerDisplayNames[g.flavor] || g.flavor}>
+                          {autoRow}
                           {visibleModels.map((m) => renderModelItem(g.id, m))}
                           {showError && renderErrorItem(g)}
                         </CommandGroup>

--- a/apps/x/apps/renderer/src/components/settings/model-selection-section.tsx
+++ b/apps/x/apps/renderer/src/components/settings/model-selection-section.tsx
@@ -2,15 +2,17 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { ModelSelector, providerDisplayNames, type ModelRef, type ModelSelection } from "@/components/model-selector"
 import { useModels, type ModelPickerGroup } from "@/hooks/use-models"
+import { AUTO_MODEL_ID } from "@x/shared/dist/models.js"
 
 // The unified model-selection surface (signed-in and BYOK alike): ONE
 // required Assistant model plus per-task overrides that default to
-// "Same as Assistant". No "Auto" rows — every choice is an explicit model;
-// recommendation logic only ever picks INITIAL models at provider-connect
-// time, never appears as a dropdown option. The Image model is the one
-// slot outside that inheritance: it can't inherit the assistant (a text
-// model), so it's its own explicit pick — or unset, which turns image
-// generation off.
+// "Same as Assistant". Every choice is explicit — a concrete model, or the
+// provider-scoped "Auto" row, which persists the sentinel and follows
+// Rowboat's current recommendation at run time (task inheritance from an
+// Auto assistant resolves per task, so background work stays on the
+// recommended lite tier). The Image model is the one slot outside that
+// inheritance: it can't inherit the assistant (a text model), so it's its
+// own explicit pick — or unset, which turns image generation off.
 
 // One provider in the image-model catalog (models:listImageModels). Every
 // image-capable provider lists its own models; a provider whose listing
@@ -43,12 +45,13 @@ const TASKS: Array<{ key: TaskKey; label: string; description: string }> = [
 ]
 
 function refLabel(ref: ModelRef): string {
-  return `${providerDisplayNames[ref.provider] || ref.provider} · ${ref.model}`
+  const model = ref.model === AUTO_MODEL_ID ? "Auto" : ref.model
+  return `${providerDisplayNames[ref.provider] || ref.provider} · ${model}`
 }
 
 export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
   // The effective assistant model — the same value every picker shows.
-  const { defaultModel, defaultEffort, groups } = useModels()
+  const { defaultModel, defaultIsAuto, defaultEffort, groups } = useModels()
   const [taskModels, setTaskModels] = useState<Partial<Record<TaskKey, ModelSelection | null>>>({})
   const [imageModel, setImageModel] = useState<ModelRef | null>(null)
   const [imageProviders, setImageProviders] = useState<ImageProviderEntry[]>([])
@@ -62,17 +65,22 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
     ...(p.error ? { error: p.error } : {}),
   })), [imageProviders])
   // The assistant field's value: the stored pair, reassembled from the two
-  // snapshot fields the models store exposes.
+  // snapshot fields the models store exposes. An Auto assistant reads back
+  // as the sentinel (the STORED choice), not the model it resolved to —
+  // the picker's Auto row shows the resolution as secondary text.
   const assistantSelection: ModelSelection | null = defaultModel
-    ? { ...defaultModel, ...(defaultEffort ? { effort: defaultEffort } : {}) }
+    ? defaultIsAuto
+      ? { provider: defaultModel.provider, model: AUTO_MODEL_ID }
+      : { ...defaultModel, ...(defaultEffort ? { effort: defaultEffort } : {}) }
     : null
 
   // Retired-model detection: the saved assistant no longer appears in its
   // provider's live list. Only trusted lists count — a failed fetch or an
   // openai-compatible endpoint (whose /models is often unreliable) must not
-  // flag a working model.
+  // flag a working model. Auto never flags: it's a selection policy, not a
+  // model that can retire — resolution already prefers listed models.
   const assistantUnavailable = (() => {
-    if (!defaultModel) return false
+    if (!defaultModel || defaultIsAuto) return false
     const group = groups.find((g) => g.id === defaultModel.provider)
     if (!group || group.status !== "ok" || group.models.length === 0) return false
     if (group.flavor === "openai-compatible") return false
@@ -197,11 +205,16 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
         <div className="grid grid-cols-2 gap-x-4 gap-y-4">
           {TASKS.map(({ key, label, description }) => {
             const override = taskModels[key] ?? null
+            // Under an Auto assistant, inheritance is category-aware (each
+            // task resolves against its own recommendation slot), so don't
+            // claim the assistant's resolved model runs here.
             const inheritText = key === "subagent"
               ? "Uses the spawning chat's model"
-              : defaultModel
-                ? `Currently uses ${refLabel(defaultModel)}`
-                : "Uses the Assistant model"
+              : defaultIsAuto
+                ? "Auto — uses Rowboat's recommendation for this task"
+                : defaultModel
+                  ? `Currently uses ${refLabel(defaultModel)}`
+                  : "Uses the Assistant model"
             return (
               <div key={key} className="space-y-1.5 min-w-0">
                 <div className="flex items-baseline justify-between gap-2">
@@ -226,7 +239,11 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
                   triggerTitle={label}
                 />
                 <p className="text-[11px] text-muted-foreground truncate" title={override ? refLabel(override) : inheritText}>
-                  {override ? "Uses a different model from the Assistant" : inheritText}
+                  {override
+                    ? override.model === AUTO_MODEL_ID
+                      ? "Auto — uses Rowboat's recommendation for this task"
+                      : "Uses a different model from the Assistant"
+                    : inheritText}
                 </p>
                 <p className="sr-only">{description}</p>
               </div>

--- a/apps/x/apps/renderer/src/hooks/use-models.ts
+++ b/apps/x/apps/renderer/src/hooks/use-models.ts
@@ -35,8 +35,12 @@ export interface ModelsSnapshot {
   reasoningByKey: Record<string, boolean>
   // The effective runtime default (what a run actually uses when the user
   // hasn't picked a model) — shown in pickers instead of guessing from list
-  // order, which can disagree with the real default.
+  // order, which can disagree with the real default. Always a CONCRETE
+  // model: an Auto assistant arrives resolved (defaultIsAuto marks it).
   defaultModel: ModelRef | null
+  // True when the saved assistant is the Auto selection — defaultModel then
+  // holds what Auto currently resolves to, for "Auto · <model>" displays.
+  defaultIsAuto: boolean
   // The reasoning effort stored WITH the assistant model ('' = Auto). Seeds
   // new chats' composer state and the settings field display.
   defaultEffort: '' | 'low' | 'medium' | 'high'
@@ -60,6 +64,7 @@ const EMPTY_SNAPSHOT: ModelsSnapshot = {
   groups: [],
   reasoningByKey: {},
   defaultModel: null,
+  defaultIsAuto: false,
   defaultEffort: '',
   isRowboatConnected: false,
   catalogByProvider: {},
@@ -126,6 +131,7 @@ async function buildSnapshot(refreshProvider?: string): Promise<ModelsSnapshot> 
     groups,
     reasoningByKey,
     defaultModel,
+    defaultIsAuto: catalog.defaultModel?.isAuto === true,
     defaultEffort,
     isRowboatConnected: catalog.providers.some((p) => p.id === 'rowboat'),
     catalogByProvider,

--- a/apps/x/packages/core/src/config/rowboat.ts
+++ b/apps/x/packages/core/src/config/rowboat.ts
@@ -1,15 +1,81 @@
+import fs from "fs/promises";
+import path from "path";
 import { z } from "zod";
 import { RowboatApiConfig } from "@x/shared/dist/rowboat-account.js";
 import { API_URL } from "./env.js";
+import { WorkDir } from "./config.js";
 
-let cached: z.infer<typeof RowboatApiConfig> | null = null;
+type Config = z.infer<typeof RowboatApiConfig>;
 
-export async function getRowboatConfig(): Promise<z.infer<typeof RowboatApiConfig>> {
-  if (cached) {
+// Refetch cadence. The config used to be cached for the whole process
+// lifetime, which was fine while it only carried service URLs — but the
+// Auto model selection resolves against modelRecommendations at run time,
+// so a long-running app must eventually see a rotated recommendation
+// without a restart. Startup stays fresh for free: the in-memory timestamp
+// does not survive the process.
+const CONFIG_TTL_MS = 6 * 60 * 60 * 1000;
+
+let cached: Config | null = null;
+// 0 = the cache is stale (never fetched live, or hydrated from disk):
+// serve it on failure, but try the network on every call.
+let fetchedAt = 0;
+
+// Last-good copy of the parsed config, so an offline start still resolves
+// Auto selections (and knows service URLs) deterministically. NOT the
+// source of truth — only ever read when the live fetch fails with nothing
+// in memory.
+const snapshotPath = path.join(WorkDir, "config", "rowboat-config.json");
+
+async function readSnapshot(): Promise<Config | null> {
+  try {
+    return RowboatApiConfig.parse(JSON.parse(await fs.readFile(snapshotPath, "utf8")));
+  } catch {
+    // Missing, corrupt, or schema-drifted snapshot — behave as if absent.
+    return null;
+  }
+}
+
+async function writeSnapshot(config: Config): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+    const tmpPath = `${snapshotPath}.tmp`;
+    await fs.writeFile(tmpPath, JSON.stringify(config, null, 2));
+    await fs.rename(tmpPath, snapshotPath);
+  } catch (error) {
+    // Best-effort: a failed snapshot only costs the next offline start.
+    console.warn("[config] Could not persist the rowboat config snapshot:", error);
+  }
+}
+
+export async function getRowboatConfig(): Promise<Config> {
+  if (cached && Date.now() - fetchedAt < CONFIG_TTL_MS) {
     return cached;
   }
-  const response = await fetch(`${API_URL}/v1/config`);
-  const data = RowboatApiConfig.parse(await response.json());
-  cached = data;
-  return data;
+  try {
+    const response = await fetch(`${API_URL}/v1/config`);
+    const data = RowboatApiConfig.parse(await response.json());
+    cached = data;
+    fetchedAt = Date.now();
+    void writeSnapshot(data);
+    return data;
+  } catch (error) {
+    // Serve stale over failing: the expired in-memory copy first, then the
+    // last-good disk snapshot. Both leave fetchedAt at 0/expired so the
+    // next call retries the network.
+    if (cached) {
+      return cached;
+    }
+    const snapshot = await readSnapshot();
+    if (snapshot) {
+      cached = snapshot;
+      return snapshot;
+    }
+    throw error;
+  }
+}
+
+// Test-only: reset module state so each test starts cold.
+export function __resetRowboatConfigForTests(): void {
+  cached = null;
+  fetchedAt = 0;
 }

--- a/apps/x/packages/core/src/models/auto.test.ts
+++ b/apps/x/packages/core/src/models/auto.test.ts
@@ -1,0 +1,265 @@
+import fs from 'node:fs/promises';
+import { rmSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Auto sentinel resolution and its integration into the selection funnels.
+ * Pins the policy: recommendation (task slot first) only when the provider
+ * actually lists it, then the persisted last resolution, then first-listed;
+ * concrete selections never touch the resolver; task inheritance from an
+ * Auto assistant stays category-aware.
+ */
+
+// vi.mock factories are hoisted above module code — the temp path must be
+// computable inside vi.hoisted without imports (created in beforeEach).
+const workDir = vi.hoisted(() =>
+    `${process.env.TMPDIR?.replace(/\/$/, '') ?? '/tmp'}/models-auto-test-${process.pid}-${Math.random().toString(36).slice(2)}`,
+);
+
+const mocks = vi.hoisted(() => ({
+    listProviderModelIds: vi.fn(async (): Promise<string[]> => []),
+    getRowboatConfig: vi.fn(async (): Promise<unknown> => {
+        throw new Error('api unreachable');
+    }),
+    capture: vi.fn(),
+    getConfig: vi.fn(async (): Promise<unknown> => {
+        throw new Error('no models.json');
+    }),
+}));
+
+vi.mock('../config/config.js', () => ({ WorkDir: workDir }));
+vi.mock('./catalog.js', () => ({ listProviderModelIds: mocks.listProviderModelIds }));
+vi.mock('../config/rowboat.js', () => ({ getRowboatConfig: mocks.getRowboatConfig }));
+vi.mock('../analytics/posthog.js', () => ({ capture: mocks.capture }));
+vi.mock('../di/container.js', () => ({
+    default: { resolve: () => ({ getConfig: mocks.getConfig }) },
+}));
+
+import { resolveAutoSelection, __resetAutoResolutionForTests } from './auto.js';
+import { getDefaultModelAndProvider, getKgModel, getSubagentModelOverride } from './defaults.js';
+
+const configDir = path.join(workDir, 'config');
+
+function serveRecommendations(recommendations: Record<string, unknown>): void {
+    mocks.getRowboatConfig.mockResolvedValue({ modelRecommendations: recommendations });
+}
+
+function serveModelsJson(config: Record<string, unknown>): void {
+    mocks.getConfig.mockImplementation(async () => ({ version: 2, providers: {}, ...config }));
+}
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    __resetAutoResolutionForTests();
+    mocks.listProviderModelIds.mockResolvedValue([]);
+    mocks.getRowboatConfig.mockRejectedValue(new Error('api unreachable'));
+    mocks.getConfig.mockRejectedValue(new Error('no models.json'));
+    await fs.rm(configDir, { recursive: true, force: true });
+});
+
+afterEach(async () => {
+    await fs.rm(configDir, { recursive: true, force: true });
+});
+
+process.on('exit', () => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+});
+
+describe('resolveAutoSelection', () => {
+    it('resolves to the flavor assistant recommendation when the provider lists it', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['other-model', 'google/gemini-3.8-flash']);
+        serveRecommendations({ rowboat: { assistantModel: 'google/gemini-3.8-flash' } });
+
+        await expect(resolveAutoSelection('rowboat', 'assistant')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.8-flash',
+        });
+    });
+
+    it('prefers the task recommendation slot over the assistant slot for a task category', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['google/gemini-3.8-flash', 'google/gemini-3.1-flash-lite']);
+        serveRecommendations({
+            rowboat: {
+                assistantModel: 'google/gemini-3.8-flash',
+                taskModels: { knowledgeGraph: 'google/gemini-3.1-flash-lite' },
+            },
+        });
+
+        await expect(resolveAutoSelection('rowboat', 'knowledgeGraph')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.1-flash-lite',
+        });
+        // A category without its own slot inherits the assistant slot.
+        await expect(resolveAutoSelection('rowboat', 'chatTitle')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.8-flash',
+        });
+    });
+
+    it('carries a recommended effort into the resolved selection', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['gpt-5.4']);
+        serveRecommendations({ openai: { assistantModel: { model: 'gpt-5.4', effort: 'high' } } });
+
+        await expect(resolveAutoSelection('openai', 'assistant')).resolves.toEqual({
+            provider: 'openai',
+            model: 'gpt-5.4',
+            effort: 'high',
+        });
+    });
+
+    it('looks recommendations up by the provider entry FLAVOR, not the instance id', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['claude-opus-4-8']);
+        serveModelsJson({ providers: { 'anthropic-work': { flavor: 'anthropic' } } });
+        serveRecommendations({ anthropic: 'claude-opus-4-8' });
+
+        await expect(resolveAutoSelection('anthropic-work', 'assistant')).resolves.toEqual({
+            provider: 'anthropic-work',
+            model: 'claude-opus-4-8',
+        });
+    });
+
+    it('falls back to the first listed model when the recommendation is not served', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['first-model', 'second-model']);
+        serveRecommendations({ rowboat: { assistantModel: 'retired-model' } });
+
+        await expect(resolveAutoSelection('rowboat', 'assistant')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'first-model',
+        });
+    });
+
+    it('serves the persisted last resolution when offline with an unlistable provider', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['google/gemini-3.8-flash']);
+        serveRecommendations({ rowboat: { assistantModel: 'google/gemini-3.8-flash' } });
+        await resolveAutoSelection('rowboat', 'assistant');
+
+        // Cold process, dead network, no listable models: the cache file
+        // written above is the only signal left.
+        __resetAutoResolutionForTests();
+        mocks.listProviderModelIds.mockResolvedValue([]);
+        mocks.getRowboatConfig.mockRejectedValue(new Error('offline'));
+
+        await expect(resolveAutoSelection('rowboat', 'assistant')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.8-flash',
+        });
+    });
+
+    it('prefers a still-listed cached resolution over first-listed when the recommendation goes stale', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['other-model', 'cached-model']);
+        serveRecommendations({ rowboat: { assistantModel: 'cached-model' } });
+        await resolveAutoSelection('rowboat', 'assistant');
+
+        // The recommendation rotates to a model the gateway doesn't serve
+        // yet: stability beats jumping to an arbitrary first entry.
+        serveRecommendations({ rowboat: { assistantModel: 'unreleased-model' } });
+        await expect(resolveAutoSelection('rowboat', 'assistant')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'cached-model',
+        });
+    });
+
+    it('drops a cached resolution the provider no longer lists', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['cached-model']);
+        serveRecommendations({ rowboat: { assistantModel: 'cached-model' } });
+        await resolveAutoSelection('rowboat', 'assistant');
+
+        mocks.getRowboatConfig.mockRejectedValue(new Error('offline'));
+        mocks.listProviderModelIds.mockResolvedValue(['replacement-model']);
+
+        await expect(resolveAutoSelection('rowboat', 'assistant')).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'replacement-model',
+        });
+    });
+
+    it('throws when there is no recommendation, cache, or listed model', async () => {
+        await expect(resolveAutoSelection('rowboat', 'assistant')).rejects.toThrow(/Unable to resolve the Auto model/);
+    });
+
+    it('captures the resolution only when it changes', async () => {
+        mocks.listProviderModelIds.mockResolvedValue(['google/gemini-3.8-flash']);
+        serveRecommendations({ rowboat: { assistantModel: 'google/gemini-3.8-flash' } });
+
+        await resolveAutoSelection('rowboat', 'assistant');
+        await resolveAutoSelection('rowboat', 'assistant');
+
+        expect(mocks.capture).toHaveBeenCalledTimes(1);
+        expect(mocks.capture).toHaveBeenCalledWith('auto_model_resolved', {
+            provider: 'rowboat',
+            category: 'assistant',
+            model: 'google/gemini-3.8-flash',
+            source: 'recommendation',
+        });
+    });
+});
+
+describe('selection funnels with the Auto sentinel', () => {
+    it('getDefaultModelAndProvider resolves an Auto assistant', async () => {
+        serveModelsJson({ assistantModel: { provider: 'rowboat', model: 'auto' } });
+        mocks.listProviderModelIds.mockResolvedValue(['google/gemini-3.8-flash']);
+        serveRecommendations({ rowboat: { assistantModel: 'google/gemini-3.8-flash' } });
+
+        await expect(getDefaultModelAndProvider()).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.8-flash',
+        });
+    });
+
+    it('leaves a concrete assistant selection untouched', async () => {
+        serveModelsJson({ assistantModel: { provider: 'rowboat', model: 'pinned-model', effort: 'low' } });
+
+        await expect(getDefaultModelAndProvider()).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'pinned-model',
+            effort: 'low',
+        });
+        expect(mocks.listProviderModelIds).not.toHaveBeenCalled();
+    });
+
+    it('keeps task inheritance from an Auto assistant category-aware', async () => {
+        serveModelsJson({ assistantModel: { provider: 'rowboat', model: 'auto' } });
+        mocks.listProviderModelIds.mockResolvedValue(['google/gemini-3.8-flash', 'google/gemini-3.1-flash-lite']);
+        serveRecommendations({
+            rowboat: {
+                assistantModel: 'google/gemini-3.8-flash',
+                taskModels: { knowledgeGraph: 'google/gemini-3.1-flash-lite' },
+            },
+        });
+
+        // No knowledgeGraph override in models.json — inheritance resolves
+        // against the task's own recommendation slot, not the assistant's.
+        await expect(getKgModel()).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.1-flash-lite',
+        });
+    });
+
+    it('resolves an explicit Auto task override and keeps concrete overrides as-is', async () => {
+        serveModelsJson({
+            assistantModel: { provider: 'rowboat', model: 'pinned-model' },
+            taskModels: {
+                knowledgeGraph: { provider: 'rowboat', model: 'auto' },
+                subagent: { provider: 'rowboat', model: 'explicit-subagent-model' },
+            },
+        });
+        mocks.listProviderModelIds.mockResolvedValue(['google/gemini-3.1-flash-lite']);
+        serveRecommendations({ rowboat: { taskModels: { knowledgeGraph: 'google/gemini-3.1-flash-lite' }, assistantModel: 'x' } });
+
+        await expect(getKgModel()).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'google/gemini-3.1-flash-lite',
+        });
+        await expect(getSubagentModelOverride()).resolves.toEqual({
+            provider: 'rowboat',
+            model: 'explicit-subagent-model',
+        });
+    });
+
+    it('keeps the absent subagent override as parent-inherit (null)', async () => {
+        serveModelsJson({ assistantModel: { provider: 'rowboat', model: 'auto' } });
+
+        await expect(getSubagentModelOverride()).resolves.toBeNull();
+    });
+});

--- a/apps/x/packages/core/src/models/auto.ts
+++ b/apps/x/packages/core/src/models/auto.ts
@@ -1,0 +1,177 @@
+import fs from "fs/promises";
+import path from "path";
+import z from "zod";
+import {
+    ModelSelection as ModelSelectionSchema,
+    ReasoningEffort,
+    type TaskModelKey,
+} from "@x/shared/dist/models.js";
+import {
+    normalizeModelRecommendation,
+    type RecommendedModelChoice,
+} from "@x/shared/dist/rowboat-account.js";
+import { WorkDir } from "../config/config.js";
+import { getRowboatConfig } from "../config/rowboat.js";
+import { capture } from "../analytics/posthog.js";
+import container from "../di/container.js";
+import { IModelConfigRepo } from "./repo.js";
+import { listProviderModelIds } from "./catalog.js";
+
+type ModelSelection = z.infer<typeof ModelSelectionSchema>;
+
+/**
+ * Resolution of the Auto sentinel ({ provider, model: "auto" }) into a
+ * concrete model. Called from the selection funnels in defaults.ts and from
+ * run creation — never below them, so a resolved model is pinned before
+ * anything provider-facing runs (createLanguageModel refuses the sentinel
+ * outright as the last line of defense).
+ *
+ * Auto is provider-scoped: the provider on the sentinel is real and is
+ * never switched here; only the model is chosen, in this order —
+ *
+ *   1. The provider flavor's recommendation from /v1/config, task-specific
+ *      slot first when resolving a task category, then the assistant slot —
+ *      each applied only when the provider's live catalog actually lists it
+ *      (a stale recommendation must degrade, not 403/error every request).
+ *   2. The last resolution this process line persisted (stability when the
+ *      recommendation rotates to something the catalog doesn't serve yet,
+ *      and the only option while offline with an unlistable provider).
+ *   3. The first model the provider lists (the same last-resort rule as
+ *      initial selection).
+ *
+ * Concrete user selections never reach this module: the funnels only
+ * resolve entries that carry the sentinel.
+ */
+export type AutoCategory = "assistant" | TaskModelKey;
+
+// One remembered resolution per provider+category, persisted so an offline
+// start resolves Auto to what it resolved to last time instead of erroring.
+const CachedResolution = z.object({
+    model: z.string(),
+    effort: ReasoningEffort.optional(),
+});
+const ResolutionCacheFile = z.record(z.string(), CachedResolution);
+type ResolutionCache = z.infer<typeof ResolutionCacheFile>;
+
+const cachePath = path.join(WorkDir, "config", "auto-model-cache.json");
+
+// Loaded once per process; written through on change. Derived state only —
+// losing it costs nothing while online.
+let resolutionCache: ResolutionCache | null = null;
+
+async function loadResolutionCache(): Promise<ResolutionCache> {
+    if (!resolutionCache) {
+        try {
+            resolutionCache = ResolutionCacheFile.parse(JSON.parse(await fs.readFile(cachePath, "utf8")));
+        } catch {
+            // Missing, corrupt, or schema-drifted — start empty.
+            resolutionCache = {};
+        }
+    }
+    return resolutionCache;
+}
+
+async function persistResolutionCache(cache: ResolutionCache): Promise<void> {
+    try {
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        const tmpPath = `${cachePath}.tmp`;
+        await fs.writeFile(tmpPath, JSON.stringify(cache, null, 2));
+        await fs.rename(tmpPath, cachePath);
+    } catch (error) {
+        console.warn("[models] Could not persist the Auto resolution cache:", error);
+    }
+}
+
+/**
+ * Recommendations are keyed by provider FLAVOR; sentinels carry provider
+ * INSTANCE ids. Same lookup rule as resolveProviderConfig: rowboat/codex
+ * are their own flavors, everything else reads the providers map.
+ */
+async function flavorOf(providerId: string): Promise<string> {
+    if (providerId === "rowboat" || providerId === "codex") return providerId;
+    try {
+        const repo = container.resolve<IModelConfigRepo>("modelConfigRepo");
+        const cfg = await repo.getConfig();
+        return cfg.providers[providerId]?.flavor ?? providerId;
+    } catch {
+        return providerId;
+    }
+}
+
+async function remember(
+    key: string,
+    choice: { model: string; effort?: z.infer<typeof ReasoningEffort> },
+    source: "recommendation" | "cached" | "first_listed",
+    providerId: string,
+    category: AutoCategory,
+): Promise<void> {
+    const cache = await loadResolutionCache();
+    const previous = cache[key];
+    if (previous && previous.model === choice.model && previous.effort === choice.effort) return;
+    cache[key] = { model: choice.model, ...(choice.effort ? { effort: choice.effort } : {}) };
+    await persistResolutionCache(cache);
+    // Change-only, so a recommendation rotation shows up as one event per
+    // slot rather than one per run.
+    capture("auto_model_resolved", {
+        provider: providerId,
+        category,
+        model: choice.model,
+        source,
+    });
+}
+
+export async function resolveAutoSelection(
+    providerId: string,
+    category: AutoCategory,
+): Promise<ModelSelection> {
+    const cacheKey = `${providerId}/${category}`;
+    // The catalog's per-provider cache makes this cheap after the first call;
+    // an unlistable provider yields [] and the fallback chain takes over.
+    const availableIds: string[] = await listProviderModelIds(providerId).catch(() => []);
+
+    const flavor = await flavorOf(providerId);
+    const recommendations = (await getRowboatConfig().catch(() => null))?.modelRecommendations;
+    const recommendation = normalizeModelRecommendation(recommendations, flavor);
+    const candidates: RecommendedModelChoice[] = [];
+    if (recommendation) {
+        if (category !== "assistant") {
+            const taskRecommendation = recommendation.taskModels[category];
+            if (taskRecommendation) candidates.push(taskRecommendation);
+        }
+        candidates.push(recommendation.assistantModel);
+    }
+
+    const recommended = candidates.find((c) => availableIds.includes(c.model));
+    if (recommended) {
+        await remember(cacheKey, recommended, "recommendation", providerId, category);
+        return {
+            provider: providerId,
+            model: recommended.model,
+            ...(recommended.effort ? { effort: recommended.effort } : {}),
+        };
+    }
+
+    const cached = (await loadResolutionCache())[cacheKey];
+    if (cached && (availableIds.length === 0 || availableIds.includes(cached.model))) {
+        return {
+            provider: providerId,
+            model: cached.model,
+            ...(cached.effort ? { effort: cached.effort } : {}),
+        };
+    }
+
+    const first = availableIds[0];
+    if (first) {
+        await remember(cacheKey, { model: first }, "first_listed", providerId, category);
+        return { provider: providerId, model: first };
+    }
+
+    throw new Error(
+        `Unable to resolve the Auto model for provider '${providerId}': no applicable recommendation, cached resolution, or listed model`,
+    );
+}
+
+// Test-only: drop the in-memory cache so each test starts cold.
+export function __resetAutoResolutionForTests(): void {
+    resolutionCache = null;
+}

--- a/apps/x/packages/core/src/models/catalog.ts
+++ b/apps/x/packages/core/src/models/catalog.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { LlmModelConfig, LlmProvider } from "@x/shared/dist/models.js";
+import { LlmModelConfig, LlmProvider, isAutoModel } from "@x/shared/dist/models.js";
 import { isSignedIn } from "../account/account.js";
 import { getChatGPTStatus } from "../auth/chatgpt-auth.js";
 import container from "../di/container.js";
@@ -49,8 +49,11 @@ export interface CatalogProviderEntry {
 export interface ModelCatalogResult {
     providers: CatalogProviderEntry[];
     /** The effective runtime default (what runs when nothing is picked),
-     *  with the effort stored alongside it — seeds new chats' composers. */
-    defaultModel: { provider: string; model: string; effort?: "low" | "medium" | "high" } | null;
+     *  with the effort stored alongside it — seeds new chats' composers.
+     *  Always a CONCRETE model: an Auto assistant arrives resolved, with
+     *  isAuto set so pickers can present it as "Auto" rather than treating
+     *  the sentinel as a missing model. */
+    defaultModel: { provider: string; model: string; effort?: "low" | "medium" | "high"; isAuto?: boolean } | null;
 }
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
@@ -230,26 +233,50 @@ export interface GetModelCatalogOptions {
     refreshProvider?: string;
 }
 
+// One models.dev read serves every cloud flavor in the build (disk cache,
+// no network — refreshed by its own background loop). Empty map on failure
+// → cloud flavors fall through to live listing.
+async function readModelsDevByFlavor(): Promise<Map<string, CatalogModelEntry[]>> {
+    const modelsDevByFlavor = new Map<string, CatalogModelEntry[]>();
+    try {
+        const catalog = await listOnboardingModels();
+        for (const p of catalog.providers) {
+            modelsDevByFlavor.set(p.id, p.models.map(({ id, name, reasoning }) => ({
+                id,
+                ...(name ? { name } : {}),
+                ...(reasoning !== undefined ? { reasoning } : {}),
+            })));
+        }
+    } catch {
+        // Empty map → cloud flavors fall through to live listing.
+    }
+    return modelsDevByFlavor;
+}
+
+/**
+ * The model ids one provider currently serves, through the same
+ * per-provider cache the catalog uses (so callers piggyback on picker
+ * listings and vice versa). Empty when the provider isn't connected or its
+ * list failed — the caller owns the fallback; used by the Auto resolver to
+ * validate recommendations before applying them.
+ */
+export async function listProviderModelIds(providerId: string): Promise<string[]> {
+    const discovered = await discoverProviders();
+    const provider = discovered.find((p) => p.id === providerId);
+    if (!provider) return [];
+    const modelsDevByFlavor = MODELS_DEV_FLAVORS.has(provider.flavor)
+        ? await readModelsDevByFlavor()
+        : new Map<string, CatalogModelEntry[]>();
+    const entry = await resolveProviderEntry(provider, modelsDevByFlavor, false);
+    return entry.models.map((m) => m.id);
+}
+
 export async function getModelCatalog(options?: GetModelCatalogOptions): Promise<ModelCatalogResult> {
     const discovered = await discoverProviders();
 
-    // One models.dev read serves every cloud flavor in the build (disk cache,
-    // no network — refreshed by its own background loop).
-    const modelsDevByFlavor = new Map<string, CatalogModelEntry[]>();
-    if (discovered.some((p) => MODELS_DEV_FLAVORS.has(p.flavor))) {
-        try {
-            const catalog = await listOnboardingModels();
-            for (const p of catalog.providers) {
-                modelsDevByFlavor.set(p.id, p.models.map(({ id, name, reasoning }) => ({
-                    id,
-                    ...(name ? { name } : {}),
-                    ...(reasoning !== undefined ? { reasoning } : {}),
-                })));
-            }
-        } catch {
-            // Empty map → cloud flavors fall through to live listing.
-        }
-    }
+    const modelsDevByFlavor = discovered.some((p) => MODELS_DEV_FLAVORS.has(p.flavor))
+        ? await readModelsDevByFlavor()
+        : new Map<string, CatalogModelEntry[]>();
 
     const entries = await Promise.all(discovered.map(async (provider) => {
         const entry = await resolveProviderEntry(
@@ -269,7 +296,12 @@ export async function getModelCatalog(options?: GetModelCatalogOptions): Promise
 
     let defaultModel: ModelCatalogResult["defaultModel"] = null;
     try {
-        defaultModel = await getDefaultModelAndProvider();
+        // Always the RESOLVED default — an Auto assistant comes back as the
+        // concrete model it currently resolves to, flagged so pickers can
+        // present it as "Auto" instead of a plain model choice.
+        const resolved = await getDefaultModelAndProvider();
+        const isAuto = isAutoModel((await readModelConfig())?.assistantModel?.model);
+        defaultModel = { ...resolved, ...(isAuto ? { isAuto: true } : {}) };
     } catch {
         // No default resolvable (no config, signed out) — the picker copes.
     }

--- a/apps/x/packages/core/src/models/defaults.ts
+++ b/apps/x/packages/core/src/models/defaults.ts
@@ -1,6 +1,7 @@
 import z from "zod";
-import { LlmModelConfig, LlmProvider, ModelSelection as ModelSelectionSchema, type TaskModelKey } from "@x/shared/dist/models.js";
+import { LlmModelConfig, LlmProvider, ModelSelection as ModelSelectionSchema, isAutoModel, type TaskModelKey } from "@x/shared/dist/models.js";
 import { IModelConfigRepo } from "./repo.js";
+import { resolveAutoSelection } from "./auto.js";
 import container from "../di/container.js";
 
 // THE canonical selection: provider + model + the effort picked with them,
@@ -30,6 +31,9 @@ export async function getDefaultModelAndProvider(): Promise<ModelSelection> {
     const assistant = cfg?.assistantModel;
     if (!assistant) {
         throw new Error("No assistant model configured (connect a provider or sign in)");
+    }
+    if (isAutoModel(assistant.model)) {
+        return resolveAutoSelection(assistant.provider, "assistant");
     }
     return {
         model: assistant.model,
@@ -94,16 +98,29 @@ export async function resolveProviderConfig(name: string): Promise<z.infer<typeo
  * effort stored on it), else the assistant model+effort pair. No hidden
  * per-task defaults — the v2 migration materialized the historical curated
  * models as visible overrides.
+ *
+ * Auto stays category-aware through inheritance: a task inheriting from an
+ * Auto assistant resolves against the TASK's recommendation slot first, so
+ * always-on background work keeps running on the recommended lite-tier
+ * models (the credit economics that per-task recommendations exist for)
+ * instead of whatever the assistant resolves to.
  */
 async function getCategoryModel(category: TaskModelKey): Promise<ModelSelection> {
     const cfg = await readConfig();
     const override = cfg?.taskModels?.[category];
     if (override) {
+        if (isAutoModel(override.model)) {
+            return resolveAutoSelection(override.provider, category);
+        }
         return {
             model: override.model,
             provider: override.provider,
             ...(override.effort ? { effort: override.effort } : {}),
         };
+    }
+    const assistant = cfg?.assistantModel;
+    if (assistant && isAutoModel(assistant.model)) {
+        return resolveAutoSelection(assistant.provider, category);
     }
     return getDefaultModelAndProvider();
 }
@@ -149,5 +166,12 @@ export async function getBackgroundTaskAgentModel(): Promise<ModelSelection> {
  */
 export async function getSubagentModelOverride(): Promise<ModelSelection | null> {
     const cfg = await readConfig();
-    return cfg?.taskModels?.subagent ?? null;
+    const override = cfg?.taskModels?.subagent ?? null;
+    if (override && isAutoModel(override.model)) {
+        // An EXPLICIT Auto override resolves like any task slot; the
+        // absent-override default stays the parent turn's model (which is
+        // already concrete by the time a subagent spawns).
+        return resolveAutoSelection(override.provider, "subagent");
+    }
+    return override;
 }

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -6,7 +6,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOllama } from "ollama-ai-provider-v2";
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { LlmModelConfig, LlmProvider } from "@x/shared/dist/models.js";
+import { LlmModelConfig, LlmProvider, isAutoModel } from "@x/shared/dist/models.js";
 import z from "zod";
 import { getGatewayProvider } from "./gateway.js";
 import { getCodexProvider } from "./codex.js";
@@ -97,6 +97,12 @@ export function createLanguageModel(
     providerConfig: z.infer<typeof Provider>,
     modelId: string,
 ): LanguageModel {
+    if (isAutoModel(modelId)) {
+        // Last line of defense: the sentinel resolves in the selection
+        // funnels (defaults.ts / run creation). Reaching a provider SDK —
+        // or the gateway, which would 403 it — means a funnel was bypassed.
+        throw new Error("The Auto model selection must be resolved to a concrete model before invoking a provider");
+    }
     const model = createProvider(providerConfig).languageModel(modelId);
     return applyLocalModelSettings(model, providerConfig);
 }

--- a/apps/x/packages/core/src/models/rowboat-selection.ts
+++ b/apps/x/packages/core/src/models/rowboat-selection.ts
@@ -3,6 +3,7 @@ import { IModelConfigRepo } from "./repo.js";
 import { listGatewayModels } from "./gateway.js";
 import { getRowboatConfig } from "../config/rowboat.js";
 import { selectInitialModel, selectInitialTaskModels } from "./initial-selection.js";
+import { AUTO_MODEL_ID } from "@x/shared/dist/models.js";
 import { normalizeModelRecommendation } from "@x/shared/dist/rowboat-account.js";
 import { capture } from "../analytics/posthog.js";
 
@@ -13,8 +14,10 @@ import { capture } from "../analytics/posthog.js";
  *
  * - Connect with no saved assistant → pick an initial model (backend
  *   recommendation if the gateway lists it, else the first listed model)
- *   and save it. A saved assistant is NEVER replaced — recommendations only
- *   ever choose the initial model.
+ *   and save it. When the backend's autoModelDefault rollout flag is on,
+ *   the initial pick is the Auto sentinel instead — resolved per run by
+ *   core/models/auto.ts. A saved assistant is NEVER replaced —
+ *   recommendations only ever choose the initial model.
  * - Connect with no saved image model → seed the gateway's image model.
  *   Its own guard, not the assistant's: the image model cannot inherit the
  *   assistant (a text model), so a BYOK user who already has an assistant
@@ -40,9 +43,28 @@ type Config = Awaited<ReturnType<IModelConfigRepo["getConfig"]>>;
 async function seedAssistantModel(repo: IModelConfigRepo, cfg: Config | null): Promise<void> {
     try {
         if (cfg?.assistantModel) return; // saved choice — never replaced
+        const rowboatConfig = await getRowboatConfig().catch(() => null);
+        if (rowboatConfig?.features?.autoModelDefault) {
+            // Rollout-flagged Auto default: seed the sentinel instead of a
+            // pinned model, and skip materializing task overrides — Auto
+            // resolution is category-aware, so the per-task recommendations
+            // keep steering background work without frozen copies. An older
+            // backend (no features block) keeps the pinning path below.
+            await repo.updateConfig({
+                assistantModel: { provider: "rowboat", model: AUTO_MODEL_ID },
+            });
+            capture("llm_initial_model_selected", {
+                flavor: "rowboat",
+                model: AUTO_MODEL_ID,
+                auto_default: true,
+                task_overrides_seeded: 0,
+                source: "sign_in",
+            });
+            return;
+        }
         const catalog = await listGatewayModels();
         const ids = catalog.providers[0]?.models.map((m) => m.id) ?? [];
-        const recommendations = (await getRowboatConfig().catch(() => null))?.modelRecommendations;
+        const recommendations = rowboatConfig?.modelRecommendations;
         const choice = selectInitialModel("rowboat", ids, recommendations);
         if (choice) {
             // Task recommendations ride along the seeding moment: the

--- a/apps/x/packages/core/src/runtime/legacy/runs.ts
+++ b/apps/x/packages/core/src/runtime/legacy/runs.ts
@@ -13,6 +13,8 @@ import { extractCommandNames } from "../../application/lib/command-executor.js";
 import { addFileAccessGrant, addToSecurityConfig } from "../../config/security.js";
 import { loadAgent } from "../assembly/registry.js";
 import { getDefaultModelAndProvider } from "../../models/defaults.js";
+import { resolveAutoSelection } from "../../models/auto.js";
+import { isAutoModel } from "@x/shared/dist/models.js";
 
 export async function createRun(opts: z.infer<typeof CreateRunOptions>): Promise<z.infer<typeof Run>> {
     const repo = container.resolve<IRunsRepo>('runsRepo');
@@ -25,8 +27,14 @@ export async function createRun(opts: z.infer<typeof CreateRunOptions>): Promise
     // next link in the chain instead of being treated as a real value.
     const agent = await loadAgent(opts.agentId);
     const defaults = await getDefaultModelAndProvider();
-    const model = opts.model || agent.model || defaults.model;
+    let model = opts.model || agent.model || defaults.model;
     const provider = opts.provider || agent.provider || defaults.provider;
+    if (isAutoModel(model)) {
+        // An Auto sentinel from opts or an agent declaration (defaults come
+        // back already resolved) pins its concrete resolution here, so the
+        // run keeps one model for its whole life like any other run.
+        ({ model } = await resolveAutoSelection(provider, "assistant"));
+    }
     const useCase = opts.useCase ?? "copilot_chat";
 
     const run = await repo.create({

--- a/apps/x/packages/core/src/runtime/turns/bridges/inline-agent-resolver.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/inline-agent-resolver.ts
@@ -9,6 +9,8 @@ import {
 import { ResolvedAgent as ResolvedAgentSchema } from "@x/shared/dist/turns.js";
 import { BuiltinTools } from "../../tools/catalog.js";
 import { getDefaultModelAndProvider } from "../../../models/defaults.js";
+import { resolveAutoSelection } from "../../../models/auto.js";
+import { isAutoModel } from "@x/shared/dist/models.js";
 import { builtinToolDescriptor } from "../../tools/descriptors.js";
 
 // Default tool profile for inline agents that omit `tools`: every builtin
@@ -59,6 +61,13 @@ export class InlineAgentResolver {
         if (!model) {
             const fallback = await this.defaultModel();
             model = { provider: fallback.provider, model: fallback.model };
+        }
+        if (isAutoModel(model.model)) {
+            // An Auto sentinel on an inline spec pins its concrete
+            // resolution into this agent's snapshot (the default fallback
+            // arrives already resolved).
+            const resolved = await resolveAutoSelection(model.provider, "assistant");
+            model = { provider: resolved.provider, model: resolved.model };
         }
 
         const names =

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-agent-resolver.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-agent-resolver.ts
@@ -17,6 +17,8 @@ import { BuiltinTools } from "../../tools/catalog.js";
 import { skillToolNames } from "../../assembly/skills/index.js";
 import { ModeFlags } from "../../assembly/capabilities/types.js";
 import { getDefaultModelAndProvider } from "../../../models/defaults.js";
+import { resolveAutoSelection } from "../../../models/auto.js";
+import { isAutoModel } from "@x/shared/dist/models.js";
 import {
     builtinToolDescriptor,
     toJsonValue,
@@ -155,6 +157,13 @@ export class RealAgentResolver {
                 provider: agent.provider ?? fallback.provider,
                 model: agent.model ?? fallback.model,
             };
+        }
+        if (isAutoModel(model.model)) {
+            // An Auto sentinel from a turn override or an agent declaration
+            // (the app default arrives already resolved) pins its concrete
+            // resolution into this turn's snapshot.
+            const resolved = await resolveAutoSelection(model.provider, "assistant");
+            model = { provider: resolved.provider, model: resolved.model };
         }
 
         const parsed = CompositionOverrides.safeParse(

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -885,8 +885,10 @@ export const ipcSchemas = {
         })),
       })),
       // The effective runtime default (what runs when nothing is picked),
-      // effort included — it seeds new chats' composer state.
-      defaultModel: ModelSelection.nullable(),
+      // effort included — it seeds new chats' composer state. Always a
+      // CONCRETE model: an Auto assistant arrives resolved, with isAuto set
+      // so pickers can present it as "Auto" rather than a plain choice.
+      defaultModel: ModelSelection.extend({ isAuto: z.boolean().optional() }).nullable(),
     }),
   },
   // The image-model catalog for the settings "Image model" picker: the

--- a/apps/x/packages/shared/src/models.ts
+++ b/apps/x/packages/shared/src/models.ts
@@ -41,6 +41,20 @@ export const ModelRef = z.object({
   model: z.string(),
 });
 
+// The reserved model id for the Auto selection: "whatever Rowboat currently
+// recommends for this provider". Provider-scoped — the provider on the ref
+// is real and never switched; only the model resolves dynamically, at run
+// creation (core/models/auto.ts), against the /v1/config recommendations.
+// The sentinel is a valid ModelRef.model string on purpose: it persists in
+// models.json and crosses IPC without schema changes, and resolution is the
+// job of the core selection funnels — it must never reach a provider SDK.
+export const AUTO_MODEL_ID = "auto";
+
+/** True when a ref/selection is the Auto sentinel rather than a concrete model. */
+export function isAutoModel(model: string | null | undefined): boolean {
+  return model === AUTO_MODEL_ID;
+}
+
 // Stored effort is lenient on read: missing, null, and "auto" all mean Auto
 // (send nothing; provider default) and normalize to `undefined`. Writers
 // emit the canonical form — the key omitted when Auto.

--- a/apps/x/packages/shared/src/rowboat-account.ts
+++ b/apps/x/packages/shared/src/rowboat-account.ts
@@ -37,14 +37,15 @@ export const RowboatApiConfig = z.object({
   // task key = inherit the assistant — task recs exist only where the
   // intended model differs; for rowboat they reproduce the pre-v2 curated
   // lite-tier task models so plan credits aren't burned by background
-  // services). Hints for the INITIAL selection when a provider is first
-  // connected — never a catalog, and never applied over a saved choice
-  // (see shared/initial-selection.ts). The bare-string form is the legacy
-  // wire shape, accepted so backend deploy order and rollback are
-  // non-events. Local/custom flavors are intentionally absent: the API
-  // can't know which models exist in a user's environment. Optional so
-  // older API deployments and failed fetches never break parsing —
-  // recommendations are best-effort by design.
+  // services). Two consumers, same rule — never applied over a concrete
+  // saved choice: they steer the INITIAL selection when a provider is first
+  // connected (see shared/initial-selection.ts), and they are what a saved
+  // "auto" sentinel selection resolves to at run time (core/models/auto.ts).
+  // The bare-string form is the legacy wire shape, accepted so backend
+  // deploy order and rollback are non-events. Local/custom flavors are
+  // intentionally absent: the API can't know which models exist in a user's
+  // environment. Optional so older API deployments and failed fetches never
+  // break parsing — recommendations are best-effort by design.
   modelRecommendations: z.record(z.string(), z.union([
     z.string(),
     z.object({
@@ -52,6 +53,16 @@ export const RowboatApiConfig = z.object({
       taskModels: z.record(z.string(), RecommendedChoice).optional(),
     }),
   ])).optional(),
+  // App rollout flags. Additive by contract: absent (older API deployments,
+  // failed fetches) reads the same as all-false, and each flag is parsed
+  // leniently — a backend experimenting with non-boolean values must
+  // degrade the flag, never fail the /v1/config parse that auth and
+  // billing also ride on. autoModelDefault: fresh Rowboat sign-ins seed
+  // the assistant as the Auto selection instead of pinning a concrete
+  // model (core/models/rowboat-selection.ts).
+  features: z.object({
+    autoModelDefault: z.unknown().transform((v) => v === true).optional(),
+  }).optional(),
 });
 
 export type ModelRecommendations = NonNullable<z.infer<typeof RowboatApiConfig>['modelRecommendations']>;


### PR DESCRIPTION
## Purpose

Adds an **Auto** model option: the assistant (and any task slot) can persist the provider-scoped sentinel `{ provider, model: "auto" }`, and the concrete model is resolved at run creation from the backend's `/v1/config` `modelRecommendations`. Today a recommendation change only steers first-connect seeding — existing users stay pinned forever. With Auto, rotating a recommendation retargets every Auto user's **new** runs, with no app release.

Companion backend PR (flag + safety invariant): rowboatlabs/rowboatx-backend#31.

## Semantics

- **Provider-scoped**: Auto never switches providers, only the model within the sentinel's provider.
- **Resolution order** (`packages/core/src/models/auto.ts`): task recommendation slot (for task categories) → assistant recommendation slot — each applied only when the provider's live catalog lists it → persisted last resolution (`auto-model-cache.json`; offline stability) → first listed model → same error as an unset assistant.
- **Pinning**: `createRun` and both turn agent-resolvers resolve the sentinel and snapshot the concrete model, so existing conversations never switch midstream; new chats/tasks pick up rotations. `createLanguageModel` hard-refuses `"auto"` as the last line of defense — the sentinel can never reach a provider SDK or the gateway (which would 403 it).
- **Category-aware inheritance**: a task with no override under an Auto assistant resolves against the *task's* recommendation slot first, keeping always-on background work on the recommended lite tier (the credit economics the per-task recommendations exist for).
- **Subagent**: absent override still means parent-inherit; an explicit Auto override resolves like any slot.
- **Explicit selections always win**: the funnels only resolve entries carrying the sentinel; concrete saved choices are byte-for-byte untouched.
- **Seeding**: fresh Rowboat sign-ins seed Auto **only when** the backend serves `features.autoModelDefault: true`; older backend / flag off keeps today's pin-at-sign-in path. Sign-out cleanup already drops rowboat-scoped selections (`removeProvider`).
- **Config freshness**: `/v1/config` now refetches on a 6h TTL with a last-good disk snapshot (was: cached for the whole process lifetime); stale is served over failing so offline starts resolve deterministically.
- **UI**: picker groups with a recommendation get an "Auto" row (secondary text shows the current resolution when known); settings shows an Auto assistant as **Auto** — never "Unavailable" — and the task-inherit caption reflects category-aware resolution; the composer pill reads "Auto · <model>" while following an Auto default.
- **Parity**: shared IPC schema change (`models:list` → `defaultModel.isAuto`) flows through both Electron main and rowboat-server handlers unchanged (both pass the catalog through).

## Compatibility

- **New app + old backend**: `features` absent → parsed as all-false → sign-in behavior unchanged; the Auto picker row still works as a user opt-in (resolution falls back rec→cache→first-listed).
- **Old app + new backend**: unknown `features` field is stripped by the lenient wire schema — no effect.
- **models.json stays schema v2** — the sentinel is a valid model string; no migration, clean rollback among Auto-aware builds. Known (accepted) downgrade edge: a pre-Auto build reading `model: "auto"` would send it to the gateway and get a clear "Model not allowed" error; re-picking a model recovers.

## Tests

All green in this branch's worktree:
- `test:core` **841 passed (73 files)** — includes new `auto.test.ts` (recommendation/task-slot precedence, effort carry, flavor-vs-instance lookup, stale-rec fallback, offline cache, cache invalidation, throw case, change-only telemetry, funnel integration incl. category-aware inheritance and subagent null).
- `test:shared` **304 passed**, `test:server` **24 passed**, `test:renderer` **373 passed**.
- `npm run typecheck` (shared/core/client/server/renderer) and `npm run lint` clean; preload + Electron main + rowboat-server bundles build.
- Note: `spaces/client.test.ts` requires the sibling `apps/harbor` package to be built (`cd apps/harbor && pnpm install && npm run build`) — pre-existing environment requirement, not related to this change.

## Rollout (order matters only for the default, not for safety)

1. Merge + deploy backend PR #31 with `AUTO_MODEL_DEFAULT_ENABLED` unset (off). Any order is safe, but the flag must exist before it can be turned on.
2. Ship this app release — Auto is picker-opt-in only at this point.
3. Enable `AUTO_MODEL_DEFAULT_ENABLED=true` per environment → fresh sign-ins default to Auto.
4. Watch: `llm_initial_model_selected` (`model: "auto"`, `auto_default`), new `auto_model_resolved` (source mix — rising `first_listed` means rec/allowlist drift), gateway "Model not allowed" 403 rate (must stay flat).
5. Rollback: unset the env flag (stops new Auto defaults; existing Auto selections keep resolving client-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)