### PR TITLE
feat(x): Spaces — WYSIWYG composer on TipTap (Slack-style live formatting)

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { caretContext, composerExtensions, composerMarkdown } from './composer-editor'
+
+// The composer's contract: what the editor holds serializes back to the
+// exact markdown the wire (and every downstream consumer: drafts, slash
+// commands, @rowboat detection) expects. These tests pin that round trip.
+
+let editors: Editor[] = []
+
+function makeEditor(content = ''): Editor {
+    const editor = new Editor({
+        element: document.createElement('div'),
+        extensions: composerExtensions(() => ''),
+        content,
+    })
+    editors.push(editor)
+    return editor
+}
+
+afterEach(() => {
+    for (const e of editors) e.destroy()
+    editors = []
+})
+
+describe('markdown round trip', () => {
+    const cases: [string, string][] = [
+        ['plain text', 'hello world'],
+        ['bold', '**bold** text'],
+        ['italic', 'an *italic* word'],
+        ['strike', '~~gone~~ now'],
+        ['inline code', 'run `npm test` now'],
+        ['link', '[docs](https://example.com)'],
+        ['bullet list', '- one\n- two'],
+        ['ordered list', '1. one\n2. two'],
+        ['blockquote', '> quoted'],
+        ['code block', '```\nconst x = 1\nconst y = 2\n```'],
+        ['image', '![](https://example.com/cat.gif)'],
+        ['two paragraphs', 'first\n\nsecond'],
+        ['slash command draft', '/ask how do I ship this'],
+        ['mention text', '@Ada Lovelace can you look?'],
+    ]
+    it.each(cases)('%s', (_name, md) => {
+        expect(composerMarkdown(makeEditor(md))).toBe(md)
+    })
+
+    it('serializes an empty doc to the empty string', () => {
+        expect(composerMarkdown(makeEditor(''))).toBe('')
+    })
+})
+
+describe('formatting commands produce wire markdown', () => {
+    it('toggleBold', () => {
+        const e = makeEditor('hello')
+        e.chain().selectAll().toggleBold().run()
+        expect(composerMarkdown(e)).toBe('**hello**')
+    })
+
+    it('toggleStrike', () => {
+        const e = makeEditor('hello')
+        e.chain().selectAll().toggleStrike().run()
+        expect(composerMarkdown(e)).toBe('~~hello~~')
+    })
+
+    it('toggleBulletList', () => {
+        const e = makeEditor('hello')
+        e.chain().selectAll().toggleBulletList().run()
+        expect(composerMarkdown(e)).toBe('- hello')
+    })
+
+    it('toggleBlockquote', () => {
+        const e = makeEditor('hello')
+        e.chain().selectAll().toggleBlockquote().run()
+        expect(composerMarkdown(e)).toBe('> hello')
+    })
+
+    it('toggleCodeBlock turns the paragraph into a fence', () => {
+        const e = makeEditor('hello')
+        e.chain().selectAll().toggleCodeBlock().run()
+        expect(composerMarkdown(e)).toBe('```\nhello\n```')
+    })
+
+    it('text typed inside a code block keeps literal markdown characters', () => {
+        const e = makeEditor('```\nhello\n```')
+        e.chain().focus('end').insertContent({ type: 'text', text: ' *raw*' }).run()
+        expect(composerMarkdown(e)).toBe('```\nhello *raw*\n```')
+    })
+
+    it('literal text inserted as a text node survives as text (escaped on the wire)', () => {
+        const e = makeEditor('')
+        e.chain().insertContent({ type: 'text', text: 'a * b _c_' }).run()
+        const md = composerMarkdown(e)
+        expect(e.getText()).toBe('a * b _c_')
+        // Whatever escaping the serializer chose, it must parse back to the same text.
+        expect(makeEditor(md).getText()).toBe('a * b _c_')
+    })
+})
+
+describe('caretContext', () => {
+    it('reports the text before the caret in the current block', () => {
+        const e = makeEditor('hello @ro')
+        e.commands.focus('end')
+        expect(caretContext(e)).toEqual({ text: 'hello @ro', from: e.state.selection.from })
+    })
+
+    it('reads a hard break as a newline, so "@" after Shift+Enter sits on a word boundary', () => {
+        const e = makeEditor('hello')
+        e.chain().focus('end').setHardBreak().insertContent({ type: 'text', text: '@ro' }).run()
+        expect(caretContext(e)?.text).toBe('hello\n@ro')
+    })
+
+    it('is null for a range selection and inside code', () => {
+        const e = makeEditor('hello')
+        e.commands.selectAll()
+        expect(caretContext(e)).toBeNull()
+        const code = makeEditor('```\nx\n```')
+        code.commands.focus('end')
+        expect(caretContext(code)).toBeNull()
+    })
+})

