### PR TITLE
docs: add Parallel Search MCP setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,26 @@ That means you can plug in (for example) search, databases, CRMs, support tools,
 
 Examples: Exa (web search), Twitter/X, ElevenLabs (voice), Slack, Linear/Jira, GitHub, and more.
 
+### Example: Parallel web search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides `web_search` and `web_fetch` for public web search and page extraction without a Parallel account or API key. Free access is rate limited.
+
+Open **Settings → MCP Servers**, add the `parallel` entry to your existing `mcpServers` object, and click **Save**. Keep any other server entries. If no servers are configured, use:
+
+```json
+{
+  "mcpServers": {
+    "parallel": {
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+This connects through Rowboat's existing Streamable HTTP client. Ask Rowboat to list the tools on the `parallel` server, then try: "Use Parallel to find the official MCP documentation."
+
+Once configured, Rowboat can invoke these tools during its work, subject to your MCP tool permissions. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. This setup leaves Exa and other configured providers unchanged. To remove it, delete the `parallel` entry in **Settings → MCP Servers** and save.
+
 ## Local-first by design
 
 - All data is stored locally as plain Markdown


### PR DESCRIPTION
Adds a working Parallel Search MCP example to the README so users can set up public web search and page extraction without a Parallel account or API key. It shows the existing Settings → MCP Servers path, how to preserve other entries, and how to remove the connection.

This is documentation only. It leaves existing providers and defaults unchanged and explains that enabled tools send queries, URLs, and supplied context to Parallel. Free access is rate limited.

Rowboat already [enables Exa search for signed-in users and sends requests with `type: auto`](https://github.com/rowboatlabs/rowboat/blob/5ed14fca5d92ea975b590fbeb094f06a683d8ed4/apps/x/packages/core/src/runtime/tools/domains/web.ts#L24-L65), so that’s the comparison I’d focus on. In [Artificial Analysis’s August 31 leaderboard](https://artificialanalysis.ai/agents/search-api), Parallel advanced scores **81 vs 78 on DeepSearchQA** and **77 vs 74 on BrowseComp**, with an overall Search Index of **75 vs 74** for Exa auto. If better search quality is the goal, I’d also consider evaluating Parallel advanced as a replacement for the Exa auto default. It does trade speed for those gains: 42.7s vs 33.1s per benchmark task, and Exa leads on Omniscience, 70 vs 67.

The [free MCP setup uses fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp#configure-search-behavior); advanced needs authentication and a separate mode setting. Parallel fast still beats Exa auto on DeepSearchQA, **80 vs 78**, and cuts benchmark time per task from **33.1s to 19.2s**. Its measured search API cost is **$8.41 vs $65.57 per 1,000 benchmark tasks**, about **87% lower**, excluding model costs. Its overall index is slightly lower, 73 vs 74. These are AA’s [fixed-harness API results](https://artificialanalysis.ai/methodology/search-api), not a Rowboat benchmark or a measurement of free MCP billing. AA’s task time combines measured search time with estimated model time.

Verified the exact example through Rowboat’s `FSMcpConfigRepo` and `listServers`, `listTools`, and `executeTool` functions with the locked MCP SDK 1.25.1 and Zod 4.2.1. Anonymous discovery, search, and fetch passed. The focused check isolated the workspace path, dependency container, and unrelated spaces registry. `git diff --check` passes. The desktop UI, repository build, and full test suite were not run.

I work at Parallel, which operates this service.
