### PR TITLE
Spaces header: identity left, search centre, one home per tool

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -1,13 +1,13 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
-import { Bell, BellOff, Check, ChevronDown, Clock, Columns2, FileText, FolderOpen, Link as LinkIcon, Loader2, MoreHorizontal, PenTool, Plus } from 'lucide-react'
+import { Bell, BellOff, Check, Clock, Columns2, Copy, FileText, FolderOpen, Hash, Link as LinkIcon, Loader2, MoreHorizontal, PenTool, Plus, Users } from 'lucide-react'
 import { spaces } from '@x/shared'
 import { Button } from '@/components/ui/button'
 import {
-    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSub, DropdownMenuSubContent,
-    DropdownMenuSubTrigger, DropdownMenuTrigger,
+    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { AddOrgDialog, AvatarStack, MemberAvatar, MemberProfilePopover, OrgMonogram } from '@/components/spaces/atoms'
+import { AddOrgDialog, MemberAvatar, MemberProfilePopover, OrgMonogram } from '@/components/spaces/atoms'
 import { BookmarksPopover } from '@/components/spaces/bookmarks'
 import { FileColumn, TrashDialog, UploadFilesDialog } from '@/components/spaces/files-tab'
 import { GeneralStream } from '@/components/spaces/general-stream'
@@ -623,27 +623,68 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
         <div className="relative flex-1 min-h-0 flex flex-col">
             {/* One per pane — covers the stream and thread panes alike. */}
             {active && <SelectionCopy />}
-            <header className="flex items-center gap-3 px-4 h-12 shrink-0 border-b border-border">
-                <OrgMonogram org={org} />
-                <h1 className="text-[15px] font-semibold truncate">{space.name}</h1>
-                <span className="text-xs text-muted-foreground truncate hidden md:inline" title={`${org.address} · you are ${org.memberId}`}>
-                    {org.address}
-                </span>
+            <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+                {/* Left: the org's mark, then # the space. Hover it for what the
+                    old identity card said — org name, address, who you are.
+                    Inviting lives with the members; nothing here repeats it. */}
+                <HoverCard openDelay={200} closeDelay={150}>
+                    <HoverCardTrigger asChild>
+                        <button
+                            type="button"
+                            className="flex h-9 max-w-[320px] shrink-0 items-center gap-2 rounded-md pl-1 pr-2 hover:bg-accent/60 data-[state=open]:bg-accent/60"
+                        >
+                            <OrgMonogram org={org} />
+                            <span className="flex min-w-0 items-center gap-0.5">
+                                <Hash className="size-4 shrink-0 text-muted-foreground" />
+                                <h1 className="truncate text-[15px] font-semibold">{space.name}</h1>
+                            </span>
+                        </button>
+                    </HoverCardTrigger>
+                    <HoverCardContent align="start" sideOffset={4} className="w-72 p-3">
+                        <div className="flex items-center gap-2.5">
+                            <OrgMonogram org={org} />
+                            <div className="min-w-0">
+                                <div className="truncate text-sm font-medium">{org.name}</div>
+                                <div className="truncate text-xs text-muted-foreground">{org.address}</div>
+                            </div>
+                        </div>
+                        <div className="mt-2 truncate text-xs text-muted-foreground">
+                            #{space.name} · you are <span className="font-mono">{org.memberId}</span>
+                        </div>
+                        <div className="mt-2 border-t border-border pt-2">
+                            <button
+                                type="button"
+                                onClick={() => void navigator.clipboard.writeText(org.address).then(() => toast('Address copied', 'success'))}
+                                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+                            >
+                                <Copy className="size-3.5" /> Copy address
+                            </button>
+                        </div>
+                    </HoverCardContent>
+                </HoverCard>
+
+                {/* Centre: search gets the room. */}
+                <div className="flex min-w-0 flex-1 justify-center px-2">
+                    <SpaceSearch orgId={org.id} spaceId={space.id} selfMemberId={org.memberId} onNavigate={select} className="w-full max-w-[480px]" />
+                </div>
+
+                {/* Right: members as one pill (a dot when anyone is here — the
+                    roster says who), then the tools. */}
                 <Popover>
                     <PopoverTrigger asChild>
                         <button
                             type="button"
-                            className="group flex cursor-pointer items-center gap-2 rounded-md px-1 py-0.5 hover:bg-accent/60 data-[state=open]:bg-accent/60"
-                            title="See who's in this space"
+                            className="inline-flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-border px-2 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground data-[state=open]:bg-accent/60 data-[state=open]:text-foreground"
+                            title={here.length > 0 ? `${members.length} members · ${here.length} here` : `${members.length} members`}
                         >
-                            <AvatarStack members={members} />
-                            <span className="text-xs text-muted-foreground whitespace-nowrap">
-                                {members.length} {members.length === 1 ? 'member' : 'members'}
+                            <span className="relative">
+                                <Users className="size-3.5" />
+                                {here.length > 0 && <span className="absolute -right-1 -top-1 size-2 rounded-full bg-[var(--rowboat-success)] ring-2 ring-background" />}
                             </span>
-                            <ChevronDown className="-ml-1 size-3 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-data-[state=open]:opacity-100" />
+                            <span className="tabular-nums">{members.length}</span>
                         </button>
                     </PopoverTrigger>
-                    <PopoverContent align="start" className="w-64 p-1.5">
+                    <PopoverContent align="end" className="w-64 p-1.5">
                         <div className="px-2 pb-1 pt-0.5 text-[13px] text-muted-foreground">
                             Members — {members.length}
                         </div>
@@ -681,30 +722,37 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                         </div>
                     </PopoverContent>
                 </Popover>
-                {here.length > 0 && (
-                    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground" title={here.map((id) => memberNames.get(id) ?? id).join(', ')}>
-                        <span className="size-1.5 rounded-full bg-[var(--rowboat-success)]" /> {here.length} here
-                    </span>
-                )}
-                <div className="flex-1" />
-                <SpaceSearch orgId={org.id} spaceId={space.id} selfMemberId={org.memberId} onNavigate={select} />
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                         <button
                             type="button"
-                            title={dndActive ? `Do not disturb until ${new Date(dndUntil!).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}` : 'Do not disturb'}
+                            title={dndActive
+                                ? `Do not disturb until ${new Date(dndUntil!).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+                                : `Notifications — ${notifyChoices.find((c) => c.level === (notify.spaceLevel ?? 'mentions'))?.label ?? 'Mentions only'}`}
                             className={cn(
                                 'inline-flex size-7 items-center justify-center rounded-md hover:bg-accent',
                                 dndActive ? 'text-amber-600 dark:text-amber-400' : 'text-muted-foreground hover:text-foreground',
                             )}
                         >
-                            {dndActive ? <BellOff className="size-4" /> : <Bell className="size-4" />}
+                            {dndActive || notify.spaceLevel === 'mute' ? <BellOff className="size-4" /> : <Bell className="size-4" />}
                         </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                        {/* The space's level — what reaches you from here. */}
+                        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">This space</DropdownMenuLabel>
+                        {notifyChoices.map((c) => (
+                            <DropdownMenuItem key={c.level} onClick={() => notify.setSpaceLevel(c.level)}>
+                                <Check className={cn('size-3.5 mr-2', (notify.spaceLevel ?? 'mentions') !== c.level && 'opacity-0')} /> {c.label}
+                            </DropdownMenuItem>
+                        ))}
+                        <DropdownMenuSeparator />
+                        {/* Do not disturb — everything, for a while. */}
+                        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                            {dndActive ? `Do not disturb until ${new Date(dndUntil!).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}` : 'Do not disturb'}
+                        </DropdownMenuLabel>
                         {dndActive && (
                             <DropdownMenuItem onClick={() => setDnd(null)}>
-                                <Bell className="size-3.5 mr-2" /> Turn off do not disturb
+                                <Bell className="size-3.5 mr-2" /> Turn off
                             </DropdownMenuItem>
                         )}
                         <DropdownMenuItem onClick={() => setDnd(30)}>For 30 minutes</DropdownMenuItem>
@@ -753,27 +801,12 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                         <Button variant="ghost" size="icon" className="size-7 text-muted-foreground"><MoreHorizontal className="size-4" /></Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => void invite()}>
-                            <LinkIcon className="size-3.5 mr-2" /> Copy invite link
-                        </DropdownMenuItem>
                         <DropdownMenuItem onClick={markAllRead}>
                             <Check className="size-3.5 mr-2" /> Mark all read
                         </DropdownMenuItem>
                         <DropdownMenuItem onClick={() => setScheduledOpen(true)}>
                             <Clock className="size-3.5 mr-2" /> Scheduled
                         </DropdownMenuItem>
-                        <DropdownMenuSub>
-                            <DropdownMenuSubTrigger>
-                                <Bell className="size-3.5 mr-2" /> Notifications
-                            </DropdownMenuSubTrigger>
-                            <DropdownMenuSubContent>
-                                {notifyChoices.map((c) => (
-                                    <DropdownMenuItem key={c.level} onClick={() => notify.setSpaceLevel(c.level)}>
-                                        <Check className={cn('size-3.5 mr-2', (notify.spaceLevel ?? 'mentions') !== c.level && 'opacity-0')} /> {c.label}
-                                    </DropdownMenuItem>
-                                ))}
-                            </DropdownMenuSubContent>
-                        </DropdownMenuSub>
                     </DropdownMenuContent>
                 </DropdownMenu>
             </header>

--- a/apps/x/apps/renderer/src/components/spaces/space-search.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-search.tsx
@@ -32,6 +32,8 @@ interface Props {
     spaceId: string
     /** Resolves `me` in from:/mentions: to the viewer. */
     selfMemberId?: string
+    /** The wrapper's size — the header gives it the centre of the row. */
+    className?: string
     onNavigate: (sel: RailSelection) => void
 }
 
@@ -47,7 +49,7 @@ const PAGE = 5
 /** The org's per-category cap — a filtered query fetches this and narrows it here. */
 const FILTERED_PAGE = 50
 
-export function SpaceSearch({ orgId, spaceId, selfMemberId, onNavigate }: Props) {
+export function SpaceSearch({ orgId, spaceId, selfMemberId, onNavigate, className }: Props) {
     const names = useMemberNames()
     const inputRef = useRef<HTMLInputElement>(null)
     const [query, setQuery] = useState('')
@@ -252,15 +254,15 @@ export function SpaceSearch({ orgId, spaceId, selfMemberId, onNavigate }: Props)
     }
 
     return (
-        <div className="relative">
+        <div className={cn('relative', className)}>
             <label
                 className={cn(
-                    'flex h-7 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground',
-                    'w-40 transition-[width] focus-within:w-64 focus-within:border-foreground/30',
+                    'flex h-8 w-full items-center gap-2 rounded-md border border-transparent bg-muted/60 px-2.5 text-[13px] text-muted-foreground',
+                    'transition-colors focus-within:border-foreground/25 focus-within:bg-background hover:bg-muted',
                 )}
                 title={`Search this space (${chord('K', { shift: true })})`}
             >
-                <Search className="size-3 shrink-0" />
+                <Search className="size-3.5 shrink-0" />
                 <input
                     ref={inputRef}
                     value={query}
@@ -268,13 +270,13 @@ export function SpaceSearch({ orgId, spaceId, selfMemberId, onNavigate }: Props)
                     onFocus={() => setFocused(true)}
                     onBlur={() => setFocused(false)}
                     onKeyDown={onKeyDown}
-                    placeholder="Search"
+                    placeholder="Search this space"
                     className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
                 />
-                {!focused && <kbd className="rounded border border-border bg-muted px-1 text-[10px]">{chord('K', { shift: true })}</kbd>}
+                {!focused && <kbd className="rounded border border-border bg-background px-1 text-[10px]">{chord('K', { shift: true })}</kbd>}
             </label>
             {open && (
-                <div className="absolute right-0 top-full z-30 mt-1 max-h-96 w-[26rem] overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md">
+                <div className="absolute left-0 right-0 top-full z-30 mt-1 max-h-96 min-w-[26rem] overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md">
                     {sections.map((s) => (
                         <div key={s.label}>
                             <div className="flex items-baseline justify-between px-2 pb-0.5 pt-1.5 text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground/80">


### PR DESCRIPTION
## What

The space header was an identity card (monogram, name, URL, five avatar tiles, "5 members", "1 here") with the tools crowded on the right. The wrong things got the attention. Now, left to right on the same row:

- **Left: org mark, `#`, space name.** Hovering the name floats a panel with the org name, the address, which space and your member id, and "Copy address". The URL, avatar tiles and "1 here" are gone from the row.
- **Centre: search.** A filled bar up to 480px wide with the ⌘⇧K hint at its edge; it focuses into a white field and its results drop under the bar's full width instead of a fixed box hanging off the right.
- **Right: a members pill**, people icon plus count, with a green dot when anyone is here. Opens the same roster popover, which still lists who is online and is now the only home of the invite link. Then bell, bookmarks, the reopen-file chip when there is one, Board, ⋯.

## Redundancies removed

- **Invite link** was in three places (hover panel, members popover, ⋯ menu). Now only in the members popover.
- **Notifications** were split between the bell (do-not-disturb) and a submenu under ⋯ (the space's level). One bell menu now holds both: "This space" with All messages / Mentions only / Muted, and "Do not disturb" with the timed options. The bell shows crossed out when muted as well as during DND, and its tooltip names the current level.
- **⋯** is down to Mark all read and Scheduled.

## Files

- `apps/renderer/src/components/spaces-view.tsx`: the header.
- `apps/renderer/src/components/spaces/space-search.tsx`: `className` prop, filled full-width bar, results under the bar.

## Verified

- `tsc -b` in the renderer passes on the touched files. The one error in the tree is `browser-tab-rail.tsx` from #956 on main, unrelated.
- Checked visually via hot reload; not covered by automated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdKK6pfaNc4cBZqZBf1USA