--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.ts
@@ -1,0 +1,82 @@
+import { Extension, type Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import Image from '@tiptap/extension-image'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Markdown } from 'tiptap-markdown'
+
+// The Spaces composer's TipTap setup. The editor is the input surface only —
+// markdown stays the wire format: tiptap-markdown parses drafts/seeds INTO
+// the doc, and composerMarkdown() serializes the doc back out on every
+// update, so everything downstream of the composer (drafts, slash commands,
+// @rowboat detection, buildBody) keeps operating on the same markdown string
+// a textarea used to hold. StarterKit's input rules give the Slack behavior
+// of `**bold**` converting live as you type.
+
+/**
+ * Slack's formatting chords on top of TipTap's defaults (⌘B/⌘I bold/italic,
+ * ⌘E code, ⌘⇧7/8 ordered/bullet come built in).
+ */
+const ChatFormatKeys = Extension.create({
+    name: 'chatFormatKeys',
+    addKeyboardShortcuts() {
+        return {
+            'Mod-Shift-x': () => this.editor.commands.toggleStrike(),
+            'Mod-Shift-c': () => this.editor.commands.toggleCode(),
+            'Mod-Shift-9': () => this.editor.commands.toggleBlockquote(),
+            'Mod-Alt-Shift-c': () => this.editor.commands.toggleCodeBlock(),
+        }
+    },
+})
+
+/**
+ * The chat editor's extension set. `getPlaceholder` is read per render so a
+ * changing placeholder prop never needs an editor rebuild.
+ */
+export function composerExtensions(getPlaceholder: () => string) {
+    return [
+        StarterKit.configure({ link: false }),
+        Link.configure({ openOnClick: false, autolink: true }),
+        // Pasted GIF/image links become the image itself (matches what the
+        // message will show); serializes back to ![](url).
+        Image,
+        Placeholder.configure({ placeholder: () => getPlaceholder() }),
+        Markdown.configure({
+            html: false,
+            breaks: true,
+            tightLists: true,
+            // Pastes stay literal text — a pasted `*` must not turn italic.
+            transformPastedText: false,
+            transformCopiedText: false,
+        }),
+        ChatFormatKeys,
+    ]
+}
+
+/** The doc as wire markdown (tiptap-markdown's serializer), sans trailing newlines. */
+export function composerMarkdown(editor: Editor): string {
+    const storage = editor.storage as unknown as { markdown: { getMarkdown: () => string } }
+    return storage.markdown.getMarkdown().replace(/\n+$/, '')
+}
+
+/** The caret's text block up to the caret — what the @/:emoji: triggers match against. */
+export interface CaretContext {
+    text: string
+    /** The caret's document position (deleting a trigger counts back from here). */
+    from: number
+}
+
+/**
+ * null when autocompletes have no business firing: a range selection, a code
+ * block or inline-code caret (the same guards the notes editor uses).
+ */
+export function caretContext(editor: Editor): CaretContext | null {
+    const { selection } = editor.state
+    if (!selection.empty) return null
+    const { $from } = selection
+    if (!$from.parent.isTextblock || $from.parent.type.name === 'codeBlock') return null
+    if (editor.isActive('code')) return null
+    // Leaf nodes (hard breaks, images) read as newlines so an "@" right
+    // after a Shift+Enter still sits on a word boundary, like in a textarea.
+    return { text: $from.parent.textBetween(0, $from.parentOffset, '\n', '\n'), from: selection.from }
+}

--- a/apps/x/apps/renderer/src/components/spaces/composer-toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer-toolbar.tsx
@@ -1,4 +1,5 @@
 import { useState, type RefObject } from 'react'
+import { useEditorState, type Editor } from '@tiptap/react'
 import {
     BoldIcon, CodeIcon, CodeSquareIcon, ItalicIcon, LinkIcon, ListIcon, ListOrderedIcon, QuoteIcon, StrikethroughIcon,
 } from 'lucide-react'
