### PR TITLE
feat(x): code mode sidebar on the shared SecondaryRail shell — two-line session cards with branch, subtler working indicator

### DIFF
--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -1687,43 +1687,18 @@
   opacity: 1;
 }
 
-/* Code rail: the session that is currently working wears an outline that
-   orbits its row — a comet travelling a faint ring — so the live session is
-   findable at a glance even when it isn't the selected one. The gradient's
-   start angle is a registered property so it can animate. */
-@property --code-orbit {
-  syntax: '<angle>';
-  inherits: false;
-  initial-value: 0deg;
+/* Code rail: the working session's status dot ripples — a soft ring
+   swelling off the dot and fading, with a quiet beat between pulses — so
+   the live session reads at a glance without lighting its card. */
+@keyframes code-dot-ripple {
+  0% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--rowboat-git) 45%, transparent); }
+  60%, 100% { box-shadow: 0 0 0 5px transparent; }
 }
-@keyframes code-orbit-spin {
-  to { --code-orbit: 360deg; }
-}
-.code-working-outline {
-  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--rowboat-git) 28%, transparent);
-}
-.code-working-outline::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1.5px;
-  background: conic-gradient(
-    from var(--code-orbit),
-    transparent 0deg,
-    transparent 230deg,
-    color-mix(in oklab, var(--rowboat-git) 35%, transparent) 300deg,
-    var(--rowboat-git) 360deg
-  );
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  animation: code-orbit-spin 2.4s linear infinite;
-  pointer-events: none;
+.code-working-dot {
+  animation: code-dot-ripple 2.4s ease-out infinite;
 }
 @media (prefers-reduced-motion: reduce) {
-  .code-working-outline::after { animation: none; }
+  .code-working-dot { animation: none; }
 }
 
 

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -53,7 +53,6 @@ import { MeetingsView } from '@/components/meetings-view';
 import { CodeView, type ActiveCodeSession } from '@/components/code/code-view';
 import { CodeWorkspaceDrawer } from '@/components/code/workspace-drawer';
 import type { CodePanel } from '@/components/code/code-panels';
-import { CODE_RAIL_WIDTH } from '@/components/code/session-rail';
 import { useCodeGitStatus } from '@/components/code/use-code-git-status';
 import { refreshCodeSessions } from '@/components/code/use-code-sessions';
 import { CodeDiffOpenerProvider } from '@/contexts/code-diff-context';
@@ -2670,6 +2669,10 @@ function App() {
   // Deep-link into the Code section (a Home Deck strip's door): select this
   // session when the view opens, then clear.
   const [codeFocusSessionId, setCodeFocusSessionId] = useState<string | null>(null)
+  // The code rail's width (drag-resizable, persisted by its SecondaryRail
+  // shell) — the middle pane hugs it while a session's chat is the main
+  // surface. The rail reports before first paint, so the default never shows.
+  const [codeRailWidth, setCodeRailWidth] = useState(280)
   // A file the code chat asked to review — consumed by the workspace drawer.
   const [codeDiffPath, setCodeDiffPath] = useState<string | null>(null)
   // Which workspace panel (changes / files / terminal) is open beside the
@@ -6628,7 +6631,7 @@ function App() {
     const style: React.CSSProperties = { maxWidth: insetMaxWidth }
     if (!isRightPaneContext || !chatPaneOpen || isRightPaneMaximized) return style
     if (codeChatMain) {
-      return { ...style, width: CODE_RAIL_WIDTH, flex: '0 0 auto' }
+      return { ...style, width: codeRailWidth, flex: '0 0 auto' }
     }
     if (chatPaneSize === 'chat-equal') {
       return { ...style, width: 0, flex: '1 1 0' }
@@ -6637,7 +6640,7 @@ function App() {
       return { ...style, width: DEFAULT_CHAT_PANE_WIDTH, flex: '0 0 auto' }
     }
     return style
-  }, [chatPaneSize, codeChatMain, chatPaneOpen, insetMaxWidth, isRightPaneContext, isRightPaneMaximized])
+  }, [chatPaneSize, codeChatMain, codeRailWidth, chatPaneOpen, insetMaxWidth, isRightPaneContext, isRightPaneMaximized])
   // Collapsing: pin max-width to the snapshot px (no transition) for one frame so it's
   // binding immediately (no flex jump), then animate to 0. Expanding goes back to 100%
   // — its non-binding range lands at the end of the range, where it isn't visible.
