### PR TITLE
fix(models): sanitize PCRE patterns in tool schemas for llama.cpp compatibility

### DIFF
--- a/apps/x/packages/core/src/models/local.test.ts
+++ b/apps/x/packages/core/src/models/local.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { makeOllamaThinkFetch, resolveThinkValue, rewrapOllamaErrorBody } from "./local.js";
+import {
+    makeOllamaThinkFetch,
+    resolveThinkValue,
+    rewrapOllamaErrorBody,
+    sanitizePatternsForGBNF,
+} from "./local.js";
 
 describe("resolveThinkValue", () => {
     it("passes effort levels straight through for gpt-oss variants", () => {
@@ -126,5 +131,139 @@ describe("makeOllamaThinkFetch", () => {
         });
         expect(res.status).toBe(200);
         expect(await res.json()).toEqual({});
+    });
+});
+
+describe("sanitizePatternsForGBNF", () => {
+    it("replaces \\d with [0-9]", () => {
+        const schema = { type: "object", properties: { time: { type: "string", pattern: "^([01]\\d|2[0-3]):[0-5]\\d$" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { time: { type: "string", pattern: "^([01][0-9]|2[0-3]):[0-5][0-9]$" } },
+        });
+    });
+
+    it("replaces \\D with [^0-9]", () => {
+        const schema = { type: "object", properties: { name: { type: "string", pattern: "^\\D+$" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { name: { type: "string", pattern: "^[^0-9]+$" } },
+        });
+    });
+
+    it("replaces \\w with [A-Za-z0-9_]", () => {
+        const schema = { type: "object", properties: { id: { type: "string", pattern: "^\\w+$" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { id: { type: "string", pattern: "^[A-Za-z0-9_]+$" } },
+        });
+    });
+
+    it("replaces \\W with [^A-Za-z0-9_]", () => {
+        const schema = { type: "object", properties: { slug: { type: "string", pattern: "^\\W+$" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { slug: { type: "string", pattern: "^[^A-Za-z0-9_]+$" } },
+        });
+    });
+
+    it("replaces \\s with [ \\t\\n\\r]", () => {
+        const schema = { type: "object", properties: { text: { type: "string", pattern: "^\\s+$" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { text: { type: "string", pattern: "^[ \\t\\n\\r]+$" } },
+        });
+    });
+
+    it("replaces \\S with [^ \\t\\n\\r]", () => {
+        const schema = { type: "object", properties: { text: { type: "string", pattern: "^\\S+$" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { text: { type: "string", pattern: "^[^ \\t\\n\\r]+$" } },
+        });
+    });
+
+    it("removes \\b (word boundary)", () => {
+        const schema = { type: "object", properties: { word: { type: "string", pattern: "\\btest\\b" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { word: { type: "string", pattern: "test" } },
+        });
+    });
+
+    it("removes \\B (non-word boundary)", () => {
+        const schema = { type: "object", properties: { word: { type: "string", pattern: "\\Btest\\B" } } };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: { word: { type: "string", pattern: "test" } },
+        });
+    });
+
+    it("handles nested objects and arrays", () => {
+        const schema = {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: { type: "string", pattern: "^\\d+$" },
+                },
+                nested: {
+                    type: "object",
+                    properties: { time: { type: "string", pattern: "^\\d{2}:\\d{2}$" } },
+                },
+            },
+        };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: { type: "string", pattern: "^[0-9]+$" },
+                },
+                nested: {
+                    type: "object",
+                    properties: { time: { type: "string", pattern: "^[0-9]{2}:[0-9]{2}$" } },
+                },
+            },
+        });
+    });
+
+    it("leaves non-pattern properties unchanged", () => {
+        const schema = {
+            type: "object",
+            properties: {
+                name: { type: "string", minLength: 1 },
+                time: { type: "string", pattern: "^\\d{2}:\\d{2}$" },
+            },
+        };
+        const sanitized = sanitizePatternsForGBNF(schema);
+        expect(sanitized).toEqual({
+            type: "object",
+            properties: {
+                name: { type: "string", minLength: 1 },
+                time: { type: "string", pattern: "^[0-9]{2}:[0-9]{2}$" },
+            },
+        });
+    });
+
+    it("handles null and primitive values", () => {
+        expect(sanitizePatternsForGBNF(null)).toBeNull();
+        expect(sanitizePatternsForGBNF("string")).toBe("string");
+        expect(sanitizePatternsForGBNF(123)).toBe(123);
+        expect(sanitizePatternsForGBNF(true)).toBe(true);
+    });
+
+    it("handles empty objects and arrays", () => {
+        expect(sanitizePatternsForGBNF({})).toEqual({});
+        expect(sanitizePatternsForGBNF([])).toEqual([]);
     });
 });