@@ -180,6 +181,174 @@ export function FormattingToolbar({ textareaRef, value, onChange, onCaret, class
             {GROUPS[2]!.map(button)}
             {separator}
             {GROUPS[3]!.map(button)}
+        </div>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The same bar, driven by the rich composer's TipTap editor: real commands
+// with pressed states instead of string transforms. (The message editor's
+// textarea still uses FormattingToolbar above.)
+// ---------------------------------------------------------------------------
+
+type RichToolKey = 'bold' | 'italic' | 'strike' | 'ordered' | 'bullet' | 'quote' | 'code' | 'codeblock'
+
+interface RichToolDef {
+    key: RichToolKey
+    title: string
+    icon: typeof BoldIcon
+    run: (editor: Editor) => void
+}
+
+const RICH_GROUPS: RichToolDef[][] = [
+    [
+        { key: 'bold', title: `Bold (${mod}B)`, icon: BoldIcon, run: (e) => e.chain().focus().toggleBold().run() },
+        { key: 'italic', title: `Italic (${mod}I)`, icon: ItalicIcon, run: (e) => e.chain().focus().toggleItalic().run() },
+        { key: 'strike', title: `Strikethrough (${mod}⇧X)`, icon: StrikethroughIcon, run: (e) => e.chain().focus().toggleStrike().run() },
+    ],
+    [
+        { key: 'ordered', title: `Ordered list (${mod}⇧7)`, icon: ListOrderedIcon, run: (e) => e.chain().focus().toggleOrderedList().run() },
+        { key: 'bullet', title: `Bulleted list (${mod}⇧8)`, icon: ListIcon, run: (e) => e.chain().focus().toggleBulletList().run() },
+    ],
+    [
+        { key: 'quote', title: `Blockquote (${mod}⇧9)`, icon: QuoteIcon, run: (e) => e.chain().focus().toggleBlockquote().run() },
+    ],
+    [
+        { key: 'code', title: `Code (${mod}E)`, icon: CodeIcon, run: (e) => e.chain().focus().toggleCode().run() },
+        { key: 'codeblock', title: `Code block (${mod}⌥⇧C)`, icon: CodeSquareIcon, run: (e) => e.chain().focus().toggleCodeBlock().run() },
+    ],
+]
+
+export function RichFormattingToolbar({ editor, className }: { editor: Editor | null; className?: string }) {
+    const [linkOpen, setLinkOpen] = useState(false)
+    // The selection as it stood when the link popover opened — its inputs
+    // steal focus, so the live selection is gone by submit time.
+    const [linkText, setLinkText] = useState('')
+    const [linkUrl, setLinkUrl] = useState('')
+    const active = useEditorState({
+        editor,
+        selector: ({ editor: ed }) =>
+            ed
+                ? {
+                      bold: ed.isActive('bold'),
+                      italic: ed.isActive('italic'),
+                      strike: ed.isActive('strike'),
+                      link: ed.isActive('link'),
+                      ordered: ed.isActive('orderedList'),
+                      bullet: ed.isActive('bulletList'),
+                      quote: ed.isActive('blockquote'),
+                      code: ed.isActive('code'),
+                      codeblock: ed.isActive('codeBlock'),
+                  }
+                : null,
+    })
+    if (!editor) return null
+
+    const openLink = () => {
+        const { from, to } = editor.state.selection
+        setLinkText(editor.state.doc.textBetween(from, to, ' '))
+        setLinkUrl((editor.getAttributes('link').href as string | undefined) ?? '')
+        setLinkOpen(true)
+    }
+
+    const submitLink = () => {
+        const url = linkUrl.trim()
+        if (!url) return
+        const href = /^[a-z][a-z0-9+.-]*:/i.test(url) ? url : `https://${url}`
+        if (active?.link) {
+            // Re-addressing an existing link keeps its text.
+            editor.chain().focus().extendMarkRange('link').setLink({ href }).run()
+        } else {
+            // Replace the selection (or insert at the caret) with linked text,
+            // then a plain space so typing continues unlinked.
+            editor.chain().focus().insertContent([
+                { type: 'text', text: linkText.trim() || href, marks: [{ type: 'link', attrs: { href } }] },
+                { type: 'text', text: ' ' },
+            ]).run()
+        }
+        setLinkOpen(false)
+    }
+
+    const button = (t: RichToolDef) => (
+        <Tooltip key={t.key} delayDuration={400}>
+            <TooltipTrigger asChild>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={t.title}
+                    aria-pressed={active?.[t.key] ?? false}
+                    className={cn('size-7 text-muted-foreground hover:text-foreground', active?.[t.key] && 'bg-accent text-foreground')}
+                    // Keep the editor focused (and its selection alive) through the click.
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => t.run(editor)}
+                >
+                    <t.icon className="size-4" />
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">{t.title}</TooltipContent>
+        </Tooltip>
+    )
+
+    const separator = <span className="mx-1 h-4 w-px shrink-0 bg-border" />
+
+    return (
+        <div className={cn('flex items-center', className)}>
+            {RICH_GROUPS[0]!.map(button)}
+            {separator}
+            <Popover open={linkOpen} onOpenChange={setLinkOpen}>
+                <PopoverTrigger asChild>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Link"
+                        aria-pressed={active?.link ?? false}
+                        className={cn('size-7 text-muted-foreground hover:text-foreground', active?.link && 'bg-accent text-foreground')}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={openLink}
+                    >
+                        <LinkIcon className="size-4" />
+                    </Button>
+                </PopoverTrigger>
+                <PopoverContent align="start" sideOffset={6} className="w-72 p-2.5">
+                    <div className="flex flex-col gap-2">
+                        <Input
+                            placeholder="Text"
+                            value={linkText}
+                            onChange={(e) => setLinkText(e.target.value)}
+                            className="h-8 text-sm"
+                        />
+                        <Input
+                            autoFocus
+                            placeholder="Link"
+                            value={linkUrl}
+                            onChange={(e) => setLinkUrl(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                    e.preventDefault()
+                                    submitLink()
+                                }
+                            }}
+                            className="h-8 text-sm"
+                        />
+                        <div className="flex justify-end gap-1.5">
+                            <Button type="button" variant="ghost" size="sm" className="h-7" onClick={() => setLinkOpen(false)}>
+                                Cancel
+                            </Button>
+                            <Button type="button" size="sm" className="h-7" disabled={!linkUrl.trim()} onClick={submitLink}>
+                                Add
+                            </Button>
+                        </div>
+                    </div>
+                </PopoverContent>
+            </Popover>
+            {separator}
+            {RICH_GROUPS[1]!.map(button)}
+            {separator}
+            {RICH_GROUPS[2]!.map(button)}
+            {separator}
+            {RICH_GROUPS[3]!.map(button)}
         </div>
     )
 }

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import type { EditorView } from '@tiptap/pm/view'
 import { uploadInputFor } from '@/lib/spaces-upload'
 import { ArrowUp, BarChart3, Bot, Clock, FileText, Globe, Loader2, Megaphone, Paperclip, ShieldCheck, Terminal, X as XIcon } from 'lucide-react'
 import type { spaces } from '@x/shared'
@@ -6,13 +8,13 @@ import { cn } from '@/lib/utils'
 import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Textarea } from '@/components/ui/textarea'
 import { ModelSelector } from '@/components/model-selector'
 import type { ModelSelection } from '@/hooks/use-models'
 import { MemberAvatar } from '@/components/spaces/atoms'
-import { FormattingToolbar } from '@/components/spaces/composer-toolbar'
-import { toggleCodeBlock, toggleInline, toggleLinePrefix, type FormatResult } from '@/lib/spaces-format'
+import { caretContext, composerExtensions, composerMarkdown, type CaretContext } from '@/components/spaces/composer-editor'
+import { RichFormattingToolbar } from '@/components/spaces/composer-toolbar'
 import { isDirectImageUrl, useSpaceRefs } from '@/components/spaces/space-markdown'
+import '@/styles/space-composer.css'
 import { noteEmojiUsed, replaceShortcodes, searchEmoji, type EmojiEntry } from '@/lib/emoji-data'
 import { containsRowboatAddress } from '@/lib/spaces-mentions'
 import { schedulePresets } from '@/lib/spaces-schedule'
@@ -122,7 +124,45 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         }
     }, [draftKey, draft])
     const [appliedSeed, setAppliedSeed] = useState<number | null>(null)
