### PR TITLE
fix: prevent infinite loops for unprocessed notes

### DIFF
--- a/apps/x/packages/core/src/knowledge/note_tagging_state.ts
+++ b/apps/x/packages/core/src/knowledge/note_tagging_state.ts
@@ -6,13 +6,23 @@ const STATE_FILE = path.join(WorkDir, 'note_tagging_state.json');
 
 export interface NoteTaggingState {
     processedFiles: Record<string, { taggedAt: string }>;
+    failedFiles?: Record<string, {
+        failedAt: string;
+        retryCount: number;
+        nextRetryAt: number;
+        lastModifiedMs: number;
+    }>;
     lastRunTime: string;
 }
 
 export function loadNoteTaggingState(): NoteTaggingState {
     if (fs.existsSync(STATE_FILE)) {
         try {
-            return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+            const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+            if (!state.failedFiles) {
+                state.failedFiles = {};
+            }
+            return state;
         } catch (error) {
             console.error('Error loading note tagging state:', error);
         }
@@ -20,6 +30,7 @@ export function loadNoteTaggingState(): NoteTaggingState {
 
     return {
         processedFiles: {},
+        failedFiles: {},
         lastRunTime: new Date(0).toISOString(),
     };
 }
@@ -42,7 +53,35 @@ export function markNoteAsTagged(filePath: string, state: NoteTaggingState): voi
 export function resetNoteTaggingState(): void {
     const emptyState: NoteTaggingState = {
         processedFiles: {},
+        failedFiles: {},
         lastRunTime: new Date().toISOString(),
     };
     saveNoteTaggingState(emptyState);
+}
+
+const BASE_DELAY_MS = 60 * 1000; // 1 minute
+
+export function markNoteAsFailed(filePath: string, state: NoteTaggingState, mtimeMs: number): void {
+    if (!state.failedFiles) {
+        state.failedFiles = {};
+    }
+    
+    const existing = state.failedFiles[filePath];
+    const retryCount = existing ? existing.retryCount + 1 : 1;
+    
+    // Exponential backoff: 1m, 2m, 4m, 8m, etc.
+    const backoffMs = Math.pow(2, retryCount - 1) * BASE_DELAY_MS;
+    
+    state.failedFiles[filePath] = {
+        failedAt: new Date().toISOString(),
+        retryCount,
+        nextRetryAt: Date.now() + backoffMs,
+        lastModifiedMs: mtimeMs
+    };
+}
+
+export function clearNoteFailure(filePath: string, state: NoteTaggingState): void {
+    if (state.failedFiles && state.failedFiles[filePath]) {
+        delete state.failedFiles[filePath];
+    }
 }

--- a/apps/x/packages/core/src/knowledge/tag_notes.test.ts
+++ b/apps/x/packages/core/src/knowledge/tag_notes.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// Mock config BEFORE anything else is imported.
+// By hardcoding the string here, we bypass all variable hoisting issues!
+vi.mock('../config/config.js', () => ({
+    WorkDir: '/tmp/rowboat-test-sandbox-tag-notes'
+}));
+
+import { WorkDir } from '../config/config.js';
+import { processUntaggedNotes } from './tag_notes.js';
+import * as headlessApp from '../runtime/assembly/headless-app.js';
+import { loadNoteTaggingState } from './note_tagging_state.js';
+import { getNoteTypeDefinitions } from './note_system.js';
+import { serviceLogger } from '../services/service_logger.js';
+
+vi.mock('../runtime/assembly/headless-app.js', () => ({
+    runWhenPossible: vi.fn(),
+    toolInputPaths: vi.fn(),
+}));
+
+vi.mock('../services/service_logger.js', () => ({
+    serviceLogger: {
+        startRun: vi.fn().mockResolvedValue({ service: 'test', runId: 'test-run-id', startedAt: Date.now() }),
+        log: vi.fn().mockResolvedValue(undefined),
+    }
+}));
+
+vi.mock('../models/defaults.js', () => ({
+    getKgModel: vi.fn().mockResolvedValue({ model: 'mock-model', provider: 'mock-provider' }),
+    asRunModelOptions: vi.fn().mockReturnValue({ model: 'mock-model', provider: 'mock-provider' })
+}));
+
+describe('tag_notes', () => {
+    beforeEach(() => {
+        // Create necessary directories using the mocked WorkDir
+        process.env.ROWBOAT_WORKDIR = WorkDir;
+        if (fs.existsSync(WorkDir)) {
+            fs.rmSync(WorkDir, { recursive: true, force: true });
+        }
+        fs.mkdirSync(WorkDir, { recursive: true });
+        
+        fs.mkdirSync(path.join(WorkDir, 'knowledge'), { recursive: true });
+        fs.mkdirSync(path.join(WorkDir, 'config'), { recursive: true });
+        
+        for (const def of getNoteTypeDefinitions()) {
+            fs.mkdirSync(path.join(WorkDir, 'knowledge', def.folder), { recursive: true });
+        }
+    });
+
+    afterEach(() => {
+        fs.rmSync(WorkDir, { recursive: true, force: true });
+        vi.clearAllMocks();
+    });
+
+    it('should mark notes as processed even if the agent fails to tag them to prevent infinite loops', async () => {
+        // Create an untagged note
+        const notePath = path.join(WorkDir, 'knowledge', 'People', 'TestNote.md');
+        fs.writeFileSync(notePath, '# Test Note\nNo frontmatter here.');
+
+        // Verify it is untagged
+        let state = loadNoteTaggingState();
+        expect(state.processedFiles[notePath]).toBeUndefined();
+
+        // Mock the agent to simulate a SKIP or FAILURE (returns empty set of files edited)
+        vi.mocked(headlessApp.runWhenPossible).mockResolvedValue({
+            turnId: 'test-turn',
+            state: {} as any,
+            outcome: {} as any,
+            summary: null
+        });
+        vi.mocked(headlessApp.toolInputPaths).mockReturnValue(new Set()); // No files edited
+
+        // Run the process
+        await processUntaggedNotes();
+
+        // Verify the file was marked as processed despite the agent failing
+        state = loadNoteTaggingState();
+        expect(state.processedFiles[notePath]).toBeDefined();
+        
+        // Prove the AI was called exactly 1 time on the first run
+        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1);
+
+        // Simulate the 15-second timer ticking and triggering a SECOND run
+        await processUntaggedNotes();
+
+        // Prove the AI was STILL only called 1 time overall! 
+        // This proves the note was correctly skipped on the second run.
+        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1);
+
+        // Furthermore, prove that the file wasn't even sent for processing internally!
+        // `serviceLogger.startRun` is ONLY called if `untagged.length > 0`.
+        // Because it was only called 1 time, it proves `getUntaggedNotes` returned an empty list on the second run.
+        expect(serviceLogger.startRun).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/x/packages/core/src/knowledge/tag_notes.test.ts
+++ b/apps/x/packages/core/src/knowledge/tag_notes.test.ts
@@ -54,20 +54,15 @@ describe('tag_notes', () => {
         vi.clearAllMocks();
     });
 
-    it('should mark notes as processed even if the agent fails to tag them to prevent infinite loops', async () => {
-        // Create an untagged note
+    it('should mark notes as failed when skipped by the agent and backoff', async () => {
         const notePath = path.join(WorkDir, 'knowledge', 'People', 'TestNote.md');
         fs.writeFileSync(notePath, '# Test Note\nNo frontmatter here.');
-
-        // Verify it is untagged
-        let state = loadNoteTaggingState();
-        expect(state.processedFiles[notePath]).toBeUndefined();
 
         // Mock the agent to simulate a SKIP or FAILURE (returns empty set of files edited)
         vi.mocked(headlessApp.runWhenPossible).mockResolvedValue({
             turnId: 'test-turn',
             state: {} as any,
-            outcome: {} as any,
+            outcome: { status: 'completed' } as any,
             summary: null
         });
         vi.mocked(headlessApp.toolInputPaths).mockReturnValue(new Set()); // No files edited
@@ -75,23 +70,141 @@ describe('tag_notes', () => {
         // Run the process
         await processUntaggedNotes();
 
-        // Verify the file was marked as processed despite the agent failing
+        let state = loadNoteTaggingState();
+        expect(state.processedFiles[notePath]).toBeUndefined();
+        expect(state.failedFiles?.[notePath]).toBeDefined();
+        expect(state.failedFiles?.[notePath].retryCount).toBe(1);
+        
+        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1);
+
+        // Second run - it should be skipped due to backoff
+        await processUntaggedNotes();
+        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle provider failure with backoff and eventual recovery', async () => {
+        const notePath = path.join(WorkDir, 'knowledge', 'People', 'TestNote.md');
+        fs.writeFileSync(notePath, '# Test Note\nNo frontmatter here.');
+
+        // First run: provider throws an error
+        vi.mocked(headlessApp.runWhenPossible).mockRejectedValueOnce(new Error('Provider API down'));
+        
+        await processUntaggedNotes();
+        
+        let state = loadNoteTaggingState();
+        expect(state.processedFiles[notePath]).toBeUndefined();
+        expect(state.failedFiles?.[notePath]).toBeDefined();
+        expect(state.failedFiles?.[notePath].retryCount).toBe(1);
+        
+        // Fast forward time to pass the backoff 
+        state.failedFiles![notePath].nextRetryAt = Date.now() - 1000;
+        fs.writeFileSync(path.join(WorkDir, 'note_tagging_state.json'), JSON.stringify(state));
+
+        // Second run: provider recovers and agent successfully tags the note
+        vi.mocked(headlessApp.runWhenPossible).mockResolvedValueOnce({
+            turnId: 'test-turn-2',
+            state: {} as any,
+            outcome: { status: 'completed' } as any,
+            summary: null
+        });
+        vi.mocked(headlessApp.toolInputPaths).mockReturnValueOnce(new Set(['knowledge/People/TestNote.md']));
+        
+        await processUntaggedNotes();
+        
         state = loadNoteTaggingState();
         expect(state.processedFiles[notePath]).toBeDefined();
-        
-        // Prove the AI was called exactly 1 time on the first run
-        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1);
+        expect(state.failedFiles?.[notePath]).toBeUndefined(); // Cleared on success
+    });
 
-        // Simulate the 15-second timer ticking and triggering a SECOND run
+    it('should handle partially processed batches correctly', async () => {
+        const note1Path = path.join(WorkDir, 'knowledge', 'People', 'Note1.md');
+        const note2Path = path.join(WorkDir, 'knowledge', 'People', 'Note2.md');
+        fs.writeFileSync(note1Path, '# Note 1\n');
+        fs.writeFileSync(note2Path, '# Note 2\n');
+
+        vi.mocked(headlessApp.runWhenPossible).mockResolvedValueOnce({
+            turnId: 'test-turn',
+            state: {} as any,
+            outcome: { status: 'completed' } as any,
+            summary: null
+        });
+        // Agent edits Note 1 but skips Note 2
+        vi.mocked(headlessApp.toolInputPaths).mockReturnValueOnce(new Set(['knowledge/People/Note1.md']));
+
         await processUntaggedNotes();
 
-        // Prove the AI was STILL only called 1 time overall! 
-        // This proves the note was correctly skipped on the second run.
-        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1);
+        const state = loadNoteTaggingState();
+        
+        // Note 1 should be processed
+        expect(state.processedFiles[note1Path]).toBeDefined();
+        expect(state.failedFiles?.[note1Path]).toBeUndefined();
+        
+        // Note 2 should be failed
+        expect(state.processedFiles[note2Path]).toBeUndefined();
+        expect(state.failedFiles?.[note2Path]).toBeDefined();
+    });
 
-        // Furthermore, prove that the file wasn't even sent for processing internally!
-        // `serviceLogger.startRun` is ONLY called if `untagged.length > 0`.
-        // Because it was only called 1 time, it proves `getUntaggedNotes` returned an empty list on the second run.
-        expect(serviceLogger.startRun).toHaveBeenCalledTimes(1);
+    it('should save partial successes when an error is thrown mid-batch', async () => {
+        const note1Path = path.join(WorkDir, 'knowledge', 'People', 'Note1.md');
+        const note2Path = path.join(WorkDir, 'knowledge', 'People', 'Note2.md');
+        fs.writeFileSync(note1Path, '# Note 1\n');
+        fs.writeFileSync(note2Path, '# Note 2\n');
+
+        vi.mocked(headlessApp.runWhenPossible).mockResolvedValueOnce({
+            turnId: 'test-turn',
+            state: {} as any,
+            outcome: { status: 'failed', error: 'Mid-batch provider error' } as any,
+            summary: null
+        });
+        // Agent edits Note 1 but fails before editing Note 2
+        vi.mocked(headlessApp.toolInputPaths).mockReturnValueOnce(new Set(['knowledge/People/Note1.md']));
+
+        await processUntaggedNotes();
+
+        const state = loadNoteTaggingState();
+        
+        // Note 1 should be processed because it was edited before the error
+        expect(state.processedFiles[note1Path]).toBeDefined();
+        expect(state.failedFiles?.[note1Path]).toBeUndefined();
+        
+        // Note 2 should be failed
+        expect(state.processedFiles[note2Path]).toBeUndefined();
+        expect(state.failedFiles?.[note2Path]).toBeDefined();
+    });
+
+    it('should reset retries if a failed file is edited', async () => {
+        const notePath = path.join(WorkDir, 'knowledge', 'People', 'EditMe.md');
+        fs.writeFileSync(notePath, '# Edit Me\n');
+
+        // Fail first time
+        vi.mocked(headlessApp.runWhenPossible).mockResolvedValue({
+            turnId: 'test-turn',
+            state: {} as any,
+            outcome: { status: 'completed' } as any,
+            summary: null
+        });
+        vi.mocked(headlessApp.toolInputPaths).mockReturnValue(new Set()); // No edits
+
+        await processUntaggedNotes();
+
+        let state = loadNoteTaggingState();
+        expect(state.failedFiles?.[notePath]).toBeDefined();
+        
+        // Set retry count to MAX (5)
+        state.failedFiles![notePath].retryCount = 5;
+        state.failedFiles![notePath].nextRetryAt = Date.now() - 1000;
+        fs.writeFileSync(path.join(WorkDir, 'note_tagging_state.json'), JSON.stringify(state));
+
+        // It should skip it now because of max retries
+        await processUntaggedNotes();
+        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(1); 
+
+        // Now user edits the file! Wait a small bit so mtime changes (or touch)
+        await new Promise(resolve => setTimeout(resolve, 50));
+        fs.appendFileSync(notePath, 'New content here.');
+
+        // Second run after edit - it should pick it up again!
+        await processUntaggedNotes();
+        expect(headlessApp.runWhenPossible).toHaveBeenCalledTimes(2); 
     });
 });

--- a/apps/x/packages/core/src/knowledge/tag_notes.ts
+++ b/apps/x/packages/core/src/knowledge/tag_notes.ts
@@ -10,6 +10,8 @@ import {
     loadNoteTaggingState,
     saveNoteTaggingState,
     markNoteAsTagged,
+    markNoteAsFailed,
+    clearNoteFailure,
     type NoteTaggingState,
 } from './note_tagging_state.js';
 import { getNoteTypeDefinitions } from './note_system.js';
@@ -49,6 +51,20 @@ function getUntaggedNotes(state: NoteTaggingState): string[] {
             // Skip if already tracked in state
             if (state.processedFiles[fullPath]) {
                 continue;
+            }
+
+            const failedInfo = state.failedFiles?.[fullPath];
+            if (failedInfo) {
+                if (stat.mtimeMs > failedInfo.lastModifiedMs) {
+                    // File was edited since last failure, reset retry count
+                    clearNoteFailure(fullPath, state);
+                } else if (Date.now() < failedInfo.nextRetryAt) {
+                    // Not time to retry yet
+                    continue;
+                } else if (failedInfo.retryCount >= 5) {
+                    // Max retries reached, wait for manual edit
+                    continue;
+                }
             }
 
             // Skip if file already has frontmatter
@@ -97,18 +113,23 @@ async function tagNoteBatch(
         message += `\n\n---\n\n`;
     }
 
-    const { turnId, state } = await runWhenPossible({
+    const { turnId, state, outcome } = await runWhenPossible({
         agentId: NOTE_TAGGING_AGENT,
         message,
         useCase: 'knowledge_sync',
         subUseCase: 'tag_notes',
         ...asRunModelOptions(await getKgModel()),
-        throwOnError: true,
     });
 
-    // Edited paths come from the durable turn state instead of streaming
-    // bus subscriptions.
-    return { runId: turnId, filesEdited: toolInputPaths(state, ['file-editText']) };
+    const filesEdited = toolInputPaths(state, ['file-editText']);
+
+    if (outcome.status !== 'completed') {
+        const error = new Error(outcome.status === 'failed' ? outcome.error : `turn ${outcome.status}`);
+        (error as any).partialFilesEdited = filesEdited;
+        throw error;
+    }
+
+    return { runId: turnId, filesEdited };
 }
 
 /**
@@ -186,14 +207,15 @@ export async function processUntaggedNotes(): Promise<void> {
             const result = await tagNoteBatch(files);
             totalEdited += result.filesEdited.size;
 
-            // Mark all files in the batch as processed to avoid infinite loops
-            // if the agent fails or refuses to edit them
             for (const file of files) {
-                markNoteAsTagged(file.path, state);
-                
                 const relativePath = path.relative(WorkDir, file.path);
-                if (!result.filesEdited.has(relativePath)) {
+                if (result.filesEdited.has(relativePath)) {
+                    markNoteAsTagged(file.path, state);
+                    clearNoteFailure(file.path, state);
+                } else {
                     console.log(`[NoteTagging] Agent skipped or failed to edit: ${relativePath}`);
+                    const stat = fs.statSync(file.path);
+                    markNoteAsFailed(file.path, state, stat.mtimeMs);
                 }
             }
 
@@ -205,10 +227,23 @@ export async function processUntaggedNotes(): Promise<void> {
             const errorDetails = getErrorDetails(error);
             console.error(`[NoteTagging] Error processing batch ${batchNumber}:`, error);
             
-            // Prevent infinite loops on catastrophic batch failures (e.g. no AI provider configured)
-            // We mark them as processed here so it doesn't endlessly retry every 15 seconds.
+            const partialEdited: Set<string> = (error as any).partialFilesEdited || new Set();
+
+            // Mark batch as failed so we can backoff and retry later, but save partial successes
             for (const filePath of batchPaths) {
-                markNoteAsTagged(filePath, state);
+                const relativePath = path.relative(WorkDir, filePath);
+                if (partialEdited.has(relativePath)) {
+                    markNoteAsTagged(filePath, state);
+                    clearNoteFailure(filePath, state);
+                    totalEdited++;
+                } else {
+                    try {
+                        const stat = fs.statSync(filePath);
+                        markNoteAsFailed(filePath, state, stat.mtimeMs);
+                    } catch (e) {
+                        // Ignore if file was deleted
+                    }
+                }
             }
             saveNoteTaggingState(state);
 

--- a/apps/x/packages/core/src/knowledge/tag_notes.ts
+++ b/apps/x/packages/core/src/knowledge/tag_notes.ts
@@ -186,11 +186,14 @@ export async function processUntaggedNotes(): Promise<void> {
             const result = await tagNoteBatch(files);
             totalEdited += result.filesEdited.size;
 
-            // Only mark files that were actually edited by the agent
+            // Mark all files in the batch as processed to avoid infinite loops
+            // if the agent fails or refuses to edit them
             for (const file of files) {
+                markNoteAsTagged(file.path, state);
+                
                 const relativePath = path.relative(WorkDir, file.path);
-                if (result.filesEdited.has(relativePath)) {
-                    markNoteAsTagged(file.path, state);
+                if (!result.filesEdited.has(relativePath)) {
+                    console.log(`[NoteTagging] Agent skipped or failed to edit: ${relativePath}`);
                 }
             }
 
@@ -201,6 +204,14 @@ export async function processUntaggedNotes(): Promise<void> {
             failedBatches++;
             const errorDetails = getErrorDetails(error);
             console.error(`[NoteTagging] Error processing batch ${batchNumber}:`, error);
+            
+            // Prevent infinite loops on catastrophic batch failures (e.g. no AI provider configured)
+            // We mark them as processed here so it doesn't endlessly retry every 15 seconds.
+            for (const filePath of batchPaths) {
+                markNoteAsTagged(filePath, state);
+            }
+            saveNoteTaggingState(state);
+
             await serviceLogger.log({
                 type: 'error',
                 service: run.service,


### PR DESCRIPTION
If notes are in untagged state even after processing, it will be picked up again to be processed, to prevent this, marking this as tagged even when there was issue in processing. 