### PR TITLE
feat(x): Spaces — agent-activity feed replaces the topic watchdog; input origin on turns

### DIFF
--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -9,6 +9,7 @@ import { syncSpaceMentionWatch } from '@x/core/dist/spaces/mention-watch.js';
 import { getDndUntil, getNotifyPrefs, setDndUntil, setNotifyPref } from '@x/core/dist/spaces/notify-prefs.js';
 import { cancelScheduled, listScheduled, scheduleItem } from '@x/core/dist/spaces/scheduler.js';
 import { invokeTopicAgent, stopTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
+import { onSpaceAgentActivity, startSpaceAgentActivity } from '@x/core/dist/spaces/agent-activity.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
 import { fetchLinkPreview } from './link-preview.js';
 
@@ -95,6 +96,13 @@ const openBrowser = (url: string) => shell.openExternal(url);
 // space subscription to ride — relay them to every window as they arrive; the
 // renderer's orgs store refreshes its listing on them.
 orgs.onMemberFrame((orgId, frame) => broadcastSpacesEvent({ orgId, frame }));
+
+// The agent-activity feed ("my Rowboat is working on this thread"): core
+// folds turn/session bus events into per-org lists and emits each whole list
+// on change; windows replace their copy. Started here, before any mention
+// can be sent.
+onSpaceAgentActivity((event) => broadcastSpacesEvent(event));
+void startSpaceAgentActivity().catch((err) => console.error('[spaces] agent activity feed failed to start:', err));
 
 function broadcastSpacesEvent(event: spacesShared.SpacesBusEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -15,6 +15,7 @@ import { MessageRow, NewDivider, TypingIndicator } from '@/components/spaces/mes
 import type { ChatMessage, SpacePresence } from '@/hooks/use-space-chat'
 import { buildPendingMessage, getThreadSnapshot, ingestTopic, putThreadSnapshot, removeTopicByRoot, updateStreamMessage, usePresenceSender } from '@/hooks/use-space-chat'
 import { useTopicAgentPermissionWait } from '@/hooks/use-topic-agent-permission'
+import { useSpaceAgentActivity } from '@/lib/spaces-agent-activity'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { subscribeComposeInsert } from '@/lib/spaces-compose'
 import { applyReaction, artifactsForThread, isContinuation, mergeMessages, threadLabelOf } from '@/lib/spaces-conventions'
@@ -202,6 +203,7 @@ export function ThreadPane({
     }
 
     const workingAgents = presence.working.get(rootMessageId) ?? []
+    const ownActivity = useSpaceAgentActivity(org.id, space.id)
     // Your own agent, blocked mid-turn on a tool permission: surface it here
     // instead of letting it idle behind a "working…" spinner (or silence).
     const permissionWait = useTopicAgentPermissionWait(org.id, space.id, rootMessageId, visible)
@@ -528,6 +530,13 @@ export function ThreadPane({
     }
 
     const openTopicSession = async () => {
+        // A live record names the session outright; the registry lookup
+        // covers a thread whose agent is idle.
+        const live = ownActivity.get(rootMessageId)
+        if (live && onOpenSession) {
+            onOpenSession(live.sessionId)
+            return
+        }
         try {
             const { sessionId } = await window.ipc.invoke('spaces:topicSession', { orgId: org.id, spaceId: space.id, threadRootId: rootMessageId })
             if (sessionId && onOpenSession) onOpenSession(sessionId)

--- a/apps/x/apps/renderer/src/hooks/use-space-chat.ts
+++ b/apps/x/apps/renderer/src/hooks/use-space-chat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import type { spaces } from '@x/shared'
 import { subscribeSpacesFeed } from '@/lib/spaces-feed'
+import { useSpaceAgentActivity } from '@/lib/spaces-agent-activity'
 import { applyReaction, mergeMessages, threadRootOf } from '@/lib/spaces-conventions'
 import { applyPollVote } from '@/lib/spaces-poll'
 import { feedSyncedRecently, getSpaceFeed, getSpacesOrgs, refreshSpaceFeed, subscribeOrgs, subscribeSpaceFeedStore, useSpaceLive } from '@/hooks/use-spaces'
@@ -341,6 +342,7 @@ function wireBus(): void {
     if (busWired) return
     busWired = true
     subscribeSpacesFeed((event) => {
+        if (!('frame' in event)) return
         const frame = event.frame
         if (frame.kind === 'subscribed') {
             // A (re)connected subscription. Whatever was published while the
@@ -673,7 +675,11 @@ export interface SpacePresence {
     here: string[]
     /** threadRootId ('' = the stream) → members typing there. */
     typing: ReadonlyMap<string, string[]>
-    /** threadRootId → members whose agent holds an agent_working lease there. */
+    /**
+     * threadRootId → members whose agent is working there. Others' agents
+     * come from their agent_working leases; YOUR own comes from the local
+     * agent-activity feed (instant, and it knows about queued mentions).
+     */
     working: ReadonlyMap<string, string[]>
 }
 
@@ -691,7 +697,9 @@ function foldLeases(leases: Map<string, Lease>, selfMemberId: string): SpacePres
     for (const [k, lease] of leases) {
         const memberId = k.slice(0, k.indexOf('|'))
         if (lease.state === 'agent_working') {
-            working.set(lease.threadRootId, [...(working.get(lease.threadRootId) ?? []), memberId])
+            // Own-agent leases are the echo of frames this app sent; the local
+            // activity feed is the source for those (merged in useSpacePresence).
+            if (memberId !== selfMemberId) working.set(lease.threadRootId, [...(working.get(lease.threadRootId) ?? []), memberId])
             continue
         }
         here.add(memberId)
@@ -703,6 +711,7 @@ function foldLeases(leases: Map<string, Lease>, selfMemberId: string): SpacePres
 export function useSpacePresence(orgId: string, spaceId: string, selfMemberId: string): SpacePresence {
     const leasesRef = useRef<Map<string, Lease>>(new Map())
     const [presence, setPresence] = useState<SpacePresence>(EMPTY_PRESENCE)
+    const ownActivity = useSpaceAgentActivity(orgId, spaceId)
 
     useSpaceLive(orgId, spaceId, (frame) => {
         if (frame.kind !== 'presence') return
@@ -732,7 +741,15 @@ export function useSpacePresence(orgId: string, spaceId: string, selfMemberId: s
         return () => clearInterval(timer)
     }, [selfMemberId])
 
-    return presence
+    // Your own agent: every thread the activity feed lists (queued or running).
+    return useMemo(() => {
+        if (ownActivity.size === 0) return presence
+        const working = new Map(presence.working)
+        for (const threadRootId of ownActivity.keys()) {
+            working.set(threadRootId, [selfMemberId, ...(working.get(threadRootId) ?? [])])
+        }
+        return { ...presence, working }
+    }, [presence, ownActivity, selfMemberId])
 }
 
 /**

--- a/apps/x/apps/renderer/src/hooks/use-spaces.ts
+++ b/apps/x/apps/renderer/src/hooks/use-spaces.ts
@@ -178,7 +178,7 @@ export function useSpaceLive(
         let cancelled = false
         const release = acquireSpaceLive(orgId, spaceId)
         const unsubscribe = subscribeSpacesFeed((event) => {
-            if (cancelled || event.orgId !== orgId) return
+            if (cancelled || event.orgId !== orgId || !('frame' in event)) return
             const frame = event.frame
             if ('spaceId' in frame && frame.spaceId === spaceId) handlerRef.current(frame)
         })
@@ -266,6 +266,7 @@ function wireFeedBus(): void {
     if (feedBusWired) return
     feedBusWired = true
     subscribeSpacesFeed((event) => {
+        if (!('frame' in event)) return
         const frame = event.frame
         if (frame.kind === 'space_added') {
             // Someone opened a DM with us. The listing is how we learn its

--- a/apps/x/apps/renderer/src/lib/spaces-agent-activity.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-agent-activity.ts
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from 'react'
+import type { spaces } from '@x/shared'
+import { subscribeSpacesFeed } from '@/lib/spaces-feed'
+
+// "My Rowboat is working on this thread" — a mirror of core's agent-activity
+// feed (core/spaces/agent-activity.ts). Core folds the runtime's turn and
+// session buses into one list per org and emits the WHOLE list on every
+// change (and every 10s while non-empty, so a window that loads mid-turn
+// catches up); this store replaces its copy wholesale. Nothing is looked up
+// or computed at render time: a thread row asks the map for its root id.
+
+type Activity = spaces.SpaceAgentActivity
+type ThreadMap = ReadonlyMap<string, Activity>
+
+const EMPTY: ThreadMap = new Map()
+const listsByOrg = new Map<string, Activity[]>()
+// Per (org, space) views, rebuilt lazily after an org's list changes — a
+// stable reference between changes, which useSyncExternalStore requires.
+const views = new Map<string, ThreadMap>()
+const listeners = new Set<() => void>()
+
+subscribeSpacesFeed((event) => {
+  if (!('agentActivity' in event)) return
+  listsByOrg.set(event.orgId, event.agentActivity)
+  for (const key of [...views.keys()]) {
+    if (key.startsWith(`${event.orgId}/`)) views.delete(key)
+  }
+  for (const listener of listeners) listener()
+})
+
+function view(orgId: string, spaceId: string): ThreadMap {
+  const key = `${orgId}/${spaceId}`
+  let map = views.get(key)
+  if (!map) {
+    const inSpace = (listsByOrg.get(orgId) ?? []).filter((a) => a.spaceId === spaceId)
+    map = inSpace.length === 0 ? EMPTY : new Map(inSpace.map((a) => [a.threadRootId, a]))
+    views.set(key, map)
+  }
+  return map
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** threadRootId → this member's live agent activity there (queued or running), for one space. */
+export function useSpaceAgentActivity(orgId: string, spaceId: string): ThreadMap {
+  return useSyncExternalStore(subscribe, () => view(orgId, spaceId))
+}

--- a/apps/x/apps/server/src/spaces-deps.ts
+++ b/apps/x/apps/server/src/spaces-deps.ts
@@ -6,6 +6,7 @@ import { syncSpaceMentionWatch } from '@x/core/dist/spaces/mention-watch.js';
 import { getDndUntil, getNotifyPrefs, setDndUntil, setNotifyPref } from '@x/core/dist/spaces/notify-prefs.js';
 import { cancelScheduled, listScheduled, scheduleItem } from '@x/core/dist/spaces/scheduler.js';
 import { invokeTopicAgent, stopTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
+import { onSpaceAgentActivity, startSpaceAgentActivity } from '@x/core/dist/spaces/agent-activity.js';
 import { fetchLinkPreview } from '@x/core/dist/spaces/link-preview.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
 import { openExternalUrl } from '@x/core/dist/auth/url-opener.js';
@@ -36,6 +37,13 @@ export function subscribeSpacesEvents(listener: SpacesEventListener): () => void
 function emitSpacesEvent(event: spacesShared.SpacesBusEvent): void {
   for (const listener of spacesEventListeners) listener(event);
 }
+
+// The agent-activity feed ("my Rowboat is working on this thread"): core
+// folds turn/session bus events into per-org lists and emits each whole list
+// on change; clients replace their copy. Started here, before any mention
+// can be sent.
+onSpaceAgentActivity((event) => emitSpacesEvent(event));
+void startSpaceAgentActivity().catch((err) => console.error('[spaces] agent activity feed failed to start:', err));
 
 // Keyed by org/space; each entry remembers WHICH live client it subscribed
 // on. A re-auth (orgs.upsertOAuthOrg) closes and replaces the org's client —

--- a/apps/x/packages/core/docs/session-design.md
+++ b/apps/x/packages/core/docs/session-design.md
@@ -476,6 +476,14 @@ choice):
   the head becomes a new turn via the normal locked send path, using the
   config it arrived with; the remainder stays queued and steers the new
   turn at its first boundary (call 0) — the earliest the model can see it.
+- A steered entry joins the live turn, whose configuration wins — except
+  the config's `origin` (what outside the runtime caused the message: a
+  space mention today; `@x/shared` origins.ts), which rides along on BOTH
+  paths: `turn_created.origin` at promotion, `input_added.origin` at steer.
+  The queue entry exposes it too (`QueuedSessionMessage.origin`), so a
+  consumer can show a queued mention before it is delivered. The runtime
+  records origins and never reads them; consumers (the spaces
+  agent-activity feed) match on them from bus events alone.
 - The enqueue and the settled-check share one session-lock hold, and
   promotion re-checks everything under the same lock, so a concurrent
   settle cannot strand a message (no lost wakeup).

--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -729,6 +729,7 @@ interface InputAdded extends BaseTurnEvent {
   type: "input_added";
   inputIndex: number; // 1-based; index 0 is turn_created.input
   message: UserMessage;
+  origin?: InputOrigin; // as turn_created.origin: recorded verbatim, never read
 }
 ```
 
@@ -739,8 +740,13 @@ turn-definition immutability. Rules:
 - The messages come from a caller-supplied drain (`takeInputs`,
   section 15.2) polled once per loop iteration at the boundary: the tool
   batch has settled, completion was ruled out, the budget check and the
-  next `model_call_requested` are about to run. The loop never learns where
-  the messages come from (session queue, test fixture).
+  next `model_call_requested` are about to run. The loop never learns which
+  SOURCE drains (session queue, test fixture). Each message may carry an
+  `origin` — what outside the runtime caused it (`@x/shared` origins.ts, a
+  discriminated union: a space mention today) — written onto its
+  `input_added` verbatim and never acted on, exactly like
+  `turn_created.origin` for the first input. Consumers answer "is the agent
+  working on the thing I did?" from bus events alone.
 - Injection is purely additive. It never interrupts an in-flight model
   stream or tool execution and never cancels pending work; the message
   lands as a plain user message positioned after the batch's tool results.
@@ -1396,7 +1402,11 @@ interface CreateTurnInput {
 // the abort signal — both are ephemeral per-invocation channels into a live
 // advance that become durable only when acted on (turn_cancelled /
 // input_added respectively).
-type TakeAddedInputs = () => UserMessage[] | Promise<UserMessage[]>;
+interface AddedInput {
+  message: UserMessage;
+  origin?: InputOrigin; // lands on input_added.origin
+}
+type TakeAddedInputs = () => AddedInput[] | Promise<AddedInput[]>;
 
 interface ITurnRuntime {
   createTurn(input: CreateTurnInput): Promise<string>;

--- a/apps/x/packages/core/src/runtime/sessions/api.ts
+++ b/apps/x/packages/core/src/runtime/sessions/api.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type { UseCase } from "@x/shared/dist/analytics.js";
 import type { UserMessage } from "@x/shared/dist/message.js";
+import type { InputOrigin } from "@x/shared/dist/origins.js";
 import type {
     QueuedSessionMessage,
     SessionIndexEntry,
@@ -16,8 +17,8 @@ import type { Turn } from "../turns/api.js";
 /**
  * The cancel reason sendOrQueueMessage records when it reclaims a
  * crash-orphaned turn (idle in the log, no live advance — nothing will ever
- * settle it). Consumers that narrate turn endings (e.g. the spaces topic
- * watchdog) match on it to tell a reclaim apart from a person pressing Stop.
+ * settle it). Consumers that narrate turn endings can match on it to tell a
+ * reclaim apart from a person pressing Stop.
  */
 export const RECLAIMED_TURN_REASON =
     "interrupted: the app quit or crashed while this turn was running";
@@ -34,6 +35,11 @@ export interface SendMessageConfig {
     humanAvailable?: boolean;
     maxModelCalls?: number;
     reasoningEffort?: "low" | "medium" | "high";
+    // What outside the runtime caused this message (a space mention, ...).
+    // Lands on turn_created when the message starts a turn, on input_added
+    // when it is steered into a live one; a queued entry carries it until
+    // then. Recorded, never read, by the runtime — see @x/shared origins.
+    origin?: InputOrigin;
 }
 
 export interface ISessions {

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -1350,10 +1350,74 @@ describe("pending queue (sendOrQueueMessage, steering, promotion)", () => {
         const takeInputs = fake.advanceCalls[0].takeInputs;
         expect(takeInputs).toBeDefined();
         // The loop draining the source consumes the queue.
-        expect(await takeInputs!()).toEqual([user("steer me in")]);
+        expect(await takeInputs!()).toEqual([{ message: user("steer me in") }]);
         expect(sessions.listQueued(sessionId)).toEqual([]);
         // A second drain finds nothing.
         expect(await takeInputs!()).toEqual([]);
+    });
+
+    it("carries the send config's origin onto the queue entry and the steer drain", async () => {
+        const origin = {
+            kind: "space_mention" as const,
+            orgId: "org-1",
+            spaceId: "space-1",
+            threadRootId: "root-1",
+            messageId: "msg-1",
+        };
+        const { sessions, fake } = makeSessions();
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>(() => {}),
+        });
+        const sessionId = await sessions.createSession();
+        await sessions.sendMessage(sessionId, user("first"), {
+            agent: { agentId: "copilot" },
+        });
+        await sessions.sendOrQueueMessage(sessionId, user("from a thread"), {
+            agent: { agentId: "copilot" },
+            origin,
+        });
+        expect(sessions.listQueued(sessionId)).toMatchObject([{ message: user("from a thread"), origin }]);
+        const takeInputs = fake.advanceCalls[0].takeInputs;
+        expect(await takeInputs!()).toEqual([{ message: user("from a thread"), origin }]);
+    });
+
+    it("stamps the origin on the turn a message starts, immediately or by promotion", async () => {
+        const origin = {
+            kind: "space_mention" as const,
+            orgId: "org-1",
+            spaceId: "space-1",
+            threadRootId: "root-1",
+            messageId: "msg-1",
+        };
+        const { sessions, fake } = makeSessions();
+        const sessionId = await sessions.createSession();
+        // Immediate start: the config's origin is on createTurn's input.
+        let settle!: (outcome: TurnOutcome) => void;
+        fake.script = () => ({
+            pending: new Promise<TurnOutcome>((resolve) => {
+                settle = resolve;
+            }),
+        });
+        const { turnId } = await sessions.sendMessage(sessionId, user("first"), {
+            agent: { agentId: "copilot" },
+            origin,
+        });
+        expect(fake.createTurnInputs[0]).toMatchObject({ origin });
+        // Promotion: the queued entry's own origin, not the live turn's.
+        await sessions.sendOrQueueMessage(sessionId, user("after you finish"), {
+            agent: { agentId: "copilot" },
+            origin: { ...origin, messageId: "msg-2" },
+        });
+        fake.script = undefined;
+        fake.setLog(turnId, turnLog(turnId, sessionId, "completed"));
+        settle(completedOutcome());
+        await flush();
+        await flush();
+        expect(fake.createTurnInputs).toHaveLength(2);
+        expect(fake.createTurnInputs[1]).toMatchObject({
+            input: user("after you finish"),
+            origin: { ...origin, messageId: "msg-2" },
+        });
     });
 
     it("promotes the pending head into a new turn when the running turn settles", async () => {

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -23,6 +23,7 @@ import {
 import type { IMonotonicallyIncreasingIdGenerator } from "../../application/lib/id-gen.js";
 import { chatActivity } from "../../application/lib/chat-activity.js";
 import {
+    type AddedInput,
     type ITurnRuntime,
     type Turn,
     type TurnExecution,
@@ -67,7 +68,9 @@ interface ActiveAdvance {
 
 // One pending-queue entry (QueuedSessionMessage plus the SendMessageConfig it
 // arrived with — used only if the entry is promoted to a new turn; a steered
-// entry joins the live turn, whose configuration wins).
+// entry joins the live turn, whose configuration wins. The config's origin
+// is the one field that rides along either way: it lands on turn_created at
+// promotion and on input_added at steer).
 interface PendingSessionEntry {
     queueId: string;
     message: z.infer<typeof UserMessage>;
@@ -76,7 +79,14 @@ interface PendingSessionEntry {
 }
 
 function publicQueueEntry(entry: PendingSessionEntry): QueuedSessionMessage {
-    return { queueId: entry.queueId, message: entry.message, ts: entry.ts };
+    return {
+        queueId: entry.queueId,
+        message: entry.message,
+        ts: entry.ts,
+        ...(entry.config.origin === undefined
+            ? {}
+            : { origin: entry.config.origin }),
+    };
 }
 
 // The session layer per session-design.md: owns conversations as ordered
@@ -388,6 +398,7 @@ export class SessionsImpl implements ISessions {
                     ? { subUseCase: config.subUseCase }
                     : {}),
             },
+            ...(config.origin === undefined ? {} : { origin: config.origin }),
             config: {
                 humanAvailable: config.humanAvailable ?? true,
                 ...(config.autoPermission === undefined
@@ -845,16 +856,19 @@ export class SessionsImpl implements ISessions {
     // The loop-facing drain (TakeAddedInputs): hand every pending message to
     // the live turn. Synchronous mutation — no interleaving with the
     // lock-holding paths' own synchronous queue access is possible.
-    private drainQueuedForSteer(
-        sessionId: string,
-    ): Array<z.infer<typeof UserMessage>> {
+    private drainQueuedForSteer(sessionId: string): AddedInput[] {
         const queue = this.pending.get(sessionId);
         if (!queue || queue.length === 0) {
             return [];
         }
-        const messages = queue.splice(0).map((entry) => entry.message);
+        const inputs = queue.splice(0).map((entry) => ({
+            message: entry.message,
+            ...(entry.config.origin === undefined
+                ? {}
+                : { origin: entry.config.origin }),
+        }));
         this.publishQueue(sessionId);
-        return messages;
+        return inputs;
     }
 
     private publishQueue(sessionId: string): void {

--- a/apps/x/packages/core/src/runtime/turns/api.ts
+++ b/apps/x/packages/core/src/runtime/turns/api.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type { TurnAnalytics } from "@x/shared/dist/analytics.js";
 import type { AssistantMessage, UserMessage } from "@x/shared/dist/message.js";
+import type { InputOrigin } from "@x/shared/dist/origins.js";
 import type {
     JsonValue,
     RequestedAgent,
@@ -18,6 +19,8 @@ export interface CreateTurnInput {
     context: z.infer<typeof TurnContext>;
     input: z.infer<typeof UserMessage>;
     analytics?: TurnAnalytics;
+    // Persisted verbatim as turn_created.origin (see @x/shared origins).
+    origin?: InputOrigin;
     config: {
         autoPermission?: boolean;
         humanAvailable: boolean;
@@ -34,12 +37,16 @@ export interface CreateTurnInput {
 // are treated as consumed and appended durably as input_added events, so
 // they ride the very next request. The dual of the abort signal: both are
 // ephemeral per-invocation channels into a live advance that become durable
-// only when acted on. The turn layer never learns where the messages come
-// from (session queue, test fixture); an accepted input resets the
-// model-call budget.
-export type TakeAddedInputs = () =>
-    | Array<z.infer<typeof UserMessage>>
-    | Promise<Array<z.infer<typeof UserMessage>>>;
+// only when acted on. The turn layer never learns which SOURCE drains
+// (session queue, test fixture); each message may carry an origin label
+// (what outside the runtime caused it — see @x/shared origins) that is
+// written onto its input_added verbatim and never acted on. An accepted
+// input resets the model-call budget.
+export interface AddedInput {
+    message: z.infer<typeof UserMessage>;
+    origin?: InputOrigin;
+}
+export type TakeAddedInputs = () => AddedInput[] | Promise<AddedInput[]>;
 
 // Exactly one external input per advanceTurn invocation.
 export type TurnExternalInput =

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -3240,7 +3240,7 @@ describe("added inputs (steering)", () => {
                 return [];
             }
             state.armed = false;
-            return [user(text)];
+            return [{ message: user(text) }];
         };
         return { state, takeInputs };
     }
@@ -3295,8 +3295,45 @@ describe("added inputs (steering)", () => {
         expect(wire[wire.length - 1]).toEqual(user("also check the tests"));
     });
 
+    it("writes a steered message's origin onto its input_added, verbatim", async () => {
+        const origin = {
+            kind: "space_mention" as const,
+            orgId: "org-1",
+            spaceId: "space-1",
+            threadRootId: "root-1",
+            messageId: "msg-1",
+        };
+        const pending = [{ message: user("from a space thread"), origin }];
+        const { runtime, repo } = makeRuntime({
+            models: [respond(completedResp(assistantText("done")))],
+        });
+        const turnId = await newTurn(runtime);
+        const { outcome } = await advanceAndSettle(runtime, turnId, undefined, {
+            takeInputs: () => pending.splice(0),
+        });
+        expect(outcome?.status).toBe("completed");
+        const log = await persisted(repo, turnId);
+        const added = log.find((e) => e.type === "input_added");
+        expect(added).toMatchObject({ message: user("from a space thread"), origin });
+    });
+
+    it("persists a createTurn origin on turn_created and omits the field otherwise", async () => {
+        const origin = {
+            kind: "space_mention" as const,
+            orgId: "org-1",
+            spaceId: "space-1",
+            threadRootId: "root-1",
+            messageId: "msg-1",
+        };
+        const { runtime, repo } = makeRuntime({ models: [] });
+        const tagged = await newTurn(runtime, { origin });
+        const plain = await newTurn(runtime);
+        expect((await persisted(repo, tagged))[0]).toMatchObject({ type: "turn_created", origin });
+        expect((await persisted(repo, plain))[0]).not.toHaveProperty("origin");
+    });
+
     it("injects a message already pending before the first model call on call 0", async () => {
-        const pending = [user("and one more thing")];
+        const pending = [{ message: user("and one more thing") }];
         const { runtime, repo, models } = makeRuntime({
             models: [respond(completedResp(assistantText("done")))],
         });
@@ -3367,7 +3404,7 @@ describe("added inputs (steering)", () => {
         expect(first.outcome?.status).toBe("suspended");
 
         // The message typed while suspended rides the resuming advance.
-        const pending = [user("typed while waiting")];
+        const pending = [{ message: user("typed while waiting") }];
         const { outcome } = await advanceAndSettle(
             runtime,
             turnId,

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -167,6 +167,7 @@ export class TurnRuntime implements ITurnRuntime {
             context: input.context,
             input: input.input,
             analytics: input.analytics ?? { useCase: "copilot_chat" },
+            ...(input.origin === undefined ? {} : { origin: input.origin }),
             config: {
                 autoPermission: input.config.autoPermission ?? false,
                 humanAvailable: input.config.humanAvailable,
@@ -591,18 +592,19 @@ class TurnAdvance {
         if (!this.takeInputs || this.signal.aborted) {
             return;
         }
-        const messages = await this.takeInputs();
-        if (messages.length === 0) {
+        const inputs = await this.takeInputs();
+        if (inputs.length === 0) {
             return;
         }
         await this.appendWith(() => {
             const base = this.state.addedInputs.length;
-            return messages.map((message, i) => ({
+            return inputs.map(({ message, origin }, i) => ({
                 type: "input_added" as const,
                 turnId: this.turnId,
                 ts: this.now(),
                 inputIndex: base + i + 1,
                 message,
+                ...(origin === undefined ? {} : { origin }),
             }));
         });
     }

--- a/apps/x/packages/core/src/spaces/agent-activity.test.ts
+++ b/apps/x/packages/core/src/spaces/agent-activity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { SpacesBusEvent } from '@x/shared/dist/spaces.js';
+import type { TurnBusEvent } from '@x/shared/dist/turns.js';
+import { SpaceAgentActivityTracker } from './agent-activity.js';
+
+const origin = (threadRootId: string, messageId = 'msg-1') => ({
+  kind: 'space_mention' as const,
+  orgId: 'org-1',
+  spaceId: 'space-1',
+  threadRootId,
+  messageId,
+});
+
+function harness() {
+  const presence: string[] = [];
+  const emitted: SpacesBusEvent[] = [];
+  let tick: (() => void) | null = null;
+  const tracker = new SpaceAgentActivityTracker(
+    (orgId, spaceId, state, threadRootId) => presence.push(`${state}:${orgId}/${spaceId}/${threadRootId}`),
+    (event) => emitted.push(event),
+    (fn) => {
+      tick = fn;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    },
+    () => {
+      tick = null;
+    },
+  );
+  const turn = (turnId: string, event: Record<string, unknown>, sessionId = 'sess-1'): TurnBusEvent =>
+    ({ turnId, sessionId, event }) as unknown as TurnBusEvent;
+  const lastList = () => {
+    const last = emitted[emitted.length - 1];
+    return last && 'agentActivity' in last ? last.agentActivity : undefined;
+  };
+  return { tracker, presence, emitted, turn, lastList, tick: () => tick?.(), hasTimer: () => tick !== null };
+}
+
+describe('SpaceAgentActivityTracker', () => {
+  it('tracks a turn created from a mention: running, lease, feed; released on settle', () => {
+    const h = harness();
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    expect(h.lastList()).toEqual([
+      { spaceId: 'space-1', threadRootId: 'root-1', state: 'running', sessionId: 'sess-1', turnId: 't1' },
+    ]);
+    expect(h.presence).toEqual(['agent_working:org-1/space-1/root-1']);
+    expect(h.hasTimer()).toBe(true);
+
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_completed' }));
+    expect(h.lastList()).toEqual([]);
+    expect(h.presence).toEqual(['agent_working:org-1/space-1/root-1', 'agent_idle:org-1/space-1/root-1']);
+    expect(h.hasTimer()).toBe(false);
+  });
+
+  it('ignores turns without a mention origin (the person chatting in the session)', () => {
+    const h = harness();
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_created', analytics: { useCase: 'copilot_chat' } }));
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'input_added', message: { role: 'user', content: 'hi' } }));
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_completed' }));
+    expect(h.emitted).toEqual([]);
+    expect(h.presence).toEqual([]);
+  });
+
+  it('a mention steered into an untracked turn makes that turn running for the thread', () => {
+    const h = harness();
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_created' }));
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'input_added', origin: origin('root-2') }));
+    expect(h.lastList()).toEqual([
+      { spaceId: 'space-1', threadRootId: 'root-2', state: 'running', sessionId: 'sess-1', turnId: 't1' },
+    ]);
+    // A second mention in another thread steered into the same turn: both threads busy.
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'input_added', origin: origin('root-3') }));
+    expect(h.lastList()?.map((a) => a.threadRootId).sort()).toEqual(['root-2', 'root-3']);
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_failed', error: 'x' }));
+    expect(h.lastList()).toEqual([]);
+    expect(h.presence.filter((p) => p.startsWith('agent_idle')).sort()).toEqual([
+      'agent_idle:org-1/space-1/root-2',
+      'agent_idle:org-1/space-1/root-3',
+    ]);
+  });
+
+  it('shows queued mentions from queue-changed, and running wins over queued for a thread', () => {
+    const h = harness();
+    h.tracker.handleSessionEvent({
+      kind: 'queue-changed',
+      sessionId: 'sess-1',
+      queue: [
+        { queueId: 'q1', message: { role: 'user', content: 'a' }, ts: 't', origin: origin('root-1') },
+        { queueId: 'q2', message: { role: 'user', content: 'plain chat' }, ts: 't' },
+      ],
+    });
+    expect(h.lastList()).toEqual([{ spaceId: 'space-1', threadRootId: 'root-1', state: 'queued', sessionId: 'sess-1' }]);
+    expect(h.presence).toEqual(['agent_working:org-1/space-1/root-1']);
+
+    // The live turn accepts it (steer): running, and the queue empties.
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'input_added', origin: origin('root-1') }));
+    expect(h.lastList()).toEqual([
+      { spaceId: 'space-1', threadRootId: 'root-1', state: 'running', sessionId: 'sess-1', turnId: 't1' },
+    ]);
+    h.tracker.handleSessionEvent({ kind: 'queue-changed', sessionId: 'sess-1', queue: [] });
+    expect(h.lastList()?.[0]?.state).toBe('running');
+    // No duplicate lease for a thread that stayed busy throughout.
+    expect(h.presence).toEqual(['agent_working:org-1/space-1/root-1']);
+  });
+
+  it('renews every lease and re-emits the lists on the timer while busy', () => {
+    const h = harness();
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    const before = h.emitted.length;
+    h.tick();
+    expect(h.presence).toEqual(['agent_working:org-1/space-1/root-1', 'agent_working:org-1/space-1/root-1']);
+    expect(h.emitted.length).toBe(before + 1);
+    expect(h.lastList()?.[0]?.state).toBe('running');
+  });
+
+  it('emits per org, and one final empty list for an org that went quiet', () => {
+    const h = harness();
+    const other = { ...origin('root-9'), orgId: 'org-2', spaceId: 'space-9' };
+    h.tracker.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    h.tracker.handleTurnEvent(h.turn('t2', { type: 'turn_created', origin: other }, 'sess-2'));
+    const orgsEmitted = h.emitted.map((e) => e.orgId);
+    expect(orgsEmitted).toContain('org-1');
+    expect(orgsEmitted).toContain('org-2');
+    h.tracker.handleTurnEvent(h.turn('t2', { type: 'turn_cancelled' }));
+    const last = h.emitted[h.emitted.length - 1];
+    expect(last).toEqual({ orgId: 'org-2', agentActivity: [] });
+    // org-1 is still busy and was re-emitted unchanged on that change.
+    const org1 = h.emitted.filter((e) => e.orgId === 'org-1');
+    const lastOrg1 = org1[org1.length - 1]!;
+    expect('agentActivity' in lastOrg1 ? lastOrg1.agentActivity : []).toHaveLength(1);
+  });
+});

--- a/apps/x/packages/core/src/spaces/agent-activity.ts
+++ b/apps/x/packages/core/src/spaces/agent-activity.ts
@@ -1,0 +1,275 @@
+import type { SessionBusEvent } from '@x/shared/dist/sessions.js';
+import type { SpaceAgentActivity, SpacesBusEvent } from '@x/shared/dist/spaces.js';
+import type { SpaceMentionOrigin } from '@x/shared/dist/origins.js';
+import type { TurnBusEvent } from '@x/shared/dist/turns.js';
+import type { PresenceState } from '@rowboat/spaces-protocol';
+import { getLive } from './orgs.js';
+
+// "Is my Rowboat working on the mention I made?" — answered from bus events
+// alone. This is the ONE spaces-side consumer of the general turn and
+// session buses. It keeps a small map of live activity keyed by the origin
+// stamped on the events (turns created from, or steered with, a space
+// mention; mentions still waiting in a session's pending queue), and from
+// that map it:
+//
+// - tells the room: an agent_working presence lease per busy thread, renewed
+//   every 10s, released with agent_idle (viewers prune stale chips themselves);
+// - emits its OWN feed: the org's WHOLE activity list on every change, on
+//   'spaces:events' next to the live frames. The renderer replaces its copy
+//   wholesale (queue-changed's posture — small by nature). The list is also
+//   re-emitted on every lease renewal while non-empty, so a window that loads
+//   mid-turn catches up within 10s with no snapshot channel.
+//
+// Nothing here reads sessions or turns, and nothing is looked up at render
+// time. The runtime knows nothing of this module: it stamps the origin the
+// invoker passed and publishes events, as it does for every consumer.
+//
+// Turns without a space_mention origin — the user chatting in the thread's
+// session, which is user-openable — never appear here: no chip, no lease.
+
+const RENEW_MS = 10_000;
+
+type Presence = (orgId: string, spaceId: string, state: PresenceState, threadRootId: string) => void;
+type Emit = (event: SpacesBusEvent) => void;
+
+interface RunningTurn {
+  sessionId: string;
+  /** Every mention origin the turn has accepted (created + steered), keyed by thread. */
+  origins: Map<string, SpaceMentionOrigin>;
+}
+
+interface QueuedEntry {
+  sessionId: string;
+  origin: SpaceMentionOrigin;
+}
+
+function threadKey(o: { orgId: string; spaceId: string; threadRootId: string }): string {
+  return `${o.orgId}/${o.spaceId}/${o.threadRootId}`;
+}
+
+function mentionOrigin(event: unknown): SpaceMentionOrigin | null {
+  const origin = (event as { origin?: { kind?: string } }).origin;
+  return origin?.kind === 'space_mention' ? (origin as SpaceMentionOrigin) : null;
+}
+
+/**
+ * The map and the two things derived from it. Pure apart from the injected
+ * presence/emit/timer seams (tested); the module-level instance below wires
+ * the real ones.
+ */
+export class SpaceAgentActivityTracker {
+  private readonly running = new Map<string, RunningTurn>();
+  /** sessionId → the queued mentions in that session (full replace per queue-changed). */
+  private readonly queued = new Map<string, QueuedEntry[]>();
+  /** Threads currently holding an agent_working lease, by thread key. */
+  private readonly leased = new Map<string, { orgId: string; spaceId: string; threadRootId: string }>();
+  /** Orgs whose last emitted list was non-empty — so they get one final [] when cleared. */
+  private readonly emittedOrgs = new Set<string>();
+  private renewTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly presence: Presence,
+    private readonly emit: Emit,
+    private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setInterval> = (fn, ms) => {
+      const t = setInterval(fn, ms);
+      t.unref?.();
+      return t;
+    },
+    private readonly clearTimer: (t: ReturnType<typeof setInterval>) => void = clearInterval,
+  ) {}
+
+  handleTurnEvent(busEvent: TurnBusEvent): void {
+    const event = busEvent.event as { type?: string };
+    switch (event.type) {
+      case 'turn_created':
+      case 'input_added': {
+        const origin = mentionOrigin(event);
+        if (!origin) return; // the person chatting in the session, or another invoker
+        let turn = this.running.get(busEvent.turnId);
+        if (!turn) {
+          // input_added into a turn we never recorded = a mention steered
+          // into the user's own chat turn. It IS now working on the thread.
+          turn = { sessionId: busEvent.sessionId ?? '', origins: new Map() };
+          this.running.set(busEvent.turnId, turn);
+        }
+        turn.origins.set(threadKey(origin), origin);
+        this.changed();
+        return;
+      }
+      case 'turn_completed':
+      case 'turn_failed':
+      case 'turn_cancelled': {
+        if (this.running.delete(busEvent.turnId)) this.changed();
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  handleSessionEvent(event: SessionBusEvent): void {
+    if (event.kind !== 'queue-changed') return;
+    const entries: QueuedEntry[] = [];
+    for (const message of event.queue) {
+      const origin = mentionOrigin(message);
+      if (origin) entries.push({ sessionId: event.sessionId, origin });
+    }
+    const had = this.queued.has(event.sessionId);
+    if (entries.length === 0) {
+      this.queued.delete(event.sessionId);
+      if (had) this.changed();
+      return;
+    }
+    this.queued.set(event.sessionId, entries);
+    this.changed();
+  }
+
+  /** The current list per org — what the feed carries (running wins over queued for a thread). */
+  snapshot(): Map<string, SpaceAgentActivity[]> {
+    const byThread = new Map<string, { orgId: string; activity: SpaceAgentActivity }>();
+    for (const entries of this.queued.values()) {
+      for (const { sessionId, origin } of entries) {
+        byThread.set(threadKey(origin), {
+          orgId: origin.orgId,
+          activity: { spaceId: origin.spaceId, threadRootId: origin.threadRootId, state: 'queued', sessionId },
+        });
+      }
+    }
+    for (const [turnId, turn] of this.running) {
+      for (const origin of turn.origins.values()) {
+        byThread.set(threadKey(origin), {
+          orgId: origin.orgId,
+          activity: {
+            spaceId: origin.spaceId,
+            threadRootId: origin.threadRootId,
+            state: 'running',
+            sessionId: turn.sessionId,
+            turnId,
+          },
+        });
+      }
+    }
+    const byOrg = new Map<string, SpaceAgentActivity[]>();
+    for (const { orgId, activity } of byThread.values()) {
+      byOrg.set(orgId, [...(byOrg.get(orgId) ?? []), activity]);
+    }
+    return byOrg;
+  }
+
+  private changed(): void {
+    const byOrg = this.snapshot();
+    this.reconcileLeases(byOrg);
+    this.emitAll(byOrg);
+    this.reconcileTimer(byOrg.size > 0);
+  }
+
+  private reconcileLeases(byOrg: Map<string, SpaceAgentActivity[]>): void {
+    const live = new Set<string>();
+    for (const [orgId, list] of byOrg) {
+      for (const a of list) {
+        const thread = { orgId, spaceId: a.spaceId, threadRootId: a.threadRootId };
+        const key = threadKey(thread);
+        live.add(key);
+        if (!this.leased.has(key)) {
+          this.leased.set(key, thread);
+          this.send(orgId, a.spaceId, 'agent_working', a.threadRootId);
+        }
+      }
+    }
+    for (const [key, thread] of [...this.leased]) {
+      if (live.has(key)) continue;
+      this.leased.delete(key);
+      // agent_idle, not idle: both frames carry the member's id, and idle
+      // would read as the human lease ending.
+      this.send(thread.orgId, thread.spaceId, 'agent_idle', thread.threadRootId);
+    }
+  }
+
+  private emitAll(byOrg: Map<string, SpaceAgentActivity[]>): void {
+    for (const [orgId, agentActivity] of byOrg) {
+      this.emittedOrgs.add(orgId);
+      this.emit({ orgId, agentActivity });
+    }
+    for (const orgId of [...this.emittedOrgs]) {
+      if (byOrg.has(orgId)) continue;
+      this.emittedOrgs.delete(orgId);
+      this.emit({ orgId, agentActivity: [] });
+    }
+  }
+
+  private reconcileTimer(active: boolean): void {
+    if (active && !this.renewTimer) {
+      this.renewTimer = this.setTimer(() => this.renew(), RENEW_MS);
+    } else if (!active && this.renewTimer) {
+      this.clearTimer(this.renewTimer);
+      this.renewTimer = null;
+    }
+  }
+
+  /** Every 10s while busy: renew each lease and re-emit the lists (late windows catch up). */
+  private renew(): void {
+    const byOrg = this.snapshot();
+    for (const [orgId, list] of byOrg) {
+      for (const a of list) this.send(orgId, a.spaceId, 'agent_working', a.threadRootId);
+    }
+    this.emitAll(byOrg);
+  }
+
+  private send(orgId: string, spaceId: string, state: PresenceState, threadRootId: string): void {
+    try {
+      this.presence(orgId, spaceId, state, threadRootId);
+    } catch {
+      // org removed mid-run; nothing to signal
+    }
+  }
+}
+
+// --- the process-wide instance ----------------------------------------------
+
+const listeners = new Set<Emit>();
+
+/** The activity feed: hosts relay these onto 'spaces:events' (main → windows, server → WS hub). */
+export function onSpaceAgentActivity(listener: Emit): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+const tracker = new SpaceAgentActivityTracker(
+  (orgId, spaceId, state, threadRootId) => getLive(orgId).presence(spaceId, state, threadRootId),
+  (event) => {
+    for (const listener of listeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        console.error('[spaces] agent activity listener failed:', err);
+      }
+    }
+  },
+);
+
+let started: Promise<void> | null = null;
+
+/**
+ * Subscribe the tracker to the runtime's buses. Idempotent; hosts call it at
+ * boot (before any mention can be sent — the first send would otherwise
+ * publish its turn_created to nobody). Lazy DI resolution keeps this module
+ * off the container's static import graph, like topic-agent.
+ */
+export function startSpaceAgentActivity(): Promise<void> {
+  if (started) return started;
+  started = (async () => {
+    const { lazyResolve } = await import('../di/lazy-resolve.js');
+    const [turnEventBus, sessionBus] = await Promise.all([
+      lazyResolve<{ subscribeAll(listener: (event: TurnBusEvent) => void): () => void }>('turnEventBus'),
+      lazyResolve<{ subscribe(listener: (event: SessionBusEvent) => void): () => void }>('sessionBus'),
+    ]);
+    turnEventBus.subscribeAll((event) => tracker.handleTurnEvent(event));
+    sessionBus.subscribe((event) => tracker.handleSessionEvent(event));
+  })();
+  started.catch(() => {
+    started = null; // let a later call retry
+  });
+  return started;
+}

--- a/apps/x/packages/core/src/spaces/topic-agent.test.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RECLAIMED_TURN_REASON } from '../runtime/sessions/api.js';
-import { backstopBody, buildInvocationMessage, describeTurnError, finalAssistantText, isTopicReceiptCall } from './topic-agent.js';
+import { buildInvocationMessage, mentionOrigin } from './topic-agent.js';
 
 const input = {
     orgId: 'org-1',
@@ -39,81 +38,14 @@ describe('buildInvocationMessage', () => {
     });
 });
 
-describe('isTopicReceiptCall', () => {
-    const receipt = {
-        type: 'tool_invocation_requested',
-        toolName: 'executeMcpTool',
-        input: {
-            serverName: 'spaces-rowboat-labs-dev',
-            toolName: 'post_message',
-            arguments: { spaceId: input.spaceId, threadRoot: input.threadRootId, body: 'Moved SSO to P1 in roadmap.md.' },
-        },
-    };
-
-    it('matches the receipt call into this thread', () => {
-        expect(isTopicReceiptCall(receipt, input.threadRootId)).toBe(true);
-    });
-
-    it('rejects other tools, other threads, and non-invocation events', () => {
-        expect(isTopicReceiptCall({ ...receipt, input: { ...receipt.input, toolName: 'propose_change' } }, input.threadRootId)).toBe(false);
-        expect(isTopicReceiptCall(receipt, 'someother-root')).toBe(false);
-        expect(isTopicReceiptCall({ ...receipt, type: 'tool_result' }, input.threadRootId)).toBe(false);
-        // post_message WITHOUT threadRoot posts a new stream root — that is not the receipt
-        expect(
-            isTopicReceiptCall(
-                { ...receipt, input: { ...receipt.input, arguments: { spaceId: input.spaceId, body: 'hi' } } },
-                input.threadRootId,
-            ),
-        ).toBe(false);
-    });
-});
-
-describe('finalAssistantText', () => {
-    it('reads string output, message arrays, and part arrays', () => {
-        expect(finalAssistantText('done')).toBe('done');
-        expect(finalAssistantText([{ role: 'assistant', content: 'all set' }])).toBe('all set');
-        expect(
-            finalAssistantText([
-                { role: 'assistant', content: 'draft' },
-                { role: 'assistant', content: [{ type: 'text', text: 'final ' }, { type: 'text', text: 'answer' }] },
-            ]),
-        ).toBe('final answer');
-    });
-
-    it('returns null when nothing usable exists', () => {
-        expect(finalAssistantText(undefined)).toBeNull();
-        expect(finalAssistantText([])).toBeNull();
-        expect(finalAssistantText([{ role: 'user', content: 'hi' }])).toBeNull();
-    });
-});
-
-describe('describeTurnError', () => {
-    it('turns auth failures into a sign-in hint and keeps other errors verbatim', () => {
-        expect(describeTurnError('unexpected HTTP response status code')).toMatch(/isn't signed in/);
-        expect(describeTurnError('401 Unauthorized')).toMatch(/isn't signed in/);
-        expect(describeTurnError('429 Too Many Requests')).toMatch(/rate-limited/);
-        expect(describeTurnError('tool foo exploded')).toBe('tool foo exploded');
-        expect(describeTurnError(undefined)).toBe('unknown error');
-    });
-});
-
-describe('backstopBody', () => {
-    it('tells a reclaimed crash-orphaned turn apart from a person pressing Stop', () => {
-        expect(backstopBody({ type: 'turn_cancelled', reason: RECLAIMED_TURN_REASON })).toBe(
-            '⚠️ An earlier Rowboat run here was interrupted — picking up your latest message now.',
-        );
-        expect(backstopBody({ type: 'turn_cancelled' })).toBe(
-            "⚠️ Rowboat's run was stopped before it finished.",
-        );
-        expect(backstopBody({ type: 'turn_cancelled', reason: 'user asked' })).toBe(
-            "⚠️ Rowboat's run was stopped before it finished.",
-        );
-    });
-
-    it('keeps the failed and no-receipt wordings', () => {
-        expect(backstopBody({ type: 'turn_failed', error: '401' })).toMatch(/isn't signed in/);
-        expect(backstopBody({ type: 'turn_completed' })).toBe(
-            'Rowboat finished without posting a receipt or leaving a note.',
-        );
+describe('mentionOrigin', () => {
+    it('is the typed space_mention origin the activity feed keys on', () => {
+        expect(mentionOrigin(input)).toEqual({
+            kind: 'space_mention',
+            orgId: 'org-1',
+            spaceId: '01M07B68G1BQFP70TX5RPHJX89',
+            threadRootId: '01M07ROOTAAAAAAAAAAAAAAAA1',
+            messageId: '01M07MSGAAAAAAAAAAAAAAAAA1',
+        });
     });
 });

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import type { ITurnEventBus } from '../runtime/turns/event-hub.js';
-import { type ISessions, RECLAIMED_TURN_REASON } from '../runtime/sessions/api.js';
-import { deriveTurnStatus, reduceTurn, type TurnBusEvent } from '@x/shared/dist/turns.js';
+import type { ISessions } from '../runtime/sessions/api.js';
+import type { SpaceMentionOrigin } from '@x/shared/dist/origins.js';
+import { deriveTurnStatus, reduceTurn } from '@x/shared/dist/turns.js';
 import { WorkDir } from '../config/config.js';
-import { getClient, getLive, spacesMcpServerNameFor } from './orgs.js';
+import { spacesMcpServerNameFor } from './orgs.js';
 
 // @rowboat in a space (spec §8 grammar, §11 beat 7): an addressed message
 // routes into ONE session per thread — the anchor is the addressed message's
@@ -16,14 +16,16 @@ import { getClient, getLive, spacesMcpServerNameFor } from './orgs.js';
 //
 // Contracts kept here:
 // - The agent's final act is one post_message reply into the thread (spaces
-//   skill). A WATCHDOG enforces never-go-dark: any turn that ends without
-//   having posted gets a short mechanical receipt posted on its behalf,
-//   attributed actingMode 'agent' — the thread never ends in silence.
-// - While turns run, an agent_working presence lease (renewed every 10s,
-//   thread-scoped) tells the room; viewers prune stale chips themselves.
+//   skill). Nothing mechanical posts on its behalf.
+// - Every message this module sends carries a space_mention ORIGIN (org,
+//   space, thread root, feed message). The runtime stamps it on the turn it
+//   starts, or on the input_added when it steers a live one, and the
+//   agent-activity feed (agent-activity.ts) turns those events into the
+//   room's "Rowboat is working" chip and lease. The session is user-openable
+//   (thread pane + chat sidebar), so the person's own chat turns there carry
+//   no origin and never light the chip.
 
 const REGISTRY_FILE = path.join(WorkDir, 'config', 'spaces_topic_sessions.json');
-const PRESENCE_RENEW_MS = 10_000;
 
 export interface InvokeTopicAgentInput {
   orgId: string;
@@ -79,7 +81,10 @@ function writeRegistry(registry: Registry): void {
   fs.writeFileSync(REGISTRY_FILE, JSON.stringify(registry, null, 2));
 }
 
-/** The thread's session, if one has been created — the renderer's "open the turn" affordance. */
+/**
+ * The thread's session, if one has been created — the renderer's "open the
+ * agent session" affordance when no live activity record names it.
+ */
 export function topicSessionId(orgId: string, spaceId: string, threadRootId: string): string | null {
   return readRegistry().sessions[registryKey(orgId, spaceId, threadRootId)] ?? null;
 }
@@ -108,205 +113,31 @@ export function buildInvocationMessage(input: InvokeTopicAgentInput, mcpServerNa
   ].join('\n');
 }
 
-/**
- * Receipt wording for a failed turn (pure; tested). A dead sign-in is the common
- * case and should say so — a bare HTTP status helps nobody in a team feed.
- */
-export function describeTurnError(error: string | undefined): string {
-  const raw = (error ?? '').trim();
-  if (!raw) return 'unknown error';
-  if (/\b401\b|unauthori[sz]ed|unexpected HTTP response status code|not signed in|session expired/i.test(raw)) {
-    return "your Rowboat isn't signed in (or the session expired). Sign in again in Settings → Account, then retry.";
-  }
-  if (/\b(402|payment|credits?|quota)\b/i.test(raw)) {
-    return 'your Rowboat account is out of credits or the plan needs attention — check Settings → Account.';
-  }
-  if (/\b(429|rate limit)/i.test(raw)) return 'the model is rate-limited right now — try again in a minute.';
-  return truncate(raw, 200);
-}
-
-/** Does this turn event carry the agent's receipt into the given thread? (pure; tested) */
-export function isTopicReceiptCall(event: unknown, threadRootId: string): boolean {
-  const e = event as {
-    type?: string;
-    toolName?: string;
-    input?: { toolName?: string; arguments?: { threadRoot?: string } };
+/** The origin every mention-sent message carries (pure; tested). */
+export function mentionOrigin(input: Pick<InvokeTopicAgentInput, 'orgId' | 'spaceId' | 'threadRootId' | 'messageId'>): SpaceMentionOrigin {
+  return {
+    kind: 'space_mention',
+    orgId: input.orgId,
+    spaceId: input.spaceId,
+    threadRootId: input.threadRootId,
+    messageId: input.messageId,
   };
-  return (
-    e.type === 'tool_invocation_requested' &&
-    e.toolName === 'executeMcpTool' &&
-    e.input?.toolName === 'post_message' &&
-    e.input?.arguments?.threadRoot === threadRootId
-  );
-}
-
-// --- the watchdog ------------------------------------------------------------
-
-interface TurnRecord {
-  posted: boolean;
-  terminal: boolean;
-}
-
-interface TopicWatch {
-  orgId: string;
-  spaceId: string;
-  threadRootId: string;
-  turns: Map<string, TurnRecord>;
-  activeTurns: Set<string>;
-  presenceTimer: ReturnType<typeof setInterval> | null;
-}
-
-const watches = new Map<string, TopicWatch>();
-
-function ensureWatch(bus: ITurnEventBus, sessionId: string, scope: { orgId: string; spaceId: string; threadRootId: string }): void {
-  if (watches.has(sessionId)) return;
-  const watch: TopicWatch = {
-    ...scope,
-    turns: new Map(),
-    activeTurns: new Set(),
-    presenceTimer: null,
-  };
-  watches.set(sessionId, watch);
-  // Subscription lives for the process (one per topic-session; bounded by
-  // topics the user actually invokes in).
-  bus.subscribeAll((busEvent) => {
-    if (busEvent.sessionId !== sessionId) return;
-    handleTurnEvent(watch, busEvent);
-  });
-}
-
-function handleTurnEvent(watch: TopicWatch, busEvent: TurnBusEvent): void {
-  let record = watch.turns.get(busEvent.turnId);
-  if (!record) {
-    record = { posted: false, terminal: false };
-    watch.turns.set(busEvent.turnId, record);
-    watch.activeTurns.add(busEvent.turnId);
-    startPresence(watch);
-  }
-  if (record.terminal) return;
-
-  const event = busEvent.event as { type?: string };
-  if (isTopicReceiptCall(event, watch.threadRootId)) {
-    record.posted = true;
-    return;
-  }
-  // NOTE: turn_suspended is deliberately NOT terminal — a turn waiting on a
-  // permission keeps its presence chip; the invoker resolves it in the session.
-  if (event.type === 'turn_completed' || event.type === 'turn_failed' || event.type === 'turn_cancelled') {
-    record.terminal = true;
-    watch.activeTurns.delete(busEvent.turnId);
-    if (watch.activeTurns.size === 0) stopPresence(watch);
-    if (!record.posted) {
-      void postBackstop(watch, event as never).catch((err) => {
-        console.error('[spaces] backstop receipt failed:', err);
-      });
-    }
-  }
-}
-
-function startPresence(watch: TopicWatch): void {
-  if (watch.presenceTimer) return;
-  const send = () => {
-    try {
-      getLive(watch.orgId).presence(watch.spaceId, 'agent_working', watch.threadRootId);
-    } catch {
-      // org removed mid-run; nothing to signal
-    }
-  };
-  send();
-  watch.presenceTimer = setInterval(send, PRESENCE_RENEW_MS);
-  watch.presenceTimer.unref?.();
-}
-
-function stopPresence(watch: TopicWatch): void {
-  if (!watch.presenceTimer) return;
-  clearInterval(watch.presenceTimer);
-  watch.presenceTimer = null;
-  try {
-    // agent_idle, not idle: both frames carry the member's id, and idle would
-    // read as the human lease ending (the agent chip then lingers to its TTL).
-    getLive(watch.orgId).presence(watch.spaceId, 'agent_idle', watch.threadRootId);
-  } catch {
-    // best effort
-  }
-}
-
-/** Extract the assistant's final text from a turn_completed output, defensively. */
-export function finalAssistantText(output: unknown): string | null {
-  if (typeof output === 'string') return output || null;
-  if (!Array.isArray(output)) return null;
-  for (let i = output.length - 1; i >= 0; i--) {
-    const message = output[i] as { role?: string; content?: unknown };
-    if (message?.role !== 'assistant') continue;
-    if (typeof message.content === 'string') return message.content || null;
-    if (Array.isArray(message.content)) {
-      const text = message.content
-        .map((part) => (typeof (part as { text?: unknown }).text === 'string' ? (part as { text: string }).text : ''))
-        .join('')
-        .trim();
-      if (text) return text;
-    }
-  }
-  return null;
 }
 
 function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
 
-/**
- * The backstop receipt's wording (pure; tested). A cancelled turn is usually a
- * person pressing Stop — except a reclaim: sendOrQueueMessage cancelling a
- * crash-orphaned turn because a NEW mention just arrived. That one must not
- * read as the new run failing; the new turn posts its own receipt right after.
- */
-export function backstopBody(event: {
-  type: string;
-  error?: string;
-  reason?: string;
-  output?: unknown;
-}): string {
-  if (event.type === 'turn_failed') {
-    return `⚠️ Rowboat couldn't complete this — ${describeTurnError(event.error)}`;
-  }
-  if (event.type === 'turn_cancelled') {
-    return event.reason === RECLAIMED_TURN_REASON
-      ? '⚠️ An earlier Rowboat run here was interrupted — picking up your latest message now.'
-      : `⚠️ Rowboat's run was stopped before it finished.`;
-  }
-  const text = finalAssistantText(event.output);
-  return text
-    ? `Rowboat finished without posting a receipt. Its final note: "${truncate(text, 300)}"`
-    : 'Rowboat finished without posting a receipt or leaving a note.';
-}
-
-/** Never go dark: the turn ended without posting its receipt — post one for it. */
-async function postBackstop(
-  watch: TopicWatch,
-  event: { type: string; error?: string; reason?: string; output?: unknown },
-): Promise<void> {
-  const body = backstopBody(event);
-  await getClient(watch.orgId).postMessage(watch.spaceId, {
-    threadRoot: watch.threadRootId,
-    body,
-    actingMode: 'agent',
-    agentName: 'Rowboat',
-  });
-}
-
 // --- the entry point ---------------------------------------------------------
 
-async function resolveDeps(): Promise<{ sessions: ISessions; turnEventBus: ITurnEventBus }> {
+async function resolveSessions(): Promise<ISessions> {
   // Lazy DI resolution to avoid module-init cycles (same idiom as todo/runner).
   const { lazyResolve } = await import('../di/lazy-resolve.js');
-  return {
-    sessions: await lazyResolve<ISessions>('sessions'),
-    turnEventBus: await lazyResolve<ITurnEventBus>('turnEventBus'),
-  };
+  return lazyResolve<ISessions>('sessions');
 }
 
 export async function invokeTopicAgent(input: InvokeTopicAgentInput): Promise<InvokeTopicAgentResult> {
-  const { sessions, turnEventBus } = await resolveDeps();
+  const sessions = await resolveSessions();
 
   // The thread's session — verified alive, or recreated (todo-runner idiom).
   const key = registryKey(input.orgId, input.spaceId, input.threadRootId);
@@ -326,13 +157,6 @@ export async function invokeTopicAgent(input: InvokeTopicAgentInput): Promise<In
     registry.sessions[key] = sessionId;
     writeRegistry(registry);
   }
-
-  // Watchdog before send — race-free for every event after turn_created.
-  ensureWatch(turnEventBus, sessionId, {
-    orgId: input.orgId,
-    spaceId: input.spaceId,
-    threadRootId: input.threadRootId,
-  });
 
   const serverName = spacesMcpServerNameFor(input.orgId);
   const content = buildInvocationMessage(input, serverName);
@@ -360,6 +184,7 @@ export async function invokeTopicAgent(input: InvokeTopicAgentInput): Promise<In
       },
       useCase: 'copilot_chat',
       subUseCase: 'space_topic',
+      origin: mentionOrigin(input),
       ...(selection.effort ? { reasoningEffort: selection.effort } : {}),
       // Auto unless the composer asked for manual approval prompts (they
       // surface in the topic's session, reachable from the working chip).
@@ -384,7 +209,7 @@ export async function stopTopicAgent(input: {
 }): Promise<{ stopped: boolean }> {
   const sessionId = topicSessionId(input.orgId, input.spaceId, input.threadRootId);
   if (!sessionId) return { stopped: false };
-  const { sessions } = await resolveDeps();
+  const sessions = await resolveSessions();
   let latestTurnId: string | undefined;
   try {
     latestTurnId = (await sessions.getSession(sessionId)).latestTurnId;
@@ -398,8 +223,8 @@ export async function stopTopicAgent(input: {
     return { stopped: false };
   }
   // idle or suspended = live (running, or parked on a permission/async tool).
-  // The watchdog sees the turn_cancelled, posts the "stopped" receipt, and
-  // releases the presence lease — the room learns what happened either way.
+  // The agent-activity feed sees the turn_cancelled: the chip clears and the
+  // presence lease is released. Nothing is posted into the thread.
   await sessions.stopTurn(latestTurnId, 'stopped from the space');
   return { stopped: true };
 }

--- a/apps/x/packages/shared/src/origins.ts
+++ b/apps/x/packages/shared/src/origins.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+// Where an input came from: the thing OUTSIDE the runtime that caused a user
+// message to be sent (a space mention today; a todo item, a channel message,
+// ... later). Stamped on turn_created for the turn's first input, on
+// input_added when a queued message is steered into a live turn, and carried
+// by pending-queue entries until delivery. The runtime records it and never
+// reads it. Consumers (the spaces agent-activity feed) match on it to answer
+// "is the agent working on the thing I did?" from bus events alone, without
+// inspecting sessions or turns.
+//
+// A discriminated union so each kind carries typed fields instead of a
+// joined key readers would have to split back apart. Closed by design: a
+// build that does not know a kind cannot read a turn file that uses it —
+// the same posture as the UseCase enum.
+export const SpaceMentionOrigin = z.object({
+    kind: z.literal("space_mention"),
+    orgId: z.string(),
+    spaceId: z.string(),
+    // The thread the mention lives in: the message's root (its own id when
+    // it IS a root). Activity is keyed per thread.
+    threadRootId: z.string(),
+    // The @rowboat feed message itself — the invocation's provenance.
+    messageId: z.string(),
+});
+export type SpaceMentionOrigin = z.infer<typeof SpaceMentionOrigin>;
+
+export const InputOrigin = z.discriminatedUnion("kind", [SpaceMentionOrigin]);
+export type InputOrigin = z.infer<typeof InputOrigin>;

--- a/apps/x/packages/shared/src/sessions.ts
+++ b/apps/x/packages/shared/src/sessions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { UserMessage } from "./message.js";
+import type { InputOrigin } from "./origins.js";
 import { ModelDescriptor, type TurnStatus } from "./turns.js";
 
 // Durable session contract for the session layer (see
@@ -179,6 +180,9 @@ export interface QueuedSessionMessage {
     queueId: string;
     message: z.infer<typeof UserMessage>;
     ts: string;
+    // Carried from the send config until delivery, where it lands on the
+    // turn event (turn_created or input_added) — see origins.ts.
+    origin?: InputOrigin;
 }
 
 // What the renderer's session-feed consumer receives over IPC: session index

--- a/apps/x/packages/shared/src/spaces.ts
+++ b/apps/x/packages/shared/src/spaces.ts
@@ -157,10 +157,29 @@ export interface SpacesProposeInput {
 }
 
 /** Envelope for 'spaces:events' pushes: which org the live frame came from. */
-export interface SpacesBusEvent {
-  orgId: string;
-  frame: ServerFrame;
+/**
+ * One thread where this member's Rowboat is working (or waiting to) on a
+ * space mention — the agent-activity feed's unit (core/spaces/agent-activity).
+ * `running` = a live turn was created from, or steered with, a mention in the
+ * thread; `queued` = the mention waits in the session's pending queue.
+ */
+export interface SpaceAgentActivity {
+  spaceId: string;
+  threadRootId: string;
+  state: 'queued' | 'running';
+  /** The thread's agent session — the chip's click target. */
+  sessionId: string;
+  /** The live turn, when running. */
+  turnId?: string;
 }
+
+// What rides 'spaces:events': the org's live frames (per-space subscription
+// + member-addressed), and the agent-activity feed — the WHOLE list for the
+// org on every change, replaced wholesale by the renderer (queue-changed's
+// posture: small by nature).
+export type SpacesBusEvent =
+  | { orgId: string; frame: ServerFrame }
+  | { orgId: string; agentActivity: SpaceAgentActivity[] };
 
 // ---------------------------------------------------------------------------
 // Whiteboard — the app-side vocabulary inside the org's opaque `payload`

--- a/apps/x/packages/shared/src/turns.ts
+++ b/apps/x/packages/shared/src/turns.ts
@@ -8,6 +8,7 @@ import {
 } from "./message.js";
 import { ReasoningEffort } from "./models.js";
 import { TurnAnalytics } from "./analytics.js";
+import { InputOrigin } from "./origins.js";
 
 // Durable turn contract for the turn runtime (see
 // packages/core/docs/turn-runtime-design.md). This module is the
@@ -180,6 +181,10 @@ export const TurnCreated = z.object({
     // analytics agent_name from drifting from the actual resolved agent.
     // Optional on read for turn files written before durable attribution.
     analytics: TurnAnalytics.optional(),
+    // What outside the runtime caused this turn's first input (a space
+    // mention, ...). Recorded, never read by the runtime; see origins.ts.
+    // Optional: most turns are a person typing, which has no origin.
+    origin: InputOrigin.optional(),
     config: z.object({
         autoPermission: z.boolean(),
         humanAvailable: z.boolean(),
@@ -419,6 +424,9 @@ export const InputAdded = z.object({
     ts: z.string(),
     inputIndex: z.number().int().positive(),
     message: UserMessage,
+    // The steered message's origin, when it had one (a queued space mention
+    // merged into a live turn). Same contract as turn_created.origin.
+    origin: InputOrigin.optional(),
 });
 
 export const TurnSuspended = z.object({


### PR DESCRIPTION
## What

Replaces the spaces topic watchdog with an event-driven "my Rowboat is working on this thread" feed, and gives turns a durable record of what outside the runtime caused each input.

Supersedes the approach in #987 (which stays a valid stopgap; this PR deletes the code it patches).

## Why

The watchdog subscribed to every turn in a thread's agent session. That session is user-openable (thread pane + chat sidebar), so each of the person's own chat replies there ended a turn with no `post_message`, and the watchdog posted "Rowboat finished without posting a receipt or leaving a note." into the team feed and lit the room's working chip. The subscription was session-scoped; the actual question is "is the agent working on the mention I made, queued or running?"

Design (agreed in review): make origin a typed, durable field the runtime stamps and never reads; have ONE spaces-side consumer fold bus events into a small map and emit it whole; have the renderer replace its copy and do a map lookup per row. No render-time queries, no receipt posting.

## How

**Runtime** (`@x/shared`, `core/runtime`) — additive optional fields, no `schemaVersion` bump (same as `analytics`):
- `origins.ts`: `InputOrigin` discriminated union; `space_mention` carries `orgId`, `spaceId`, `threadRootId`, `messageId` as fields (no joined keys).
- `turn_created.origin`, `input_added.origin`, `QueuedSessionMessage.origin`, `SendMessageConfig.origin`.
- Steer drain returns `{ message, origin? }` so a queued mention merged into a live turn is recorded on its `input_added`; promotion stamps it on `turn_created`. The context materializer reads only `.message`, so origin never reaches the model.

**Backend** (`core/spaces/agent-activity.ts`, wired in Electron main and the server host):
- Subscribes once to the turn and session buses at boot. `turn_created`/`input_added` with a `space_mention` origin → running; terminal events → removed; `queue-changed` → queued entries. Running wins over queued per thread.
- Per busy thread: `agent_working` lease renewed every 10s, `agent_idle` on release (unchanged wire contract).
- Emits the org's whole list as a new `spaces:events` variant `{ orgId, agentActivity }` on every change and on every renewal tick, so a window that loads mid-turn catches up without a snapshot channel.
- `topic-agent.ts` keeps the thread→session registry and the invocation message, passes the origin, and loses the watchdog, backstop receipts, and their helpers.

**Renderer**
- `lib/spaces-agent-activity.ts`: store that replaces its per-org list wholesale; `useSpaceAgentActivity(orgId, spaceId)` returns a `threadRootId → activity` map.
- `useSpacePresence` merges your own agent from that store (instant, includes queued) and ignores the echo of your own `agent_working` frames; other members' agents still come from presence leases. Consumers of `presence.working` are unchanged.
- Thread pane chip click opens the session the live record names, falling back to the registry lookup.

**Docs**: `session-design.md` §12.1 and `turn-runtime-design.md` §8.6 / §15.2 updated for the origin field and the widened drain contract.

## Testing

- New: `agent-activity.test.ts` (6 cases: created/settled lifecycle + leases, untagged turns ignored, steer into an untracked turn, queued→running with no duplicate lease, renewal re-emits, per-org emit + final empty list).
- Runtime: origin on `input_added` via steer, on `turn_created` immediately and by promotion, on the queue entry and drain.
- `tsc --noEmit` clean in shared, core, renderer, main, server. Suites: shared 309/309, core 823/823, renderer 508/508. One core file (`spaces/client.test.ts`) fails to import `@rowboat/harbor` on this machine — pre-existing on `main`, untouched here.
- **Not verified live.** Needs a run against a Harbor org: mention while idle → chip; mention while a turn runs → chip stays (queued, then running); chatting in the thread's session → no chip, no feed post; reload the window mid-turn → chip within 10s; a second member sees the chip via presence; same on the server host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdKK6pfaNc4cBZqZBf1USA
