### PR TITLE
feat(migrations): re-encrypt stored tokens from OS keychain to file c…

### DIFF
--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -33,6 +33,8 @@ import { shutdown as shutdownAppsServer } from "@x/core/dist/apps/server.js";
 import { registerAppsHostApi } from "@x/core/dist/apps/host-api.js";
 import { setTokenCipher as setGithubTokenCipher } from "@x/core/dist/apps/github-auth.js";
 import { setTokenCipher as setChatGPTTokenCipher } from "@x/core/dist/auth/chatgpt-auth.js";
+import { migrateKeychainTokens } from "@x/core/dist/migrations/keychain-token-migration.js";
+import { createFileCipher } from "@x/server";
 import { shutdown as shutdownAnalytics } from "@x/core/dist/analytics/posthog.js";
 import { identifyIfSignedIn } from "@x/core/dist/analytics/identify.js";
 import { syncModelProviderPersonProperties } from "@x/core/dist/analytics/model-providers.js";
@@ -643,6 +645,34 @@ app.whenReady().then(async () => {
     encrypt: (plain) => safeStorage.encryptString(plain).toString('base64'),
     decrypt: (encrypted) => safeStorage.decryptString(Buffer.from(encrypted, 'base64')),
   });
+
+  // One-time migration: re-encrypt any tokens that were stored by the pre-
+  // separation app using safeStorage (OS keychain) into the file-cipher format
+  // that the child/standalone rowboat-server expects (#940).
+  //
+  // Only runs in child-server mode: in-process mode keeps using safeStorage
+  // as the active cipher, so there is nothing to migrate.  The migration reads
+  // the old ciphertext through the safeStorage cipher above (which is still
+  // wired at this point), re-encrypts it with the file cipher the child server
+  // will use, and writes the result back to the same JSON files.  It is fully
+  // idempotent and safe to call on every launch.
+  if (childServerMode()) {
+    try {
+      const newCipher = await createFileCipher(WorkDir);
+      await migrateKeychainTokens(WorkDir, {
+        oldCipher: {
+          isAvailable: () => safeStorage.isEncryptionAvailable(),
+          encrypt: (plain) => safeStorage.encryptString(plain).toString('base64'),
+          decrypt: (encrypted) => safeStorage.decryptString(Buffer.from(encrypted, 'base64')),
+        },
+        newCipher,
+      });
+    } catch (err: unknown) {
+      // Migration is best-effort: a failure here means affected users will
+      // be asked to re-authenticate once. It must never block boot.
+      console.error('[token-migration] failed:', err);
+    }
+  }
 
   // Resident app (Granola-style): register as an OS login item once, on the
   // first packaged run — and on Windows, migrate pre-existing registrations