@@ -7079,6 +7082,7 @@ function App() {
                     onSessionSelected={handleCodeSessionSelected}
                     focusSessionId={codeFocusSessionId}
                     onFocusConsumed={() => setCodeFocusSessionId(null)}
+                    onRailWidthChange={setCodeRailWidth}
                   />
                 </div>
                 </Activity>

--- a/apps/x/apps/renderer/src/components/code/code-view.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-view.tsx
@@ -15,7 +15,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { useCodeSessions, projectLabel } from './use-code-sessions'
-import { SessionRail, CODE_RAIL_WIDTH } from './session-rail'
+import { SessionRail } from './session-rail'
 import { AGENT_LABEL, fetchCodeAgentsStatus, isAgentReady, type CodeAgentsStatus } from './code-agent-status'
 
 // Remember which session was open so leaving the Code section (which unmounts
@@ -42,12 +42,16 @@ export function CodeView({
   onSessionSelected,
   focusSessionId,
   onFocusConsumed,
+  onRailWidthChange,
 }: {
   onSessionSelected?: (active: ActiveCodeSession | null) => void
   // Deep-link from elsewhere (a Home Deck strip): select this session on
   // mount/change instead of the remembered one.
   focusSessionId?: string | null
   onFocusConsumed?: () => void
+  // The rail's drag-resizable width, reported up so App can size the middle
+  // pane to the rail while a session's chat is the main surface.
+  onRailWidthChange?: (width: number) => void
 }) {
   const { projects, sessions, statusOf, refresh } = useCodeSessions()
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(readStoredSelectedSessionId)
@@ -179,37 +183,37 @@ export function CodeView({
 
   return (
     <div className="flex h-full min-h-0">
-      {/* Session rail. With a session selected this IS the middle pane (App
-          sizes the pane to the rail); without one the empty state fills the
-          rest and the chat pane stays out of the way. */}
-      <div
-        className={selectedSession ? 'min-w-0 flex-1' : 'shrink-0 border-r border-border'}
-        style={selectedSession ? undefined : { width: CODE_RAIL_WIDTH }}
-      >
-        <SessionRail
-          projects={projects}
-          sessions={sessions}
-          statusOf={statusOf}
-          agentsStatus={agentsStatus}
-          selectedSessionId={selectedSessionId}
-          onSelectSession={(id) => {
-            setSelectedSessionId(id)
-            // Re-clicking the already-selected session is a no-op for React
-            // state, but the user means "show me this session's chat" — the
-            // chat may have been rebound to another conversation meanwhile.
-            // Re-notify so App re-asserts the binding (it dedupes).
-            if (id === selectedSessionId) {
-              const session = sessions.find((s) => s.id === id)
-              if (session) onSessionSelected?.({ session, status: statusOf(session.id) })
-            }
-          }}
-          onAddProject={() => void handleAddProject()}
-          onRemoveProject={(id) => void handleRemoveProject(id)}
-          onNewSession={(projectId, agent) => void handleNewSession(projectId, agent)}
-          onSetDone={(session, done) => void handleSetDone(session, done)}
-          onDeleteSession={setDeleteTarget}
-        />
-      </div>
+      {/* Session rail, on the shared SecondaryRail shell (it owns its width
+          and drag-resize). With a session selected this IS the middle pane —
+          App sizes the pane to the width the rail reports; without one the
+          empty state fills the rest and the chat pane stays out of the way. */}
+      <SessionRail
+        projects={projects}
+        sessions={sessions}
+        statusOf={statusOf}
+        agentsStatus={agentsStatus}
+        selectedSessionId={selectedSessionId}
+        onSelectSession={(id) => {
+          setSelectedSessionId(id)
+          // Re-clicking the already-selected session is a no-op for React
+          // state, but the user means "show me this session's chat" — the
+          // chat may have been rebound to another conversation meanwhile.
+          // Re-notify so App re-asserts the binding (it dedupes).
+          if (id === selectedSessionId) {
+            const session = sessions.find((s) => s.id === id)
+            if (session) onSessionSelected?.({ session, status: statusOf(session.id) })
+          }
+        }}
+        onAddProject={() => void handleAddProject()}
+        onRemoveProject={(id) => void handleRemoveProject(id)}
+        onNewSession={(projectId, agent) => void handleNewSession(projectId, agent)}
+        onSetDone={(session, done) => void handleSetDone(session, done)}
+        onDeleteSession={setDeleteTarget}
+        onWidthChange={onRailWidthChange}
+        // With a session selected the chat pane sits flush right and draws
+        // the divider (its border-l) — the rail's own would double it.
+        className={selectedSession ? 'border-r-0' : undefined}
+      />
 
       {!selectedSession && (
         <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 text-center">

--- a/apps/x/apps/renderer/src/components/code/session-rail.tsx
+++ b/apps/x/apps/renderer/src/components/code/session-rail.tsx
@@ -14,6 +14,7 @@ import type { CodeSession, CodeSessionStatus } from '@x/shared/src/code-sessions
 import type { CodingAgent } from '@x/shared/src/code-mode.js'
 import { cn, compactPath, parentPath } from '@/lib/utils'
 import { formatRelativeTime } from '@/lib/relative-time'
+import { SecondaryRail } from '@/components/secondary-rail'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -26,8 +27,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { projectLabel, type ProjectRow } from './use-code-sessions'
 import { AGENT_LABEL, isAgentReady, type CodeAgentsStatus } from './code-agent-status'
 
-export const CODE_RAIL_WIDTH = 272
-
 // The Done pile shows this many before asking for "Show all" — a display
 // cap, never a deletion policy.
 const DONE_VISIBLE_LIMIT = 25
@@ -38,31 +37,30 @@ function readDoneOpen(): boolean {
   return window.localStorage.getItem(DONE_OPEN_STORAGE_KEY) === '1'
 }
 
-// Inline status prefix: a dot plus a word, only when there is something to
-// say. Idle rows carry no prefix so the list stays quiet.
-function StatusPrefix({ status }: { status: CodeSessionStatus }) {
-  if (status === 'working') {
-    return (
-      <span className="flex shrink-0 items-center gap-1.5 text-[12px] font-medium text-[var(--rowboat-git)]">
-        <span className="size-1.5 rounded-full bg-current" />
-        Working
-      </span>
-    )
-  }
-  if (status === 'needs-you') {
-    return (
-      <span className="flex shrink-0 items-center gap-1.5 text-[12px] font-medium text-[var(--rowboat-attention)]">
-        <span className="size-1.5 animate-pulse rounded-full bg-current" />
-        Needs you
-      </span>
-    )
-  }
-  return null
+// The dot in each card's gutter carries the session's state: quiet grey at
+// rest, the git accent rippling softly while an agent works (see
+// `.code-working-dot` in App.css), the attention color pulsing when the
+// session waits on the user. Color and motion do the talking — no words,
+// and nothing lights the card itself.
+function StatusDot({ status }: { status: CodeSessionStatus }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'mt-1.5 size-2 shrink-0 rounded-full',
+        status === 'working' && 'code-working-dot bg-[var(--rowboat-git)]',
+        status === 'needs-you' && 'animate-pulse bg-[var(--rowboat-attention)]',
+        status === 'idle' && 'bg-muted-foreground/40',
+      )}
+    />
+  )
 }
 
-// One session row. Active rows show the time and, on hover, a check (mark
-// done) beside the menu; done rows show when they were finished and a
-// reopen arrow instead. Rows keep their looks in either pile — only the
+// One session card: two lines — the title, then the branch the session
+// works on (or the agent, when it runs without a worktree) — behind a
+// status dot. Active cards show the time and, on hover, a check (mark
+// done) beside the menu; done cards show when they were finished and a
+// reopen arrow instead. Cards keep their looks in either pile — only the
 // heading above them changes.
 function SessionRow({
   session,
@@ -86,20 +84,22 @@ function SessionRow({
   onSetDone: (done: boolean) => void
   onDelete: () => void
 }) {
-  const worktree = session.worktree && !session.worktree.removedAt
+  const worktree = session.worktree && !session.worktree.removedAt ? session.worktree : undefined
   const when = formatRelativeTime((done && session.doneAt) || session.lastActivityAt || session.createdAt)
+  // The second line: the branch, or the agent when there is none — every
+  // card keeps its two-line shape.
+  const detail = worktree?.branch ?? AGENT_LABEL[session.agent] ?? session.agent
   const ToggleIcon = done ? RotateCcw : Check
   const toggleLabel = done ? 'Reopen' : 'Mark as done'
   return (
     <div
       role="button"
       tabIndex={0}
-      title={`${session.title}\n${AGENT_LABEL[session.agent] ?? session.agent}${worktree ? ` · ${session.worktree?.branch}` : ''}`}
+      title={`${session.title}\n${AGENT_LABEL[session.agent] ?? session.agent}${worktree ? ` · ${worktree.branch}` : ''}`}
       className={cn(
-        'group relative mt-0.5 flex h-8 cursor-pointer items-center gap-2 rounded-lg pl-2 pr-1.5',
+        'group relative mt-0.5 flex cursor-pointer items-start gap-2.5 rounded-lg py-1.5 pl-2.5 pr-1.5',
         indent && 'ml-3',
         selected ? 'bg-accent text-foreground' : 'hover:bg-accent/60',
-        status === 'working' && !done && 'code-working-outline',
       )}
       onClick={onSelect}
       onKeyDown={(e) => {
@@ -109,16 +109,21 @@ function SessionRow({
         }
       }}
     >
-      {!done && <StatusPrefix status={status} />}
-      <span className={cn('min-w-0 flex-1 truncate text-[13px]', selected ? 'font-medium' : 'text-foreground/90')}>
-        {prefix && <span className="text-muted-foreground">{prefix} · </span>}
-        {session.title}
-      </span>
-      <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70 transition-opacity group-hover:opacity-0">
-        {when}
-      </span>
-      {/* Hover actions sit over the time so the row never reflows. */}
-      <div className="absolute right-1 flex items-center opacity-0 transition-opacity group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
+      <StatusDot status={done ? 'idle' : status} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className={cn('min-w-0 flex-1 truncate text-[13px] leading-5', selected ? 'font-medium' : 'text-foreground/90')}>
+            {prefix && <span className="text-muted-foreground">{prefix} · </span>}
+            {session.title}
+          </span>
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70 transition-opacity group-hover:opacity-0">
+            {when}
+          </span>
+        </div>
+        <div className="truncate text-[11px] leading-4 text-muted-foreground/70">{detail}</div>
+      </div>
+      {/* Hover actions sit over the time so the card never reflows. */}
+      <div className="absolute right-1 top-1 flex items-center opacity-0 transition-opacity group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -163,10 +168,13 @@ function SessionRow({
 }
 
 // Left rail of the Code section: registered projects with their active
-// sessions, attention-first, and a Done pile pinned to the bottom. The
-// session that is currently working wears an orbiting outline (see
-// `.code-working-outline` in App.css) so it can be found at a glance even
-// when it is not the selected one.
+// sessions as two-line cards (title, then branch), attention-first, and a
+// Done pile pinned to the bottom. Status lives in each card's gutter dot —
+// the working session's ripples (see `.code-working-dot` in App.css) so it
+// can be found at a glance even when it is not the selected one. The rail
+// chrome (docked width + drag-resize, persisted) is the shared
+// SecondaryRail shell that Spaces and Email use; this file owns only
+// what's IN the rail.
 export function SessionRail({
   projects,
   sessions,
@@ -179,6 +187,8 @@ export function SessionRail({
   onNewSession,
   onSetDone,
   onDeleteSession,
+  onWidthChange,
+  className,
 }: {
   projects: ProjectRow[]
   sessions: CodeSession[]
@@ -193,6 +203,12 @@ export function SessionRail({
   onNewSession: (projectId: string, agent?: CodingAgent) => void
   onSetDone: (session: CodeSession, done: boolean) => void
   onDeleteSession: (session: CodeSession) => void
+  /** The shell reports the rail's (drag-resizable, persisted) width here so
+   *  App can size the code middle pane to it. */
+  onWidthChange?: (width: number) => void
+  /** Extra classes for the shell's aside — CodeView drops the right border
+   *  while the chat pane beside it draws the divider. */
+  className?: string
 }) {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
   const toggleCollapsed = (projectId: string) => {
@@ -218,8 +234,9 @@ export function SessionRail({
   const visibleDone = showAllDone ? done : done.slice(0, DONE_VISIBLE_LIMIT)
   const labelByProject = new Map(projects.map((row) => [row.project.id, projectLabel(row)]))
 
-  return (
-    <div className="flex h-full min-h-0 flex-col bg-[var(--rowboat-panel-soft)]">
+  // The rail's content — the shell renders it at the docked width.
+  const body = (
+    <div className="flex h-full min-h-0 flex-col">
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border pl-3 pr-1.5">
         <span className="text-[13px] text-muted-foreground">Projects</span>
         <Tooltip>
@@ -421,5 +438,14 @@ export function SessionRail({
         </div>
       )}
     </div>
+  )
+
+  return (
+    // Always docked: the middle pane above this rail (header + chat binding)
+    // sizes itself to the rail, so the collapsed-sliver/peek mode the shell
+    // offers Spaces and Email has nowhere to go here yet.
+    <SecondaryRail open onTogglePin={() => {}} widthStorageKey="code:railWidth" onWidthChange={onWidthChange} className={className}>
+      {() => body}
+    </SecondaryRail>
   )
 }

--- a/apps/x/apps/renderer/src/components/secondary-rail.tsx
+++ b/apps/x/apps/renderer/src/components/secondary-rail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
 // The shared shell for a section's secondary sidebar (Spaces' rail, Email's
@@ -33,7 +33,7 @@ export interface SecondaryRailContext {
     onMenuOpenChange: (open: boolean) => void
 }
 
-export function SecondaryRail({ open, onTogglePin, widthStorageKey, edgeDot = false, persistent, children }: {
+export function SecondaryRail({ open, onTogglePin, widthStorageKey, edgeDot = false, persistent, onWidthChange, className, children }: {
     /** Docked (in the flow, pushing the content). False = the edge sliver + hover drawer. */
     open: boolean
     /** The lock: docks a peeked rail, closes a docked one. */
@@ -45,6 +45,12 @@ export function SecondaryRail({ open, onTogglePin, widthStorageKey, edgeDot = fa
     /** Rendered directly in the <aside>, mounted in BOTH modes — for hidden
      *  inputs that must survive the dock/collapse remount of the body. */
     persistent?: ReactNode
+    /** Reports the docked width — on mount and live through an edge drag —
+     *  for a parent whose own pane must track the rail (Code's middle pane). */
+    onWidthChange?: (width: number) => void
+    /** Extra classes for the aside — e.g. `border-r-0` when the neighboring
+     *  pane draws the divider itself. */
+    className?: string
     children: (ctx: SecondaryRailContext) => ReactNode
 }) {
     // Docked width: drag the rail's right edge. The drawer uses the same width.
@@ -52,6 +58,8 @@ export function SecondaryRail({ open, onTogglePin, widthStorageKey, edgeDot = fa
         const stored = Number(localStorage.getItem(widthStorageKey))
         return Number.isFinite(stored) && stored >= WIDTH_MIN && stored <= WIDTH_MAX ? stored : WIDTH_DEFAULT
     })
+    // Layout effect so a tracking parent resizes in the same paint.
+    useLayoutEffect(() => { onWidthChange?.(width) }, [width, onWidthChange])
     const [resizingWidth, setResizingWidth] = useState(false)
     const startWidthResize = (e: React.MouseEvent) => {
         e.preventDefault()
@@ -139,6 +147,7 @@ export function SecondaryRail({ open, onTogglePin, widthStorageKey, edgeDot = fa
                 open ? 'z-10 overflow-hidden bg-[var(--rowboat-panel-soft)]' : 'overflow-visible bg-background',
                 // The drawer rides over the content's own sticky layers (z-20).
                 !open && (peek ? 'z-30' : 'z-10'),
+                className,
             )}
         >
             {persistent}


### PR DESCRIPTION
## What

Revamps the Code section's session sidebar:

- **Shared shell**: the session rail now renders inside `SecondaryRail` — the same shell component behind the Spaces and Email rails — inheriting the panel chrome and a drag-resizable right edge, persisted per surface (`code:railWidth`).
- **Two-line session cards**: each session is now a taller, easier-to-click card — title with the relative time on the first line, the worktree branch below it in muted text (or the agent name for in-repo sessions, so every card keeps its shape).
- **Status moved into a gutter dot**: quiet grey at rest, the attention color pulsing when a session needs you, the git accent while an agent works. The word prefixes ("Working" / "Needs you") are gone.
- **Subtler working animation**: the orbiting card outline is replaced by a soft ripple on the working session's dot (`.code-working-dot`, reduced-motion aware) — the live session still reads at a glance, but nothing lights the card.

## How

- `SecondaryRail` gains an optional `onWidthChange` (reports the docked width before paint, live through a drag) and a `className` passthrough for the aside.
- App sizes the code middle pane to the width the rail reports instead of the old fixed `CODE_RAIL_WIDTH`, so drag-resizing tracks live and persists; the rail drops its right border while the chat pane beside it draws the divider.
- The rail stays permanently docked (`open` pinned true): in code mode the rail IS the middle pane — header above, `overflow-hidden` — so the collapsed-sliver/hover-peek mode would squish the header and clip the drawer. Enabling it needs a pane-level restructure, left for a follow-up.

## Testing

- Renderer typecheck clean; all 458 renderer tests pass (including the existing `secondary-rail` and `email-rail` suites).
- Live-drove a scratch Electron instance: verified the cards (branch line, agent fallback), pane hugging the rail exactly (280/280), live tracking during a drag with persistence (340 → `code:railWidth`), a single divider beside the chat pane, dark mode, and the dot ripple across animation frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)