### PR TITLE
Fix Spaces reply threads not reopening after navigating back

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -4677,6 +4677,14 @@ function App() {
     return { type: 'chat', runId }
   }, [selectedBackgroundTask, isEmailOpen, isMeetingsOpen, isLiveNotesOpen, isBgTasksOpen, isAppsOpen, isSpacesOpen, spaceSelection, railSelection, isSuggestedTopicsOpen, selectedPath, isGraphOpen, isWorkspaceOpen, isKnowledgeViewOpen, knowledgeViewFolderPath, knowledgeViewMode, isChatHistoryOpen, isHomeOpen, isCodeOpen, workspaceInitialPath, runId])
 
+  // Navigation handlers can be invoked from closures frozen in older renders
+  // (Spaces' MessageRow memoizes by data and ignores handler identity), so
+  // dedupe/history logic must read the view state through this render-filled
+  // ref — a captured `currentViewState` can be stale, making "already there"
+  // checks eat real navigations.
+  const currentViewStateRef = useRef(currentViewState)
+  currentViewStateRef.current = currentViewState
+
   // applyViewState is declared further down (it needs the chat-binding
   // helpers); handlers above it reach it through this render-filled ref.
   const applyViewStateRef = useRef<((view: ViewState) => Promise<void>) | null>(null)
