### PR TITLE
Spaces: direct messages

### DIFF
--- a/apps/harbor/CONTRACT.md
+++ b/apps/harbor/CONTRACT.md
@@ -188,6 +188,33 @@ team and a Roadboard space (`src/main.ts`).
   text is refused. Topic listings fold their root like any page read, so a
   poll root card carries its votes. No `is_finalized` dance: every vote lands
   under the space lock, so folded counts are exact, live.
+- **Direct messages are spaces** (`Space.kind`, the `openDirect` route, the
+  `space_added` live frame, `list_spaces {includeDirect}` — 2026-09-07). A DM
+  is a space of kind `direct` between exactly two members: the same container
+  on the same substrate (stream, threads, discussions, files, blobs, search,
+  offsets, agent sessions — nothing forked), with a **fixed membership** —
+  `createInvite` and `leaveSpace` refuse (`invalid_request`), and the two
+  `joined` events at offsets 1 and 2 are its whole membership history. Both
+  participants hold ordinary membership rows (the access gate is unchanged);
+  the org additionally keys the DM on its **sorted participant pair**
+  (`participants` on the wire; a partial unique index in storage), so
+  `openDirect` is get-or-create and idempotent from either side — concurrent
+  opens converge on one space (`created` says who made it). No invite, no
+  acceptance: the org is the trust boundary, as inside one Slack workspace;
+  self-DM (`invalid_request`) and unknown members (`not_found`) refuse. **A
+  direct space is private forever** — any future path that opens spaces to
+  non-members (browse, self-join) MUST require `kind === 'shared'`. Its stored
+  `name` is a constant placeholder; clients label a DM by the other
+  participant's current display name (`listMembers` on the space). **Opt-in
+  visibility on both faces**: `listSpaces` and `list_spaces` return shared
+  spaces only unless `includeDirect` is passed, so a pre-DM client or skill
+  never renders a DM as a space. **The other participant is told live** by
+  `space_added` — the protocol's first frame addressed to a member rather than
+  a space (the hub grew a per-member channel): ephemeral, never replayed,
+  carrying `spaceId`/`spaceKind`/`by`; the durable truth is the membership row
+  and the `joined` event on the new space's own log. Clients refresh their
+  listing and subscribe from offset 0 so an opener's first message that beat
+  the subscription still arrives. Migration 014 adds `kind` + `direct_key`.
 - **Unknown invite tokens are 404**; `expired`/`revoked` are resolvable states.
 - **MCP face attribution**: acting mode defaults to `agent`; automations
   declare `x-acting-mode: scheduled`; `x-agent-name` carries the display label.

--- a/apps/harbor/packages/protocol/src/api.ts
+++ b/apps/harbor/packages/protocol/src/api.ts
@@ -10,7 +10,7 @@ import {
   RestoreAssetResult,
 } from './changeset.js';
 import { ActingMode, Member, Message, ReactionEmoji, Space, Topic } from './core.js';