--- a/apps/x/packages/core/src/models/local.ts
+++ b/apps/x/packages/core/src/models/local.ts
@@ -1,4 +1,5 @@
 import { wrapLanguageModel, type LanguageModel } from "ai";
+import { LanguageModelV4Middleware, type JSONSchema7 } from "@ai-sdk/provider";
 import type { z } from "zod";
 import type { LlmProvider } from "@x/shared/dist/models.js";
 
@@ -171,3 +172,79 @@ export function makeOllamaThinkFetch(
         return res.ok ? res : rewrapErrorResponse(res);
     };
 }
+
+/**
+ * GBNF (used by llama.cpp for constrained decoding) does not support PCRE
+ * shorthand character classes (\d, \w, \s, \b, etc.). This function recursively
+ * sanitizes a JSON Schema by replacing PCRE shorthands in `pattern` properties
+ * with GBNF-safe equivalents.
+ *
+ * Replacements:
+ *   \d  -> [0-9]
+ *   \D  -> [^0-9]
+ *   \w  -> [A-Za-z0-9_]
+ *   \W  -> [^A-Za-z0-9_]
+ *   \s  -> [ \t\n\r]
+ *   \S  -> [^ \t\n\r]
+ *   \b  -> (removed - word boundary not representable in GBNF)
+ *   \B  -> (removed - non-word boundary not representable in GBNF)
+ */
+export function sanitizePatternsForGBNF(schema: unknown): unknown {
+    if (schema === null || typeof schema !== "object") {
+        return schema;
+    }
+
+    if (Array.isArray(schema)) {
+        return schema.map((item) => sanitizePatternsForGBNF(item));
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+        if (key === "pattern" && typeof value === "string") {
+            let sanitized = value;
+            sanitized = sanitized.replace(/\\d/g, "[0-9]");
+            sanitized = sanitized.replace(/\\D/g, "[^0-9]");
+            sanitized = sanitized.replace(/\\w/g, "[A-Za-z0-9_]");
+            sanitized = sanitized.replace(/\\W/g, "[^A-Za-z0-9_]");
+            sanitized = sanitized.replace(/\\s/g, "[ \\t\\n\\r]");
+            sanitized = sanitized.replace(/\\S/g, "[^ \\t\\n\\r]");
+            sanitized = sanitized.replace(/\\b/g, "");
+            sanitized = sanitized.replace(/\\B/g, "");
+            result[key] = sanitized;
+        } else {
+            result[key] = sanitizePatternsForGBNF(value);
+        }
+    }
+    return result;
+}
+
+/**
+ * Middleware to sanitize tool schemas for llama.cpp-backed OpenAI-compatible
+ * endpoints (e.g., LM Studio). Applied via wrapLanguageModel so every request
+ * with tools gets its JSON Schema patterns sanitized before being sent.
+ */
+export const gbnfPatternSanitizerMiddleware: LanguageModelV4Middleware = {
+    specificationVersion: "v4" as const,
+    transformParams: async ({ params }) => {
+        if (!params.tools || !Array.isArray(params.tools)) {
+            return params;
+        }
+
+        const sanitizedTools = params.tools.map((tool) => {
+            // Tool has inputSchema property (not parameters)
+            const toolWithSchema = tool as Record<string, unknown>;
+            if (!toolWithSchema.inputSchema || typeof toolWithSchema.inputSchema !== "object") {
+                return tool;
+            }
+            return {
+                ...tool,
+                inputSchema: sanitizePatternsForGBNF(toolWithSchema.inputSchema) as JSONSchema7,
+            };
+        });
+
+        return {
+            ...params,
+            tools: sanitizedTools,
+        };
+    },
+};

