### PR TITLE
feat(spaces): rename a space — protocol route, durable event, sidebar UI

### DIFF
--- a/apps/harbor/packages/protocol/src/api.ts
+++ b/apps/harbor/packages/protocol/src/api.ts
@@ -118,6 +118,19 @@ export const routes = {
     request: z.object({ name: z.string().min(1).max(128) }),
     response: z.object({ space: Space }),
   },
+  /**
+   * Rename a space. Any member may rename (Slack channel semantics); direct
+   * spaces refuse — their label derives from the participants. An identical
+   * name is an idempotent no-op (no event). Everyone else learns by the
+   * durable `space_renamed` event on the space's log.
+   */
+  renameSpace: {
+    method: 'POST',
+    path: '/v1/spaces/:spaceId/rename',
+    params: z.object({ spaceId: SpaceId }),
+    request: z.object({ name: z.string().min(1).max(128), actingMode: ActingMode, agentName: z.string().max(64).optional() }),
+    response: z.object({ space: Space }),
+  },
   listMembers: {
     method: 'GET',
     path: '/v1/spaces/:spaceId/members',

--- a/apps/harbor/packages/protocol/src/events.ts
+++ b/apps/harbor/packages/protocol/src/events.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ChangeSet } from './changeset.js';
-import { Attribution, Membership, Message, MessageDeletion, MessageEdit, PollEnd, PollVote, Reaction, SpaceKind, Topic, TopicRemoval } from './core.js';
+import { Attribution, Membership, Message, MessageDeletion, MessageEdit, PollEnd, PollVote, Reaction, Space, SpaceKind, Topic, TopicRemoval } from './core.js';
 import { AssetPath, MemberId, MessageId, SpaceId, StreamOffset } from './ids.js';
 
 // Decision 2 (CONTRACT.md): one WebSocket per org, per-space subscriptions,
@@ -78,6 +78,16 @@ export const SpaceEvent = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('poll_ended'),
     end: PollEnd,
+  }),
+  /**
+   * The space was renamed (api.ts renameSpace) — the full row plus who did
+   * it, so clients update their listings and the feed can render an
+   * attributed "renamed the space" line. Identical-name renames emit nothing.
+   */
+  z.object({
+    type: z.literal('space_renamed'),
+    space: Space,
+    by: Attribution,
   }),
 ]);
 export type SpaceEvent = z.infer<typeof SpaceEvent>;

--- a/apps/harbor/packages/server/src/http.ts
+++ b/apps/harbor/packages/server/src/http.ts
@@ -142,6 +142,12 @@ export function buildHttpApp(deps: {
     return reply(c, routes.createSpace.response, { space: await service.createSpace(actor(c), input.name) });
   });
 