-import { AssetPath, AssetVersion, BlobHash, ChangeSetId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
+import { AssetPath, AssetVersion, BlobHash, ChangeSetId, MemberId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
 import {
   AcceptInvite,
   AcceptInviteResult,
@@ -84,10 +84,33 @@ export const routes = {
     response: z.object({ member: Member }),
   },
   // --- spaces & membership -------------------------------------------------
+  /**
+   * The spaces you are a member of. Default = SHARED spaces only (today's
+   * shape, unchanged). `includeDirect` adds your direct messages — opt-in so
+   * a pre-DM client never renders a DM as a space. Any present value counts
+   * as true (coerce semantics, like every flag here).
+   */
   listSpaces: {
     method: 'GET',
     path: '/v1/spaces',
+    query: z.object({ includeDirect: z.coerce.boolean().optional() }),
     response: z.object({ spaces: z.array(Space) }),
+  },
+  /**
+   * Direct messages (2026-09-07): a DM is a `direct` space between exactly
+   * two members — same substrate, fixed membership (see SpaceKind). Get-or-
+   * create, idempotent: the org keys DMs on the sorted participant pair, so
+   * two members can only ever have one; `created` says whether this call
+   * made it. No invite and no acceptance — the org is the trust boundary,
+   * as inside one Slack workspace. The other participant learns of the space
+   * by a `space_added` live frame (events.ts) and on their next listing.
+   * Refuses yourself (no self-DM in v1) and unknown members.
+   */
+  openDirect: {
+    method: 'POST',
+    path: '/v1/direct',
+    request: z.object({ memberId: MemberId }),
+    response: z.object({ space: Space, created: z.boolean() }),
   },
   createSpace: {
     method: 'POST',

--- a/apps/harbor/packages/protocol/src/core.ts
+++ b/apps/harbor/packages/protocol/src/core.ts
@@ -32,10 +32,30 @@ export const Member = z.object({
 });
 export type Member = z.infer<typeof Member>;
 
+/**
+ * What a space IS at the org level (direct messages, 2026-09-07). `shared` =
+ * the ordinary space: invites, leave, files, feed. `direct` = a DM: the SAME
+ * container on the same substrate (stream, threads, files, offsets, agent
+ * sessions all unchanged), with a FIXED membership — exactly `participants`,
+ * no invites, no leave — and private forever: any later access path that
+ * opens spaces to non-members (browse, self-join) MUST require `shared`.
+ * Defaulted so payloads from pre-DM servers still parse as shared spaces.
+ */
+export const SpaceKind = z.enum(['shared', 'direct']);
+export type SpaceKind = z.infer<typeof SpaceKind>;
+
 export const Space = z.object({
   id: SpaceId,
+  /**
+   * Display name of a shared space. A direct space carries a constant
+   * placeholder — nothing is stored to go stale; clients label a DM by its
+   * other participant's CURRENT display name (listMembers on the space).
+   */
   name: z.string().min(1).max(128),
   createdAt: z.iso.datetime(),
+  kind: SpaceKind.default('shared'),
+  /** Direct spaces only: the fixed member set, sorted — the DM's identity. Absent on shared spaces. */
+  participants: z.array(MemberId).min(2).optional(),
 });
 export type Space = z.infer<typeof Space>;
 

--- a/apps/harbor/packages/protocol/src/events.ts
+++ b/apps/harbor/packages/protocol/src/events.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ChangeSet } from './changeset.js';
-import { Attribution, Membership, Message, MessageDeletion, MessageEdit, PollEnd, PollVote, Reaction, Topic, TopicRemoval } from './core.js';
+import { Attribution, Membership, Message, MessageDeletion, MessageEdit, PollEnd, PollVote, Reaction, SpaceKind, Topic, TopicRemoval } from './core.js';
 import { AssetPath, MemberId, MessageId, SpaceId, StreamOffset } from './ids.js';
 
 // Decision 2 (CONTRACT.md): one WebSocket per org, per-space subscriptions,
@@ -133,6 +133,26 @@ export const ServerFrame = z.discriminatedUnion('kind', [
    * kinds by contract, so this is a v0-legal addition.
    */
   z.object({ kind: z.literal('ping'), at: z.iso.datetime() }),
+  /**
+   * Addressed to a MEMBER, not a space (direct messages, 2026-09-07): someone
+   * else put you into a space — a DM opened with you today; admin-adds and
+   * org invites tomorrow. Every other way into a space is an act you perform
+   * yourself, so your client already knows to refresh; this is the one case
+   * where it cannot. Ephemeral and never replayed: the durable truth is the
+   * membership row plus the `joined` event on the new space's own log, which
+   * you could not have been subscribed to yet. On receipt, refresh the space
+   * listing and subscribe from offset 0 — the log is a few events long and
+   * the opener's first message may already be on it. Pre-DM clients ignore
+   * unknown frame kinds by contract.
+   */
+  z.object({
+    kind: z.literal('space_added'),
+    spaceId: SpaceId,
+    spaceKind: SpaceKind,
+    /** Who put you here. */
+    by: MemberId,
+    at: z.iso.datetime(),
+  }),
   /**
    * Ephemeral whiteboard collaboration traffic (scene diffs, cursors, idle
    * state), fanned out to the space's subscribers. The payload is opaque to

--- a/apps/harbor/packages/protocol/src/mcp.ts
+++ b/apps/harbor/packages/protocol/src/mcp.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { BlobInfo } from './blob.js';
 import { DeleteAssetResult, MoveAssetResult, ProposeChangeResult, ReadAssetResult } from './changeset.js';
-import { Message, Topic } from './core.js';
-import { AssetPath, AssetVersion, BlobHash, MessageId, SpaceId, TopicId } from './ids.js';
+import { Message, SpaceKind, Topic } from './core.js';
+import { AssetPath, AssetVersion, BlobHash, MemberId, MessageId, SpaceId, TopicId } from './ids.js';
 import { SearchKind, SearchLimit, SearchResults } from './search.js';
 
 // Decision 5 (CONTRACT.md): the agent face — direct projections of the core
@@ -39,13 +39,22 @@ export const listSpaces = tool({
     'List the spaces you are a member of on this org, each with its file listing. ' +
     'Call this first: it resolves a space name (e.g. "Roadboard") to the spaceId every other ' +
     'tool needs, and shows the asset paths available to read_asset. Discovery is mechanical — ' +
-    'do not guess spaceIds or file paths.',
-  input: z.object({}),
+    'do not guess spaceIds or file paths. Shared spaces only by default; pass includeDirect to ' +
+    'also list your direct messages (kind "direct": a private conversation with exactly one other ' +
+    'member — its participants are listed; label it by the other member, its name is a placeholder). ' +
+    'Every other tool works on a DM exactly as on a space.',
+  input: z.object({
+    /** Also list the member's direct messages (kind 'direct'). Default false: pre-DM skills never see one. */
+    includeDirect: z.boolean().optional(),
+  }),
   output: z.object({
     spaces: z.array(
       z.object({
         id: SpaceId,
         name: z.string(),
+        kind: SpaceKind,
+        /** Direct spaces only: the two member ids. */
+        participants: z.array(MemberId).optional(),
         memberCount: z.number().int().nonnegative(),
         assets: z.array(
           z.object({

--- a/apps/harbor/packages/server/src/http.ts
+++ b/apps/harbor/packages/server/src/http.ts
@@ -128,13 +128,23 @@ export function buildHttpApp(deps: {
 
   // --- spaces & membership ---------------------------------------------------
 
-  app.get(routes.listSpaces.path, async (c) =>
-    reply(c, routes.listSpaces.response, { spaces: await service.listSpaces(actor(c)) }),
-  );
+  app.get(routes.listSpaces.path, async (c) => {
+    // Any present value counts as true (coerce semantics; clients send the flag only when they mean it).
+    const q = parseWith(routes.listSpaces.query, {
+      ...(c.req.query('includeDirect') !== undefined ? { includeDirect: c.req.query('includeDirect') } : {}),
+    });
+    const spaces = await service.listSpaces(actor(c), { includeDirect: q.includeDirect ?? false });
+    return reply(c, routes.listSpaces.response, { spaces });
+  });
 
   app.post(routes.createSpace.path, async (c) => {
     const input = await body(c, routes.createSpace.request);
     return reply(c, routes.createSpace.response, { space: await service.createSpace(actor(c), input.name) });
+  });
+
+  app.post(routes.openDirect.path, async (c) => {
+    const input = await body(c, routes.openDirect.request);
+    return reply(c, routes.openDirect.response, await service.openDirect(actor(c), input.memberId));
   });
 
   app.get('/v1/spaces/:spaceId/members', async (c) => {

--- a/apps/harbor/packages/server/src/hub.ts
+++ b/apps/harbor/packages/server/src/hub.ts
@@ -8,6 +8,13 @@ import type { ServerFrame } from '@rowboat/spaces-protocol';
  */
 export class SpaceHub {
   private listeners = new Map<string, Set<(frame: ServerFrame) => void>>();
+  /**
+   * The second channel (direct messages, 2026-09-07): frames addressed to a
+   * MEMBER rather than a space — `space_added`, for the one case where
+   * someone else puts you into a space you cannot yet be subscribed to.
+   * Every live connection registers under its member id at connect.
+   */
+  private memberListeners = new Map<string, Set<(frame: ServerFrame) => void>>();
 
   subscribe(spaceId: string, fn: (frame: ServerFrame) => void): () => void {
     let set = this.listeners.get(spaceId);
@@ -24,6 +31,29 @@ export class SpaceHub {
 
   publish(spaceId: string, frame: ServerFrame): void {
     for (const fn of this.listeners.get(spaceId) ?? []) {
+      try {
+        fn(frame);
+      } catch {
+        // one bad listener never blocks the others
+      }
+    }
+  }
+
+  subscribeMember(memberId: string, fn: (frame: ServerFrame) => void): () => void {
+    let set = this.memberListeners.get(memberId);
+    if (!set) {
+      set = new Set();
+      this.memberListeners.set(memberId, set);
+    }
+    set.add(fn);
+    return () => {
+      set.delete(fn);
+      if (set.size === 0) this.memberListeners.delete(memberId);
+    };
+  }
+
+  publishToMember(memberId: string, frame: ServerFrame): void {
+    for (const fn of this.memberListeners.get(memberId) ?? []) {
       try {
         fn(frame);
       } catch {

--- a/apps/harbor/packages/server/src/mcp.ts
+++ b/apps/harbor/packages/server/src/mcp.ts
@@ -124,12 +124,15 @@ async function dispatch(service: HarborService, actor: McpActor, name: string, a
   const ctx = { memberId: actor.memberId };
   switch (name) {
     case 'list_spaces': {
-      const spaces = await service.listSpaces(ctx);
+      const a = args as { includeDirect?: boolean };
+      const spaces = await service.listSpaces(ctx, { includeDirect: a.includeDirect ?? false });
       return {
         spaces: await Promise.all(
           spaces.map(async (space) => ({
             id: space.id,
             name: space.name,
+            kind: space.kind,
+            ...(space.participants ? { participants: space.participants } : {}),
             memberCount: (await service.listMembers(ctx, space.id)).length,
             assets: await service.listAssets(ctx, space.id),
           })),

--- a/apps/harbor/packages/server/src/memory-store.ts
+++ b/apps/harbor/packages/server/src/memory-store.ts
@@ -7,6 +7,7 @@ import type {
   Topic,
 } from '@rowboat/spaces-protocol';
 import { extractSearchText, matchesAllTerms, snippetAround, type SearchQuery } from './search.js';
+import { directKeyFor } from './store.js';
 import type {
   AssetRecord,
   AssetSearchRow,
@@ -43,6 +44,7 @@ export class MemoryStore implements Store {
   private members = new Map<string, Member>();
   private identities = new Map<string, string>(); // `${iss}\n${sub}` → memberId
   private spaces = new Map<string, SpaceState>();
+  private directKeys = new Map<string, string>(); // direct key → spaceId (the unique index, in memory)
   private invites = new Map<string, StoredInvite>();
 
   private state(spaceId: string): SpaceState | undefined {
@@ -78,6 +80,14 @@ export class MemoryStore implements Store {
       existing.space = space;
       return;
     }
+    if (space.kind === 'direct') {
+      const key = directKeyFor(space.participants ?? []);
+      const holder = this.directKeys.get(key);
+      if (holder !== undefined && holder !== space.id) {
+        throw new Error(`direct space ${holder} already holds key ${key}`);
+      }
+      this.directKeys.set(key, space.id);
+    }
     this.spaces.set(space.id, {
       space,
       memberships: new Map(),
@@ -102,11 +112,17 @@ export class MemoryStore implements Store {
     return this.state(id)?.space;
   }
 
-  async listSpacesFor(memberId: string): Promise<Space[]> {
+  async listSpacesFor(memberId: string, opts: { includeDirect?: boolean } = {}): Promise<Space[]> {
     return [...this.spaces.values()]
       .filter((s) => s.memberships.has(memberId))
       .map((s) => s.space)
+      .filter((s) => opts.includeDirect || s.kind !== 'direct')
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }
+
+  async getDirectSpace(directKey: string): Promise<Space | undefined> {
+    const id = this.directKeys.get(directKey);
+    return id === undefined ? undefined : this.state(id)?.space;
   }
 
   async getMembership(spaceId: string, memberId: string): Promise<Membership | undefined> {

--- a/apps/harbor/packages/server/src/migrations.ts
+++ b/apps/harbor/packages/server/src/migrations.ts
@@ -482,6 +482,20 @@ export const MIGRATIONS: Migration[] = [
       `create index if not exists poll_votes_space_message on poll_votes (space_id, message_id)`,
     ],
   },
+  {
+    // Direct messages: a DM is a space of kind 'direct' whose identity is its
+    // sorted participant set (direct_key = JSON of the sorted member ids).
+    // The partial unique index IS the get-or-create race guard: two members
+    // opening the same DM at once both pass the lookup, one insert wins, the
+    // other re-reads. Membership rows are the access truth as for any space;
+    // the key only answers "which space is the DM between these two".
+    id: '014-direct-spaces',
+    statements: [
+      `alter table spaces add column if not exists kind text not null default 'shared'`,
+      `alter table spaces add column if not exists direct_key text`,
+      `create unique index if not exists spaces_direct_key on spaces (org_id, direct_key) where kind = 'direct'`,
+    ],
+  },
 ];
 
 export async function migrate(db: SqlDb): Promise<void> {

--- a/apps/harbor/packages/server/src/pg-store.ts
+++ b/apps/harbor/packages/server/src/pg-store.ts
@@ -12,17 +12,18 @@ import type {
 import { migrate } from './migrations.js';
 import { extractSearchText, matchesAllTerms, snippetAround, toPathPatterns, toTsQueryString, type SearchQuery } from './search.js';
 import type { SqlDb, SqlExecutor } from './sql.js';
-import type {
-  AssetRecord,
-  AssetSearchRow,
-  AssetVersionData,
-  MessageSearchRow,
-  Store,
-  StoredEvent,
-  StoredInvite,
-  StoredPollVote,
-  StoredReaction,
-  StoredSpaceBlob,
+import {
+  directKeyFor,
+  type AssetRecord,
+  type AssetSearchRow,
+  type AssetVersionData,
+  type MessageSearchRow,
+  type Store,
+  type StoredEvent,
+  type StoredInvite,
+  type StoredPollVote,
+  type StoredReaction,
+  type StoredSpaceBlob,
 } from './store.js';
 
 // The real Harbor's storage: mergeable text lives inline in Postgres (≤1MB,
@@ -51,6 +52,24 @@ function rowToMember(r: MemberRow): Member {
     displayName: r.display_name,
     ...(r.avatar_url !== null ? { avatarUrl: r.avatar_url } : {}),
     role: r.role,
+  };
+}
+
+interface SpaceRow {
+  id: string;
+  name: string;
+  created_at: string;
+  kind: Space['kind'];
+  direct_key: string | null;
+}
+
+function rowToSpace(r: SpaceRow): Space {
+  return {
+    id: r.id,
+    name: r.name,
+    createdAt: r.created_at,
+    kind: r.kind,
+    ...(r.kind === 'direct' && r.direct_key !== null ? { participants: JSON.parse(r.direct_key) as string[] } : {}),
   };
 }
 
@@ -300,32 +319,51 @@ export class PgStore implements Store {
   // --- spaces ----------------------------------------------------------------
 
   async putSpace(space: Space): Promise<void> {
+    // ON CONFLICT names the primary key only: a second direct space with the
+    // same direct_key trips the partial unique index (migration 014) and
+    // raises — the service treats that as "lost the race, re-read".
     await this.sql.query(
-      `insert into spaces (org_id, id, name, created_at) values ($1, $2, $3, $4)
+      `insert into spaces (org_id, id, name, created_at, kind, direct_key) values ($1, $2, $3, $4, $5, $6)
        on conflict (id) do update set name = excluded.name`,
-      [this.orgId, space.id, space.name, space.createdAt],
+      [
+        this.orgId,
+        space.id,
+        space.name,
+        space.createdAt,
+        space.kind,
+        space.kind === 'direct' ? directKeyFor(space.participants ?? []) : null,
+      ],
     );
   }
 
   async getSpace(id: string): Promise<Space | undefined> {
     // Org-scoped on purpose: this is what makes a foreign org's space ids
     // (and invite tokens, which resolve through here) not_found.
-    const rows = await this.sql.query<{ id: string; name: string; created_at: string }>(
-      'select id, name, created_at from spaces where org_id = $1 and id = $2',
+    const rows = await this.sql.query<SpaceRow>(
+      'select id, name, created_at, kind, direct_key from spaces where org_id = $1 and id = $2',
       [this.orgId, id],
     );
-    const r = rows[0];
-    return r ? { id: r.id, name: r.name, createdAt: r.created_at } : undefined;
+    return rows[0] ? rowToSpace(rows[0]) : undefined;
   }
 
-  async listSpacesFor(memberId: string): Promise<Space[]> {
-    const rows = await this.sql.query<{ id: string; name: string; created_at: string }>(
-      `select s.id, s.name, s.created_at from spaces s
+  async listSpacesFor(memberId: string, opts: { includeDirect?: boolean } = {}): Promise<Space[]> {
+    const rows = await this.sql.query<SpaceRow>(
+      `select s.id, s.name, s.created_at, s.kind, s.direct_key from spaces s
        join memberships m on m.space_id = s.id
-       where s.org_id = $1 and m.member_id = $2 order by s.created_at, s.id`,
-      [this.orgId, memberId],
+       where s.org_id = $1 and m.member_id = $2 and ($3::boolean or s.kind <> 'direct')
+       order by s.created_at, s.id`,
+      [this.orgId, memberId, opts.includeDirect === true],
     );
-    return rows.map((r) => ({ id: r.id, name: r.name, createdAt: r.created_at }));
+    return rows.map(rowToSpace);
+  }
+
+  async getDirectSpace(directKey: string): Promise<Space | undefined> {
+    const rows = await this.sql.query<SpaceRow>(
+      `select id, name, created_at, kind, direct_key from spaces
+       where org_id = $1 and kind = 'direct' and direct_key = $2`,
+      [this.orgId, directKey],
+    );
+    return rows[0] ? rowToSpace(rows[0]) : undefined;
   }
 
   // --- memberships -----------------------------------------------------------

--- a/apps/harbor/packages/server/src/service.ts
+++ b/apps/harbor/packages/server/src/service.ts
@@ -51,7 +51,16 @@ import { SpaceHub } from './hub.js';
 import { merge3 } from './merge.js';
 import { dispositionFor, imageDimensions, resolveMime } from './mime.js';
 import { parseSearchQuery } from './search.js';
-import type { AssetRecord, AssetVersionData, Store, StoredEvent, StoredPollVote, StoredReaction } from './store.js';
+import {
+  DIRECT_SPACE_NAME,
+  directKeyFor,
+  type AssetRecord,
+  type AssetVersionData,
+  type Store,
+  type StoredEvent,
+  type StoredPollVote,
+  type StoredReaction,
+} from './store.js';
 
 // The one service core (spec §9: one core, two faces). REST (http.ts) and MCP
 // (mcp.ts) are thin projections over this class; neither has a privileged path.
@@ -136,6 +145,13 @@ export class HarborService {
     return space;
   }
 
+  /**
+   * THE access gate: a membership row, nothing else. Direct spaces pass
+   * through it unchanged — their two participants are ordinary members. If
+   * this ever grows a non-membership path (open spaces: browse/self-join for
+   * any org member), that path MUST require `space.kind === 'shared'`; a DM
+   * is private forever (SpaceKind, core.ts).
+   */
   async requireMember(ctx: ActorCtx, spaceId: string): Promise<Space> {
     const space = await this.requireSpace(spaceId);
     const membership = await this.store.getMembership(spaceId, ctx.memberId);
@@ -152,14 +168,14 @@ export class HarborService {
 
   // --- spaces & membership ---------------------------------------------------
 
-  async listSpaces(ctx: ActorCtx): Promise<Space[]> {
-    return this.store.listSpacesFor(ctx.memberId);
+  async listSpaces(ctx: ActorCtx, opts: { includeDirect?: boolean } = {}): Promise<Space[]> {
+    return this.store.listSpacesFor(ctx.memberId, opts);
   }
 
   async createSpace(ctx: ActorCtx, name: string): Promise<Space> {
     this.guardWrite();
     const now = this.now();
-    const space: Space = { id: this.ulid(), name, createdAt: now };
+    const space: Space = { id: this.ulid(), name, createdAt: now, kind: 'shared' };
     await this.store.putSpace(space);
     return this.store.withSpaceLock(space.id, async () => {
       const membership: Membership = { spaceId: space.id, memberId: ctx.memberId, joinedAt: now };
@@ -170,6 +186,55 @@ export class HarborService {
       // space's root messages, born empty.
       return space;
     });
+  }
+
+  /**
+   * Direct messages (api.ts openDirect): get-or-create the one DM between
+   * the caller and `otherMemberId`. Membership is written for both under the
+   * new space's lock — two `joined` events are the whole membership history
+   * of a DM, forever (no invites, no leave). The other participant is told
+   * by a member-addressed `space_added` frame: the org is the trust
+   * boundary, so there is no acceptance step. Two participants opening the
+   * same DM at once both pass the lookup; the store's direct-key uniqueness
+   * refuses the second row and that caller re-reads the winner's space.
+   */
+  async openDirect(ctx: ActorCtx, otherMemberId: string): Promise<{ space: Space; created: boolean }> {
+    if (otherMemberId === ctx.memberId) {
+      throw new HarborError('invalid_request', 'a direct message needs someone else — there is no self-DM');
+    }
+    const other = await this.store.getMember(otherMemberId);
+    if (!other) throw new HarborError('not_found', 'no such member on this org');
+    const participants = [ctx.memberId, otherMemberId].sort();
+    const key = directKeyFor(participants);
+    const existing = await this.store.getDirectSpace(key);
+    if (existing) return { space: existing, created: false };
+
+    this.guardWrite();
+    const now = this.now();
+    const space: Space = { id: this.ulid(), name: DIRECT_SPACE_NAME, createdAt: now, kind: 'direct', participants };
+    try {
+      await this.store.putSpace(space);
+    } catch (err) {
+      const raced = await this.store.getDirectSpace(key);
+      if (raced) return { space: raced, created: false };
+      throw err;
+    }
+    await this.store.withSpaceLock(space.id, async () => {
+      let offset = await this.store.head(space.id);
+      for (const memberId of participants) {
+        const membership: Membership = { spaceId: space.id, memberId, joinedAt: now };
+        await this.store.putMembership(membership);
+        await this.append(space.id, ++offset, now, { type: 'membership', membership, action: 'joined' });
+      }
+    });
+    this.hub.publishToMember(otherMemberId, {
+      kind: 'space_added',
+      spaceId: space.id,
+      spaceKind: 'direct',
+      by: ctx.memberId,
+      at: now,
+    });
+    return { space, created: true };
   }
 
   async listMembers(ctx: ActorCtx, spaceId: string): Promise<Member[]> {
@@ -184,7 +249,10 @@ export class HarborService {
   }
 
   async leaveSpace(ctx: ActorCtx, spaceId: string): Promise<void> {
-    await this.requireMember(ctx, spaceId);
+    const space = await this.requireMember(ctx, spaceId);
+    if (space.kind === 'direct') {
+      throw new HarborError('invalid_request', 'a direct message has a fixed membership — it cannot be left');
+    }
     await this.store.withSpaceLock(spaceId, async () => {
       const membership = await this.store.getMembership(spaceId, ctx.memberId);
       if (!membership) return;
@@ -197,7 +265,10 @@ export class HarborService {
   // --- invites ---------------------------------------------------------------
 
   async createInvite(ctx: ActorCtx, spaceId: string, expiresInHours?: number): Promise<CreateInviteResult> {
-    await this.requireMember(ctx, spaceId);
+    const space = await this.requireMember(ctx, spaceId);
+    if (space.kind === 'direct') {
+      throw new HarborError('invalid_request', 'a direct message has a fixed membership — nobody can be invited');
+    }
     this.guardWrite();
     const token = randomBytes(24).toString('base64url');
     const now = this.now();

--- a/apps/harbor/packages/server/src/store.ts
+++ b/apps/harbor/packages/server/src/store.ts
@@ -67,6 +67,21 @@ export interface StoredInvite {
   revoked: boolean;
 }
 
+/**
+ * The stored name of every direct space — a constant placeholder, never
+ * displayed: clients label a DM by its other participant's current name.
+ */
+export const DIRECT_SPACE_NAME = 'Direct message';
+
+/**
+ * A DM's identity: its sorted participant ids, JSON-encoded (unambiguous for
+ * any member id). Both drivers key their uniqueness guard on exactly this
+ * string, and `participants` on the wire is its decoding.
+ */
+export function directKeyFor(participants: readonly string[]): string {
+  return JSON.stringify([...participants].sort());
+}
+
 /** A durable, offsetted fact as stored — exactly what WS replay sends. */
 export interface StoredEvent {
   offset: number;
@@ -122,10 +137,15 @@ export interface Store {
   getMemberByIdentity(iss: string, sub: string): Promise<Member | undefined>;
   putIdentity(iss: string, sub: string, memberId: string): Promise<void>;
 
-  // spaces
+  // spaces — `kind` (migration 014) rides the row; a direct space also
+  // stores its direct key, and putSpace MUST refuse a second direct space
+  // with the same key (the get-or-create race guard the service relies on).
   putSpace(space: Space): Promise<void>;
   getSpace(id: string): Promise<Space | undefined>;
-  listSpacesFor(memberId: string): Promise<Space[]>;
+  /** Shared spaces only unless `includeDirect` — the listing's compatibility posture (api.ts). */
+  listSpacesFor(memberId: string, opts?: { includeDirect?: boolean }): Promise<Space[]>;
+  /** The DM whose participants encode to `directKey` (directKeyFor), if it exists. */
+  getDirectSpace(directKey: string): Promise<Space | undefined>;
 
   // membership
   getMembership(spaceId: string, memberId: string): Promise<Membership | undefined>;

--- a/apps/harbor/packages/server/src/ws.ts
+++ b/apps/harbor/packages/server/src/ws.ts
@@ -119,6 +119,10 @@ function handleConnection(ws: LiveSocket, memberId: string, deps: Deps): void {
     send({ kind: 'error', ...(spaceId ? { spaceId } : {}), code, message });
   };
 
+  // Member-addressed frames (space_added) need no subscription — the whole
+  // point is that the space is one you could not have subscribed to yet.
+  const unsubscribeMember = deps.hub.subscribeMember(memberId, send);
+
   ws.on('message', (data) => {
     ws.sawLifeSinceLastBeat = true;
     void (async () => {
@@ -202,6 +206,7 @@ function handleConnection(ws: LiveSocket, memberId: string, deps: Deps): void {
   });
 
   ws.on('close', () => {
+    unsubscribeMember();
     for (const unsubscribe of subscriptions.values()) unsubscribe();
     subscriptions.clear();
   });

--- a/apps/harbor/packages/server/test/direct.test.ts
+++ b/apps/harbor/packages/server/test/direct.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { ServerFrame, Space } from '@rowboat/spaces-protocol';
+import { PgStore } from '../src/pg-store.js';
+import { startHarbor, type HarborOptions, type RunningHarbor } from '../src/server.js';
+import type { SqlDb } from '../src/sql.js';
+import { agentClient, callStructured, liveClient, restClient } from './helpers.js';
+import { pgliteDb } from './pglite.js';
+
+// Direct messages (2026-09-07): a DM is a `direct` space — same substrate,
+// fixed membership, private forever. Runs on both stores: the direct-key
+// uniqueness guard is a partial unique index on Postgres and a map in memory,
+// and the service's race handling must hold on either.
+
+let harbor: RunningHarbor;
+let sqlDb: SqlDb | undefined;
+let ramnique: ReturnType<typeof restClient>;
+let harsh: ReturnType<typeof restClient>;
+let gagan: ReturnType<typeof restClient>;
+
+async function startForStore(kind: 'memory' | 'postgres'): Promise<void> {
+  const options: HarborOptions = {
+    orgName: 'Rowboat Labs',
+    seedMembers: [
+      { id: 'ramnique', displayName: 'Ramnique' },
+      { id: 'harsh', displayName: 'Harsh' },
+      { id: 'gagan', displayName: 'Gagan' },
+    ],
+    seedSpaces: [{ name: 'Main', creator: 'ramnique' }],
+  };
+  if (kind === 'postgres') {
+    sqlDb = await pgliteDb();
+    const store = new PgStore(sqlDb);
+    await store.init();
+    options.store = store;
+  }
+  harbor = await startHarbor(options);
+  ramnique = restClient(harbor, 'dev-ramnique');
+  harsh = restClient(harbor, 'dev-harsh');
+  gagan = restClient(harbor, 'dev-gagan');
+}
+
+function spaceAdded(frames: ServerFrame[]) {
+  return frames.filter((f): f is Extract<ServerFrame, { kind: 'space_added' }> => f.kind === 'space_added');
+}
+
+describe.each([['memory'], ['postgres']] as const)('direct messages (%s store)', (storeKind) => {
+  let dm: Space;
+
+  beforeAll(async () => {
+    await startForStore(storeKind);
+  });
+
+  afterAll(async () => {
+    await harbor.close();
+    await sqlDb?.close();
+    sqlDb = undefined;
+  });
+
+  it('opens a DM: a direct space with the sorted pair as participants and a placeholder name', async () => {
+    const r = await ramnique.post('/v1/direct', { memberId: 'harsh' });
+    expect(r.status).toBe(200);
+    expect(r.body.created).toBe(true);
+    dm = r.body.space;
+    expect(dm.kind).toBe('direct');
+    expect(dm.participants).toEqual(['harsh', 'ramnique']);
+    expect(dm.name).toBe('Direct message');
+  });
+
+  it('is get-or-create from either side: the same space comes back, never a second one', async () => {
+    const again = await ramnique.post('/v1/direct', { memberId: 'harsh' });
+    expect(again.body).toMatchObject({ created: false, space: { id: dm.id } });
+    const fromHarsh = await harsh.post('/v1/direct', { memberId: 'ramnique' });
+    expect(fromHarsh.body).toMatchObject({ created: false, space: { id: dm.id } });
+  });
+
+  it('both participants are ordinary members; their membership history is two joined events', async () => {
+    const members = await ramnique.get(`/v1/spaces/${dm.id}/members`);
+    expect(members.body.members.map((m: any) => m.id).sort()).toEqual(['harsh', 'ramnique']);
+    const events = await harbor.service.eventsAfter(dm.id, 0);
+    expect(events.map((e) => e.event.type)).toEqual(['membership', 'membership']);
+    expect(events.map((e) => e.offset)).toEqual([1, 2]);
+  });
+
+  it('the listing hides DMs unless asked, and shows them only to participants', async () => {
+    const plain = await ramnique.get('/v1/spaces');
+    expect(plain.body.spaces.map((s: Space) => s.id)).not.toContain(dm.id);
+    expect(plain.body.spaces.every((s: Space) => s.kind === 'shared')).toBe(true);
+
+    const withDirect = await ramnique.get('/v1/spaces?includeDirect=1');
+    const mine = withDirect.body.spaces.find((s: Space) => s.id === dm.id);
+    expect(mine).toMatchObject({ kind: 'direct', participants: ['harsh', 'ramnique'] });
+    expect((await harsh.get('/v1/spaces?includeDirect=1')).body.spaces.map((s: Space) => s.id)).toContain(dm.id);
+    expect((await gagan.get('/v1/spaces?includeDirect=1')).body.spaces.map((s: Space) => s.id)).not.toContain(dm.id);
+  });
+
+  it('is private by construction: a third member is forbidden, participants talk as in any space', async () => {
+    expect((await gagan.get(`/v1/spaces/${dm.id}/stream`)).status).toBe(403);
+    const post = await harsh.post(`/v1/spaces/${dm.id}/messages`, { body: 'hey — got a minute?', actingMode: 'direct' });
+    expect(post.status).toBe(200);
+    const stream = await ramnique.get(`/v1/spaces/${dm.id}/stream`);
+    expect(stream.body.messages.map((m: any) => m.body)).toEqual(['hey — got a minute?']);
+  });
+
+  it('has a fixed membership: no invites, no leaving', async () => {
+    const invite = await ramnique.post('/v1/invites', { spaceId: dm.id });
+    expect(invite.status).toBe(400);
+    expect(invite.body.code).toBe('invalid_request');
+    const leave = await harsh.post(`/v1/spaces/${dm.id}/leave`);
+    expect(leave.status).toBe(400);
+    expect(leave.body.code).toBe('invalid_request');
+    expect((await ramnique.get(`/v1/spaces/${dm.id}/members`)).body.members).toHaveLength(2);
+  });
+
+  it('refuses a self-DM and an unknown member', async () => {
+    const self = await ramnique.post('/v1/direct', { memberId: 'ramnique' });
+    expect(self.status).toBe(400);
+    const nobody = await ramnique.post('/v1/direct', { memberId: 'nobody' });
+    expect(nobody.status).toBe(404);
+  });
+
+  it('two participants opening the same DM at once converge on one space', async () => {
+    const [a, b] = await Promise.all([
+      ramnique.post('/v1/direct', { memberId: 'gagan' }),
+      gagan.post('/v1/direct', { memberId: 'ramnique' }),
+    ]);
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(a.body.space.id).toBe(b.body.space.id);
+    expect([a.body.created, b.body.created].filter(Boolean)).toHaveLength(1);
+    const listed = (await gagan.get('/v1/spaces?includeDirect=1')).body.spaces.filter((s: Space) => s.kind === 'direct');
+    expect(listed).toHaveLength(1);
+  });
+
+  it('tells the other participant live (space_added), and a from-zero subscribe catches the first message', async () => {
+    const gaganLive = await liveClient(harbor, 'dev-gagan');
+    const opened = await harsh.post('/v1/direct', { memberId: 'gagan' });
+    expect(opened.body.created).toBe(true);
+    const id: string = opened.body.space.id;
+    // The opener's first message may land before the other side has subscribed.
+    await harsh.post(`/v1/spaces/${id}/messages`, { body: 'hi gagan', actingMode: 'direct' });
+
+    await gaganLive.until((fs) => spaceAdded(fs).length > 0, 'space_added frame');
+    expect(spaceAdded(gaganLive.frames)[0]).toMatchObject({ spaceId: id, spaceKind: 'direct', by: 'harsh' });
+
+    gaganLive.send({ kind: 'subscribe', spaceId: id, afterOffset: 0 });
+    await gaganLive.until((fs) => fs.filter((f) => f.kind === 'event').length >= 3, 'replay from zero');
+    expect(gaganLive.events().map((e) => e.event.type)).toEqual(['membership', 'membership', 'message']);
+    gaganLive.close();
+  });
+
+  it('never addresses the opener or bystanders with space_added', async () => {
+    const ramLive = await liveClient(harbor, 'dev-ramnique');
+    const harshLive = await liveClient(harbor, 'dev-harsh');
+    // A brand-new pair so the open actually creates.
+    await harbor.store.putMember({ id: 'prakhar', displayName: 'Prakhar', role: 'member' });
+    const prakhar = restClient(harbor, 'dev-prakhar');
+    const prakharLive = await liveClient(harbor, 'dev-prakhar');
+    await ramnique.post('/v1/direct', { memberId: 'prakhar' });
+    await prakharLive.until((fs) => spaceAdded(fs).length > 0, 'prakhar told');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(spaceAdded(ramLive.frames)).toHaveLength(0);
+    expect(spaceAdded(harshLive.frames)).toHaveLength(0);
+    expect((await prakhar.get('/v1/spaces?includeDirect=1')).body.spaces.some((s: Space) => s.kind === 'direct')).toBe(true);
+    ramLive.close();
+    harshLive.close();
+    prakharLive.close();
+  });
+
+  it('the agent face sees DMs only when asked, with kind and participants, and works on them like any space', async () => {
+    const agent: Client = await agentClient(harbor, 'dev-ramnique', { agentName: 'Rowboat' });
+    const plain = await callStructured<{ spaces: Array<{ id: string; kind: string }> }>(agent, 'list_spaces', {});
+    expect(plain.spaces.every((s) => s.kind === 'shared')).toBe(true);
+    const all = await callStructured<{ spaces: Array<{ id: string; kind: string; participants?: string[] }> }>(
+      agent,
+      'list_spaces',
+      { includeDirect: true },
+    );
+    const mine = all.spaces.find((s) => s.id === dm.id);
+    expect(mine).toMatchObject({ kind: 'direct', participants: ['harsh', 'ramnique'] });
+    try {
+      const posted = await callStructured<{ messageId: string }>(agent, 'post_message', {
+        spaceId: dm.id,
+        body: 'Ramnique is in a meeting until 3 — will reply after.',
+      });
+      const stream = await harsh.get(`/v1/spaces/${dm.id}/stream`);
+      const mine = stream.body.messages.find((m: any) => m.id === posted.messageId);
+      expect(mine.author).toMatchObject({ memberId: 'ramnique', actingMode: 'agent', agentName: 'Rowboat' });
+    } finally {
+      await agent.close();
+    }
+  });
+});

--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -30,6 +30,7 @@ type SpacesHandlers = {
   'spaces:removeOrg': InvokeHandler<'spaces:removeOrg'>;
   'spaces:listSpaces': InvokeHandler<'spaces:listSpaces'>;
   'spaces:createSpace': InvokeHandler<'spaces:createSpace'>;
+  'spaces:openDirect': InvokeHandler<'spaces:openDirect'>;
   'spaces:listMembers': InvokeHandler<'spaces:listMembers'>;
   'spaces:createInvite': InvokeHandler<'spaces:createInvite'>;
   'spaces:resolveInvite': InvokeHandler<'spaces:resolveInvite'>;
@@ -87,6 +88,11 @@ function orgSummary(record: orgs.OrgRecord): spacesShared.SpacesOrgSummary {
 }
 
 const openBrowser = (url: string) => shell.openExternal(url);
+
+// Member-addressed frames (space_added: someone opened a DM with us) have no
+// space subscription to ride — relay them to every window as they arrive; the
+// renderer's orgs store refreshes its listing on them.
+orgs.onMemberFrame((orgId, frame) => broadcastSpacesEvent({ orgId, frame }));
 
 function broadcastSpacesEvent(event: spacesShared.SpacesBusEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -162,7 +168,7 @@ export const spacesIpcHandlers: SpacesHandlers = {
   },
 
   'spaces:listSpaces': async (_event, args) => {
-    const spaces = await orgs.getClient(args.orgId).listSpaces();
+    const spaces = await orgs.getClient(args.orgId).listSpaces({ includeDirect: args.includeDirect ?? false });
     // The renderer just reached this org — if it was down at boot (or restarted),
     // this is the earliest signal that its spaces are watchable again. Unforced:
     // repeated refreshes collapse into one sync.
@@ -174,6 +180,12 @@ export const spacesIpcHandlers: SpacesHandlers = {
     const space = await orgs.getClient(args.orgId).createSpace(args.name);
     void syncSpaceMentionWatch({ force: true });
     return { space };
+  },
+
+  'spaces:openDirect': async (_event, args) => {
+    const result = await orgs.getClient(args.orgId).openDirect(args.memberId);
+    if (result.created) void syncSpaceMentionWatch({ force: true });
+    return result;
   },
 
   'spaces:listMembers': async (_event, args) => ({

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -41,7 +41,8 @@ import { BgTasksView } from '@/components/bg-tasks-view';
 import { AppsView } from '@/components/apps/apps-view';
 import { SpacesView, type SpaceSelection } from '@/components/spaces-view';
 import { railKey, type RailSelection } from '@/lib/spaces-selection';
-import { useSpacesOrgs } from '@/hooks/use-spaces';
+import { findSpace, useSpacesOrgs } from '@/hooks/use-spaces';
+import { spaceDisplayName } from '@/lib/spaces-direct';
 import { EmailView } from '@/components/email-view';
 import { WorkspaceView } from '@/components/workspace-view';
 import { KnowledgeView, type KnowledgeViewMode } from '@/components/knowledge-view';
@@ -4641,7 +4642,8 @@ function App() {
       case 'apps': return 'Apps'
       case 'spaces': {
         const org = spacesOrgs.find((o) => o.id === currentViewState.orgId)
-        return org?.spaces.find((sp) => sp.id === currentViewState.spaceId)?.name ?? 'Spaces'
+        const space = org ? findSpace(org, currentViewState.spaceId) : undefined
+        return org && space ? spaceDisplayName(org, space) : 'Spaces'
       }
       case 'workspace': return 'Workspace'
       case 'knowledge-view': return 'Brain'

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -71,7 +71,10 @@ import { SidebarCreditRewards } from "@/components/sidebar-credit-rewards"
 import { SPACES_ENABLED } from "@/lib/feature-flags"
 import { AddOrgDialog, OrgMonogram, type SpaceSelection } from "@/components/spaces-view"
 import { useSpacesOrgs, type OrgWithSpaces } from "@/hooks/use-spaces"
-import { useSpacesUnreadCounts } from "@/hooks/use-space-chat"
+import { prefetchStream, spaceLastActivityAt, useSpacesUnreadCounts } from "@/hooks/use-space-chat"
+import { MemberAvatar } from "@/components/spaces/atoms"
+import { NewDirectDialog } from "@/components/spaces/new-direct-dialog"
+import { otherParticipant, spaceDisplayName } from "@/lib/spaces-direct"
 import { MascotFaceIcon } from "@/components/talking-head"
 import { extractConferenceLink } from "@/lib/calendar-event"
 import { useBilling } from "@/hooks/useBilling"
@@ -874,7 +877,7 @@ export function DockSidebar({
     for (const count of spacesUnread.values()) sum += count
     return sum
   }, [spacesUnread])
-  const totalSpaces = useMemo(() => orgs.reduce((n, o) => n + o.spaces.length, 0), [orgs])
+  const totalSpaces = useMemo(() => orgs.reduce((n, o) => n + o.spaces.length + o.directs.length, 0), [orgs])
 
   // ----- data: sync status (for the Settings tooltip + activity popover) -----
   const { isSyncing, hasServiceErrors, statusLabel: syncStatusLabel, setServiceErrors } = useSyncStatus()
@@ -888,7 +891,7 @@ export function DockSidebar({
       last = JSON.parse(window.localStorage.getItem(LAST_SPACE_STORAGE_KEY) ?? 'null') as { orgId: string; spaceId: string } | null
     } catch { /* ignore */ }
     const isValid = last != null
-      && orgs.some((o) => o.id === last.orgId && o.spaces.some((s) => s.id === last.spaceId))
+      && orgs.some((o) => o.id === last.orgId && (o.spaces.some((s) => s.id === last.spaceId) || o.directs.some((s) => s.id === last.spaceId)))
     const target = isValid && last
       ? last
       : (() => {
@@ -1238,6 +1241,13 @@ export function DockSidebar({
               <ContextMenuItem key={`${org.id}/${space.id}`} onClick={() => onOpenSpace?.(org.id, space.id)}>
                 <MessagesSquare className="mr-2 size-3.5 text-muted-foreground" />
                 <span className="truncate">{space.name}</span>
+                {orgs.length > 1 && <span className="ml-2 truncate text-xs text-muted-foreground">{org.name}</span>}
+              </ContextMenuItem>
+            )))}
+            {orgs.flatMap((org) => org.directs.map((dm) => (
+              <ContextMenuItem key={`${org.id}/${dm.id}`} onClick={() => onOpenSpace?.(org.id, dm.id)}>
+                <MemberAvatar id={otherParticipant(dm, org.memberId) ?? dm.id} name={spaceDisplayName(org, dm)} size="sm" className="mr-2 size-3.5 rounded-[3px] text-[7px]" />
+                <span className="truncate">{spaceDisplayName(org, dm)}</span>
                 {orgs.length > 1 && <span className="ml-2 truncate text-xs text-muted-foreground">{org.name}</span>}
               </ContextMenuItem>
             )))}
@@ -1725,6 +1735,7 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
 }) {
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
+  const [newDirectOpen, setNewDirectOpen] = useState(false)
   // A dead OAuth session shows as a gentle "Sign in again" (org.authError, from core);
   // an unreachable org shows Retry.
   const needsSignIn = !!org.authError
@@ -1755,6 +1766,14 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
       toast(err instanceof Error ? err.message : 'Could not create the space', 'error')
     }
   }
+
+  // DMs: people, most recent conversation first (their streams are warmed so
+  // unread and recency read the loaded tail — a DM has no discussions to badge from).
+  useEffect(() => {
+    for (const dm of org.directs) prefetchStream(org.id, dm.id)
+  }, [org.id, org.directs])
+  const directs = [...org.directs].sort((a, b) =>
+    (spaceLastActivityAt(org.id, b.id) ?? b.createdAt).localeCompare(spaceLastActivityAt(org.id, a.id) ?? a.createdAt))
 
   return (
     <>
@@ -1794,6 +1813,9 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
           <DropdownMenuContent side="right" align="start">
             <DropdownMenuItem onClick={() => setCreating(true)}>
               <Plus className="mr-2 size-3.5" /> New space
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setNewDirectOpen(true)}>
+              <MessagesSquare className="mr-2 size-3.5" /> New message
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
@@ -1837,6 +1859,46 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
           <span className="flex-1 truncate">Create the first space</span>
         </button>
       )}
+      {/* Direct messages — a DM is a space with a two-person roster; the row is the person. */}
+      {!org.error && (
+        <div className="flex h-6 items-end pl-5 pr-2.5 text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground/70">
+          <span className="truncate">Direct messages</span>
+        </div>
+      )}
+      {!org.error && directs.map((dm) => {
+        const active = activeSpace?.orgId === org.id && activeSpace.spaceId === dm.id
+        const count = unread.get(`${org.id}/${dm.id}`) ?? 0
+        const label = spaceDisplayName(org, dm)
+        return (
+          <button
+            key={dm.id}
+            type="button"
+            onClick={() => onOpenSpace(org.id, dm.id)}
+            onMouseEnter={() => prefetchStream(org.id, dm.id)}
+            className={cn(
+              'flex w-full items-center gap-2.5 rounded-[9px] py-2 pl-5 pr-2.5 text-left text-[13.5px] text-foreground/90 hover:bg-accent',
+              active && 'bg-[var(--sidebar-accent)]',
+            )}
+          >
+            <MemberAvatar id={otherParticipant(dm, org.memberId) ?? dm.id} name={label} size="sm" className="size-4 rounded-[3px] text-[8px]" />
+            <span className={cn('min-w-0 flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{label}</span>
+            {count > 0 && (
+              <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
+            )}
+          </button>
+        )
+      })}
+      {!org.error && (
+        <button
+          type="button"
+          onClick={() => setNewDirectOpen(true)}
+          className="flex w-full items-center gap-2 rounded-[9px] py-2 pl-5 pr-2.5 text-left text-xs text-muted-foreground hover:bg-accent"
+        >
+          <Plus className="size-3.5 shrink-0" />
+          <span className="flex-1 truncate">New message</span>
+        </button>
+      )}
+      <NewDirectDialog org={org} open={newDirectOpen} onOpenChange={setNewDirectOpen} onOpened={onOpenSpace} />
       {creating && (
         <div className="flex items-center gap-1 py-0.5 pl-5 pr-2">
           <Input

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ChevronRight, Hash, Loader2, MessagesSquare, MoreVertical, Plus, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
@@ -8,13 +8,18 @@ import {
 import { Input } from '@/components/ui/input'
 import { AddOrgDialog, OrgMonogram, type SpaceSelection } from '@/components/spaces-view'
 import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
-import { prefetchStream, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
+import { prefetchStream, spaceLastActivityAt, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
+import { MemberAvatar } from '@/components/spaces/atoms'
+import { NewDirectDialog } from '@/components/spaces/new-direct-dialog'
+import { otherParticipant, spaceDisplayName } from '@/lib/spaces-direct'
 import { prefetchMembers } from '@/hooks/use-space-members'
 import { bumpSpaceUse, readSpaceUse, spaceUseKey } from '@/lib/space-usage'
 import { toast } from '@/lib/toast'
 
 /** The fold: how many spaces the section shows before "Show all". */
 const MAX_VISIBLE_SPACES = 5
+/** DMs fold too, by recency — the people you talk to stay in view. */
+const MAX_VISIBLE_DIRECTS = 5
 
 // The sidebar's SPACES section (design: "App shell scope planning"): every
 // org this install is signed into, its spaces underneath with unread counts,
@@ -135,6 +140,8 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
 }) {
     const [creating, setCreating] = useState(false)
     const [newName, setNewName] = useState('')
+    const [newDirectOpen, setNewDirectOpen] = useState(false)
+    const [showAllDirects, setShowAllDirects] = useState(false)
     // A dead OAuth session shows as a gentle "Sign in again" (org.authError, from core);
     // an unreachable org shows Retry.
     const needsSignIn = !!org.authError
@@ -165,6 +172,16 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
             toast(err instanceof Error ? err.message : 'Could not create the space', 'error')
         }
     }
+
+    // DMs: people, most recent conversation first. A DM has no discussions
+    // to badge from, so its stream is warmed here — unread and recency both
+    // read the loaded tail.
+    useEffect(() => {
+        for (const dm of org.directs) prefetchStream(org.id, dm.id)
+    }, [org.id, org.directs])
+    const directs = [...org.directs].sort((a, b) =>
+        (spaceLastActivityAt(org.id, b.id) ?? b.createdAt).localeCompare(spaceLastActivityAt(org.id, a.id) ?? a.createdAt))
+    const visibleDirects = showAllDirects ? directs : directs.slice(0, MAX_VISIBLE_DIRECTS)
 
     return (
         <>
@@ -205,6 +222,9 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                         <DropdownMenuContent side="right" align="start">
                             <DropdownMenuItem onClick={() => setCreating(true)}>
                                 <Plus className="mr-2 size-3.5" /> New space
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => setNewDirectOpen(true)}>
+                                <MessagesSquare className="mr-2 size-3.5" /> New message
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
@@ -253,6 +273,58 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                     </SidebarMenuButton>
                 </SidebarMenuItem>
             )}
+            {/* Direct messages: the org's people you talk to, most recent first.
+                A DM is a space with a two-person roster (contract 2026-09-07);
+                the row is the person, not a channel. */}
+            {!org.error && (
+                <SidebarMenuItem>
+                    <div className="flex h-6 items-end pl-9 pr-2 text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                        <span className="truncate">Direct messages</span>
+                    </div>
+                </SidebarMenuItem>
+            )}
+            {!org.error && visibleDirects.map((dm) => {
+                const active = activeSpace?.orgId === org.id && activeSpace.spaceId === dm.id
+                const count = unread.get(`${org.id}/${dm.id}`) ?? 0
+                const label = spaceDisplayName(org, dm)
+                const other = otherParticipant(dm, org.memberId) ?? dm.id
+                return (
+                    <SidebarMenuItem key={dm.id}>
+                        <SidebarMenuButton
+                            isActive={active}
+                            onClick={() => onOpenSpace(org.id, dm.id)}
+                            onMouseEnter={() => {
+                                prefetchStream(org.id, dm.id)
+                                prefetchMembers(org.id, dm.id)
+                            }}
+                            className="pl-9"
+                        >
+                            <MemberAvatar id={other} name={label} size="sm" className="size-4 rounded-[3px] text-[8px]" />
+                            <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{label}</span>
+                            {count > 0 && (
+                                <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
+                            )}
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                )
+            })}
+            {!org.error && directs.length > MAX_VISIBLE_DIRECTS && (
+                <SidebarMenuItem>
+                    <SidebarMenuButton onClick={() => setShowAllDirects((v) => !v)} className="pl-9 text-muted-foreground">
+                        <ChevronRight className={cn('size-3.5 shrink-0 transition-transform', showAllDirects && 'rotate-90')} />
+                        <span className="flex-1 truncate text-xs">{showAllDirects ? 'Show less' : `Show all ${directs.length}`}</span>
+                    </SidebarMenuButton>
+                </SidebarMenuItem>
+            )}
+            {!org.error && (
+                <SidebarMenuItem>
+                    <SidebarMenuButton onClick={() => setNewDirectOpen(true)} className="pl-9 text-muted-foreground">
+                        <Plus className="size-3.5 shrink-0" />
+                        <span className="flex-1 truncate text-xs">New message</span>
+                    </SidebarMenuButton>
+                </SidebarMenuItem>
+            )}
+            <NewDirectDialog org={org} open={newDirectOpen} onOpenChange={setNewDirectOpen} onOpened={onOpenSpace} />
             {creating && (
                 <SidebarMenuItem>
                     <div className="flex items-center gap-1 py-0.5 pl-9 pr-2">

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -19,7 +19,8 @@ import { railKey, type RailSelection } from '@/lib/spaces-selection'
 import { ThreadPane } from '@/components/spaces/thread-pane'
 import { STREAM_READ_KEY, useSpacePresence, useStream } from '@/hooks/use-space-chat'
 import { refreshMembers, useSpaceMembers } from '@/hooks/use-space-members'
-import { useSpaceFeed, useSpaceLastReadAt, useSpaceLive, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
+import { findSpace, useSpaceFeed, useSpaceLastReadAt, useSpaceLive, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
+import { directLabel, otherParticipant } from '@/lib/spaces-direct'
 import { useSpaceNotifyPrefs, type NotifyLevel } from '@/hooks/use-spaces-notify'
 import { requestJump } from '@/lib/spaces-jump'
 import { chord } from '@/lib/shortcut'
@@ -105,7 +106,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
     const [addOrgOpen, setAddOrgOpen] = useState(false)
 
     const selectedOrg = selection ? (orgs.find((o) => o.id === selection.orgId) ?? null) : null
-    const selectedSpace = selection && selectedOrg ? (selectedOrg.spaces.find((s) => s.id === selection.spaceId) ?? null) : null
+    const selectedSpace = selection && selectedOrg ? (findSpace(selectedOrg, selection.spaceId) ?? null) : null
 
     // No (valid) selection: land on the first space there is.
     useEffect(() => {
@@ -211,6 +212,12 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     // names resolve in the same first frame as the stream's cached tail.
     const members = useSpaceMembers(org.id, space.id)
     const memberNames = useMemo(() => new Map(members.map((m) => [m.id, m.displayName])), [members])
+    // A direct message is this same pane with a two-person roster: named by
+    // the other person, no invites, every message notifies by default.
+    const isDirect = space.kind === 'direct'
+    const directOtherId = otherParticipant(space, org.memberId)
+    const spaceTitle = isDirect ? directLabel(space, members, org.memberId) : space.name
+    const notifyDefault: NotifyLevel = isDirect ? 'all' : 'mentions'
 
     // The artifacts rail: open by default when a thread has artifacts, collapsed
     // when it has none; a per-thread pin remembers a manual toggle.
@@ -638,9 +645,11 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                             className="flex h-9 max-w-[320px] shrink-0 items-center gap-2 rounded-md pl-1 pr-2 hover:bg-accent/60 data-[state=open]:bg-accent/60"
                         >
                             <OrgMonogram org={org} />
-                            <span className="flex min-w-0 items-center gap-0.5">
-                                <Hash className="size-4 shrink-0 text-muted-foreground" />
-                                <h1 className="truncate text-[15px] font-semibold">{space.name}</h1>
+                            <span className={cn('flex min-w-0 items-center', isDirect ? 'gap-1.5' : 'gap-0.5')}>
+                                {isDirect
+                                    ? <MemberAvatar id={directOtherId ?? space.id} name={spaceTitle} size="sm" />
+                                    : <Hash className="size-4 shrink-0 text-muted-foreground" />}
+                                <h1 className="truncate text-[15px] font-semibold">{spaceTitle}</h1>
                             </span>
                         </button>
                     </HoverCardTrigger>
@@ -651,11 +660,15 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                             belongs to, and who you are in it. */}
                         <div className="flex flex-col items-center text-center">
                             <OrgMonogram org={org} size="xl" />
-                            <div className="mt-3 flex items-center gap-0.5 text-lg font-semibold leading-tight">
-                                <Hash className="size-4 text-muted-foreground" />
-                                <span className="truncate">{space.name}</span>
+                            <div className={cn('mt-3 flex items-center text-lg font-semibold leading-tight', isDirect ? 'gap-1.5' : 'gap-0.5')}>
+                                {isDirect
+                                    ? <MemberAvatar id={directOtherId ?? space.id} name={spaceTitle} size="sm" />
+                                    : <Hash className="size-4 text-muted-foreground" />}
+                                <span className="truncate">{spaceTitle}</span>
                             </div>
-                            <div className="mt-0.5 text-xs text-muted-foreground">A space in {org.name}</div>
+                            <div className="mt-0.5 text-xs text-muted-foreground">
+                                {isDirect ? `A direct message in ${org.name} — just the two of you` : `A space in ${org.name}`}
+                            </div>
                         </div>
                         <dl className="mt-4 grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-1.5 text-[13px]">
                             <dt className="text-right font-medium">Organization</dt>
@@ -724,15 +737,18 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                                 )
                             })}
                         </div>
-                        <div className="mt-1 border-t border-border pt-1">
-                            <button
-                                type="button"
-                                onClick={() => void invite()}
-                                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-                            >
-                                <LinkIcon className="size-3.5" /> Copy invite link
-                            </button>
-                        </div>
+                        {/* A DM's membership is fixed — there is nobody to invite. */}
+                        {!isDirect && (
+                            <div className="mt-1 border-t border-border pt-1">
+                                <button
+                                    type="button"
+                                    onClick={() => void invite()}
+                                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+                                >
+                                    <LinkIcon className="size-3.5" /> Copy invite link
+                                </button>
+                            </div>
+                        )}
                     </PopoverContent>
                 </Popover>
                 <DropdownMenu>
@@ -741,7 +757,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                             type="button"
                             title={dndActive
                                 ? `Do not disturb until ${new Date(dndUntil!).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
-                                : `Notifications — ${notifyChoices.find((c) => c.level === (notify.spaceLevel ?? 'mentions'))?.label ?? 'Mentions only'}`}
+                                : `Notifications — ${notifyChoices.find((c) => c.level === (notify.spaceLevel ?? notifyDefault))?.label ?? 'Mentions only'}`}
                             className={cn(
                                 'inline-flex size-7 items-center justify-center rounded-md hover:bg-accent',
                                 dndActive ? 'text-amber-600 dark:text-amber-400' : 'text-muted-foreground hover:text-foreground',
@@ -755,7 +771,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                         <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">This space</DropdownMenuLabel>
                         {notifyChoices.map((c) => (
                             <DropdownMenuItem key={c.level} onClick={() => notify.setSpaceLevel(c.level)}>
-                                <Check className={cn('size-3.5 mr-2', (notify.spaceLevel ?? 'mentions') !== c.level && 'opacity-0')} /> {c.label}
+                                <Check className={cn('size-3.5 mr-2', (notify.spaceLevel ?? notifyDefault) !== c.level && 'opacity-0')} /> {c.label}
                             </DropdownMenuItem>
                         ))}
                         <DropdownMenuSeparator />

--- a/apps/x/apps/renderer/src/components/spaces/new-direct-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/new-direct-dialog.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { MemberAvatar } from '@/components/spaces/atoms'
+import { useOrgRoster } from '@/hooks/use-space-members'
+import { refreshSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
+import { otherParticipant } from '@/lib/spaces-direct'
+import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
+
+// "New message": pick a person, land in the DM. Get-or-create on the org, so
+// picking someone you already talk to just opens that conversation. The
+// candidates are everyone you share a space with on this org.
+
+export function NewDirectDialog({ org, open, onOpenChange, onOpened }: {
+    org: OrgWithSpaces
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onOpened: (orgId: string, spaceId: string) => void
+}) {
+    const spaceIds = useMemo(() => org.spaces.map((s) => s.id), [org.spaces])
+    const roster = useOrgRoster(org.id, spaceIds)
+    const [query, setQuery] = useState('')
+    const [active, setActive] = useState(0)
+    const [opening, setOpening] = useState<string | null>(null)
+    const listRef = useRef<HTMLDivElement>(null)
+
+    // Who already has a DM with you floats up; then A–Z (the roster's order).
+    const existing = useMemo(() => {
+        const set = new Set<string>()
+        for (const dm of org.directs) {
+            const other = otherParticipant(dm, org.memberId)
+            if (other) set.add(other)
+        }
+        return set
+    }, [org.directs, org.memberId])
+    const candidates = useMemo(() => {
+        const q = query.trim().toLowerCase()
+        return roster
+            .filter((m) => m.id !== org.memberId && (!q || m.displayName.toLowerCase().includes(q)))
+            .sort((a, b) => Number(existing.has(b.id)) - Number(existing.has(a.id)))
+    }, [roster, org.memberId, query, existing])
+
+    useEffect(() => {
+        if (!open) return
+        setQuery('')
+        setActive(0)
+        setOpening(null)
+    }, [open])
+    useEffect(() => {
+        setActive((i) => Math.min(i, Math.max(0, candidates.length - 1)))
+    }, [candidates.length])
+    useEffect(() => {
+        listRef.current?.querySelector<HTMLElement>(`[data-index="${active}"]`)?.scrollIntoView({ block: 'nearest' })
+    }, [active])
+
+    const pick = async (memberId: string) => {
+        if (opening) return
+        setOpening(memberId)
+        try {
+            const { space } = await window.ipc.invoke('spaces:openDirect', { orgId: org.id, memberId })
+            // The listing carries the label the sidebar renders — refresh
+            // before landing so the new row paints with a name, not an id.
+            await refreshSpacesOrgs()
+            onOpenChange(false)
+            onOpened(org.id, space.id)
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not open the conversation', 'error')
+        } finally {
+            setOpening(null)
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-sm gap-0 p-0" onOpenAutoFocus={(e) => e.preventDefault()}>
+                <DialogHeader className="px-4 pb-2 pt-4">
+                    <DialogTitle className="text-sm">New message</DialogTitle>
+                    <DialogDescription className="text-xs">A private conversation with someone in {org.name}.</DialogDescription>
+                </DialogHeader>
+                <div className="px-3 pb-2">
+                    <Input
+                        autoFocus
+                        value={query}
+                        placeholder="To: a teammate's name"
+                        className="h-8 text-sm"
+                        onChange={(e) => {
+                            setQuery(e.target.value)
+                            setActive(0)
+                        }}
+                        onKeyDown={(e) => {
+                            if (e.key === 'ArrowDown') {
+                                e.preventDefault()
+                                setActive((i) => Math.min(i + 1, candidates.length - 1))
+                            } else if (e.key === 'ArrowUp') {
+                                e.preventDefault()
+                                setActive((i) => Math.max(i - 1, 0))
+                            } else if (e.key === 'Enter') {
+                                e.preventDefault()
+                                const m = candidates[active]
+                                if (m) void pick(m.id)
+                            }
+                        }}
+                    />
+                </div>
+                <div ref={listRef} className="max-h-72 overflow-y-auto border-t border-border p-1.5">
+                    {candidates.length === 0 ? (
+                        <div className="px-2 py-6 text-center text-xs text-muted-foreground">
+                            {roster.length <= 1
+                                ? 'Nobody to message yet — you can DM anyone you share a space with.'
+                                : 'No one matches.'}
+                        </div>
+                    ) : (
+                        candidates.map((m, i) => (
+                            <button
+                                key={m.id}
+                                type="button"
+                                data-index={i}
+                                onMouseEnter={() => setActive(i)}
+                                onClick={() => void pick(m.id)}
+                                className={cn(
+                                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm',
+                                    i === active && 'bg-accent',
+                                )}
+                            >
+                                <MemberAvatar id={m.id} name={m.displayName} size="md" />
+                                <span className="min-w-0 flex-1 truncate">{m.displayName}</span>
+                                {opening === m.id ? (
+                                    <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+                                ) : existing.has(m.id) ? (
+                                    <span className="shrink-0 text-[10.5px] text-muted-foreground">open</span>
+                                ) : null}
+                            </button>
+                        ))
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/apps/x/apps/renderer/src/hooks/use-space-chat.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-chat.ts
@@ -841,6 +841,27 @@ export function countSpaceUnread(orgId: string, spaceId: string, selfMemberId: s
     return count
 }
 
+/**
+ * When something last happened in a space's chat — the sidebar's DM list
+ * sorts by it: the newest loaded root or reply, else the rail's newest topic
+ * activity, else null (callers fall back to the space's createdAt).
+ */
+export function spaceLastActivityAt(orgId: string, spaceId: string): string | null {
+    const state = streamState.get(key(orgId, spaceId))
+    let latest: string | null = null
+    if (state?.ready) {
+        for (const m of state.messages) {
+            if (m.pending || m.failed) continue
+            const at = m.lastReplyAt && m.lastReplyAt > m.postedAt ? m.lastReplyAt : m.postedAt
+            if (!latest || at > latest) latest = at
+        }
+    }
+    for (const t of getSpaceFeed(orgId, spaceId).topics) {
+        if (!latest || t.lastActivityAt > latest) latest = t.lastActivityAt
+    }
+    return latest
+}
+
 /** `${orgId}/${spaceId}` → unread count, for the sidebar badges. */
 export function useSpacesUnreadCounts(): Map<string, number> {
     const version = useSyncExternalStore(
@@ -856,7 +877,9 @@ export function useSpacesUnreadCounts(): Map<string, number> {
     return useMemo(() => {
         const counts = new Map<string, number>()
         for (const org of getSpacesOrgs()) {
-            for (const space of org.spaces) counts.set(key(org.id, space.id), countSpaceUnread(org.id, space.id, org.memberId))
+            for (const space of [...org.spaces, ...org.directs]) {
+                counts.set(key(org.id, space.id), countSpaceUnread(org.id, space.id, org.memberId))
+            }
         }
         return counts
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/x/apps/renderer/src/hooks/use-space-members.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-members.ts
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useSyncExternalStore } from 'react'
 import type { spaces } from '@x/shared'
 
 // The space roster, module-level and persisted per install (localStorage),
@@ -113,22 +113,46 @@ export function refreshMembers(orgId: string, spaceId: string): void {
     void loadMembers(orgId, spaceId)
 }
 
+function subscribeMembers(l: () => void): () => void {
+    listeners.add(l)
+    return () => {
+        listeners.delete(l)
+    }
+}
+
 /** The space's roster: cached names in the first frame, refreshed behind. */
 export function useSpaceMembers(orgId: string, spaceId: string): spaces.Member[] {
     // Before the snapshot read, not in an effect: a revisited space must
     // resolve names in its FIRST frame, beside the stream's cached tail.
     hydrateMembers(key(orgId, spaceId))
-    const state = useSyncExternalStore(
-        (l) => {
-            listeners.add(l)
-            return () => {
-                listeners.delete(l)
-            }
-        },
-        () => memberState,
-    )
+    const state = useSyncExternalStore(subscribeMembers, () => memberState)
     useEffect(() => {
         void loadMembers(orgId, spaceId)
     }, [orgId, spaceId])
     return state.get(key(orgId, spaceId)) ?? EMPTY_MEMBERS
+}
+
+/**
+ * Everyone your person shares a space with on this org, A–Z — the people a
+ * DM can be opened with. There is no org roster route yet; the rosters the
+ * app already fetches ARE the directory (Discord's "people you share a
+ * server with" rule, by construction rather than policy).
+ */
+export function useOrgRoster(orgId: string, spaceIds: readonly string[]): spaces.Member[] {
+    const idsKey = spaceIds.join('|')
+    for (const id of spaceIds) hydrateMembers(key(orgId, id))
+    const state = useSyncExternalStore(subscribeMembers, () => memberState)
+    useEffect(() => {
+        for (const id of spaceIds) void loadMembers(orgId, id)
+        // The joined key IS the dependency — the array identity changes every render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [orgId, idsKey])
+    return useMemo(() => {
+        const byId = new Map<string, spaces.Member>()
+        for (const id of spaceIds) {
+            for (const m of state.get(key(orgId, id)) ?? []) if (!byId.has(m.id)) byId.set(m.id, m)
+        }
+        return [...byId.values()].sort((a, b) => a.displayName.localeCompare(b.displayName))
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [state, orgId, idsKey])
 }

--- a/apps/x/apps/renderer/src/hooks/use-spaces.ts
+++ b/apps/x/apps/renderer/src/hooks/use-spaces.ts
@@ -5,9 +5,23 @@ import { SPACES_ENABLED } from '@/lib/feature-flags'
 import { getLastReadAt, subscribeReadState } from '@/lib/spaces-read-state'
 
 export interface OrgWithSpaces extends spaces.SpacesOrgSummary {
+    /** Shared spaces — what every "the spaces" surface renders. */
     spaces: spaces.Space[]
+    /**
+     * Direct messages (kind 'direct'), kept apart so no space consumer ever
+     * lists one by accident; the sidebar renders them as people.
+     */
+    directs: spaces.Space[]
+    /** DM space id → the other participant's current display name (resolved from the DM's own roster). */
+    directLabels: Record<string, string>
     /** Set when the org could not be reached — the sidebar's "org unreachable" state. */
     error?: string
+}
+
+/** A space by id, shared or direct. */
+export function findSpace(org: OrgWithSpaces, spaceId: string | undefined): spaces.Space | undefined {
+    if (!spaceId) return undefined
+    return org.spaces.find((s) => s.id === spaceId) ?? org.directs.find((s) => s.id === spaceId)
 }
 
 // ---------------------------------------------------------------------------
@@ -36,11 +50,28 @@ export function refreshSpacesOrgs(): Promise<void> {
             const { orgs: records } = await window.ipc.invoke('spaces:listOrgs', null)
             const withSpaces = await Promise.all(
                 records.map(async (org): Promise<OrgWithSpaces> => {
+                    const previous = orgsState.orgs.find((o) => o.id === org.id)
                     try {
-                        const { spaces: list } = await window.ipc.invoke('spaces:listSpaces', { orgId: org.id })
-                        return { ...org, spaces: list }
+                        const { spaces: list } = await window.ipc.invoke('spaces:listSpaces', { orgId: org.id, includeDirect: true })
+                        const shared = list.filter((s) => s.kind !== 'direct')
+                        const directs = list.filter((s) => s.kind === 'direct')
+                        // A DM is labelled by the other person's CURRENT name — its
+                        // stored name is a placeholder. The DM's own two-member
+                        // roster is the lookup (no org roster route exists).
+                        const directLabels: Record<string, string> = {}
+                        await Promise.all(directs.map(async (dm) => {
+                            const other = (dm.participants ?? []).find((id) => id !== org.memberId)
+                            if (!other) return
+                            try {
+                                const { members } = await window.ipc.invoke('spaces:listMembers', { orgId: org.id, spaceId: dm.id })
+                                directLabels[dm.id] = members.find((m) => m.id === other)?.displayName ?? other
+                            } catch {
+                                directLabels[dm.id] = previous?.directLabels[dm.id] ?? other
+                            }
+                        }))
+                        return { ...org, spaces: shared, directs, directLabels }
                     } catch (err) {
-                        return { ...org, spaces: [], error: err instanceof Error ? err.message : String(err) }
+                        return { ...org, spaces: [], directs: [], directLabels: {}, error: err instanceof Error ? err.message : String(err) }
                     }
                 }),
             )
@@ -222,6 +253,13 @@ function wireFeedBus(): void {
     feedBusWired = true
     subscribeSpacesFeed((event) => {
         const frame = event.frame
+        if (frame.kind === 'space_added') {
+            // Someone opened a DM with us. The listing is how we learn its
+            // label and start watching it — no per-space subscription can
+            // exist for a space we did not know about.
+            void refreshSpacesOrgs()
+            return
+        }
         if (frame.kind !== 'event') return
         const key = liveKey(event.orgId, frame.spaceId)
         if (!feedReleases.has(key) || feedRefreshTimers.has(key)) return
@@ -243,7 +281,7 @@ function syncFeedSubscriptions(): void {
     wireFeedBus()
     const wanted = new Set<string>()
     for (const org of orgsState.orgs) {
-        for (const space of org.spaces) {
+        for (const space of [...org.spaces, ...org.directs]) {
             const key = liveKey(org.id, space.id)
             wanted.add(key)
             if (!feedReleases.has(key)) {

--- a/apps/x/apps/renderer/src/lib/spaces-direct.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-direct.ts
@@ -1,0 +1,25 @@
+import type { spaces } from '@x/shared'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+
+// Direct messages are spaces of kind 'direct' (contract 2026-09-07): the same
+// container with a fixed two-member roster and a placeholder name. Everything
+// that NAMES a DM goes through here — the label is the other person's current
+// display name, never anything stored.
+
+/** The member on the other side of a DM; undefined on shared spaces. */
+export function otherParticipant(space: spaces.Space, selfId: string): string | undefined {
+    if (space.kind !== 'direct') return undefined
+    return (space.participants ?? []).find((id) => id !== selfId)
+}
+
+/** A DM's label from a roster: the other person's display name, their id until the roster lands. */
+export function directLabel(space: spaces.Space, members: readonly spaces.Member[], selfId: string): string {
+    const other = otherParticipant(space, selfId)
+    if (!other) return 'Direct message'
+    return members.find((m) => m.id === other)?.displayName ?? other
+}
+
+/** What to call a space wherever it is named: its name, or for a DM the other person (from the orgs store). */
+export function spaceDisplayName(org: Pick<OrgWithSpaces, 'directLabels'>, space: spaces.Space): string {
+    return space.kind === 'direct' ? (org.directLabels[space.id] ?? 'Direct message') : space.name
+}

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -278,6 +278,7 @@ export const RPC_CHANNELS = [
   'spaces:removeOrg',
   'spaces:listSpaces',
   'spaces:createSpace',
+  'spaces:openDirect',
   'spaces:listMembers',
   'spaces:createInvite',
   'spaces:resolveInvite',

--- a/apps/x/apps/server/src/spaces-deps.ts
+++ b/apps/x/apps/server/src/spaces-deps.ts
@@ -38,6 +38,10 @@ function emitSpacesEvent(event: spacesShared.SpacesBusEvent): void {
 
 const liveSubscriptions = new Map<string, () => void>();
 
+// Member-addressed frames (space_added) ride no space subscription — relay
+// them to every client as they arrive.
+orgs.onMemberFrame((orgId, frame) => emitSpacesEvent({ orgId, frame }));
+
 function orgSummary(record: orgs.OrgRecord): spacesShared.SpacesOrgSummary {
   return {
     id: record.id,
@@ -53,7 +57,7 @@ function orgSummary(record: orgs.OrgRecord): spacesShared.SpacesOrgSummary {
 type SpacesRpcChannel =
   | 'spaces:listOrgs' | 'spaces:addOrg' | 'spaces:resolveInviteLink' | 'spaces:joinInvite'
   | 'spaces:signInOrg' | 'spaces:createOrg' | 'spaces:apexInfo' | 'spaces:removeOrg'
-  | 'spaces:listSpaces' | 'spaces:createSpace' | 'spaces:listMembers' | 'spaces:createInvite'
+  | 'spaces:listSpaces' | 'spaces:createSpace' | 'spaces:openDirect' | 'spaces:listMembers' | 'spaces:createInvite'
   | 'spaces:resolveInvite' | 'spaces:acceptInvite' | 'spaces:listAssets' | 'spaces:moveAsset'
   | 'spaces:deleteAsset' | 'spaces:restoreAsset' | 'spaces:uploadBlob' | 'spaces:readAsset'
   | 'spaces:proposeChange' | 'spaces:assetHistory' | 'spaces:diff' | 'spaces:listTopics'
@@ -126,7 +130,7 @@ export const spacesRpcHandlers: SpacesHandlers = {
   },
 
   'spaces:listSpaces': async (args) => {
-    const spaces = await orgs.getClient(args.orgId).listSpaces();
+    const spaces = await orgs.getClient(args.orgId).listSpaces({ includeDirect: args.includeDirect ?? false });
     // The renderer just reached this org — if it was down at boot (or restarted),
     // this is the earliest signal that its spaces are watchable again. Unforced:
     // repeated refreshes collapse into one sync.
@@ -138,6 +142,12 @@ export const spacesRpcHandlers: SpacesHandlers = {
     const space = await orgs.getClient(args.orgId).createSpace(args.name);
     void syncSpaceMentionWatch({ force: true });
     return { space };
+  },
+
+  'spaces:openDirect': async (args) => {
+    const result = await orgs.getClient(args.orgId).openDirect(args.memberId);
+    if (result.created) void syncSpaceMentionWatch({ force: true });
+    return result;
   },
 
   'spaces:listMembers': async (args) => ({

--- a/apps/x/packages/core/src/runtime/assembly/skills/spaces/skill.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/spaces/skill.ts
@@ -8,8 +8,10 @@ A **space** is a shared container on your person's team org: a folder of markdow
 Each org your person belongs to appears as an MCP server named \`spaces-<org>\`:
 
 1. \`listMcpServers\` → find servers whose name starts with \`spaces-\`.
-2. \`executeMcpTool(<server>, 'list_spaces', {})\` → the member's spaces, each with \`id\`, \`name\`, \`memberCount\`, and its full file listing (\`assets\`: path + version). Resolve space names here ("Roadboard" → its \`id\`, case-insensitive). Never guess a spaceId or a file path — this call makes discovery mechanical.
+2. \`executeMcpTool(<server>, 'list_spaces', {})\` → the member's spaces, each with \`id\`, \`name\`, \`kind\`, \`memberCount\`, and its full file listing (\`assets\`: path + version). Resolve space names here ("Roadboard" → its \`id\`, case-insensitive). Never guess a spaceId or a file path — this call makes discovery mechanical.
 3. Every other tool takes that \`spaceId\`.
+
+**Direct messages are spaces too.** Pass \`{ includeDirect: true }\` to \`list_spaces\` and your person's DMs appear with \`kind: "direct"\` and two \`participants\` (member ids); the DM's \`name\` is a placeholder — call it by the other person. A DM is private to those two people and has a fixed membership, but every tool works on it exactly as on a space (\`read_stream\`, \`post_message\`, files). "My DM with Harsh" → list with includeDirect, match the participant whose display name is Harsh (names come from the space's members in the UI; when you only have ids, say so and ask). Never post into a DM your person did not point you at.
 
 The server's tools: \`list_spaces\`, \`read_stream\`, \`read_thread\`, \`read_asset\`, \`propose_change\`, \`move_asset\`, \`delete_asset\`, \`post_message\`, \`list_topics\`, \`create_topic\`, \`manage_topic\`, \`search_space\` (\`listMcpTools\` shows full schemas). Alongside them you have two local bridge tools for binary files — \`spaces-upload-blob\` and \`spaces-download-blob\` (see "Binary files & attachments") — which take the same server name, not \`executeMcpTool\`.
 

--- a/apps/x/packages/core/src/spaces/client.test.ts
+++ b/apps/x/packages/core/src/spaces/client.test.ts
@@ -258,6 +258,19 @@ describe('SpacesClient', () => {
     expect((await ramnique.readAsset(spaceId, 'notes/scratch.md')).content).toBe('scratch\n');
   });
 
+  it('direct messages: get-or-create from either side, hidden unless asked, fixed membership', async () => {
+    const opened = await ramnique.openDirect('gagan');
+    expect(opened.created).toBe(true);
+    expect(opened.space.kind).toBe('direct');
+    expect(opened.space.participants).toEqual(['gagan', 'ramnique']);
+    const again = await gagan.openDirect('ramnique');
+    expect(again).toMatchObject({ created: false, space: { id: opened.space.id } });
+    expect((await ramnique.listSpaces()).some((s) => s.id === opened.space.id)).toBe(false);
+    expect((await gagan.listSpaces({ includeDirect: true })).some((s) => s.id === opened.space.id)).toBe(true);
+    await expect(ramnique.createInvite(opened.space.id)).rejects.toMatchObject({ code: 'invalid_request' });
+    await expect(gagan.leaveSpace(opened.space.id)).rejects.toMatchObject({ code: 'invalid_request' });
+  });
+
   it('errors carry the wire code', async () => {
     await expect(ramnique.readAsset(spaceId, 'ghost.md')).rejects.toMatchObject({
       code: 'not_found',
@@ -303,6 +316,21 @@ describe('SpacesLive', () => {
     expect(seen.filter((f) => f.kind === 'event').map((f) => f.offset)).toEqual([1, 2, 3]);
 
     live.close();
+  });
+
+  it('a member-addressed space_added frame reaches the other participant without any subscription', async () => {
+    await harbor.store.putMember({ id: 'harsh', displayName: 'Harsh', role: 'member' });
+    const harsh = new SpacesLive({ baseUrl: harbor.url, token: 'dev-harsh' });
+    const added: Array<{ spaceId: string; by: string }> = [];
+    harsh.onMemberFrame((frame) => {
+      if (frame.kind === 'space_added') added.push({ spaceId: frame.spaceId, by: frame.by });
+    });
+    await waitFor(() => harsh.status === 'open', 'harsh socket open (no subscriptions, just the member handler)');
+
+    const opened = await ramnique.openDirect('harsh');
+    await waitFor(() => added.length >= 1, 'space_added frame');
+    expect(added[0]).toEqual({ spaceId: opened.space.id, by: 'ramnique' });
+    harsh.close();
   });
 
   it('whiteboard frames round-trip: opaque payload out, sender-stamped frame in', async () => {

--- a/apps/x/packages/core/src/spaces/client.ts
+++ b/apps/x/packages/core/src/spaces/client.ts
@@ -150,8 +150,15 @@ export class SpacesClient {
 
   // --- spaces & membership --------------------------------------------------
 
-  async listSpaces(): Promise<Space[]> {
-    return (await this.request('GET', routes.listSpaces.path, routes.listSpaces.response)).spaces;
+  /** Shared spaces by default; `includeDirect` adds the member's DMs (api.ts listSpaces). */
+  async listSpaces(opts: { includeDirect?: boolean } = {}): Promise<Space[]> {
+    const qs = opts.includeDirect ? '?includeDirect=true' : '';
+    return (await this.request('GET', `${routes.listSpaces.path}${qs}`, routes.listSpaces.response)).spaces;
+  }
+
+  /** Get-or-create the DM with another member — idempotent from either side (api.ts openDirect). */
+  async openDirect(memberId: string): Promise<{ space: Space; created: boolean }> {
+    return this.request('POST', routes.openDirect.path, routes.openDirect.response, { memberId });
   }
 
   async createSpace(name: string): Promise<Space> {

--- a/apps/x/packages/core/src/spaces/live.ts
+++ b/apps/x/packages/core/src/spaces/live.ts
@@ -52,6 +52,13 @@ export class SpacesLive {
   private ws: WebSocket | undefined;
   private connecting = false;
   private subs = new Map<string, Subscription>();
+  /**
+   * Frames addressed to the MEMBER, not a space (`space_added`, direct
+   * messages 2026-09-07): someone else put us into a space we could not have
+   * subscribed to yet. No per-space state; a registered handler keeps the
+   * socket alive like a subscription does.
+   */
+  private memberHandlers = new Set<SpaceFrameHandler>();
   private statusHandlers = new Set<(status: SpacesLiveStatus) => void>();
   private attempts = 0;
   private closed = false;
@@ -110,6 +117,15 @@ export class SpacesLive {
           this.ws.send(JSON.stringify({ kind: 'unsubscribe', spaceId }));
         }
       }
+    };
+  }
+
+  /** Receive member-addressed frames (`space_added`). Keeps the socket connected while registered. */
+  onMemberFrame(handler: SpaceFrameHandler): () => void {
+    this.memberHandlers.add(handler);
+    this.ensureConnected();
+    return () => {
+      this.memberHandlers.delete(handler);
     };
   }
 
@@ -239,6 +255,10 @@ export class SpacesLive {
       } catch {
         return; // a frame we don't understand is not a reason to drop the socket
       }
+      if (frame.kind === 'space_added') {
+        for (const h of this.memberHandlers) h(frame);
+        return;
+      }
       const spaceId = 'spaceId' in frame ? frame.spaceId : undefined;
       if (!spaceId) return;
       const sub = this.subs.get(spaceId);
@@ -268,7 +288,7 @@ export class SpacesLive {
     this.attempts += 1;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = undefined;
-      if (this.subs.size > 0 || this.statusHandlers.size > 0) this.ensureConnected();
+      if (this.subs.size > 0 || this.statusHandlers.size > 0 || this.memberHandlers.size > 0) this.ensureConnected();
     }, delay);
   }
 }

--- a/apps/x/packages/core/src/spaces/mention-watch.ts
+++ b/apps/x/packages/core/src/spaces/mention-watch.ts
@@ -6,7 +6,7 @@ import { notifyIfEnabled } from '../application/notification/notifier.js';
 import type { NotifyInput } from '../application/notification/service.js';
 import { WorkDir } from '../config/config.js';
 import { dndActive, notifyLevelFor } from './notify-prefs.js';
-import { getClient, getLive, listOrgs } from './orgs.js';
+import { getClient, getLive, listOrgs, onMemberFrame } from './orgs.js';
 
 // Space mention notifications: main-side watcher that subscribes to EVERY
 // space of every org (independent of what's on screen), scans incoming
@@ -50,6 +50,8 @@ export interface MentionHit {
    * level is 'all'.
    */
   kind: 'you' | 'here' | 'message';
+  /** A direct message: `spaceName` is the other person, so titles don't repeat it. */
+  direct?: boolean;
 }
 
 export function isMissedArrival(postedAt: string, now: number = Date.now()): boolean {
@@ -85,8 +87,11 @@ export function mentionExcerpt(body: string, max = 140): string {
 }
 
 export function buildMentionNotify(hit: MentionHit): NotifyInput {
-  const title =
-    hit.kind === 'message'
+  const title = hit.direct
+    ? hit.kind === 'message'
+      ? hit.authorName
+      : `${hit.authorName} mentioned you`
+    : hit.kind === 'message'
       ? `${hit.authorName} · ${hit.spaceName}`
       : `${hit.authorName} ${hit.kind === 'here' ? 'mentioned everyone' : 'mentioned you'} · ${hit.spaceName}`;
   return {
@@ -169,6 +174,7 @@ const offsets = readOffsets();
 let offsetsFlush: ReturnType<typeof setTimeout> | null = null;
 let resyncTimer: ReturnType<typeof setInterval> | null = null;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
+let memberFrameUnsubscribe: (() => void) | null = null;
 let lastSyncAt = 0;
 let syncing = false;
 
@@ -218,8 +224,15 @@ function queueMissed(k: string, orgId: string, spaceId: string, spaceName: strin
   missed.set(k, bucket);
 }
 
-function makeHandler(orgId: string, spaceId: string, spaceName: string, me: MentionIdentity): (frame: ServerFrame) => void {
+function makeHandler(
+  orgId: string,
+  spaceId: string,
+  spaceName: string,
+  me: MentionIdentity,
+  opts: { direct?: boolean } = {},
+): (frame: ServerFrame) => void {
   const k = key(orgId, spaceId);
+  const direct = opts.direct === true;
   return (frame) => {
     if (frame.kind !== 'event') return;
     noteOffset(k, frame.offset);
@@ -234,7 +247,8 @@ function makeHandler(orgId: string, spaceId: string, spaceName: string, me: Ment
     // floods, only real mentions fold into the away summary).
     // The thread this message belongs to — a root stands for its own thread.
     const threadRootId = message.threadRoot ?? message.id;
-    const level = notifyLevelFor(orgId, spaceId, threadRootId);
+    // A DM defaults to 'all' — it is addressed to you by construction.
+    const level = notifyLevelFor(orgId, spaceId, threadRootId, direct ? 'all' : 'mentions');
     if (level === 'mute') return;
     // People type the NAME (ids are opaque); agent-written mentions may carry
     // the id. A direct mention outranks @here when both appear.
@@ -260,6 +274,7 @@ function makeHandler(orgId: string, spaceId: string, spaceName: string, me: Ment
       orgId,
       spaceId,
       spaceName,
+      ...(direct ? { direct: true } : {}),
       threadRootId,
       authorName: authorName(k, message.author.memberId),
       // The wire carries "@<memberId>" addresses — show people, not ids.
@@ -290,7 +305,9 @@ export async function syncSpaceMentionWatch(opts?: { force?: boolean }): Promise
     for (const org of listOrgs()) {
       let spaces;
       try {
-        spaces = await getClient(org.id).listSpaces();
+        // DMs ride the same watcher — the sidebar is not the only surface
+        // that must know a message landed.
+        spaces = await getClient(org.id).listSpaces({ includeDirect: true });
       } catch {
         // Org unreachable right now — keep its subscriptions and try again soon.
         unreachable = true;
@@ -317,11 +334,20 @@ export async function syncSpaceMentionWatch(opts?: { force?: boolean }): Promise
         }
 
         const myName = memberNames.get(k)?.get(org.auth.memberId);
-        const handler = makeHandler(org.id, space.id, space.name, {
+        const direct = space.kind === 'direct';
+        // A DM is labelled by the other person (its stored name is a placeholder).
+        const other = direct ? (space.participants ?? []).find((id) => id !== org.auth.memberId) : undefined;
+        const label = direct ? authorName(k, other ?? '') : space.name;
+        const handler = makeHandler(org.id, space.id, label, {
           id: org.auth.memberId,
           ...(myName ? { displayName: myName } : {}),
-        });
-        const stored = offsets[k];
+        }, { direct });
+        // A shared space we have never watched starts live-only (no replay
+        // flood on first sight). A DM starts from offset 0: its log is a few
+        // events long, and the opener's first message may already be on it —
+        // that message must notify, and must fold into the away summary if
+        // we were closed when it landed.
+        const stored = offsets[k] ?? (direct ? 0 : undefined);
         const unsubscribe = getLive(org.id).subscribe(space.id, handler, stored);
         subs.set(k, { memberId: org.auth.memberId, unsubscribe });
       }));
@@ -348,6 +374,12 @@ export async function syncSpaceMentionWatch(opts?: { force?: boolean }): Promise
 /** Boot the watcher: initial sync + a slow re-sync loop (new spaces/orgs). */
 export function startSpaceMentionWatch(): void {
   void syncSpaceMentionWatch({ force: true });
+  // Someone opened a DM with us: watch it now, not at the next slow loop.
+  if (!memberFrameUnsubscribe) {
+    memberFrameUnsubscribe = onMemberFrame((_orgId, frame) => {
+      if (frame.kind === 'space_added') void syncSpaceMentionWatch({ force: true });
+    });
+  }
   if (!resyncTimer) {
     resyncTimer = setInterval(() => void syncSpaceMentionWatch({ force: true }), RESYNC_INTERVAL_MS);
     resyncTimer.unref?.();
@@ -357,6 +389,8 @@ export function startSpaceMentionWatch(): void {
 export function stopSpaceMentionWatch(): void {
   if (resyncTimer) clearInterval(resyncTimer);
   resyncTimer = null;
+  memberFrameUnsubscribe?.();
+  memberFrameUnsubscribe = null;
   if (retryTimer) clearTimeout(retryTimer);
   retryTimer = null;
   for (const sub of subs.values()) sub.unsubscribe();

--- a/apps/x/packages/core/src/spaces/notify-prefs.ts
+++ b/apps/x/packages/core/src/spaces/notify-prefs.ts
@@ -104,7 +104,12 @@ export function setNotifyPref(orgId: string, spaceId: string, topicId: string | 
 }
 
 /** The effective level for one message's destination: topic override → space level → 'mentions'. */
-export function notifyLevelFor(orgId: string, spaceId: string, topicId: string): NotifyLevel {
+/**
+ * Thread override → space level → `fallback`. The fallback is the space
+ * kind's default: 'mentions' for shared spaces, 'all' for direct messages
+ * (a DM is addressed to you by construction — every message counts).
+ */
+export function notifyLevelFor(orgId: string, spaceId: string, topicId: string, fallback: NotifyLevel = 'mentions'): NotifyLevel {
   const space = load()[key(orgId, spaceId)];
-  return space?.topics[topicId] ?? space?.level ?? 'mentions';
+  return space?.topics[topicId] ?? space?.level ?? fallback;
 }

--- a/apps/x/packages/core/src/spaces/orgs.ts
+++ b/apps/x/packages/core/src/spaces/orgs.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import * as oauthClient from '../auth/oauth-client.js';
 import { WorkDir } from '../config/config.js';
+import type { ServerFrame } from '@rowboat/spaces-protocol';
 import { SpacesClient } from './client.js';
 import { SpacesLive } from './live.js';
 
@@ -268,6 +269,22 @@ export function bounceAllLive(): void {
   for (const runtime of runtimes.values()) runtime.live.bounce();
 }
 
+type MemberFrameListener = (orgId: string, frame: ServerFrame) => void;
+const memberFrameListeners = new Set<MemberFrameListener>();
+
+/**
+ * Member-addressed live frames from EVERY org (`space_added`: someone opened
+ * a DM with us — direct messages 2026-09-07). One registration covers orgs
+ * added later too: each org's socket fans out to this set as it is created.
+ * Hosts relay these to the renderer; the mention watcher re-syncs on them.
+ */
+export function onMemberFrame(listener: MemberFrameListener): () => void {
+  memberFrameListeners.add(listener);
+  return () => {
+    memberFrameListeners.delete(listener);
+  };
+}
+
 /** The client pair for an org — created lazily, one WS per org for the process lifetime. */
 export function orgRuntime(orgId: string): OrgRuntime {
   const cached = runtimes.get(orgId);
@@ -279,6 +296,9 @@ export function orgRuntime(orgId: string): OrgRuntime {
     client: new SpacesClient({ baseUrl: org.baseUrl, token }),
     live: new SpacesLive({ baseUrl: org.baseUrl, token }),
   };
+  runtime.live.onMemberFrame((frame) => {
+    for (const listener of memberFrameListeners) listener(orgId, frame);
+  });
   runtimes.set(orgId, runtime);
   return runtime;
 }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3701,13 +3701,22 @@ export const ipcSchemas = {
     req: z.object({ orgId: z.string() }),
     res: z.object({ success: z.literal(true) }),
   },
+  // Shared spaces by default; includeDirect adds the member's DMs (kind
+  // 'direct') — opt-in on the wire so a pre-DM build never renders one as a space.
   'spaces:listSpaces': {
-    req: z.object({ orgId: z.string() }),
+    req: z.object({ orgId: z.string(), includeDirect: z.boolean().optional() }),
     res: z.object({ spaces: z.array(z.custom<SpacesTypes.Space>()) }),
   },
   'spaces:createSpace': {
     req: z.object({ orgId: z.string(), name: z.string() }),
     res: z.object({ space: z.custom<SpacesTypes.Space>() }),
+  },
+  // Direct messages: get-or-create the DM with another org member. No
+  // invite, no acceptance — the other side learns of it by a space_added
+  // frame on 'spaces:events' and shows it in their sidebar.
+  'spaces:openDirect': {
+    req: z.object({ orgId: z.string(), memberId: z.string() }),
+    res: z.object({ space: z.custom<SpacesTypes.Space>(), created: z.boolean() }),
   },
   'spaces:listMembers': {
     req: z.object({ orgId: z.string(), spaceId: z.string() }),


### PR DESCRIPTION
## Summary

A DM is a **space of kind `direct`**: the same container on the same substrate (stream, flat threads, discussions, files, blobs, search, offsets, `@rowboat` sessions), with a fixed two-member roster and private forever. Nothing is forked; every mature chat system converged on this shape. Design conversation and decisions are recorded in the private spec (§5 "Direct messages", harbor `faba9ee`) and in `apps/harbor/CONTRACT.md`.

**Two commits, one per side.** Both are additive on the wire, so the server deploys first with no same-day coupling: listings hide DMs unless a client asks, so pre-DM app builds and old agent skills never render a DM as a space.

### Harbor (`19dc4722`)
- `Space.kind` (`shared | direct`, zod-defaulted) + `participants`; `POST /v1/direct {memberId}` is get-or-create, idempotent from either side, refuses self and unknown members.
- Migration **014**: `spaces.kind` + `direct_key` (JSON of the sorted pair) with a partial unique index — the get-or-create race guard. Memory store mirrors it.
- Fixed membership: `createInvite` and `leaveSpace` refuse on direct spaces; both participants hold ordinary membership rows and the two `joined` events are the whole membership history. `requireMember` records the invariant: **any future open-space path must require kind `shared`**.
- `space_added`: the protocol's first **member-addressed** live frame (the hub grew a per-member channel; the socket registers each connection by member). Ephemeral, never replayed — the durable truth is on the new space's own log, which the other participant could not have been subscribed to yet.
- Agent face: `list_spaces {includeDirect}` with `kind`/`participants`; every other tool works on a DM as on any space.

### App (`2963824f`)
- `SpacesLive.onMemberFrame` + `orgs.onMemberFrame` fan-out; main and the standalone server relay member frames to the renderer; the orgs store refreshes on them and the mention watcher re-syncs, subscribing a new DM from offset 0 so a first message that beat the subscription still notifies. DMs default to notify on every message; notification titles drop the space suffix.
- Orgs store keeps `directs` apart from `spaces` and resolves each DM's label from its own roster (the other person's *current* name — nothing stored to go stale).
- Sidebar section + dock: a "Direct messages" group per org, sorted by recency, fold at 5, "New message" row and org-menu item. `NewDirectDialog` lists people you share a space with (no org roster route yet — by construction, Discord's rule).
- SpacePane direct mode: avatar + name header, no invite link, notifications default to all. Title crumb and last-space restore resolve DMs.
- The spaces skill gained a DM paragraph.

### Decisions (from the design conversation)
1:1 only in v1 (a group is a named space); no self-DM; anyone in the org can be opened, the picker shows people you share a space with; files stay in DMs; agents see a member's DMs only when they ask; **admins cannot read DMs** (falls out of the role-flat content plane — now written into spec §4). Follow-on agreed and queued as STATUS 1c: **open spaces** (org membership + a visibility flag) — independent of this PR; the one hook is that direct implies private.

## Test plan
- [x] Harbor: `pnpm -r typecheck`; suite **262** tests green on both stores, incl. new `test/direct.test.ts` (22: idempotence, listing opt-in, third-member 403, guards, concurrent-open convergence, `space_added` + from-zero replay, MCP face)
- [x] apps/x: shared/core/client/server/renderer typecheck; main process builds; core spaces suite 53, renderer 461, server 27 passing; lint on touched files has zero new errors (remaining ones pre-existing in `spaces-view.tsx`/`dock-sidebar.tsx`)
- [ ] Not visually verified in the running app — sidebar rows, picker, and the pane's direct mode need a dogfood pass
- [ ] Deploy: Harbor first (014 self-applies), app build after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nKs8dZxNqbbnq9ckXsPy9