-    const ref = useRef<HTMLTextAreaElement | null>(null)
+
+    // ------------------------------------------------------------------
+    // The rich input (TipTap). The editor owns what you see; `draft` is the
+    // serialized markdown mirror, re-derived on every update, so drafts,
+    // slash commands, @rowboat detection and buildBody all keep reading the
+    // exact string a textarea used to hold. Editor callbacks go through
+    // latest-closure refs — the instance is created once per mount.
+    // ------------------------------------------------------------------
+    const placeholderRef = useRef(placeholder)
+    const onTypeRef = useRef(onType)
+    const keydownRef = useRef<(view: EditorView, event: KeyboardEvent) => boolean>(() => false)
+    const pasteRef = useRef<(event: ClipboardEvent) => boolean>(() => false)
+    const dropRef = useRef<(event: DragEvent) => boolean>(() => false)
+    /** Where the caret sits (text-before-caret + doc position) — drives the autocompletes. */
+    const [context, setContext] = useState<CaretContext | null>(null)
+    const [mentionOpen, setMentionOpen] = useState(false)
+
+    const editor = useEditor({
+        // The getter runs inside Placeholder's decoration pass (post-render,
+        // in the editor), never during this render — a false positive here.
+        // eslint-disable-next-line react-hooks/refs
+        extensions: composerExtensions(() => placeholderRef.current),
+        content: draft,
+        autofocus: autoFocus ? 'end' : false,
+        editorProps: {
+            handleKeyDown: (view, event) => keydownRef.current(view, event),
+            handlePaste: (_view, event) => pasteRef.current(event),
+            handleDrop: (_view, event) => dropRef.current(event),
+        },
+        onUpdate: ({ editor: ed }) => {
+            setDraft(composerMarkdown(ed))
+            const ctx = caretContext(ed)
+            setContext(ctx)
+            // Open on "@" at a word start; stay open while the query grows.
+            setMentionOpen(!!ctx && MENTION_RE.test(ctx.text))
+            onTypeRef.current?.()
+        },
+        onSelectionUpdate: ({ editor: ed }) => setContext(caretContext(ed)),
+    })
 
     // --- attachments ---------------------------------------------------------
     const refs = useSpaceRefs()
@@ -197,38 +237,32 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         setDragOver(false)
         addFiles(Array.from(e.dataTransfer.files))
     }
-    const onPaste = (e: React.ClipboardEvent) => {
-        if (refs) {
-            const files = Array.from(e.clipboardData.items)
+    // Pasted files attach; a pasted direct image address (a GIF link) becomes
+    // the image itself, nothing re-hosted — but only when the paste IS the
+    // URL; a URL inside a sentence stays as typed.
+    const handleEditorPaste = (event: ClipboardEvent): boolean => {
+        const data = event.clipboardData
+        if (refs && data) {
+            const files = Array.from(data.items)
                 .filter((item) => item.kind === 'file')
                 .map((item) => item.getAsFile())
                 .filter((f): f is File => f !== null)
             if (files.length > 0) {
-                e.preventDefault()
                 addFiles(files)
-                return
+                return true
             }
         }
-        // A pasted direct image address (a GIF link) becomes the image, not
-        // the URL text — markdown image syntax, nothing re-hosted: the message
-        // keeps pointing at the original. Only when the paste IS the URL;
-        // a URL inside a sentence stays as typed.
-        const text = e.clipboardData.getData('text/plain').trim()
-        if (!text || /\s/.test(text) || !isDirectImageUrl(text)) return
-        e.preventDefault()
-        const el = ref.current
-        const start = el?.selectionStart ?? draft.length
-        const end = el?.selectionEnd ?? draft.length
-        const inserted = `![](${text})`
-        setDraft(draft.slice(0, start) + inserted + draft.slice(end))
-        onType?.()
-        requestAnimationFrame(() => {
-            const node = ref.current
-            if (!node) return
-            const pos = start + inserted.length
-            node.setSelectionRange(pos, pos)
-        })
+        const text = data?.getData('text/plain').trim() ?? ''
+        if (text && !/\s/.test(text) && isDirectImageUrl(text) && editor) {
+            editor.chain().focus().insertContent({ type: 'image', attrs: { src: text } }).run()
+            return true
+        }
+        return false
     }
+    // Files dropped on the editor belong to the container's drop handler (the
+    // overlay + addFiles above) — only stop ProseMirror from inserting.
+    const editorDropGuard = (event: DragEvent): boolean =>
+        !!(refs && event.dataTransfer && Array.from(event.dataTransfer.types).includes('Files'))
 
     // Agent options — only meaningful (and only shown) when @rowboat is addressed.
     const [model, setModel] = useState<ModelSelection | null>(null)
@@ -247,34 +281,28 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         return () => window.removeEventListener('code-mode-config-changed', load)
     }, [])
 
-    // Apply a new seed during render (React's adjust-state-on-prop-change pattern).
-    if (seed && seed.nonce !== appliedSeed) {
-        setAppliedSeed(seed.nonce)
-        // Append (the profile popover's "Mention") joins a draft in progress;
-        // a plain seed replaces it (quote-reply, ask-rowboat).
-        setDraft(seed.append && draft ? `${draft}${/\s$/.test(draft) ? '' : ' '}${seed.text}` : seed.text)
-    }
-    const seedNonce = seed?.nonce ?? null
+    // Apply a new seed by rebuilding the doc from its markdown. Append (the
+    // profile popover's "Mention") joins a draft in progress; a plain seed
+    // replaces it (quote-reply, ask-rowboat). Caret lands at the end.
     useEffect(() => {
-        if (seedNonce === null) return
-        const el = ref.current
-        if (!el) return
-        el.focus()
-        const end = el.value.length
-        el.setSelectionRange(end, end)
-    }, [seedNonce])
+        if (!editor || !seed || seed.nonce === appliedSeed) return
+        setAppliedSeed(seed.nonce)
+        const current = composerMarkdown(editor)
+        const next = seed.append && current ? `${current}${/\s$/.test(current) ? '' : ' '}${seed.text}` : seed.text
+        editor.commands.setContent(next)
+        setDraft(composerMarkdown(editor))
+        editor.commands.focus('end')
+    }, [editor, seed, appliedSeed])
 
     // --- @ autocomplete ------------------------------------------------------
