### PR TITLE
fix(x): Spaces - stop the topic watchdog receipting the user's own chat turns

### DIFF
--- a/apps/x/packages/core/src/spaces/topic-agent.test.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { RECLAIMED_TURN_REASON } from '../runtime/sessions/api.js';
-import { backstopBody, buildInvocationMessage, describeTurnError, finalAssistantText, isTopicReceiptCall } from './topic-agent.js';
+import {
+    backstopBody,
+    buildInvocationMessage,
+    describeTurnError,
+    finalAssistantText,
+    isTopicReceiptCall,
+    isTopicTurnCreated,
+    TOPIC_SUB_USE_CASE,
+} from './topic-agent.js';
 
 const input = {
     orgId: 'org-1',
@@ -68,10 +76,35 @@ describe('isTopicReceiptCall', () => {
     });
 });
 
+describe('isTopicTurnCreated', () => {
+    it('matches only turn_created events tagged with the topic subUseCase', () => {
+        expect(
+            isTopicTurnCreated({ type: 'turn_created', analytics: { useCase: 'copilot_chat', subUseCase: TOPIC_SUB_USE_CASE } }),
+        ).toBe(true);
+        // The user chatting in the same session from the chat pane: no tag.
+        expect(isTopicTurnCreated({ type: 'turn_created', analytics: { useCase: 'copilot_chat' } })).toBe(false);
+        expect(isTopicTurnCreated({ type: 'turn_created' })).toBe(false);
+        expect(isTopicTurnCreated({ type: 'turn_completed', analytics: { useCase: 'copilot_chat', subUseCase: TOPIC_SUB_USE_CASE } })).toBe(false);
+    });
+});
+
 describe('finalAssistantText', () => {
-    it('reads string output, message arrays, and part arrays', () => {
+    it('reads the single assistant message a turn_completed carries', () => {
+        expect(finalAssistantText({ role: 'assistant', content: 'all set' })).toBe('all set');
+        expect(
+            finalAssistantText({
+                role: 'assistant',
+                content: [
+                    { type: 'reasoning', text: 'let me think… ' },
+                    { type: 'text', text: 'final ' },
+                    { type: 'text', text: 'answer' },
+                ],
+            }),
+        ).toBe('final answer');
+    });
+
+    it('still reads string output and message arrays', () => {
         expect(finalAssistantText('done')).toBe('done');
-        expect(finalAssistantText([{ role: 'assistant', content: 'all set' }])).toBe('all set');
         expect(
             finalAssistantText([
                 { role: 'assistant', content: 'draft' },
@@ -83,7 +116,9 @@ describe('finalAssistantText', () => {
     it('returns null when nothing usable exists', () => {
         expect(finalAssistantText(undefined)).toBeNull();
         expect(finalAssistantText([])).toBeNull();
-        expect(finalAssistantText([{ role: 'user', content: 'hi' }])).toBeNull();
+        expect(finalAssistantText({ role: 'user', content: 'hi' })).toBeNull();
+        // Reasoning-only content must never surface in a feed.
+        expect(finalAssistantText({ role: 'assistant', content: [{ type: 'reasoning', text: 'hmm' }] })).toBeNull();
     });
 });
 
@@ -115,5 +150,11 @@ describe('backstopBody', () => {
         expect(backstopBody({ type: 'turn_completed' })).toBe(
             'Rowboat finished without posting a receipt or leaving a note.',
         );
+    });
+
+    it("quotes the agent's final note from the turn_completed assistant message", () => {
+        expect(
+            backstopBody({ type: 'turn_completed', output: { role: 'assistant', content: 'Posted the summary to roadmap.md.' } }),
+        ).toBe('Rowboat finished without posting a receipt. Its final note: "Posted the summary to roadmap.md."');
     });
 });

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -16,9 +16,13 @@ import { getClient, getLive, spacesMcpServerNameFor } from './orgs.js';
 //
 // Contracts kept here:
 // - The agent's final act is one post_message reply into the thread (spaces
-//   skill). A WATCHDOG enforces never-go-dark: any turn that ends without
-//   having posted gets a short mechanical receipt posted on its behalf,
-//   attributed actingMode 'agent' — the thread never ends in silence.
+//   skill). A WATCHDOG enforces never-go-dark: any TOPIC turn that ends
+//   without having posted gets a short mechanical receipt posted on its
+//   behalf, attributed actingMode 'agent' — the thread never ends in silence.
+//   Only turns this module started count (turn_created carrying the
+//   space_topic subUseCase): the session is user-openable from the thread
+//   pane, and receipting the user's private chat turns there would post
+//   "finished without a receipt" into the feed on every reply.
 // - While turns run, an agent_working presence lease (renewed every 10s,
 //   thread-scoped) tells the room; viewers prune stale chips themselves.
 
@@ -125,6 +129,15 @@ export function describeTurnError(error: string | undefined): string {
   return truncate(raw, 200);
 }
 
+/** Marks turns this module starts; the watchdog receipts ONLY these. */
+export const TOPIC_SUB_USE_CASE = 'space_topic';
+
+/** Was this turn started by a topic invocation (vs the user chatting in the session)? (pure; tested) */
+export function isTopicTurnCreated(event: unknown): boolean {
+  const e = event as { type?: string; analytics?: { subUseCase?: string } };
+  return e.type === 'turn_created' && e.analytics?.subUseCase === TOPIC_SUB_USE_CASE;
+}
+
 /** Does this turn event carry the agent's receipt into the given thread? (pure; tested) */
 export function isTopicReceiptCall(event: unknown, threadRootId: string): boolean {
   const e = event as {
@@ -152,6 +165,8 @@ interface TopicWatch {
   spaceId: string;
   threadRootId: string;
   turns: Map<string, TurnRecord>;
+  /** Session turns that are NOT topic invocations (the user chatting in the pane). */
+  ignoredTurns: Set<string>;
   activeTurns: Set<string>;
   presenceTimer: ReturnType<typeof setInterval> | null;
 }
@@ -163,6 +178,7 @@ function ensureWatch(bus: ITurnEventBus, sessionId: string, scope: { orgId: stri
   const watch: TopicWatch = {
     ...scope,
     turns: new Map(),
+    ignoredTurns: new Set(),
     activeTurns: new Set(),
     presenceTimer: null,
   };
@@ -176,16 +192,37 @@ function ensureWatch(bus: ITurnEventBus, sessionId: string, scope: { orgId: stri
 }
 
 function handleTurnEvent(watch: TopicWatch, busEvent: TurnBusEvent): void {
+  const event = busEvent.event as { type?: string; reason?: string };
   let record = watch.turns.get(busEvent.turnId);
   if (!record) {
-    record = { posted: false, terminal: false };
-    watch.turns.set(busEvent.turnId, record);
-    watch.activeTurns.add(busEvent.turnId);
-    startPresence(watch);
+    if (watch.ignoredTurns.has(busEvent.turnId)) return;
+    if (event.type === 'turn_created') {
+      if (!isTopicTurnCreated(event)) {
+        // The user chatting in this session from the chat pane — private
+        // conversation, not a topic invocation. No receipt, no presence chip.
+        watch.ignoredTurns.add(busEvent.turnId);
+        return;
+      }
+      record = { posted: false, terminal: false };
+      watch.turns.set(busEvent.turnId, record);
+      watch.activeTurns.add(busEvent.turnId);
+      startPresence(watch);
+    } else if (event.type === 'turn_cancelled' && event.reason === RECLAIMED_TURN_REASON) {
+      // A crash-orphaned turn reclaimed by the mention that just created this
+      // watch: its turn_created predates the process, so no record exists —
+      // the "interrupted, picking up your latest message" beat still applies.
+      void postBackstop(watch, event as never).catch((err) => {
+        console.error('[spaces] backstop receipt failed:', err);
+      });
+      return;
+    } else {
+      // Mid-flight events of a turn whose creation this watch never saw:
+      // not a turn this module started — nothing to receipt.
+      return;
+    }
   }
   if (record.terminal) return;
 
-  const event = busEvent.event as { type?: string };
   if (isTopicReceiptCall(event, watch.threadRootId)) {
     record.posted = true;
     return;
@@ -231,17 +268,25 @@ function stopPresence(watch: TopicWatch): void {
   }
 }
 
-/** Extract the assistant's final text from a turn_completed output, defensively. */
+/**
+ * Extract the assistant's final text from a turn_completed output, defensively.
+ * The event carries a single AssistantMessage ({ role, content }); strings and
+ * message arrays are accepted too. Only 'text' parts count — a reasoning part
+ * also has .text, and chain-of-thought must never land in a team feed.
+ */
 export function finalAssistantText(output: unknown): string | null {
   if (typeof output === 'string') return output || null;
-  if (!Array.isArray(output)) return null;
-  for (let i = output.length - 1; i >= 0; i--) {
-    const message = output[i] as { role?: string; content?: unknown };
+  const messages = Array.isArray(output) ? output : [output];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i] as { role?: string; content?: unknown } | null | undefined;
     if (message?.role !== 'assistant') continue;
     if (typeof message.content === 'string') return message.content || null;
     if (Array.isArray(message.content)) {
       const text = message.content
-        .map((part) => (typeof (part as { text?: unknown }).text === 'string' ? (part as { text: string }).text : ''))
+        .map((part) => {
+          const p = part as { type?: string; text?: unknown };
+          return p.type === 'text' && typeof p.text === 'string' ? p.text : '';
+        })
         .join('')
         .trim();
       if (text) return text;
@@ -359,7 +404,9 @@ export async function invokeTopicAgent(input: InvokeTopicAgentInput): Promise<In
         },
       },
       useCase: 'copilot_chat',
-      subUseCase: 'space_topic',
+      // The watchdog keys on this tag to tell topic turns from the user's own
+      // chat turns in the same session — keep them in lockstep.
+      subUseCase: TOPIC_SUB_USE_CASE,
       ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
       // Auto unless the composer asked for manual approval prompts (they
       // surface in the topic's session, reachable from the working chip).


### PR DESCRIPTION
## What

Fixes the repeated "Rowboat finished without posting a receipt or leaving a note." messages that pile up in space feeds.

## Why

Two stacked bugs in `apps/x/packages/core/src/spaces/topic-agent.ts`:

1. **The watchdog watched every turn in the topic's session, not just topic invocations.** The session is user-openable (thread pane "open the agent session" affordance, plus the normal chat sidebar), so every ordinary chat reply there ended a turn with no `post_message` receipt - and the watchdog posted its backstop into the space feed each time. It also flashed the `agent_working` presence chip at the whole room during those private chats.

2. **The backstop always used the generic no-note wording.** `turn_completed` carries a single `AssistantMessage` object, but `finalAssistantText()` only handled a string or an array of messages, so it always returned null and dropped the agent's actual final text. The tests encoded the wrong shape, so they passed.

## How

- `invokeTopicAgent` tags its turns with `subUseCase: 'space_topic'` (`TOPIC_SUB_USE_CASE`); the watchdog only creates a record for a `turn_created` carrying that tag (new pure helper `isTopicTurnCreated`). Other session turns are ignored - no backstop, no presence chip. The reclaimed-orphan notice still fires for pre-watch turns cancelled with `RECLAIMED_TURN_REASON`.
- `finalAssistantText` now reads the real single-message shape (strings and arrays still accepted) and extracts only `type: 'text'` parts - reasoning parts also carry `.text`, and chain-of-thought must never land in a team feed.

Both hosts get the fix for free since the change is entirely in `packages/core`.

## Testing

- Updated `topic-agent.test.ts` to the real event shapes; added cases for the gate, the reasoning-part filter, and the quoted final note.
- `tsc --noEmit` clean; full core suite: 838/838 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)