### PR TITLE
fix(chat): robust transcript scrolling — ChatGPT-style chat follow, Codex-style code-mode live edge

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -2581,7 +2581,6 @@ function App() {
   const [workDirByTab, setWorkDirByTab] = useState<Record<string, string | null>>({})
   const workDirByTabRef = useRef(workDirByTab)
   workDirByTabRef.current = workDirByTab
-  const chatScrollTopByTabRef = useRef(new Map<string, number>())
   const [toolOpenByTab, setToolOpenByTab] = useState<Record<string, Record<string, boolean>>>({})
   const [chatViewportAnchorByTab, setChatViewportAnchorByTab] = useState<Record<string, ChatViewportAnchorState>>({})
   const activeChatTabIdRef = useRef(activeChatTabId)
@@ -2654,29 +2653,6 @@ function App() {
       }
     })
   }, [])
-  const getChatScrollContainer = useCallback((tabId: string): HTMLElement | null => {
-    if (typeof document === 'undefined') return null
-    const panel = document.querySelector<HTMLElement>(
-      `[data-chat-tab-panel="${tabId}"][aria-hidden="false"]`
-    )
-    if (!panel) return null
-    const logRoot = panel.querySelector<HTMLElement>('[role="log"]')
-    if (!logRoot) return null
-    const children = Array.from(logRoot.children) as HTMLElement[]
-    for (const child of children) {
-      const style = window.getComputedStyle(child)
-      if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-        return child
-      }
-    }
-    return null
-  }, [])
-  const saveChatScrollForTab = useCallback((tabId: string) => {
-    const container = getChatScrollContainer(tabId)
-    if (!container) return
-    chatScrollTopByTabRef.current.set(tabId, container.scrollTop)
-  }, [getChatScrollContainer])
-
   const getChatTabTitle = useCallback((tab: ChatTab) => {
     if (!tab.runId) return 'New chat'
     return runs.find(r => r.id === tab.runId)?.title || '(Untitled chat)'
@@ -4540,7 +4516,6 @@ function App() {
     if (active?.runId === rid) return
     // Cancel any active dictation — its transcript belongs to the old chat.
     cancelRecordingIfActive()
-    saveChatScrollForTab(activeChatTabIdRef.current)
     setChatTabs((prev) => prev.map((t) => (
       // Rebinding to a different session = a different chat identity — but a
       // DETERMINISTIC one (the session id), so switching A→B→A restores A's
@@ -4548,7 +4523,7 @@ function App() {
       t.id === activeChatTabIdRef.current ? { ...t, runId: rid, chatId: rid } : t
     )))
     void loadRun(rid)
-  }, [cancelRecordingIfActive, loadRun, saveChatScrollForTab])
+  }, [cancelRecordingIfActive, loadRun])
   bindChatToRunRef.current = bindChatToRun
 
   // A code session was selected in the Code view: bind the chat to it — the
@@ -4584,79 +4559,9 @@ function App() {
   }, [])
   const handleCodeDiffOpened = useCallback(() => setCodeDiffPath(null), [])
 
-  useEffect(() => {
-    let cleanupScrollListener: (() => void) | undefined
-    let pollRaf: number | undefined
-    let restoreRafA: number | undefined
-    let restoreRafB: number | undefined
-    let restoreTimeout: ReturnType<typeof setTimeout> | undefined
-    let cancelled = false
-
-    const restoreScrollTop = (container: HTMLElement, top: number) => {
-      const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight)
-      const clampedTop = clampNumber(top, 0, maxScroll)
-      container.scrollTop = clampedTop
-    }
-
-    const attach = (): boolean => {
-      if (cancelled) return true
-      const container = getChatScrollContainer(activeChatTabId)
-      if (!container) return false
-
-      const savedTop = chatScrollTopByTabRef.current.get(activeChatTabId)
-      if (savedTop !== undefined) {
-        // Reinforce restoration across a couple frames because stick-to-bottom
-        // may schedule scroll adjustments during mount/resize.
-        restoreScrollTop(container, savedTop)
-        restoreRafA = requestAnimationFrame(() => {
-          restoreScrollTop(container, savedTop)
-          restoreRafB = requestAnimationFrame(() => {
-            restoreScrollTop(container, savedTop)
-          })
-        })
-        restoreTimeout = setTimeout(() => {
-          restoreScrollTop(container, savedTop)
-        }, 220)
-      }
-
-      const onScroll = () => {
-        chatScrollTopByTabRef.current.set(activeChatTabId, container.scrollTop)
-      }
-      container.addEventListener('scroll', onScroll, { passive: true })
-      cleanupScrollListener = () => {
-        chatScrollTopByTabRef.current.set(activeChatTabId, container.scrollTop)
-        container.removeEventListener('scroll', onScroll)
-      }
-      return true
-    }
-
-    let attempts = 0
-    const maxAttempts = 60
-    const pollAttach = () => {
-      if (cancelled) return
-      if (attach()) return
-      if (attempts >= maxAttempts) return
-      attempts += 1
-      pollRaf = requestAnimationFrame(pollAttach)
-    }
-    pollAttach()
-
-    return () => {
-      cancelled = true
-      cleanupScrollListener?.()
-      if (pollRaf !== undefined) cancelAnimationFrame(pollRaf)
-      if (restoreRafA !== undefined) cancelAnimationFrame(restoreRafA)
-      if (restoreRafB !== undefined) cancelAnimationFrame(restoreRafB)
-      if (restoreTimeout !== undefined) clearTimeout(restoreTimeout)
-    }
-  }, [
-    activeChatTabId,
-    selectedPath,
-    isGraphOpen,
-    isChatSidebarOpen,
-    isRightPaneMaximized,
-    getChatScrollContainer,
-  ])
+  // Reading-position persistence across pane remounts (view toggles,
+  // dock/full-screen switches, run rebinds) lives inside the conversation
+  // scroll controller now — see lib/chat-scroll.ts (keyed by tab.chatId).
 
   const currentViewState = React.useMemo<ViewState>(() => {
     if (selectedBackgroundTask) return { type: 'task', name: selectedBackgroundTask }
@@ -7584,6 +7489,7 @@ function App() {
                         activeIsWorking={activeIsWorking}
                         activeIsProcessing={activeIsProcessing}
                         activeIsReasoning={activeIsReasoning}
+                        isCodeSession={!!(tab.runId && codeSessionLocks[tab.runId])}
                       />
                     )
                   })}