-    const [caret, setCaret] = useState(0)
-    const [mentionOpen, setMentionOpen] = useState(false)
     const [mentionIndex, setMentionIndex] = useState(0)
     const mentionMatch = useMemo(() => {
-        if (!mentionOpen) return null
-        const before = draft.slice(0, caret)
-        const m = MENTION_RE.exec(before)
+        if (!mentionOpen || !context) return null
+        const m = MENTION_RE.exec(context.text)
         if (!m) return null
-        return { query: (m[2] ?? '').toLowerCase(), start: caret - (m[2]?.length ?? 0) - 1 }
-    }, [draft, caret, mentionOpen])
+        const query = m[2] ?? ''
+        return { query: query.toLowerCase(), from: context.from - query.length - 1, to: context.from }
+    }, [context, mentionOpen])
     const candidates = useMemo<MentionCandidate[]>(() => {
         if (!mentionMatch) return []
         const q = mentionMatch.query
@@ -313,10 +341,11 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     // ":fi" at the caret offers 🔥 etc.; a completed ":fire:" left as text
     // still converts at send time (replaceShortcodes).
     const emojiMatch = useMemo(() => {
-        const m = /(^|[\s([{]):([a-z0-9_+-]{2,})$/.exec(draft.slice(0, caret))
+        if (!context) return null
+        const m = /(^|[\s([{]):([a-z0-9_+-]{2,})$/.exec(context.text)
         if (!m) return null
-        return { query: m[2]!, start: caret - m[2]!.length - 1 }
-    }, [draft, caret])
+        return { query: m[2]!, from: context.from - m[2]!.length - 1, to: context.from }
+    }, [context])
     const emojiCandidates = useMemo<EmojiEntry[]>(() => (emojiMatch ? searchEmoji(emojiMatch.query, 8) : []), [emojiMatch])
     const [emojiIndex, setEmojiIndex] = useState(0)
     const [emojiDismissed, setEmojiDismissed] = useState(false)
@@ -328,9 +357,9 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         setEmojiDismissed(false)
     }
     const pickEmoji = (entry: EmojiEntry) => {
-        if (!emojiMatch) return
+        if (!emojiMatch || !editor) return
         noteEmojiUsed(entry.e)
-        insertAt(emojiMatch.start, caret, `${entry.e} `)
+        editor.chain().focus().deleteRange({ from: emojiMatch.from, to: emojiMatch.to }).insertContent({ type: 'text', text: `${entry.e} ` }).run()
     }
 
     // --- slash commands ------------------------------------------------------
@@ -356,76 +385,40 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     })()
 
     const pickCommand = (c: CommandEntry) => {
+        if (!editor) return
         if (c.args) {
             // Complete to "/name " — the person types the argument, Enter runs.
-            const next = `/${c.name} `
-            setDraft(next)
-            requestAnimationFrame(() => {
-                const el = ref.current
-                if (!el) return
-                el.focus()
-                el.setSelectionRange(next.length, next.length)
-                setCaret(next.length)
-            })
+            editor.chain().focus().clearContent().insertContent({ type: 'text', text: `/${c.name} ` }).run()
         } else {
-            setDraft('')
+            editor.chain().clearContent().run()
             if (c.run) void c.run('')
         }
     }
 
-    const insertAt = (start: number, end: number, text: string) => {
-        const next = `${draft.slice(0, start)}${text}${draft.slice(end)}`
-        setDraft(next)
-        setMentionOpen(false)
-        requestAnimationFrame(() => {
-            const el = ref.current
-            if (!el) return
-            el.focus()
-            const pos = start + text.length
-            el.setSelectionRange(pos, pos)
-            setCaret(pos)
-        })
-    }
     // The draft shows the person's name; send() encodes it back to the wire
     // address @<memberId> (what notifications and agent invocation scan for).
-    // A file inserts a plain markdown link — relative links in messages mean
-    // space files, standard syntax on the wire.
+    // A file becomes a live link to the space path — standard markdown on the
+    // wire. Inserted as literal nodes, never re-parsed as markdown.
     const pickCandidate = (c: MentionCandidate) => {
-        if (!mentionMatch) return
-        if (c.filePath) insertAt(mentionMatch.start, caret, `[${c.filePath}](${encodeSpaceLinkTarget(c.filePath)}) `)
-        else insertAt(mentionMatch.start, caret, `@${c.label} `)
-    }
-
-    // Markdown formatting: the toolbar's buttons and the keyboard shortcuts
-    // run the same pure helpers (composer-toolbar.tsx) through here — one
-    // draft rewrite, one selection restore, caret kept in sync for the
-    // autocompletes.
-    const applyFormat = (run: (value: string, start: number, end: number) => FormatResult) => {
-        const el = ref.current
-        if (!el) return
-        const start = el.selectionStart ?? draft.length
-        const end = el.selectionEnd ?? start
-        const r = run(draft, Math.min(start, end), Math.max(start, end))
-        setDraft(r.next)
-        requestAnimationFrame(() => {
-            el.focus()
-            el.setSelectionRange(r.selStart, r.selEnd)
-            setCaret(r.selEnd)
-        })
+        if (!mentionMatch || !editor) return
+        const chain = editor.chain().focus().deleteRange({ from: mentionMatch.from, to: mentionMatch.to })
+        if (c.filePath) {
+            chain.insertContent([
+                { type: 'text', text: c.filePath, marks: [{ type: 'link', attrs: { href: encodeSpaceLinkTarget(c.filePath) } }] },
+                { type: 'text', text: ' ' },
+            ]).run()
+        } else {
+            chain.insertContent({ type: 'text', text: `@${c.label} ` }).run()
+        }
+        setMentionOpen(false)
     }
 
     const insertRowboatChip = () => {
-        const el = ref.current
-        const mention = '@rowboat '
-        if (!el) {
-            setDraft((d) => (d.includes('@rowboat') ? d : `${mention}${d}`))
-            return
-        }
-        const start = el.selectionStart ?? draft.length
-        const end = el.selectionEnd ?? draft.length
-        const before = draft.slice(0, start)
+        if (!editor) return
+        const { $from, empty } = editor.state.selection
+        const before = empty && $from.parent.isTextblock ? $from.parent.textBetween(0, $from.parentOffset, ' ', ' ') : ''
         const needsSpace = before.length > 0 && !/\s$/.test(before)
-        insertAt(start, end, `${needsSpace ? ' ' : ''}${mention}`)
+        editor.chain().focus().insertContent({ type: 'text', text: `${needsSpace ? ' ' : ''}@rowboat ` }).run()
     }
 
     // --- send ----------------------------------------------------------------
@@ -457,6 +450,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         const body = buildBody(raw)
         if (!body) return
         await onSchedule(body, at)
+        editor?.chain().clearContent().run()
         setDraft('')
         setAttachments([])
         setMentionOpen(false)
@@ -477,6 +471,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                     return
                 }
                 if (found.run) {
+                    editor?.chain().clearContent().run()
                     setDraft('')
                     await found.run(args)
                     return
@@ -502,10 +497,109 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
               }
             : undefined
         await onSend(body, agent)
+        editor?.chain().clearContent().run()
         setDraft('')
         setAttachments([])
         setMentionOpen(false)
     }
+
+    // The editor's keydown: popover navigation first (it must beat every
+    // editor keymap), then the send keys. Formatting chords live in the
+    // editor's own extensions. Returning true consumes the event.
+    const handleEditorKeyDown = (view: EditorView, e: KeyboardEvent): boolean => {
+        if (showCommands) {
+            if (e.key === 'ArrowDown') {
+                setCmdIndex((i) => (i + 1) % cmdCandidates.length)
+                return true
+            }
+            if (e.key === 'ArrowUp') {
+                setCmdIndex((i) => (i - 1 + cmdCandidates.length) % cmdCandidates.length)
+                return true
+            }
+            if (e.key === 'Enter' || e.key === 'Tab') {
+                const c = cmdCandidates[cmdIndex]
+                if (c) pickCommand(c)
+                return true
+            }
+            if (e.key === 'Escape') {
+                setCmdDismissed(true)
+                return true
+            }
+        }
+        if (showMentions) {
+            if (e.key === 'ArrowDown') {
+                setMentionIndex((i) => (i + 1) % candidates.length)
+                return true
+            }
+            if (e.key === 'ArrowUp') {
+                setMentionIndex((i) => (i - 1 + candidates.length) % candidates.length)
+                return true
+            }
+            if (e.key === 'Enter' || e.key === 'Tab') {
+                const c = candidates[mentionIndex]
+                if (c) pickCandidate(c)
+                return true
+            }
+            if (e.key === 'Escape') {
+                setMentionOpen(false)
+                return true
+            }
+        }
+        if (showEmoji) {
+            if (e.key === 'ArrowDown') {
+                setEmojiIndex((i) => (i + 1) % emojiCandidates.length)
+                return true
+            }
+            if (e.key === 'ArrowUp') {
+                setEmojiIndex((i) => (i - 1 + emojiCandidates.length) % emojiCandidates.length)
+                return true
+            }
+            if (e.key === 'Enter' || e.key === 'Tab') {
+                const c = emojiCandidates[emojiIndex]
+                if (c) pickEmoji(c)
+                return true
+            }
+            if (e.key === 'Escape') {
+                setEmojiDismissed(true)
+                return true
+            }
+        }
+        if (e.key !== 'Enter') return false
+        // ⌘Enter always sends — even from inside a code fence.
+        if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+            void send()
+            return true
+        }
+        if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && editor) {
+            // Shift+Enter continues a list — next item, or out of the list
+            // from an empty one; elsewhere the default hard break applies.
+            if (editor.isActive('listItem')) {
+                const { $from } = editor.state.selection
+                if ($from.parent.textContent === '') return editor.chain().focus().liftListItem('listItem').run()
+                return editor.chain().focus().splitListItem('listItem').run()
+            }
+            return false
+        }
+        if (!e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !view.composing) {
+            // Inside a code fence Enter breaks the line (the Slack posture);
+            // everywhere else it sends.
+            if (view.state.selection.$from.parent.type.name === 'codeBlock') return false
+            void send()
+            return true
+        }
+        return false
+    }
+
+    // The editor reads its callbacks through refs, re-pointed after every
+    // render so the closures always see current state (the ref-mirror
+    // pattern the notes editor uses).
+    useEffect(() => {
+        placeholderRef.current = placeholder
+        onTypeRef.current = onType
+        keydownRef.current = handleEditorKeyDown
+        pasteRef.current = handleEditorPaste
+        dropRef.current = editorDropGuard
+    })
 
     return (
         <div className="px-3 pb-3 pt-1 shrink-0">
@@ -591,16 +685,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                     </div>
                 )}
                 {/* The formatting bar rides the top edge, Slack-style. */}