@@ -5216,7 +5224,7 @@ function App() {
   applyViewStateRef.current = applyViewState
 
   const navigateToView = useCallback(async (nextView: ViewState) => {
-    const current = currentViewState
+    const current = currentViewStateRef.current
     if (viewStatesEqual(current, nextView)) {
       if (isBrowserOpen) {
         dismissBrowserOverlay()
@@ -5231,7 +5239,7 @@ function App() {
     }
     setHistory(nextHistory)
     await applyViewState(nextView)
-  }, [appendUnique, applyViewState, cancelRecordingIfActive, currentViewState, setHistory, isBrowserOpen, dismissBrowserOverlay])
+  }, [appendUnique, applyViewState, cancelRecordingIfActive, setHistory, isBrowserOpen, dismissBrowserOverlay])
 
   // Move the maximized/full-screen chat into the right side pane: restore the
   // view we expanded from (or fall back to Home) and dock the chat on the right.
@@ -5284,11 +5292,12 @@ function App() {
   }, [navigateToView])
 
   const navigateBack = useCallback(async () => {
+    const current = currentViewStateRef.current
     const { back, forward } = historyRef.current
     if (back.length === 0) return
 
     let i = back.length - 1
-    while (i >= 0 && viewStatesEqual(back[i], currentViewState)) i -= 1
+    while (i >= 0 && viewStatesEqual(back[i], current)) i -= 1
     if (i < 0) {
       setHistory({ back: [], forward })
       return
@@ -5297,18 +5306,19 @@ function App() {
     const target = back[i]
     const nextHistory = {
       back: back.slice(0, i),
-      forward: appendUnique(forward, currentViewState),
+      forward: appendUnique(forward, current),
     }
     setHistory(nextHistory)
     await applyViewState(target)
-  }, [appendUnique, applyViewState, currentViewState, setHistory])
+  }, [appendUnique, applyViewState, setHistory])
 
   const navigateForward = useCallback(async () => {
+    const current = currentViewStateRef.current
     const { back, forward } = historyRef.current
     if (forward.length === 0) return
 
     let i = forward.length - 1
-    while (i >= 0 && viewStatesEqual(forward[i], currentViewState)) i -= 1
+    while (i >= 0 && viewStatesEqual(forward[i], current)) i -= 1
     if (i < 0) {
       setHistory({ back, forward: [] })
       return
@@ -5316,12 +5326,12 @@ function App() {
 
     const target = forward[i]
     const nextHistory = {
-      back: appendUnique(back, currentViewState),
+      back: appendUnique(back, current),
       forward: forward.slice(0, i),
     }
     setHistory(nextHistory)
     await applyViewState(target)
-  }, [appendUnique, applyViewState, currentViewState, setHistory])
+  }, [appendUnique, applyViewState, setHistory])
 
   const canNavigateBack = React.useMemo(() => {
     for (let i = viewHistory.back.length - 1; i >= 0; i--) {
@@ -5801,16 +5811,17 @@ function App() {
   }, [sessionChat.chatState?.conversation, runId, navigateToView])
 
   const navigateToFullScreenChat = useCallback(() => {
+    const current = currentViewStateRef.current
     // Only treat this as navigation when coming from another view
-    if (currentViewState.type !== 'chat') {
+    if (current.type !== 'chat') {
       const nextHistory = {
-        back: appendUnique(historyRef.current.back, currentViewState),
+        back: appendUnique(historyRef.current.back, current),
         forward: [] as ViewState[],
       }
       setHistory(nextHistory)
     }
     handleOpenFullScreenChat()
-  }, [appendUnique, currentViewState, handleOpenFullScreenChat, setHistory])
+  }, [appendUnique, handleOpenFullScreenChat, setHistory])
 
   // Handle image upload for the markdown editor
   const handleImageUpload = useCallback(async (file: File): Promise<string | null> => {


### PR DESCRIPTION
## The bug

In Spaces, clicking a reply/thread opens it the first time. Navigate back to the stream and click the same reply again — nothing happens. The click is silently swallowed until something remounts the stream.

## Root cause: a stale closure frozen inside memoized `MessageRow`

`MessageRow` is memoized **by data only**, deliberately ignoring handler-prop identity (`message-row.tsx`). Its documented safety contract is that handlers only read per-pane-stable values or data that flows through compared props — but the handler chain (`onOpenThread` → `select` → `onRailSelect` → `navigateToView`) terminates in App's `navigateToView`, whose `useCallback` captured `currentViewState`. That breaks the contract:

1. **First click** — the row's closure was frozen while on the stream (`currentViewState = general`), so the dedupe guard in `navigateToView` passes and the thread opens. ✅
2. **While the thread is open**, the general stream stays mounted (keep-alive, CSS-hidden) and keeps rendering. Opening the thread marks it read, flipping the row's `unreadCount` (replying flips `replyCount`/`lastActivityAt`) — a compared field — so that one row re-renders **now** and freezes fresh closures in which `currentViewState = thread:X`.
3. **Navigate back** — the row's compared data is unchanged, so the memo skips it; the stale closure survives.
4. **Second click** — the frozen `navigateToView` compares stale `current = thread:X` against `next = thread:X`, the "already there" guard returns early, and `setRailSelection` never runs. Dead click. ❌

It also explains the corollary: clicking a *different* reply still worked, but pushed a wrong `thread:X` entry onto back-history.

## The fix

Read the view state through a render-filled ref (the same pattern App already uses for `applyViewStateRef`):

```ts
const currentViewStateRef = useRef(currentViewState)
currentViewStateRef.current = currentViewState
```

`navigateToView`, `navigateBack`, `navigateForward`, and `navigateToFullScreenChat` now read `currentViewStateRef.current` for their dedupe checks and history pushes, and drop `currentViewState` from their dependency arrays. The guards always compare against the **live** view state no matter how old the invoking closure is — restoring the contract `MessageRow`'s memo relies on, without giving up the memo (comparing handler props there would defeat it, per its design comment). Side benefit: these callbacks no longer change identity on every view change.

## Verification

- `npm run typecheck:renderer` (`tsc -b`) — clean
- `npm run test:renderer` — 37 files, 373 tests, all passing
- `eslint src/App.tsx` — 8 pre-existing `exhaustive-deps` warnings, byte-identical to HEAD (confirmed by linting the pre-edit file); no new issues
- Manual repro after fix: open a reply thread → post a reply inside it → back (thread arrow or header ‹) → click the same reply chip → opens every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)