### PR TITLE
feat(x): Spaces — name-only server create, hidden address, unified "Add a server" dialog

### DIFF
--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -142,7 +142,7 @@ export const spacesIpcHandlers: SpacesHandlers = {
   },
 
   'spaces:createOrg': async (_event, args) => {
-    const org = orgSummary(await spacesOAuth.createOrgOnDeployment({ name: args.name, slug: args.slug, openBrowser }));
+    const org = orgSummary(await spacesOAuth.createOrgOnDeployment({ name: args.name, openBrowser }));
     void syncSpaceMentionWatch({ force: true });
     return { org };
   },

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -868,6 +868,7 @@ export function DockSidebar({
   }, [recentRuns, pinnedChatIds])
 
   const [deleteChatTarget, setDeleteChatTarget] = useState<{ id: string; title: string } | null>(null)
+  const [removeOrgTarget, setRemoveOrgTarget] = useState<{ id: string; name: string } | null>(null)
 
   // ----- data: spaces (safe when the flag is off — the store stays empty) -----
   const { orgs, loading: spacesLoading, refresh: refreshSpaces } = useSpacesOrgs()
@@ -1427,6 +1428,7 @@ export function DockSidebar({
           onOpenSpace={(orgId, spaceId) => { closeFlyouts(); onOpenSpace?.(orgId, spaceId) }}
           onAddOrg={() => setAddOrgOpen(true)}
           onChanged={() => void refreshSpaces()}
+          onRequestRemoveOrg={(id, name) => setRemoveOrgTarget({ id, name })}
         />
       )}
 
@@ -1501,6 +1503,32 @@ export function DockSidebar({
               }}
             >
               Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Remove-server confirm — hoisted to the root like delete-chat: the