--- a/apps/x/apps/server/src/index.ts
+++ b/apps/x/apps/server/src/index.ts
@@ -6,3 +6,4 @@ export { loadOrCreateServerKey, rotateServerKey, tokenMatches, extractBearer, SE
 export { loadServerConfig, saveServerConfig, ServerConfig, DEFAULT_PORT } from './config.js';
 export { buildPairingPayload, collectPairingUrls, type PairingPayload } from './pairing.js';
 export { createCoreRpcHandlers, createCoreEventSources, resolveWorkspacePath } from './core-deps.js';
+export { createFileCipher } from './file-cipher.js';

--- a/apps/x/packages/core/src/migrations/keychain-token-migration.test.ts
+++ b/apps/x/packages/core/src/migrations/keychain-token-migration.test.ts
@@ -1,0 +1,320 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { migrateKeychainTokens, type MigrationCiphers } from './keychain-token-migration.js';
+
+// Isolated workdir so tests never touch the real ~/.rowboat.
+const tmpWorkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rowboat-token-migration-test-'));
+
+afterAll(() => {
+  fs.rmSync(tmpWorkDir, { recursive: true, force: true });
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const configDir = path.join(tmpWorkDir, 'config');
+const stateFile = path.join(configDir, 'token-migration.json');
+const chatgptFile = path.join(configDir, 'chatgpt-auth.json');
+const githubFile = path.join(configDir, 'github-auth.json');
+
+function ensureConfigDir(): void {
+  fs.mkdirSync(configDir, { recursive: true });
+}
+
+function writeFile(p: string, obj: unknown): void {
+  ensureConfigDir();
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2) + '\n', { mode: 0o600 });
+}
+
+function readJson(p: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(p, 'utf-8')) as Record<string, unknown>;
+}
+
+/** Old cipher simulates safeStorage: produces base64 without "v1:" prefix. */
+function makeOldCipher(available = true) {
+  return {
+    isAvailable: () => available,
+    // safeStorage output is an opaque base64 blob – no prefix.
+    encrypt: (plain: string) => Buffer.from(`old:${plain}`).toString('base64'),
+    decrypt: (ct: string) => {
+      const raw = Buffer.from(ct, 'base64').toString('utf-8');
+      if (!raw.startsWith('old:')) throw new Error('bad old ciphertext');
+      return raw.slice(4);
+    },
+  };
+}
+
+/** New cipher produces ciphertext starting with "v1:" (matches production). */
+function makeNewCipher(available = true) {
+  return {
+    isAvailable: () => available,
+    encrypt: (plain: string) => `v1:${Buffer.from(plain).toString('base64')}:tag:data`,
+    decrypt: (ct: string) => {
+      const [version, b64] = ct.split(':');
+      if (version !== 'v1' || !b64) throw new Error('unrecognized format');
+      return Buffer.from(b64, 'base64').toString('utf-8');
+    },
+  };
+}
+
+function makeCiphers(
+  oldAvailable = true,
+  newAvailable = true,
+): MigrationCiphers {
+  return {
+    oldCipher: makeOldCipher(oldAvailable),
+    newCipher: makeNewCipher(newAvailable),
+  };
+}
+
+beforeEach(() => {
+  // Clean slate for each test.
+  for (const f of [stateFile, chatgptFile, githubFile]) {
+    try { fs.rmSync(f, { force: true }); } catch { /* ignore */ }
+  }
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('migrateKeychainTokens', () => {
+  it('migrates old-format tokensEncrypted to v1 format', async () => {
+    const oldCipher = makeOldCipher();
+    const newCipher = makeNewCipher();
+    const plainMaterial = JSON.stringify({ accessToken: 'at_abc', refreshToken: 'rt_xyz' });
+    const oldEncrypted = oldCipher.encrypt(plainMaterial);
+
+    writeFile(chatgptFile, {
+      accountId: 'acct_1',
+      email: 'user@example.com',
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: oldEncrypted,
+    });
+
+    const result = await migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher });
+
+    expect(result.done).toBe(true);
+    expect(result.migrated).toContain('chatgpt-auth.json');
+    expect(result.skipped).toHaveLength(0);
+
+    const stored = readJson(chatgptFile);
+    // Must use the new cipher format.
+    expect(typeof stored.tokensEncrypted).toBe('string');
+    expect((stored.tokensEncrypted as string).startsWith('v1:')).toBe(true);
+
+    // The new cipher must decrypt back to the original plaintext.
+    const decrypted = newCipher.decrypt(stored.tokensEncrypted as string);
+    const material = JSON.parse(decrypted) as Record<string, string>;
+    expect(material.accessToken).toBe('at_abc');
+    expect(material.refreshToken).toBe('rt_xyz');
+
+    // Non-secret metadata is preserved.
+    expect(stored.accountId).toBe('acct_1');
+    expect(stored.email).toBe('user@example.com');
+
+    // State file written.
+    expect(fs.existsSync(stateFile)).toBe(true);
+  });
+
+  it('migrates the tokenEncrypted field used by github-auth', async () => {
+    const oldCipher = makeOldCipher();
+    const newCipher = makeNewCipher();
+    const oldToken = oldCipher.encrypt('ghp_secret_token_123');
+
+    writeFile(githubFile, {
+      login: 'dev-user',
+      createdAt: '2025-06-01T00:00:00.000Z',
+      tokenEncrypted: oldToken,
+    });
+
+    const result = await migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher });
+
+    expect(result.done).toBe(true);
+    expect(result.migrated).toContain('github-auth.json');
+
+    const stored = readJson(githubFile);
+    expect((stored.tokenEncrypted as string).startsWith('v1:')).toBe(true);
+    expect(newCipher.decrypt(stored.tokenEncrypted as string)).toBe('ghp_secret_token_123');
+    expect(stored.login).toBe('dev-user');
+  });
+
+  it('skips when no old credentials exist (fresh install)', async () => {
+    const result = await migrateKeychainTokens(tmpWorkDir, makeCiphers());
+
+    expect(result.done).toBe(true);
+    expect(result.migrated).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+    // State file written so subsequent launches skip immediately.
+    expect(fs.existsSync(stateFile)).toBe(true);
+  });
+
+  it('skips a file that already has a v1 ciphertext (already migrated)', async () => {
+    const newCipher = makeNewCipher();
+    const alreadyMigrated = newCipher.encrypt(JSON.stringify({ accessToken: 'at', refreshToken: 'rt' }));
+
+    writeFile(chatgptFile, {
+      accountId: 'acct_1',
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: alreadyMigrated,
+    });
+
+    const result = await migrateKeychainTokens(tmpWorkDir, makeCiphers());
+
+    expect(result.done).toBe(true);
+    expect(result.migrated).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+
+    // File unchanged.
+    const stored = readJson(chatgptFile);
+    expect(stored.tokensEncrypted).toBe(alreadyMigrated);
+  });
+
+  it('is idempotent: running twice does not corrupt or duplicate state', async () => {
+    const oldCipher = makeOldCipher();
+    const newCipher = makeNewCipher();
+    const oldEncrypted = oldCipher.encrypt(JSON.stringify({ accessToken: 'at', refreshToken: 'rt' }));
+    writeFile(chatgptFile, {
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: oldEncrypted,
+    });
+
+    const first = await migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher });
+    const storedAfterFirst = readJson(chatgptFile).tokensEncrypted as string;
+
+    const second = await migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher });
+
+    // Second run is a no-op: returns done=true immediately.
+    expect(second.done).toBe(true);
+    expect(second.migrated).toHaveLength(0);
+
+    // File not touched again.
+    expect(readJson(chatgptFile).tokensEncrypted).toBe(storedAfterFirst);
+
+    // State file still valid.
+    const state = readJson(stateFile);
+    expect(typeof state.migratedAt).toBe('string');
+
+    void first; // used above
+  });
+
+  it('handles graceful failure: old credential cannot be decrypted → file unchanged', async () => {
+    const badOld = {
+      isAvailable: () => true,
+      encrypt: (p: string) => p,
+      decrypt: () => { throw new Error('keychain unavailable'); },
+    };
+    const oldEncrypted = Buffer.from('old:some_blob').toString('base64');
+
+    writeFile(chatgptFile, {
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: oldEncrypted,
+    });
+
+    const result = await migrateKeychainTokens(tmpWorkDir, { oldCipher: badOld, newCipher: makeNewCipher() });
+
+    expect(result.done).toBe(true);
+    expect(result.migrated).toHaveLength(0);
+    expect(result.skipped).toContain('chatgpt-auth.json');
+
+    // Original file untouched.
+    expect(readJson(chatgptFile).tokensEncrypted).toBe(oldEncrypted);
+  });
+
+  it('old credential intact when server-side persistence fails after decryption', async () => {
+    // Simulate a new cipher whose encrypt throws (e.g. cipher-key write failure).
+    const oldCipher = makeOldCipher();
+    const brokenNewCipher = {
+      isAvailable: () => true,
+      encrypt: (): string => { throw new Error('disk full'); },
+      decrypt: (): string => { throw new Error('never called'); },
+    };
+    const oldEncrypted = oldCipher.encrypt('token_value');
+    writeFile(chatgptFile, {
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: oldEncrypted,
+    });
+
+    // Should not throw; the error should bubble as a rejection.
+    await expect(
+      migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher: brokenNewCipher }),
+    ).rejects.toThrow('disk full');
+
+    // The original file must still be there and unchanged.
+    expect(readJson(chatgptFile).tokensEncrypted).toBe(oldEncrypted);
+    // State file must NOT have been written.
+    expect(fs.existsSync(stateFile)).toBe(false);
+  });
+
+  it('skips all work when the old cipher is unavailable', async () => {
+    const oldEncrypted = makeOldCipher().encrypt('secret');
+    writeFile(chatgptFile, { expiresAt: 9999999999, createdAt: '2025-01-01T00:00:00.000Z', tokensEncrypted: oldEncrypted });
+
+    const result = await migrateKeychainTokens(tmpWorkDir, makeCiphers(false, true));
+
+    expect(result.done).toBe(false);
+    expect(result.migrated).toHaveLength(0);
+    // File unchanged.
+    expect(readJson(chatgptFile).tokensEncrypted).toBe(oldEncrypted);
+    // No state file — will retry next launch when the cipher becomes available.
+    expect(fs.existsSync(stateFile)).toBe(false);
+  });
+
+  it('skips all work when the new cipher is unavailable', async () => {
+    const result = await migrateKeychainTokens(tmpWorkDir, makeCiphers(true, false));
+    expect(result.done).toBe(false);
+  });
+
+  it('does not log or persist the plaintext token value', async () => {
+    const consoleSpy = vi.spyOn(console, 'log');
+    const oldCipher = makeOldCipher();
+    const newCipher = makeNewCipher();
+    const secretToken = 'PLAINTEXT_SECRET_DO_NOT_LOG';
+    writeFile(chatgptFile, {
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: oldCipher.encrypt(secretToken),
+    });
+
+    await migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher });
+
+    // No console.log call should contain the plaintext secret.
+    for (const call of consoleSpy.mock.calls) {
+      for (const arg of call) {
+        expect(String(arg)).not.toContain(secretToken);
+      }
+    }
+
+    // The written file should not contain the plaintext secret.
+    const fileContents = fs.readFileSync(chatgptFile, 'utf-8');
+    expect(fileContents).not.toContain(secretToken);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('migrates both files in one run', async () => {
+    const oldCipher = makeOldCipher();
+    const newCipher = makeNewCipher();
+
+    writeFile(chatgptFile, {
+      expiresAt: 9999999999,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokensEncrypted: oldCipher.encrypt(JSON.stringify({ accessToken: 'at', refreshToken: 'rt' })),
+    });
+    writeFile(githubFile, {
+      login: 'user',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      tokenEncrypted: oldCipher.encrypt('ghp_abc'),
+    });
+
+    const result = await migrateKeychainTokens(tmpWorkDir, { oldCipher, newCipher });
+
+    expect(result.migrated).toContain('chatgpt-auth.json');
+    expect(result.migrated).toContain('github-auth.json');
+    expect(result.migrated).toHaveLength(2);
+  });
+});