-                <FormattingToolbar
-                    textareaRef={ref}
-                    value={draft}
-                    onChange={(next) => {
-                        setDraft(next)
-                        onType?.()
-                    }}
-                    onCaret={setCaret}
-                    className="px-2 pt-1.5"
-                />
+                <RichFormattingToolbar editor={editor} className="px-2 pt-1.5" />
                 {attachments.length > 0 && (
                     <div className="flex flex-wrap items-center gap-1.5 px-2.5 pt-2">
                         {attachments.map((a) => (
@@ -633,129 +718,9 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                         ))}
                     </div>
                 )}
-                <Textarea
-                    ref={ref}
-                    autoFocus={autoFocus}
-                    value={draft}
-                    placeholder={placeholder}
-                    rows={1}
-                    className="min-h-9 max-h-40 resize-none border-0 bg-transparent dark:bg-transparent px-3 pt-1.5 pb-1 text-sm shadow-none focus-visible:ring-0 field-sizing-content"
-                    onPaste={onPaste}
-                    onChange={(e) => {
-                        setDraft(e.target.value)
-                        const pos = e.target.selectionStart ?? e.target.value.length
-                        setCaret(pos)
-                        // Open on "@" at a word start; stay open while the query grows.
-                        setMentionOpen(MENTION_RE.test(e.target.value.slice(0, pos)))
-                        onType?.()
-                    }}
-                    onSelect={(e) => setCaret((e.target as HTMLTextAreaElement).selectionStart ?? 0)}
-                    onKeyDown={(e) => {
-                        if (showCommands) {
-                            if (e.key === 'ArrowDown') {
-                                e.preventDefault()
-                                setCmdIndex((i) => (i + 1) % cmdCandidates.length)
-                                return
-                            }
-                            if (e.key === 'ArrowUp') {
-                                e.preventDefault()
-                                setCmdIndex((i) => (i - 1 + cmdCandidates.length) % cmdCandidates.length)
-                                return
-                            }
-                            if (e.key === 'Enter' || e.key === 'Tab') {
-                                e.preventDefault()
-                                const c = cmdCandidates[cmdIndex]
-                                if (c) pickCommand(c)
-                                return
-                            }
-                            if (e.key === 'Escape') {
-                                e.preventDefault()
-                                setCmdDismissed(true)
-                                return
-                            }
-                        }
-                        if (showMentions) {
-                            if (e.key === 'ArrowDown') {
-                                e.preventDefault()
-                                setMentionIndex((i) => (i + 1) % candidates.length)
-                                return
-                            }
-                            if (e.key === 'ArrowUp') {
-                                e.preventDefault()
-                                setMentionIndex((i) => (i - 1 + candidates.length) % candidates.length)
-                                return
-                            }
-                            if (e.key === 'Enter' || e.key === 'Tab') {
-                                e.preventDefault()
-                                const c = candidates[mentionIndex]
-                                if (c) pickCandidate(c)
-                                return
-                            }
-                            if (e.key === 'Escape') {
-                                e.preventDefault()
-                                setMentionOpen(false)
-                                return
-                            }
-                        }
-                        if (showEmoji) {
-                            if (e.key === 'ArrowDown') {
-                                e.preventDefault()
-                                setEmojiIndex((i) => (i + 1) % emojiCandidates.length)
-                                return
-                            }
-                            if (e.key === 'ArrowUp') {
-                                e.preventDefault()
-                                setEmojiIndex((i) => (i - 1 + emojiCandidates.length) % emojiCandidates.length)
-                                return
-                            }
-                            if (e.key === 'Enter' || e.key === 'Tab') {
-                                e.preventDefault()
-                                const c = emojiCandidates[emojiIndex]
-                                if (c) pickEmoji(c)
-                                return
-                            }
-                            if (e.key === 'Escape') {
-                                e.preventDefault()
-                                setEmojiDismissed(true)
-                                return
-                            }
-                        }
-                        // The Slack chords: ⌘B/⌘I/⌘⇧X inline marks, ⌘E and
-                        // ⌘⇧C inline code, ⌘⇧7/8/9 ordered/bullet/quote
-                        // (e.code — shift turns the digits into symbols),
-                        // ⌘⌥⇧C a fenced code block.
-                        if ((e.metaKey || e.ctrlKey) && e.altKey && e.shiftKey && e.code === 'KeyC') {
-                            e.preventDefault()
-                            applyFormat(toggleCodeBlock)
-                            return
-                        }
-                        if ((e.metaKey || e.ctrlKey) && !e.altKey) {
-                            const key = e.key.toLowerCase()
-                            let run: ((v: string, s: number, en: number) => FormatResult) | null = null
-                            if (e.shiftKey) {
-                                if (key === 'x') run = (v, s, en) => toggleInline(v, s, en, '~~')
-                                else if (e.code === 'KeyC') run = (v, s, en) => toggleInline(v, s, en, '`')
-                                else if (e.code === 'Digit7') run = (v, s, en) => toggleLinePrefix(v, s, en, 'ordered')
-                                else if (e.code === 'Digit8') run = (v, s, en) => toggleLinePrefix(v, s, en, 'bullet')
-                                else if (e.code === 'Digit9') run = (v, s, en) => toggleLinePrefix(v, s, en, 'quote')
-                            } else {
-                                if (key === 'b') run = (v, s, en) => toggleInline(v, s, en, '**')
-                                else if (key === 'i') run = (v, s, en) => toggleInline(v, s, en, '*')
-                                else if (key === 'e') run = (v, s, en) => toggleInline(v, s, en, '`')
-                            }
-                            if (run) {
-                                e.preventDefault()
-                                applyFormat(run)
-                                return
-                            }
-                        }
-                        // Enter sends; Shift+Enter breaks a line.
-                        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-                            e.preventDefault()
-                            void send()
-                        }
-                    }}
-                />
+                {/* The rich input. What you see is what sends — the doc
+                    serializes back to wire markdown on every update. */}
+                <EditorContent editor={editor} className="space-composer" />
                 <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2">
                     {refs && (
                         <>

--- a/apps/x/apps/renderer/src/styles/space-composer.css
+++ b/apps/x/apps/renderer/src/styles/space-composer.css
@@ -1,0 +1,111 @@
+/* Spaces composer body — TipTap content, chat-sized to the old textarea's
+   metrics (text-sm, min-h-9, px-3) and styled to match how SpaceMarkdown
+   renders the posted message, so the draft looks like what it becomes. */
+
+.space-composer {
+  max-height: 10rem; /* the textarea's max-h-40 */
+  overflow-y: auto;
+}
+
+.space-composer .ProseMirror {
+  outline: none;
+  min-height: 2.25rem;
+  padding: 6px 12px 4px;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.space-composer .ProseMirror p {
+  margin: 2px 0;
+}
+
+.space-composer .ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  color: var(--muted-foreground);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+
+.space-composer .ProseMirror h1,
+.space-composer .ProseMirror h2,
+.space-composer .ProseMirror h3 {
+  margin: 4px 0 2px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.space-composer .ProseMirror ul,
+.space-composer .ProseMirror ol {
+  margin: 2px 0;
+  padding-left: 22px;
+}
+
+.space-composer .ProseMirror ul {
+  list-style: disc;
+}
+
+.space-composer .ProseMirror ol {
+  list-style: decimal;
+}
+
+.space-composer .ProseMirror li {
+  margin: 1px 0;
+}
+
+.space-composer .ProseMirror li > p {
+  margin: 0;
+}
+
+.space-composer .ProseMirror blockquote {
+  margin: 2px 0;
+  padding-left: 12px;
+  border-left: 4px solid var(--border);
+  color: var(--muted-foreground);
+}
+
+.space-composer .ProseMirror a {
+  color: var(--stream-link, var(--primary));
+  text-decoration: underline;
+}
+
+.space-composer .ProseMirror s {
+  opacity: 0.8;
+}
+
+.space-composer .ProseMirror code {
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+}
+
+.space-composer .ProseMirror pre {
+  margin: 4px 0;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.space-composer .ProseMirror pre code {
+  padding: 0;
+  background: none;
+  font-size: inherit;
+}
+
+.space-composer .ProseMirror img {
+  max-height: 8rem;
+  border-radius: 6px;
+}
+
+.space-composer .ProseMirror img.ProseMirror-selectednode {
+  outline: 2px solid var(--ring);
+}


### PR DESCRIPTION
## Summary

Stacked on #977 (retarget to `main` once that merges). The Spaces composer's textarea becomes a **TipTap rich editor**: clicking Bold bolds the selection visually instead of inserting `**` markers, and typing markdown (`**bold**`, `- `, `> `, ` ``` `) converts live as you type — Slack's exact behavior, using the same editor stack the notes and email composers already ship.

### The load-bearing idea

**Markdown stays the wire format.** The editor owns what you see; `draft` is its serialized-markdown mirror, re-derived on every update (`tiptap-markdown` in both directions). Everything downstream — draft persistence (same localStorage keys; old textarea drafts parse right in), slash-command detection, `@rowboat` detection, `buildBody`/attachments/scheduling — keeps reading the exact string the textarea used to hold. A **25-test suite pins the md ⇄ doc round trip** for every construct the composer can produce (marks, lists, quotes, fences, images, mentions-as-text, slash drafts, escaping).

### What changed

- **Autocompletes survive the swap**: `@` members/files, `:emoji:`, and slash commands are rebuilt on ProseMirror caret positions (`caretContext` helper) with the same popover UIs and key handling. Insertions are literal text/link nodes, never re-parsed as markdown. They stay off inside code, and hard breaks read as newlines so `@` after Shift+Enter still triggers (regression-tested).
- **Enter semantics**: Enter sends — except inside a code fence, where it breaks the line (Slack's posture); ⌘Enter always sends; Shift+Enter continues a list (a new item; an empty item exits the list) or inserts a line break; IME-composing guarded.
- **Chords**: TipTap defaults (⌘B/⌘I/⌘E/⌘⇧7/8) plus a small keymap extension for ⌘⇧X strike, ⌘⇧C code, ⌘⇧9 quote, ⌘⌥⇧C code block.
- **Toolbar**: `RichFormattingToolbar` drives editor commands with pressed-state highlights (`useEditorState`) and a text+URL link popover. The inline message editor (`message-row`) still uses the textarea bar — that's the planned follow-up.
- **Paste/drop**: files attach exactly as before; a pasted GIF/image URL renders as the inline image (serializes to `![](url)`); pasted text stays literal (a pasted `*` never turns italic).
- **Styling**: `space-composer.css`, chat-sized to the old textarea's metrics and matched to how `SpaceMarkdown` renders the posted message.

### Deviations from the plan (deliberate)

1. **No notes-serializer extraction.** Instead of hardening `markdown-editor.tsx`'s custom serializer, the composer uses `tiptap-markdown`'s own (proper escaping, strike support) with the round trip pinned by tests. Zero blast radius on the notes editor.
2. **Mentions stay plain text** (`@Name` → `encodeMentions` on send, unchanged) rather than pill nodes — the pill node is the natural follow-up, not a blocker.
3. **No markup-mode toggle** — the swap is complete; reverting the PR is the fallback.

## Test plan

- 505/505 renderer tests (25 new: round trips, formatting commands, caret context incl. the hard-break boundary case); `tsc -b` clean; eslint clean (one documented disable for a false-positive ref read inside TipTap's decoration pass); production `vite build` succeeds.
- Manual QA checklist: toolbar buttons bold/etc. render live with pressed states; typing `**bold**`/`- `/`> ` auto-converts; @-mention, :emoji:, /command popovers navigate and insert; Enter/⇧Enter/⌘Enter per above; drafts persist and restore across space switches; quote-reply seeds render as a live blockquote; attachments paste/drop; @rowboat chip + agent strip; send produces identical wire markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)