### PR TITLE
fix(x): Spaces — cached roster and thread snapshots end the member-id flash and reply-open delay

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input'
 import { AddOrgDialog, OrgMonogram, type SpaceSelection } from '@/components/spaces-view'
 import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { prefetchStream, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
+import { prefetchMembers } from '@/hooks/use-space-members'
 import { bumpSpaceUse, readSpaceUse, spaceUseKey } from '@/lib/space-usage'
 import { toast } from '@/lib/toast'
 
@@ -226,9 +227,12 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                         <SidebarMenuButton
                             isActive={active}
                             onClick={() => onOpenSpace(org.id, space.id)}
-                            // Hover = intent: warm the cached tail + start the
-                            // refresh, so the click paints instantly.
-                            onMouseEnter={() => prefetchStream(org.id, space.id)}
+                            // Hover = intent: warm the cached tail + roster and
+                            // start the refresh, so the click paints instantly.
+                            onMouseEnter={() => {
+                                prefetchStream(org.id, space.id)
+                                prefetchMembers(org.id, space.id)
+                            }}
                             className="pl-9"
                         >
                             {/* A space is a channel — # says so. */}

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -18,6 +18,7 @@ import { SpaceSearch } from '@/components/spaces/space-search'
 import { railKey, type RailSelection } from '@/lib/spaces-selection'
 import { ThreadPane } from '@/components/spaces/thread-pane'
 import { STREAM_READ_KEY, useSpacePresence, useStream } from '@/hooks/use-space-chat'
+import { refreshMembers, useSpaceMembers } from '@/hooks/use-space-members'
 import { useSpaceFeed, useSpaceLastReadAt, useSpaceLive, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { useSpaceNotifyPrefs, type NotifyLevel } from '@/hooks/use-spaces-notify'
 import { requestJump } from '@/lib/spaces-jump'
@@ -194,7 +195,6 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     /** False while the Spaces view is kept mounted but hidden. */
     active?: boolean
 }) {
-    const [members, setMembers] = useState<spaces.Member[]>([])
     const [entries, setEntries] = useState<spaces.SpacesAssetEntry[]>([])
     // Local-only empty folders: folders are key prefixes, so an empty one has
     // nothing to store — it lives here until its first file lands (then the
@@ -207,6 +207,9 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     const stream = useStream(org.id, space.id)
     const presence = useSpacePresence(org.id, space.id, org.memberId)
     const lastReadAt = useSpaceLastReadAt(org.id, space.id)
+    // The roster comes from the module store (cached, hydrated in render) so
+    // names resolve in the same first frame as the stream's cached tail.
+    const members = useSpaceMembers(org.id, space.id)
     const memberNames = useMemo(() => new Map(members.map((m) => [m.id, m.displayName])), [members])
 
     // The artifacts rail: open by default when a thread has artifacts, collapsed
@@ -215,13 +218,12 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
 
     useEffect(() => {
         let cancelled = false
-        void Promise.all([
-            window.ipc.invoke('spaces:listMembers', { orgId: org.id, spaceId: space.id }),
-            window.ipc.invoke('spaces:listAssets', { orgId: org.id, spaceId: space.id }),
-        ])
-            .then(([membersRes, assetsRes]) => {
+        // The roster store fetches on its own mount; the tick keeps it fresh
+        // on live activity (throttled inside — one refetch per burst).
+        refreshMembers(org.id, space.id)
+        void window.ipc.invoke('spaces:listAssets', { orgId: org.id, spaceId: space.id })
+            .then((assetsRes) => {
                 if (cancelled) return
-                setMembers(membersRes.members)
                 setEntries(assetsRes.entries)
             })
             .catch(() => {

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -7,7 +7,7 @@ import { DayDivider, MessageRow, NewDivider, TypingIndicator, type ThreadRowData
 import type { SpacePresence, StreamState } from '@/hooks/use-space-chat'
 import {
     STREAM_READ_KEY, buildPendingMessage, failPendingStreamMessage, ingestStreamMessage, loadOlderStreamMessages,
-    removeStreamMessage, resolvePendingStreamMessage, updateStreamMessage, usePresenceSender,
+    prefetchThread, removeStreamMessage, resolvePendingStreamMessage, updateStreamMessage, usePresenceSender,
 } from '@/hooks/use-space-chat'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { subscribeComposeInsert } from '@/lib/spaces-compose'
@@ -586,6 +586,7 @@ export function GeneralStream({
                 thread={thread}
                 selfMemberId={org.memberId}
                 onOpenThread={onOpenThread}
+                onPrefetchThread={(id) => prefetchThread(org.id, space.id, id)}
                 onReplyInThread={replyInThread}
                 onAskRowboat={askRowboat}
                 onCopyLink={(m) => void copyLink(m)}

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -126,7 +126,7 @@ export interface ThreadRowData {
 }
 
 function MessageRowImpl({
-    message, memberNames, continuation, thread, onOpenThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onQuoteReply, onForward, onToggleSave, saved, onRetryFailed, onDiscardFailed, onVotePoll, onRemovePollVote, onEndPoll, dense, selfMemberId,
+    message, memberNames, continuation, thread, onOpenThread, onPrefetchThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onQuoteReply, onForward, onToggleSave, saved, onRetryFailed, onDiscardFailed, onVotePoll, onRemovePollVote, onEndPoll, dense, selfMemberId,
 }: {
     message: spaces.Message & { pending?: boolean; failed?: boolean }
     memberNames: Map<string, string>
@@ -136,6 +136,8 @@ function MessageRowImpl({
     /** Present when a thread hangs under this message (stream only). */
     thread?: ThreadRowData | null
     onOpenThread?: (rootMessageId: string) => void
+    /** Hover = intent: warm the thread's replies so the click paints instantly. */
+    onPrefetchThread?: (rootMessageId: string) => void
     onReplyInThread?: (message: spaces.Message) => void
     onAskRowboat?: (message: spaces.Message) => void
     onCopyLink?: (message: spaces.Message) => void
@@ -322,6 +324,7 @@ function MessageRowImpl({
                     <button
                         type="button"
                         onClick={() => onOpenThread(thread.rootMessageId)}
+                        onMouseEnter={() => onPrefetchThread?.(thread.rootMessageId)}
                         className={cn(
                             'group/thread mt-1.5 flex w-full max-w-2xl items-center gap-2 rounded-md border border-transparent px-2 py-1 text-left text-xs transition-colors hover:border-border hover:bg-[var(--rowboat-raised)]',
                             thread.archived && 'opacity-60',

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -17,7 +17,7 @@ import { FileTree } from '@/components/spaces/files-tab'
 import { refreshSpaceFeed } from '@/hooks/use-spaces'
 import type { NotifyLevel, SpaceNotifyHandle } from '@/hooks/use-spaces-notify'
 import type { SpacePresence, StreamState } from '@/hooks/use-space-chat'
-import { STREAM_READ_KEY } from '@/hooks/use-space-chat'
+import { prefetchThread, STREAM_READ_KEY } from '@/hooks/use-space-chat'
 import { useMemberNames } from '@/components/spaces/member-text'
 import { threadRefOf } from '@/lib/spaces-conventions'
 import { formatFeedTime, resolveMentions } from '@/lib/spaces-presentation'
@@ -343,6 +343,8 @@ export function SpaceRail({
                                                     <button
                                                         type="button"
                                                         onClick={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}
+                                                        // Hover = intent: warm the replies so the click paints instantly.
+                                                        onMouseEnter={() => prefetchThread(orgId, spaceId, topic.rootMessageId)}
                                                         // The row shows only what changes what you do next: unread,
                                                         // a Rowboat at work, muted. The full title, replies, recency
                                                         // and touched files ride the tooltip — the list is already

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -13,7 +13,7 @@ import { MemberName, MemberText } from '@/components/spaces/member-text'
 import { SpaceMarkdown } from '@/components/spaces/space-markdown'
 import { MessageRow, NewDivider, TypingIndicator } from '@/components/spaces/message-row'
 import type { ChatMessage, SpacePresence } from '@/hooks/use-space-chat'
-import { buildPendingMessage, ingestTopic, removeTopicByRoot, updateStreamMessage, usePresenceSender } from '@/hooks/use-space-chat'
+import { buildPendingMessage, getThreadSnapshot, ingestTopic, putThreadSnapshot, removeTopicByRoot, updateStreamMessage, usePresenceSender } from '@/hooks/use-space-chat'
 import { useTopicAgentPermissionWait } from '@/hooks/use-topic-agent-permission'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { subscribeComposeInsert } from '@/lib/spaces-compose'
@@ -72,15 +72,22 @@ export function ThreadPane({
     /** False while kept mounted but off screen (read mode, hidden Spaces view) — no presence, no read marks. */
     visible?: boolean
 }) {
-    const [root, setRoot] = useState<spaces.Message | null>(rootFromStream ?? null)
-    const [topic, setTopic] = useState<spaces.Topic | null>(topicFromStream ?? null)
-    const [messages, setMessages] = useState<ChatMessage[]>([])
-    const [loaded, setLoaded] = useState(false)
-    const [hasMore, setHasMore] = useState(false)
+    // The cached copy from the last open — plus any replies that streamed in
+    // live while the pane was closed. Seeding paints the whole thread in the
+    // first frame; the fetch below reconciles right behind it. A PARTIAL
+    // snapshot (live replies grafted without a full fetch) paints too, but
+    // doesn't count as loaded — earlier replies may still be missing.
+    const [seeded] = useState(() => getThreadSnapshot(org.id, space.id, rootMessageId))
+    const [root, setRoot] = useState<spaces.Message | null>(rootFromStream ?? seeded?.root ?? null)
+    const [topic, setTopic] = useState<spaces.Topic | null>(topicFromStream ?? seeded?.topic ?? null)
+    const [messages, setMessages] = useState<ChatMessage[]>(seeded?.messages ?? [])
+    const [loaded, setLoaded] = useState(!!seeded && !seeded.partial)
+    const [hasMore, setHasMore] = useState(seeded?.hasMore ?? false)
     const [loadingOlder, setLoadingOlder] = useState(false)
     // The deepest (oldest) offset any fetch has reached — a refetch of the
     // newest page must not reset hasMore after the reader paged further back.
-    const oldestLoadedRef = useRef<number | null>(null)
+    // Starts at the cache's depth: hasMore above describes exactly that.
+    const oldestLoadedRef = useRef<number | null>(seeded?.messages[0]?.offset ?? null)
     const [folding, setFolding] = useState(false)
     const bottomRef = useRef<HTMLDivElement | null>(null)
     const scrollRef = useRef<HTMLDivElement | null>(null)
@@ -159,6 +166,17 @@ export function ThreadPane({
             cancelled = true
         }
     }, [org.id, space.id, rootMessageId, refreshTick])
+    // Write the settled thread back to the cache: the next open (and live
+    // replies arriving while it is closed) paints from it, no round trip.
+    useEffect(() => {
+        if (!loaded || !root) return
+        putThreadSnapshot(org.id, space.id, rootMessageId, {
+            root,
+            topic,
+            messages: messages.filter((m) => !m.pending && !m.failed),
+            hasMore,
+        })
+    }, [org.id, space.id, rootMessageId, loaded, root, topic, messages, hasMore])
     // Refetches that landed while hidden left the thread unread on purpose —
     // becoming visible again is the moment the reader actually sees them.
     useEffect(() => {

--- a/apps/x/apps/renderer/src/hooks/use-space-chat.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-chat.ts
@@ -361,8 +361,14 @@ function wireBus(): void {
         if (!state) return
         if (frame.event.type === 'message') {
             const message = frame.event.message
-            if (message.threadRoot === undefined) ingestStreamMessage(event.orgId, frame.spaceId, message)
-            else noteReplyActivity(event.orgId, frame.spaceId, message)
+            if (message.threadRoot === undefined) {
+                ingestStreamMessage(event.orgId, frame.spaceId, message)
+            } else {
+                // Cache the body first (while the chip denorm still reflects
+                // the count BEFORE this reply), then bump the chip.
+                ingestThreadReply(event.orgId, frame.spaceId, message)
+                noteReplyActivity(event.orgId, frame.spaceId, message)
+            }
         } else if (frame.event.type === 'topic') {
             ingestTopic(event.orgId, frame.spaceId, frame.event.topic)
         } else if (frame.event.type === 'topic_removed') {
@@ -489,6 +495,172 @@ export function useStream(orgId: string, spaceId: string): StreamState {
         }
     }, [orgId, spaceId])
     return state.get(key(orgId, spaceId)) ?? EMPTY_STREAM
+}
+
+// ---------------------------------------------------------------------------
+// Thread cache — the replies behind each chip. ThreadPane owns its working
+// copy (optimistic sends, edits and votes fold into its local state), so this
+// is not a live store: it is what lets a thread PAINT before its fetch lands.
+// The pane seeds from here on mount and writes back what it settles; live
+// replies land here even while no pane is open (they used to be dropped after
+// bumping the chip, and re-fetched on every open); hovering a chip warms it.
+// Persisted per space (bounded) like the stream's tail.
+// ---------------------------------------------------------------------------
+
+export interface ThreadSnapshot {
+    root: spaces.Message
+    topic: spaces.Topic | null
+    /** Settled replies only — pending/failed rows never cache. */
+    messages: spaces.Message[]
+    hasMore: boolean
+    /** Grafted from live replies without a full fetch — earlier replies may be missing. */
+    partial?: boolean
+}
+
+const THREAD_CACHE_VERSION = 1
+/** Most-recently-touched threads persisted per space. */
+const THREAD_CACHE_MAX = 10
+/** Newest replies kept per persisted thread. */
+const THREAD_CACHE_TAIL = 30
+/** Hover fires often — one warm fetch per thread per half-minute is plenty. */
+const THREAD_PREFETCH_MIN_MS = 30_000
+
+interface ThreadCacheEntry { snapshot: ThreadSnapshot; touchedAt: number }
+interface ThreadsCache { v: number; threads: Record<string, ThreadCacheEntry> }
+
+function threadCacheKey(k: string): string {
+    return `spaces:threads:${k}`
+}
+
+/** `${orgId}/${spaceId}` → rootMessageId → cached thread. */
+const threadCaches = new Map<string, Map<string, ThreadCacheEntry>>()
+const threadsHydrated = new Set<string>()
+const threadPrefetching = new Set<string>()
+const threadFetchedAt = new Map<string, number>()
+
+/** Seed a space's thread cache from the persisted copy. Render-safe: no emits, idempotent. */
+function hydrateThreads(k: string): void {
+    if (threadsHydrated.has(k)) return
+    threadsHydrated.add(k)
+    try {
+        const raw = window.localStorage.getItem(threadCacheKey(k))
+        if (!raw) return
+        const cached = JSON.parse(raw) as ThreadsCache
+        if (cached.v !== THREAD_CACHE_VERSION || typeof cached.threads !== 'object' || cached.threads === null) return
+        threadCaches.set(k, new Map(Object.entries(cached.threads)))
+    } catch {
+        // A corrupt entry paints nothing; opens just fetch.
+    }
+}
+
+function threadSpaceCache(k: string): Map<string, ThreadCacheEntry> {
+    hydrateThreads(k)
+    let cache = threadCaches.get(k)
+    if (!cache) {
+        cache = new Map()
+        threadCaches.set(k, cache)
+    }
+    return cache
+}
+
+function persistThreads(k: string): void {
+    const cache = threadCaches.get(k)
+    if (!cache) return
+    const kept = [...cache.entries()].sort((a, b) => b[1].touchedAt - a[1].touchedAt).slice(0, THREAD_CACHE_MAX)
+    const threads: Record<string, ThreadCacheEntry> = {}
+    for (const [rootId, entry] of kept) {
+        const tail = entry.snapshot.messages.slice(-THREAD_CACHE_TAIL)
+        threads[rootId] = {
+            touchedAt: entry.touchedAt,
+            snapshot: {
+                ...entry.snapshot,
+                messages: tail,
+                // A truncated tail reaches less deep than what was loaded.
+                hasMore: entry.snapshot.hasMore || tail.length < entry.snapshot.messages.length,
+            },
+        }
+    }
+    try {
+        window.localStorage.setItem(threadCacheKey(k), JSON.stringify({ v: THREAD_CACHE_VERSION, threads } satisfies ThreadsCache))
+    } catch {
+        // Best-effort (quota, private mode) — cold opens just fetch.
+    }
+}
+
+/** The cached thread behind a chip, if any — ThreadPane seeds from this so opening paints instantly. */
+export function getThreadSnapshot(orgId: string, spaceId: string, rootMessageId: string): ThreadSnapshot | undefined {
+    return threadSpaceCache(key(orgId, spaceId)).get(rootMessageId)?.snapshot
+}
+
+/** ThreadPane writes back what it settled (prefetch writes too); the next open paints from it. */
+export function putThreadSnapshot(orgId: string, spaceId: string, rootMessageId: string, snapshot: ThreadSnapshot): void {
+    const k = key(orgId, spaceId)
+    threadSpaceCache(k).set(rootMessageId, { snapshot, touchedAt: Date.now() })
+    // A full snapshot counts as a fetch for the hover-prefetch throttle.
+    if (!snapshot.partial) threadFetchedAt.set(`${k}/${rootMessageId}`, Date.now())
+    persistThreads(k)
+}
+
+/**
+ * Warm a thread before it opens (hovering its chip calls this): fetch the
+ * newest page into the cache, so the click that follows paints everything.
+ * Throttled — hover is a noisy signal.
+ */
+export function prefetchThread(orgId: string, spaceId: string, rootMessageId: string): void {
+    const k = key(orgId, spaceId)
+    const tk = `${k}/${rootMessageId}`
+    if (threadPrefetching.has(tk)) return
+    if (Date.now() - (threadFetchedAt.get(tk) ?? 0) < THREAD_PREFETCH_MIN_MS) return
+    threadPrefetching.add(tk)
+    void window.ipc
+        .invoke('spaces:listThread', { orgId, spaceId, rootMessageId })
+        .then((res) => {
+            putThreadSnapshot(orgId, spaceId, rootMessageId, {
+                root: res.root,
+                topic: res.topic ?? null,
+                messages: res.messages,
+                hasMore: res.hasMore,
+            })
+        })
+        .catch(() => {})
+        .finally(() => threadPrefetching.delete(tk))
+}
+
+/**
+ * A reply streamed in over the live bus: keep the body. Into the cached
+ * snapshot when the thread has one; otherwise grafted onto the stream's copy
+ * of the root as a PARTIAL snapshot, so even a first open paints this reply
+ * while its fetch runs.
+ */
+function ingestThreadReply(orgId: string, spaceId: string, reply: spaces.Message): void {
+    const rootId = reply.threadRoot
+    if (!rootId) return
+    const k = key(orgId, spaceId)
+    const cache = threadSpaceCache(k)
+    const entry = cache.get(rootId)
+    if (entry) {
+        if (entry.snapshot.messages.some((m) => m.id === reply.id)) return
+        cache.set(rootId, {
+            touchedAt: Date.now(),
+            snapshot: { ...entry.snapshot, messages: mergeMessages(entry.snapshot.messages, [reply]) },
+        })
+    } else {
+        const state = streamState.get(k)
+        const root = state?.messages.find((m) => m.id === rootId)
+        if (!root || root.pending || root.failed) return
+        cache.set(rootId, {
+            touchedAt: Date.now(),
+            snapshot: {
+                root,
+                topic: state?.topicsByRoot.get(rootId) ?? null,
+                messages: [reply],
+                // Replies before this one may exist below the graft.
+                hasMore: (root.replyCount ?? 0) > 0,
+                partial: true,
+            },
+        })
+    }
+    persistThreads(k)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/x/apps/renderer/src/hooks/use-space-members.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-members.ts
@@ -1,0 +1,134 @@
+import { useEffect, useSyncExternalStore } from 'react'
+import type { spaces } from '@x/shared'
+
+// The space roster, module-level and persisted per install (localStorage),
+// like the stream's cached tail: names must paint in the same first frame as
+// the messages beside them. A roster held in component state arrives a round
+// trip after the cached messages, so every (re)mount of the pane showed raw
+// member ids in the author lines until the fetch landed.
+
+function key(orgId: string, spaceId: string): string {
+    return `${orgId}/${spaceId}`
+}
+
+const CACHE_VERSION = 1
+
+function cacheKey(k: string): string {
+    return `spaces:members:${k}`
+}
+
+interface MembersCache {
+    v: number
+    members: spaces.Member[]
+}
+
+const EMPTY_MEMBERS: spaces.Member[] = []
+
+let memberState: ReadonlyMap<string, spaces.Member[]> = new Map()
+const listeners = new Set<() => void>()
+const membersLoading = new Set<string>()
+/** Keys painted from the cache and not yet confirmed by the org. */
+const membersCacheOnly = new Set<string>()
+const lastLoadedAt = new Map<string, number>()
+/** Live activity is coarse (every event ticks) — one roster refetch per burst is plenty. */
+const REFRESH_MIN_MS = 5_000
+
+function emitMembers(): void {
+    for (const l of listeners) l()
+}
+
+function setMembers(k: string, members: spaces.Member[]): void {
+    const prev = memberState.get(k)
+    // Identity-stable: a refetch that changed nothing must not re-render
+    // every name in the pane (or rewrite the cache entry).
+    if (prev && JSON.stringify(prev) === JSON.stringify(members)) return
+    const next = new Map(memberState)
+    next.set(k, members)
+    memberState = next
+    try {
+        window.localStorage.setItem(cacheKey(k), JSON.stringify({ v: CACHE_VERSION, members } satisfies MembersCache))
+    } catch {
+        // Best-effort (quota, private mode) — cold opens just fetch.
+    }
+    emitMembers()
+}
+
+/**
+ * Seed module state from the persisted cache. Render-safe on purpose: it
+ * swaps the snapshot WITHOUT notifying listeners, so useSpaceMembers can call
+ * it during render and the pane's very first frame already resolves names.
+ * Idempotent once state exists.
+ */
+function hydrateMembers(k: string): void {
+    if (memberState.has(k)) return
+    try {
+        const raw = window.localStorage.getItem(cacheKey(k))
+        if (!raw) return
+        const cached = JSON.parse(raw) as MembersCache
+        if (cached.v !== CACHE_VERSION || !Array.isArray(cached.members)) return
+        membersCacheOnly.add(k)
+        const next = new Map(memberState)
+        next.set(k, cached.members)
+        memberState = next
+    } catch {
+        // A corrupt entry resolves nothing; the fetch rebuilds it.
+    }
+}
+
+async function loadMembers(orgId: string, spaceId: string): Promise<void> {
+    const k = key(orgId, spaceId)
+    if (membersLoading.has(k)) return
+    membersLoading.add(k)
+    try {
+        const res = await window.ipc.invoke('spaces:listMembers', { orgId, spaceId })
+        membersCacheOnly.delete(k)
+        lastLoadedAt.set(k, Date.now())
+        setMembers(k, res.members)
+    } catch {
+        // org unreachable — cached names (or ids) stand until a retry.
+    } finally {
+        membersLoading.delete(k)
+    }
+}
+
+/**
+ * Warm a space's roster before it opens (the sidebar calls this on hover,
+ * beside prefetchStream): hydrate the cached copy and start the refresh, so
+ * the click that follows finds every name already in.
+ */
+export function prefetchMembers(orgId: string, spaceId: string): void {
+    const k = key(orgId, spaceId)
+    hydrateMembers(k)
+    if (!memberState.has(k) || membersCacheOnly.has(k)) void loadMembers(orgId, spaceId)
+}
+
+/**
+ * Refetch on live activity. The pane's tick fires on EVERY event (and on
+ * resubscribe), so this throttles: membership changes ride the next quiet
+ * moment, not every message in a burst.
+ */
+export function refreshMembers(orgId: string, spaceId: string): void {
+    const k = key(orgId, spaceId)
+    if (Date.now() - (lastLoadedAt.get(k) ?? 0) < REFRESH_MIN_MS) return
+    void loadMembers(orgId, spaceId)
+}
+
+/** The space's roster: cached names in the first frame, refreshed behind. */
+export function useSpaceMembers(orgId: string, spaceId: string): spaces.Member[] {
+    // Before the snapshot read, not in an effect: a revisited space must
+    // resolve names in its FIRST frame, beside the stream's cached tail.
+    hydrateMembers(key(orgId, spaceId))
+    const state = useSyncExternalStore(
+        (l) => {
+            listeners.add(l)
+            return () => {
+                listeners.delete(l)
+            }
+        },
+        () => memberState,
+    )
+    useEffect(() => {
+        void loadMembers(orgId, spaceId)
+    }, [orgId, spaceId])
+    return state.get(key(orgId, spaceId)) ?? EMPTY_MEMBERS
+}


### PR DESCRIPTION
## Summary

Two Spaces symptoms with one root cause: the message stream caches aggressively (module store + localStorage, hydrated synchronously in render) but the member roster and thread replies did not. So every pane mount painted cached messages beside **raw member ids** for a round trip, and every click on "N replies" was a **cold `listThread` fetch**.

### Member-id flash
- New `hooks/use-space-members.ts`: a module store persisted per space (`spaces:members:<org>/<space>`), hydrated in render so names resolve in the same first frame as the stream's cached tail, then refreshed stale-while-revalidate.
- Live-activity refreshes are throttled (5s), which also removes the redundant second `listMembers` that fired on every resubscribe.
- Sidebar hover now warms the roster alongside the existing `prefetchStream`.

### Reply-open delay
- Thread cache in `use-space-chat.ts`: bounded per-space snapshots (10 most-recent threads, 30-reply tail; root + topic + hasMore) persisted like the stream tail. `ThreadPane` seeds from it on mount — reopening a thread paints instantly while its fetch reconciles behind — and writes back what it settles.
- Live replies are **kept instead of dropped**: the WS bus folds reply bodies into the cache before bumping the chip denorm. A reply to a never-opened thread grafts a *partial* snapshot onto the stream's copy of the root, so even a first open paints it while the fetch runs (partial seeds don't count as loaded, so read-marking still waits for real data).
- Hover prefetch (30s throttle) on both paths into a thread: the replies chip in the stream and the discussion rows in the rail.

Renderer-only — no wire, main-process, or server changes, so dual-mode behavior is untouched.

## Test plan

- `tsc -b` clean; eslint findings on touched files verified identical to the pre-change tree (pre-existing `react-hooks/refs` idioms).
- `vitest run`: 45 files / 458 tests pass.
- Manual: switch out of and back into Spaces (names paint in first frame), reopen a thread (replies paint instantly, background refetch reconciles), reply from a second account with the thread closed then open it (reply already visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)