--- a/apps/x/packages/core/src/migrations/keychain-token-migration.ts
+++ b/apps/x/packages/core/src/migrations/keychain-token-migration.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { TokenCipher } from '../auth/chatgpt-auth.js';
+
+// One-time migration: re-encrypt tokens that were written by the Electron
+// main process using safeStorage (OS keychain) into the new file-cipher format
+// used by the standalone rowboat-server (Phase 8b, #929).
+//
+// BACKGROUND
+// Before the client/server separation, the main process injected a
+// safeStorage-backed cipher into core so tokens were encrypted at rest with
+// the OS keychain.  After the split, the child/standalone server injects a
+// file-backed AES-256-GCM cipher (cipher-key, mode 0600) instead.  The two
+// formats are incompatible:
+//   • old (safeStorage):  raw DPAPI/libsecret blob stored as base64
+//   • new (file cipher):  "v1:<iv>:<tag>:<data>", all base64 segments
+//
+// When the file cipher encounters old-format ciphertext, its decrypt() throws
+// "Unrecognized ciphertext format" which triggers a store-clear, forcing the
+// user to re-authenticate.  This migration runs ONCE in the Electron main
+// process – the only place that can hold both ciphers simultaneously –
+// translating each old-format credential to the new format before the child
+// server starts.
+//
+// SECURITY PROPERTIES
+//   • Plaintext material lives only in a local variable between the two cipher
+//     calls; it is never written to disk, never logged, never placed on IPC.
+//   • Migration is idempotent: a state file records completion; subsequent
+//     launches skip all of the below.
+//   • Partial failure is safe:
+//       – If decryption fails, the file is left untouched (the child server
+//         will treat missing material as a sign-in prompt, same as before).
+//       – If re-encryption or the write fails, the original file is left
+//         untouched.
+//       – The state file is only written after ALL auth files have been
+//         processed without a hard error.
+//   • After success the old tokenEncrypted value is gone from disk, replaced
+//     by the new-format value.  safeStorage is never called again for these
+//     files.
+
+const STATE_FILE_NAME = 'token-migration.json';
+
+// Sentinel: the new file cipher always produces ciphertext beginning with this
+// prefix.  Any tokenEncrypted value that already starts with 'v1:' was written
+// by the file cipher and needs no migration.
+const FILE_CIPHER_PREFIX = 'v1:';
+
+export interface MigrationCiphers {
+  /** The safeStorage-backed cipher available in the Electron main process. */
+  oldCipher: TokenCipher;
+  /** The file-backed AES-256-GCM cipher used by the child/standalone server. */
+  newCipher: TokenCipher;
+}
+
+export interface MigrationResult {
+  /** true when the migration ran and completed (or was already done). */
+  done: boolean;
+  /** Names of files that were re-encrypted this run. */
+  migrated: string[];
+  /** Names of files that could not be migrated (decryption failed). */
+  skipped: string[];
+}
+
+/**
+ * Attempt to re-encrypt a single auth JSON file.
+ *
+ * Returns 'migrated' | 'skipped' | 'unchanged':
+ *   migrated  – the file was re-written with a new-format tokensEncrypted value
+ *   skipped   – there was encrypted content but decryption failed; file unchanged
+ *   unchanged – no old-format encrypted content found; nothing to do
+ */
+async function migrateAuthFile(
+  filePath: string,
+  ciphers: MigrationCiphers,
+): Promise<'migrated' | 'skipped' | 'unchanged'> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 'unchanged';
+    throw err;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // Corrupt JSON – leave the file alone; the auth module will deal with it.
+    return 'skipped';
+  }
+
+  const encrypted = parsed['tokensEncrypted'] ?? parsed['tokenEncrypted'];
+  if (typeof encrypted !== 'string' || !encrypted) return 'unchanged';
+
+  // Already in the new format – nothing to do.
+  if (encrypted.startsWith(FILE_CIPHER_PREFIX)) return 'unchanged';
+
+  // Old safeStorage format.  Attempt to decrypt.
+  let plaintext: string;
+  try {
+    plaintext = ciphers.oldCipher.decrypt(encrypted);
+  } catch {
+    // Decryption failed (wrong key, corrupt blob, cipher not available).
+    // Leave the file untouched so the server can surface a sign-in prompt.
+    console.warn(`[token-migration] could not decrypt ${path.basename(filePath)}; skipping`);
+    return 'skipped';
+  }
+
+  // Re-encrypt with the new cipher.
+  const newEncrypted = ciphers.newCipher.encrypt(plaintext);
+  // Overwrite the plaintext ref in memory immediately.
+  // (JS strings are GC'd; we cannot zero-fill them, but we limit their scope.)
+
+  // Determine which field name was used in the original file.
+  const fieldName = 'tokensEncrypted' in parsed ? 'tokensEncrypted' : 'tokenEncrypted';
+  const updated: Record<string, unknown> = {
+    ...parsed,
+    [fieldName]: newEncrypted,
+    // Remove any plaintext fallback field that may have been written when no
+    // cipher was available; the token is now encrypted.
+    tokens: undefined,
+    token: undefined,
+    plaintext: undefined,
+  };
+  // Drop keys we explicitly cleared.
+  for (const k of ['tokens', 'token', 'plaintext'] as const) {
+    if (updated[k] === undefined) delete updated[k];
+  }
+
+  await fs.writeFile(filePath, JSON.stringify(updated, null, 2) + '\n', { mode: 0o600 });
+  console.log(`[token-migration] re-encrypted ${path.basename(filePath)}`);
+  return 'migrated';
+}
+
+/**
+ * Migrate any pre-separation keychain-encrypted tokens to the file-cipher format.
+ *
+ * This function is called once in the Electron main process, after both
+ * ciphers are available but before the child rowboat-server is started.
+ * It is safe to call on every launch; on the second and subsequent launches it
+ * returns immediately because the state file is present.
+ *
+ * @param workDir  The Rowboat work directory (e.g. ~/.rowboat).
+ * @param ciphers  The two ciphers: old (safeStorage) and new (file-backed).
+ */
+export async function migrateKeychainTokens(
+  workDir: string,
+  ciphers: MigrationCiphers,
+): Promise<MigrationResult> {
+  const stateFile = path.join(workDir, 'config', STATE_FILE_NAME);
+
+  // Idempotency guard: already done.
+  try {
+    await fs.access(stateFile);
+    return { done: true, migrated: [], skipped: [] };
+  } catch {
+    // Not yet run.
+  }
+
+  // Only attempt when both ciphers are usable.
+  if (!ciphers.oldCipher.isAvailable() || !ciphers.newCipher.isAvailable()) {
+    console.warn('[token-migration] one or both ciphers unavailable; skipping migration');
+    return { done: false, migrated: [], skipped: [] };
+  }
+
+  const authFiles = [
+    path.join(workDir, 'config', 'chatgpt-auth.json'),
+    path.join(workDir, 'config', 'github-auth.json'),
+  ];
+
+  const migrated: string[] = [];
+  const skipped: string[] = [];
+
+  for (const filePath of authFiles) {
+    const result = await migrateAuthFile(filePath, ciphers);
+    if (result === 'migrated') migrated.push(path.basename(filePath));
+    if (result === 'skipped') skipped.push(path.basename(filePath));
+  }
+
+  // Record completion.  We write the state file even when some files were
+  // skipped: a skipped file means decryption failed, which can't be fixed by
+  // retrying with the same ciphers; we don't want to re-attempt on every
+  // launch and generate log noise.
+  const state = {
+    migratedAt: new Date().toISOString(),
+    migrated,
+    skipped,
+  };
+  await fs.mkdir(path.dirname(stateFile), { recursive: true });
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+
+  console.log(`[token-migration] complete: migrated=[${migrated.join(',')}] skipped=[${skipped.join(',')}]`);
+  return { done: true, migrated, skipped };
+}


### PR DESCRIPTION

- Add keychain-token-migration module to handle one-time re-encryption of tokens stored by pre-separation app using safeStorage (OS keychain) into file-cipher format for child/standalone server
- Implement migrateKeychainTokens function with comprehensive test coverage for GitHub and ChatGPT auth token files
- Add migration logic to main.ts that runs on child-server mode startup to decrypt old tokens and re-encrypt with new cipher
- Integrate createFileCipher export from server package to provide encryption for migrated tokens
- Make migration fully idempotent and non-blocking: failures log but don't prevent app boot, allowing users to re-authenticate if needed
- Migration reads through old safeStorage cipher, re-encrypts with file cipher, and writes back to same JSON files