+  app.post('/v1/spaces/:spaceId/rename', async (c) => {
+    const { spaceId } = parseWith(routes.renameSpace.params, c.req.param());
+    const input = await body(c, routes.renameSpace.request);
+    return reply(c, routes.renameSpace.response, { space: await service.renameSpace(actor(c), spaceId, input) });
+  });
+
   app.post(routes.openDirect.path, async (c) => {
     const input = await body(c, routes.openDirect.request);
     return reply(c, routes.openDirect.response, await service.openDirect(actor(c), input.memberId));

--- a/apps/harbor/packages/server/src/service.ts
+++ b/apps/harbor/packages/server/src/service.ts
@@ -86,6 +86,7 @@ function seedDisplayName(identity: BindIdentity): string {
 }
 
 type NewMessage = z.infer<Routes['postMessage']['request']>;
+type RenameSpaceInput = z.infer<Routes['renameSpace']['request']>;
 type CreateTopicInput = z.infer<Routes['createTopic']['request']>;
 type ManageTopicAction = z.infer<Routes['manageTopic']['request']>;
 type ReactInput = z.infer<Routes['reactToMessage']['request']>;
@@ -185,6 +186,35 @@ export class HarborService {
       // The stream needs no object (annotation model): it is simply the
       // space's root messages, born empty.
       return space;
+    });
+  }
+
+  /**
+   * Rename a space (api.ts renameSpace): any member, Slack channel
+   * semantics. Direct spaces refuse — their label derives from the
+   * participants, not the stored name. Identical-name renames are an
+   * idempotent no-op with no event; a real rename appends `space_renamed`
+   * under the space lock so every follower updates its listing.
+   */
+  async renameSpace(ctx: ActorCtx, spaceId: string, input: RenameSpaceInput): Promise<Space> {
+    const space = await this.requireMember(ctx, spaceId);
+    if (space.kind === 'direct') {
+      throw new HarborError('invalid_request', 'a direct message cannot be renamed — its name is the other person');
+    }
+    this.guardWrite();
+    const by: Attribution = {
+      memberId: ctx.memberId,
+      actingMode: input.actingMode,
+      ...(input.agentName ? { agentName: input.agentName } : {}),
+    };
+    return this.store.withSpaceLock(spaceId, async () => {
+      const current = (await this.store.getSpace(spaceId)) ?? space;
+      if (current.name === input.name) return current; // idempotent, no event
+      const updated: Space = { ...current, name: input.name };
+      await this.store.putSpace(updated);
+      const offset = (await this.store.head(spaceId)) + 1;
+      await this.append(spaceId, offset, this.now(), { type: 'space_renamed', space: updated, by });
+      return updated;
     });
   }
 

--- a/apps/harbor/packages/server/test/api.test.ts
+++ b/apps/harbor/packages/server/test/api.test.ts
@@ -127,6 +127,30 @@ describe('spaces, invites, membership', () => {
     expect((await prakhar.post(`/v1/spaces/${spaceId}/leave`)).status).toBe(200);
     expect((await prakhar.get(`/v1/spaces/${spaceId}/assets`)).status).toBe(403);
   });
