### PR TITLE
feat(x): email - prefix important inbox section headers with "Important"

### DIFF
--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -3852,7 +3852,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
             {(inboxFilter === 'all' || inboxFilter === 'important') && (visibleNeedsYou.length > 0 ? (
               <section className="gmail-section">
                 <div className="gmail-list-header">
-                  <span>Needs you</span>
+                  <span>Important - Needs you</span>
                   <span>
                     {visibleNeedsYou.length}{important.hasReachedEnd ? '' : '+'} thread{visibleNeedsYou.length === 1 ? '' : 's'}
                   </span>
@@ -3865,7 +3865,7 @@ export function EmailView({ initialThreadId, threadIdVersion, initialSearchQuery
             {(inboxFilter === 'all' || inboxFilter === 'important') && visibleWaiting.length > 0 && (
               <section className="gmail-section">
                 <div className="gmail-list-header">
-                  <span>Waiting on them</span>
+                  <span>Important - Waiting on them</span>
                   <span>
                     {visibleWaiting.length}{important.hasReachedEnd ? '' : '+'} thread{visibleWaiting.length === 1 ? '' : 's'}
                   </span>


### PR DESCRIPTION
## What

Renames the email app's two important-mail section headers:

- "Needs you" → **"Important - Needs you"**
- "Waiting on them" → **"Important - Waiting on them"**

## Why

Both sections hold mail the classifier marked important, but nothing in the list itself said so. Prefixing the headers makes the grouping explicit and matches the rail's "Important" view.

Pure JSX text change in `email-view.tsx`; the "Needs you" strings in the todo deck and code session header are different surfaces and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)