--- a/apps/x/packages/core/src/models/models.ts
+++ b/apps/x/packages/core/src/models/models.ts
@@ -18,7 +18,9 @@ import {
     makeOllamaThinkFetch,
     DEFAULT_OLLAMA_CONTEXT_LENGTH,
     DEFAULT_OLLAMA_REASONING_EFFORT,
+    gbnfPatternSanitizerMiddleware,
 } from "./local.js";
+import { wrapLanguageModel } from "ai";
 
 export const Provider = LlmProvider;
 export const ModelConfig = LlmModelConfig;
@@ -98,7 +100,16 @@ export function createLanguageModel(
     modelId: string,
 ): LanguageModel {
     const model = createProvider(providerConfig).languageModel(modelId);
-    return applyLocalModelSettings(model, providerConfig);
+    let wrapped = applyLocalModelSettings(model, providerConfig);
+    if (providerConfig.flavor === "openai-compatible") {
+        // The provider's languageModel() always returns a LanguageModelV4, not a string
+        const baseModel = wrapped as Parameters<typeof wrapLanguageModel>[0]["model"];
+        wrapped = wrapLanguageModel({
+            model: baseModel,
+            middleware: gbnfPatternSanitizerMiddleware,
+        });
+    }
+    return wrapped;
 }
 
 export interface ModelCapabilities {

--- a/apps/x/packages/shared/src/live-note.ts
+++ b/apps/x/packages/shared/src/live-note.ts
@@ -59,8 +59,8 @@ export type LiveNote = {
 };
 
 const TriggerWindowSchema = z.object({
-    startTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).describe('24h HH:MM, local time. Also the daily cycle anchor — once the agent fires after this time, the window is done for the day.'),
-    endTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/).describe('24h HH:MM, local time. After this, the window is closed for the day.'),
+    startTime: z.string().regex(/^([01][0-9]|2[0-3]):[0-5][0-9]$/).describe('24h HH:MM, local time. Also the daily cycle anchor — once the agent fires after this time, the window is done for the day.'),
+    endTime: z.string().regex(/^([01][0-9]|2[0-3]):[0-5][0-9]$/).describe('24h HH:MM, local time. After this, the window is closed for the day.'),
 });
 
 export const TriggersSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes tool calling failures on LM Studio / llama.cpp backends caused by PCRE shorthand character classes (`\d`, `\w`, `\s`, `\b`) in JSON Schema patterns that GBNF grammar compilation does not support.

## Root Cause

llama.cpp compiles `pattern` regexes from tool schemas into a GBNF grammar for constrained decoding. GBNF has no PCRE shorthand classes (`\d`, `\w`, `\s`) or word boundaries (`\b`). One offending field fails grammar compilation and takes down the entire request with HTTP 400.

The built-in time-window validation pattern (`^([01]\\d|2[0-3]):[0-5]\\d$`) uses `\d`, which is the primary offender. Third-party MCP tool schemas may contain other shorthands.

## Changes

1. **`apps/x/packages/shared/src/live-note.ts`** — Replace `\d` with `[0-9]` in the built-in time-window regex at source
2. **`apps/x/packages/core/src/models/local.ts`** — Add `sanitizePatternsForGBNF()` utility and `gbnfPatternSanitizerMiddleware` to translate PCRE shorthands to GBNF-safe equivalents at the openai-compatible provider boundary
3. **`apps/x/packages/core/src/models/models.ts`** — Apply the middleware to the `openai-compatible` provider
4. **`apps/x/packages/core/src/models/local.test.ts`** — Add comprehensive tests for the sanitization function

## PCRE → GBNF Replacements

| PCRE | GBNF |
|------|------|
| `\d` | `[0-9]` |
| `\D` | `[^0-9]` |
| `\w` | `[A-Za-z0-9_]` |
| `\W` | `[^A-Za-z0-9_]` |
| `\s` | `[ \\t\\n\\r]` |
| `\S` | `[^ \\t\\n\\r]` |
| `\b` | (removed) |
| `\B` | (removed) |

## Verification

1. `cd apps/x && pnpm run deps` — build passes
2. `cd apps/x/packages/shared && pnpm test` — 304 tests pass
3. `cd apps/x/packages/core && pnpm vitest run --exclude src/spaces/client.test.ts` — 814 tests pass
4. `pnpm run lint` — no lint errors

## Related

- ggml-org/llama.cpp#16714
- ggml-org/llama.cpp#22314

Fixes #740