+
+  it('rename: any member renames, the listing follows, identical name no-ops', async () => {
+    const r = await gagan.post(`/v1/spaces/${spaceId}/rename`, { name: 'Launch plan', actingMode: 'direct' });
+    expect(r.status).toBe(200);
+    expect(r.body.space.name).toBe('Launch plan');
+    const list = await ramnique.get('/v1/spaces');
+    expect(list.body.spaces.find((s: any) => s.id === spaceId)?.name).toBe('Launch plan');
+    // Idempotent: the same name again succeeds and appends no event.
+    const before = await harbor.store.head(spaceId);
+    const again = await gagan.post(`/v1/spaces/${spaceId}/rename`, { name: 'Launch plan', actingMode: 'direct' });
+    expect(again.status).toBe(200);
+    expect(await harbor.store.head(spaceId)).toBe(before);
+    // A real rename appends the durable space_renamed event.
+    await gagan.post(`/v1/spaces/${spaceId}/rename`, { name: 'Show HN draft', actingMode: 'direct' });
+    expect(await harbor.store.head(spaceId)).toBe(before + 1);
+  });
+
+  it('rename: non-members are forbidden; a DM refuses; empty names are 400', async () => {
+    expect((await prakhar.post(`/v1/spaces/${spaceId}/rename`, { name: 'Nope', actingMode: 'direct' })).status).toBe(403);
+    expect((await ramnique.post(`/v1/spaces/${spaceId}/rename`, { name: '', actingMode: 'direct' })).status).toBe(400);
+    const dm = await ramnique.post('/v1/direct', { memberId: 'gagan' });
+    expect(dm.status).toBe(200);
+    expect((await ramnique.post(`/v1/spaces/${dm.body.space.id}/rename`, { name: 'Us', actingMode: 'direct' })).status).toBe(400);
+  });
 });
 
 describe('assets and the change-set log', () => {

--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -30,6 +30,7 @@ type SpacesHandlers = {
   'spaces:removeOrg': InvokeHandler<'spaces:removeOrg'>;
   'spaces:listSpaces': InvokeHandler<'spaces:listSpaces'>;
   'spaces:createSpace': InvokeHandler<'spaces:createSpace'>;
+  'spaces:renameSpace': InvokeHandler<'spaces:renameSpace'>;
   'spaces:openDirect': InvokeHandler<'spaces:openDirect'>;
   'spaces:listMembers': InvokeHandler<'spaces:listMembers'>;
   'spaces:createInvite': InvokeHandler<'spaces:createInvite'>;
@@ -181,6 +182,10 @@ export const spacesIpcHandlers: SpacesHandlers = {
     void syncSpaceMentionWatch({ force: true });
     return { space };
   },
+
+  'spaces:renameSpace': async (_event, args) => ({
+    space: await orgs.getClient(args.orgId).renameSpace(args.spaceId, args.name),
+  }),
 
   'spaces:openDirect': async (_event, args) => {
     const result = await orgs.getClient(args.orgId).openDirect(args.memberId);

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -1768,6 +1768,9 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, onReq
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
   const [newDirectOpen, setNewDirectOpen] = useState(false)
+  // Rename-in-place: the row's label becomes an input (same shape as create).
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
   // A dead OAuth session shows as a gentle "Sign in again" (org.authError, from core);
   // an unreachable org shows Retry.
   const needsSignIn = !!org.authError
@@ -1796,6 +1799,18 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, onReq
       onOpenSpace(org.id, space.id)
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Could not create the space', 'error')
+    }
+  }
+
+  const renameSpace = async (spaceId: string) => {
+    const name = renameValue.trim()
+    setRenamingId(null)
+    if (!name || name === org.spaces.find((s) => s.id === spaceId)?.name) return
+    try {
+      await window.ipc.invoke('spaces:renameSpace', { orgId: org.id, spaceId, name })
+      onChanged()
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Could not rename the space', 'error')
     }
   }
 
@@ -1862,21 +1877,54 @@ function FlyoutOrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, onReq
       {org.spaces.map((space) => {
         const active = activeSpace?.orgId === org.id && activeSpace.spaceId === space.id
         const count = unread.get(`${org.id}/${space.id}`) ?? 0
+        if (renamingId === space.id) {
+          return (
+            <div key={space.id} className="flex items-center gap-1 py-0.5 pl-5 pr-2">
+              <Input
+                autoFocus
+                value={renameValue}
+                className="h-7 text-xs"
+                onChange={(e) => setRenameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void renameSpace(space.id)
+                  if (e.key === 'Escape') {
+                    e.stopPropagation()
+                    setRenamingId(null)
+                  }
+                }}
+                onBlur={() => void renameSpace(space.id)}
+              />
+            </div>
+          )
+        }
         return (
-          <button
-            key={space.id}
-            type="button"
-            onClick={() => onOpenSpace(org.id, space.id)}
-            className={cn(
-              'flex w-full items-center gap-2.5 rounded-[9px] py-2 pl-5 pr-2.5 text-left text-[13.5px] text-foreground/90 hover:bg-accent',
-              active && 'bg-[var(--sidebar-accent)]',
-            )}
-          >
-            <span className={cn('min-w-0 flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
-            {count > 0 && (
-              <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
-            )}
-          </button>
+          <ContextMenu key={space.id}>
+            <ContextMenuTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onOpenSpace(org.id, space.id)}
+                className={cn(
+                  'flex w-full items-center gap-2.5 rounded-[9px] py-2 pl-5 pr-2.5 text-left text-[13.5px] text-foreground/90 hover:bg-accent',
+                  active && 'bg-[var(--sidebar-accent)]',
+                )}
+              >
+                <span className={cn('min-w-0 flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
+                {count > 0 && (
+                  <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
+                )}
+              </button>
+            </ContextMenuTrigger>
+            <ContextMenuContent>
+              <ContextMenuItem
+                onClick={() => {
+                  setRenameValue(space.name)
+                  setRenamingId(space.id)
+                }}
+              >
+                <Pencil className="mr-2 size-3.5" /> Rename space
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
         )
       })}
       {org.spaces.length === 0 && !org.error && !creating && (

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { ChevronRight, Hash, Loader2, MessagesSquare, MoreVertical, Plus, Trash2 } from 'lucide-react'
+import { ChevronRight, Hash, Loader2, MessagesSquare, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
 import {
@@ -9,6 +9,9 @@ import {
 import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import {
+    ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { Input } from '@/components/ui/input'
 import { AddOrgDialog, OrgMonogram, type SpaceSelection } from '@/components/spaces-view'
 import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
@@ -144,6 +147,9 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
 }) {
     const [creating, setCreating] = useState(false)
     const [newName, setNewName] = useState('')
+    // Rename-in-place: the row's label becomes an input (same shape as create).
+    const [renamingId, setRenamingId] = useState<string | null>(null)
+    const [renameValue, setRenameValue] = useState('')
     const [newDirectOpen, setNewDirectOpen] = useState(false)
     const [showAllDirects, setShowAllDirects] = useState(false)
     const [confirmRemove, setConfirmRemove] = useState(false)
@@ -175,6 +181,18 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
             onOpenSpace(org.id, space.id)
         } catch (err) {
             toast(err instanceof Error ? err.message : 'Could not create the space', 'error')
+        }
+    }
+
+    const renameSpace = async (spaceId: string) => {
+        const name = renameValue.trim()
+        setRenamingId(null)
+        if (!name || name === org.spaces.find((s) => s.id === spaceId)?.name) return
+        try {
+            await window.ipc.invoke('spaces:renameSpace', { orgId: org.id, spaceId, name })
+            onChanged()
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not rename the space', 'error')
         }
     }
 
@@ -267,26 +285,59 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
             {org.spaces.filter((space) => !visibleSpaceKeys || visibleSpaceKeys.has(spaceUseKey(org.id, space.id))).map((space) => {
                 const active = activeSpace?.orgId === org.id && activeSpace.spaceId === space.id
                 const count = unread.get(`${org.id}/${space.id}`) ?? 0
+                if (renamingId === space.id) {
+                    return (
+                        <SidebarMenuItem key={space.id}>
+                            <div className="flex items-center gap-1 py-0.5 pl-9 pr-2">
+                                <Input
+                                    autoFocus
+                                    value={renameValue}
+                                    className="h-7 text-xs"
+                                    onChange={(e) => setRenameValue(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') void renameSpace(space.id)
+                                        if (e.key === 'Escape') setRenamingId(null)
+                                    }}
+                                    onBlur={() => void renameSpace(space.id)}
+                                />
+                            </div>
+                        </SidebarMenuItem>
+                    )
+                }
                 return (
                     <SidebarMenuItem key={space.id}>
-                        <SidebarMenuButton
-                            isActive={active}
-                            onClick={() => onOpenSpace(org.id, space.id)}
-                            // Hover = intent: warm the cached tail + roster and
-                            // start the refresh, so the click paints instantly.
-                            onMouseEnter={() => {
-                                prefetchStream(org.id, space.id)
-                                prefetchMembers(org.id, space.id)
-                            }}
-                            className="pl-9"
-                        >
-                            {/* A space is a channel — # says so. */}
-                            <Hash className="size-3.5 shrink-0 text-muted-foreground" />
-                            <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
-                            {count > 0 && (
-                                <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
-                            )}
-                        </SidebarMenuButton>
+                        <ContextMenu>
+                            <ContextMenuTrigger asChild>
+                                <SidebarMenuButton
+                                    isActive={active}
+                                    onClick={() => onOpenSpace(org.id, space.id)}
+                                    // Hover = intent: warm the cached tail + roster and
+                                    // start the refresh, so the click paints instantly.
+                                    onMouseEnter={() => {
+                                        prefetchStream(org.id, space.id)
+                                        prefetchMembers(org.id, space.id)
+                                    }}
+                                    className="pl-9"
+                                >
+                                    {/* A space is a channel — # says so. */}
+                                    <Hash className="size-3.5 shrink-0 text-muted-foreground" />
+                                    <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
+                                    {count > 0 && (
+                                        <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
+                                    )}
+                                </SidebarMenuButton>
+                            </ContextMenuTrigger>
+                            <ContextMenuContent>
+                                <ContextMenuItem
+                                    onClick={() => {
+                                        setRenameValue(space.name)
+                                        setRenamingId(space.id)
+                                    }}
+                                >
+                                    <Pencil className="mr-2 size-3.5" /> Rename space
+                                </ContextMenuItem>
+                            </ContextMenuContent>
+                        </ContextMenu>
                     </SidebarMenuItem>
                 )
             })}

--- a/apps/x/apps/renderer/src/hooks/use-spaces.ts
+++ b/apps/x/apps/renderer/src/hooks/use-spaces.ts
@@ -261,6 +261,9 @@ function wireFeedBus(): void {
             return
         }
         if (frame.kind !== 'event') return
+        // A rename lands as a durable event on the space's log — refresh the
+        // org listing so the sidebar label follows on every device.
+        if (frame.event.type === 'space_renamed') void refreshSpacesOrgs()
         const key = liveKey(event.orgId, frame.spaceId)
         if (!feedReleases.has(key) || feedRefreshTimers.has(key)) return
         // Trailing debounce: a burst of events (an agent replying, a thread's

--- a/apps/x/packages/core/src/spaces/client.ts
+++ b/apps/x/packages/core/src/spaces/client.ts
@@ -165,6 +165,16 @@ export class SpacesClient {
     return (await this.request('POST', routes.createSpace.path, routes.createSpace.response, { name })).space;
   }
 
+  /** Rename a shared space (api.ts renameSpace). Identical name = idempotent no-op. */
+  async renameSpace(spaceId: string, name: string): Promise<Space> {
+    return (
+      await this.request('POST', this.space(spaceId, '/rename'), routes.renameSpace.response, {
+        name,
+        actingMode: 'direct',
+      })
+    ).space;
+  }
+
   async listMembers(spaceId: string): Promise<Member[]> {
     return (await this.request('GET', this.space(spaceId, '/members'), routes.listMembers.response)).members;
   }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3713,6 +3713,10 @@ export const ipcSchemas = {
     req: z.object({ orgId: z.string(), name: z.string() }),
     res: z.object({ space: z.custom<SpacesTypes.Space>() }),
   },
+  'spaces:renameSpace': {
+    req: z.object({ orgId: z.string(), spaceId: z.string(), name: z.string() }),
+    res: z.object({ space: z.custom<SpacesTypes.Space>() }),
+  },
   // Direct messages: get-or-create the DM with another org member. No
   // invite, no acceptance — the other side learns of it by a space_added
   // frame on 'spaces:events' and shows it in their sidebar.


### PR DESCRIPTION
## What

Adds the ability to rename a space, end to end.

### Protocol (`@rowboat/spaces-protocol`)
- `renameSpace` route: `POST /v1/spaces/:spaceId/rename` — any member may rename (Slack channel semantics); direct spaces refuse (their label derives from the participants); an identical name is an idempotent no-op.
- New durable `space_renamed` event (full space row + attribution) appended to the space's log so every follower updates its listing.

### Harbor
- `service.renameSpace` under the space lock (putSpace is already an upsert in both stores), HTTP route, and api.test coverage: rename + listing follows, idempotent no-op appends no event, real rename appends exactly one, non-member 403, DM 400, empty name 400.

### apps/x (desktop)
- Core `SpacesClient.renameSpace` + `spaces:renameSpace` IPC.
- Sidebar: right-click a space → **Rename space** — the row turns into an inline input (Enter saves, Esc cancels), same shape as space creation.
- Live: a `space_renamed` event triggers a spaces-listing refresh, so other devices' sidebars follow immediately.

## Notes
- Old clients validate live frames against the previous `SpaceEvent` union, so a rename event will fail their frame parse — fine under the v0 "deliberately unstable" posture, but the hosted Harbor needs a redeploy before the button works against production.

## Test plan
- `packages/server`: `vitest run test/api.test.ts` — 53/53.
- `apps/x`: `npm run typecheck` clean; core spaces tests 53/53.
- Manual: rename from the sidebar, second client follows live.