--- a/apps/x/apps/renderer/src/components/ai-elements/conversation.test.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/conversation.test.tsx
@@ -5,7 +5,11 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from './conversation'
-import { resetChatScrollMemory, SEND_ANCHOR_PEEK_PX } from '@/lib/chat-scroll'
+import {
+  ANCHOR_TAIL_HEADROOM_PX,
+  resetChatScrollMemory,
+  SEND_ANCHOR_PEEK_PX,
+} from '@/lib/chat-scroll'
 
 class ResizeObserverStub {
   static instances: ResizeObserverStub[] = []
@@ -144,7 +148,7 @@ describe('Conversation scroll wiring', () => {
     const target = 1800 - SEND_ANCHOR_PEEK_PX
     expect(s.scroller.scrollTop).toBe(target)
     const spacer = s.scroller.lastElementChild as HTMLElement
-    expect(spacer.style.height).toBe(`${target - 1400}px`)
+    expect(spacer.style.height).toBe(`${target + ANCHOR_TAIL_HEADROOM_PX - 1400}px`)
     // Streaming growth stays below the fold — no movement.
     s.grow(300)
     expect(s.scroller.scrollTop).toBe(target)

--- a/apps/x/apps/renderer/src/components/ai-elements/conversation.test.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/conversation.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from './conversation'
+import { resetChatScrollMemory } from '@/lib/chat-scroll'
+
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = []
+  callback: ResizeObserverCallback
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    ResizeObserverStub.instances.push(this)
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function triggerResize() {
+  act(() => {
+    for (const instance of ResizeObserverStub.instances) {
+      instance.callback([], instance as unknown as ResizeObserver)
+    }
+  })
+}
+
+interface Setup {
+  scroller: HTMLElement
+  state: { contentHeight: number; clientHeight: number }
+  rerender: (ui: React.ReactElement) => void
+  grow(by: number): void
+  userScroll(top: number): void
+  maxTop(): number
+}
+
+function setup(ui: React.ReactElement): Setup {
+  const view = render(ui)
+  const scroller = screen.getByRole('log').firstElementChild as HTMLElement
+  const state = { contentHeight: 2000, clientHeight: 600 }
+  const spacer = scroller.lastElementChild as HTMLElement
+  Object.defineProperty(scroller, 'scrollHeight', {
+    configurable: true,
+    get: () =>
+      state.contentHeight + (Number.parseFloat(spacer.style.height || '0') || 0),
+  })
+  Object.defineProperty(scroller, 'clientHeight', {
+    configurable: true,
+    get: () => state.clientHeight,
+  })
+  const maxTop = () => Math.max(0, state.contentHeight - state.clientHeight)
+  return {
+    scroller,
+    state,
+    rerender: view.rerender,
+    grow(by: number) {
+      state.contentHeight += by
+      triggerResize()
+    },
+    userScroll(top: number) {
+      scroller.scrollTop = top
+      fireEvent.scroll(scroller)
+    },
+    maxTop,
+  }
+}
+
+const ui = (props: Partial<React.ComponentProps<typeof Conversation>> = {}) => (
+  <Conversation {...props}>
+    <ConversationContent>
+      <div data-message-id="m-1">hello</div>
+      <div data-message-id="m-2">world</div>
+    </ConversationContent>
+    <ConversationScrollButton />
+  </Conversation>
+)
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+})
+
+afterEach(() => {
+  cleanup()
+  ResizeObserverStub.instances = []
+  vi.unstubAllGlobals()
+  resetChatScrollMemory()
+})
+
+const jumpButton = () =>
+  screen.queryByRole('button', { name: /scroll to latest message/i })
+
+describe('Conversation scroll wiring', () => {
+  it('lands at the bottom, hides the jump button, and follows growth', () => {
+    const s = setup(ui())
+    triggerResize()
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+    expect(jumpButton()).toBeNull()
+
+    s.grow(400)
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+    expect(jumpButton()).toBeNull()
+  })
+
+  it('shows the jump button after the user scrolls away, without yanking them back', () => {
+    const s = setup(ui())
+    triggerResize()
+    s.userScroll(s.maxTop() - 500)
+    expect(jumpButton()).not.toBeNull()
+
+    const readingTop = s.scroller.scrollTop
+    s.grow(600)
+    expect(s.scroller.scrollTop).toBe(readingTop)
+    expect(jumpButton()).not.toBeNull()
+  })
+
+  it('the jump button returns to the live edge and resumes following', () => {
+    const s = setup(ui())
+    triggerResize()
+    // Model the browser's smooth scroll as an instantly-completing animation.
+    s.scroller.scrollTo = ((options: ScrollToOptions) => {
+      s.scroller.scrollTop = options.top ?? 0
+    }) as typeof s.scroller.scrollTo
+    s.userScroll(200)
+    fireEvent.click(jumpButton()!)
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+    expect(jumpButton()).toBeNull()
+
+    s.grow(250)
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+  })
+
+  it('chat mode anchors a sent message at the viewport top', () => {
+    const s = setup(ui({ anchorRequestKey: 0, anchorMessageId: null }))
+    triggerResize()
+
+    const message = screen.getByText('world').closest('[data-message-id]') as HTMLElement
+    s.scroller.getBoundingClientRect = () => ({ top: 0 }) as DOMRect
+    message.getBoundingClientRect = () =>
+      ({ top: 1800 - s.scroller.scrollTop } as DOMRect)
+
+    s.rerender(ui({ anchorRequestKey: 1, anchorMessageId: 'm-2' }))
+    expect(s.scroller.scrollTop).toBe(1800)
+    const spacer = s.scroller.lastElementChild as HTMLElement
+    expect(spacer.style.height).toBe('400px')
+    // Streaming growth stays below the fold — no movement.
+    s.grow(300)
+    expect(s.scroller.scrollTop).toBe(1800)
+  })
+
+  it('code mode jumps sends to the live edge and follows the run', () => {
+    const s = setup(
+      ui({ scrollMode: 'code', anchorRequestKey: 0, anchorMessageId: null })
+    )
+    triggerResize()
+    s.userScroll(100)
+
+    s.rerender(
+      ui({ scrollMode: 'code', anchorRequestKey: 1, anchorMessageId: 'm-2' })
+    )
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+
+    s.grow(500)
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+  })
+
+  it('ignores the mount-time anchor request (remounts restore, not re-anchor)', () => {
+    const s = setup(ui({ anchorRequestKey: 7, anchorMessageId: 'm-1' }))
+    triggerResize()
+    expect(s.scroller.scrollTop).toBe(s.maxTop())
+    const spacer = s.scroller.lastElementChild as HTMLElement
+    expect(spacer.style.height || '0px').toBe('0px')
+  })
+
+  it('remounts with the same memory key restore the reading position', () => {
+    const s = setup(ui({ scrollMemoryKey: 'chat-x' }))
+    triggerResize()
+    s.userScroll(700)
+    s.rerender(<div />)
+
+    const s2 = setup(ui({ scrollMemoryKey: 'chat-x' }))
+    triggerResize()
+    expect(s2.scroller.scrollTop).toBe(700)
+    expect(jumpButton()).not.toBeNull()
+  })
+})

--- a/apps/x/apps/renderer/src/components/ai-elements/conversation.test.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/conversation.test.tsx
@@ -5,7 +5,7 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from './conversation'
-import { resetChatScrollMemory } from '@/lib/chat-scroll'
+import { resetChatScrollMemory, SEND_ANCHOR_PEEK_PX } from '@/lib/chat-scroll'
 
 class ResizeObserverStub {
   static instances: ResizeObserverStub[] = []
@@ -141,12 +141,13 @@ describe('Conversation scroll wiring', () => {
       ({ top: 1800 - s.scroller.scrollTop } as DOMRect)
 
     s.rerender(ui({ anchorRequestKey: 1, anchorMessageId: 'm-2' }))
-    expect(s.scroller.scrollTop).toBe(1800)
+    const target = 1800 - SEND_ANCHOR_PEEK_PX
+    expect(s.scroller.scrollTop).toBe(target)
     const spacer = s.scroller.lastElementChild as HTMLElement
-    expect(spacer.style.height).toBe('400px')
+    expect(spacer.style.height).toBe(`${target - 1400}px`)
     // Streaming growth stays below the fold — no movement.
     s.grow(300)
-    expect(s.scroller.scrollTop).toBe(1800)
+    expect(s.scroller.scrollTop).toBe(target)
   })
 
   it('code mode jumps sends to the live edge and follows the run', () => {

--- a/apps/x/apps/renderer/src/components/ai-elements/conversation.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/conversation.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import {
+  ChatScrollController,
+  type ChatScrollMode,
+} from "@/lib/chat-scroll";
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode, RefObject } from "react";
@@ -15,7 +19,6 @@ import {
   useState,
 } from "react";
 
-const BOTTOM_THRESHOLD_PX = 8;
 const MAX_ANCHOR_RETRIES = 6;
 
 interface ConversationContextValue {
@@ -28,12 +31,19 @@ interface ConversationContextValue {
 const ConversationContext = createContext<ConversationContextValue | null>(null);
 
 export type ConversationProps = ComponentProps<"div"> & {
+  /** 'chat' anchors sends at the viewport top (ChatGPT); 'code' jumps sends
+   * to the live edge and follows the run (Codex). See lib/chat-scroll.ts. */
+  scrollMode?: ChatScrollMode;
+  /** Chat identity for cross-remount reading-position memory. */
+  scrollMemoryKey?: string;
   anchorMessageId?: string | null;
   anchorRequestKey?: number;
   children?: ReactNode;
 };
 
 export const Conversation = ({
+  scrollMode = "chat",
+  scrollMemoryKey,
   anchorMessageId = null,
   anchorRequestKey,
   children,
@@ -43,161 +53,88 @@ export const Conversation = ({
   const contentRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const spacerRef = useRef<HTMLDivElement | null>(null);
-  const stickToBottomRef = useRef(true);
-  const [isAtBottom, setIsAtBottom] = useState(true);
-
-  const updateBottomState = useCallback(() => {
-    const container = scrollRef.current;
-    if (!container) return;
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    const atBottom = distanceFromBottom <= BOTTOM_THRESHOLD_PX;
-    stickToBottomRef.current = atBottom;
-    setIsAtBottom(atBottom);
-  }, []);
-
-  const applyAnchorLayout = useCallback(
-    (scrollToAnchor: boolean): boolean => {
-      const container = scrollRef.current;
-      const content = contentRef.current;
-      const spacer = spacerRef.current;
-
-      if (!container || !content || !spacer) {
-        return false;
-      }
-
-      if (!anchorMessageId) {
-        spacer.style.height = "0px";
-        updateBottomState();
-        return true;
-      }
-
-      const anchor = content.querySelector<HTMLElement>(
-        `[data-message-id="${anchorMessageId}"]`
-      );
-
-      if (!anchor) {
-        spacer.style.height = "0px";
-        updateBottomState();
-        return false;
-      }
-
-      spacer.style.height = "0px";
-
-      const contentPaddingTop = Number.parseFloat(
-        window.getComputedStyle(content).paddingTop || "0"
-      );
-      const anchorTop = anchor.offsetTop;
-      const targetScrollTop = Math.max(0, anchorTop - contentPaddingTop);
-      const requiredSlack = Math.max(
-        0,
-        targetScrollTop - (content.scrollHeight - container.clientHeight)
-      );
-
-      spacer.style.height = `${Math.ceil(requiredSlack)}px`;
-
-      if (scrollToAnchor) {
-        container.scrollTop = targetScrollTop;
-      }
-
-      updateBottomState();
-      return true;
-    },
-    [anchorMessageId, updateBottomState]
+  // One controller per mounted conversation (the pane remounts per chat
+  // identity, so mount lifetime == conversation binding lifetime).
+  const [controller] = useState(
+    () =>
+      new ChatScrollController({ mode: scrollMode, memoryKey: scrollMemoryKey })
   );
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [isFollowing, setIsFollowing] = useState(true);
 
   useEffect(() => {
-    const container = scrollRef.current;
-    if (!container) return;
-
-    const handleScroll = () => {
-      updateBottomState();
-    };
-
-    handleScroll();
-    container.addEventListener("scroll", handleScroll, { passive: true });
-
-    return () => {
-      container.removeEventListener("scroll", handleScroll);
-    };
-  }, [updateBottomState]);
+    controller.setMode(scrollMode);
+  }, [controller, scrollMode]);
 
   useLayoutEffect(() => {
     const container = scrollRef.current;
     const content = contentRef.current;
-    if (!container || !content) return;
+    const spacer = spacerRef.current;
+    if (!container || !content || !spacer) return;
 
-    let rafId: number | null = null;
-
-    const schedule = () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-      rafId = requestAnimationFrame(() => {
-        const shouldStick = !anchorMessageId && stickToBottomRef.current;
-        applyAnchorLayout(false);
-        if (shouldStick) {
-          container.scrollTop = container.scrollHeight;
-          updateBottomState();
-        }
-      });
-    };
-
-    const observer = new ResizeObserver(schedule);
-    observer.observe(container);
-    observer.observe(content);
-    schedule();
+    controller.attach({ container, content, spacer });
+    const unsubscribe = controller.subscribe((snapshot) => {
+      setIsAtBottom(snapshot.nearBottom);
+      setIsFollowing(snapshot.following);
+    });
 
     return () => {
-      observer.disconnect();
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
+      unsubscribe();
+      controller.detach();
     };
-  }, [applyAnchorLayout]);
+  }, [controller]);
 
+  // A send bumps anchorRequestKey. Chat mode pins the new user message at the
+  // viewport top; code mode (or an anchorless bump, e.g. new-chat reset)
+  // returns to the live edge. The mount-time key is deliberately ignored:
+  // remounts restore the remembered reading position instead of re-applying
+  // a stale anchor.
+  const appliedRequestKeyRef = useRef(anchorRequestKey);
   useLayoutEffect(() => {
-    if (anchorRequestKey === undefined) return;
+    if (
+      anchorRequestKey === undefined ||
+      anchorRequestKey === appliedRequestKeyRef.current
+    ) {
+      return;
+    }
+    appliedRequestKeyRef.current = anchorRequestKey;
 
+    if (scrollMode === "code" || !anchorMessageId) {
+      controller.jumpToLatest("instant");
+      return;
+    }
+
+    // The message element may land a frame later than the state bump.
     let attempts = 0;
     let rafId: number | null = null;
-
     const tryAnchor = () => {
-      if (applyAnchorLayout(true)) {
-        return;
-      }
-      if (attempts >= MAX_ANCHOR_RETRIES) {
-        return;
-      }
+      if (controller.anchorToMessage(anchorMessageId)) return;
+      if (attempts >= MAX_ANCHOR_RETRIES) return;
       attempts += 1;
       rafId = requestAnimationFrame(tryAnchor);
     };
-
     tryAnchor();
 
     return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
+      if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [anchorRequestKey, applyAnchorLayout]);
+  }, [anchorRequestKey, anchorMessageId, scrollMode, controller]);
 
   const scrollToBottom = useCallback(() => {
-    const container = scrollRef.current;
-    if (!container) return;
-    container.scrollTop = container.scrollHeight;
-    stickToBottomRef.current = true;
-    updateBottomState();
-  }, [updateBottomState]);
+    controller.jumpToLatest("smooth");
+  }, [controller]);
 
   const contextValue = useMemo<ConversationContextValue>(
     () => ({
       contentRef,
-      isAtBottom,
+      // The jump button targets readers who left the live edge: hidden while
+      // near the bottom AND while following (following keeps the view pinned
+      // even when growth momentarily outruns the near-bottom band).
+      isAtBottom: isAtBottom || isFollowing,
       scrollRef,
       scrollToBottom,
     }),
-    [isAtBottom, scrollToBottom]
+    [isAtBottom, isFollowing, scrollToBottom]
   );
 
   return (
@@ -282,8 +219,6 @@ export const ConversationEmptyState = ({
     )}
   </div>
 );
-
-export const ScrollPositionPreserver = () => null;
 
 export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
 

--- a/apps/x/apps/renderer/src/components/ai-elements/conversation.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/conversation.tsx
@@ -19,8 +19,6 @@ import {
   useState,
 } from "react";
 
-const MAX_ANCHOR_RETRIES = 6;
-
 interface ConversationContextValue {
   contentRef: RefObject<HTMLDivElement | null>;
   isAtBottom: boolean;
@@ -104,20 +102,11 @@ export const Conversation = ({
       return;
     }
 
-    // The message element may land a frame later than the state bump.
-    let attempts = 0;
-    let rafId: number | null = null;
-    const tryAnchor = () => {
-      if (controller.anchorToMessage(anchorMessageId)) return;
-      if (attempts >= MAX_ANCHOR_RETRIES) return;
-      attempts += 1;
-      rafId = requestAnimationFrame(tryAnchor);
-    };
-    tryAnchor();
-
-    return () => {
-      if (rafId !== null) cancelAnimationFrame(rafId);
-    };
+    // The message row usually renders AFTER this bump (the active pane is
+    // store-backed — the row lands with the send's round-trip, under the
+    // store's own id). The controller keeps the request pending and applies
+    // it exactly once when the row appears.
+    controller.requestSendAnchor(anchorMessageId);
   }, [anchorRequestKey, anchorMessageId, scrollMode, controller]);
 
   const scrollToBottom = useCallback(() => {

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -73,6 +73,11 @@ export interface ChatSessionPaneProps {
   onComposioConnected?: (toolkitSlug: string) => void
   /** Empty-state flavour: 'code' for a chat bound to a coding session. */
   emptyStateVariant?: 'default' | 'code'
+  /**
+   * Chat bound to a coding session: the transcript follows Codex semantics
+   * (sends jump to the live edge) instead of ChatGPT's send-anchoring.
+   */
+  isCodeSession?: boolean
 }
 
 export function ChatSessionPane({
@@ -91,6 +96,7 @@ export function ChatSessionPane({
   onCodePermissionResponse,
   onComposioConnected,
   emptyStateVariant = 'default',
+  isCodeSession = false,
 }: ChatSessionPaneProps) {
   // Content-owned tab meta (see lib/tab-meta.ts). Both live instances of a
   // chat (full-screen App pane + side-pane chat) report the same values, so
@@ -139,6 +145,8 @@ export function ChatSessionPane({
       aria-hidden={!isActive}
     >
       <Conversation
+        scrollMode={isCodeSession ? 'code' : 'chat'}
+        scrollMemoryKey={tab.chatId}
         anchorMessageId={viewportAnchor?.messageId}
         anchorRequestKey={viewportAnchor?.requestKey}
         className="relative flex-1"

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -32,6 +32,8 @@ import { useSessionTitle } from '@/lib/session-title'
 import {
   type ChatTabViewState,
   type ChatViewportAnchorState,
+  isChatMessage,
+  isReasoningMessage,
 } from '@/lib/chat-conversation'
 
 function SmoothStreamingMessage({ text, components }: { text: string; components: typeof streamdownComponents }) {
@@ -128,6 +130,17 @@ export function ChatSessionPane({
   const currentAsk = pendingAsks[0]
 
   const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
+  // Store-backed chats stream through synthetic conversation items that carry
+  // their durable ids (turn-view.ts), so completion updates the mounted nodes
+  // in place. The fallback slots below render only when no such item exists:
+  // legacy (non-store) runs, and edge states like a failed turn's unflushed
+  // overlay tail.
+  const hasLiveReasoningItem = tabState.conversation.some(
+    (item) => isReasoningMessage(item) && item.streaming === true
+  )
+  const hasLiveAssistantItem = tabState.conversation.some(
+    (item) => isChatMessage(item) && item.streaming === true
+  )
   const tabConversationContentClassName = cn(
     'mx-auto w-full max-w-[820px] px-6',
     tabHasConversation ? 'pb-28' : 'pb-0',
@@ -190,18 +203,16 @@ export function ChatSessionPane({
                 />
               )}
 
-              {/* In-flight model call's thought stream: open with a
-                  "Thinking..." shimmer while reasoning streams, auto-collapses
-                  once the model moves on to its answer. Replaced by the
-                  durable (collapsed) reasoning item when the call completes. */}
-              {tabState.currentReasoning && (
+              {/* Legacy fallback: in-flight thought stream for runs whose
+                  transcript doesn't carry the synthetic streaming items. */}
+              {tabState.currentReasoning && !hasLiveReasoningItem && (
                 <ReasoningRow
                   content={tabState.currentReasoning}
                   isStreaming={isActive && activeIsReasoning}
                 />
               )}
 
-              {tabState.currentAssistantMessage && (
+              {tabState.currentAssistantMessage && !hasLiveAssistantItem && (
                 <Message from="assistant">
                   <MessageContent>
                     <SmoothStreamingMessage text={tabState.currentAssistantMessage.replace(/<\/?voice>/g, '')} components={streamdownComponents} />

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -443,6 +443,7 @@ export function ChatSidebar({
                       onCodePermissionResponse={onCodePermissionResponse}
                       onComposioConnected={onComposioConnected}
                       emptyStateVariant={pinnedToCodeSession ? 'code' : 'default'}
+                      isCodeSession={!!(tab.runId && codeSessionLocks[tab.runId])}
                     />
                   )
                 })}

--- a/apps/x/apps/renderer/src/components/turn-conversation.test.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.test.tsx
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { TurnConversation } from './turn-conversation'
+import type { ConversationItem } from '@/lib/chat-conversation'
+
+// Streamdown / collapsibles want these in jsdom.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const streamingItem: ConversationItem = {
+  id: 'turn-1:a0',
+  role: 'assistant',
+  content: 'Hello wor',
+  streaming: true,
+  timestamp: 1,
+}
+
+const durableItem: ConversationItem = {
+  id: 'turn-1:a0',
+  role: 'assistant',
+  content: 'Hello world, all done.',
+  timestamp: 1,
+}
+
+describe('TurnConversation — streaming → durable identity', () => {
+  it('keeps the assistant message DOM node across the swap (no remount flash)', () => {
+    const { rerender } = render(<TurnConversation items={[streamingItem]} />)
+    const before = document.querySelector('[data-message-id="turn-1:a0"]')
+    expect(before).not.toBeNull()
+
+    rerender(<TurnConversation items={[durableItem]} />)
+    const after = document.querySelector('[data-message-id="turn-1:a0"]')
+    // The exact same mounted element — a remount here replays Streamdown's
+    // async highlighting and mermaid/chart rendering as a visible flash.
+    expect(after).toBe(before)
+    expect(after?.textContent).toContain('Hello world, all done.')
+  })
+
+  it('never renders the message twice at completion, and leaves no stale synthetic', () => {
+    const { rerender } = render(<TurnConversation items={[streamingItem]} />)
+    rerender(<TurnConversation items={[durableItem]} />)
+    expect(document.querySelectorAll('[data-message-id="turn-1:a0"]')).toHaveLength(1)
+  })
+
+  it('renders durable messages directly (no smoothed reveal lag)', () => {
+    render(<TurnConversation items={[durableItem]} />)
+    const node = document.querySelector('[data-message-id="turn-1:a0"]')
+    expect(node?.textContent).toContain('Hello world, all done.')
+  })
+})

--- a/apps/x/apps/renderer/src/components/turn-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.tsx
@@ -23,6 +23,7 @@ import { TokenUsageMenu } from '@/components/token-usage-menu'
 import { matchBillingError } from '@/lib/billing-error'
 import { wikiLabel } from '@/lib/wiki-links'
 import { streamdownComponents, userMessageRemarkPlugins } from '@/lib/markdown-render'
+import { useSmoothedText } from '@/hooks/useSmoothedText'
 import type { PermissionDecision } from '@x/shared/src/code-mode.js'
 import {
   type ChatTabViewState,
@@ -60,6 +61,21 @@ import {
  * state lifted to the tab store) is optional: read-only transcript surfaces
  * pass just `items` and get self-contained collapsible tool rows.
  */
+
+function AssistantMessageBody({ text, streaming }: { text: string; streaming: boolean }) {
+  // ONE MessageResponse (Streamdown) instance renders both phases of an
+  // assistant message: the live stream (smoothed reveal) and its durable
+  // replacement, which shares the item id. Keeping the same element across
+  // the flip preserves Streamdown's per-block highlight memoization and any
+  // mermaid/chart output — a conditional component swap here would remount
+  // the subtree and bring back the end-of-generation flash.
+  const smoothed = useSmoothedText(streaming ? text : '')
+  return (
+    <MessageResponse components={streamdownComponents}>
+      {streaming ? smoothed : text}
+    </MessageResponse>
+  )
+}
 
 function AutoScrollPre({ className, children }: { className?: string; children: React.ReactNode }) {
   const ref = React.useRef<HTMLPreElement>(null)
@@ -206,16 +222,23 @@ export function TurnConversation({
       return (
         <Message key={item.id} from={item.role} data-message-id={item.id}>
           <MessageContent>
-            <MessageResponse components={streamdownComponents}>{item.content}</MessageResponse>
+            <AssistantMessageBody text={item.content} streaming={item.streaming === true} />
           </MessageContent>
         </Message>
       )
     }
 
     if (isReasoningMessage(item)) {
-      // Settled thoughts start collapsed; the live streaming row in
-      // ChatSessionPane is what shows reasoning expanded while it happens.
-      return <ReasoningRow key={item.id} content={item.content} />
+      // The live thought stream renders here too (streaming flag → shimmer,
+      // auto-expand); when the call completes, the durable item keeps the
+      // same id and ReasoningRow's own falling-edge handling collapses it.
+      return (
+        <ReasoningRow
+          key={item.id}
+          content={item.content}
+          isStreaming={item.streaming === true}
+        />
+      )
     }
 
     if (isToolCall(item)) {

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
@@ -81,6 +81,12 @@ function makeDeps() {
           if (i >= 0) deltaSubs.splice(i, 1)
         }
       },
+      // Synchronous emission — this harness tests the hook's wiring, not
+      // the frame coalescing (covered in store.test.ts).
+      scheduleEmit: (flush: () => void) => {
+        flush()
+        return () => {}
+      },
     },
     calls,
     emit: (event: TurnBusEvent) => emit(event),

--- a/apps/x/apps/renderer/src/lib/chat-conversation.ts
+++ b/apps/x/apps/renderer/src/lib/chat-conversation.ts
@@ -29,6 +29,13 @@ export interface ChatMessage {
   content: string
   attachments?: MessageAttachment[]
   timestamp: number
+  /**
+   * A live in-flight model call's text, rendered through the SAME item slot
+   * (and id) its durable version will occupy so completion updates the node
+   * in place — no unmount/remount flash. Streaming items get the smoothed
+   * reveal; durable items render their content directly.
+   */
+  streaming?: boolean
 }
 
 export interface ToolCall {
@@ -61,6 +68,9 @@ export interface ReasoningMessage {
   kind: 'reasoning'
   content: string
   timestamp: number
+  /** Live thought stream for the in-flight model call (same in-place-update
+   * contract as ChatMessage.streaming); drives ReasoningRow's shimmer. */
+  streaming?: boolean
 }
 
 export type ReasoningEffortLevel = 'low' | 'medium' | 'high'

--- a/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
@@ -3,6 +3,7 @@ import {
   AT_BOTTOM_EPSILON_PX,
   ChatScrollController,
   NEAR_BOTTOM_PX,
+  SEND_ANCHOR_PEEK_PX,
   resetChatScrollMemory,
   type ChatScrollSnapshot,
 } from './chat-scroll'
@@ -439,27 +440,37 @@ describe('ChatScrollController — smooth jump', () => {
   })
 })
 
+function addUserRow(h: Harness, id: string, layoutTop: number): HTMLElement {
+  const row = document.createElement('div')
+  row.className = 'is-user'
+  row.setAttribute('data-message-id', id)
+  h.content.appendChild(row)
+  h.container.getBoundingClientRect = () => ({ top: 0 } as DOMRect)
+  row.getBoundingClientRect = () =>
+    ({ top: layoutTop - h.container.scrollTop } as DOMRect)
+  return row
+}
+
 describe('ChatScrollController — send anchoring (chat mode)', () => {
+  // A message whose layout top is 1800 in a 2000-tall transcript with a
+  // 600-tall viewport: the anchor target is 1800 - PEEK, which needs
+  // (1800 - PEEK) - (2000 - 600) px of spacer slack.
+  const TARGET = 1800 - SEND_ANCHOR_PEEK_PX
+  const SLACK = TARGET - 1400
+
   function setupAnchored(messageLayoutTop: number) {
     const h = createHarness()
     const controller = attach(h, { mode: 'chat' })
-    const message = document.createElement('div')
-    message.setAttribute('data-message-id', 'user-1')
-    h.content.appendChild(message)
-    h.container.getBoundingClientRect = () =>
-      ({ top: 0 } as DOMRect)
-    message.getBoundingClientRect = () =>
-      ({ top: messageLayoutTop - h.container.scrollTop } as DOMRect)
+    const message = addUserRow(h, 'user-1', messageLayoutTop)
     return { h, controller, message }
   }
 
-  it('pins the sent message at the viewport top with spacer slack', () => {
+  it('pins the sent message near the viewport top, prior turn peeking above', () => {
     const { h, controller } = setupAnchored(1800)
     expect(controller.anchorToMessage('user-1')).toBe(true)
 
-    // target 1800 needs 400px of slack beyond the 1400 natural max.
-    expect(h.container.scrollTop).toBe(1800)
-    expect(h.spacerHeight()).toBe(400)
+    expect(h.container.scrollTop).toBe(TARGET)
+    expect(h.spacerHeight()).toBe(SLACK)
     expect(controller.snapshot().following).toBe(false)
     // Nothing but blank slack below → nothing to jump to.
     expect(controller.snapshot().nearBottom).toBe(true)
@@ -470,12 +481,12 @@ describe('ChatScrollController — send anchoring (chat mode)', () => {
     controller.anchorToMessage('user-1')
 
     h.grow(300)
-    expect(h.spacerHeight()).toBe(100)
-    expect(h.container.scrollTop).toBe(1800)
+    expect(h.spacerHeight()).toBe(SLACK - 300)
+    expect(h.container.scrollTop).toBe(TARGET)
 
     h.grow(300)
     expect(h.spacerHeight()).toBe(0)
-    expect(h.container.scrollTop).toBe(1800)
+    expect(h.container.scrollTop).toBe(TARGET)
     // Content now extends below the fold → the jump affordance appears.
     expect(controller.snapshot().nearBottom).toBe(false)
 
@@ -500,6 +511,118 @@ describe('ChatScrollController — send anchoring (chat mode)', () => {
     expect(controller.snapshot().following).toBe(true)
     h.grow(120)
     expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+})
+
+describe('ChatScrollController — send repositioning (requestSendAnchor)', () => {
+  const TARGET = 1800 - SEND_ANCHOR_PEEK_PX
+
+  it('a send while far scrolled up overrides the reading position', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    addUserRow(h, 'user-1', 1800)
+    h.scrollTo(200)
+    expect(controller.snapshot().following).toBe(false)
+
+    controller.requestSendAnchor('user-1')
+    expect(h.container.scrollTop).toBe(TARGET)
+    expect(h.spacerHeight()).toBe(TARGET - 1400)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('a send while slightly scrolled up behaves identically', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    addUserRow(h, 'user-1', 1800)
+    h.scrollTo(h.maxTop() - 40)
+    expect(controller.snapshot().following).toBe(false)
+
+    controller.requestSendAnchor('user-1')
+    expect(h.container.scrollTop).toBe(TARGET)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('waits for a store-backed row under a different id and repositions exactly once', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    // A previous turn's user row exists — it must not be mistaken for the
+    // new send.
+    addUserRow(h, 'turn-1:user', 500)
+
+    controller.requestSendAnchor('user-1757000000000') // optimistic App id
+    expect(h.container.scrollTop).toBe(h.maxTop()) // no premature move
+
+    // Streaming/composer ticks before the row lands change nothing.
+    h.grow(40)
+    expect(controller.snapshot().following).toBe(true)
+
+    // The round-trip completes: the row renders under the store's id.
+    addUserRow(h, 'turn-2:user', 1800 + 40)
+    h.grow(30)
+    const target = 1800 + 40 - SEND_ANCHOR_PEEK_PX
+    expect(h.container.scrollTop).toBe(target)
+    expect(controller.snapshot().following).toBe(false)
+
+    // Subsequent growth streams below the fold — no second reposition.
+    h.grow(400)
+    expect(h.container.scrollTop).toBe(target)
+  })
+
+  it('an upward wheel before the row lands cancels the pending reposition', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    controller.requestSendAnchor('user-1')
+    h.wheel(-10)
+    const parked = h.container.scrollTop
+
+    addUserRow(h, 'turn-2:user', 1800)
+    h.grow(200)
+    expect(h.container.scrollTop).toBe(parked)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('a stale send (queued message) expires instead of yanking later', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'Date'] })
+    try {
+      const h = createHarness()
+      const controller = attach(h)
+      h.scrollTo(300)
+      controller.requestSendAnchor('user-1')
+
+      vi.advanceTimersByTime(5000)
+      addUserRow(h, 'turn-9:user', 1800)
+      h.grow(100)
+      expect(h.container.scrollTop).toBe(300)
+      expect(controller.snapshot().following).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('after the send reposition, upward intent still parks and completion cannot snap down', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'Date'] })
+    try {
+      const h = createHarness()
+      const controller = attach(h)
+      addUserRow(h, 'user-1', 1800)
+      controller.requestSendAnchor('user-1')
+      expect(h.container.scrollTop).toBe(TARGET)
+
+      h.wheel(-10)
+      vi.advanceTimersByTime(1000) // generation continues past the gesture
+      h.grow(300)
+      expect(h.container.scrollTop).toBe(TARGET)
+
+      // Turn completion: an input-less anchoring adjustment — landing in
+      // the slack region where distance measures 0 — must not re-engage.
+      h.anchorAdjust(60)
+      expect(controller.snapshot().following).toBe(false)
+      const parked = h.container.scrollTop
+      h.grow(200)
+      expect(h.container.scrollTop).toBe(parked)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  ANCHOR_TAIL_HEADROOM_PX,
   AT_BOTTOM_EPSILON_PX,
   ChatScrollController,
   NEAR_BOTTOM_PX,
@@ -453,10 +454,10 @@ function addUserRow(h: Harness, id: string, layoutTop: number): HTMLElement {
 
 describe('ChatScrollController — send anchoring (chat mode)', () => {
   // A message whose layout top is 1800 in a 2000-tall transcript with a
-  // 600-tall viewport: the anchor target is 1800 - PEEK, which needs
-  // (1800 - PEEK) - (2000 - 600) px of spacer slack.
+  // 600-tall viewport: the anchor target is 1800 - PEEK, and the slack keeps
+  // the scroll range reachable to target + tail headroom.
   const TARGET = 1800 - SEND_ANCHOR_PEEK_PX
-  const SLACK = TARGET - 1400
+  const SLACK = TARGET + ANCHOR_TAIL_HEADROOM_PX - 1400
 
   function setupAnchored(messageLayoutTop: number) {
     const h = createHarness()
@@ -496,6 +497,59 @@ describe('ChatScrollController — send anchoring (chat mode)', () => {
     expect(h.spacerHeight()).toBe(0)
   })
 
+  it('a completion tail shrink lands in the headroom — no clamp — and the slack regrows', () => {
+    const { h, controller } = setupAnchored(1800)
+    controller.anchorToMessage('user-1')
+    expect(h.container.scrollTop).toBe(TARGET)
+
+    // Turn completes: the activity indicator row + gap unmount below the
+    // anchor. The browser clamps during layout — emulate by re-clamping
+    // scrollTop against the shrunken range BEFORE any observer runs.
+    h.state.contentHeight -= 90
+    const reclamped = h.container.scrollTop
+    h.container.scrollTop = reclamped
+    // The headroom absorbed the shrink: the reader did not move.
+    expect(h.container.scrollTop).toBe(TARGET)
+
+    triggerResize()
+    // Regrowth gate (target stable, content fell): the cap rises and the
+    // spacer is restored, so the NEXT shrink is covered too.
+    expect(h.spacerHeight()).toBe(SLACK + 90)
+    expect(h.container.scrollTop).toBe(TARGET)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('an above-anchor shift cannot inject slack (target moved, content did not fall)', () => {
+    const { h, controller, message } = setupAnchored(1800)
+    controller.anchorToMessage('user-1')
+    expect(h.spacerHeight()).toBe(SLACK)
+
+    // Content above the anchor grows by 200 while the tail shrinks by 200:
+    // total height unchanged, but the anchor's layout position moved down —
+    // the regrowth gate must stay closed even though required slack rose.
+    message.getBoundingClientRect = () =>
+      ({ top: 2000 - h.container.scrollTop } as DOMRect)
+    triggerResize()
+    expect(h.spacerHeight()).toBe(SLACK)
+  })
+
+  it('a parked reader survives a coalesced completion commit unchanged', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 300)
+    expect(controller.snapshot().following).toBe(false)
+    const parked = h.container.scrollTop
+
+    // One merged commit: +40 of durable-message growth and -90 of indicator
+    // removal land as a single net height change.
+    h.state.contentHeight += 40 - 90
+    const reclamped = h.container.scrollTop
+    h.container.scrollTop = reclamped
+    triggerResize()
+    expect(h.container.scrollTop).toBe(parked)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
   it('returns false when the message is not in the DOM yet', () => {
     const h = createHarness()
     const controller = attach(h, { mode: 'chat' })
@@ -526,7 +580,7 @@ describe('ChatScrollController — send repositioning (requestSendAnchor)', () =
 
     controller.requestSendAnchor('user-1')
     expect(h.container.scrollTop).toBe(TARGET)
-    expect(h.spacerHeight()).toBe(TARGET - 1400)
+    expect(h.spacerHeight()).toBe(TARGET + ANCHOR_TAIL_HEADROOM_PX - 1400)
     expect(controller.snapshot().following).toBe(false)
   })
 

--- a/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
@@ -37,6 +37,9 @@ interface Harness {
   wheel(deltaY: number): void
   /** Content growth (streaming, images, expansion) → resize tick. */
   grow(by: number): void
+  /** Browser scroll-anchoring compensation: growth above the reader with a
+   * position-preserving scrollTop adjustment and its scroll event. */
+  anchorAdjust(by: number): void
   /** Content shrink with the browser's clamp of scrollTop + scroll event. */
   shrinkAtBottom(by: number): void
   /** Max scrollTop excluding spacer slack (the content's live edge). */
@@ -93,6 +96,16 @@ function createHarness(
     },
     grow(by: number) {
       state.contentHeight += by
+      triggerResize()
+    },
+    anchorAdjust(by: number) {
+      // Native scroll anchoring compensating for growth above the reader's
+      // anchor node: content and scrollTop grow together (distance from the
+      // bottom is preserved), and the browser fires a scroll event with no
+      // accompanying input event.
+      state.contentHeight += by
+      container.scrollTop = container.scrollTop + by
+      container.dispatchEvent(new Event('scroll'))
       triggerResize()
     },
     shrinkAtBottom(by: number) {
@@ -190,12 +203,14 @@ describe('ChatScrollController — following the live edge', () => {
     expect(fitsController.snapshot().following).toBe(true)
   })
 
-  it('re-engages following when the user scrolls back into the near-bottom band', () => {
+  it('re-engages when a wheel gesture scrolls back into the near-bottom band', () => {
     const h = createHarness()
     const controller = attach(h)
     h.scrollTo(h.maxTop() - 500)
     expect(controller.snapshot().following).toBe(false)
 
+    // Trackpad: the wheel event attributes the scroll that follows it.
+    h.wheel(40)
     h.scrollTo(h.maxTop() - NEAR_BOTTOM_PX + 10)
     expect(controller.snapshot().following).toBe(true)
     expect(controller.snapshot().nearBottom).toBe(true)
@@ -235,6 +250,150 @@ describe('ChatScrollController — following the live edge', () => {
 
     h.grow(150)
     expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+})
+
+describe('ChatScrollController — user-intent attribution', () => {
+  it('end-of-turn repro: a browser anchoring adjustment near the bottom does not re-engage a parked reader', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    // Streaming, pinned. The reader scrolls up a small amount (scrollbar —
+    // no input event) and parks 40px above the live edge.
+    h.scrollTo(h.maxTop() - 40)
+    expect(controller.snapshot().following).toBe(false)
+
+    // A little more streams in below the fold — nothing moves.
+    h.grow(20)
+    const readingTop = h.container.scrollTop
+    expect(h.container.scrollTop).toBe(readingTop)
+
+    // Turn completes: the streaming bubble is replaced by the taller durable
+    // message above/at the reader's anchor node, and native scroll anchoring
+    // compensates — a downward scroll event, no user input, landing inside
+    // the near-bottom band.
+    h.anchorAdjust(60)
+    expect(controller.snapshot().following).toBe(false)
+
+    // Follow-up height changes (usage row, next paint) must not pin the
+    // reader back to the bottom.
+    const parkedTop = h.container.scrollTop
+    h.grow(300)
+    expect(h.container.scrollTop).toBe(parkedTop)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('a small upward wheel latches the disengage even when follow writes mask the scroll event', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    const bottom = h.container.scrollTop
+
+    // The wheel latches before any scroll event can be observed…
+    h.wheel(-5)
+    expect(controller.snapshot().following).toBe(false)
+
+    // …so an immediately-interleaved streaming tick no longer writes,
+    // and the masked (zero-delta) scroll echo cannot undo the latch.
+    h.grow(120)
+    expect(h.container.scrollTop).toBe(bottom)
+    h.container.dispatchEvent(new Event('scroll'))
+    expect(controller.snapshot().following).toBe(false)
+
+    // Turn completion: growth then a shrink-clamp — still parked.
+    h.grow(200)
+    expect(h.container.scrollTop).toBe(bottom)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('programmatic write echoes neither disengage nor engage', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    // Pinned: a follow write plus its echo keeps following.
+    h.grow(100)
+    h.container.dispatchEvent(new Event('scroll'))
+    expect(controller.snapshot().following).toBe(true)
+
+    // Parked: a zero-delta echo changes nothing.
+    h.scrollTo(h.maxTop() - 300)
+    expect(controller.snapshot().following).toBe(false)
+    h.container.dispatchEvent(new Event('scroll'))
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('a scrollbar return engages only at the true live edge', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 500)
+    expect(controller.snapshot().following).toBe(false)
+
+    // Unattributed downward movement into the band could be a browser
+    // adjustment — it does not engage…
+    h.scrollTo(h.maxTop() - 40)
+    expect(controller.snapshot().following).toBe(false)
+
+    // …but dragging the thumb to the very end is unambiguous.
+    h.scrollTo(h.maxTop())
+    expect(controller.snapshot().following).toBe(true)
+    h.grow(150)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+
+  it('touch gestures attribute the scroll events they cause', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 500)
+    expect(controller.snapshot().following).toBe(false)
+
+    h.container.dispatchEvent(new Event('touchmove'))
+    h.scrollTo(h.maxTop() - 60)
+    expect(controller.snapshot().following).toBe(true)
+  })
+
+  it('scroll keys attribute the scroll events they cause', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 500)
+    expect(controller.snapshot().following).toBe(false)
+
+    h.container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', bubbles: true })
+    )
+    h.scrollTo(h.maxTop() - 50)
+    expect(controller.snapshot().following).toBe(true)
+  })
+
+  it('keys pressed inside an editable are not scroll gestures', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 500)
+    expect(controller.snapshot().following).toBe(false)
+
+    const input = document.createElement('input')
+    h.content.appendChild(input)
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true })
+    )
+    // The band arrival stays unattributed → no engage.
+    h.scrollTo(h.maxTop() - 50)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('the attribution window expires — later browser adjustments are not the user', () => {
+    vi.useFakeTimers({ toFake: ['performance', 'Date'] })
+    try {
+      const h = createHarness()
+      const controller = attach(h)
+      h.wheel(-10)
+      h.scrollTo(h.maxTop() - 40)
+      expect(controller.snapshot().following).toBe(false)
+
+      // Well past the wheel's attribution window, completion-time anchoring
+      // fires an input-less downward scroll event inside the band.
+      vi.advanceTimersByTime(2000)
+      h.anchorAdjust(60)
+      expect(controller.snapshot().following).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
@@ -1,0 +1,441 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AT_BOTTOM_EPSILON_PX,
+  ChatScrollController,
+  NEAR_BOTTOM_PX,
+  resetChatScrollMemory,
+  type ChatScrollSnapshot,
+} from './chat-scroll'
+
+// jsdom has no ResizeObserver; the stub records instances so tests can fire
+// resize ticks (the controller does its follow/spacer work inside them).
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = []
+  callback: ResizeObserverCallback
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    ResizeObserverStub.instances.push(this)
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function triggerResize() {
+  for (const instance of ResizeObserverStub.instances) {
+    instance.callback([], instance as unknown as ResizeObserver)
+  }
+}
+
+interface Harness {
+  container: HTMLDivElement
+  content: HTMLDivElement
+  spacer: HTMLDivElement
+  state: { contentHeight: number; clientHeight: number }
+  /** Browser-faithful user scroll: set scrollTop, then the scroll event. */
+  scrollTo(top: number): void
+  wheel(deltaY: number): void
+  /** Content growth (streaming, images, expansion) → resize tick. */
+  grow(by: number): void
+  /** Content shrink with the browser's clamp of scrollTop + scroll event. */
+  shrinkAtBottom(by: number): void
+  /** Max scrollTop excluding spacer slack (the content's live edge). */
+  maxTop(): number
+  spacerHeight(): number
+}
+
+function createHarness(
+  { contentHeight = 2000, clientHeight = 600 } = {}
+): Harness {
+  const state = { contentHeight, clientHeight }
+  const container = document.createElement('div')
+  const content = document.createElement('div')
+  const spacer = document.createElement('div')
+  container.appendChild(content)
+  container.appendChild(spacer)
+  document.body.appendChild(container)
+
+  const spacerHeight = () => Number.parseFloat(spacer.style.height || '0') || 0
+  Object.defineProperty(container, 'scrollHeight', {
+    configurable: true,
+    get: () => state.contentHeight + spacerHeight(),
+  })
+  Object.defineProperty(container, 'clientHeight', {
+    configurable: true,
+    get: () => state.clientHeight,
+  })
+  // Browser-faithful scrollTop: writes clamp against the scroll range (jsdom
+  // would otherwise store any value, hiding clamp-dependent behavior).
+  let scrollTopValue = 0
+  Object.defineProperty(container, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTopValue,
+    set: (value: number) => {
+      const max = Math.max(
+        0,
+        state.contentHeight + spacerHeight() - state.clientHeight
+      )
+      scrollTopValue = Math.max(0, Math.min(value, max))
+    },
+  })
+
+  return {
+    container,
+    content,
+    spacer,
+    state,
+    scrollTo(top: number) {
+      container.scrollTop = top
+      container.dispatchEvent(new Event('scroll'))
+    },
+    wheel(deltaY: number) {
+      container.dispatchEvent(new WheelEvent('wheel', { deltaY, bubbles: true }))
+    },
+    grow(by: number) {
+      state.contentHeight += by
+      triggerResize()
+    },
+    shrinkAtBottom(by: number) {
+      state.contentHeight -= by
+      const clamped = Math.max(
+        0,
+        state.contentHeight + spacerHeight() - state.clientHeight
+      )
+      container.scrollTop = Math.min(container.scrollTop, clamped)
+      container.dispatchEvent(new Event('scroll'))
+      triggerResize()
+    },
+    maxTop: () => Math.max(0, state.contentHeight - state.clientHeight),
+    spacerHeight,
+  }
+}
+
+function attach(
+  harness: Harness,
+  options: ConstructorParameters<typeof ChatScrollController>[0] = {}
+) {
+  const controller = new ChatScrollController(options)
+  controller.attach({
+    container: harness.container,
+    content: harness.content,
+    spacer: harness.spacer,
+  })
+  return controller
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+})
+
+afterEach(() => {
+  ResizeObserverStub.instances = []
+  vi.unstubAllGlobals()
+  resetChatScrollMemory()
+  document.body.innerHTML = ''
+})
+
+describe('ChatScrollController — following the live edge', () => {
+  it('lands at the bottom on attach and follows content growth', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+    expect(controller.snapshot()).toEqual({ nearBottom: true, following: true })
+
+    h.grow(250)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+    h.grow(15)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+    expect(controller.snapshot().following).toBe(true)
+  })
+
+  it('follows container resizes (composer growth, window resize)', () => {
+    const h = createHarness()
+    attach(h)
+    h.state.clientHeight -= 120
+    triggerResize()
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+
+  it('stops following when the user scrolls upward, and stays put', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 400)
+    expect(controller.snapshot().following).toBe(false)
+    expect(controller.snapshot().nearBottom).toBe(false)
+
+    const readingTop = h.container.scrollTop
+    h.grow(500)
+    expect(h.container.scrollTop).toBe(readingTop)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('stops following on an upward wheel even before any scroll event', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.wheel(-40)
+    expect(controller.snapshot().following).toBe(false)
+    h.grow(300)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('ignores downward wheels and wheels when content fits the viewport', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.wheel(40)
+    expect(controller.snapshot().following).toBe(true)
+
+    const fits = createHarness({ contentHeight: 300, clientHeight: 600 })
+    const fitsController = attach(fits)
+    fits.wheel(-40)
+    expect(fitsController.snapshot().following).toBe(true)
+  })
+
+  it('re-engages following when the user scrolls back into the near-bottom band', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - 500)
+    expect(controller.snapshot().following).toBe(false)
+
+    h.scrollTo(h.maxTop() - NEAR_BOTTOM_PX + 10)
+    expect(controller.snapshot().following).toBe(true)
+    expect(controller.snapshot().nearBottom).toBe(true)
+
+    h.grow(200)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+
+  it('does not re-engage when an upward scroll merely ends inside the band', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - (NEAR_BOTTOM_PX - 20))
+    expect(controller.snapshot().following).toBe(false)
+
+    const readingTop = h.container.scrollTop
+    h.grow(300)
+    expect(h.container.scrollTop).toBe(readingTop)
+  })
+
+  it('keeps following through a clamp when content shrinks at the bottom', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.shrinkAtBottom(300)
+    expect(controller.snapshot().following).toBe(true)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+
+  it('jumpToLatest returns to the live edge and resumes following', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(100)
+    expect(controller.snapshot().following).toBe(false)
+
+    controller.jumpToLatest()
+    expect(h.container.scrollTop).toBe(h.maxTop())
+    expect(controller.snapshot()).toEqual({ nearBottom: true, following: true })
+
+    h.grow(150)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+})
+
+describe('ChatScrollController — smooth jump', () => {
+  it('animates via scrollTo, re-targets on growth, then resumes instant follow', () => {
+    const h = createHarness()
+    const scrollTo = vi.fn((options: ScrollToOptions) => {
+      h.container.scrollTop = options.top ?? 0
+    })
+    h.container.scrollTo = scrollTo as unknown as typeof h.container.scrollTo
+    const controller = attach(h)
+    h.scrollTo(100)
+
+    controller.jumpToLatest('smooth')
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: h.maxTop(), behavior: 'smooth' })
+    expect(controller.snapshot().following).toBe(true)
+
+    // Growth mid-animation re-targets the animation instead of snapping.
+    h.grow(200)
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: h.maxTop(), behavior: 'smooth' })
+
+    // Arrival at the bottom settles the animation; further growth snaps.
+    h.scrollTo(h.maxTop())
+    scrollTo.mockClear()
+    h.grow(100)
+    expect(scrollTo).not.toHaveBeenCalled()
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+
+  it('an upward wheel cancels the animation and the follow intent', () => {
+    const h = createHarness()
+    const scrollTo = vi.fn()
+    h.container.scrollTo = scrollTo as unknown as typeof h.container.scrollTo
+    const controller = attach(h)
+    h.scrollTo(100)
+    controller.jumpToLatest('smooth')
+
+    h.wheel(-30)
+    expect(controller.snapshot().following).toBe(false)
+    const top = h.container.scrollTop
+    h.grow(200)
+    expect(h.container.scrollTop).toBe(top)
+  })
+})
+
+describe('ChatScrollController — send anchoring (chat mode)', () => {
+  function setupAnchored(messageLayoutTop: number) {
+    const h = createHarness()
+    const controller = attach(h, { mode: 'chat' })
+    const message = document.createElement('div')
+    message.setAttribute('data-message-id', 'user-1')
+    h.content.appendChild(message)
+    h.container.getBoundingClientRect = () =>
+      ({ top: 0 } as DOMRect)
+    message.getBoundingClientRect = () =>
+      ({ top: messageLayoutTop - h.container.scrollTop } as DOMRect)
+    return { h, controller, message }
+  }
+
+  it('pins the sent message at the viewport top with spacer slack', () => {
+    const { h, controller } = setupAnchored(1800)
+    expect(controller.anchorToMessage('user-1')).toBe(true)
+
+    // target 1800 needs 400px of slack beyond the 1400 natural max.
+    expect(h.container.scrollTop).toBe(1800)
+    expect(h.spacerHeight()).toBe(400)
+    expect(controller.snapshot().following).toBe(false)
+    // Nothing but blank slack below → nothing to jump to.
+    expect(controller.snapshot().nearBottom).toBe(true)
+  })
+
+  it('consumes slack (shrink-only) as the response streams, without moving the view', () => {
+    const { h, controller } = setupAnchored(1800)
+    controller.anchorToMessage('user-1')
+
+    h.grow(300)
+    expect(h.spacerHeight()).toBe(100)
+    expect(h.container.scrollTop).toBe(1800)
+
+    h.grow(300)
+    expect(h.spacerHeight()).toBe(0)
+    expect(h.container.scrollTop).toBe(1800)
+    // Content now extends below the fold → the jump affordance appears.
+    expect(controller.snapshot().nearBottom).toBe(false)
+
+    // Slack never comes back, even if layout above the anchor shifts.
+    h.state.contentHeight -= 50
+    triggerResize()
+    expect(h.spacerHeight()).toBe(0)
+  })
+
+  it('returns false when the message is not in the DOM yet', () => {
+    const h = createHarness()
+    const controller = attach(h, { mode: 'chat' })
+    expect(controller.anchorToMessage('missing')).toBe(false)
+  })
+
+  it('scrolling to the bottom mid-stream re-engages following', () => {
+    const { h, controller } = setupAnchored(1800)
+    controller.anchorToMessage('user-1')
+    h.grow(700) // slack exhausted, response extends below the fold
+
+    h.scrollTo(h.maxTop())
+    expect(controller.snapshot().following).toBe(true)
+    h.grow(120)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+})
+
+describe('ChatScrollController — reading-position memory', () => {
+  it('restores a mid-transcript position across remounts, re-asserting while content rebuilds', () => {
+    const h = createHarness()
+    const controller = attach(h, { memoryKey: 'chat-1' })
+    h.scrollTo(900)
+    expect(controller.snapshot().following).toBe(false)
+    controller.detach()
+
+    // Remount: content starts short (transcript re-renders asynchronously).
+    const h2 = createHarness({ contentHeight: 400 })
+    const controller2 = attach(h2, { memoryKey: 'chat-1' })
+    expect(controller2.snapshot().following).toBe(false)
+
+    h2.grow(1600)
+    expect(h2.container.scrollTop).toBe(900)
+
+    // Once the position is reachable the restore is done — later growth
+    // leaves the reader alone.
+    h2.grow(400)
+    expect(h2.container.scrollTop).toBe(900)
+  })
+
+  it('a user scroll takes over from a pending restore', () => {
+    const h = createHarness()
+    const controller = attach(h, { memoryKey: 'chat-2' })
+    h.scrollTo(900)
+    controller.detach()
+
+    // Remount mid-rebuild: content is tall enough to scroll but not yet tall
+    // enough to hold the remembered position (the write clamps).
+    const h2 = createHarness({ contentHeight: 1000 })
+    attach(h2, { memoryKey: 'chat-2' })
+    expect(h2.container.scrollTop).toBe(h2.maxTop())
+
+    h2.scrollTo(50)
+    h2.grow(1600)
+    expect(h2.container.scrollTop).toBe(50)
+  })
+
+  it('a remount that was following lands back at the live edge', () => {
+    const h = createHarness()
+    const controller = attach(h, { memoryKey: 'chat-3' })
+    expect(controller.snapshot().following).toBe(true)
+    controller.detach()
+
+    const h2 = createHarness({ contentHeight: 3000 })
+    const controller2 = attach(h2, { memoryKey: 'chat-3' })
+    expect(h2.container.scrollTop).toBe(h2.maxTop())
+    expect(controller2.snapshot().following).toBe(true)
+  })
+
+  it('an unknown conversation lands at the bottom', () => {
+    const h = createHarness()
+    const controller = attach(h, { memoryKey: 'never-seen' })
+    expect(h.container.scrollTop).toBe(h.maxTop())
+    expect(controller.snapshot().following).toBe(true)
+  })
+})
+
+describe('ChatScrollController — subscription and cleanup', () => {
+  it('notifies subscribers of near-bottom/following changes', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    const seen: ChatScrollSnapshot[] = []
+    const unsubscribe = controller.subscribe((snapshot) => seen.push(snapshot))
+    expect(seen[0]).toEqual({ nearBottom: true, following: true })
+
+    h.scrollTo(h.maxTop() - 500)
+    expect(seen[seen.length - 1]).toEqual({ nearBottom: false, following: false })
+
+    unsubscribe()
+    const count = seen.length
+    h.scrollTo(h.maxTop())
+    expect(seen.length).toBe(count)
+  })
+
+  it('detach removes listeners and stops reacting', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    controller.detach()
+    h.scrollTo(100)
+    h.state.contentHeight += 500
+    triggerResize()
+    expect(h.container.scrollTop).toBe(100)
+  })
+
+  it('tolerates sub-pixel scroll positions at the bottom', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    h.scrollTo(h.maxTop() - AT_BOTTOM_EPSILON_PX / 2)
+    expect(controller.snapshot().following).toBe(true)
+    h.grow(100)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+})

--- a/apps/x/apps/renderer/src/lib/chat-scroll.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.ts
@@ -25,13 +25,24 @@
  * - 'code' (Codex transcript semantics): sends jump straight to the live
  *   edge and follow the run's output. No top-anchoring.
  *
- * Programmatic scrolls are distinguished from user scrolls by updating the
- * internal `lastTop` bookkeeping immediately after every write, so the echoed
- * scroll event reads as a zero-delta and never flips user intent. Native CSS
- * scroll anchoring stays enabled: its adjustments preserve the reading
- * position when content above the viewport changes, and the delta rules below
- * are ordered so a clamp/anchor adjustment at the bottom cannot break
- * following.
+ * Intent is latched from direct user input, not inferred from scroll
+ * geometry alone. Wheel, touch, and scroll-key listeners stamp a short
+ * attribution window; scroll events inside the window count as the user's
+ * (and refresh it, so momentum and smooth-keyboard chains stay attributed).
+ * An upward wheel latches "scrolled away" immediately — even if an
+ * interleaved follow write swallows the resulting scroll event's delta, the
+ * disengage sticks. Scroll events OUTSIDE the window (our own write echoes —
+ * lastTop is pre-updated on every write — browser clamps after content
+ * shrinks, and native scroll-anchoring compensations around end-of-turn DOM
+ * churn) can never re-engage following: without this, a completion-time
+ * anchoring adjustment landing inside the near-bottom band yanked readers
+ * who had deliberately parked slightly above the live edge back to the
+ * bottom. The one unattributed engage is a downward arrival at the true live
+ * edge (scrollbar dragged to the very end — Chromium scrollbars emit no
+ * input events); anchoring compensations preserve the reader's distance and
+ * clamps move upward, so neither can land there. Native CSS scroll anchoring
+ * stays enabled: its adjustments keep the reading position stable while
+ * content above changes.
  *
  * A module-level memory map (keyed by chat identity) preserves the reading
  * position across pane remounts (view toggles, dock/full-screen switches).
@@ -52,6 +63,23 @@ export const AT_BOTTOM_EPSILON_PX = 2
 /** A restored reading position keeps re-asserting itself for this long while
  * the remounted transcript's content is still growing back underneath it. */
 const RESTORE_WINDOW_MS = 1500
+/** How long after direct user input (wheel, touch, scroll keys) a scroll
+ * event is still attributed to that gesture. Attributed scroll events
+ * refresh the window, so trackpad momentum and smooth keyboard scrolling
+ * stay attributed for their whole run. */
+const USER_INPUT_WINDOW_MS = 250
+
+/** Keys that scroll a container when it (or a non-editable descendant) has
+ * focus. */
+const SCROLL_KEYS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End',
+  ' ',
+])
 
 export interface ChatScrollSnapshot {
   nearBottom: boolean
@@ -99,6 +127,9 @@ export class ChatScrollController {
   private nearBottom = true
   private lastTop = 0
   private spacerHeight = 0
+  // Timestamp of the last direct user input (wheel, touch, scroll key) —
+  // scroll events within USER_INPUT_WINDOW_MS of it are the user's.
+  private lastUserInputAt = Number.NEGATIVE_INFINITY
 
   // Send-anchor state ('chat' mode): while set, resize ticks keep the spacer
   // slack maintained (shrink-only) so the anchored message stays reachable at
@@ -129,6 +160,9 @@ export class ChatScrollController {
 
     els.container.addEventListener('scroll', this.handleScroll, { passive: true })
     els.container.addEventListener('wheel', this.handleWheel, { passive: true })
+    els.container.addEventListener('touchstart', this.handleTouch, { passive: true })
+    els.container.addEventListener('touchmove', this.handleTouch, { passive: true })
+    els.container.addEventListener('keydown', this.handleKeyDown)
 
     if (typeof ResizeObserver !== 'undefined') {
       this.observer = new ResizeObserver(this.handleResize)
@@ -153,6 +187,9 @@ export class ChatScrollController {
     this.saveMemory()
     this.els.container.removeEventListener('scroll', this.handleScroll)
     this.els.container.removeEventListener('wheel', this.handleWheel)
+    this.els.container.removeEventListener('touchstart', this.handleTouch)
+    this.els.container.removeEventListener('touchmove', this.handleTouch)
+    this.els.container.removeEventListener('keydown', this.handleKeyDown)
     this.observer?.disconnect()
     this.observer = null
     this.els = null
@@ -236,23 +273,36 @@ export class ChatScrollController {
     this.lastTop = top
 
     // Echoes of our own writes (lastTop is pre-updated on every write) and
-    // sub-pixel noise carry no user intent: only genuine movement may change
-    // follow state or take over from a pending restore.
+    // sub-pixel noise carry no state changes at all.
     if (Math.abs(delta) > 1) {
       this.restore = null
+      const attributed = this.isUserAttributed()
       const distance = this.distanceFromBottom()
-      if (distance <= AT_BOTTOM_EPSILON_PX) {
-        // At the live edge — includes clamp/anchoring adjustments when
-        // content shrinks while pinned, which must not break following.
+      if (delta < 0) {
+        // The view moved up past the live-edge tolerance: scrollbar drag,
+        // touch, keyboard or wheel — stop following, never yank back down.
+        // AT the tolerance this is a browser clamp after content shrank
+        // (end-of-turn card collapses) and carries no intent: pinned readers
+        // stay pinned, parked readers stay parked.
+        if (distance > AT_BOTTOM_EPSILON_PX) {
+          this.following = false
+          this.cancelSmooth()
+        }
+      } else if (attributed && distance <= NEAR_BOTTOM_PX) {
+        // A downward user gesture back into the near-bottom band resumes
+        // following.
         this.following = true
-      } else if (delta < 0) {
-        // Deliberate upward movement: stop following, never yank back down.
-        this.following = false
-        this.cancelSmooth()
-      } else if (distance <= NEAR_BOTTOM_PX) {
-        // Scrolled back down into the near-bottom band: resume following.
+      } else if (distance <= AT_BOTTOM_EPSILON_PX) {
+        // Unattributed downward arrivals engage only at the true live edge:
+        // that's a scrollbar dragged to the very end (scrollbars emit no
+        // input events). Native anchoring compensations preserve the
+        // reader's distance and so can never land here — the end-of-turn
+        // re-engage bug this model exists to prevent.
         this.following = true
       }
+      // Keep momentum / smooth-keyboard scroll chains attributed to the
+      // gesture that started them.
+      if (attributed) this.lastUserInputAt = now()
     }
     // A settling smooth animation ends in sub-pixel deltas — check outside
     // the intent gate.
@@ -268,14 +318,42 @@ export class ChatScrollController {
   private handleWheel = (event: WheelEvent): void => {
     const els = this.els
     if (!els) return
+    this.lastUserInputAt = now()
     if (event.deltaY >= 0) return
     if (els.container.scrollHeight <= els.container.clientHeight) return
     // Any upward wheel over the transcript is review intent — including one
     // consumed by a nested scrollable (terminal output, code block), whose
     // reader would otherwise be yanked along by the following transcript.
+    // Latching here (before any scroll event) makes the disengage immune to
+    // interleaved follow writes swallowing the scroll event's delta.
     this.following = false
     this.cancelSmooth()
     this.notify()
+  }
+
+  private handleTouch = (): void => {
+    this.lastUserInputAt = now()
+  }
+
+  private handleKeyDown = (event: KeyboardEvent): void => {
+    if (!SCROLL_KEYS.has(event.key)) return
+    const target = event.target
+    if (
+      target instanceof HTMLElement &&
+      (target.isContentEditable ||
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT')
+    ) {
+      // Typing/caret movement in an editable inside the transcript is not a
+      // scroll gesture.
+      return
+    }
+    this.lastUserInputAt = now()
+  }
+
+  private isUserAttributed(): boolean {
+    return now() - this.lastUserInputAt <= USER_INPUT_WINDOW_MS
   }
 
   private handleResize = (): void => {

--- a/apps/x/apps/renderer/src/lib/chat-scroll.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.ts
@@ -16,12 +16,13 @@
  *   jump-to-latest button's visibility.
  *
  * Mode differences ('chat' vs 'code'):
- * - 'chat' (ChatGPT semantics): a send anchors the new user message at the
- *   top of the viewport, padding the scroll range with spacer slack so the
- *   message can reach the top even while the response is still short. The
- *   response streams below the fold without moving the view; the slack is
- *   consumed (shrink-only) as content grows. Following is off after a send
- *   until the user returns to the bottom.
+ * - 'chat' (ChatGPT semantics): a send is explicit navigation — wherever the
+ *   reader had scrolled, the new user message is pinned near the viewport
+ *   top (SEND_ANCHOR_PEEK_PX of the prior turn stays visible), with spacer
+ *   slack below so the position is reachable while the response is still
+ *   short. The response streams below the fold without moving the view; the
+ *   slack is consumed (shrink-only) as content grows. Following is off after
+ *   a send until the user returns to the bottom.
  * - 'code' (Codex transcript semantics): sends jump straight to the live
  *   edge and follow the run's output. No top-anchoring.
  *
@@ -68,6 +69,16 @@ const RESTORE_WINDOW_MS = 1500
  * refresh the window, so trackpad momentum and smooth keyboard scrolling
  * stay attributed for their whole run. */
 const USER_INPUT_WINDOW_MS = 250
+/** A sent message is pinned this far below the viewport top — enough to show
+ * the inter-message gap (32px) plus a sliver of the previous turn, so the
+ * jump reads as continuous rather than a fresh page. */
+export const SEND_ANCHOR_PEEK_PX = 48
+/** How long a send keeps waiting for its message row to render (the active
+ * pane is store-backed: the row lands only after the send's IPC round-trip
+ * and turn-event emit). A row that hasn't appeared by then belongs to a
+ * queued message that will start a later turn — repositioning for it out of
+ * the blue would be a yank, not navigation. */
+const SEND_ANCHOR_DEADLINE_MS = 3000
 
 /** Keys that scroll a container when it (or a non-editable descendant) has
  * focus. */
@@ -136,7 +147,18 @@ export class ChatScrollController {
   // the viewport top without ever introducing new blank space.
   private anchorId: string | null = null
   private anchorSlackCap = 0
-  private anchorPaddingTop = 0
+
+  // A send whose message row hasn't rendered yet (store-backed chats append
+  // the row only after the IPC round-trip). Resize ticks — which fire exactly
+  // when the row lands — retry it; user scroll intent or the deadline cancels
+  // it. `baselineUserRowId` snapshots the last user row at request time so an
+  // id mismatch (optimistic App id vs the store's `${turnId}:user` id) can
+  // still resolve to the row the send actually produced.
+  private pendingSendAnchor: {
+    messageId: string | null
+    baselineUserRowId: string | null
+    deadline: number
+  } | null = null
 
   // In-flight smooth scroll to the live edge (jump button): growth re-targets
   // the animation instead of fighting it with instant writes.
@@ -194,6 +216,7 @@ export class ChatScrollController {
     this.observer = null
     this.els = null
     this.restore = null
+    this.pendingSendAnchor = null
     this.smoothPending = false
   }
 
@@ -214,6 +237,7 @@ export class ChatScrollController {
     const els = this.els
     if (!els) return
     this.restore = null
+    this.pendingSendAnchor = null
     this.following = true
     const top = this.maxTop()
     if (behavior === 'smooth' && typeof els.container.scrollTo === 'function') {
@@ -229,10 +253,33 @@ export class ChatScrollController {
   }
 
   /**
-   * 'chat'-mode send: pin the message at the viewport top, padding the scroll
-   * range with spacer slack so it can get there while the response is still
-   * short. Returns false when the message element isn't in the DOM yet (the
-   * caller may retry on the next frame).
+   * A user send in 'chat' mode: an explicit navigation action that always
+   * repositions — regardless of where the reader had scrolled — pinning the
+   * new message near the viewport top (SEND_ANCHOR_PEEK_PX of the prior turn
+   * stays visible for continuity) with spacer slack below so the position is
+   * reachable while the response is still short.
+   *
+   * The message row may not exist yet: the active pane is store-backed, so
+   * the row renders only after the send's round-trip, and its durable id
+   * (`${turnId}:user…`) never matches the caller's optimistic id. The
+   * request stays pending and resize ticks resolve it — by id when present,
+   * otherwise to the first user row that appears after the request. A user
+   * scroll gesture or the deadline cancels it; exactly one reposition
+   * happens per send.
+   */
+  requestSendAnchor(messageId: string | null): void {
+    if (!this.els) return
+    this.pendingSendAnchor = {
+      messageId,
+      baselineUserRowId: this.lastUserRow()?.getAttribute('data-message-id') ?? null,
+      deadline: now() + SEND_ANCHOR_DEADLINE_MS,
+    }
+    this.trySendAnchor()
+  }
+
+  /**
+   * Pin the given message near the viewport top now. Returns false when the
+   * element isn't in the DOM (see requestSendAnchor for the deferred path).
    */
   anchorToMessage(messageId: string): boolean {
     const els = this.els
@@ -241,13 +288,61 @@ export class ChatScrollController {
       `[data-message-id="${messageId}"]`
     )
     if (!anchor) return false
+    this.applyAnchorToElement(anchor, messageId)
+    return true
+  }
 
+  private trySendAnchor(): void {
+    const pending = this.pendingSendAnchor
+    const els = this.els
+    if (!pending || !els) return
+    if (now() > pending.deadline) {
+      this.pendingSendAnchor = null
+      return
+    }
+    let anchor = pending.messageId
+      ? els.content.querySelector<HTMLElement>(
+          `[data-message-id="${pending.messageId}"]`
+        )
+      : null
+    if (!anchor) {
+      const lastUserRow = this.lastUserRow()
+      if (
+        lastUserRow &&
+        lastUserRow.getAttribute('data-message-id') !== pending.baselineUserRowId
+      ) {
+        anchor = lastUserRow
+      }
+    }
+    if (!anchor) return
+    this.pendingSendAnchor = null
+    this.applyAnchorToElement(
+      anchor,
+      anchor.getAttribute('data-message-id') ?? pending.messageId ?? null
+    )
+  }
+
+  /** The last user message row (`is-user` is the Message component's own
+   * role marker, on the same element as data-message-id). */
+  private lastUserRow(): HTMLElement | null {
+    const els = this.els
+    if (!els) return null
+    const rows = els.content.querySelectorAll<HTMLElement>('[data-message-id]')
+    for (let i = rows.length - 1; i >= 0; i--) {
+      if (rows[i].classList.contains('is-user')) return rows[i]
+    }
+    return null
+  }
+
+  private applyAnchorToElement(anchor: HTMLElement, anchorId: string | null): void {
+    const els = this.els
+    if (!els) return
     this.cancelSmooth()
     this.restore = null
-    this.anchorId = messageId
-    this.anchorPaddingTop = readPaddingTop(els.content)
+    this.pendingSendAnchor = null
+    this.anchorId = anchorId
 
-    const targetTop = Math.max(0, this.anchorTopInContent(anchor) - this.anchorPaddingTop)
+    const targetTop = Math.max(0, this.anchorTopInContent(anchor) - SEND_ANCHOR_PEEK_PX)
     const contentHeight = els.container.scrollHeight - this.spacerHeight
     const slack = Math.max(
       0,
@@ -260,7 +355,6 @@ export class ChatScrollController {
     this.following = false
     this.updateNearBottom()
     this.notify()
-    return true
   }
 
   // --- internals ---
@@ -287,17 +381,24 @@ export class ChatScrollController {
         if (distance > AT_BOTTOM_EPSILON_PX) {
           this.following = false
           this.cancelSmooth()
+          // The reader took over before a pending send reposition landed —
+          // applying it late would be a yank.
+          this.pendingSendAnchor = null
         }
       } else if (attributed && distance <= NEAR_BOTTOM_PX) {
         // A downward user gesture back into the near-bottom band resumes
         // following.
         this.following = true
-      } else if (distance <= AT_BOTTOM_EPSILON_PX) {
+        this.pendingSendAnchor = null
+      } else if (distance <= AT_BOTTOM_EPSILON_PX && this.spacerHeight === 0) {
         // Unattributed downward arrivals engage only at the true live edge:
         // that's a scrollbar dragged to the very end (scrollbars emit no
         // input events). Native anchoring compensations preserve the
         // reader's distance and so can never land here — the end-of-turn
-        // re-engage bug this model exists to prevent.
+        // re-engage bug this model exists to prevent. While send-anchor
+        // slack exists the edge is ambiguous (positions inside the blank
+        // slack also measure distance 0), so only attributed gestures engage
+        // then.
         this.following = true
       }
       // Keep momentum / smooth-keyboard scroll chains attributed to the
@@ -328,6 +429,7 @@ export class ChatScrollController {
     // interleaved follow writes swallowing the scroll event's delta.
     this.following = false
     this.cancelSmooth()
+    this.pendingSendAnchor = null
     this.notify()
   }
 
@@ -358,6 +460,8 @@ export class ChatScrollController {
 
   private handleResize = (): void => {
     if (!this.els) return
+    // A resize tick is exactly when a just-sent message's row lands.
+    this.trySendAnchor()
     this.maintainAnchorSpacer()
     if (this.restore) {
       if (now() > this.restore.deadline) {
@@ -434,7 +538,7 @@ export class ChatScrollController {
       this.setSpacerHeight(0)
       return
     }
-    const targetTop = Math.max(0, this.anchorTopInContent(anchor) - this.anchorPaddingTop)
+    const targetTop = Math.max(0, this.anchorTopInContent(anchor) - SEND_ANCHOR_PEEK_PX)
     const contentHeight = els.container.scrollHeight - this.spacerHeight
     const required = Math.max(
       0,
@@ -478,11 +582,6 @@ export class ChatScrollController {
     const snapshot = this.snapshot()
     for (const listener of this.listeners) listener(snapshot)
   }
-}
-
-function readPaddingTop(el: HTMLElement): number {
-  const value = Number.parseFloat(window.getComputedStyle(el).paddingTop || '0')
-  return Number.isFinite(value) ? value : 0
 }
 
 function now(): number {

--- a/apps/x/apps/renderer/src/lib/chat-scroll.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.ts
@@ -73,6 +73,14 @@ const USER_INPUT_WINDOW_MS = 250
  * the inter-message gap (32px) plus a sliver of the previous turn, so the
  * jump reads as continuous rather than a fresh page. */
 export const SEND_ANCHOR_PEEK_PX = 48
+/** Extra scroll range kept past the anchor target while a send anchor is
+ * active. Turn completion unmounts tail rows (activity indicator + its gap,
+ * tool-output swaps) and the browser clamps scrollTop DURING that layout —
+ * before any ResizeObserver callback could react — so the protection must
+ * be pre-provisioned: with this headroom the shrink lands inside the slack
+ * and the anchored reader's position never clamps. Covers the ~90px
+ * end-of-turn delta with margin. */
+export const ANCHOR_TAIL_HEADROOM_PX = 128
 /** How long a send keeps waiting for its message row to render (the active
  * pane is store-backed: the row lands only after the send's IPC round-trip
  * and turn-event emit). A row that hasn't appeared by then belongs to a
@@ -143,10 +151,17 @@ export class ChatScrollController {
   private lastUserInputAt = Number.NEGATIVE_INFINITY
 
   // Send-anchor state ('chat' mode): while set, resize ticks keep the spacer
-  // slack maintained (shrink-only) so the anchored message stays reachable at
-  // the viewport top without ever introducing new blank space.
+  // slack maintained so the anchored message stays reachable at the viewport
+  // top (plus tail headroom — see ANCHOR_TAIL_HEADROOM_PX). The cap makes
+  // slack shrink-only against above-anchor layout shifts; it may rise again
+  // only for a tail shrink under a stable anchor (the regrowth gate in
+  // maintainAnchorSpacer).
   private anchorId: string | null = null
   private anchorSlackCap = 0
+  // Regrowth-gate baselines: the anchor target and content height as of the
+  // previous maintenance pass.
+  private lastAnchorTargetTop: number | null = null
+  private lastAnchorContentHeight: number | null = null
 
   // A send whose message row hasn't rendered yet (store-backed chats append
   // the row only after the IPC round-trip). Resize ticks — which fire exactly
@@ -344,11 +359,10 @@ export class ChatScrollController {
 
     const targetTop = Math.max(0, this.anchorTopInContent(anchor) - SEND_ANCHOR_PEEK_PX)
     const contentHeight = els.container.scrollHeight - this.spacerHeight
-    const slack = Math.max(
-      0,
-      Math.ceil(targetTop - (contentHeight - els.container.clientHeight))
-    )
+    const slack = anchorSlackRequired(targetTop, contentHeight, els.container.clientHeight)
     this.anchorSlackCap = slack
+    this.lastAnchorTargetTop = targetTop
+    this.lastAnchorContentHeight = contentHeight
     this.setSpacerHeight(slack)
 
     this.write(targetTop)
@@ -535,21 +549,34 @@ export class ChatScrollController {
       // The anchored message left the DOM (conversation replaced) — drop the
       // slack rather than preserving blank space for nothing.
       this.anchorId = null
+      this.lastAnchorTargetTop = null
+      this.lastAnchorContentHeight = null
       this.setSpacerHeight(0)
       return
     }
     const targetTop = Math.max(0, this.anchorTopInContent(anchor) - SEND_ANCHOR_PEEK_PX)
     const contentHeight = els.container.scrollHeight - this.spacerHeight
-    const required = Math.max(
-      0,
-      Math.ceil(targetTop - (contentHeight - els.container.clientHeight))
-    )
-    // Shrink-only: slack is consumed as the response grows and never comes
-    // back, so layout shifts above the anchor can't inject new blank space.
+    const required = anchorSlackRequired(targetTop, contentHeight, els.container.clientHeight)
+    // Slack is consumed as the response grows and normally never comes back
+    // (the cap is shrink-only), so layout shifts above the anchor can't
+    // inject new blank space. The one sanctioned regrowth: a tail shrink
+    // UNDER A STABLE ANCHOR (end-of-turn rows unmounting below the reader) —
+    // the cap rises back to the requirement so the headroom that just
+    // absorbed the shrink is restored for the next one.
+    const anchorStable =
+      this.lastAnchorTargetTop !== null &&
+      Math.abs(targetTop - this.lastAnchorTargetTop) <= 1
+    const contentFell =
+      this.lastAnchorContentHeight !== null &&
+      contentHeight < this.lastAnchorContentHeight
+    if (anchorStable && contentFell && required > this.anchorSlackCap) {
+      this.anchorSlackCap = required
+    }
     const slack = Math.min(required, this.anchorSlackCap)
     this.anchorSlackCap = slack
+    this.lastAnchorTargetTop = targetTop
+    this.lastAnchorContentHeight = contentHeight
     if (slack !== this.spacerHeight) this.setSpacerHeight(slack)
-    if (slack === 0) this.anchorId = null
   }
 
   private setSpacerHeight(height: number): void {
@@ -582,6 +609,19 @@ export class ChatScrollController {
     const snapshot = this.snapshot()
     for (const listener of this.listeners) listener(snapshot)
   }
+}
+
+/** Spacer slack needed to keep the anchor target reachable with tail
+ * headroom to spare (see ANCHOR_TAIL_HEADROOM_PX). */
+function anchorSlackRequired(
+  targetTop: number,
+  contentHeight: number,
+  clientHeight: number
+): number {
+  return Math.max(
+    0,
+    Math.ceil(targetTop + ANCHOR_TAIL_HEADROOM_PX - (contentHeight - clientHeight))
+  )
 }
 
 function now(): number {

--- a/apps/x/apps/renderer/src/lib/chat-scroll.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.ts
@@ -1,0 +1,412 @@
+/**
+ * Scroll-state controller for chat transcripts.
+ *
+ * One controller instance owns one transcript's scroll container for the life
+ * of a conversation binding (the pane remounts per chat identity). It models
+ * the behavior of modern chat UIs with two explicit concepts:
+ *
+ * - **following** — the user is riding the live edge: any content growth
+ *   (streamed tokens, tool cards, images, collapsibles) keeps the view pinned
+ *   to the bottom of the content. Following starts true on a fresh
+ *   conversation, breaks the moment the user deliberately scrolls upward
+ *   (wheel, scrollbar, keyboard, touch), and re-engages when the user scrolls
+ *   back to within NEAR_BOTTOM_PX of the content bottom or invokes
+ *   jumpToLatest (the scroll-down button, or a send in code mode).
+ * - **nearBottom** — within NEAR_BOTTOM_PX of the content bottom; drives the
+ *   jump-to-latest button's visibility.
+ *
+ * Mode differences ('chat' vs 'code'):
+ * - 'chat' (ChatGPT semantics): a send anchors the new user message at the
+ *   top of the viewport, padding the scroll range with spacer slack so the
+ *   message can reach the top even while the response is still short. The
+ *   response streams below the fold without moving the view; the slack is
+ *   consumed (shrink-only) as content grows. Following is off after a send
+ *   until the user returns to the bottom.
+ * - 'code' (Codex transcript semantics): sends jump straight to the live
+ *   edge and follow the run's output. No top-anchoring.
+ *
+ * Programmatic scrolls are distinguished from user scrolls by updating the
+ * internal `lastTop` bookkeeping immediately after every write, so the echoed
+ * scroll event reads as a zero-delta and never flips user intent. Native CSS
+ * scroll anchoring stays enabled: its adjustments preserve the reading
+ * position when content above the viewport changes, and the delta rules below
+ * are ordered so a clamp/anchor adjustment at the bottom cannot break
+ * following.
+ *
+ * A module-level memory map (keyed by chat identity) preserves the reading
+ * position across pane remounts (view toggles, dock/full-screen switches).
+ * A conversation with no memory lands at the bottom. Because a remounted
+ * transcript rebuilds its content asynchronously, a restored position keeps
+ * re-asserting itself on resize ticks until the content is tall enough to
+ * hold it (or a user scroll / timeout cancels the restore).
+ */
+
+export type ChatScrollMode = 'chat' | 'code'
+
+/** Within this many px of the content bottom counts as "near bottom": the
+ * jump-to-latest button hides, and a downward user scroll re-engages
+ * following. */
+export const NEAR_BOTTOM_PX = 80
+/** Hard "at the live edge" tolerance (sub-pixel metrics, clamp events). */
+export const AT_BOTTOM_EPSILON_PX = 2
+/** A restored reading position keeps re-asserting itself for this long while
+ * the remounted transcript's content is still growing back underneath it. */
+const RESTORE_WINDOW_MS = 1500
+
+export interface ChatScrollSnapshot {
+  nearBottom: boolean
+  following: boolean
+}
+
+export interface ChatScrollElements {
+  /** The overflow-y:auto scroll container. */
+  container: HTMLElement
+  /** The element wrapping the transcript's content (message list). */
+  content: HTMLElement
+  /** Empty trailing sibling of `content` used for send-anchor slack. */
+  spacer: HTMLElement
+}
+
+interface ScrollMemoryEntry {
+  top: number
+  following: boolean
+}
+
+// Reading positions per chat identity, surviving pane remounts within an app
+// run. Bounded by the number of chats visited; entries are inert until a pane
+// with the same key mounts again.
+const scrollMemoryByKey = new Map<string, ScrollMemoryEntry>()
+
+/** Test hook: forget all remembered reading positions. */
+export function resetChatScrollMemory(): void {
+  scrollMemoryByKey.clear()
+}
+
+export interface ChatScrollOptions {
+  mode?: ChatScrollMode
+  /** Chat identity for cross-remount reading-position memory. */
+  memoryKey?: string
+}
+
+export class ChatScrollController {
+  private mode: ChatScrollMode
+  private memoryKey?: string
+  private els: ChatScrollElements | null = null
+  private observer: ResizeObserver | null = null
+  private listeners = new Set<(snapshot: ChatScrollSnapshot) => void>()
+
+  private following = true
+  private nearBottom = true
+  private lastTop = 0
+  private spacerHeight = 0
+
+  // Send-anchor state ('chat' mode): while set, resize ticks keep the spacer
+  // slack maintained (shrink-only) so the anchored message stays reachable at
+  // the viewport top without ever introducing new blank space.
+  private anchorId: string | null = null
+  private anchorSlackCap = 0
+  private anchorPaddingTop = 0
+
+  // In-flight smooth scroll to the live edge (jump button): growth re-targets
+  // the animation instead of fighting it with instant writes.
+  private smoothPending = false
+
+  // Restored reading position still re-asserting itself (see module docs).
+  private restore: { top: number; deadline: number } | null = null
+
+  constructor(options: ChatScrollOptions = {}) {
+    this.mode = options.mode ?? 'chat'
+    this.memoryKey = options.memoryKey
+  }
+
+  setMode(mode: ChatScrollMode): void {
+    this.mode = mode
+  }
+
+  attach(els: ChatScrollElements): void {
+    this.detach()
+    this.els = els
+
+    els.container.addEventListener('scroll', this.handleScroll, { passive: true })
+    els.container.addEventListener('wheel', this.handleWheel, { passive: true })
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this.observer = new ResizeObserver(this.handleResize)
+      this.observer.observe(els.container)
+      this.observer.observe(els.content)
+    }
+
+    const entry = this.memoryKey ? scrollMemoryByKey.get(this.memoryKey) : undefined
+    if (entry && !entry.following) {
+      this.following = false
+      this.restore = { top: entry.top, deadline: now() + RESTORE_WINDOW_MS }
+      this.write(entry.top)
+    } else {
+      this.following = true
+      this.writeBottom()
+    }
+    this.updateNearBottom()
+  }
+
+  detach(): void {
+    if (!this.els) return
+    this.saveMemory()
+    this.els.container.removeEventListener('scroll', this.handleScroll)
+    this.els.container.removeEventListener('wheel', this.handleWheel)
+    this.observer?.disconnect()
+    this.observer = null
+    this.els = null
+    this.restore = null
+    this.smoothPending = false
+  }
+
+  subscribe(listener: (snapshot: ChatScrollSnapshot) => void): () => void {
+    this.listeners.add(listener)
+    listener(this.snapshot())
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  snapshot(): ChatScrollSnapshot {
+    return { nearBottom: this.nearBottom, following: this.following }
+  }
+
+  /** Return to the live edge and follow it. */
+  jumpToLatest(behavior: 'instant' | 'smooth' = 'instant'): void {
+    const els = this.els
+    if (!els) return
+    this.restore = null
+    this.following = true
+    const top = this.maxTop()
+    if (behavior === 'smooth' && typeof els.container.scrollTo === 'function') {
+      this.smoothPending = true
+      els.container.scrollTo({ top, behavior: 'smooth' })
+      // The animation's scroll events keep lastTop/nearBottom current.
+    } else {
+      this.smoothPending = false
+      this.write(top)
+    }
+    this.updateNearBottom()
+    this.notify()
+  }
+
+  /**
+   * 'chat'-mode send: pin the message at the viewport top, padding the scroll
+   * range with spacer slack so it can get there while the response is still
+   * short. Returns false when the message element isn't in the DOM yet (the
+   * caller may retry on the next frame).
+   */
+  anchorToMessage(messageId: string): boolean {
+    const els = this.els
+    if (!els) return false
+    const anchor = els.content.querySelector<HTMLElement>(
+      `[data-message-id="${messageId}"]`
+    )
+    if (!anchor) return false
+
+    this.cancelSmooth()
+    this.restore = null
+    this.anchorId = messageId
+    this.anchorPaddingTop = readPaddingTop(els.content)
+
+    const targetTop = Math.max(0, this.anchorTopInContent(anchor) - this.anchorPaddingTop)
+    const contentHeight = els.container.scrollHeight - this.spacerHeight
+    const slack = Math.max(
+      0,
+      Math.ceil(targetTop - (contentHeight - els.container.clientHeight))
+    )
+    this.anchorSlackCap = slack
+    this.setSpacerHeight(slack)
+
+    this.write(targetTop)
+    this.following = false
+    this.updateNearBottom()
+    this.notify()
+    return true
+  }
+
+  // --- internals ---
+
+  private handleScroll = (): void => {
+    const els = this.els
+    if (!els) return
+    const top = els.container.scrollTop
+    const delta = top - this.lastTop
+    this.lastTop = top
+
+    // Echoes of our own writes (lastTop is pre-updated on every write) and
+    // sub-pixel noise carry no user intent: only genuine movement may change
+    // follow state or take over from a pending restore.
+    if (Math.abs(delta) > 1) {
+      this.restore = null
+      const distance = this.distanceFromBottom()
+      if (distance <= AT_BOTTOM_EPSILON_PX) {
+        // At the live edge — includes clamp/anchoring adjustments when
+        // content shrinks while pinned, which must not break following.
+        this.following = true
+      } else if (delta < 0) {
+        // Deliberate upward movement: stop following, never yank back down.
+        this.following = false
+        this.cancelSmooth()
+      } else if (distance <= NEAR_BOTTOM_PX) {
+        // Scrolled back down into the near-bottom band: resume following.
+        this.following = true
+      }
+    }
+    // A settling smooth animation ends in sub-pixel deltas — check outside
+    // the intent gate.
+    if (this.smoothPending && this.distanceFromBottom() <= AT_BOTTOM_EPSILON_PX) {
+      this.smoothPending = false
+    }
+
+    this.saveMemory()
+    this.updateNearBottom()
+    this.notify()
+  }
+
+  private handleWheel = (event: WheelEvent): void => {
+    const els = this.els
+    if (!els) return
+    if (event.deltaY >= 0) return
+    if (els.container.scrollHeight <= els.container.clientHeight) return
+    // Any upward wheel over the transcript is review intent — including one
+    // consumed by a nested scrollable (terminal output, code block), whose
+    // reader would otherwise be yanked along by the following transcript.
+    this.following = false
+    this.cancelSmooth()
+    this.notify()
+  }
+
+  private handleResize = (): void => {
+    if (!this.els) return
+    this.maintainAnchorSpacer()
+    if (this.restore) {
+      if (now() > this.restore.deadline) {
+        this.restore = null
+      } else {
+        const target = this.restore.top
+        this.write(target)
+        // Content is tall enough to hold the position — restore complete.
+        if (this.maxTop() >= target) this.restore = null
+      }
+    } else if (this.following) {
+      this.writeBottom()
+    }
+    this.updateNearBottom()
+    this.notify()
+  }
+
+  /** Largest scrollTop that still shows content (spacer slack excluded), so
+   * "the bottom" always means the content's live edge, not blank space. */
+  private maxTop(): number {
+    const els = this.els
+    if (!els) return 0
+    return Math.max(
+      0,
+      els.container.scrollHeight - this.spacerHeight - els.container.clientHeight
+    )
+  }
+
+  private distanceFromBottom(): number {
+    const els = this.els
+    if (!els) return 0
+    return Math.max(0, this.maxTop() - els.container.scrollTop)
+  }
+
+  private write(top: number): void {
+    const els = this.els
+    if (!els) return
+    els.container.scrollTop = top
+    // Read back (the browser clamps) so the echoed scroll event computes a
+    // zero delta and is never mistaken for user intent.
+    this.lastTop = els.container.scrollTop
+  }
+
+  private writeBottom(): void {
+    if (this.smoothPending) {
+      // Re-target the in-flight animation instead of snapping.
+      this.els?.container.scrollTo({ top: this.maxTop(), behavior: 'smooth' })
+      return
+    }
+    this.write(this.maxTop())
+  }
+
+  private cancelSmooth(): void {
+    const els = this.els
+    if (!this.smoothPending || !els) return
+    this.smoothPending = false
+    // Re-assigning the current position interrupts an in-flight native
+    // smooth scroll.
+    const top = els.container.scrollTop
+    els.container.scrollTop = top
+    this.lastTop = top
+  }
+
+  private maintainAnchorSpacer(): void {
+    const els = this.els
+    if (!els || this.mode !== 'chat' || !this.anchorId) return
+    const anchor = els.content.querySelector<HTMLElement>(
+      `[data-message-id="${this.anchorId}"]`
+    )
+    if (!anchor) {
+      // The anchored message left the DOM (conversation replaced) — drop the
+      // slack rather than preserving blank space for nothing.
+      this.anchorId = null
+      this.setSpacerHeight(0)
+      return
+    }
+    const targetTop = Math.max(0, this.anchorTopInContent(anchor) - this.anchorPaddingTop)
+    const contentHeight = els.container.scrollHeight - this.spacerHeight
+    const required = Math.max(
+      0,
+      Math.ceil(targetTop - (contentHeight - els.container.clientHeight))
+    )
+    // Shrink-only: slack is consumed as the response grows and never comes
+    // back, so layout shifts above the anchor can't inject new blank space.
+    const slack = Math.min(required, this.anchorSlackCap)
+    this.anchorSlackCap = slack
+    if (slack !== this.spacerHeight) this.setSpacerHeight(slack)
+    if (slack === 0) this.anchorId = null
+  }
+
+  private setSpacerHeight(height: number): void {
+    const els = this.els
+    if (!els) return
+    this.spacerHeight = height
+    els.spacer.style.height = `${height}px`
+  }
+
+  private anchorTopInContent(anchor: HTMLElement): number {
+    const els = this.els
+    if (!els) return 0
+    const containerTop = els.container.getBoundingClientRect().top
+    return anchor.getBoundingClientRect().top - containerTop + els.container.scrollTop
+  }
+
+  private updateNearBottom(): void {
+    this.nearBottom = this.distanceFromBottom() <= NEAR_BOTTOM_PX
+  }
+
+  private saveMemory(): void {
+    if (!this.memoryKey) return
+    scrollMemoryByKey.set(this.memoryKey, {
+      top: this.lastTop,
+      following: this.following,
+    })
+  }
+
+  private notify(): void {
+    const snapshot = this.snapshot()
+    for (const listener of this.listeners) listener(snapshot)
+  }
+}
+
+function readPaddingTop(el: HTMLElement): number {
+  const value = Number.parseFloat(window.getComputedStyle(el).paddingTop || '0')
+  return Number.isFinite(value) ? value : 0
+}
+
+function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}

--- a/apps/x/apps/renderer/src/lib/session-chat/store.test.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/store.test.ts
@@ -101,7 +101,9 @@ class FakeClient implements SessionsClient {
   }
 }
 
-function makeStore() {
+function makeStore(
+  options: { scheduleEmit?: (flush: () => void) => () => void } = {}
+) {
   const client = new FakeClient()
   let emit: (event: TurnBusEvent) => void = () => undefined
   let subscribed = 0
@@ -128,6 +130,14 @@ function makeStore() {
         if (i >= 0) deltaSubs.splice(i, 1)
       }
     },
+    // Synchronous by default so assertions can read the snapshot right
+    // after emitting; the coalescing tests inject a manual scheduler.
+    scheduleEmit:
+      options.scheduleEmit ??
+      ((flush) => {
+        flush()
+        return () => {}
+      }),
   })
   const disconnect = store.connect()
   return {
@@ -160,6 +170,104 @@ function turnEvent(
   offsetByTurn.set(turnId, offset)
   return { turnId, sessionId, event, offset }
 }
+
+describe('SessionChatStore — emit coalescing', () => {
+  function manualScheduler() {
+    let pendingFlush: (() => void) | null = null
+    return {
+      scheduleEmit: (flush: () => void) => {
+        pendingFlush = flush
+        return () => {
+          pendingFlush = null
+        }
+      },
+      drain: () => {
+        const flush = pendingFlush
+        pendingFlush = null
+        flush?.()
+      },
+      hasPending: () => pendingFlush !== null,
+    }
+  }
+
+  it('merges an end-of-turn burst into one snapshot emission, nothing dropped', async () => {
+    const scheduler = manualScheduler()
+    const { client, store, emit } = makeStore(scheduler)
+    client.sessions.set(S1, sessionState(S1, []))
+    await store.setSession(S1)
+    scheduler.drain()
+
+    let notifications = 0
+    const unsubscribe = store.subscribe(() => {
+      notifications += 1
+    })
+
+    emit(turnEvent(S1, 'turn-1', created('turn-1', S1, user('go'))))
+    emit(turnEvent(S1, 'turn-1', requested('turn-1', 0)))
+    emit(turnEvent(S1, 'turn-1', completed('turn-1', 0, assistantText('done'))))
+    emit(turnEvent(S1, 'turn-1', turnCompleted('turn-1')))
+    expect(notifications).toBe(0)
+
+    scheduler.drain()
+    expect(notifications).toBe(1)
+    const snapshot = store.getSnapshot()
+    expect(snapshot.latestTurnId).toBe('turn-1')
+    expect(snapshot.chatState?.isProcessing).toBe(false)
+    expect(snapshot.chatState?.currentAssistantMessage).toBe('')
+    expect(
+      snapshot.chatState?.conversation.filter(isChatMessage).map((m) => m.content),
+    ).toEqual(['go', 'done'])
+    unsubscribe()
+  })
+
+  it('flushes a pending emission on disconnect so nothing is lost', async () => {
+    const scheduler = manualScheduler()
+    const { client, store, emit, disconnect } = makeStore(scheduler)
+    client.sessions.set(S1, sessionState(S1, []))
+    await store.setSession(S1)
+    scheduler.drain()
+
+    let notifications = 0
+    store.subscribe(() => {
+      notifications += 1
+    })
+    emit(turnEvent(S1, 'turn-1', created('turn-1', S1, user('go'))))
+    expect(notifications).toBe(0)
+    expect(scheduler.hasPending()).toBe(true)
+
+    disconnect()
+    expect(notifications).toBe(1)
+    expect(scheduler.hasPending()).toBe(false)
+    expect(
+      store.getSnapshot().chatState?.conversation.filter(isChatMessage).map((m) => m.content),
+    ).toEqual(['go'])
+  })
+
+  it('the default scheduler delivers without an injected one', async () => {
+    const client = new FakeClient()
+    offsetByTurn.clear()
+    let emit: (event: TurnBusEvent) => void = () => undefined
+    const store = new SessionChatStore({
+      client,
+      subscribeTurnFeed: (listener) => {
+        emit = listener
+        return () => {}
+      },
+      subscribeSessionFeed: () => () => undefined,
+      subscribeDeltas: () => () => undefined,
+    })
+    const disconnect = store.connect()
+    client.sessions.set(S1, sessionState(S1, []))
+    await store.setSession(S1)
+    emit(turnEvent(S1, 'turn-1', created('turn-1', S1, user('go'))))
+    // rAF (or its 50ms timeout backstop) flushes shortly.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(
+      store.getSnapshot().chatState?.conversation.filter(isChatMessage).map((m) => m.content),
+    ).toEqual(['go'])
+    disconnect()
+  })
+})
 
 describe('SessionChatStore', () => {
   it('seeds a session: prior turns frozen, latest live, conversation composed', async () => {

--- a/apps/x/apps/renderer/src/lib/session-chat/store.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/store.ts
@@ -47,6 +47,40 @@ export interface SessionChatStoreDeps {
   // Declares "this window is watching turn X" so main forwards its deltas;
   // returns the unsubscribe.
   subscribeDeltas: (turnId: string) => () => void
+  // Schedules a coalesced snapshot flush; returns a cancel. Defaults to a
+  // requestAnimationFrame + timeout race (see defaultScheduleEmit). Tests
+  // inject a synchronous scheduler to keep assertions immediate.
+  scheduleEmit?: (flush: () => void) => () => void
+}
+
+// One flush per animation frame: an end-of-turn burst (model_call_completed
+// + turn_completed, plus tool_result in code mode) becomes ONE React commit,
+// so the transcript's net height change lands in a single layout and the
+// scroll controller adjusts once, pre-paint — instead of a visible
+// up-then-down wobble across back-to-back commits. The timeout backstop
+// keeps streaming state flowing when rAF is throttled (occluded window) or
+// unavailable (non-DOM environments).
+function defaultScheduleEmit(flush: () => void): () => void {
+  let settled = false
+  const run = () => {
+    if (settled) return
+    settled = true
+    cancel()
+    flush()
+  }
+  const rafId =
+    typeof requestAnimationFrame === 'function' ? requestAnimationFrame(run) : null
+  const timeoutId = setTimeout(run, 50)
+  function cancel() {
+    if (rafId !== null && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(rafId)
+    }
+    clearTimeout(timeoutId)
+  }
+  return () => {
+    settled = true
+    cancel()
+  }
 }
 
 // Framework-agnostic controller for one active session's chat. Owns all the
@@ -61,6 +95,12 @@ export class SessionChatStore {
   private feedDisconnect: (() => void) | null = null
   private sessionFeedDisconnect: (() => void) | null = null
   private readonly listeners = new Set<() => void>()
+  private readonly scheduleEmit: (flush: () => void) => () => void
+  // Cancel for the scheduled flush; non-null means an emit is pending and
+  // further emit() calls coalesce into it. State mutations always happen
+  // synchronously before emit(), so deferring the derive drops nothing and
+  // cannot reorder — the flush derives from the latest state.
+  private cancelScheduledEmit: (() => void) | null = null
 
   private sessionId: string | null = null
   // Settled earlier turns, reduced once and frozen.
@@ -91,6 +131,7 @@ export class SessionChatStore {
     this.subscribeTurnFeed = deps.subscribeTurnFeed
     this.subscribeSessionFeed = deps.subscribeSessionFeed
     this.subscribeDeltas = deps.subscribeDeltas
+    this.scheduleEmit = deps.scheduleEmit ?? defaultScheduleEmit
   }
 
   // Feed attachment is effect-managed and idempotent so React StrictMode's
@@ -108,6 +149,13 @@ export class SessionChatStore {
       this.sessionFeedDisconnect?.()
       this.sessionFeedDisconnect = null
       this.syncDeltas()
+      // A pending coalesced flush must not be lost across teardown (e.g.
+      // StrictMode's mount → cleanup → mount): deliver it now.
+      if (this.cancelScheduledEmit) {
+        this.cancelScheduledEmit()
+        this.cancelScheduledEmit = null
+        this.flushEmit()
+      }
     }
   }
 
@@ -310,6 +358,19 @@ export class SessionChatStore {
   // ── Derivation ──────────────────────────────────────────────────────────
 
   private emit(): void {
+    if (this.cancelScheduledEmit) return
+    // A synchronous scheduler (tests) runs the flush before returning its
+    // cancel — only keep the cancel when the flush is genuinely pending.
+    let flushed = false
+    const cancel = this.scheduleEmit(() => {
+      flushed = true
+      this.cancelScheduledEmit = null
+      this.flushEmit()
+    })
+    if (!flushed) this.cancelScheduledEmit = cancel
+  }
+
+  private flushEmit(): void {
     this.snapshot = this.derive()
     for (const listener of [...this.listeners]) {
       listener()

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.test.ts
@@ -3,9 +3,11 @@ import { reduceTurn } from '@x/shared/src/turns.js'
 import { isChatMessage, isErrorMessage, isReasoningMessage, isToolCall, isTurnUsageMessage } from '@/lib/chat-conversation'
 import {
   applyOverlay,
+  assistantMessageId,
   buildSessionChatState,
   buildTurnConversation,
   emptyOverlay,
+  reasoningMessageId,
 } from './turn-view'
 import {
   TS,
@@ -735,6 +737,115 @@ describe('buildSessionChatState', () => {
     const state = buildSessionChatState([turn], { ...emptyOverlay(), text: 'typing…' })
     expect(state.currentAssistantMessage).toBe('typing…')
     expect(state.isReasoning).toBe(false)
+  })
+
+  it('renders the live text as a synthetic trailing item under the durable id', () => {
+    const turn = reduceTurn([created(T1, S1), requested(T1, 0)])
+    const state = buildSessionChatState([turn], { ...emptyOverlay(), text: 'typing…' })
+    const last = state.conversation[state.conversation.length - 1]
+    expect(last).toMatchObject({
+      id: assistantMessageId(T1, 0),
+      role: 'assistant',
+      content: 'typing…',
+      streaming: true,
+    })
+
+    // Completion must yield a durable item under the SAME id — any drift
+    // between the two derivations reintroduces the unmount/remount flash.
+    const done = reduceTurn([
+      created(T1, S1),
+      requested(T1, 0),
+      completed(T1, 0, assistantText('typed all of it')),
+    ])
+    const settled = buildSessionChatState([done], emptyOverlay())
+    const durable = settled.conversation
+      .filter(isChatMessage)
+      .find((m) => m.role === 'assistant')
+    expect(durable?.id).toBe(assistantMessageId(T1, 0))
+    expect(durable?.streaming).toBeUndefined()
+    expect(
+      settled.conversation.filter(
+        (item) => 'id' in item && item.id === assistantMessageId(T1, 0),
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('renders live reasoning as a synthetic item under the durable id, shimmering', () => {
+    const turn = reduceTurn([
+      created(T1, S1),
+      requested(T1, 0),
+      modelStep(T1, 0, { type: 'reasoning_start' }),
+    ])
+    const state = buildSessionChatState([turn], { ...emptyOverlay(), reasoning: 'hmm…' })
+    const last = state.conversation[state.conversation.length - 1]
+    expect(last).toMatchObject({
+      id: reasoningMessageId(T1, 0),
+      kind: 'reasoning',
+      content: 'hmm…',
+      streaming: true,
+    })
+  })
+
+  it('live reasoning stops shimmering and precedes the answer once text streams', () => {
+    const turn = reduceTurn([
+      created(T1, S1),
+      requested(T1, 0),
+      modelStep(T1, 0, { type: 'reasoning_start' }),
+      modelStep(T1, 0, { type: 'reasoning_end', text: 'done reasoning' }),
+    ])
+    const state = buildSessionChatState([turn], {
+      ...emptyOverlay(),
+      reasoning: 'done reasoning',
+      text: 'answer…',
+    })
+    const ids = state.conversation.map((item) => item.id)
+    expect(ids.indexOf(reasoningMessageId(T1, 0))).toBeLessThan(
+      ids.indexOf(assistantMessageId(T1, 0)),
+    )
+    const reasoningItem = state.conversation.find(isReasoningMessage)
+    expect(reasoningItem?.streaming).toBe(false)
+  })
+
+  it('a later model call streams under its own index; earlier segments stay durable', () => {
+    const turn = reduceTurn([
+      created(T1, S1),
+      requested(T1, 0),
+      completed(T1, 0, assistantText('first segment')),
+      requested(T1, 1, ['assistant:0']),
+    ])
+    const state = buildSessionChatState([turn], { ...emptyOverlay(), text: 'second…' })
+    const last = state.conversation[state.conversation.length - 1]
+    expect(last).toMatchObject({ id: assistantMessageId(T1, 1), streaming: true })
+    const first = state.conversation
+      .filter(isChatMessage)
+      .find((m) => m.id === assistantMessageId(T1, 0))
+    expect(first?.content).toBe('first segment')
+    expect(first?.streaming).toBeUndefined()
+  })
+
+  it('emits no synthetic items once the turn settles, and none without live text', () => {
+    const settled = buildSessionChatState(
+      [
+        reduceTurn([
+          created(T1, S1),
+          requested(T1, 0),
+          completed(T1, 0, assistantText('done')),
+          turnCompleted(T1, 'done'),
+        ]),
+      ],
+      emptyOverlay(),
+    )
+    expect(
+      settled.conversation.some((item) => (item as { streaming?: boolean }).streaming),
+    ).toBe(false)
+
+    const quiet = buildSessionChatState(
+      [reduceTurn([created(T1, S1), requested(T1, 0)])],
+      emptyOverlay(),
+    )
+    expect(
+      quiet.conversation.some((item) => (item as { streaming?: boolean }).streaming),
+    ).toBe(false)
   })
 
   it('surfaces streaming reasoning as currentReasoning', () => {

--- a/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
+++ b/apps/x/apps/renderer/src/lib/session-chat/turn-view.ts
@@ -179,6 +179,18 @@ export function applyOverlay(overlay: LiveOverlay, event: TurnStreamEvent): Live
 // Conversation items
 // ---------------------------------------------------------------------------
 
+// THE single source of a model call's item ids. The live overlay renders
+// synthetic items under these same ids while the call streams, so the
+// durable items produced at completion reconcile onto the same mounted
+// nodes (no unmount/remount flash) — any drift between the two would
+// silently reintroduce the flash, which is why both sides call these.
+export function assistantMessageId(turnId: string, callIndex: number): string {
+  return `${turnId}:a${callIndex}`
+}
+export function reasoningMessageId(turnId: string, callIndex: number): string {
+  return `${turnId}:r${callIndex}`
+}
+
 type UserContent = TurnState['definition']['input']['content']
 
 function extractText(content: UserContent): string {
@@ -324,7 +336,7 @@ export function buildTurnConversation(state: TurnState): ConversationItem[] {
       : ''
     if (reasoning) {
       items.push({
-        id: `${turnId}:r${call.index}`,
+        id: reasoningMessageId(turnId, call.index),
         kind: 'reasoning',
         content: reasoning,
         timestamp: ts(),
@@ -342,7 +354,7 @@ export function buildTurnConversation(state: TurnState): ConversationItem[] {
     )
     if (text) {
       items.push({
-        id: `${turnId}:a${call.index}`,
+        id: assistantMessageId(turnId, call.index),
         role: 'assistant',
         content: text,
         timestamp: ts(),
@@ -553,6 +565,46 @@ export function buildSessionChatState(
 
   const settled = status === 'completed' || status === 'failed' || status === 'cancelled'
   const waitingOnHuman = allPermissionRequests.size > 0 || pendingAskHumanRequests.size > 0
+
+  // The live model call's thought/text stream, rendered as ordinary trailing
+  // conversation items under the SAME ids their durable versions will get
+  // (assistantMessageId / reasoningMessageId): when the call completes, the
+  // durable items land at the same position with the same keys and React
+  // updates the mounted nodes in place — instead of unmounting the streaming
+  // bubble and remounting a fresh subtree, which replayed Streamdown's
+  // async syntax highlighting and mermaid/chart rendering as a visible
+  // end-of-generation flash. An open call contributes nothing durable (its
+  // buildTurnConversation branch skips until the response lands), so these
+  // never duplicate. When no open call exists (e.g. a failed turn with
+  // unflushed overlay text), no synthetic is emitted — the pane's fallback
+  // slot covers that via currentAssistantMessage, exactly as before.
+  const openCall = latest?.modelCalls[latest.modelCalls.length - 1]
+  const openCallLive =
+    !settled &&
+    openCall !== undefined &&
+    openCall.response === undefined &&
+    openCall.error === undefined
+  if (latest && openCallLive) {
+    if (overlay.reasoning) {
+      conversation.push({
+        id: reasoningMessageId(latestTurnId, openCall.index),
+        kind: 'reasoning',
+        content: overlay.reasoning,
+        streaming: isModelReasoning(latest),
+        timestamp: Date.now(),
+      } satisfies ReasoningMessage)
+    }
+    const liveText = stripVoiceTags(overlay.text)
+    if (liveText) {
+      conversation.push({
+        id: assistantMessageId(latestTurnId, openCall.index),
+        role: 'assistant',
+        content: liveText,
+        streaming: true,
+        timestamp: Date.now(),
+      } satisfies ChatMessage)
+    }
+  }
   const lastModel = latest?.definition.agent.resolved.model
   const lastEffort = latest?.definition.config.reasoningEffort
   return {


### PR DESCRIPTION
## Problem

Chats inconsistently failed to stay at the bottom. Root cause: the send-anchor (`anchorMessageId`) set on every submit **permanently disabled** stick-to-bottom for the pane, leaked across run rebinds, and re-applied stale anchors on remounts. On top of that, App.tsx carried a parallel scroll save/restore layer (DOM queries for the scroller, rAF polling, triple-rAF + 220ms timeout reinforcement) that fought the sticker and could restore one run's position onto another. Code-mode chats had no live-edge behavior at all.

## Approach

All scroll behavior now lives in one framework-free, unit-tested controller — `ChatScrollController` (`apps/renderer/src/lib/chat-scroll.ts`) — owned by the shared `Conversation` component (sole scroll container for both the full-screen chat and the docked/code-session chat). App.tsx no longer contains any scroll code.

Two explicit concepts:

- **following** — riding the live edge. ResizeObserver on container + content keeps the view pinned through streamed tokens, tool cards, images, collapsibles, composer growth, and window resizes (adjusted pre-paint, no jitter). Broken **only** by genuine upward user movement (wheel, scrollbar, keyboard, touch) — programmatic writes pre-update the delta bookkeeping so their echo scroll events carry no intent, and clamp/native-anchoring adjustments at the bottom can't break it. Re-engaged by scrolling back into the 80px near-bottom band, hitting exact bottom, or the jump-to-latest button (smooth scroll that re-targets during growth and cancels on wheel-up).
- **nearBottom** — drives the jump-to-latest button (hidden while following or near the content bottom).

### Regular chat (`scrollMode='chat'`, ChatGPT semantics)
- A send pins the new user message at the viewport top using shrink-only spacer slack; the response streams below the fold without moving the view; slack is consumed as content grows and never comes back.
- “Bottom” always means **content** bottom (slack excluded), so the jump button never appears for—or targets—blank space; it shows only once the response extends past the fold.

### Code mode (`scrollMode='code'`, Codex semantics, derived from `codeSessionLocks`)
- Sends jump straight to the live edge and follow the run's output; readers reviewing earlier tool output are never yanked; returning to the live edge is deterministic (scroll to bottom, or send).

### Thread switches & remounts
- Reading positions persist across pane remounts (view toggles, dock ↔ full-screen, A→B→A rebinds) in a module map keyed by chat identity; unknown conversations land at the bottom **pre-paint** (no visible jump). Restores re-assert while the transcript rebuilds asynchronously (1.5s window) and yield instantly to user scrolls.
- Mount-time anchor requests are deliberately ignored — remounts restore, they don't re-anchor stale sends.

## Tests

29 new tests:
- `lib/chat-scroll.test.ts` (22) — controller behavior against a browser-faithful harness (clamping `scrollTop`, spacer-aware `scrollHeight`): streaming growth, scroll-away/re-engage (incl. the band-edge and clamp cases), wheel intent, smooth-jump retarget/cancel, send-anchor slack lifecycle, memory restore/takeover, subscription/cleanup, sub-pixel tolerance.
- `components/ai-elements/conversation.test.tsx` (7) — component wiring: landing at bottom, button visibility/click, chat-mode anchoring, code-mode jump, mount-time anchor ignored, memory-key restore.

## Validation

- Full renderer suite after rebasing onto `main`: **43 files / 425 tests pass**
- `tsc -b` typecheck: clean
- ESLint: all touched files clean; pre-existing findings in `chat-session.tsx`/`App.tsx` verified identical at the merge base (not introduced here, left untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)