### PR TITLE
fix(spaces): self-healing live client — the '@rowboat is working' status is back

### DIFF
--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -8,7 +8,7 @@ import * as spacesOAuth from '@x/core/dist/spaces/oauth.js';
 import { syncSpaceMentionWatch } from '@x/core/dist/spaces/mention-watch.js';
 import { getDndUntil, getNotifyPrefs, setDndUntil, setNotifyPref } from '@x/core/dist/spaces/notify-prefs.js';
 import { cancelScheduled, listScheduled, scheduleItem } from '@x/core/dist/spaces/scheduler.js';
-import { invokeTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
+import { invokeTopicAgent, stopTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
 import { fetchLinkPreview } from './link-preview.js';
 
@@ -61,6 +61,7 @@ type SpacesHandlers = {
   'spaces:endPoll': InvokeHandler<'spaces:endPoll'>;
   'spaces:invokeRowboat': InvokeHandler<'spaces:invokeRowboat'>;
   'spaces:topicSession': InvokeHandler<'spaces:topicSession'>;
+  'spaces:stopRowboat': InvokeHandler<'spaces:stopRowboat'>;
   'spaces:getNotifyPrefs': InvokeHandler<'spaces:getNotifyPrefs'>;
   'spaces:setNotifyPref': InvokeHandler<'spaces:setNotifyPref'>;
   'spaces:schedule': InvokeHandler<'spaces:schedule'>;
@@ -105,7 +106,8 @@ function broadcastSpacesEvent(event: spacesShared.SpacesBusEvent): void {
 // One core-level live subscription per (org, space), fanned out to all windows.
 // The renderer's afterOffset drives replay on first subscribe; core's
 // SpacesLive owns reconnect + resume from the last seen offset after that.
-const liveSubscriptions = new Map<string, () => void>();
+// Each entry remembers WHICH live client it subscribed on (see subscribeSpace).
+const liveSubscriptions = new Map<string, { live: unknown; unsubscribe: () => void }>();
 
 /**
  * Spaces IPC handlers, exported as a plain object and spread into the main
@@ -157,9 +159,9 @@ export const spacesIpcHandlers: SpacesHandlers = {
 
   'spaces:removeOrg': async (_event, args) => {
     void syncSpaceMentionWatch({ force: true });
-    for (const [key, unsubscribe] of liveSubscriptions) {
+    for (const [key, entry] of liveSubscriptions) {
       if (key.startsWith(`${args.orgId}/`)) {
-        unsubscribe();
+        entry.unsubscribe();
         liveSubscriptions.delete(key);
       }
     }
@@ -379,6 +381,8 @@ export const spacesIpcHandlers: SpacesHandlers = {
     sessionId: topicSessionId(args.orgId, args.spaceId, args.threadRootId),
   }),
 
+  'spaces:stopRowboat': async (_event, args) => stopTopicAgent(args),
+
   'spaces:getNotifyPrefs': async (_event, args) => getNotifyPrefs(args.orgId, args.spaceId),
 
   'spaces:setNotifyPref': async (_event, args) => {
@@ -413,20 +417,25 @@ export const spacesIpcHandlers: SpacesHandlers = {
 
   'spaces:subscribeSpace': async (_event, args) => {
     const key = `${args.orgId}/${args.spaceId}`;
-    if (!liveSubscriptions.has(key)) {
-      const unsubscribe = orgs.getLive(args.orgId).subscribe(
+    const live = orgs.getLive(args.orgId);
+    const cached = liveSubscriptions.get(key);
+    // Instance check: a re-auth (upsertOAuthOrg) replaces the org's live
+    // client; a subscription cached on the dead one would eat frames forever.
+    if (!cached || cached.live !== live) {
+      cached?.unsubscribe();
+      const unsubscribe = live.subscribe(
         args.spaceId,
         (frame) => broadcastSpacesEvent({ orgId: args.orgId, frame }),
         args.afterOffset,
       );
-      liveSubscriptions.set(key, unsubscribe);
+      liveSubscriptions.set(key, { live, unsubscribe });
     }
     return { success: true };
   },
 
   'spaces:unsubscribeSpace': async (_event, args) => {
     const key = `${args.orgId}/${args.spaceId}`;
-    liveSubscriptions.get(key)?.();
+    liveSubscriptions.get(key)?.unsubscribe();
     liveSubscriptions.delete(key);
     return { success: true };
   },

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -918,6 +918,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                             memberNames={memberNames}
                             entries={entries}
                             onOpenThread={(id) => select({ kind: 'thread', rootMessageId: id })}
+                            onOpenSession={onOpenSession}
                             onClose={split ? closeChat : undefined}
                             visible={active && showChat && !chatRootId}
                         />

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -44,7 +44,7 @@ const NEW_FADE_MS = 800
 const PIN_BANNER_MAX = 3
 
 export function GeneralStream({
-    org, space, stream, presence, members, memberNames, entries = [], onOpenThread, onClose, visible = true,
+    org, space, stream, presence, members, memberNames, entries = [], onOpenThread, onOpenSession, onClose, visible = true,
 }: {
     org: OrgWithSpaces
     space: spaces.Space
@@ -56,6 +56,8 @@ export function GeneralStream({
     entries?: spaces.SpacesAssetEntry[]
     /** Open a thread pane on this root (replying to a fresh message included — no draft state exists). */
     onOpenThread: (rootMessageId: string) => void
+    /** Navigate to a chat session — the working strip's "Open chat" affordance. */
+    onOpenSession?: (sessionId: string) => void
     /** Set while a doc column sits beside the chat: closes THIS column, the doc takes the width. */
     onClose?: () => void
     /**
@@ -222,6 +224,28 @@ export function GeneralStream({
     // Reply creates NOTHING: the thread pane opens on the message itself —
     // a thread with zero replies is just a thread (annotation model).
     const replyInThread = (parent: spaces.Message) => onOpenThread(parent.id)
+
+    // The working strip's "Open chat": the thread's agent session, one click.
+    const openAgentChat = async (rootMessageId: string) => {
+        try {
+            const { sessionId } = await window.ipc.invoke('spaces:topicSession', { orgId: org.id, spaceId: space.id, threadRootId: rootMessageId })
+            if (sessionId && onOpenSession) onOpenSession(sessionId)
+            else if (!sessionId) toast('No agent chat for this thread yet', 'info')
+        } catch {
+            toast('Could not open the agent chat', 'error')
+        }
+    }
+
+    // The working strip's stop square: cancel your Rowboat's run right here.
+    // The chip clears when the cancelled turn releases its presence lease.
+    const stopAgent = async (rootMessageId: string) => {
+        try {
+            const { stopped } = await window.ipc.invoke('spaces:stopRowboat', { orgId: org.id, spaceId: space.id, threadRootId: rootMessageId })
+            if (!stopped) toast('Nothing to stop — the run already finished', 'info')
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not stop the run', 'error')
+        }
+    }
 
     const askRowboat = (message: spaces.Message) => {
         const name = memberNames.get(message.author.memberId) ?? message.author.memberId
@@ -587,6 +611,8 @@ export function GeneralStream({
                 selfMemberId={org.memberId}
                 onOpenThread={onOpenThread}
                 onPrefetchThread={(id) => prefetchThread(org.id, space.id, id)}
+                onOpenAgentChat={onOpenSession ? (id) => void openAgentChat(id) : undefined}
+                onStopAgent={(id) => void stopAgent(id)}
                 onReplyInThread={replyInThread}
                 onAskRowboat={askRowboat}
                 onCopyLink={(m) => void copyLink(m)}

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -1,5 +1,5 @@
 import { memo, useRef, useState } from 'react'
-import { Bookmark, BookmarkCheck, Bot, ChevronRight, Copy, Forward, Link as LinkIcon, Loader2, MessageSquare, MoreHorizontal, Pencil, Pin, PinOff, Quote, SmilePlus, Trash2 } from 'lucide-react'
+import { Bookmark, BookmarkCheck, Bot, ChevronRight, Copy, Forward, Link as LinkIcon, Loader2, MessageSquare, MessageSquareText, MoreHorizontal, Pencil, Pin, PinOff, Quote, SmilePlus, Square, Trash2 } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -127,7 +127,7 @@ export interface ThreadRowData {
 }
 
 function MessageRowImpl({
-    message, memberNames, continuation, thread, onOpenThread, onPrefetchThread, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onQuoteReply, onForward, onToggleSave, saved, onRetryFailed, onDiscardFailed, onVotePoll, onRemovePollVote, onEndPoll, dense, selfMemberId,
+    message, memberNames, continuation, thread, onOpenThread, onPrefetchThread, onOpenAgentChat, onStopAgent, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onQuoteReply, onForward, onToggleSave, saved, onRetryFailed, onDiscardFailed, onVotePoll, onRemovePollVote, onEndPoll, dense, selfMemberId,
 }: {
     message: spaces.Message & { pending?: boolean; failed?: boolean }
     memberNames: Map<string, string>
@@ -139,6 +139,10 @@ function MessageRowImpl({
     onOpenThread?: (rootMessageId: string) => void
     /** Hover = intent: warm the thread's replies so the click paints instantly. */
     onPrefetchThread?: (rootMessageId: string) => void
+    /** Opens the thread's agent session in the chat view (working strip's "Open chat"). */
+    onOpenAgentChat?: (rootMessageId: string) => void
+    /** Stops the viewer's own Rowboat working this thread (working strip's stop square). */
+    onStopAgent?: (rootMessageId: string) => void
     onReplyInThread?: (message: spaces.Message) => void
     onAskRowboat?: (message: spaces.Message) => void
     onCopyLink?: (message: spaces.Message) => void
@@ -361,13 +365,36 @@ function MessageRowImpl({
                     </button>
                 )}
                 {thread && thread.replyCount === 0 && thread.workingAgents.length > 0 && onOpenThread && (
-                    <button
-                        type="button"
-                        onClick={() => onOpenThread(thread.rootMessageId)}
-                        className="mt-1.5 inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
-                    >
-                        <Loader2 className="size-3 animate-spin" /> Rowboat is working on a reply…
-                    </button>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                        <button
+                            type="button"
+                            onClick={() => onOpenThread(thread.rootMessageId)}
+                            title="Open the thread"
+                            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                        >
+                            <Loader2 className="size-3 animate-spin" /> Rowboat is working on a reply…
+                        </button>
+                        {onOpenAgentChat && (
+                            <button
+                                type="button"
+                                onClick={() => onOpenAgentChat(thread.rootMessageId)}
+                                title="Open the agent chat for this run"
+                                className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-[var(--stream-link)] hover:bg-accent/50"
+                            >
+                                <MessageSquareText className="size-3" /> Open chat
+                            </button>
+                        )}
+                        {onStopAgent && !!selfMemberId && thread.workingAgents.includes(selfMemberId) && (
+                            <button
+                                type="button"
+                                onClick={() => onStopAgent(thread.rootMessageId)}
+                                title="Stop your Rowboat"
+                                className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
+                            >
+                                <Square className="size-2.5 fill-current" /> Stop
+                            </button>
+                        )}
+                    </div>
                 )}
             </div>
             {showActions && (

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Anchor, Archive, ArchiveRestore, ArrowLeft, ArrowUp, Bot, Loader2, MessageSquareOff, MoreHorizontal, Pencil, ShieldAlert, Tag, X } from 'lucide-react'
+import { Anchor, Archive, ArchiveRestore, ArrowLeft, ArrowUp, Bot, Loader2, MessageSquareOff, MoreHorizontal, Pencil, ShieldAlert, Square, Tag, X } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { Button } from '@/components/ui/button'
 import {
@@ -537,6 +537,39 @@ export function ThreadPane({
         }
     }
 
+    // Whether an agent session exists for this thread — powers the header's
+    // persistent "Chat" link (the working chip only exists while a turn runs).
+    const [hasSession, setHasSession] = useState(false)
+    useEffect(() => {
+        let cancelled = false
+        void window.ipc
+            .invoke('spaces:topicSession', { orgId: org.id, spaceId: space.id, threadRootId: rootMessageId })
+            .then((res) => {
+                if (!cancelled) setHasSession(!!res.sessionId)
+            })
+            .catch(() => {})
+        return () => {
+            cancelled = true
+        }
+        // workingAgents.length: the session is born on first invoke — the
+        // moment a chip appears is the moment the link becomes real.
+    }, [org.id, space.id, rootMessageId, refreshTick, workingAgents.length])
+
+    // The stop square beside your working chip: cancel the run from here.
+    // The chip clears when the cancelled turn releases its presence lease.
+    const [stopping, setStopping] = useState(false)
+    const stopRowboat = async () => {
+        setStopping(true)
+        try {
+            const { stopped } = await window.ipc.invoke('spaces:stopRowboat', { orgId: org.id, spaceId: space.id, threadRootId: rootMessageId })
+            if (!stopped) toast('Nothing to stop — the run already finished', 'info')
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not stop the run', 'error')
+        } finally {
+            setStopping(false)
+        }
+    }
+
     // Replies with compaction and the New line. Deleted replies disappear
     // (nothing anchors to a reply, so no tombstone row is needed here).
     const visibleReplies = replies.filter((m) => !m.deletedAt)
@@ -614,6 +647,14 @@ export function ThreadPane({
                     )}
                 </span>
                 <span className="flex-1" />
+                {hasSession && onOpenSession && (
+                    // Persistent, unlike the working chip: the conversation the
+                    // agent had about this thread stays one click away after
+                    // the run ends.
+                    <Button variant="ghost" size="xs" className="gap-1 px-2 text-muted-foreground" onClick={() => void openTopicSession()} title="Open the agent chat for this thread">
+                        <Bot className="size-3.5" /> Chat
+                    </Button>
+                )}
                 {topic?.archived && <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10.5px] text-muted-foreground">archived</span>}
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -760,9 +801,20 @@ export function ThreadPane({
                             const own = memberId === org.memberId
                             const label = own ? 'Your Rowboat is working…' : <><MemberName id={memberId} />’s Rowboat is working…</>
                             return own ? (
-                                <button key={memberId} className="flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground" title="Open the agent session for this thread" onClick={() => void openTopicSession()}>
-                                    <Loader2 className="size-3 animate-spin" />{label}
-                                </button>
+                                <span key={memberId} className="flex items-center gap-1">
+                                    <button className="flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent/50 hover:text-foreground" title="Open the agent chat for this thread" onClick={() => void openTopicSession()}>
+                                        <Loader2 className="size-3 animate-spin" />{label}
+                                        <span className="font-medium text-[var(--stream-link)]">Open chat</span>
+                                    </button>
+                                    <button
+                                        className="flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-60"
+                                        title="Stop your Rowboat"
+                                        disabled={stopping}
+                                        onClick={() => void stopRowboat()}
+                                    >
+                                        {stopping ? <Loader2 className="size-2.5 animate-spin" /> : <Square className="size-2.5 fill-current" />} Stop
+                                    </button>
+                                </span>
                             ) : (
                                 <span key={memberId} className="flex items-center gap-1.5 rounded-full border border-border/60 px-2 py-0.5 text-xs text-muted-foreground"><Bot className="size-3" />{label}</span>
                             )

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -307,6 +307,7 @@ export const RPC_CHANNELS = [
   'spaces:endPoll',
   'spaces:invokeRowboat',
   'spaces:topicSession',
+  'spaces:stopRowboat',
   'spaces:subscribeSpace',
   'spaces:unsubscribeSpace',
   'spaces:presence',

--- a/apps/x/apps/server/src/spaces-deps.ts
+++ b/apps/x/apps/server/src/spaces-deps.ts
@@ -5,7 +5,7 @@ import * as spacesOAuth from '@x/core/dist/spaces/oauth.js';
 import { syncSpaceMentionWatch } from '@x/core/dist/spaces/mention-watch.js';
 import { getDndUntil, getNotifyPrefs, setDndUntil, setNotifyPref } from '@x/core/dist/spaces/notify-prefs.js';
 import { cancelScheduled, listScheduled, scheduleItem } from '@x/core/dist/spaces/scheduler.js';
-import { invokeTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
+import { invokeTopicAgent, stopTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
 import { fetchLinkPreview } from '@x/core/dist/spaces/link-preview.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
 import { openExternalUrl } from '@x/core/dist/auth/url-opener.js';
@@ -37,7 +37,11 @@ function emitSpacesEvent(event: spacesShared.SpacesBusEvent): void {
   for (const listener of spacesEventListeners) listener(event);
 }
 
-const liveSubscriptions = new Map<string, () => void>();
+// Keyed by org/space; each entry remembers WHICH live client it subscribed
+// on. A re-auth (orgs.upsertOAuthOrg) closes and replaces the org's client —
+// a cached subscription on the dead instance would swallow live frames
+// forever while every later subscribeSpace call no-ops against the cache.
+const liveSubscriptions = new Map<string, { live: unknown; unsubscribe: () => void }>();
 
 // Member-addressed frames (space_added) ride no space subscription — relay
 // them to every client as they arrive.
@@ -66,7 +70,7 @@ type SpacesRpcChannel =
   | 'spaces:listStream' | 'spaces:listThread' | 'spaces:linkPreview' | 'spaces:postMessage' | 'spaces:createTopic'
   | 'spaces:manageTopic' | 'spaces:reactToMessage'
   | 'spaces:deleteMessage' | 'spaces:editMessage' | 'spaces:votePoll' | 'spaces:endPoll'
-  | 'spaces:invokeRowboat' | 'spaces:topicSession'
+  | 'spaces:invokeRowboat' | 'spaces:topicSession' | 'spaces:stopRowboat'
   | 'spaces:subscribeSpace' | 'spaces:unsubscribeSpace' | 'spaces:presence' | 'spaces:whiteboard'
   | 'spaces:bounceLive'
   | 'spaces:getNotifyPrefs' | 'spaces:setNotifyPref' | 'spaces:getDnd' | 'spaces:setDnd'
@@ -120,9 +124,9 @@ export const spacesRpcHandlers: SpacesHandlers = {
 
   'spaces:removeOrg': async (args) => {
     void syncSpaceMentionWatch({ force: true });
-    for (const [key, unsubscribe] of liveSubscriptions) {
+    for (const [key, entry] of liveSubscriptions) {
       if (key.startsWith(`${args.orgId}/`)) {
-        unsubscribe();
+        entry.unsubscribe();
         liveSubscriptions.delete(key);
       }
     }
@@ -317,22 +321,27 @@ export const spacesRpcHandlers: SpacesHandlers = {
     sessionId: topicSessionId(args.orgId, args.spaceId, args.threadRootId),
   }),
 
+  'spaces:stopRowboat': async (args) => stopTopicAgent(args),
+
   'spaces:subscribeSpace': async (args) => {
     const key = `${args.orgId}/${args.spaceId}`;
-    if (!liveSubscriptions.has(key)) {
-      const unsubscribe = orgs.getLive(args.orgId).subscribe(
+    const live = orgs.getLive(args.orgId);
+    const cached = liveSubscriptions.get(key);
+    if (!cached || cached.live !== live) {
+      cached?.unsubscribe();
+      const unsubscribe = live.subscribe(
         args.spaceId,
         (frame) => emitSpacesEvent({ orgId: args.orgId, frame }),
         args.afterOffset,
       );
-      liveSubscriptions.set(key, unsubscribe);
+      liveSubscriptions.set(key, { live, unsubscribe });
     }
     return { success: true };
   },
 
   'spaces:unsubscribeSpace': async (args) => {
     const key = `${args.orgId}/${args.spaceId}`;
-    liveSubscriptions.get(key)?.();
+    liveSubscriptions.get(key)?.unsubscribe();
     liveSubscriptions.delete(key);
     return { success: true };
   },

--- a/apps/x/packages/core/src/spaces/live.test.ts
+++ b/apps/x/packages/core/src/spaces/live.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpacesLive } from './live.js';
+
+// Incoming frames are schema-parsed; ids must be shape-valid (SpaceId is a ULID).
+const SPACE_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+
+// Recovery tests: every wedge here was a REAL production state — the live
+// client dark forever while REST kept working, which silently killed all
+// presence ("Rowboat is working…" chips included) and live frames.
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  readyState = 0;
+  url: string;
+  sent: string[] = [];
+  private listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: (event: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(fn);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    this.emit('close', {});
+  }
+
+  emit(type: string, event: unknown): void {
+    for (const fn of this.listeners.get(type) ?? []) fn(event);
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit('open', {});
+  }
+}
+
+class ThrowingWebSocket {
+  static OPEN = 1;
+  static attempts = 0;
+  constructor() {
+    ThrowingWebSocket.attempts += 1;
+    throw new Error('no dice');
+  }
+  addEventListener(): void {}
+}
+
+function makeLive(opts?: {
+  token?: string | (() => Promise<string>);
+  impl?: unknown;
+  staleAfterMs?: number;
+  watchdogTickMs?: number;
+  tokenTimeoutMs?: number;
+}): SpacesLive {
+  return new SpacesLive({
+    baseUrl: 'https://org.example',
+    token: opts?.token ?? 'tok',
+    webSocketImpl: (opts?.impl ?? FakeWebSocket) as typeof WebSocket,
+    staleAfterMs: opts?.staleAfterMs ?? 1_000,
+    watchdogTickMs: opts?.watchdogTickMs ?? 100,
+    tokenTimeoutMs: opts?.tokenTimeoutMs ?? 500,
+  });
+}
+
+/** Let the async token/connect hop inside ensureConnected run. */
+async function settle(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  FakeWebSocket.instances = [];
+  ThrowingWebSocket.attempts = 0;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SpacesLive recovery', () => {
+  it('abandons a token resolution that never settles and retries with backoff', async () => {
+    let calls = 0;
+    const live = makeLive({
+      token: () => {
+        calls += 1;
+        // First resolution hangs FOREVER (an un-timed-out refresh fetch on a
+        // dead network); later ones succeed.
+        return calls === 1 ? new Promise<never>(() => {}) : Promise.resolve('tok');
+      },
+    });
+    live.subscribe('space-1', () => {});
+    await settle();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    // Past the token timeout + reconnect backoff: a fresh attempt must run —
+    // `connecting` was previously pinned true here forever.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(calls).toBeGreaterThan(1);
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
+    live.close();
+  });
+
+  it('watchdog revives a client whose connect attempt died scheduling nothing', async () => {
+    const live = makeLive({ impl: ThrowingWebSocket });
+    live.subscribe('space-1', () => {});
+    await settle();
+    const first = ThrowingWebSocket.attempts;
+    expect(first).toBeGreaterThan(0);
+
+    // Constructor throw → scheduleReconnect → throw again → … the loop must
+    // keep trying (backoff-capped), not stop after the first death.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(ThrowingWebSocket.attempts).toBeGreaterThan(first);
+    live.close();
+  });
+
+  it('drops a socket stuck in CONNECTING once it goes stale', async () => {
+    const live = makeLive();
+    live.subscribe('space-1', () => {});
+    await settle();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    // Never opens — a handshake hung by a vanished network path.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(1);
+    live.close();
+  });
+
+  it('presence while disconnected kick-starts the connection instead of dropping forever', async () => {
+    const live = makeLive();
+    // No subscriptions at all — the agent-presence path (topic agent holds no
+    // subscription of its own, it only renews a working lease every 10s).
+    live.presence('space-1', 'agent_working', 'root-1');
+    await settle();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    FakeWebSocket.instances[0].open();
+    // The dropped frame is gone (droppable by contract) but the NEXT renewal
+    // rides the socket the first one opened.
+    live.presence('space-1', 'agent_working', 'root-1');
+    expect(FakeWebSocket.instances[0].sent.map((s) => JSON.parse(s).kind)).toContain('presence');
+    live.close();
+  });
+
+  it('bounce reconnects immediately even when no socket object exists', async () => {
+    let calls = 0;
+    const live = makeLive({
+      token: () => {
+        calls += 1;
+        return calls === 1 ? Promise.reject(new Error('offline')) : Promise.resolve('tok');
+      },
+    });
+    live.subscribe('space-1', () => {});
+    await settle();
+    expect(FakeWebSocket.instances).toHaveLength(0); // failed, waiting out backoff
+
+    live.bounce(); // wake-from-sleep: reconnect NOW — used to be a no-op here
+    await settle();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    FakeWebSocket.instances[0].open();
+    expect(FakeWebSocket.instances[0].sent.map((s) => JSON.parse(s).kind)).toContain('subscribe');
+    live.close();
+  });
+
+  it('reconnect resubscribes with the last seen offset', async () => {
+    const live = makeLive();
+    const frames: unknown[] = [];
+    live.subscribe(SPACE_ULID, (frame) => frames.push(frame), 5);
+    await settle();
+    const first = FakeWebSocket.instances[0];
+    first.open();
+    expect(JSON.parse(first.sent[0])).toEqual({ kind: 'subscribe', spaceId: SPACE_ULID, afterOffset: 5 });
+    first.emit('message', {
+      data: JSON.stringify({
+        kind: 'event',
+        spaceId: SPACE_ULID,
+        offset: 6,
+        at: '2026-01-01T00:00:00.000Z',
+        event: {
+          type: 'membership',
+          membership: { spaceId: SPACE_ULID, memberId: 'm-1', joinedAt: '2026-01-01T00:00:00.000Z' },
+          action: 'joined',
+        },
+      }),
+    });
+    expect(frames.some((f) => (f as { kind?: string }).kind === 'event')).toBe(true);
+
+    first.close(); // server drop → reconnect
+    // Past the max backoff jitter (1s at attempt 0) but inside the stale
+    // window, so the reconnect attempt exists and hasn't been recycled yet.
+    await vi.advanceTimersByTimeAsync(1_100);
+    const second = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+    expect(second).not.toBe(first);
+    second.open();
+    expect(JSON.parse(second.sent[0])).toEqual({ kind: 'subscribe', spaceId: SPACE_ULID, afterOffset: 6 });
+    live.close();
+  });
+});

--- a/apps/x/packages/core/src/spaces/live.ts
+++ b/apps/x/packages/core/src/spaces/live.ts
@@ -29,6 +29,14 @@ const BACKOFF_CAP_MS = 30_000;
 /** ~3 missed server beacons (25s cadence) before a silent socket is presumed dead. */
 const DEFAULT_STALE_AFTER_MS = 80_000;
 const DEFAULT_WATCHDOG_TICK_MS = 15_000;
+/**
+ * Cap on resolving the connection token. The provider chains OAuth discovery
+ * + refresh fetches with no timeout of their own; on a bad network (sleep,
+ * captive portal) such a fetch can hang FOREVER, and a hung token used to
+ * pin `connecting` true permanently — no reconnect, presence silently
+ * dropped, and nothing (not even bounce) could revive the client.
+ */
+const DEFAULT_TOKEN_TIMEOUT_MS = 20_000;
 
 export interface SpacesLiveOptions {
   /** http(s)://host[:port] — same base as the REST client. */
@@ -41,6 +49,8 @@ export interface SpacesLiveOptions {
   staleAfterMs?: number;
   /** Watchdog cadence (test knob). */
   watchdogTickMs?: number;
+  /** Cap on one token resolution before the attempt is abandoned and retried (test knob). */
+  tokenTimeoutMs?: number;
 }
 
 export class SpacesLive {
@@ -49,6 +59,7 @@ export class SpacesLive {
   private readonly WebSocketImpl: typeof WebSocket;
   private readonly staleAfterMs: number;
   private readonly watchdogTickMs: number;
+  private readonly tokenTimeoutMs: number;
   private ws: WebSocket | undefined;
   private connecting = false;
   private subs = new Map<string, Subscription>();
@@ -72,6 +83,7 @@ export class SpacesLive {
     this.WebSocketImpl = options.webSocketImpl ?? WebSocket;
     this.staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
     this.watchdogTickMs = options.watchdogTickMs ?? DEFAULT_WATCHDOG_TICK_MS;
+    this.tokenTimeoutMs = options.tokenTimeoutMs ?? DEFAULT_TOKEN_TIMEOUT_MS;
   }
 
   status: SpacesLiveStatus = 'closed';
@@ -134,6 +146,12 @@ export class SpacesLive {
       this.ws.send(
         JSON.stringify({ kind: 'presence', spaceId, state, ...(threadRootId !== undefined ? { threadRootId } : {}) }),
       );
+    } else {
+      // The frame itself is droppable (senders renew), but wanting to send is
+      // proof someone needs the socket — an agent's working lease renews every
+      // 10s, so a downed connection comes back within a renewal or two instead
+      // of staying dark for the whole turn. No-op when already connecting.
+      this.ensureConnected();
     }
   }
 
@@ -146,6 +164,8 @@ export class SpacesLive {
   whiteboard(spaceId: string, boardId: string, payload: unknown): void {
     if (this.ws?.readyState === this.WebSocketImpl.OPEN) {
       this.ws.send(JSON.stringify({ kind: 'whiteboard', spaceId, boardId, payload }));
+    } else {
+      this.ensureConnected(); // same posture as presence
     }
   }
 
@@ -167,9 +187,21 @@ export class SpacesLive {
    * machinery is already on it).
    */
   bounce(): void {
-    if (this.closed || !this.ws) return;
+    if (this.closed) return;
     this.attempts = 0;
-    this.dropSocket(this.ws);
+    if (this.ws) {
+      this.dropSocket(this.ws);
+    } else if (!this.connecting) {
+      // No socket at all — a failed attempt waiting out its backoff, or a
+      // wedged one that died without scheduling a retry. Wake is the moment
+      // the host KNOWS the network changed: reconnect now, not in 30s (or
+      // never).
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = undefined;
+      }
+      this.ensureConnected();
+    }
   }
 
   /** Detach + discard a socket and get reconnection going. Safe on already-dead sockets. */
@@ -191,10 +223,23 @@ export class SpacesLive {
       // After sleep this timer fires promptly on wake, sees the huge silence
       // gap, and bounces — so recovery needs no OS-specific hooks to work.
       const ws = this.ws;
-      if (!ws || ws.readyState !== this.WebSocketImpl.OPEN) return;
-      if (Date.now() - this.lastTraffic > this.staleAfterMs) {
-        this.attempts = 0;
-        this.dropSocket(ws);
+      if (ws) {
+        // Covers OPEN-but-silent (half-open after sleep) and stuck mid
+        // handshake alike: lastTraffic resets when the attempt starts, so a
+        // socket that never reaches OPEN goes just as stale.
+        if (Date.now() - this.lastTraffic > this.staleAfterMs) {
+          this.attempts = 0;
+          this.dropSocket(ws);
+        }
+        return;
+      }
+      // No socket, someone wants one (a space subscription or a member-frame
+      // handler — same gate as scheduleReconnect), and no attempt is in
+      // flight or scheduled: a connect attempt died without arranging its own
+      // retry (openSocket threw, a token attempt was abandoned). Self-heal —
+      // this state used to be permanent and silently killed all live traffic.
+      if (!this.closed && !this.connecting && !this.reconnectTimer && (this.subs.size > 0 || this.memberHandlers.size > 0)) {
+        this.ensureConnected();
       }
     }, this.watchdogTickMs);
   }
@@ -213,26 +258,50 @@ export class SpacesLive {
     if (this.closed || this.ws || this.connecting) return;
     this.connecting = true;
     this.setStatus('connecting');
+    this.ensureWatchdog();
     void (async () => {
       let token: string;
       try {
-        token = typeof this.token === 'string' ? this.token : await this.token();
+        // The timeout guards `connecting` itself: an un-timed-out provider
+        // fetch that never settles would pin it true forever, blocking every
+        // future attempt. An abandoned attempt just retries with backoff; the
+        // provider's own single-flight absorbs the duplicate resolution.
+        token =
+          typeof this.token === 'string'
+            ? this.token
+            : await Promise.race([
+                this.token(),
+                new Promise<never>((_, reject) => {
+                  const t = setTimeout(() => reject(new Error('token timeout')), this.tokenTimeoutMs);
+                  (t as { unref?: () => void }).unref?.();
+                }),
+              ]);
       } catch {
-        // Token source failed (refresh dead → org needs re-login). Back off
-        // like a connection failure so a later re-auth resumes the stream.
+        // Token source failed (refresh dead → org needs re-login) or hung.
+        // Back off like a connection failure so a later re-auth resumes the
+        // stream.
         this.connecting = false;
         this.scheduleReconnect();
         return;
       }
       this.connecting = false;
       if (this.closed || this.ws) return;
-      this.openSocket(`${this.wsBase}/v1/live?token=${encodeURIComponent(token)}`);
+      try {
+        this.openSocket(`${this.wsBase}/v1/live?token=${encodeURIComponent(token)}`);
+      } catch {
+        // Constructor threw (bad URL from a mangled base, a runtime without
+        // the impl). Without this the attempt died scheduling nothing.
+        this.scheduleReconnect();
+      }
     })();
   }
 
   private openSocket(wsUrl: string): void {
     const ws = new this.WebSocketImpl(wsUrl);
     this.ws = ws;
+    // The attempt itself counts as traffic: a handshake stuck in CONNECTING
+    // goes stale on the same clock as a silent OPEN socket.
+    this.lastTraffic = Date.now();
     this.ensureWatchdog();
 
     ws.addEventListener('open', () => {

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type { ITurnEventBus } from '../runtime/turns/event-hub.js';
 import { type ISessions, RECLAIMED_TURN_REASON } from '../runtime/sessions/api.js';
-import type { TurnBusEvent } from '@x/shared/dist/turns.js';
+import { deriveTurnStatus, reduceTurn, type TurnBusEvent } from '@x/shared/dist/turns.js';
 import { WorkDir } from '../config/config.js';
 import { getClient, getLive, spacesMcpServerNameFor } from './orgs.js';
 
@@ -368,4 +368,38 @@ export async function invokeTopicAgent(input: InvokeTopicAgentInput): Promise<In
   );
 
   return { sessionId, queued: outcome.queued };
+}
+
+/**
+ * The stop square on the space's working chip: cancel the thread session's
+ * live turn from where the user is watching, no session hop needed. Returns
+ * stopped:false when there is nothing to stop (no session for the thread, or
+ * its latest turn already settled) — the chip clears on its own then, when
+ * the agent_working lease expires.
+ */
+export async function stopTopicAgent(input: {
+  orgId: string;
+  spaceId: string;
+  threadRootId: string;
+}): Promise<{ stopped: boolean }> {
+  const sessionId = topicSessionId(input.orgId, input.spaceId, input.threadRootId);
+  if (!sessionId) return { stopped: false };
+  const { sessions } = await resolveDeps();
+  let latestTurnId: string | undefined;
+  try {
+    latestTurnId = (await sessions.getSession(sessionId)).latestTurnId;
+  } catch {
+    return { stopped: false }; // session deleted since the registry entry
+  }
+  if (!latestTurnId) return { stopped: false };
+  const turn = await sessions.getTurn(latestTurnId);
+  const status = deriveTurnStatus(reduceTurn(turn.events));
+  if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+    return { stopped: false };
+  }
+  // idle or suspended = live (running, or parked on a permission/async tool).
+  // The watchdog sees the turn_cancelled, posts the "stopped" receipt, and
+  // releases the presence lease — the room learns what happened either way.
+  await sessions.stopTurn(latestTurnId, 'stopped from the space');
+  return { stopped: true };
 }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3974,6 +3974,14 @@ export const ipcSchemas = {
     req: z.object({ orgId: z.string(), spaceId: z.string(), threadRootId: z.string() }),
     res: z.object({ sessionId: z.string().nullable() }),
   },
+  // The stop square on the working chip: cancel the thread session's live
+  // turn without leaving the space. Invoker-only by construction — the
+  // topic→session registry is local, so only the member whose Rowboat runs
+  // here has anything to stop. stopped:false = nothing was running.
+  'spaces:stopRowboat': {
+    req: z.object({ orgId: z.string(), spaceId: z.string(), threadRootId: z.string() }),
+    res: z.object({ stopped: z.boolean() }),
+  },
   // Upload phase 1 (spec §6): bytes in, {hash, size, mime} out. Bytes travel
   // either inline (clipboard pastes — ArrayBuffer over structured clone) or as
   // an absolute file path (drag-drop / picker via electronUtils.getPathForFile)


### PR DESCRIPTION
## Problem

Mentioning `@rowboat` in a space no longer showed the "Rowboat is working…" status — replies still arrived, but every presence chip (working, typing, here-dots) was gone.

**Root cause, verified against the running packaged app:** core's `SpacesLive` (the one WebSocket per org carrying all live frames) can wedge into a permanently dead state while REST keeps working. Probed live: a presence RPC to the app's server child returned 200 while a parallel watcher on the harbor server saw nothing arrive, and the child made **zero** reconnect attempts over 60s. Three unrecoverable states caused it:

- a hung token fetch (no timeout in the OAuth refresh chain) pinned `connecting` true forever, blocking every future attempt;
- a connect attempt that threw synchronously scheduled no retry;
- `bounce()` (wake-from-sleep recovery) was a no-op when no socket object existed.

Since the agent's `agent_working` lease rides this socket and drops silently when it's down, the working status died with it — REST kept the replies flowing, masking the breakage.

## Fix (`packages/core/src/spaces/live.ts`)

- Token resolution now times out (20s) instead of pinning the connection machinery forever.
- The watchdog revives a dead client (no socket, subs want one, nothing in flight) and drops sockets stuck mid-handshake, not just silent OPEN ones.
- `bounce()` reconnects even from the fully-wedged socketless state.
- `presence()`/`whiteboard()` while disconnected kick-start the connection — the agent renews its lease every 10s, so a downed socket recovers mid-turn.
- The per-space subscription cache in **both** hosts (Electron main + server RPC) re-subscribes when a re-auth replaced the org's live client instance.
- New `live.test.ts`: every recovery path covered with a scripted fake WebSocket + fake timers.

## Features on the working indicator (both column modes)

- **Open chat, one click:** the stream's working strip gains an "Open chat" link, the thread pane's working chip carries one inline, and the thread header gets a persistent **Chat** button once the thread has an agent session.
- **Stop button:** new `spaces:stopRowboat` channel (Electron main + server RPC, dual-mode) → core `stopTopicAgent` cancels the thread session's live turn; the existing watchdog posts the "stopped" receipt and releases the presence lease.

## Validation

- Full typecheck clean; Electron main + rowboat-server bundles build.
- Tests: core 832, server 27, renderer 461 — all passing (re-run after rebasing onto `main` over #975's thread-snapshot rework).
- Deployed harbor's presence echo verified directly over WS (server side was never the problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)