### PR TITLE
Hands-free voice on Windows, and the Skipper's floating companion

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1028,6 +1028,19 @@ export function setupIpcHandlers() {
         }
       }
     },
+    // --- Theme relay ---
+    // The app window owns the setting (localStorage); utility windows have no
+    // ThemeProvider and get told. Relayed through main because renderers have
+    // no channel to each other. Fire-and-forget: a window that has not loaded
+    // yet needs no catch-up push — it reads the same localStorage on mount.
+    'theme:set': async (event, args) => {
+      const sender = BrowserWindow.fromWebContents(event.sender);
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (win.isDestroyed() || win === sender) continue;
+        win.webContents.send('theme:changed', args);
+      }
+      return {};
+    },
     // --- Hover companion relays ---
     'quickAsk:getShortcut': async () => {
       return getQuickAskShortcutState();

--- a/apps/x/apps/main/src/ptt.ts
+++ b/apps/x/apps/main/src/ptt.ts
@@ -1,10 +1,11 @@
 /**
  * Global push-to-talk key hook (uiohook-napi).
  *
- * Watches the Right ⌘ key system-wide while a call (or the quick-ask bar)
- * needs it and relays down/up/chord transitions to the app window, which
- * owns the PTT state machine. The hook only runs while a consumer is
- * registered — no input monitoring outside calls.
+ * Watches the hold-to-talk key system-wide while a call (or the quick-ask
+ * bar) needs it and relays down/up/chord transitions to the app window,
+ * which owns the PTT state machine. The key is platform-dependent (right ⌘
+ * on macOS, right Ctrl elsewhere — see shared/ptt-key.ts); the hook only
+ * runs while a consumer is registered — no input monitoring outside calls.
  *
  * macOS gates global event taps behind the Input Monitoring permission
  * (TCC). Starting the hook triggers the system consent prompt on first use,
@@ -15,16 +16,19 @@
  * way).
  */
 import { app, BrowserWindow, shell } from 'electron';
+import { pttKey } from '@x/shared';
 
 type PttKeyEvent = {
   type: 'down' | 'up' | 'chord';
-  /** Ghostwriter chord: ⇧ was already held when Right ⌘ went down — the
-   * utterance's result should be pasted at the user's cursor. */
+  /** Ghostwriter chord: ⇧ was already held when the talk key went down —
+   * the utterance's result should be pasted at the user's cursor. */
   paste?: boolean;
 };
 
-// libuiohook VC_META_R — the Right ⌘ key.
-const META_RIGHT = 3676;
+// The talk key's libuiohook keycode: VC_META_R (right ⌘) on macOS,
+// VC_CONTROL_R (right Ctrl) everywhere else — Windows owns the right Win
+// key, so a tap there opens the Start menu instead of talking.
+const PTT_KEYCODE = pttKey.pttUiohookKeycode(process.platform);
 
 type UiohookModule = typeof import('uiohook-napi');
 
@@ -35,7 +39,7 @@ let running = false;
 // True once ANY input event arrives — mouse moves land within moments of
 // hook start on a granted system, so a stale false means no permission.
 let eventsSeen = false;
-let metaRightHeld = false;
+let pttKeyHeld = false;
 
 const reasons = new Set<string>();
 
@@ -106,10 +110,10 @@ function attachListeners(mod: UiohookModule) {
   listenersAttached = true;
   mod.uIOhook.on('keydown', guarded((e: { keycode: number; shiftKey?: boolean }) => {
     eventsSeen = true;
-    if (e.keycode === META_RIGHT) {
+    if (e.keycode === PTT_KEYCODE) {
       // OS key-repeat refires keydown while held — only the edge matters.
-      if (!metaRightHeld) {
-        metaRightHeld = true;
+      if (!pttKeyHeld) {
+        pttKeyHeld = true;
         const paste = e.shiftKey === true;
         if (paste) {
           // Remember the frontmost app NOW — it's the paste target.
@@ -117,23 +121,23 @@ function attachListeners(mod: UiohookModule) {
         }
         broadcast({ type: 'down', paste });
       }
-    } else if (metaRightHeld) {
-      // Right ⌘ is acting as a modifier (⌘C etc.), not as the PTT key —
-      // the renderer cancels the capture.
+    } else if (pttKeyHeld) {
+      // The talk key is acting as a modifier (⌘C / Ctrl+C etc.), not as the
+      // PTT key — the renderer cancels the capture.
       broadcast({ type: 'chord' });
     }
   }));
   mod.uIOhook.on('keyup', guarded((e: { keycode: number }) => {
     eventsSeen = true;
-    if (e.keycode === META_RIGHT && metaRightHeld) {
-      metaRightHeld = false;
+    if (e.keycode === PTT_KEYCODE && pttKeyHeld) {
+      pttKeyHeld = false;
       broadcast({ type: 'up' });
     }
   }));
   mod.uIOhook.on('mousedown', guarded(() => {
     eventsSeen = true;
-    // ⌘-click with the held key: a chord, same as a keyboard one.
-    if (metaRightHeld) broadcast({ type: 'chord' });
+    // A click with the talk key held: a chord, same as a keyboard one.
+    if (pttKeyHeld) broadcast({ type: 'chord' });
   }));
   mod.uIOhook.on('mousemove', guarded(() => {
     eventsSeen = true;
@@ -161,7 +165,7 @@ function stopHook() {
     console.error('[ptt] failed to stop hook:', err);
   }
   running = false;
-  metaRightHeld = false;
+  pttKeyHeld = false;
   eventsSeen = false;
 }
 
@@ -178,7 +182,7 @@ export async function setPttActive(reason: string, active: boolean) {
   if (active) reasons.add(reason);
   else reasons.delete(reason);
   if (reasons.size > 0 && !running) await startHook();
-  else if (reasons.size === 0) metaRightHeld = false;
+  else if (reasons.size === 0) pttKeyHeld = false;
 }
 
 export function getPttStatus() {

--- a/apps/x/apps/main/src/quick-ask.ts
+++ b/apps/x/apps/main/src/quick-ask.ts
@@ -173,6 +173,32 @@ export function onAppWindowClosed() {
 let skipperCorner: { x: number; y: number } | null = null;
 let applyingBounds = false;
 
+// --- Drag cursor ---
+// The card and the mascot are drag handles, and a handle should say so under
+// the hand: grab at rest, GRABBING while it moves. The renderer cannot tell
+// on its own — a drag region is native (HTCAPTION on Windows, a layered view
+// on macOS), so no mousedown ever reaches the page and `:active` stays false.
+// Main owns the one witness that always fires — its own 'move' — and pushes
+// the edges of a drag burst: true on the first move, false once the moves
+// stop. The tail is short enough not to linger after the button is released
+// and long enough to survive the gaps between frames of a slow drag.
+const DRAG_IDLE_MS = 180;
+let dragging = false;
+let dragIdleTimer: ReturnType<typeof setTimeout> | null = null;
+
+function markDragging(win: BrowserWindow) {
+  if (!dragging) {
+    dragging = true;
+    win.webContents.send('quick-ask:dragging', { dragging: true });
+  }
+  if (dragIdleTimer) clearTimeout(dragIdleTimer);
+  dragIdleTimer = setTimeout(() => {
+    dragIdleTimer = null;
+    dragging = false;
+    if (!win.isDestroyed()) win.webContents.send('quick-ask:dragging', { dragging: false });
+  }, DRAG_IDLE_MS);
+}
+
 // --- Click-through ---
 // The frame is far bigger than anything it paints: the card sits at the
 // bottom with a tall transparent stage above it (so popovers open upward
@@ -470,6 +496,7 @@ function createWindow(): BrowserWindow {
     if (applyingBounds || win.isDestroyed() || mode !== 'pinned') return;
     const b = win.getBounds();
     skipperCorner = { x: b.x + b.width, y: b.y + b.height };
+    markDragging(win);
   });
   win.on('closed', () => {
     if (quickAskWin === win) quickAskWin = null;

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Activity, useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
-import { workspace, quickAskShortcut } from '@x/shared';
+import { workspace, quickAskShortcut, pttKey } from '@x/shared';
 import { RunEvent } from '@x/shared/src/runs.js';
 import type { ToolUIPart } from 'ai';
 import './App.css'
@@ -124,6 +124,7 @@ import { useAnalyticsIdentity } from '@/hooks/useAnalyticsIdentity'
 import * as analytics from '@/lib/analytics'
 import { playAckCue, playAlertCue, playPopCue } from '@/lib/call-sounds'
 import { useTheme } from '@/contexts/theme-context'
+import { isMac } from '@/lib/shortcut'
 
 type DirEntry = z.infer<typeof workspace.DirEntry>
 type RunEventType = z.infer<typeof RunEvent>
@@ -146,11 +147,14 @@ const graphPalette = [
   { hue: 0, sat: 72, light: 52 },
 ]
 
-// Push-to-talk gesture timing: a Right-⌘ press shorter than PTT_TAP_MS is a
-// tap (toggles hands-free lock); anything longer is a hold (release
+// Push-to-talk gesture timing: a talk-key press shorter than PTT_TAP_MS is
+// a tap (toggles hands-free lock); anything longer is a hold (release
 // submits). PTT_EDGE_ECHO_MS collapses the same key edge arriving from two
 // sources at once (global uiohook hook + in-window DOM listener).
+// The key is right ⌘ on macOS, right Ctrl elsewhere — shared/ptt-key.ts.
 const PTT_TAP_MS = 350
+const PTT_CODE = pttKey.pttEventCode(isMac)
+const PTT_KEY_LABEL = pttKey.pttKeyLabel(isMac)
 // Mic-ownership token for the Home composer (chat composers use their chatId).
 const HOME_VOICE_HOLDER = 'home-composer'
 const PTT_EDGE_ECHO_MS = 80
@@ -928,7 +932,6 @@ function App() {
   // auto-closes when the active note changes.
   const [liveNotePanelPath, setLiveNotePanelPath] = useState<string | null>(null)
   const [, setActiveShortcutPane] = useState<ShortcutPane>('left')
-  const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac')
   // In dock mode the fixed toggle button overhangs the pane's left edge
   // (the gutter is narrower than traffic lights + toggle), so top bars pad
   // past it; the expanded panel absorbs the toggle, so ordinary padding.
@@ -1150,7 +1153,7 @@ function App() {
   // because segment consumption freezes while the gate is open.
   const [pttStatus, setPttStatus] = useState<'idle' | 'held' | 'locked'>('idle')
   const pttStatusRef = useRef<'idle' | 'held' | 'locked'>('idle')
-  // Ghostwriter chord (⇧ + right ⌘): the NEXT utterance's result gets
+  // Ghostwriter chord (⇧ + the talk key): the NEXT utterance's result gets
   // pasted at the user's cursor. Set on the down edge, consumed by the
   // utterance callback, cleared on cancel.
   const pttPasteIntentRef = useRef(false)
@@ -1568,7 +1571,7 @@ function App() {
     ttsEnabledRef.current = true
     ttsModeRef.current = 'full'
     // Push-to-talk: the mic + Deepgram socket stay warm for the whole call,
-    // but nothing is heard until the user opens the gate (hold Right ⌘, or
+    // but nothing is heard until the user opens the gate (hold the talk key, or
     // tap it to lock hands-free capture). The key release is the endpoint —
     // no silence detection, no misfires.
     void voiceRef.current
@@ -1857,8 +1860,8 @@ function App() {
   // in one gesture, and the next tap after a stop behaves normally.
   const pttSpokeAtDownRef = useRef(false)
   const pttLastEdgeRef = useRef<{ type: 'down' | 'up'; at: number } | null>(null)
-  // Right ⌘ was used as a modifier (⌘C etc.) during this press — the
-  // matching release must not commit/lock.
+  // The talk key was used as a modifier (⌘C / Ctrl+C etc.) during this
+  // press — the matching release must not commit/lock.
   const pttChordedRef = useRef(false)
 
   const pttEdgeIsEcho = useCallback((type: 'down' | 'up') => {
@@ -1923,7 +1926,7 @@ function App() {
       if (shown < 2) {
         localStorage.setItem('ptt-hold-tip-shown', String(shown + 1))
         toast('No need to keep holding', {
-          description: 'For longer turns, quick-tap right ⌘ instead — talk hands-free, then tap again to send.',
+          description: `For longer turns, quick-tap ${PTT_KEY_LABEL} instead — talk hands-free, then tap again to send.`,
           duration: 6000,
         })
       }
@@ -1961,7 +1964,7 @@ function App() {
       else handlePttChord()
     })
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.code === 'MetaRight') {
+      if (e.code === PTT_CODE) {
         if (!e.repeat) handlePttDown(e.shiftKey)
         return
       }
@@ -1971,10 +1974,10 @@ function App() {
         return
       }
       if (pttStatusRef.current === 'held') handlePttChord()
-      else if (pttStatusRef.current === 'locked' && e.metaKey) handlePttChord()
+      else if (pttStatusRef.current === 'locked' && pttKey.pttModifierHeld(e, isMac)) handlePttChord()
     }
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code === 'MetaRight') handlePttUp()
+      if (e.code === PTT_CODE) handlePttUp()
     }
     document.addEventListener('keydown', onKeyDown)
     document.addEventListener('keyup', onKeyUp)
@@ -1993,13 +1996,17 @@ function App() {
 
   // Global-PTT onboarding: shortly into a call, if the key hook is running
   // but has seen zero input events, macOS Input Monitoring hasn't taken
-  // effect — explain it instead of letting Right ⌘ silently do nothing from
-  // other apps. At most once per app session: once-ever proved too little
+  // effect — explain it instead of letting the talk key silently do nothing
+  // from other apps. At most once per app session: once-ever proved too little
   // (dismiss without granting and global PTT stayed silently broken), every
   // call would nag. (In-window PTT works regardless.)
   const inputMonitoringPromptedRef = useRef(false)
   useEffect(() => {
     if (!inCall) return
+    // macOS-only: Input Monitoring is a TCC grant with no Windows or Linux
+    // equivalent, so a dead hook there means something else entirely and
+    // this dialog would send the user looking for a switch that isn't there.
+    if (!isMac) return
     if (inputMonitoringPromptedRef.current) return
     const timer = setTimeout(async () => {
       try {
@@ -5926,7 +5933,8 @@ function App() {
 
     document.addEventListener('keydown', handleHistoryKeyDown, true)
     return () => document.removeEventListener('keydown', handleHistoryKeyDown, true)
-  }, [isMac, selectedPath])
+    // isMac is a module constant now (lib/shortcut), not a component value.
+  }, [selectedPath])
 
   const toggleExpand = (path: string, kind: 'file' | 'dir') => {
     if (kind === 'file') {

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -63,6 +63,9 @@ import {
   usePromptInputController,
 } from '@/components/ai-elements/prompt-input'
 import { toast } from 'sonner'
+import * as quickAskShortcut from '@x/shared/src/quick-ask-shortcut.js'
+import { useQuickAskShortcut } from '@/hooks/use-quick-ask-shortcut'
+import { isMac } from '@/lib/shortcut'
 
 export type StagedAttachment = {
   id: string
@@ -197,7 +200,8 @@ function compactWorkDirPath(path: string) {
 
 // Call presets: front doors into the same call engine, differing only in
 // starting devices. 'share' is the call button's main click — the "work
-// together" default (the hover companion — same surface as ⌥⇧Space). The
+// together" default (the hover companion — same surface the summon chord
+// opens). The
 // chevron menu holds the deviations.
 export type CallPreset = 'voice' | 'video' | 'share' | 'practice'
 
@@ -311,6 +315,11 @@ function ChatInputInner({
 }: ChatInputInnerProps) {
   const controller = usePromptInputController()
   const message = controller.textInput.value
+  // The summon chord is user-configurable and platform-formatted — never
+  // spell it out inline (the tooltip used to read "⌥⇧Space" on every OS,
+  // and stayed wrong after a rebind).
+  const summonShortcut = useQuickAskShortcut()
+  const summonShortcutLabel = quickAskShortcut.formatShortcut(summonShortcut.accelerator, isMac)
   const [attachments, setAttachments] = useState<StagedAttachment[]>([])
   const [focusNonce, setFocusNonce] = useState(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -1278,8 +1287,8 @@ function ChatInputInner({
                     if (inCall && callOnThisChat) {
                       onEndCall?.()
                     } else if (callAvailable) {
-                      // Voice hover companion — the same surface ⌥⇧Space
-                      // summons. During a live call on ANOTHER chat this
+                      // Voice hover companion — the same surface the summon
+                      // chord opens. During a live call on ANOTHER chat this
                       // re-points the call at this one (same devices).
                       onStartCall('voice')
                     }
@@ -1303,7 +1312,7 @@ function ChatInputInner({
                       ? 'End call'
                       : 'On a call about another chat — click to bring THIS chat into it')
                   : callAvailable
-                    ? 'Talk it through — summons your hover companion (⌥⇧Space)'
+                    ? `Talk it through — summons your hover companion (${summonShortcutLabel})`
                     : 'Calls need voice input and output configured'}
               </TooltipContent>
             </Tooltip>

--- a/apps/x/apps/renderer/src/components/permission-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/permission-dialog.tsx
@@ -1,4 +1,5 @@
 import { Keyboard, Mic, MonitorUp, Video } from 'lucide-react'
+import { pttKey } from '@x/shared'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -9,8 +10,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { isMac } from '@/lib/shortcut'
 
 export type PermissionKind = 'microphone' | 'camera' | 'screen-recording' | 'input-monitoring'
+
+// Where the user actually goes to fix it. The IPC handler already deep-links
+// ms-settings: on Windows (see main's app:openPrivacySettings) — only the
+// copy was still telling every platform to open macOS System Settings.
+const OS = isMac ? 'macOS' : 'Windows'
+const SETTINGS_APP = isMac ? 'System Settings' : 'Settings'
+const MIC_PATH = isMac ? 'System Settings → Privacy & Security → Microphone' : 'Settings → Privacy & security → Microphone'
+const CAM_PATH = isMac ? 'System Settings → Privacy & Security → Camera' : 'Settings → Privacy & security → Camera'
 
 const COPY: Record<
   PermissionKind,
@@ -20,35 +30,45 @@ const COPY: Record<
     icon: Mic,
     title: 'Rowboat needs microphone access',
     body:
-      'Voice input is off because macOS is blocking the microphone for Rowboat. ' +
-      'Enable it under System Settings → Privacy & Security → Microphone, then try again.',
+      `Voice input is off because ${OS} is blocking the microphone for Rowboat. ` +
+      `Enable it under ${MIC_PATH}, then try again.`,
     section: 'microphone',
   },
   camera: {
     icon: Video,
     title: 'Rowboat needs camera access',
     body:
-      'Video calls are off because macOS is blocking the camera for Rowboat. ' +
-      'Enable it under System Settings → Privacy & Security → Camera, then start the call again.',
+      `Video calls are off because ${OS} is blocking the camera for Rowboat. ` +
+      `Enable it under ${CAM_PATH}, then start the call again.`,
     section: 'camera',
   },
+  // Screen Recording is a macOS TCC grant; on Windows a failed capture is a
+  // cancelled picker or a driver problem, not a permission to go and flip —
+  // so don't send those users hunting through Settings for a switch that
+  // doesn't exist (app:openPrivacySettings has no Windows deep link for it,
+  // and the button is hidden below to match).
   'screen-recording': {
     icon: MonitorUp,
     title: 'Rowboat can’t see your screen',
-    body:
-      'macOS is blocking Screen Recording, so the assistant would only see black frames. ' +
-      'Enable Rowboat under System Settings → Privacy & Security → Screen Recording, then ' +
-      'relaunch Rowboat. If Rowboat is already enabled there, toggle it off and on — an ' +
-      'updated app needs a fresh grant — and relaunch.',
+    body: isMac
+      ? 'macOS is blocking Screen Recording, so the assistant would only see black frames. ' +
+        'Enable Rowboat under System Settings → Privacy & Security → Screen Recording, then ' +
+        'relaunch Rowboat. If Rowboat is already enabled there, toggle it off and on — an ' +
+        'updated app needs a fresh grant — and relaunch.'
+      : 'Screen capture didn’t start, so the assistant can’t see your screen. If you ' +
+        'dismissed the picker, just try sharing again. If it keeps failing, restart ' +
+        'Rowboat — the call carries on fine without sharing.',
     section: 'screen-recording',
   },
+  // Input Monitoring is macOS-only: nothing gates a global key hook on
+  // Windows or Linux, so App.tsx never raises this kind there.
   'input-monitoring': {
     icon: Keyboard,
     title: 'Enable push-to-talk from any app',
     body:
-      'Hold Right ⌘ to talk during a call — even while you’re in another app. ' +
-      'For Rowboat to see that key outside its own window, macOS requires the ' +
-      'Input Monitoring permission. Without it, push-to-talk still works while ' +
+      `Hold ${pttKey.pttKeyLabelCap(isMac)} to talk during a call — even while you’re in ` +
+      'another app. For Rowboat to see that key outside its own window, macOS requires ' +
+      'the Input Monitoring permission. Without it, push-to-talk still works while ' +
       'Rowboat is focused.',
     section: 'input-monitoring',
   },
@@ -56,9 +76,9 @@ const COPY: Record<
 
 /**
  * The one dialog behind every "a call feature silently did nothing" case:
- * explains which macOS permission is missing, deep-links to the exact
- * System Settings pane, and (for input monitoring) re-arms the global key
- * hook after the user grants it.
+ * explains which OS permission is missing, deep-links to the exact settings
+ * pane (System Settings on macOS, ms-settings: on Windows), and (for input
+ * monitoring) re-arms the global key hook after the user grants it.
  */
 export function PermissionDialog({
   kind,
@@ -72,6 +92,11 @@ export function PermissionDialog({
 }) {
   const copy = kind ? COPY[kind] : null
   const Icon = copy?.icon ?? Mic
+  // Only offer the settings button where main can actually deep-link the
+  // pane: everything on macOS, but only mic and camera on Windows (see
+  // app:openPrivacySettings). A button whose handler silently returns
+  // { success: false } is worse than no button.
+  const hasSettingsLink = isMac || kind === 'microphone' || kind === 'camera'
   return (
     <Dialog open={kind !== null} onOpenChange={onOpenChange}>
       {/* z-[120]: share/PTT failures surface mid-call, above the z-[100]
@@ -89,14 +114,16 @@ export function PermissionDialog({
             {/* Stacked, full-width buttons: uniform sizing and no label
                 overflow regardless of how many actions a kind has. */}
             <DialogFooter className="flex-col gap-2 sm:flex-col">
-              <Button
-                className="w-full"
-                onClick={() => {
-                  void window.ipc.invoke('app:openPrivacySettings', { section: copy.section }).catch(() => {})
-                }}
-              >
-                Open System Settings
-              </Button>
+              {hasSettingsLink && (
+                <Button
+                  className="w-full"
+                  onClick={() => {
+                    void window.ipc.invoke('app:openPrivacySettings', { section: copy.section }).catch(() => {})
+                  }}
+                >
+                  Open {SETTINGS_APP}
+                </Button>
+              )}
               {kind === 'screen-recording' && (
                 <Button
                   variant="outline"

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -644,7 +644,7 @@ export function QuickAskBar() {
       {card.mounted && (
       <div
         data-qa-passthrough
-        className={`relative min-w-0 flex-1 ${card.exiting ? 'pointer-events-none' : ''}`}
+        className={`relative min-w-0 flex-1 ${card.exiting ? 'qa-card-out pointer-events-none' : 'qa-card-in'}`}
       >
       {/* Near-white card with a hairline dark border in light; near-black
           with a hairline light one in dark. #810 introduced the light skin as
@@ -653,7 +653,7 @@ export function QuickAskBar() {
           outline the whole transparent frame) — the card draws its own, and
           draws it heavier in dark, where a soft grey haze would just vanish
           into whatever is behind the window. */}
-      <div ref={cardRef} style={dragRegion} className={`qa-card ${card.exiting ? 'qa-card-out' : 'qa-card-in'} relative w-full cursor-grab overflow-hidden rounded-[26px] border border-black/10 bg-white/[0.97] text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.18),0_2px_10px_rgba(0,0,0,0.10)] dark:border-white/15 dark:bg-neutral-900/[0.97] dark:text-neutral-100 dark:shadow-[0_12px_32px_rgba(0,0,0,0.55),0_2px_10px_rgba(0,0,0,0.4)]`}>
+      <div ref={cardRef} style={dragRegion} className="qa-card relative w-full cursor-grab overflow-hidden rounded-[26px] border border-black/10 bg-white/[0.97] text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.18),0_2px_10px_rgba(0,0,0,0.10)] dark:border-white/15 dark:bg-neutral-900/[0.97] dark:text-neutral-100 dark:shadow-[0_12px_32px_rgba(0,0,0,0.55),0_2px_10px_rgba(0,0,0,0.4)]">
         {/* The card is a drag handle, like the mascot: every bit of bare
             surface — the border, the gutters around the action strip, the
             frame around the composer — picks the Skipper up. The CONTROLS
@@ -1193,11 +1193,12 @@ const COMPANION_MOTION_CSS = `
   }
   /* Both halves name their own easing rather than a shared ease: the card
      should LEAVE with gathering speed and ARRIVE with none, which is the
-     difference between a fold that snaps and one that settles. will-change
-     keeps the whole animation on one composited layer — without it the
-     first frame is where the judder came from. */
+     difference between a fold that snaps and one that settles. Both classes
+     sit on the card's WRAPPER, never on the card itself: the card is a drag
+     region, and a region that animates its transform leaves Electron
+     punching the hole where the animation started. */
   .qa-card-in,
-  .qa-card-out { transform-origin: 100% 80%; will-change: transform, opacity; }
+  .qa-card-out { transform-origin: 100% 80%; }
   .qa-card-in { animation: qa-card-in 0.3s cubic-bezier(0.16, 1, 0.3, 1); }
   .qa-card-out { animation: qa-card-out ${CARD_EXIT_MS}ms cubic-bezier(0.4, 0, 0.9, 0.3) forwards; }
   .qa-rise { animation: qa-rise 0.2s cubic-bezier(0.16, 1, 0.3, 1); }
@@ -1425,12 +1426,24 @@ function UnfoldBubble({ onExpand }: { onExpand: () => void }) {
   const shortcutState = useQuickAskShortcut()
   const shortcutLabel = quickAskShortcut.formatShortcut(shortcutState.accelerator, isMac)
   return (
-    // The wrapper owns the CENTERING transform; the button owns the
-    // animated one. A CSS animation replaces an element's whole transform,
-    // so sharing one element would have the bubble fly in off-centre.
+    // The wrapper is the DRAG-REGION HOLE, and it must never move: Electron
+    // punches holes from the rect Blink last computed for the element, on
+    // style/layout invalidation — not once per composited frame. Put
+    // `no-drag` on something whose transform is animating (as the button's
+    // is) and the hole stays wherever the animation STARTED — a 0.7-scaled
+    // box 10px low — so pressing the bubble where it paints lands on the
+    // drag region instead. On Windows that means HTCAPTION: the window
+    // enters the OS move loop, the click never happens, and the companion
+    // looks frozen until the button comes back up.
+    //
+    // So: the hole is static and transform-free (centred with calc, not
+    // translate — a static transform is one more thing that can go stale),
+    // and it is DELIBERATELY bigger than the art it covers, 40px around a
+    // 28px bubble, the same way the pins carry oversized targets. The motion
+    // lives on the button inside it.
     <span
-      className="absolute left-1/2 z-30 -translate-x-1/2 -translate-y-1/2"
-      style={{ ...noDragRegion, top: '55%' }}
+      className="absolute z-30 flex h-10 w-10 items-center justify-center"
+      style={{ ...noDragRegion, top: 'calc(55% - 20px)', left: 'calc(50% - 20px)' }}
     >
       <Tooltip>
         <TooltipTrigger asChild>
@@ -1438,7 +1451,6 @@ function UnfoldBubble({ onExpand }: { onExpand: () => void }) {
             type="button"
             onClick={onExpand}
             aria-label="Bring the text back"
-            style={noDragRegion}
             className="qa-bubble flex h-7 w-7 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_4px_14px_rgba(0,0,0,0.18)] transition hover:-translate-y-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_4px_14px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
           >
             <ChevronsLeft className="h-3.5 w-3.5" />

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -941,6 +941,8 @@ export function QuickAskBar() {
           className="relative -mb-4"
           style={{ animation: 'skipper-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}
         >
+          {/* Tucked: the one way back, over the head. */}
+          {collapsed && <UnfoldBubble onExpand={() => requestCollapsed(false)} />}
           {/* Listening halo — rings pulse around the head while the mic
               gate is open, so "press the talk key and speak" is visibly working in
               both states. */}
@@ -966,12 +968,7 @@ export function QuickAskBar() {
             size={SKIPPER_SIZE}
             hat="cowboy"
             hatOverlay={
-              <SkipperPins
-                state={callState}
-                sendAction={sendAction}
-                textPin={collapsed ? 'expand' : 'collapse'}
-                onTextPin={() => requestCollapsed(!collapsed)}
-              />
+              <SkipperPins state={callState} sendAction={sendAction} />
             }
           />
         </div>
@@ -1139,7 +1136,7 @@ function useDragCursor() {
  * How long the card's fold-away runs. The node has to stay mounted for it
  * (see usePresence), so main and the renderer must agree on one number.
  */
-const CARD_EXIT_MS = 160
+const CARD_EXIT_MS = 200
 
 /**
  * Keep a node on screen for its exit animation.
@@ -1179,22 +1176,36 @@ function usePresence(visible: boolean, exitMs: number) {
  */
 const COMPANION_MOTION_CSS = `
   @keyframes qa-card-in {
-    from { opacity: 0; transform: translateX(22px) scale(0.96); }
+    from { opacity: 0; transform: translateX(28px) scale(0.94); }
     to { opacity: 1; transform: none; }
   }
   @keyframes qa-card-out {
     from { opacity: 1; transform: none; }
-    to { opacity: 0; transform: translateX(22px) scale(0.96); }
+    to { opacity: 0; transform: translateX(28px) scale(0.94); }
   }
   @keyframes qa-rise {
     from { opacity: 0; transform: translateY(6px); }
     to { opacity: 1; transform: none; }
   }
-  .qa-card-in { animation: qa-card-in 0.22s cubic-bezier(0.22, 1, 0.36, 1); transform-origin: 100% 80%; }
-  .qa-card-out { animation: qa-card-out ${CARD_EXIT_MS}ms ease-in forwards; transform-origin: 100% 80%; }
-  .qa-rise { animation: qa-rise 0.18s ease-out; }
+  @keyframes qa-bubble-in {
+    from { opacity: 0; transform: translateY(10px) scale(0.7); }
+    to { opacity: 1; transform: none; }
+  }
+  /* Both halves name their own easing rather than a shared ease: the card
+     should LEAVE with gathering speed and ARRIVE with none, which is the
+     difference between a fold that snaps and one that settles. will-change
+     keeps the whole animation on one composited layer — without it the
+     first frame is where the judder came from. */
+  .qa-card-in,
+  .qa-card-out { transform-origin: 100% 80%; will-change: transform, opacity; }
+  .qa-card-in { animation: qa-card-in 0.3s cubic-bezier(0.16, 1, 0.3, 1); }
+  .qa-card-out { animation: qa-card-out ${CARD_EXIT_MS}ms cubic-bezier(0.4, 0, 0.9, 0.3) forwards; }
+  .qa-rise { animation: qa-rise 0.2s cubic-bezier(0.16, 1, 0.3, 1); }
+  /* Delayed past the fold (backwards = held invisible until then), so the
+     bubble arrives into space the card has already left. */
+  .qa-bubble { animation: qa-bubble-in 0.26s cubic-bezier(0.34, 1.56, 0.64, 1) ${CARD_EXIT_MS}ms backwards; }
   @media (prefers-reduced-motion: reduce) {
-    .qa-card-in, .qa-rise { animation: none; }
+    .qa-card-in, .qa-rise, .qa-bubble { animation: none; }
     .qa-card-out { animation: none; opacity: 0; }
   }
 `
@@ -1230,28 +1241,28 @@ function useHeldLabel(next: string | null, holdMs = 800): string | null {
 /**
  * The Skipper's control pins — ONE cluster for both presentations (text
  * panel open or folded), riding TalkingHead's hatOverlay so they bob with
- * the artwork. Hat = voice: the mic pin, morphing into Stop while a turn is
- * in flight. Boat = surface: the share bow light, the text fold/unfold pin
- * on the left edge, ✕ end on the right. The speaker mute deliberately does
- * NOT live here — with the text folded, voice is the only output channel,
- * so the mute is the text panel's affordance. no-drag sits on EACH button:
- * Electron punches drag-region holes from painted bounds, and a zero-size
- * wrapper excludes nothing.
+ * the artwork.
+ *
+ * They all ride the BOAT now, left to right: the mic (morphing into Stop
+ * while a turn is in flight), the share bow light, ✕ end. The mic used to
+ * sit on the hat band, a reach away from the other two — one row of three
+ * on the deck is the whole control surface at a glance. The text's fold and
+ * unfold are NOT here: folding is the handle on the card's edge, unfolding
+ * the bubble above the head (UnfoldBubble), each living where the gesture
+ * actually points. The speaker mute isn't here either — with the text
+ * folded, voice is the only output channel, so the mute belongs to the text
+ * panel.
+ *
+ * no-drag sits on EACH button: Electron punches drag-region holes from
+ * painted bounds, and a zero-size wrapper excludes nothing.
  */
 function SkipperPins({
   state,
   sendAction,
-  textPin,
-  onTextPin,
 }: {
   state: CallState
   sendAction: (action: PopoutAction) => void
-  /** 'expand' = bring the text back (tucked); 'collapse' = fold it away. */
-  textPin: 'expand' | 'collapse'
-  onTextPin: () => void
 }) {
-  const shortcutState = useQuickAskShortcut()
-  const shortcutLabel = quickAskShortcut.formatShortcut(shortcutState.accelerator, isMac)
   // The mic and Stop are exclusive states of ONE control: while a turn is
   // in flight the mic is dead anyway, so the hat's single pin morphs.
   const busy = state.status === 'thinking' || state.status === 'speaking'
@@ -1264,7 +1275,7 @@ function SkipperPins({
           aria-label="Stop the assistant"
           title="Stop — cut the reply short (the session keeps going)"
           className="group/pin absolute flex h-[38px] w-[38px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-          style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
+          style={{ ...noDragRegion, left: '18%', top: '68%' }}
         >
           <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-red-600 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110">
             <Square className="h-3 w-3 fill-current text-white" />
@@ -1287,7 +1298,7 @@ function SkipperPins({
           aria-label="Hold to talk — tap for hands-free"
           title={`Hold to talk (tap for hands-free) — or hold the ${PTT_LABEL} key`}
           className="group/pin absolute flex h-[38px] w-[38px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-          style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
+          style={{ ...noDragRegion, left: '18%', top: '68%' }}
         >
           <span
             className={`flex h-[22px] w-[22px] select-none items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
@@ -1325,22 +1336,6 @@ function SkipperPins({
         </span>
         <span className="pointer-events-none absolute left-1/2 top-full mt-0.5 -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-medium text-white opacity-0 transition-opacity group-hover/pin:opacity-100">
           {state.screenSharing ? 'Sharing screen — click to stop' : 'Share your screen'}
-        </span>
-      </button>
-      <button
-        type="button"
-        onClick={onTextPin}
-        aria-label={textPin === 'expand' ? 'Bring the text back' : 'Tuck the text away'}
-        title={textPin === 'expand' ? `Bring the text back (${shortcutLabel} works too)` : 'Tuck the text away — the session keeps going'}
-        className="group/pin absolute flex h-[32px] w-[32px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
-        style={{ ...noDragRegion, left: '18%', top: '68%' }}
-      >
-        <span className="flex h-[20px] w-[20px] items-center justify-center rounded-full bg-sky-500 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-125">
-          {textPin === 'expand' ? (
-            <ChevronsLeft className="h-3 w-3 text-white" />
-          ) : (
-            <ChevronsRight className="h-3 w-3 text-white" />
-          )}
         </span>
       </button>
       <button
@@ -1405,6 +1400,46 @@ function TurnDivider({ children }: { children: React.ReactNode }) {
       {children}
       <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
     </div>
+  )
+}
+
+/**
+ * The way back, while the text is tucked: a chevron bubble floating just
+ * above the Skipper's head.
+ *
+ * It is the mirror of the card's tuck handle — same circle, same size, the
+ * chevron pointing the other way — so hiding and un-hiding are visibly one
+ * gesture with two directions. It used to be a blue enamel pin on the boat,
+ * which put "where does my text go" in the middle of the DEVICE controls and
+ * left the hull with four things competing for a glance. Above the head it
+ * points at the space the card unfolds into.
+ *
+ * The entry waits out the card's fold (COMPANION_MOTION_CSS delays it), so
+ * the two never animate over each other.
+ */
+function UnfoldBubble({ onExpand }: { onExpand: () => void }) {
+  const shortcutState = useQuickAskShortcut()
+  const shortcutLabel = quickAskShortcut.formatShortcut(shortcutState.accelerator, isMac)
+  return (
+    // The wrapper owns the CENTERING transform; the button owns the
+    // animated one. A CSS animation replaces an element's whole transform,
+    // so sharing one element would have the bubble fly in off-centre.
+    <span className="absolute -top-2 left-1/2 z-30 -translate-x-1/2" style={noDragRegion}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onExpand}
+            aria-label="Bring the text back"
+            style={noDragRegion}
+            className="qa-bubble flex h-7 w-7 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_4px_14px_rgba(0,0,0,0.18)] transition hover:-translate-y-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_4px_14px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+          >
+            <ChevronsLeft className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">Bring the text back ({shortcutLabel} works too)</TooltipContent>
+      </Tooltip>
+    </span>
   )
 }
 
@@ -1894,6 +1929,7 @@ function TuckedMascot({
       {/* -mb pulls the caption/chip up under the boat: the SVG box has dead
           space below the ripples that read as a big gap. */}
       <div className="relative -mb-4" style={{ animation: 'tucked-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}>
+        <UnfoldBubble onExpand={onExpand} />
         {/* Listening halo: expanding green rings around the head while the
             mic gate is open. Peripheral-vision feedback — the user is
             usually looking at their own work, not at the chip's small text. */}
@@ -1918,7 +1954,7 @@ function TuckedMascot({
           size={SKIPPER_SIZE}
           hat="cowboy"
           hatOverlay={
-            <SkipperPins state={state} sendAction={sendAction} textPin="expand" onTextPin={onExpand} />
+            <SkipperPins state={state} sendAction={sendAction} />
           }
         />
       </div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -41,9 +41,11 @@ import {
 import { COMMAND_CENTER_CHAT_SENTINEL } from '@x/shared/src/home-threads.js'
 import { reduceTurn } from '@x/shared/src/turns.js'
 import * as quickAskShortcut from '@x/shared/src/quick-ask-shortcut.js'
+import * as pttKey from '@x/shared/src/ptt-key.js'
 import { useQuickAskShortcut } from '@/hooks/use-quick-ask-shortcut'
 
 import { TalkingHead } from '@/components/talking-head'
+import { isMac } from '@/lib/shortcut'
 import { isChatMessage } from '@/lib/chat-conversation'
 import { runLogToConversation } from '@/lib/run-to-conversation'
 import { buildTurnConversation, stripVoiceTags } from '@/lib/session-chat/turn-view'
@@ -56,11 +58,14 @@ import {
 } from '@/components/chat-input-with-mentions'
 import type { FileMention, PromptInputMessage } from '@/components/ai-elements/prompt-input'
 
-// Hold-to-speak key by platform. macOS: right ⌘. Windows: the same physical
-// position is the right Win key, which the OS owns (a tap opens the Start
-// menu) — right Ctrl is the safe equivalent there.
-const IS_MAC = navigator.platform.startsWith('Mac')
-const PTT_CODE = IS_MAC ? 'MetaRight' : 'ControlRight'
+// Hold-to-speak key by platform (shared/ptt-key.ts is the one place that
+// decides): macOS right ⌘, elsewhere right Ctrl — the same physical position
+// on a PC is the right Win key, which the OS owns (a tap opens the Start
+// menu). The LABELS come from there too: this window used to bind Ctrl and
+// still say ⌘, which is the worst of both.
+const PTT_CODE = pttKey.pttEventCode(isMac)
+const PTT_LABEL = pttKey.pttKeyLabel(isMac)
+const PTT_KEYCAP = pttKey.pttKeycap(isMac)
 
 type CompanionMode = 'hidden' | 'pinned'
 
@@ -77,7 +82,7 @@ type CallState = {
   /** Tool-name-level "what's happening" while a turn runs, else null. */
   activityText: string | null
   interimText: string | null
-  /** A quick ⌘ tap locked hands-free capture (until the next tap). */
+  /** A quick talk-key tap locked hands-free capture (until the next tap). */
   pttLocked: boolean
   /** Latest assistant reply of this call (streams while generating). */
   responseText: string | null
@@ -477,8 +482,8 @@ export function QuickAskBar() {
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.code === PTT_CODE) sendAction('ptt-up')
     }
-    // Capture phase: right ⌘ must work even while the embedded composer (or
-    // any popover) has focus — "press ⌘ and speak" is promised in BOTH
+    // Capture phase: the talk key must work even while the embedded composer
+    // (or any popover) has focus — "press and speak" is promised in BOTH
     // Skipper states, and bubble-phase listeners can be swallowed below.
     document.addEventListener('keydown', onKeyDown, true)
     document.addEventListener('keyup', onKeyUp, true)
@@ -892,7 +897,7 @@ export function QuickAskBar() {
           style={{ animation: 'skipper-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}
         >
           {/* Listening halo — rings pulse around the head while the mic
-              gate is open, so "press ⌘ and speak" is visibly working in
+              gate is open, so "press the talk key and speak" is visibly working in
               both states. */}
           {!callState.micMuted && (callState.status === 'listening' || callState.pttLocked) && (
             <>
@@ -947,7 +952,7 @@ export function QuickAskBar() {
 }
 
 const STATUS_DISPLAY: Record<NonNullable<CallState['status']>, { label: string; dotClass: string }> = {
-  idle: { label: 'Hold right ⌘ to talk', dotClass: 'bg-neutral-500' },
+  idle: { label: `Hold ${PTT_LABEL} to talk`, dotClass: 'bg-neutral-500' },
   listening: { label: 'Listening', dotClass: 'bg-[var(--rowboat-success)] animate-pulse' },
   thinking: { label: 'Thinking…', dotClass: 'bg-amber-400' },
   speaking: { label: 'Speaking', dotClass: 'bg-sky-400 animate-pulse' },
@@ -1097,10 +1102,7 @@ function SkipperPins({
   onTextPin: () => void
 }) {
   const shortcutState = useQuickAskShortcut()
-  const shortcutLabel = quickAskShortcut.formatShortcut(
-    shortcutState.accelerator,
-    typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac'),
-  )
+  const shortcutLabel = quickAskShortcut.formatShortcut(shortcutState.accelerator, isMac)
   // The mic and Stop are exclusive states of ONE control: while a turn is
   // in flight the mic is dead anyway, so the hat's single pin morphs.
   const busy = state.status === 'thinking' || state.status === 'speaking'
@@ -1134,7 +1136,7 @@ function SkipperPins({
             if (!state.micMuted) sendAction('ptt-up')
           }}
           aria-label="Hold to talk — tap for hands-free"
-          title="Hold to talk (tap for hands-free) — or hold the right ⌘ key"
+          title={`Hold to talk (tap for hands-free) — or hold the ${PTT_LABEL} key`}
           className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
           style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
         >
@@ -1211,7 +1213,7 @@ function SkipperPins({
 /**
  * The Skipper's status line — the same words under the mascot in both
  * presentations. While the mic gate is open it goes loud (green, mic icon):
- * paired with the listening halo, holding right ⌘ is unmistakably working.
+ * paired with the listening halo, holding the talk key is unmistakably working.
  * While a turn runs, the generic "Thinking…" upgrades to the current
  * activity ("Searching the web…") when one is known — flicker-held by the
  * caller via useHeldLabel.
@@ -1233,7 +1235,7 @@ function SkipperStatusChip({ state, activity }: { state: CallState; activity?: s
       ) : state.pttLocked ? (
         <>
           <Mic className="h-3 w-3 animate-pulse" />
-          Hands-free — tap ⌘ to send
+          Hands-free — tap {PTT_KEYCAP} to send
         </>
       ) : state.status === 'listening' ? (
         <>
@@ -1244,7 +1246,7 @@ function SkipperStatusChip({ state, activity }: { state: CallState; activity?: s
         <>
           <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
           {state.status === 'idle'
-            ? 'Hold the mic — or right ⌘'
+            ? `Hold the mic — or ${PTT_LABEL}`
             : state.status === 'thinking' && activity
               ? activity
               : statusDisplay.label}
@@ -1405,7 +1407,7 @@ function PinnedPill({
             }
           `}</style>
           {/* Listening halo — same signal as the tucked mascot: while the
-              mic gate is open (right ⌘ held / hands-free), green rings pulse
+              mic gate is open (talk key held / hands-free), green rings pulse
               around the head. The corner chip alone is too easy to miss. */}
           {!state.micMuted && (state.status === 'listening' || state.pttLocked) && (
             <>
@@ -1479,7 +1481,7 @@ function PinnedPill({
       {/* Control bar — actions execute in the main app window */}
       <div className="flex h-7 shrink-0 items-center justify-center gap-2" style={noDragRegion}>
         {/* Push-to-talk: hold to talk, quick tap to lock hands-free —
-            mirrors the Right ⌘ key. Pointer capture keeps the release edge
+            mirrors the talk key. Pointer capture keeps the release edge
             even if the cursor slides off mid-hold. */}
         <button
           type="button"
@@ -1495,8 +1497,8 @@ function PinnedPill({
               ? 'bg-[var(--rowboat-success)] text-white hover:bg-[var(--rowboat-success)]/85'
               : 'bg-neutral-700 text-white/90 hover:bg-neutral-600'
           } ${state.micMuted ? 'opacity-50' : ''}`}
-          aria-label="Hold to talk — or hold the right ⌘ key from any app"
-          title="Hold to talk (tap to go hands-free) — or hold the right ⌘ key from any app"
+          aria-label={`Hold to talk — or hold the ${PTT_LABEL} key from any app`}
+          title={`Hold to talk (tap to go hands-free) — or hold the ${PTT_LABEL} key from any app`}
         >
           <Mic className="h-3 w-3" />
           {state.pttLocked ? 'Tap to send' : state.status === 'listening' ? 'Release to send' : 'Hold to talk'}
@@ -1664,7 +1666,7 @@ function TuckedMascot({
       : ''
   const caption = state.interimText || replyTail
 
-  // Mic gate open (holding right ⌘ / the pin, or hands-free lock): the ONE
+  // Mic gate open (holding the talk key / the pin, or hands-free lock): the ONE
   // state the user must never have to squint for — without visible feedback
   // there is no way to tell a working hold from a dead key hook.
   const micOpen = !state.micMuted && (state.status === 'listening' || state.pttLocked)

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -43,6 +43,7 @@ import { reduceTurn } from '@x/shared/src/turns.js'
 import * as quickAskShortcut from '@x/shared/src/quick-ask-shortcut.js'
 import * as pttKey from '@x/shared/src/ptt-key.js'
 import { useQuickAskShortcut } from '@/hooks/use-quick-ask-shortcut'
+import { useWindowTheme } from '@/hooks/use-window-theme'
 
 import { TalkingHead } from '@/components/talking-head'
 import { isMac } from '@/lib/shortcut'
@@ -120,6 +121,29 @@ type PopoutAction =
 const PINNED_BASE_HEIGHT = 320
 const PINNED_RESPONSE_HEIGHT = 560
 
+// The card's chip recipe, in both skins: a translucent tint of the OPPOSITE
+// ink over a translucent card. Tokens can't say that — `bg-accent` is a flat
+// colour, and flattening these would cost the card the frosted look it is
+// built on — so the pairs are spelled out, once, here.
+//
+// Surface and resting ink are separate because the labelled destination chip
+// rests a shade darker than the icon-only buttons beside it. Only that
+// resting shade differs, so the hover and dark inks stay with the surface.
+// The ring WIDTH (`ring-1 ring-inset`) stays at each call site — those
+// controls differ in shape, not in colour.
+const CHIP_SURFACE =
+  'bg-black/[0.04] ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900' +
+  ' dark:bg-white/[0.06] dark:ring-white/10 dark:hover:bg-white/[0.12] dark:hover:text-neutral-100'
+const CHIP_INK = 'text-neutral-500 dark:text-neutral-400'
+const CHIP_INK_LABELLED = 'text-neutral-600 dark:text-neutral-400'
+const CHIP_IDLE = `${CHIP_SURFACE} ${CHIP_INK}`
+const CHIP_ACTIVE =
+  'bg-black/[0.08] text-neutral-900 ring-black/15' +
+  ' dark:bg-white/[0.12] dark:text-neutral-100 dark:ring-white/20'
+const CHIP_DISABLED =
+  'cursor-default bg-black/[0.04] text-neutral-300 ring-black/5' +
+  ' dark:bg-white/[0.04] dark:text-neutral-600 dark:ring-white/5'
+
 /**
  * Content of the companion window (global ⌥⇧Space — see main's quick-ask.ts).
  * ONE surface: the SKIPPER — the mascot with its text panel, hosting a live
@@ -139,15 +163,14 @@ const PINNED_RESPONSE_HEIGHT = 560
  * card tucks the text away.
  */
 export function QuickAskBar() {
-  // Transparent window: clear every layer so only the card paints. This
-  // window skips the app's ThemeProvider — claim the LIGHT tokens explicitly
-  // (the light-skin redesign, #810). Removing 'dark' matters: the
-  // pre-light-redesign code added it, and the window persists across HMR, so
-  // a stale 'dark' class left code blocks rendering dark-theme tokens on the
-  // light panel.
+  // This window skips the app's ThemeProvider (main.tsx renders it on a hash
+  // route, outside the tree), so it resolves the shared setting itself and
+  // owns the light/dark class on <html>. It used to hard-force 'light' for
+  // the light-skin redesign (#810) — which meant the theme toggle could never
+  // reach the companion at all.
+  useWindowTheme()
+  // Transparent window: clear every layer so only the card paints.
   useEffect(() => {
-    document.documentElement.classList.remove('dark')
-    document.documentElement.classList.add('light')
     document.documentElement.style.background = 'transparent'
     document.body.style.background = 'transparent'
     // The document must never scroll — a wheel event could shove the whole
@@ -613,10 +636,22 @@ export function QuickAskBar() {
       <div data-qa-passthrough className="flex shrink-0 items-end justify-end gap-1 px-6 pb-5">
       {!collapsed && (
       <div data-qa-passthrough className="relative min-w-0 flex-1">
-      {/* Light skin (#810): near-white card, hairline dark border, dark
-          text. The window's native shadow is off (it would outline the
-          whole transparent frame) — the card draws its own. */}
-      <div ref={cardRef} className="qa-card w-full overflow-hidden rounded-[26px] border border-black/10 bg-white/[0.97] text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.18),0_2px_10px_rgba(0,0,0,0.10)]">
+      {/* Near-white card with a hairline dark border in light; near-black
+          with a hairline light one in dark. #810 introduced the light skin as
+          the only skin — it follows the app's theme setting now (see
+          useWindowTheme above). The window's native shadow is off (it would
+          outline the whole transparent frame) — the card draws its own, and
+          draws it heavier in dark, where a soft grey haze would just vanish
+          into whatever is behind the window. */}
+      <div ref={cardRef} style={dragRegion} className="qa-card relative w-full cursor-grab overflow-hidden rounded-[26px] border border-black/10 bg-white/[0.97] text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.18),0_2px_10px_rgba(0,0,0,0.10)] dark:border-white/15 dark:bg-neutral-900/[0.97] dark:text-neutral-100 dark:shadow-[0_12px_32px_rgba(0,0,0,0.55),0_2px_10px_rgba(0,0,0,0.4)]">
+        {/* The card is a drag handle, like the mascot: every bit of bare
+            surface — the border, the gutters around the action strip, the
+            frame around the composer — picks the Skipper up. The CONTROLS
+            punch holes in it (noDragRegion below): Electron makes children
+            draggable unless they opt out, so each chip, the response panel
+            (its scrollbar rides the card's edge, and a scrollbar that moved
+            the window instead of the text would be a trap) and the composer
+            say so explicitly. */}
         {/* Charcoal code blocks. Streamdown's own dark rule is
             background: var(--shiki-dark-bg) !important inside Tailwind's
             utilities layer — layered !important outranks any override we
@@ -630,6 +665,11 @@ export function QuickAskBar() {
           }
           .qa-card [data-streamdown="code-block"] {
             border-color: rgba(0, 0, 0, 0.3) !important;
+          }
+          /* Same charcoal block, but a dark hairline on a dark card is an
+             invisible one — the edge has to come from the light side. */
+          .dark .qa-card [data-streamdown="code-block"] {
+            border-color: rgba(255, 255, 255, 0.15) !important;
           }
         `}</style>
         {/* Action strip: the destination affordances plus the speaker mute.
@@ -645,7 +685,8 @@ export function QuickAskBar() {
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="flex min-w-0 items-center gap-1.5 rounded-full bg-black/[0.04] py-1 pl-2.5 pr-2 text-[11px] font-medium text-neutral-600 ring-1 ring-inset ring-black/10 transition-colors hover:bg-black/[0.08] hover:text-neutral-900"
+                    style={noDragRegion}
+                    className={`flex min-w-0 items-center gap-1.5 rounded-full py-1 pl-2.5 pr-2 text-[11px] font-medium ring-1 ring-inset transition-colors ${CHIP_SURFACE} ${CHIP_INK_LABELLED}`}
                   >
                     <MessageCircle className="h-3 w-3 shrink-0" />
                     <span className="max-w-[220px] truncate">{chatContext?.activeTitle ?? 'New chat'}</span>
@@ -689,9 +730,10 @@ export function QuickAskBar() {
             <TooltipTrigger asChild>
               <button
                 type="button"
+                style={noDragRegion}
                 onClick={newChat}
                 aria-label="New chat"
-                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-black/[0.04] text-neutral-500 ring-1 ring-inset ring-black/10 transition-colors hover:bg-black/[0.08] hover:text-neutral-900"
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${CHIP_IDLE}`}
               >
                 <Plus className="h-3.5 w-3.5" />
               </button>
@@ -704,15 +746,16 @@ export function QuickAskBar() {
             <TooltipTrigger asChild>
               <button
                 type="button"
+                style={noDragRegion}
                 onClick={activeRunId ? toggleHistory : undefined}
                 aria-label={showHistory ? 'Hide history' : 'Peek at recent history'}
                 aria-disabled={!activeRunId}
                 className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
                   showHistory
-                    ? 'bg-black/[0.08] text-neutral-900 ring-black/15'
+                    ? CHIP_ACTIVE
                     : activeRunId
-                      ? 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                      : 'cursor-default bg-black/[0.04] text-neutral-300 ring-black/5'
+                      ? CHIP_IDLE
+                      : CHIP_DISABLED
                 }`}
               >
                 {showHistory ? <ChevronsDown className="h-3.5 w-3.5" /> : <ChevronsUp className="h-3.5 w-3.5" />}
@@ -732,12 +775,13 @@ export function QuickAskBar() {
             <TooltipTrigger asChild>
               <button
                 type="button"
+                style={noDragRegion}
                 onClick={() => sendAction('toggle-speaker')}
                 aria-label={callState.speakerMuted ? 'Unmute spoken replies' : 'Mute spoken replies'}
                 className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
                   callState.speakerMuted
-                    ? 'bg-black/[0.04] text-neutral-500 ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900'
-                    : 'bg-sky-500/15 text-sky-700 ring-sky-500/30'
+                    ? CHIP_IDLE
+                    : 'bg-sky-500/15 text-sky-700 ring-sky-500/30 dark:bg-sky-400/20 dark:text-sky-300 dark:ring-sky-400/30'
                 }`}
               >
                 {callState.speakerMuted ? <VolumeX className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
@@ -756,9 +800,10 @@ export function QuickAskBar() {
             <TooltipTrigger asChild>
               <button
                 type="button"
+                style={noDragRegion}
                 onClick={openInApp}
                 aria-label="Open in Rowboat"
-                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-black/[0.04] text-neutral-500 ring-1 ring-inset ring-black/10 transition-colors hover:bg-black/[0.08] hover:text-neutral-900"
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${CHIP_IDLE}`}
               >
                 <ArrowUpRight className="h-3.5 w-3.5" />
               </button>
@@ -770,7 +815,8 @@ export function QuickAskBar() {
         {(panelAsked || panelText || showHistory) && (
           <div
             ref={panelScrollRef}
-            className="max-h-[280px] cursor-text select-text overflow-y-auto px-6 pb-3 pt-2 text-sm leading-relaxed text-neutral-800"
+            style={noDragRegion}
+            className="max-h-[280px] cursor-text select-text overflow-y-auto px-6 pb-3 pt-2 text-sm leading-relaxed text-neutral-800 dark:text-neutral-200"
           >
             {showHistory && historyData === null && (
               <div className="mb-2 animate-pulse text-xs text-neutral-400">Loading history…</div>
@@ -783,13 +829,13 @@ export function QuickAskBar() {
                   <div className="opacity-75">
                     {earlierItems.map((m, i) =>
                       m.role === 'user' ? (
-                        <div key={i} className="mb-1.5 mt-3 text-sm font-medium text-neutral-500 first:mt-0">
+                        <div key={i} className="mb-1.5 mt-3 text-sm font-medium text-neutral-500 first:mt-0 dark:text-neutral-400">
                           {m.content}
                         </div>
                       ) : (
                         <Streamdown
                           key={i}
-                          className="dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-800"
+                          className="dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-800 dark:[&_:not(pre)>code]:bg-white/[0.10] dark:[&_:not(pre)>code]:text-neutral-200"
                         >
                           {m.content}
                         </Streamdown>
@@ -799,27 +845,31 @@ export function QuickAskBar() {
                 )}
                 {(panelAsked || panelText) && earlierItems.length > 0 && (
                   <div className="my-2 flex items-center gap-2 text-[13px] text-neutral-400">
-                    <span className="h-px flex-1 bg-black/10" />
+                    <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
                     earlier
-                    <span className="h-px flex-1 bg-black/10" />
+                    <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
                   </div>
                 )}
               </div>
             )}
             {/* Inside the scroll area — the question scrolls away with the
                 answer instead of persisting as a header. */}
-            {panelAsked && <div className="mb-2 text-sm font-medium text-neutral-500">{panelAsked}</div>}
+            {panelAsked && <div className="mb-2 text-sm font-medium text-neutral-500 dark:text-neutral-400">{panelAsked}</div>}
             {panelText ? (
               /* `.dark` scoped to the markdown only: shiki's token colors key
                  off a .dark ancestor, so this flips code to its dark palette
-                 (matching the charcoal block bg) without darkening the rest
-                 of the light panel — the prose classes here are explicit. */
-              <Streamdown className="dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-800">
+                 (matching the charcoal block bg) whichever skin the card is
+                 wearing — the code block is charcoal in both. It does NOT
+                 darken the surrounding panel: the prose classes here are
+                 explicit, and Tailwind's `dark:` needs a .dark ANCESTOR, so
+                 the class sitting on this very element doesn't trigger the
+                 dark half of the pairs below. */
+              <Streamdown className="dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-800 dark:[&_:not(pre)>code]:bg-white/[0.10] dark:[&_:not(pre)>code]:text-neutral-200">
                 {panelText}
               </Streamdown>
             ) : (
               panelProcessing && (
-                <span className="animate-pulse text-neutral-500">{panelStatusText}</span>
+                <span className="animate-pulse text-neutral-500 dark:text-neutral-400">{panelStatusText}</span>
               )
             )}
             {panelProcessing && panelText && <span className="animate-pulse">▍</span>}
@@ -830,22 +880,26 @@ export function QuickAskBar() {
             attachments, search/code/permissions, model/effort) to the app
             window, which submits into the companion's chat exactly like an
             in-app composer message. */}
-        <div className="border-t border-black/5 p-3">
-          <ChatInputWithMentions
-            knowledgeFiles={knowledgeFiles}
-            recentFiles={[]}
-            visibleFiles={knowledgeFiles}
-            onSubmit={submit}
-            onStop={() => sendAction('stop-speaking')}
-            isProcessing={panelProcessing}
-            runId={null}
-            placeholder="Type instead — @ mentions work too…"
-            focusSignal={focusSignal}
-            onSelectionChange={(sel) => {
-              selectionRef.current = sel ?? null
-            }}
-            voiceAvailable={false}
-          />
+        <div className="p-3">
+          {/* The composer opts out of the card's drag region — the p-3 frame
+              around it stays a grab handle. */}
+          <div style={noDragRegion}>
+            <ChatInputWithMentions
+              knowledgeFiles={knowledgeFiles}
+              recentFiles={[]}
+              visibleFiles={knowledgeFiles}
+              onSubmit={submit}
+              onStop={() => sendAction('stop-speaking')}
+              isProcessing={panelProcessing}
+              runId={null}
+              placeholder="Type instead — @ mentions work too…"
+              focusSignal={focusSignal}
+              onSelectionChange={(sel) => {
+                selectionRef.current = sel ?? null
+              }}
+              voiceAvailable={false}
+            />
+          </div>
         </div>
       </div>
 
@@ -857,7 +911,7 @@ export function QuickAskBar() {
             type="button"
             onClick={() => requestCollapsed(true)}
             aria-label="Tuck the text away"
-            className="absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-colors hover:bg-neutral-50 hover:text-neutral-900"
+            className="absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-colors hover:bg-neutral-50 hover:text-neutral-900 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
           >
             <ChevronsRight className="h-3.5 w-3.5" />
           </button>
@@ -874,12 +928,12 @@ export function QuickAskBar() {
           on screen, so fold/unfold moves NOTHING here; only the card beside
           it comes and goes. It is the control surface AND the drag
           handle — which is why the column is deliberately NOT marked
-          passthrough (useClickThrough): the whole 132px footprint stays
+          passthrough (useClickThrough): the whole SKIPPER_SIZE footprint stays
           solid so the Skipper can be grabbed anywhere on it, exactly as
           before, instead of only where the artwork happens to paint. */}
       <div
-        className="relative flex w-[132px] shrink-0 cursor-grab select-none flex-col items-center"
-        style={dragRegion}
+        className="relative flex shrink-0 cursor-grab select-none flex-col items-center"
+        style={{ ...dragRegion, width: SKIPPER_SIZE }}
         title="Drag to move your Skipper"
       >
         <style>{`
@@ -903,11 +957,11 @@ export function QuickAskBar() {
             <>
               <span
                 className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-[var(--rowboat-success)]/90"
-                style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
+                style={{ top: '42%', width: HALO_SIZE, height: HALO_SIZE, marginLeft: -HALO_SIZE / 2, marginTop: -HALO_SIZE / 2, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
               />
               <span
                 className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-[var(--rowboat-success)]/90"
-                style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
+                style={{ top: '42%', width: HALO_SIZE, height: HALO_SIZE, marginLeft: -HALO_SIZE / 2, marginTop: -HALO_SIZE / 2, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
               />
             </>
           )}
@@ -918,7 +972,7 @@ export function QuickAskBar() {
                 : callState.ttsState
             }
             getLevel={synthLevel}
-            size={132}
+            size={SKIPPER_SIZE}
             hat="cowboy"
             hatOverlay={
               <SkipperPins
@@ -933,15 +987,15 @@ export function QuickAskBar() {
         {/* Fixed-height caption + chip slots: present in BOTH states so the
             head never shifts when a caption appears or the text folds. Both
             are single-line and CENTERED on the mascot — wider than the
-            132px column they overflow it symmetrically (the column doesn't
+            mascot column they overflow it symmetrically (the column doesn't
             clip), which reads as a caption under the head instead of a
             squeezed left-ragged wrap. */}
-        <div className="flex h-4 items-center">
+        <div className="flex h-5 items-center">
           {skipperCaption && (
-            <span className="max-w-[176px] truncate whitespace-nowrap rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{skipperCaption}</span>
+            <span className="max-w-[220px] truncate whitespace-nowrap rounded bg-black/70 px-2 py-0.5 text-[11px] text-white/90">{skipperCaption}</span>
           )}
         </div>
-        <div className="flex h-6 items-center">
+        <div className="flex h-7 items-center">
           <SkipperStatusChip state={callState} activity={heldActivity} />
         </div>
       </div>
@@ -1050,6 +1104,14 @@ function useClickThrough(active: boolean) {
   }, [active])
 }
 
+/**
+ * The Skipper's rendered size, in design px — shared by BOTH presentations
+ * (card-side column and tucked) so the mascot is the same object either way,
+ * and by the listening halo, whose rings are sized as a fraction of it.
+ */
+const SKIPPER_SIZE = 164
+const HALO_SIZE = Math.round(SKIPPER_SIZE * 0.79)
+
 const dragRegion = { WebkitAppRegion: 'drag' } as React.CSSProperties
 const noDragRegion = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
 
@@ -1114,11 +1176,11 @@ function SkipperPins({
           onClick={() => sendAction('stop-speaking')}
           aria-label="Stop the assistant"
           title="Stop — cut the reply short (the session keeps going)"
-          className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+          className="group/pin absolute flex h-[38px] w-[38px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
           style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
         >
-          <span className="flex h-[18px] w-[18px] items-center justify-center rounded-full bg-red-600 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110">
-            <Square className="h-2.5 w-2.5 fill-current text-white" />
+          <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-red-600 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110">
+            <Square className="h-3 w-3 fill-current text-white" />
           </span>
         </button>
       ) : (
@@ -1137,16 +1199,16 @@ function SkipperPins({
           }}
           aria-label="Hold to talk — tap for hands-free"
           title={`Hold to talk (tap for hands-free) — or hold the ${PTT_LABEL} key`}
-          className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+          className="group/pin absolute flex h-[38px] w-[38px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
           style={{ ...noDragRegion, left: '50%', top: '17.3%' }}
         >
           <span
-            className={`flex h-[18px] w-[18px] select-none items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
+            className={`flex h-[22px] w-[22px] select-none items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
               state.status === 'listening' || state.pttLocked ? 'bg-[var(--rowboat-success)]' : 'bg-amber-400'
             }`}
           >
             <Mic
-              className={`h-3 w-3 ${
+              className={`h-3.5 w-3.5 ${
                 state.status === 'listening' || state.pttLocked ? 'text-white' : 'text-[#17171B]'
               }`}
             />
@@ -1161,20 +1223,20 @@ function SkipperPins({
         type="button"
         onClick={() => sendAction('toggle-share')}
         aria-label={state.screenSharing ? 'Stop sharing your screen' : 'Share your screen'}
-        className="group/pin absolute flex h-[30px] w-[30px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+        className="group/pin absolute flex h-[38px] w-[38px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
         style={{ ...noDragRegion, left: '50%', top: '73%' }}
       >
         <span
-          className={`relative flex h-[18px] w-[18px] items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
+          className={`relative flex h-[22px] w-[22px] items-center justify-center rounded-full shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-110 ${
             state.screenSharing ? 'bg-sky-500' : 'bg-neutral-600'
           }`}
         >
-          <MonitorUp className="h-3 w-3 text-white" />
+          <MonitorUp className="h-3.5 w-3.5 text-white" />
           {state.screenSharing && (
-            <span className="absolute -right-1 -top-1 block h-[7px] w-[7px] animate-pulse rounded-full bg-sky-300 ring-1 ring-[#17171B]" />
+            <span className="absolute -right-1 -top-1 block h-[8px] w-[8px] animate-pulse rounded-full bg-sky-300 ring-1 ring-[#17171B]" />
           )}
         </span>
-        <span className="pointer-events-none absolute left-1/2 top-full mt-0.5 -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[9px] font-medium text-white opacity-0 transition-opacity group-hover/pin:opacity-100">
+        <span className="pointer-events-none absolute left-1/2 top-full mt-0.5 -translate-x-1/2 whitespace-nowrap rounded bg-black/75 px-1.5 py-0.5 text-[10px] font-medium text-white opacity-0 transition-opacity group-hover/pin:opacity-100">
           {state.screenSharing ? 'Sharing screen — click to stop' : 'Share your screen'}
         </span>
       </button>
@@ -1183,14 +1245,14 @@ function SkipperPins({
         onClick={onTextPin}
         aria-label={textPin === 'expand' ? 'Bring the text back' : 'Tuck the text away'}
         title={textPin === 'expand' ? `Bring the text back (${shortcutLabel} works too)` : 'Tuck the text away — the session keeps going'}
-        className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+        className="group/pin absolute flex h-[32px] w-[32px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
         style={{ ...noDragRegion, left: '18%', top: '68%' }}
       >
-        <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-sky-500 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-125">
+        <span className="flex h-[20px] w-[20px] items-center justify-center rounded-full bg-sky-500 shadow-sm ring-2 ring-[#17171B] transition-transform group-hover/pin:scale-125">
           {textPin === 'expand' ? (
-            <ChevronsLeft className="h-2.5 w-2.5 text-white" />
+            <ChevronsLeft className="h-3 w-3 text-white" />
           ) : (
-            <ChevronsRight className="h-2.5 w-2.5 text-white" />
+            <ChevronsRight className="h-3 w-3 text-white" />
           )}
         </span>
       </button>
@@ -1199,11 +1261,11 @@ function SkipperPins({
         onClick={() => sendAction('end-call')}
         aria-label="End the voice session and close"
         title="End & close (a live session can't be hidden while it keeps listening)"
-        className="group/pin absolute flex h-[26px] w-[26px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
+        className="group/pin absolute flex h-[32px] w-[32px] appearance-none items-center justify-center border-0 bg-transparent p-0 outline-none -translate-x-1/2 -translate-y-1/2"
         style={{ ...noDragRegion, left: '82%', top: '68%' }}
       >
-        <span className="flex h-[16px] w-[16px] items-center justify-center rounded-full bg-neutral-700 shadow-sm ring-2 ring-[#17171B] transition-colors transition-transform group-hover/pin:scale-125 group-hover/pin:bg-red-600">
-          <X className="h-2.5 w-2.5 text-white" />
+        <span className="flex h-[20px] w-[20px] items-center justify-center rounded-full bg-neutral-700 shadow-sm ring-2 ring-[#17171B] transition-colors transition-transform group-hover/pin:scale-125 group-hover/pin:bg-red-600">
+          <X className="h-3 w-3 text-white" />
         </span>
       </button>
     </div>
@@ -1223,28 +1285,28 @@ function SkipperStatusChip({ state, activity }: { state: CallState; activity?: s
   const micOpen = !state.micMuted && (state.status === 'listening' || state.pttLocked)
   return (
     <span
-      className={`flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 font-medium text-white shadow-md ${
-        micOpen ? 'bg-[var(--rowboat-success)] text-[11px] font-semibold' : 'bg-black/60 text-[10px]'
+      className={`flex items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1 font-medium text-white shadow-md ${
+        micOpen ? 'bg-[var(--rowboat-success)] text-[12px] font-semibold' : 'bg-black/60 text-[11px]'
       }`}
     >
       {state.micMuted && (state.status === 'listening' || state.status === 'idle') ? (
         <>
-          <span className="block h-1.5 w-1.5 rounded-full bg-red-500" />
+          <span className="block h-2 w-2 rounded-full bg-red-500" />
           Muted
         </>
       ) : state.pttLocked ? (
         <>
-          <Mic className="h-3 w-3 animate-pulse" />
+          <Mic className="h-3.5 w-3.5 animate-pulse" />
           Hands-free — tap {PTT_KEYCAP} to send
         </>
       ) : state.status === 'listening' ? (
         <>
-          <Mic className="h-3 w-3 animate-pulse" />
+          <Mic className="h-3.5 w-3.5 animate-pulse" />
           Listening — release to send
         </>
       ) : statusDisplay ? (
         <>
-          <span className={`block h-1.5 w-1.5 rounded-full ${statusDisplay.dotClass}`} />
+          <span className={`block h-2 w-2 rounded-full ${statusDisplay.dotClass}`} />
           {state.status === 'idle'
             ? `Hold the mic — or ${PTT_LABEL}`
             : state.status === 'thinking' && activity
@@ -1253,7 +1315,7 @@ function SkipperStatusChip({ state, activity }: { state: CallState; activity?: s
         </>
       ) : (
         <>
-          <span className="block h-1.5 w-1.5 rounded-full bg-neutral-500" />
+          <span className="block h-2 w-2 rounded-full bg-neutral-500" />
           Connecting…
         </>
       )}
@@ -1691,23 +1753,23 @@ function TuckedMascot({
       {/* On duty = cowboy hat on; the controls are enamel pins on the hat
           band, drawn in the artwork's own ink and always visible. They ride
           inside TalkingHead's bobbing container (hatOverlay) so they never
-          detach from the hat. Pin art is small; each sits in a 26px no-drag
-          hit target that grows on hover. */}
+          detach from the hat. Pin art is small; each sits in an oversized
+          no-drag hit target that grows on hover. */}
       {/* -mb pulls the caption/chip up under the boat: the SVG box has dead
           space below the ripples that read as a big gap. */}
       <div className="relative -mb-4" style={{ animation: 'tucked-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)' }}>
         {/* Listening halo: expanding green rings around the head while the
             mic gate is open. Peripheral-vision feedback — the user is
-            usually looking at their own work, not at the chip's 10px text. */}
+            usually looking at their own work, not at the chip's small text. */}
         {micOpen && (
           <>
             <span
               className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-[var(--rowboat-success)]/90"
-              style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
+              style={{ top: '42%', width: HALO_SIZE, height: HALO_SIZE, marginLeft: -HALO_SIZE / 2, marginTop: -HALO_SIZE / 2, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) infinite' }}
             />
             <span
               className="pointer-events-none absolute left-1/2 z-10 rounded-full border-[3px] border-[var(--rowboat-success)]/90"
-              style={{ top: '42%', width: 104, height: 104, marginLeft: -52, marginTop: -52, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
+              style={{ top: '42%', width: HALO_SIZE, height: HALO_SIZE, marginLeft: -HALO_SIZE / 2, marginTop: -HALO_SIZE / 2, animation: 'listen-ring 1.5s cubic-bezier(0, 0, 0.2, 1) 0.5s infinite' }}
             />
           </>
         )}
@@ -1717,7 +1779,7 @@ function TuckedMascot({
           // 'synthesizing' state, which renders bubbles + raised eyes.
           ttsState={state.status === 'thinking' && state.ttsState === 'idle' ? 'synthesizing' : state.ttsState}
           getLevel={getLevel}
-          size={132}
+          size={SKIPPER_SIZE}
           hat="cowboy"
           hatOverlay={
             <SkipperPins state={state} sendAction={sendAction} textPin="expand" onTextPin={onExpand} />
@@ -1726,13 +1788,13 @@ function TuckedMascot({
       </div>
 
       {/* Caption + status chip, readable over any desktop. */}
-      <div data-qa-passthrough className="flex h-4 max-w-full items-center px-2">
+      <div data-qa-passthrough className="flex h-5 max-w-full items-center px-2">
         {caption && (
-          <span className="truncate rounded bg-black/70 px-1.5 py-px text-[10px] text-white/90">{caption}</span>
+          <span className="truncate rounded bg-black/70 px-2 py-0.5 text-[11px] text-white/90">{caption}</span>
         )}
       </div>
       {/* Pure status line — the CONTROLS are the pins. */}
-      <div data-qa-passthrough className="flex h-6 items-center">
+      <div data-qa-passthrough className="flex h-7 items-center">
         <SkipperStatusChip state={state} activity={activity} />
       </div>
     </div>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -910,9 +910,16 @@ export function QuickAskBar() {
           the click never happens. That is the "sometimes it works" report.
 
           The hole is deliberately bigger than the art — 40px around a 32px
-          circle, the same oversized-target trick as the bubble and pins. */}
+          circle, the same oversized-target trick as the bubble and pins.
+          But it hangs 18px past the card edge and the gap to the mascot is
+          only 4px, so it reaches 14px into the mascot column — over the
+          left lip of the mic pin's own oversized target (38px at left:18%
+          of 164px starts at 10.5px). Hence pointer-events-none here with
+          the button opting back in: the hole still punches from painted
+          bounds (an app-region concern, not a hit-testing one), while
+          presses over the overlap fall through to the pin underneath. */}
       <span
-        className="absolute z-10 flex h-10 w-10 items-center justify-center"
+        className="pointer-events-none absolute z-10 flex h-10 w-10 items-center justify-center"
         style={{ ...noDragRegion, top: 'calc(50% - 20px)', right: '-18px' }}
       >
         <Tooltip>
@@ -921,7 +928,7 @@ export function QuickAskBar() {
               type="button"
               onClick={() => requestCollapsed(true)}
               aria-label="Tuck the text away"
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition hover:translate-x-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+              className="pointer-events-auto flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition hover:translate-x-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
             >
               <ChevronsRight className="h-4 w-4" />
             </button>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -234,6 +234,7 @@ export function QuickAskBar() {
   // The frame is mostly transparent stage — hand the clicks that land on it
   // back to whatever the user has underneath.
   useClickThrough(pinned)
+  useDragCursor()
 
   // Mirrors callState.speakerMuted for the fold callback below (which is
   // deliberately dependency-free).
@@ -1112,6 +1113,38 @@ function useClickThrough(active: boolean) {
 const SKIPPER_SIZE = 164
 const HALO_SIZE = Math.round(SKIPPER_SIZE * 0.79)
 
+/**
+ * Grab → GRABBING while the Skipper is actually moving.
+ *
+ * The handles (the card and the mascot column) are drag regions, and a drag
+ * region is native: on Windows the hit test answers HTCAPTION, on macOS it is
+ * a view layered over the page. Neither ever delivers the mousedown, so
+ * `:active` — the obvious way to write this — is never true here. Main
+ * watches the window's own 'move' instead and pushes the edges of the drag
+ * (quick-ask:dragging); this flips a class on <html> that the rule below
+ * turns into the closed-hand cursor everywhere, since during a drag the
+ * pointer is over a handle by definition.
+ *
+ * The rule is injected rather than rendered: the window has several
+ * presentations (card, pill, tucked mascot) and each is an early return, so
+ * a <style> in any one of them would be missing from the others.
+ */
+function useDragCursor() {
+  useEffect(() => {
+    const style = document.createElement('style')
+    style.textContent = 'html.qa-dragging, html.qa-dragging * { cursor: grabbing !important; }'
+    document.head.appendChild(style)
+    const off = window.ipc.on('quick-ask:dragging', ({ dragging }) => {
+      document.documentElement.classList.toggle('qa-dragging', dragging)
+    })
+    return () => {
+      off()
+      style.remove()
+      document.documentElement.classList.remove('qa-dragging')
+    }
+  }, [])
+}
+
 const dragRegion = { WebkitAppRegion: 'drag' } as React.CSSProperties
 const noDragRegion = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
 
@@ -1736,7 +1769,7 @@ function TuckedMascot({
   return (
     <div
       data-qa-passthrough
-      className="group relative flex h-screen w-screen select-none flex-col items-center justify-end overflow-hidden pb-2"
+      className="group relative flex h-screen w-screen cursor-grab select-none flex-col items-center justify-end overflow-hidden pb-2"
       style={dragRegion}
     >
       <style>{`

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1471,7 +1471,7 @@ function UnfoldBubble({ onExpand }: { onExpand: () => void }) {
             type="button"
             onClick={onExpand}
             aria-label="Bring the text back"
-            className="qa-bubble flex h-7 w-7 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_4px_14px_rgba(0,0,0,0.18)] transition hover:-translate-y-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_4px_14px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+            className="qa-bubble flex h-7 w-7 items-center justify-center rounded-full bg-white text-neutral-500 shadow-[0_4px_14px_rgba(0,0,0,0.18)] transition hover:-translate-y-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_4px_14px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
           >
             <ChevronsLeft className="h-3.5 w-3.5" />
           </button>

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -1405,7 +1405,7 @@ function TurnDivider({ children }: { children: React.ReactNode }) {
 
 /**
  * The way back, while the text is tucked: a chevron bubble floating just
- * above the Skipper's head.
+ * above the boat, in the gap between the Skipper and the gunwale.
  *
  * It is the mirror of the card's tuck handle — same circle, same size, the
  * chevron pointing the other way — so hiding and un-hiding are visibly one
@@ -1416,6 +1416,10 @@ function TurnDivider({ children }: { children: React.ReactNode }) {
  *
  * The entry waits out the card's fold (COMPANION_MOTION_CSS delays it), so
  * the two never animate over each other.
+ *
+ * 55% is measured off the artwork, not eyeballed: TalkingHead's viewBox is
+ * 200x190 and the hull's rim runs along y=120, so a centred 28px bubble
+ * ends just shy of the planking and clears the share pin below it.
  */
 function UnfoldBubble({ onExpand }: { onExpand: () => void }) {
   const shortcutState = useQuickAskShortcut()
@@ -1424,7 +1428,10 @@ function UnfoldBubble({ onExpand }: { onExpand: () => void }) {
     // The wrapper owns the CENTERING transform; the button owns the
     // animated one. A CSS animation replaces an element's whole transform,
     // so sharing one element would have the bubble fly in off-centre.
-    <span className="absolute -top-2 left-1/2 z-30 -translate-x-1/2" style={noDragRegion}>
+    <span
+      className="absolute left-1/2 z-30 -translate-x-1/2 -translate-y-1/2"
+      style={{ ...noDragRegion, top: '55%' }}
+    >
       <Tooltip>
         <TooltipTrigger asChild>
           <button

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -132,13 +132,13 @@ const PINNED_RESPONSE_HEIGHT = 560
 // The ring WIDTH (`ring-1 ring-inset`) stays at each call site — those
 // controls differ in shape, not in colour.
 const CHIP_SURFACE =
-  'bg-black/[0.04] ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900' +
+  'active:scale-95 bg-black/[0.04] ring-black/10 hover:bg-black/[0.08] hover:text-neutral-900' +
   ' dark:bg-white/[0.06] dark:ring-white/10 dark:hover:bg-white/[0.12] dark:hover:text-neutral-100'
 const CHIP_INK = 'text-neutral-500 dark:text-neutral-400'
 const CHIP_INK_LABELLED = 'text-neutral-600 dark:text-neutral-400'
 const CHIP_IDLE = `${CHIP_SURFACE} ${CHIP_INK}`
 const CHIP_ACTIVE =
-  'bg-black/[0.08] text-neutral-900 ring-black/15' +
+  'active:scale-95 bg-black/[0.08] text-neutral-900 ring-black/15' +
   ' dark:bg-white/[0.12] dark:text-neutral-100 dark:ring-white/20'
 const CHIP_DISABLED =
   'cursor-default bg-black/[0.04] text-neutral-300 ring-black/5' +
@@ -254,6 +254,11 @@ export function QuickAskBar() {
     // where every control looks dead) — one IPC round-trip is imperceptible.
     void window.ipc.invoke('quickAsk:setPinnedCollapsed', { collapsed: next }).catch(() => {})
   }, [])
+
+  // The card's fold is animated, so it outlives `collapsed` by the length of
+  // its exit (usePresence) — everything below keys off `card.mounted`, not
+  // `!collapsed`.
+  const card = usePresence(!collapsed, CARD_EXIT_MS)
 
   // The visible card, for hit-testing stage clicks: the window is a tall
   // transparent frame, so "clicked outside" often lands INSIDE its invisible
@@ -612,6 +617,7 @@ export function QuickAskBar() {
   // and the mascot never moves, resizes, or replays its entry animation.
   return (
     <div data-qa-passthrough className="flex h-screen w-screen select-none flex-col overflow-hidden">
+      <style>{COMPANION_MOTION_CSS}</style>
       {/* The invisible stage: popovers open into this zone. It is marked
           passthrough, so clicks that land on it go to whatever the user has
           BEHIND this window (useClickThrough) instead of being swallowed by
@@ -635,8 +641,11 @@ export function QuickAskBar() {
           both states — with the corner-anchored window, that pins the
           mascot to the exact same screen pixels across fold/unfold. */}
       <div data-qa-passthrough className="flex shrink-0 items-end justify-end gap-1 px-6 pb-5">
-      {!collapsed && (
-      <div data-qa-passthrough className="relative min-w-0 flex-1">
+      {card.mounted && (
+      <div
+        data-qa-passthrough
+        className={`relative min-w-0 flex-1 ${card.exiting ? 'pointer-events-none' : ''}`}
+      >
       {/* Near-white card with a hairline dark border in light; near-black
           with a hairline light one in dark. #810 introduced the light skin as
           the only skin — it follows the app's theme setting now (see
@@ -644,7 +653,7 @@ export function QuickAskBar() {
           outline the whole transparent frame) — the card draws its own, and
           draws it heavier in dark, where a soft grey haze would just vanish
           into whatever is behind the window. */}
-      <div ref={cardRef} style={dragRegion} className="qa-card relative w-full cursor-grab overflow-hidden rounded-[26px] border border-black/10 bg-white/[0.97] text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.18),0_2px_10px_rgba(0,0,0,0.10)] dark:border-white/15 dark:bg-neutral-900/[0.97] dark:text-neutral-100 dark:shadow-[0_12px_32px_rgba(0,0,0,0.55),0_2px_10px_rgba(0,0,0,0.4)]">
+      <div ref={cardRef} style={dragRegion} className={`qa-card ${card.exiting ? 'qa-card-out' : 'qa-card-in'} relative w-full cursor-grab overflow-hidden rounded-[26px] border border-black/10 bg-white/[0.97] text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.18),0_2px_10px_rgba(0,0,0,0.10)] dark:border-white/15 dark:bg-neutral-900/[0.97] dark:text-neutral-100 dark:shadow-[0_12px_32px_rgba(0,0,0,0.55),0_2px_10px_rgba(0,0,0,0.4)]`}>
         {/* The card is a drag handle, like the mascot: every bit of bare
             surface — the border, the gutters around the action strip, the
             frame around the composer — picks the Skipper up. The CONTROLS
@@ -687,7 +696,7 @@ export function QuickAskBar() {
                   <button
                     type="button"
                     style={noDragRegion}
-                    className={`flex min-w-0 items-center gap-1.5 rounded-full py-1 pl-2.5 pr-2 text-[11px] font-medium ring-1 ring-inset transition-colors ${CHIP_SURFACE} ${CHIP_INK_LABELLED}`}
+                    className={`flex min-w-0 items-center gap-1.5 rounded-full py-1 pl-2.5 pr-2 text-[11px] font-medium ring-1 ring-inset transition ${CHIP_SURFACE} ${CHIP_INK_LABELLED}`}
                   >
                     <MessageCircle className="h-3 w-3 shrink-0" />
                     <span className="max-w-[220px] truncate">{chatContext?.activeTitle ?? 'New chat'}</span>
@@ -734,7 +743,7 @@ export function QuickAskBar() {
                 style={noDragRegion}
                 onClick={newChat}
                 aria-label="New chat"
-                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${CHIP_IDLE}`}
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition ${CHIP_IDLE}`}
               >
                 <Plus className="h-3.5 w-3.5" />
               </button>
@@ -751,7 +760,7 @@ export function QuickAskBar() {
                 onClick={activeRunId ? toggleHistory : undefined}
                 aria-label={showHistory ? 'Hide history' : 'Peek at recent history'}
                 aria-disabled={!activeRunId}
-                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition ${
                   showHistory
                     ? CHIP_ACTIVE
                     : activeRunId
@@ -779,7 +788,7 @@ export function QuickAskBar() {
                 style={noDragRegion}
                 onClick={() => sendAction('toggle-speaker')}
                 aria-label={callState.speakerMuted ? 'Unmute spoken replies' : 'Mute spoken replies'}
-                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition ${
                   callState.speakerMuted
                     ? CHIP_IDLE
                     : 'bg-sky-500/15 text-sky-700 ring-sky-500/30 dark:bg-sky-400/20 dark:text-sky-300 dark:ring-sky-400/30'
@@ -804,7 +813,7 @@ export function QuickAskBar() {
                 style={noDragRegion}
                 onClick={openInApp}
                 aria-label="Open in Rowboat"
-                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition-colors ${CHIP_IDLE}`}
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ring-1 ring-inset transition ${CHIP_IDLE}`}
               >
                 <ArrowUpRight className="h-3.5 w-3.5" />
               </button>
@@ -817,57 +826,38 @@ export function QuickAskBar() {
           <div
             ref={panelScrollRef}
             style={noDragRegion}
-            className="max-h-[280px] cursor-text select-text overflow-y-auto px-6 pb-3 pt-2 text-sm leading-relaxed text-neutral-800 dark:text-neutral-200"
+            className="qa-rise max-h-[280px] cursor-text select-text overflow-y-auto px-6 pb-3 pt-2 text-sm leading-relaxed text-neutral-800 dark:text-neutral-200"
           >
             {showHistory && historyData === null && (
               <div className="mb-2 animate-pulse text-xs text-neutral-400">Loading history…</div>
             )}
+            {/* Peeked history and the live exchange are the SAME two turn
+                shapes in the same order — the only thing between them is the
+                rule saying where the past stops. (They used to diverge: the
+                history was blanket-dimmed, its questions were bare grey
+                text, and the rule between them was labelled "earlier" while
+                sitting above the newest turn of all.) */}
             {showHistory && earlierItems !== null && (
               <div className="mb-1">
                 {earlierItems.length === 0 ? (
                   <div className="mb-2 text-xs text-neutral-400">No earlier messages in this chat.</div>
                 ) : (
-                  <div className="opacity-75">
-                    {earlierItems.map((m, i) =>
-                      m.role === 'user' ? (
-                        <div key={i} className="mb-1.5 mt-3 text-sm font-medium text-neutral-500 first:mt-0 dark:text-neutral-400">
-                          {m.content}
-                        </div>
-                      ) : (
-                        <Streamdown
-                          key={i}
-                          className="dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-800 dark:[&_:not(pre)>code]:bg-white/[0.10] dark:[&_:not(pre)>code]:text-neutral-200"
-                        >
-                          {m.content}
-                        </Streamdown>
-                      ),
-                    )}
-                  </div>
+                  earlierItems.map((m, i) =>
+                    m.role === 'user' ? (
+                      <UserTurn key={i}>{m.content}</UserTurn>
+                    ) : (
+                      <AssistantTurn key={i}>{m.content}</AssistantTurn>
+                    ),
+                  )
                 )}
-                {(panelAsked || panelText) && earlierItems.length > 0 && (
-                  <div className="my-2 flex items-center gap-2 text-[13px] text-neutral-400">
-                    <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
-                    earlier
-                    <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
-                  </div>
-                )}
+                {(panelAsked || panelText) && earlierItems.length > 0 && <TurnDivider>now</TurnDivider>}
               </div>
             )}
             {/* Inside the scroll area — the question scrolls away with the
                 answer instead of persisting as a header. */}
-            {panelAsked && <div className="mb-2 text-sm font-medium text-neutral-500 dark:text-neutral-400">{panelAsked}</div>}
+            {panelAsked && <UserTurn>{panelAsked}</UserTurn>}
             {panelText ? (
-              /* `.dark` scoped to the markdown only: shiki's token colors key
-                 off a .dark ancestor, so this flips code to its dark palette
-                 (matching the charcoal block bg) whichever skin the card is
-                 wearing — the code block is charcoal in both. It does NOT
-                 darken the surrounding panel: the prose classes here are
-                 explicit, and Tailwind's `dark:` needs a .dark ANCESTOR, so
-                 the class sitting on this very element doesn't trigger the
-                 dark half of the pairs below. */
-              <Streamdown className="dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px] [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:text-neutral-800 dark:[&_:not(pre)>code]:bg-white/[0.10] dark:[&_:not(pre)>code]:text-neutral-200">
-                {panelText}
-              </Streamdown>
+              <AssistantTurn>{panelText}</AssistantTurn>
             ) : (
               panelProcessing && (
                 <span className="animate-pulse text-neutral-500 dark:text-neutral-400">{panelStatusText}</span>
@@ -912,7 +902,7 @@ export function QuickAskBar() {
             type="button"
             onClick={() => requestCollapsed(true)}
             aria-label="Tuck the text away"
-            className="absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition-colors hover:bg-neutral-50 hover:text-neutral-900 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+            className="absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition hover:translate-x-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
           >
             <ChevronsRight className="h-3.5 w-3.5" />
           </button>
@@ -1145,6 +1135,70 @@ function useDragCursor() {
   }, [])
 }
 
+/**
+ * How long the card's fold-away runs. The node has to stay mounted for it
+ * (see usePresence), so main and the renderer must agree on one number.
+ */
+const CARD_EXIT_MS = 160
+
+/**
+ * Keep a node on screen for its exit animation.
+ *
+ * The card's `collapsed` comes from MAIN — the renderer never flips it
+ * optimistically, because main owns the window geometry with it — so the
+ * card would otherwise vanish between one commit and the next, with nothing
+ * to animate. This holds the node for `exitMs` after it goes away and says
+ * which half of the motion it is in.
+ */
+function usePresence(visible: boolean, exitMs: number) {
+  const [mounted, setMounted] = useState(visible)
+  // Coming back is instant — remount in the SAME commit that flips visible,
+  // so the entry animation starts on the frame the fold was undone. (Render-
+  // time previous-state adjustment, React's no-effect pattern: an effect here
+  // would cost a blank frame first.)
+  const [prevVisible, setPrevVisible] = useState(visible)
+  if (prevVisible !== visible) {
+    setPrevVisible(visible)
+    if (visible) setMounted(true)
+  }
+  // Going away waits for the animation.
+  useEffect(() => {
+    if (visible) return
+    const t = setTimeout(() => setMounted(false), exitMs)
+    return () => clearTimeout(t)
+  }, [visible, exitMs])
+  return { mounted, exiting: mounted && !visible }
+}
+
+/**
+ * The window's motion, in one place. It is deliberately small and quick:
+ * this thing floats over the user's actual work, so anything showy here is
+ * a distraction rather than a delight. The card folds TOWARD the mascot
+ * (transform-origin at the corner the window is anchored by), which is
+ * where the text is going.
+ */
+const COMPANION_MOTION_CSS = `
+  @keyframes qa-card-in {
+    from { opacity: 0; transform: translateX(22px) scale(0.96); }
+    to { opacity: 1; transform: none; }
+  }
+  @keyframes qa-card-out {
+    from { opacity: 1; transform: none; }
+    to { opacity: 0; transform: translateX(22px) scale(0.96); }
+  }
+  @keyframes qa-rise {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: none; }
+  }
+  .qa-card-in { animation: qa-card-in 0.22s cubic-bezier(0.22, 1, 0.36, 1); transform-origin: 100% 80%; }
+  .qa-card-out { animation: qa-card-out ${CARD_EXIT_MS}ms ease-in forwards; transform-origin: 100% 80%; }
+  .qa-rise { animation: qa-rise 0.18s ease-out; }
+  @media (prefers-reduced-motion: reduce) {
+    .qa-card-in, .qa-rise { animation: none; }
+    .qa-card-out { animation: none; opacity: 0; }
+  }
+`
+
 const dragRegion = { WebkitAppRegion: 'drag' } as React.CSSProperties
 const noDragRegion = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
 
@@ -1301,6 +1355,55 @@ function SkipperPins({
           <X className="h-3 w-3 text-white" />
         </span>
       </button>
+    </div>
+  )
+}
+
+/**
+ * One prose recipe for every assistant turn the panel shows — a peeked
+ * message and the reply streaming in are the same object.
+ *
+ * `.dark` is scoped to the markdown only: shiki's token colors key off a
+ * .dark ancestor, so this flips code to its dark palette (matching the
+ * charcoal block bg) whichever skin the card is wearing — the code block is
+ * charcoal in both. It does NOT darken the surrounding panel: the prose
+ * classes are explicit, and Tailwind's `dark:` needs a .dark ANCESTOR, so
+ * the class sitting on this very element doesn't trigger the dark half of
+ * the pairs in it.
+ */
+const PANEL_PROSE =
+  'dark prose prose-sm max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_p]:my-1.5' +
+  ' [&_ul]:my-1.5 [&_ol]:my-1.5 [&_pre]:my-2 [&_pre]:text-[11px] [&_code]:text-[11px]' +
+  ' [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-black/[0.06] [&_:not(pre)>code]:px-1' +
+  ' [&_:not(pre)>code]:text-neutral-800 dark:[&_:not(pre)>code]:bg-white/[0.10]' +
+  ' dark:[&_:not(pre)>code]:text-neutral-200'
+
+function AssistantTurn({ children }: { children: string }) {
+  return <Streamdown className={PANEL_PROSE}>{children}</Streamdown>
+}
+
+/**
+ * A question the user asked — the same tinted bubble whether it is the one
+ * just spoken or one peeked out of the history, so "mine" is a shape rather
+ * than a shade the reader has to infer.
+ */
+function UserTurn({ children }: { children: string }) {
+  return (
+    <div className="mt-3 mb-2 flex justify-end first:mt-0">
+      <span className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-black/[0.06] px-2.5 py-1.5 text-left text-sm text-neutral-700 dark:bg-white/[0.10] dark:text-neutral-200">
+        {children}
+      </span>
+    </div>
+  )
+}
+
+/** Hairline rule with a word in it — where the peeked past stops. */
+function TurnDivider({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="my-2 flex items-center gap-2 text-[10px] uppercase tracking-wider text-neutral-400">
+      <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
+      {children}
+      <span className="h-px flex-1 bg-black/10 dark:bg-white/15" />
     </div>
   )
 }

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -895,20 +895,40 @@ export function QuickAskBar() {
       </div>
 
       {/* Tuck handle on the card's mascot-side edge: push the text into the
-          mascot → voice-to-voice. The session keeps going. */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => requestCollapsed(true)}
-            aria-label="Tuck the text away"
-            className="absolute -right-3 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition hover:translate-x-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
-          >
-            <ChevronsRight className="h-3.5 w-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top">Tuck the text away — the session keeps going</TooltipContent>
-      </Tooltip>
+          mascot → voice-to-voice. The session keeps going.
+
+          Built like UnfoldBubble, and for the same reason: this wrapper is
+          the DRAG-REGION HOLE, so it is static and transform-free (placed
+          with calc, not -translate-y-1/2). The button used to BE the hole
+          while carrying three transforms — the centring translate plus
+          hover:translate-x and active:scale — and Electron punches holes
+          from the rect Blink last computed on style/layout invalidation,
+          not once per composited frame. So the hole sat wherever the last
+          animation left it while the art painted elsewhere, and a press on
+          the visible circle landed on the card's drag region instead: on
+          Windows that is HTCAPTION, the window enters the OS move loop and
+          the click never happens. That is the "sometimes it works" report.
+
+          The hole is deliberately bigger than the art — 40px around a 32px
+          circle, the same oversized-target trick as the bubble and pins. */}
+      <span
+        className="absolute z-10 flex h-10 w-10 items-center justify-center"
+        style={{ ...noDragRegion, top: 'calc(50% - 20px)', right: '-18px' }}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => requestCollapsed(true)}
+              aria-label="Tuck the text away"
+              className="flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-white text-neutral-500 shadow-[0_2px_8px_rgba(0,0,0,0.15)] transition hover:translate-x-0.5 hover:bg-neutral-50 hover:text-neutral-900 active:scale-90 dark:border-white/15 dark:bg-neutral-800 dark:text-neutral-400 dark:shadow-[0_2px_8px_rgba(0,0,0,0.5)] dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">Tuck the text away — the session keeps going</TooltipContent>
+        </Tooltip>
+      </span>
       </div>
       )}
 

--- a/apps/x/apps/renderer/src/components/video-call-view.tsx
+++ b/apps/x/apps/renderer/src/components/video-call-view.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
 import { Mic, MicOff, Minimize2, MonitorUp, PhoneOff, Presentation, Square, User, Video, VideoOff } from 'lucide-react'
 
+import { pttKey } from '@x/shared'
+
 import { MascotFaceIcon, TalkingHead } from '@/components/talking-head'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { TTSState } from '@/hooks/useVoiceTTS'
+import { isMac } from '@/lib/shortcut'
 import { cn } from '@/lib/utils'
+
+// Hold-to-talk key: right ⌘ on macOS, right Ctrl elsewhere. Naming the wrong
+// key is worse than naming none — a ⌘ glyph on a PC keyboard points at a key
+// that isn't there.
+const PTT_LABEL = pttKey.pttKeyLabel(isMac)
 
 export type VideoCallStatus = 'idle' | 'listening' | 'thinking' | 'speaking'
 
@@ -45,7 +53,7 @@ interface VideoCallViewProps {
 }
 
 const STATUS_DISPLAY: Record<VideoCallStatus, { label: string; dotClass: string }> = {
-  idle: { label: 'Hold right ⌘ to talk · press & release it to go hands-free', dotClass: 'bg-neutral-500' },
+  idle: { label: `Hold ${PTT_LABEL} to talk · press & release it to go hands-free`, dotClass: 'bg-neutral-500' },
   listening: { label: 'Listening — release to send', dotClass: 'bg-[var(--rowboat-success)] animate-pulse' },
   thinking: { label: 'Thinking…', dotClass: 'bg-amber-400' },
   speaking: { label: 'Speaking', dotClass: 'bg-sky-400 animate-pulse' },
@@ -196,9 +204,12 @@ export function VideoCallView({
         )}
       </div>
 
-      {/* Control bar */}
-      <div className="flex items-center justify-center gap-4 pb-5">
-        <span className="flex h-10 items-center gap-2 rounded-full bg-neutral-800 px-4 text-xs font-medium text-white/90">
+      {/* Control bar. Wraps and lets the status chip shrink: seven round
+          buttons plus a full-sentence hint do not fit a 1366-wide (or merely
+          un-maximised) window, and an un-wrapped row pushed End call clean
+          off the screen edge. */}
+      <div className="flex flex-wrap items-center justify-center gap-3 px-4 pb-5">
+        <span className="flex h-10 min-w-0 max-w-full items-center gap-2 rounded-full bg-neutral-800 px-4 text-xs font-medium text-white/90">
           {/* Muted overrides the PTT hint — pressing to talk does nothing
               while muted. Thinking/speaking still show: output continues. */}
           {micMuted && (status === 'idle' || status === 'listening') ? (
@@ -209,17 +220,17 @@ export function VideoCallView({
           ) : pttStatus === 'locked' ? (
             <>
               <span className="block h-2 w-2 rounded-full bg-[var(--rowboat-success)] animate-pulse" />
-              Hands-free — press right ⌘ again to send
+              Hands-free — press {PTT_LABEL} again to send
             </>
           ) : (
             <>
-              <span className={cn('block h-2 w-2 rounded-full', STATUS_DISPLAY[status].dotClass)} />
-              {STATUS_DISPLAY[status].label}
+              <span className={cn('block h-2 w-2 shrink-0 rounded-full', STATUS_DISPLAY[status].dotClass)} />
+              <span className="truncate">{STATUS_DISPLAY[status].label}</span>
             </>
           )}
         </span>
         {/* On-screen push-to-talk: hold to talk, quick tap to lock
-            hands-free — mirrors the Right ⌘ key. Pointer capture keeps the
+            hands-free — mirrors the talk key. Pointer capture keeps the
             release edge even if the cursor slides off mid-hold. */}
         <Tooltip>
           <TooltipTrigger asChild>
@@ -245,7 +256,7 @@ export function VideoCallView({
               {pttStatus === 'idle' ? 'Hold to talk' : pttStatus === 'locked' ? 'Tap to send' : 'Release to send'}
             </button>
           </TooltipTrigger>
-          <TooltipContent className="z-[110]">Hold to talk (tap to go hands-free) — or hold the right ⌘ key</TooltipContent>
+          <TooltipContent className="z-[110]">Hold to talk (tap to go hands-free) — or hold the {PTT_LABEL} key</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/x/apps/renderer/src/contexts/theme-context.tsx
+++ b/apps/x/apps/renderer/src/contexts/theme-context.tsx
@@ -2,7 +2,9 @@
 
 import * as React from "react"
 
-export type Theme = "light" | "dark" | "system"
+import { getSystemTheme, readStoredTheme, resolveTheme, THEME_STORAGE_KEY, type Theme } from "@/lib/theme"
+
+export type { Theme }
 export type ChatPanePlacement = "right" | "middle"
 export type ChatPaneSize = "chat-smaller" | "chat-equal" | "chat-bigger"
 
@@ -18,7 +20,7 @@ type ThemeContextProps = {
 
 const ThemeContext = React.createContext<ThemeContextProps | null>(null)
 
-const STORAGE_KEY = "rowboat-theme"
+const STORAGE_KEY = THEME_STORAGE_KEY
 const CHAT_PANE_PLACEMENT_STORAGE_KEY = "rowboat-chat-pane-placement"
 const CHAT_PANE_SIZE_STORAGE_KEY = "rowboat-chat-pane-size"
 
@@ -28,11 +30,6 @@ function isChatPanePlacement(value: string | null): value is ChatPanePlacement {
 
 function isChatPaneSize(value: string | null): value is ChatPaneSize {
   return value === "chat-smaller" || value === "chat-equal" || value === "chat-bigger"
-}
-
-function getSystemTheme(): "light" | "dark" {
-  if (typeof window === "undefined") return "light"
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
 }
 
 export function useTheme() {
@@ -50,11 +47,7 @@ export function ThemeProvider({
   defaultTheme?: Theme
   children: React.ReactNode
 }) {
-  const [theme, setThemeState] = React.useState<Theme>(() => {
-    if (typeof window === "undefined") return defaultTheme
-    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
-    return stored || defaultTheme
-  })
+  const [theme, setThemeState] = React.useState<Theme>(() => readStoredTheme(defaultTheme))
   const [chatPanePlacement, setChatPanePlacementState] = React.useState<ChatPanePlacement>(() => {
     if (typeof window === "undefined") return "right"
     const stored = localStorage.getItem(CHAT_PANE_PLACEMENT_STORAGE_KEY)
@@ -66,19 +59,28 @@ export function ThemeProvider({
     return isChatPaneSize(stored) ? stored : "chat-smaller"
   })
 
-  const [resolvedTheme, setResolvedTheme] = React.useState<"light" | "dark">(() => {
-    if (theme === "system") return getSystemTheme()
-    return theme
-  })
+  const [resolvedTheme, setResolvedTheme] = React.useState<"light" | "dark">(() => resolveTheme(theme))
 
   // Apply theme to document
   React.useEffect(() => {
     const root = document.documentElement
-    const resolved = theme === "system" ? getSystemTheme() : theme
+    const resolved = resolveTheme(theme)
 
     root.classList.remove("light", "dark")
     root.classList.add(resolved)
     setResolvedTheme(resolved)
+
+    // Tell the windows that have no provider (the hover companion). The RAW
+    // setting goes over the wire, not `resolved` — "system" has to resolve
+    // per window, and a companion floating over a second display can sit on
+    // a different appearance than this one.
+    try {
+      void window.ipc?.invoke("theme:set", { theme }).catch(() => {})
+    } catch {
+      // Stale preload (app not restarted since the channel was added), or a
+      // non-Electron host. The setting still applies here; only the
+      // cross-window sync is lost, and the companion re-reads on next load.
+    }
   }, [theme])
 
   // Listen for system theme changes

--- a/apps/x/apps/renderer/src/hooks/use-window-theme.ts
+++ b/apps/x/apps/renderer/src/hooks/use-window-theme.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+
+import { readStoredTheme, resolveTheme, type Theme } from '@/lib/theme'
+
+/**
+ * Light/dark for the utility windows that render OUTSIDE the ThemeProvider —
+ * the hover companion and the other hash-route windows in main.tsx. Applies
+ * the resolved class to `documentElement` and returns it.
+ *
+ * Three inputs, in the order they matter:
+ *
+ * 1. localStorage, read on mount. Every window shares one origin and one
+ *    Electron session, so the setting is already there and the FIRST paint is
+ *    correct — no IPC round trip, no flash of the wrong skin.
+ * 2. The `theme:changed` push. A localStorage write in the app window raises
+ *    no cross-window event we can rely on, so when the user flips the toggle
+ *    in Settings the app window tells main and main relays it here.
+ * 3. matchMedia, while the setting is "system". Resolved per window on
+ *    purpose: a companion floating over a second display can sit on a
+ *    different appearance than the app window.
+ */
+export function useWindowTheme(): 'light' | 'dark' {
+  const [theme, setTheme] = useState<Theme>(() => readStoredTheme())
+  const [resolved, setResolved] = useState<'light' | 'dark'>(() => resolveTheme(readStoredTheme()))
+
+  // Live changes from the app window.
+  useEffect(() => {
+    let off: (() => void) | undefined
+    try {
+      off = window.ipc.on('theme:changed', (next) => setTheme(next.theme))
+    } catch {
+      // Stale preload (app not restarted since the channel was added) throws
+      // synchronously from schema validation — the mount-time read still
+      // holds, so the window is correct, just not live.
+    }
+    return () => off?.()
+  }, [])
+
+  // Resolve + paint. Removing BOTH classes matters: this window persists
+  // across HMR and across theme flips, so a leftover class would keep the old
+  // skin's tokens on the new one.
+  useEffect(() => {
+    const apply = () => {
+      const next = resolveTheme(theme)
+      const root = document.documentElement
+      root.classList.remove('light', 'dark')
+      root.classList.add(next)
+      setResolved(next)
+    }
+    apply()
+    if (theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    mq.addEventListener('change', apply)
+    return () => mq.removeEventListener('change', apply)
+  }, [theme])
+
+  return resolved
+}

--- a/apps/x/apps/renderer/src/lib/theme.test.ts
+++ b/apps/x/apps/renderer/src/lib/theme.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { readStoredTheme, resolveTheme, THEME_STORAGE_KEY } from './theme'
+
+function stubSystem(prefersDark: boolean) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query.includes('dark') ? prefersDark : false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+}
+
+afterEach(() => {
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+describe('readStoredTheme', () => {
+  it('reads the key the ThemeProvider writes', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    expect(readStoredTheme()).toBe('dark')
+  })
+
+  it('falls back when nothing is stored', () => {
+    expect(readStoredTheme()).toBe('system')
+    expect(readStoredTheme('light')).toBe('light')
+  })
+
+  // A window that trusted whatever was in storage would paint an unstyled
+  // card: the companion has no provider to correct it afterwards.
+  it('falls back when the stored value is junk', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'solarized')
+    expect(readStoredTheme()).toBe('system')
+  })
+})
+
+describe('resolveTheme', () => {
+  it('passes explicit choices through, whatever the OS says', () => {
+    stubSystem(true)
+    expect(resolveTheme('light')).toBe('light')
+    stubSystem(false)
+    expect(resolveTheme('dark')).toBe('dark')
+  })
+
+  it('resolves "system" against this window\'s matchMedia', () => {
+    stubSystem(true)
+    expect(resolveTheme('system')).toBe('dark')
+    stubSystem(false)
+    expect(resolveTheme('system')).toBe('light')
+  })
+})

--- a/apps/x/apps/renderer/src/lib/theme.ts
+++ b/apps/x/apps/renderer/src/lib/theme.ts
@@ -1,0 +1,37 @@
+/**
+ * The theme setting itself — storage key, reading, and resolution — with no
+ * React in it.
+ *
+ * Separate from theme-context because the windows that need it most are the
+ * ones with no provider: main.tsx renders the hover companion and the other
+ * hash-route utility windows outside the ThemeProvider tree, and they read
+ * this very key rather than keeping a second copy of the setting that could
+ * drift. (It also keeps theme-context a components-only module, which is what
+ * Fast Refresh wants.)
+ */
+
+export type Theme = 'light' | 'dark' | 'system'
+
+/** Shared across every window: one origin, one Electron session, one key. */
+export const THEME_STORAGE_KEY = 'rowboat-theme'
+
+export function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window === 'undefined') return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+/** The stored setting, or `fallback` if nothing valid is stored yet. */
+export function readStoredTheme(fallback: Theme = 'system'): Theme {
+  if (typeof window === 'undefined') return fallback
+  const stored = localStorage.getItem(THEME_STORAGE_KEY)
+  return stored === 'light' || stored === 'dark' || stored === 'system' ? stored : fallback
+}
+
+/**
+ * "system" resolved against THIS window's matchMedia — per window on purpose:
+ * a companion floating over a second display can sit on a different
+ * appearance than the app window.
+ */
+export function resolveTheme(theme: Theme): 'light' | 'dark' {
+  return theme === 'system' ? getSystemTheme() : theme
+}

--- a/apps/x/packages/shared/src/index.ts
+++ b/apps/x/packages/shared/src/index.ts
@@ -29,6 +29,7 @@ export * as time from './time.js';
 export * as todo from './todo.js';
 export * as rowboatApp from './rowboat-app.js';
 export * as quickAskShortcut from './quick-ask-shortcut.js';
+export * as pttKey from './ptt-key.js';
 export * as turns from './turns.js';
 export * as sessions from './sessions.js';
 export * as message from './message.js';

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1546,6 +1546,25 @@ export const ipcSchemas = {
     req: z.object({ accelerator: z.string(), registered: z.boolean() }),
     res: z.null(),
   },
+  // --- Theme, across windows ---
+  // The setting itself lives in the renderer's localStorage, which every
+  // window already shares (one origin, one Electron session), so a freshly
+  // loaded utility window paints the right skin with no round trip. These
+  // channels carry only the *changes*: utility windows have no ThemeProvider,
+  // and a localStorage write in the app window raises no cross-window event
+  // they can rely on, so the app window tells main and main tells them.
+  // The raw setting travels, not the resolved one — 'system' must resolve
+  // per window, against that window's own matchMedia.
+  // App window → main, on mount and on every change.
+  'theme:set': {
+    req: z.object({ theme: z.enum(['light', 'dark', 'system']) }),
+    res: z.object({}),
+  },
+  // Push: main → every OTHER window.
+  'theme:changed': {
+    req: z.object({ theme: z.enum(['light', 'dark', 'system']) }),
+    res: z.null(),
+  },
   // --- Ambient meeting detection popup (own always-on-top window) ---
   // Main → popup: the detection to display.
   'meetingDetect:payload': {

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1278,14 +1278,15 @@ export const ipcSchemas = {
       success: z.literal(true),
     }),
   },
-  // --- Global push-to-talk (Right ⌘) ---
+  // --- Global push-to-talk (right ⌘ on macOS, right Ctrl elsewhere —
+  // see ptt-key.ts) ---
   // Push channel: main → app window, a system-wide PTT key transition.
-  // 'chord' = another key/click while Right ⌘ was held (it's being used as a
+  // 'chord' = another key/click while the talk key was held (it's being used as a
   // modifier, not the talk key) — the renderer cancels the capture.
   'voice:ptt-key': {
     req: z.object({
       type: z.enum(['down', 'up', 'chord']),
-      // Ghostwriter chord (⇧ held when Right ⌘ went down): this capture's
+      // Ghostwriter chord (⇧ held when the talk key went down): this capture's
       // result should be pasted at the user's cursor.
       paste: z.boolean().optional(),
     }),

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1460,6 +1460,15 @@ export const ipcSchemas = {
     req: z.object({ x: z.number(), y: z.number() }),
     res: z.null(),
   },
+  // Main → companion: the window is being dragged right now. A drag region
+  // is a NATIVE affair — on Windows the hit test answers HTCAPTION, on macOS
+  // it is a view layered over the page — so the renderer never sees the
+  // mousedown and `:active` never fires. Main watches its own 'move' instead
+  // and says so, which is what lets the cursor go from grab to grabbing.
+  'quick-ask:dragging': {
+    req: z.object({ dragging: z.boolean() }),
+    res: z.null(),
+  },
   // (The old quickAsk:setTextMode / quick-ask:text-mode channels are gone:
   // whether a reply is SPOKEN now follows the question's modality — spoken
   // questions get spoken replies, typed ones stay silent — plus the

--- a/apps/x/packages/shared/src/ptt-key.test.ts
+++ b/apps/x/packages/shared/src/ptt-key.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  UIOHOOK_CTRL_RIGHT,
+  UIOHOOK_META_RIGHT,
+  pttEventCode,
+  pttKeyLabel,
+  pttKeyLabelCap,
+  pttKeycap,
+  pttModifierHeld,
+  pttPasteChordLabel,
+  pttUiohookKeycode,
+} from './ptt-key.js';
+
+// The bug this module exists to prevent: main's global hook, the app window
+// and the companion window each deciding the talk key on their own, and two
+// of the three landing on a key Windows never delivers.
+describe('ptt-key', () => {
+  it('watches the right ⌘ on macOS and the right Ctrl elsewhere', () => {
+    expect(pttUiohookKeycode('darwin')).toBe(UIOHOOK_META_RIGHT);
+    expect(pttUiohookKeycode('win32')).toBe(UIOHOOK_CTRL_RIGHT);
+    expect(pttUiohookKeycode('linux')).toBe(UIOHOOK_CTRL_RIGHT);
+  });
+
+  it('names the same key as a KeyboardEvent.code', () => {
+    expect(pttEventCode(true)).toBe('MetaRight');
+    expect(pttEventCode(false)).toBe('ControlRight');
+  });
+
+  it('agrees between the hook keycode and the DOM code', () => {
+    // Both windows and the hook must open the gate on ONE physical key —
+    // a mismatch is exactly how PTT worked in one surface and not the next.
+    const pairs: Array<[string, boolean, number, string]> = [
+      ['darwin', true, UIOHOOK_META_RIGHT, 'MetaRight'],
+      ['win32', false, UIOHOOK_CTRL_RIGHT, 'ControlRight'],
+    ];
+    for (const [platform, isMac, keycode, code] of pairs) {
+      expect(pttUiohookKeycode(platform)).toBe(keycode);
+      expect(pttEventCode(isMac)).toBe(code);
+    }
+  });
+
+  it('reads the chord guard off the matching modifier', () => {
+    const meta = { metaKey: true, ctrlKey: false };
+    const ctrl = { metaKey: false, ctrlKey: true };
+    expect(pttModifierHeld(meta, true)).toBe(true);
+    expect(pttModifierHeld(ctrl, true)).toBe(false);
+    expect(pttModifierHeld(ctrl, false)).toBe(true);
+    expect(pttModifierHeld(meta, false)).toBe(false);
+  });
+
+  it('never shows a ⌘ glyph off macOS', () => {
+    for (const label of [
+      pttKeycap(false),
+      pttKeyLabel(false),
+      pttKeyLabelCap(false),
+      pttPasteChordLabel(false),
+    ]) {
+      expect(label).not.toContain('⌘');
+    }
+    expect(pttKeyLabel(true)).toBe('right ⌘');
+    expect(pttKeyLabelCap(true)).toBe('Right ⌘');
+    expect(pttKeyLabel(false)).toBe('right Ctrl');
+    expect(pttKeyLabelCap(false)).toBe('Right Ctrl');
+  });
+});

--- a/apps/x/packages/shared/src/ptt-key.ts
+++ b/apps/x/packages/shared/src/ptt-key.ts
@@ -1,0 +1,69 @@
+/**
+ * The hold-to-talk (push-to-talk) key, in the three vocabularies that need
+ * it: libuiohook keycodes (main's global hook), KeyboardEvent.code (the
+ * in-window DOM listeners), and a human label (every surface that tells the
+ * user which key to hold).
+ *
+ * macOS uses the right ⌘. Windows and Linux use the right Ctrl — the same
+ * physical position there is the right Super/Win key, which the OS owns (a
+ * bare tap opens the Start menu), so it can never be a talk key.
+ *
+ * This module exists because those three vocabularies used to be decided
+ * independently in three files, and two of them drifted: main's hook and the
+ * app window still watched the right ⌘ on Windows (where nothing pressed it)
+ * while the companion window watched the right Ctrl and *labelled* it ⌘.
+ * Everything reads from here now.
+ *
+ * Platform is always a parameter, never detected: main knows it as
+ * `process.platform`, the renderer as `navigator.platform`, and neither
+ * vocabulary is available in the other's process.
+ */
+
+// libuiohook virtual keycodes (uiohook-napi's UiohookKey table).
+export const UIOHOOK_META_RIGHT = 3676;
+export const UIOHOOK_CTRL_RIGHT = 3613;
+
+/** The keycode main's global hook watches, from `process.platform`. */
+export function pttUiohookKeycode(platform: string): number {
+  return platform === 'darwin' ? UIOHOOK_META_RIGHT : UIOHOOK_CTRL_RIGHT;
+}
+
+/** The `KeyboardEvent.code` the in-window listeners watch. */
+export function pttEventCode(isMac: boolean): string {
+  return isMac ? 'MetaRight' : 'ControlRight';
+}
+
+/**
+ * Whether the PTT modifier is being held as part of some OTHER shortcut —
+ * the chord guard, so ⌘C (Ctrl+C on Windows) during a hands-free lock
+ * cancels the capture instead of committing it.
+ */
+export function pttModifierHeld(
+  e: { metaKey: boolean; ctrlKey: boolean },
+  isMac: boolean,
+): boolean {
+  return isMac ? e.metaKey : e.ctrlKey;
+}
+
+/** Bare keycap, for tight status chips: "⌘" / "Ctrl". */
+export function pttKeycap(isMac: boolean): string {
+  return isMac ? '⌘' : 'Ctrl';
+}
+
+/** Mid-sentence name: "right ⌘" / "right Ctrl". */
+export function pttKeyLabel(isMac: boolean): string {
+  return isMac ? 'right ⌘' : 'right Ctrl';
+}
+
+/** Sentence-initial name: "Right ⌘" / "Right Ctrl". */
+export function pttKeyLabelCap(isMac: boolean): string {
+  return isMac ? 'Right ⌘' : 'Right Ctrl';
+}
+
+/**
+ * The ghostwriter chord — hold ⇧ with the talk key and the answer is pasted
+ * at the user's cursor: "⇧⌘" / "Shift+Ctrl".
+ */
+export function pttPasteChordLabel(isMac: boolean): string {
+  return isMac ? '⇧⌘' : 'Shift+Ctrl';
+}


### PR DESCRIPTION
Push-to-talk works on Windows, and the companion window it summons — the Skipper — gets the pass that makes it feel like one object instead of a stack of floating parts.

## Voice

- Hands-free push-to-talk works on Windows, and every surface names the right key (right Ctrl off macOS, where the right Win key belongs to the Start menu).

## The Skipper

- Follows the app's theme instead of being light-only, and the whole card is a drag handle.
- The handles show a closed hand while it moves.
- Fold/unfold motion, press feedback, and one shape per turn.
- All three pins ride on the deck; the way back sits over the head.
- The unfold bubble rides just above the boat, and its drag-region hole no longer animates.

## Two fixes from testing this on Windows

**The tuck handle dropped presses at random.** It was the drag-region hole while carrying three transforms (the centring translate, `hover:translate-x`, `active:scale`). Electron punches holes from the rect Blink last computed on style/layout invalidation, not per composited frame — so the hole stayed where the last animation left it while the art painted elsewhere, and the press landed on the card's drag region. On Windows that is `HTCAPTION`: the window enters the OS move loop and the click never happens. It only misbehaves *after* a transform runs, which is what made it feel intermittent rather than broken.

The hole is now static and transform-free, with the motion on the button inside it — the same shape `UnfoldBubble` and the pins already use. The target also grew: 28px → 32px circle, ~2× the clickable area, in the same place as before.

**The unfold bubble's hairline crossed the mascot.** It sits directly over the Skipper's head, so its border was a ring drawn across the artwork rather than an edge between surfaces; the shadow already does that job. The tuck handle keeps its border deliberately — white circle on a near-white card.

## Testing

- `tsc -b` clean on the renderer.
- The voice and companion commits were exercised in the running app on Windows.
- The two fixes above are verified by typecheck and geometry only — the companion window exists solely during a live call, so the tuck handle wants a click-through once a call is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xKCmn9tEkSeJ2F6uT7XwD