+          flyout it's triggered from can close underneath it. */}
+      <AlertDialog open={!!removeOrgTarget} onOpenChange={(open) => { if (!open) setRemoveOrgTarget(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove {removeOrgTarget?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This only removes the server from this device — you can rejoin with an invite link.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              onClick={() => {
+                const target = removeOrgTarget
+                setRemoveOrgTarget(null)
+                if (target) void window.ipc.invoke('spaces:removeOrg', { orgId: target.id }).then(() => void refreshSpaces())
+              }}
+            >
+              Remove
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -1679,6 +1707,7 @@ function SpacesFlyout({
   onOpenSpace,
   onAddOrg,
   onChanged,
+  onRequestRemoveOrg,
 }: {
   orgs: OrgWithSpaces[]
   loading: boolean
@@ -1687,6 +1716,7 @@ function SpacesFlyout({
   onOpenSpace: (orgId: string, spaceId: string) => void
   onAddOrg: () => void
   onChanged: () => void
+  onRequestRemoveOrg: (orgId: string, name: string) => void
 }) {
   return (
     <div data-dock-flyout="" data-slot="dock-overlay" data-state="open" className="rowboat-dock-flyout titlebar-no-drag" style={{ left: DOCK_FLYOUT_LEFT_PX }}>
@@ -1697,7 +1727,7 @@ function SpacesFlyout({
           onClick={onAddOrg}
           className="flex items-center gap-1 text-xs font-semibold text-teal-700 hover:text-teal-800 dark:text-teal-400 dark:hover:text-teal-300"
         >
-          <Plus className="size-3" /> Add org
+          <Plus className="size-3" /> Add server
         </button>
       </div>
       {loading ? (
@@ -1708,7 +1738,7 @@ function SpacesFlyout({
           onClick={onAddOrg}
           className="px-2.5 pb-2 text-left text-[11.5px] italic text-muted-foreground hover:text-foreground"
         >
-          Add an org to see its spaces here.
+          Add a server to see its spaces here.
         </button>
       ) : (
         orgs.map((org) => (
@@ -1719,6 +1749,7 @@ function SpacesFlyout({
             unread={unread}
             onOpenSpace={onOpenSpace}
             onChanged={onChanged}
+            onRequestRemoveOrg={onRequestRemoveOrg}
           />
         ))
       )}
@@ -1726,12 +1757,13 @@ function SpacesFlyout({
   )
 }
 
-function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
+function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, onRequestRemoveOrg }: {
   org: OrgWithSpaces
   activeSpace: SpaceSelection
   unread: Map<string, number>
   onOpenSpace: (orgId: string, spaceId: string) => void
   onChanged: () => void
+  onRequestRemoveOrg: (orgId: string, name: string) => void
 }) {
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
@@ -1777,7 +1809,7 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
 
   return (
     <>
-      <div className="group/org flex h-8 items-center gap-1.5 rounded-[9px] px-2 text-[11.5px] text-muted-foreground" title={`${org.address} · you are ${org.memberId}`}>
+      <div className="group/org flex h-8 items-center gap-1.5 rounded-[9px] px-2 text-[11.5px] text-muted-foreground" title={`You are ${org.memberId}`}>
         <OrgMonogram org={org} size="sm" />
         <span className="flex-1 truncate">{org.name}</span>
         {needsSignIn ? (
@@ -1804,7 +1836,7 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              aria-label="Org options"
+              aria-label="Server options"
               className="flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/org:opacity-100 data-[state=open]:opacity-100"
             >
               <MoreVertical className="size-3.5" />
@@ -1820,11 +1852,9 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged }: {
             <DropdownMenuSeparator />
             <DropdownMenuItem
               className="text-destructive focus:text-destructive"
-              onClick={() => {
-                void window.ipc.invoke('spaces:removeOrg', { orgId: org.id }).then(onChanged)
-              }}
+              onClick={() => onRequestRemoveOrg(org.id, org.name)}
             >
-              <Trash2 className="mr-2 size-3.5" /> Remove org
+              <Trash2 className="mr-2 size-3.5" /> Remove server
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -3,6 +3,10 @@ import { ChevronRight, Hash, Loader2, MessagesSquare, MoreVertical, Plus, Trash2
 import { cn } from '@/lib/utils'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
 import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
+    AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
@@ -78,8 +82,8 @@ export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
                     </button>
                     <button
                         type="button"
-                        aria-label="Add an org"
-                        title="Add an org"
+                        aria-label="Add a server"
+                        title="Add a server"
                         onClick={() => setAddOrgOpen(true)}
                         className="flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/spaces-head:opacity-100"
                     >
@@ -97,7 +101,7 @@ export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
                             onClick={() => setAddOrgOpen(true)}
                             className="pl-6 pr-4 pb-2 text-left text-[11.5px] italic text-muted-foreground hover:text-foreground"
                         >
-                            Add an org to see its spaces here.
+                            Add a server to see its spaces here.
                         </button>
                     ) : (
                         <SidebarMenu>
@@ -142,6 +146,7 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
     const [newName, setNewName] = useState('')
     const [newDirectOpen, setNewDirectOpen] = useState(false)
     const [showAllDirects, setShowAllDirects] = useState(false)
+    const [confirmRemove, setConfirmRemove] = useState(false)
     // A dead OAuth session shows as a gentle "Sign in again" (org.authError, from core);
     // an unreachable org shows Retry.
     const needsSignIn = !!org.authError
@@ -186,7 +191,7 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
     return (
         <>
             <SidebarMenuItem>
-                <div className="group/org flex h-7 items-center gap-1.5 rounded-md pl-6 pr-2 text-[11.5px] text-muted-foreground" title={`${org.address} · you are ${org.memberId}`}>
+                <div className="group/org flex h-7 items-center gap-1.5 rounded-md pl-6 pr-2 text-[11.5px] text-muted-foreground" title={`You are ${org.memberId}`}>
                     <OrgMonogram org={org} size="sm" />
                     <span className="flex-1 truncate">{org.name}</span>
                     {needsSignIn ? (
@@ -213,7 +218,7 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                         <DropdownMenuTrigger asChild>
                             <button
                                 type="button"
-                                aria-label="Org options"
+                                aria-label="Server options"
                                 className="flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/org:opacity-100 data-[state=open]:opacity-100"
                             >
                                 <MoreVertical className="size-3.5" />
@@ -229,14 +234,34 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
                                 className="text-destructive focus:text-destructive"
-                                onClick={() => {
-                                    void window.ipc.invoke('spaces:removeOrg', { orgId: org.id }).then(onChanged)
-                                }}
+                                onClick={() => setConfirmRemove(true)}
                             >
-                                <Trash2 className="mr-2 size-3.5" /> Remove org
+                                <Trash2 className="mr-2 size-3.5" /> Remove server
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>
+                    <AlertDialog open={confirmRemove} onOpenChange={setConfirmRemove}>
+                        <AlertDialogContent>
+                            <AlertDialogHeader>
+                                <AlertDialogTitle>Remove {org.name}?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    This only removes the server from this device — you can rejoin with an invite link.
+                                </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction
+                                    className="bg-destructive text-white hover:bg-destructive/90"
+                                    onClick={() => {
+                                        setConfirmRemove(false)
+                                        void window.ipc.invoke('spaces:removeOrg', { orgId: org.id }).then(onChanged)
+                                    }}
+                                >
+                                    Remove
+                                </AlertDialogAction>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialog>
                 </div>
             </SidebarMenuItem>
             {org.spaces.filter((space) => !visibleSpaceKeys || visibleSpaceKeys.has(spaceUseKey(org.id, space.id))).map((space) => {

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -162,7 +162,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
                             your teammates&apos; agents work in them with you.
                         </p>
                         <Button size="sm" className="mt-4" onClick={() => setAddOrgOpen(true)}>
-                            <Plus className="size-4 mr-1" /> Add an org
+                            <Plus className="size-4 mr-1" /> Add a server
                         </Button>
                     </>
                 ) : (
@@ -170,8 +170,8 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
                         <h2 className="text-sm font-semibold">No space to open</h2>
                         <p className="mt-1 text-sm text-muted-foreground">
                             {orgs.some((o) => o.error)
-                                ? 'An org is unreachable — check it is running and you are signed in.'
-                                : 'Create the first space from the org row in the sidebar.'}
+                                ? 'A server is unreachable — check it is running and you are signed in.'
+                                : 'Create the first space from the server row in the sidebar.'}
                         </p>
                     </>
                 )}
@@ -636,8 +636,10 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
             {active && <SelectionCopy />}
             <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
                 {/* Left: the org's mark, then # the space. Hover it for what the
-                    old identity card said — org name, address, who you are.
-                    Inviting lives with the members; nothing here repeats it. */}
+                    old identity card said — server name, who you are. The address
+                    is deliberately absent (decision 2026-09-07: names are the
+                    identity; the address is plumbing). Inviting lives with the
+                    members; nothing here repeats it. */}
                 <HoverCard openDelay={200} closeDelay={150}>
                     <HoverCardTrigger asChild>
                         <button
@@ -671,10 +673,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                             </div>
                         </div>
                         <dl className="mt-4 grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-1.5 text-[13px]">
-                            <dt className="text-right font-medium">Organization</dt>
-                            <dd className="truncate text-muted-foreground">{org.name}</dd>
                             <dt className="text-right font-medium">Server</dt>
-                            <dd className="min-w-0"><CopyLine text={org.address} title="Copy the server address" className="text-[13px]" /></dd>
+                            <dd className="truncate text-muted-foreground">{org.name}</dd>
                             <dt className="text-right font-medium">Members</dt>
                             <dd className="truncate text-muted-foreground">
                                 {members.length}{here.length > 0 && <span> · {here.length} here</span>}

--- a/apps/x/apps/renderer/src/components/spaces/atoms.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/atoms.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { AtSign, Copy, Loader2, Mail } from 'lucide-react'
+import { AtSign, Copy, Loader2, Mail, MoreHorizontal } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -7,6 +7,9 @@ import { Input } from '@/components/ui/input'
 import {
     Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
+import {
+    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useMemberNames, useSpaceProfiles } from '@/components/spaces/member-text'
@@ -189,50 +192,46 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
     onOpenChange: (open: boolean) => void
     onAdded: () => void
 }) {
-    // Three ways in: create your own org on the managed deployment (free for
-    // now), paste an invite link (resolve pre-auth, then join with a
-    // system-browser sign-in), or a dev org against the stub.
-    const [mode, setMode] = useState<'invite' | 'create' | 'dev'>('invite')
+    // One dialog, two doors: paste an invite link (resolve pre-auth, then
+    // join with a system-browser sign-in), or name a new server on the
+    // managed deployment (free for now — the address is generated in core,
+    // the user only names it). A dev org against the stub stays behind a
+    // tertiary link.
+    const [mode, setMode] = useState<'main' | 'dev'>('main')
     const [inviteUrl, setInviteUrl] = useState('')
     const [preview, setPreview] = useState<{ org: string; space: string; invitedBy?: string } | null>(null)
     const [orgName, setOrgName] = useState('')
-    const [slug, setSlug] = useState('')
-    const [slugEdited, setSlugEdited] = useState(false)
-    // The org-address suffix comes from the configured apex (/v1/config via
-    // core). null = no spaces fleet for this environment; undefined = loading.
+    // The apex (/v1/config via core) gates Create. null = no spaces fleet for
+    // this environment; undefined = loading.
     const [apexDomain, setApexDomain] = useState<string | null | undefined>(undefined)
 
     useEffect(() => {
-        if (mode !== 'create' || apexDomain !== undefined) return
+        if (!open || apexDomain !== undefined) return
         void window.ipc.invoke('spaces:apexInfo', null)
             .then(({ apexDomain: domain }) => setApexDomain(domain))
             .catch(() => setApexDomain(null))
-    }, [mode, apexDomain])
+    }, [open, apexDomain])
     const [baseUrl, setBaseUrl] = useState('http://localhost:4272')
     const [memberId, setMemberId] = useState('')
     const [busy, setBusy] = useState(false)
-    const [waitingBrowser, setWaitingBrowser] = useState(false)
-
-    const suggestSlug = (name: string) =>
-        name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40)
+    // Which door fired the browser dance — its button carries the spinner.
+    const [waiting, setWaiting] = useState<'join' | 'create' | null>(null)
 
     const createOrg = async () => {
-        if (!orgName.trim() || !slug.trim()) return
+        if (!orgName.trim()) return
         setBusy(true)
-        setWaitingBrowser(true)
+        setWaiting('create')
         try {
-            const { org } = await window.ipc.invoke('spaces:createOrg', { name: orgName.trim(), slug: slug.trim() })
+            const { org } = await window.ipc.invoke('spaces:createOrg', { name: orgName.trim() })
             toast(`Created ${org.name} — you're the admin`, 'success')
             onOpenChange(false)
             setOrgName('')
-            setSlug('')
-            setSlugEdited(false)
             onAdded()
         } catch (err) {
-            toast(err instanceof Error ? err.message : 'Could not create the org', 'error')
+            toast(err instanceof Error ? err.message : 'Could not create the server', 'error')
         } finally {
             setBusy(false)
-            setWaitingBrowser(false)
+            setWaiting(null)
         }
     }
 
@@ -256,7 +255,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
     const join = async () => {
         if (!inviteUrl.trim()) return
         setBusy(true)
-        setWaitingBrowser(true)
+        setWaiting('join')
         try {
             const { org, space } = await window.ipc.invoke('spaces:joinInvite', { url: inviteUrl.trim() })
             toast(`Joined ${space.name} on ${org.name}`, 'success')
@@ -268,7 +267,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
             toast(err instanceof Error ? err.message : 'Could not join', 'error')
         } finally {
             setBusy(false)
-            setWaitingBrowser(false)
+            setWaiting(null)
         }
     }
 
@@ -281,7 +280,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
             onOpenChange(false)
             onAdded()
         } catch (err) {
-            toast(err instanceof Error ? err.message : 'Could not reach the org', 'error')
+            toast(err instanceof Error ? err.message : 'Could not reach the server', 'error')
         } finally {
             setBusy(false)
         }
@@ -291,113 +290,95 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-md">
                 <DialogHeader>
-                    <DialogTitle>
-                        {mode === 'invite' ? 'Join a space' : mode === 'create' ? 'Create an org' : 'Add a dev org'}
-                    </DialogTitle>
+                    <DialogTitle>{mode === 'dev' ? 'Add a dev server' : 'Add a server'}</DialogTitle>
                     <DialogDescription>
-                        {mode === 'invite'
-                            ? 'Paste an invite link. Signing in opens your browser.'
-                            : mode === 'create'
-                              ? 'Your team’s own corner — you’ll be its admin. Signing in opens your browser.'
-                              : 'Dev sign-in against a stub Harbor (run pnpm dev in apps/harbor/packages/server).'}
+                        {mode === 'dev'
+                            ? 'Dev sign-in against a stub Harbor (run pnpm dev in apps/harbor/packages/server).'
+                            : 'Signing in opens your browser.'}
                     </DialogDescription>
                 </DialogHeader>
-                {mode === 'create' ? (
+                {mode === 'main' ? (
                     <div className="space-y-3">
                         <div>
-                            <label className="text-xs font-medium text-muted-foreground">Org name</label>
-                            <Input
-                                autoFocus
-                                value={orgName}
-                                onChange={(e) => {
-                                    setOrgName(e.target.value)
-                                    if (!slugEdited) setSlug(suggestSlug(e.target.value))
-                                }}
-                                placeholder="Acme Inc"
-                            />
+                            <div className="text-sm font-medium">Join a server</div>
+                            <p className="text-xs text-muted-foreground">Paste an invite link someone sent you.</p>
+                            <div className="mt-1.5 flex items-center gap-2">
+                                <Input
+                                    autoFocus
+                                    value={inviteUrl}
+                                    onChange={(e) => void resolvePreview(e.target.value)}
+                                    placeholder="https://org.example/join/…"
+                                    className="flex-1"
+                                    onKeyDown={(e) => e.key === 'Enter' && void join()}
+                                />
+                                <Button onClick={() => void join()} disabled={busy || !inviteUrl.trim()} className="shrink-0">
+                                    {waiting === 'join' && <Loader2 className="size-3.5 mr-1 animate-spin" />} Join
+                                </Button>
+                            </div>
+                            {preview && (
+                                <div className="mt-2 rounded-md border px-3 py-2 text-sm">
+                                    Join <span className="font-medium">{preview.space}</span> on{' '}
+                                    <span className="font-medium">{preview.org}</span>
+                                    {preview.invitedBy ? <span className="text-muted-foreground"> — invited by {preview.invitedBy}</span> : null}
+                                </div>
+                            )}
+                        </div>
+                        <div className="flex items-center gap-3">
+                            <div className="h-px flex-1 bg-border" />
+                            <span className="text-xs text-muted-foreground">or</span>
+                            <div className="h-px flex-1 bg-border" />
                         </div>
                         <div>
-                            <label className="text-xs font-medium text-muted-foreground">Address</label>
-                            <div className="flex items-center gap-1">
+                            <div className="text-sm font-medium">Create a new server</div>
+                            <p className="text-xs text-muted-foreground">Free — you name it and you’re its admin.</p>
+                            <div className="mt-1.5 flex items-center gap-2">
                                 <Input
-                                    value={slug}
-                                    onChange={(e) => {
-                                        setSlugEdited(true)
-                                        setSlug(suggestSlug(e.target.value))
-                                    }}
-                                    placeholder="acme"
+                                    value={orgName}
+                                    onChange={(e) => setOrgName(e.target.value)}
+                                    placeholder="Acme, book club, just me…"
                                     className="flex-1"
                                     onKeyDown={(e) => e.key === 'Enter' && void createOrg()}
                                 />
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                    {apexDomain ? `.${apexDomain}` : '.…'}
-                                </span>
+                                <Button onClick={() => void createOrg()} disabled={busy || !orgName.trim() || !apexDomain} className="shrink-0">
+                                    {waiting === 'create' && <Loader2 className="size-3.5 mr-1 animate-spin" />} Create
+                                </Button>
                             </div>
+                            {apexDomain === null && (
+                                <p className="mt-1.5 text-xs text-muted-foreground">
+                                    Spaces isn’t available for this environment yet.
+                                </p>
+                            )}
                         </div>
-                        {apexDomain === null && (
-                            <p className="text-xs text-muted-foreground">
-                                Spaces isn’t available for this environment yet.
-                            </p>
-                        )}
-                        {waitingBrowser && (
+                        {waiting && (
                             <div className="text-xs text-muted-foreground flex items-center gap-1.5">
                                 <Loader2 className="size-3 animate-spin" /> Waiting for the browser sign-in…
                             </div>
                         )}
                         <div className="flex items-center justify-between">
-                            <button type="button" className="text-xs text-muted-foreground hover:underline" onClick={() => setMode('invite')}>
-                                have an invite link?
-                            </button>
-                            <div className="flex gap-2">
-                                <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
-                                <Button onClick={() => void createOrg()} disabled={busy || !orgName.trim() || !slug.trim() || !apexDomain}>
-                                    {busy && <Loader2 className="size-3.5 mr-1 animate-spin" />} Create
-                                </Button>
-                            </div>
-                        </div>
-                    </div>
-                ) : mode === 'invite' ? (
-                    <div className="space-y-3">
-                        <Input
-                            autoFocus
-                            value={inviteUrl}
-                            onChange={(e) => void resolvePreview(e.target.value)}
-                            placeholder="https://org.example/join/…"
-                            onKeyDown={(e) => e.key === 'Enter' && void join()}
-                        />
-                        {preview && (
-                            <div className="rounded-md border px-3 py-2 text-sm">
-                                Join <span className="font-medium">{preview.space}</span> on{' '}
-                                <span className="font-medium">{preview.org}</span>
-                                {preview.invitedBy ? <span className="text-muted-foreground"> — invited by {preview.invitedBy}</span> : null}
-                            </div>
-                        )}
-                        {waitingBrowser && (
-                            <div className="text-xs text-muted-foreground flex items-center gap-1.5">
-                                <Loader2 className="size-3 animate-spin" /> Waiting for the browser sign-in…
-                            </div>
-                        )}
-                        <div className="flex items-center justify-between">
-                            <div className="flex gap-3">
-                                <button type="button" className="text-xs text-muted-foreground hover:underline" onClick={() => setMode('create')}>
-                                    create an org
-                                </button>
-                                <button type="button" className="text-xs text-muted-foreground hover:underline" onClick={() => setMode('dev')}>
-                                    dev org
-                                </button>
-                            </div>
-                            <div className="flex gap-2">
-                                <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
-                                <Button onClick={() => void join()} disabled={busy || !inviteUrl.trim()}>
-                                    {busy && <Loader2 className="size-3.5 mr-1 animate-spin" />} Join
-                                </Button>
-                            </div>
+                            {/* Dev sign-in stays reachable (Tailscale dogfood runs it in
+                                packaged builds) but hides behind … — a visible link here
+                                reads as a third way in to people who only have two. */}
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <button
+                                        type="button"
+                                        aria-label="More options"
+                                        className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+                                    >
+                                        <MoreHorizontal className="size-3.5" />
+                                    </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="start">
+                                    <DropdownMenuItem onClick={() => setMode('dev')}>Add a dev server</DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                            <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
                         </div>
                     </div>
                 ) : (
                     <div className="space-y-3">
                         <div>
-                            <label className="text-xs font-medium text-muted-foreground">Org address</label>
+                            <label className="text-xs font-medium text-muted-foreground">Server URL</label>
                             <Input value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} placeholder="http://localhost:4272" />
                         </div>
                         <div>
@@ -410,8 +391,8 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
                             />
                         </div>
                         <div className="flex items-center justify-between">
-                            <button type="button" className="text-xs text-muted-foreground hover:underline" onClick={() => setMode('invite')}>
-                                invite link instead
+                            <button type="button" className="text-xs text-muted-foreground hover:underline" onClick={() => setMode('main')}>
+                                back
                             </button>
                             <div className="flex gap-2">
                                 <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>

--- a/apps/x/apps/server/src/spaces-deps.ts
+++ b/apps/x/apps/server/src/spaces-deps.ts
@@ -104,7 +104,7 @@ export const spacesRpcHandlers: SpacesHandlers = {
   },
 
   'spaces:createOrg': async (args) => {
-    const org = orgSummary(await spacesOAuth.createOrgOnDeployment({ name: args.name, slug: args.slug, openBrowser }));
+    const org = orgSummary(await spacesOAuth.createOrgOnDeployment({ name: args.name, openBrowser }));
     void syncSpaceMentionWatch({ force: true });
     return { org };
   },

--- a/apps/x/packages/core/src/spaces/oauth.ts
+++ b/apps/x/packages/core/src/spaces/oauth.ts
@@ -206,41 +206,66 @@ export async function apexUrl(): Promise<string> {
 }
 
 /**
+ * The org's address is generated, never chosen (decision 2026-09-07: names
+ * are display-only; the address is opaque). The name-derived prefix keeps
+ * logs and DB rows legible; the random suffix is ALWAYS appended — never try
+ * the bare name — so creation reveals nothing about taken slugs and the
+ * clean namespace stays free for a future vanity claim. Prefix 35 + '-' + 4
+ * fits the server's 40-char slug cap.
+ */
+function generatedSlug(name: string): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const prefix =
+    name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 35).replace(/-+$/, '') || 'server';
+  let suffix = '';
+  for (let i = 0; i < 4; i++) suffix += alphabet[Math.floor(Math.random() * alphabet.length)];
+  return `${prefix}-${suffix}`;
+}
+
+/**
  * Self-serve org creation on the managed deployment: dance against the apex
  * (same discovery, same flow), POST the org, and — because shared-realm
  * tokens are realm-generic — the dance's tokens work at the new org's
  * subdomain immediately. The caller is the org's provisioned first admin.
+ * The slug is generated here, not passed in: a suffix collision is ~one in
+ * 1.7M per prefix, so the retry is a formality; any other failure surfaces
+ * verbatim on the first pass.
  */
 export async function createOrgOnDeployment(input: {
   name: string;
-  slug: string;
   openBrowser: OpenBrowser;
   apexUrl?: string;
 }): Promise<OrgRecord> {
   const apex = (input.apexUrl ?? (await apexUrl())).replace(/\/$/, '');
   const dance = await danceForTokens({ baseUrl: apex, openBrowser: input.openBrowser });
-  const res = await fetch(`${apex}/v1/orgs`, {
-    method: 'POST',
-    headers: { authorization: `Bearer ${dance.tokens.access}`, 'content-type': 'application/json' },
-    body: JSON.stringify({ name: input.name, slug: input.slug }),
-  });
-  const body = (await res.json().catch(() => ({}))) as {
-    message?: string;
-    org?: { id: string; name: string; address: string };
-    member?: { id: string };
-  };
-  if (!res.ok || !body.org || !body.member) {
-    throw new Error(body.message ?? `org creation failed (${res.status})`);
+  let failure = 'org creation failed';
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const res = await fetch(`${apex}/v1/orgs`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${dance.tokens.access}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: input.name, slug: generatedSlug(input.name) }),
+    });
+    const body = (await res.json().catch(() => ({}))) as {
+      message?: string;
+      org?: { id: string; name: string; address: string };
+      member?: { id: string };
+    };
+    if (res.ok && body.org && body.member) {
+      return upsertOAuthOrg({
+        baseUrl: `${new URL(apex).protocol}//${body.org.address}`,
+        name: body.org.name,
+        address: body.org.address,
+        serverOrgId: body.org.id,
+        issuer: dance.issuer,
+        clientId: dance.clientId,
+        memberId: body.member.id,
+        tokens: dance.tokens,
+      });
+    }
+    failure = body.message ?? `org creation failed (${res.status})`;
+    if (!/is taken/.test(failure)) break;
   }
-  return upsertOAuthOrg({
-    baseUrl: `${new URL(apex).protocol}//${body.org.address}`,
-    name: body.org.name,
-    address: body.org.address,
-    issuer: dance.issuer,
-    clientId: dance.clientId,
-    memberId: body.member.id,
-    tokens: dance.tokens,
-  });
+  throw new Error(failure);
 }
 
 /** Pre-auth resolution of a pasted invite link — what the join card shows. */

--- a/apps/x/packages/core/src/spaces/orgs.ts
+++ b/apps/x/packages/core/src/spaces/orgs.ts
@@ -46,6 +46,8 @@ export interface OrgRecord {
   address: string;
   /** Where to reach it, scheme included, e.g. http://localhost:4272. */
   baseUrl: string;
+  /** The server's durable org id (`org-<ulid>`) when known — the cross-device identity; `id` stays the local registry key. */
+  serverOrgId?: string;
   auth: OrgAuth;
 }
 
@@ -314,6 +316,7 @@ export function upsertOAuthOrg(input: {
   baseUrl: string;
   name: string;
   address: string;
+  serverOrgId?: string;
   issuer: string;
   clientId: string;
   memberId: string;
@@ -341,6 +344,7 @@ export function upsertOAuthOrg(input: {
   record.name = input.name;
   record.address = input.address;
   record.auth = auth;
+  if (input.serverOrgId) record.serverOrgId = input.serverOrgId;
   if (!existing) config.orgs.push(record);
   writeConfig(config);
   const runtime = runtimes.get(record.id);

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3686,9 +3686,11 @@ export const ipcSchemas = {
   },
   // Self-serve org creation on the managed deployment's apex (free for now —
   // billing/limits parked by decision 2026-08-20). Browser sign-in, then the
-  // caller is the org's first admin at <slug>.spaces.rowboatlabs.com.
+  // caller is the org's first admin. The address is generated in core
+  // (name-derived prefix + always-appended random suffix — decision
+  // 2026-09-07): the user names the server; nobody picks a slug.
   'spaces:createOrg': {
-    req: z.object({ name: z.string(), slug: z.string() }),
+    req: z.object({ name: z.string() }),
     res: z.object({ org: SpacesOrgSummary }),
   },
   // Where the Create button makes orgs (from /v1/config via core). null =

--- a/proposal.md
+++ b/proposal.md
@@ -1,0 +1,140 @@
+# Proposal: Decouple server display names from addresses
+
+**Status:** Draft for discussion
+**Date:** 2026-09-07
+**Scope:** Spaces (client `apps/x`, server `apps/harbor`)
+**Related:** Spaces create/join UX revamp (org → "Server" rename, first-run redesign, clickable invites, personal servers)
+
+## Summary
+
+Today, creating an org requires the user to pick two things at once: a display name ("Org name") and a globally unique address ("Address" — a slug that becomes `<slug>.<apexDomain>`). This couples two properties with opposite constraints: names want to be free-form, friendly, and non-unique ("Book Club"); addresses must be unique, DNS-safe, and permanent. The visible symptom is the setup form itself — asking for an "address" makes creation feel like infrastructure provisioning, and uniqueness pressure will eventually force users into ugly compromises like `arjun0012`.
+
+This proposal adopts the Discord model: **the display name is what users see and it is non-unique; the unique identifier is opaque and hidden; the only handle that travels between people is the invite link; readable addresses become an optional vanity claim made later, not a setup cost.** Concretely: the create flow asks for a name only, the server generates the address by suffixing the name with random characters, the address is not shown anywhere in the normal UI, and pretty addresses can arrive later as aliases via the already-many-to-one `org_domains` table.
+
+## 1. Problem
+
+### Uniqueness and readability are fused in one field
+
+`POST /v1/orgs` takes `{name, slug}` and mints the org at `<slug>.<apexDomain>` (`apps/harbor/packages/server/src/apex.ts`). The client's create form (`apps/x/apps/renderer/src/components/spaces/atoms.tsx:305–358`) exposes both: "Org name" and "Address", with the slug auto-derived from the name but editable and mandatory. Because slugs are first-come-first-served on a shared apex, the good ones will run out, and the failure mode is a user staring at `"acme" is taken` during their first minute in the product — or settling for `acme-inc-2`, which then appears in every invite link they ever share.
+
+### The address does three jobs and is named three ways
+
+- Create form: "Address" = a slug (`acme`)
+- Dev dialog: "Org address" = a base URL (`http://localhost:4272`)
+- About card: a row labeled "Server" = a host (`acme.spaces.rowboatlabs.com`)
+
+### The one identifier that should be stable is thrown away
+
+The server mints a durable org id (`org-<ulid>`, `directory.ts`), but the client's `upsertOAuthOrg` (`apps/x/packages/core/src/spaces/orgs.ts:314–320`) generates its own local id and never reads `body.org.id` from the create response. Meanwhile the slug is *not* persisted anywhere — it exists only transiently as input to org creation, immediately baked into a domain. So today the hostname is the de-facto identity, which is exactly the thing that should be free to change.
+
+## 2. Prior art: how Discord resolves this
+
+Discord's answer is that servers have **no user-facing address at all**:
+
+1. **Display names are non-unique.** Thousands of servers are named "Minecraft". The unique identifier is an internal snowflake ID users never see. The name field carries zero uniqueness pressure.
+2. **The only handle that travels is the invite link, and it is deliberately opaque** (`discord.gg/aB3xYz9`). It is clicked or pasted, never read aloud or typed from memory. Nobody expects it to be pretty.
+3. **Readable addresses are a vanity claim made later**, not a setup step: a custom `discord.gg/fortnite` unlocks at boost Level 3 (14 boosts) or partner/verified status, first-come-first-served, revocable. Readability is opt-in polish for established communities.
+4. **The username precedent.** Discord lived the `arjun0012` problem for years with user discriminators (`Arjun#0012`) and killed them in 2023, splitting identity into a unique, rarely seen handle and a free-form display name.
+
+The general pattern: **uniqueness and readability are never resolved in the same string.** What users see is free and non-unique; what is unique is opaque and hidden; pretty unique names are optional and claimed later.
+
+## 3. Proposed model
+
+Every server has three identifiers with distinct jobs:
+
+| Identifier | Example | Unique? | User-visible? | Mutable? |
+|---|---|---|---|---|
+| Display name | `Book Club` | No | Everywhere (sidebar, headers, invites, toasts) | Freely |
+| Address (host) | `book-club-x4f2.spaces.rowboatlabs.com` | Yes | No — embedded in invite URLs, never shown as UI | Via aliases (additive) |
+| Org id | `org-01J8…` | Yes | Never | Never |
+
+Plus the one artifact that moves between people: the **invite link** (`https://<address>/join/<token>`), which inherits the address but — per the Discord precedent — is clicked, not read. The invite landing page and in-app join card show the *display name* prominently; the hostname is incidental.
+
+Rules:
+
+- **Creation asks for a name only.** The address is generated, not chosen.
+- **The org id becomes the client's durable identity** for a server (persisted from the create/list responses), so addresses can change without breaking anything local.
+- **Addresses are additive.** `org_domains` is already many-to-one (`migrations.ts:127–144`; the client comment at `orgs.ts:41` even anticipates this: "addresses can change via aliases"). Claiming a pretty address later adds a domain; old invite links keep resolving.
+
+## 4. UX changes
+
+### Create flow
+
+One field: **Server name** (placeholder: "Acme, book club, just me…"). No address field, no caption, no availability check in the UI. Submit → browser sign-in (unchanged) → land in the seeded first space with an "Invite your team" callout. The generated address is not shown anywhere in the normal UI — not even the About card. The org id becomes the support/debug identifier; a "Copy diagnostics" affordance (or the existing dev tier) can expose the address when troubleshooting genuinely needs it.
+
+### Address generation is app-side — and always suffixes
+
+**Decided 2026-09-07: no Harbor changes for creation.** The app derives a prefix from the name (the same normalizer the create dialog uses today), **always appends a short random suffix** (`book-club` → `book-club-x4f2`), and submits the existing `POST /v1/orgs {name, slug}` unchanged. On the vanishingly rare `"…is taken"` response, it regenerates the suffix and retries (bounded). If the name normalizes to nothing (emoji, non-Latin scripts), a neutral fallback prefix is used. The server keeps validating exactly as it does now.
+
+Always-suffixing (rather than trying the bare name first and suffixing only on collision) is deliberate, for three reasons:
+
+1. **Uniformity.** Once the address is invisible, a clean slug has zero user value — but try-bare-first would make some servers "lucky" and others not, which matters the moment any address leaks (invite URLs).
+2. **No probing.** Try-bare-first turns creation into an availability oracle for taken names and needs a retry loop in the common case; with always-suffix the app never submits a bare name and the first attempt essentially always lands (a 4-char suffix is ~1.7M variants per prefix).
+3. **It preserves the clean namespace.** Bare `acme` stays unclaimed until someone deliberately claims it via the vanity feature (§ below). Otherwise early throwaway creates silently squat the names real communities will want later.
+
+The name-derived prefix is kept (rather than a fully random `s-x7f2k9`) for operators, not users: logs, DB rows, and support conversations stay human-legible. The explicit `slug` path remains available to API users and self-hosters; its `"taken"` / `"reserved"` errors are unchanged. The accepted trade of doing this app-side is that create isn't atomic against a racing identical slug — with random suffixes that race is effectively impossible, and the retry covers it anyway.
+
+### Vanity addresses: "Claim a custom address" (later phase)
+
+A server-settings action for admins: pick `acme` → validated against the existing slug rules and reserved list → added as an alias domain; the new domain becomes **primary** (used by `inviteUrl()` when minting new links) while old domains keep working. Unlike Discord, we don't need to gate this behind an earned tier — it's just deferred from setup to settings, where the user who cares can find it. Rate-limit claims (e.g. a few per server per month) to blunt squatting.
+
+### Sidebar disambiguation
+
+Non-unique names mean a user could have two "Book Club" servers in their own sidebar. Discord disambiguates with server icons; we should do the same lightweight version: a per-server color/glyph (derived from org id, admin-overridable later), with the address available as tooltip/About-level secondary text. This turns the collision problem into a display concern — which is where it should live.
+
+### Personal servers
+
+This proposal is what makes the personal-server plan clean: the address can be `u-arjun-x7f2.…` — fully invisible — while the sidebar says "Arjun's server". Reserve the `u-` slug prefix for personal provisioning (today's `RESERVED_SLUGS` in `apex.ts:25–28` reserves exact names only; extend with a prefix rule) so personal servers never contend with team slugs and vice versa.
+
+### Copy sweep
+
+| Where | Today | Proposed |
+|---|---|---|
+| Create dialog fields | `Org name` + `Address` | `Server name` (only) |
+| About card row | `Server` (showing the host) | Removed |
+| About card row label | `Organization` | `Server` |
+| Dev dialog field | `Org address` | `Server URL` |
+
+## 5. Server changes (Harbor)
+
+1. **Nothing for creation.** Slug generation is app-side (decided 2026-09-07); `POST /v1/orgs` and its validation are untouched.
+2. **`u-` prefix reservation** alongside `RESERVED_SLUGS` (personal-server phase).
+3. **Primary-domain notion** for `org_domains` (a flag or ordering) so `inviteUrl()` mints from the preferred address. Today `domains: string[]` has no stated precedence.
+4. **Alias-claim endpoint** (vanity phase): admin-gated, adds an `org_domains` row after slug validation, sets primary. Lives on the apex since domains are apex-scoped.
+5. Nothing else: Host-header routing (`deployment.ts:129–141`), invites, auth, and the member-facing protocol are untouched. An org gaining a domain is already a supported shape.
+
+## 6. Client changes
+
+1. **Persist the server org id.** `upsertOAuthOrg` must store `body.org.id` (new field on `OrgRecord`) instead of discarding it. This is the keystone: it makes the address a mutable attribute rather than the identity.
+2. **Wire the dead `GET /v1/orgs`** (implemented at `apex.ts:127–146`, never called by the client) so sign-in on any device rehydrates the server list keyed by org id. Without this, org-id durability has nothing to attach to across installs.
+3. **Create dialog:** drop the Address field and the slug-derivation keystroke logic; submit name only. The slug (prefix + always-appended random suffix, bounded retry on `"taken"`) is generated in the create path before the existing `POST /v1/orgs` call.
+4. **About card and copy sweep** per §4.
+5. **Refresh address on connect:** `GET /v1/health` on an org subdomain already returns `{org: {name, address}}` — use it to pick up primary-address changes and heal stale local records.
+
+## 7. What does not change
+
+- **Self-hosting and dev mode.** Single-org Harbor (`startHarbor`, port 4272) has no apex and no slugs; the dev dialog keeps its explicit base-URL field. Addresses remain fully visible to the technical tier — that's the audience they serve.
+- **Invite mechanics.** Space-scoped bearer links, resolution, bind ceremony, policy checks — all untouched. The hostname inside invite URLs stays (unlike Discord we route by Host, so it's load-bearing), but per the Discord precedent an opaque hostname in a clicked link costs nothing.
+- **The wire protocol.** No new member-facing objects; org identity stays out of the content plane.
+
+## 8. Risks and edge cases
+
+- **The address still peeks through in three places, and that's accepted.** (a) Invite URLs carry the hostname — Host-header routing is load-bearing, and the Discord precedent says opaque clicked links cost nothing; a later polish option is minting apex-hosted links (`spaces.rowboatlabs.com/j/<token>`) that resolve token→org via the shared deployment DB, removing the hostname from links entirely. (b) Derived MCP server names use the slug (`spaces-<slug>`, `orgs.ts:144–170`) and can surface in agent/tool listings — switch derivation to the display name with the org id as the dedup tiebreaker. (c) Dev mode and self-hosting keep explicit addresses by design.
+- **Hidden ≠ gone: support still needs an identifier.** With no address in the UI, "which server are you on?" is answered by the org id via a diagnostics affordance, not by reading a hostname off the About card.
+- **Squatting shifts to the vanity claim.** First-come-first-served pretty addresses invite squatting (Discord has this problem too). Rate-limiting claims and keeping the reserved list are the v1 answer; don't over-engineer beyond that.
+- **Two servers, same name, in one sidebar** — handled by iconography (§4); accept it otherwise.
+- **Stale addresses in old local records.** An org whose primary address changed still answers on the old domain (aliases are additive), and §6.5 heals the record on connect. No breakage window.
+- **`arjun0012`-style leakage.** The generated address will appear in shared invite URLs. This is the accepted trade — the landing page and join card foreground the display name, and no flow ever asks a human to read or type the host.
+
+## 9. Rollout
+
+1. **Phase A (with the create/join revamp):** name-only create with app-side slug generation; hidden address; persist org id; copy sweep; sidebar glyphs.
+2. **Phase B:** `GET /v1/orgs` recovery keyed by org id; address refresh via health.
+3. **Phase C:** primary-domain support + "Claim a custom address" in server settings; `u-` prefix reservation landing with personal-server provisioning.
+
+## 10. Open questions
+
+- ~~Should the generated address be shown once at creation or in About?~~ Resolved: fully hidden — the address appears nowhere in the normal UI; the org id is the support identifier.
+- Should invite links eventually move to apex-hosted `spaces.rowboatlabs.com/j/<token>` so the hostname disappears from the last user-visible surface? (Deployment mode has the shared DB to resolve token→org; self-host keeps per-org links.)
+- Does display-name rename (trivial: `orgs.name` is just a column, but there's no rename endpoint or UI today) ride along in Phase A? It's cheap and reinforces the "names are free" contract.
+- For self-hosted orgs joined by URL, should the sidebar ever fall back to showing the host instead of the name? (Probably yes when the name is unset/unreachable.)


### PR DESCRIPTION
## Summary

Decouples server display names from addresses in Spaces (the Discord model — full design in `proposal.md`): names are what users see and are non-unique; the address is generated plumbing that no longer appears in the UI.

- **Name-only create**: the create flow asks for a server name only. Core derives a slug prefix from the name and **always appends** a random 4-char suffix (never tries the bare name — uniform addresses, no availability oracle, clean namespace preserved for a future vanity claim), with a bounded retry on Harbor's `"…is taken"` error. `spaces:createOrg` IPC drops `slug` in both the Electron-main and rowboat-server registrations. **No Harbor changes** — `POST /v1/orgs {name, slug}` is used as-is.
- **Hidden address**: the About card's address row (and its copy tooltip) is removed; sidebar org-row tooltips no longer show the host. The member id stays as the support identifier.
- **Durable org id**: `upsertOAuthOrg` now persists the server's `org.id` on `OrgRecord` (`serverOrgId`, additive to `spaces_orgs.json`) instead of discarding it — the keystone for later cross-device recovery and vanity aliases.
- **Unified "Add a server" dialog**: Join and Create visible side by side — "Join a server" (paste invite link, live preview, inline Join) *or* "Create a new server" ("Free — you name it and you're its admin", inline Create). Per-door Enter/spinners; apex-unavailable disables only Create; dev sign-in tucked behind a `…` menu (kept reachable in packaged builds for Tailscale dogfood).
- **org→Server copy sweep** across dialogs, sidebars, menus, toasts, and empty states (user-facing only; internal identifiers stay `org`).
- **Remove-server confirmation** (was destructive with none): "This only removes the server from this device — you can rejoin with an invite link." Hoisted to the dock-sidebar root since the flyout unmounts under dialogs.

`proposal.md` documents the design and the phased follow-ups (clickable invites, `GET /v1/orgs` recovery, personal servers, vanity addresses).

## Test plan

- `pnpm install` + `npm run deps` (shared → core → server → client → preload) build clean
- `apps/main` build (bundles rowboat-server with the spaces-deps change)
- `npm run typecheck:renderer` clean
- Tests all green: shared 309, core 812, server 27, renderer 458 (1,606 total)
- Verified `apps/harbor` untouched (`git status` clean there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)