### PR TITLE
feat(x): Spaces - voice input on the composer with LLM dictation cleanup

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -114,6 +114,7 @@ function updateSelfCaptureState() {
 import * as composioHandler from '@x/core/dist/composio/flows.js';
 import { oauthConnectBus, composioConnectBus, chatgptStatusBus } from '@x/core/dist/auth/connector-events.js';
 import { subscribeTtsChunks } from '@x/core/dist/voice/tts-bus.js';
+import { formatDictation } from '@x/core/dist/voice/format_dictation.js';
 import * as appsIndexer from '@x/core/dist/apps/indexer.js';
 import * as appsServer from '@x/core/dist/apps/server.js';
 import * as appsAgents from '@x/core/dist/apps/agents.js';
@@ -2615,6 +2616,9 @@ export function setupIpcHandlers() {
       activeTtsStreams.get(args.requestId)?.abort();
       activeTtsStreams.delete(args.requestId);
       return {};
+    },
+    'voice:formatDictation': async (_event, args) => {
+      return { text: await formatDictation(args.text) };
     },
     'voice:ensureMicAccess': async () => {
       if (process.platform !== 'darwin') return { granted: true };

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1467,6 +1467,17 @@ function App() {
     void window.ipc.invoke('app:focusMainWindow', null).catch(() => {})
   }, [permissionDialog])
 
+  // Components outside App's prop reach (the Spaces composer's dictation)
+  // surface permission problems through this event — same dialog, same cue.
+  useEffect(() => {
+    const onNeeded = (e: Event) => {
+      const kind = (e as CustomEvent<{ kind?: PermissionKind }>).detail?.kind
+      if (kind) setPermissionDialog(kind)
+    }
+    window.addEventListener('rowboat:permission-needed', onNeeded)
+    return () => window.removeEventListener('rowboat:permission-needed', onNeeded)
+  }, [])
+
   // Steal handler for PTT: another holder is taking the mic — drop the
   // in-flight recording without releasing ownership (the thief owns it now).
   const cancelPttForSteal = useCallback(() => {

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -1423,7 +1423,7 @@ function waveBarHeight(level: number): number {
   return WAVE_BAR_MIN + amp * (WAVE_BAR_MAX - WAVE_BAR_MIN)
 }
 
-function VoiceWaveform({ audioLevelsRef }: { audioLevelsRef?: React.MutableRefObject<number[]> }) {
+export function VoiceWaveform({ audioLevelsRef }: { audioLevelsRef?: React.MutableRefObject<number[]> }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [bars, setBars] = useState<number[]>([])
   // How many bars fit in the current width; recomputed on resize.

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import type { EditorView } from '@tiptap/pm/view'
 import { uploadInputFor } from '@/lib/spaces-upload'
-import { ArrowUp, BarChart3, Bot, Clock, FileText, Globe, Loader2, LoaderIcon, Megaphone, Mic, Paperclip, ShieldCheck, Terminal, X as XIcon } from 'lucide-react'
+import { ArrowUp, BarChart3, Bot, Clock, FileText, Globe, Loader2, LoaderIcon, Megaphone, Mic, Paperclip, ShieldCheck, Square, Terminal, X as XIcon } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -91,6 +91,24 @@ const ASK_COMMAND: CommandEntry = { name: 'ask', args: '<question>', hint: 'Ask 
 /** A draft that IS a command: "/name" or "/name args". */
 const COMMAND_RE = /^\/([a-zA-Z]+)(?:\s+([\s\S]*))?$/
 
+// The dictation cleanup pass: the background-agents model turns raw speech
+// ("um so I was thinking...") into a message you'd post in Slack. Strictly
+// best-effort — any failure, empty result, or timeout falls back to the raw
+// transcript; cleanup never loses a dictation.
+const FORMAT_DICTATION_TIMEOUT_MS = 15_000
+
+async function formatTranscript(raw: string): Promise<string> {
+    try {
+        const res = await Promise.race([
+            window.ipc.invoke('voice:formatDictation', { text: raw }),
+            new Promise<null>((resolve) => setTimeout(() => resolve(null), FORMAT_DICTATION_TIMEOUT_MS)),
+        ])
+        return res?.text?.trim() || raw
+    } catch {
+        return raw
+    }
+}
+
 export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, autoFocus, onType, seed, members = [], entries = [], selfMemberId, draftKey, commands = [] }: {
     placeholder: string
     onSend: (body: string, agent?: AgentOptions) => Promise<void>
@@ -148,8 +166,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
 
     const editor = useEditor({
         // The getter runs inside Placeholder's decoration pass (post-render,
-        // in the editor), never during this render — a false positive here.
-        // eslint-disable-next-line react-hooks/refs
+        // in the editor), never during this render — safe despite the ref read.
         extensions: composerExtensions(() => placeholderRef.current),
         content: draft,
         autofocus: autoFocus ? 'end' : false,
@@ -512,17 +529,24 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     }
 
     // --- voice input ---------------------------------------------------------
-    // The assistant composer's dictation, verbatim: the mic swaps the box for
-    // a live waveform + interim transcript; ↵ (or the arrow) finalizes and
-    // posts the transcript as a message, ✕/esc discards it. The typed draft
-    // and staged attachments sit untouched underneath either way. The mic is
-    // one physical resource — acquireVoice makes starting here a clean steal
-    // from any other composer, and a live call is never stolen from.
+    // The assistant composer's dictation UI: the mic swaps the box for a live
+    // waveform + interim transcript. Two ways out, both running the cleanup
+    // pass (background-agents model → Slack-ready text): Stop (■ / ↵) drops
+    // the result INTO the input box — joining any typed draft — for the
+    // person to edit and send; the arrow (⌘↵) posts it straight away.
+    // ✕/esc discards the recording. The mic is one physical resource —
+    // acquireVoice makes starting here a clean steal from any other
+    // composer, and a live call is never stolen from.
     const voice = useVoiceMode()
     const voiceAvailable = useVoiceInputAvailable()
     const voiceHolderId = `space-composer:${useId()}`
     const [recording, setRecording] = useState(false)
     const recordingRef = useRef(false)
+    // Stop/send accepted: STT finalize + the cleanup pass are running — the
+    // bar shows "Finalizing...", the clicked button spins, and further
+    // clicks are ignored until it lands.
+    const [finalizing, setFinalizing] = useState<false | 'insert' | 'send'>(false)
+    const finalizingRef = useRef(false)
 
     const startRecording = () => {
         if (voiceOwnerId() === CALL_VOICE_HOLDER) return
@@ -553,30 +577,73 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         releaseVoice(voiceHolderId)
     }
 
-    const submitRecording = async () => {
-        // Already finalizing (a second ↵ while 'submitting') must not run
-        // submit twice — that would post the transcript twice.
-        if (!recordingRef.current || voice.state === 'submitting') return
-        const text = await voice.submit()
-        setRecording(false)
-        recordingRef.current = false
-        releaseVoice(voiceHolderId)
+    /**
+     * Stop capture and run the cleanup pass. Returns the Slack-ready text
+     * ('' when nothing usable was heard, or the dictation was cancelled
+     * mid-flight) with all recording state closed down.
+     */
+    const finishRecording = async (action: 'insert' | 'send'): Promise<string> => {
+        // One shot: a second click/↵ while finalizing must not run twice.
+        if (!recordingRef.current || finalizingRef.current || voice.state === 'submitting') return ''
+        finalizingRef.current = true
+        setFinalizing(action)
+        let text = ''
+        try {
+            const raw = await voice.submit()
+            // Capture is over — free the mic while the cleanup pass runs (a
+            // recording started elsewhere must not kill this pending text).
+            releaseVoice(voiceHolderId)
+            // Cancelled (esc / steal) while the transcript was finalizing.
+            if (!recordingRef.current) return ''
+            if (raw) {
+                text = await formatTranscript(raw)
+                if (!recordingRef.current) text = ''
+            }
+        } finally {
+            finalizingRef.current = false
+            setFinalizing(false)
+            setRecording(false)
+            recordingRef.current = false
+        }
+        return text
+    }
+
+    /** Stop (■): the cleaned text goes INTO the box for review — never posts. */
+    const stopRecording = async () => {
+        const text = await finishRecording('insert')
+        if (!text || !editor) return
+        // Joins a typed draft in progress (same append rule as seeds).
+        const current = composerMarkdown(editor)
+        const next = current ? `${current}${/\s$/.test(current) ? '' : ' '}${text}` : text
+        editor.commands.setContent(next)
+        setDraft(composerMarkdown(editor))
+        // The recording bar's close hasn't painted yet (the editor is still
+        // display:none) — focus once it's visible again.
+        requestAnimationFrame(() => editor.commands.focus('end'))
+    }
+
+    /** Send (↑): the cleaned text posts immediately, skipping the review stop. */
+    const sendRecording = async () => {
+        const text = await finishRecording('send')
         if (!text) return
         const body = encodeMentions(replaceShortcodes(text), members)
         if (body) await onSend(body, agentOptionsFor(text))
     }
 
-    const submitRecordingRef = useRef(submitRecording)
+    const stopRecordingRef = useRef(stopRecording)
+    const sendRecordingRef = useRef(sendRecording)
     const cancelRecordingRef = useRef(cancelRecording)
 
-    // ↵ submits the dictation, esc discards it — document-level while
-    // recording, the same keys the assistant composer honors.
+    // ↵ stops and drops the text into the box, ⌘/Ctrl+↵ sends it straight
+    // away (the composer's own "⌘↵ always sends" chord), esc discards —
+    // document-level while recording.
     useEffect(() => {
         if (!recording) return
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Enter') {
                 e.preventDefault()
-                void submitRecordingRef.current()
+                if (e.metaKey || e.ctrlKey) void sendRecordingRef.current()
+                else void stopRecordingRef.current()
             } else if (e.key === 'Escape') {
                 e.preventDefault()
                 cancelRecordingRef.current()
@@ -688,7 +755,8 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         keydownRef.current = handleEditorKeyDown
         pasteRef.current = handleEditorPaste
         dropRef.current = editorDropGuard
-        submitRecordingRef.current = submitRecording
+        stopRecordingRef.current = stopRecording
+        sendRecordingRef.current = sendRecording
         cancelRecordingRef.current = cancelRecording
     })
 
@@ -725,26 +793,44 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                                     voice.interimText.trim() ? 'text-foreground' : 'text-muted-foreground',
                                 )}
                             >
-                                {voice.interimText.trim() || (voice.state === 'submitting' ? 'Finalizing...' : 'Listening...')}
+                                {voice.interimText.trim() || (finalizing || voice.state === 'submitting' ? 'Finalizing...' : 'Listening...')}
                             </div>
                         </div>
-                        <Button
-                            size="icon"
-                            onClick={() => void submitRecording()}
-                            disabled={voice.state === 'submitting'}
-                            className={cn(
-                                'h-7 w-7 shrink-0 rounded-full transition-all',
-                                voice.state !== 'submitting'
-                                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                                    : 'bg-muted text-muted-foreground',
-                            )}
-                        >
-                            {voice.state === 'submitting' ? (
-                                <LoaderIcon className="h-4 w-4 animate-spin" />
-                            ) : (
-                                <ArrowUp className="h-4 w-4" />
-                            )}
-                        </Button>
+                        <div className="flex shrink-0 items-center gap-1.5">
+                            <Button
+                                size="icon"
+                                onClick={() => void stopRecording()}
+                                disabled={!!finalizing || voice.state === 'submitting'}
+                                aria-label="Stop recording"
+                                title="Stop — the text lands in the box to review (↵)"
+                                className="h-7 w-7 shrink-0 rounded-full bg-muted text-foreground transition-all hover:bg-muted/80 disabled:text-muted-foreground"
+                            >
+                                {finalizing === 'insert' ? (
+                                    <LoaderIcon className="h-4 w-4 animate-spin" />
+                                ) : (
+                                    <Square className="h-3 w-3 fill-current" />
+                                )}
+                            </Button>
+                            <Button
+                                size="icon"
+                                onClick={() => void sendRecording()}
+                                disabled={!!finalizing || voice.state === 'submitting'}
+                                aria-label="Stop and send"
+                                title="Send it straight away (⌘↵)"
+                                className={cn(
+                                    'h-7 w-7 shrink-0 rounded-full transition-all',
+                                    !(finalizing || voice.state === 'submitting')
+                                        ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                                        : 'bg-muted text-muted-foreground',
+                                )}
+                            >
+                                {finalizing === 'send' ? (
+                                    <LoaderIcon className="h-4 w-4 animate-spin" />
+                                ) : (
+                                    <ArrowUp className="h-4 w-4" />
+                                )}
+                            </Button>
+                        </div>
                     </div>
                 )}
                 {/* The composer body stays mounted while recording — the TipTap doc

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -1,16 +1,21 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import type { EditorView } from '@tiptap/pm/view'
 import { uploadInputFor } from '@/lib/spaces-upload'
-import { ArrowUp, BarChart3, Bot, Clock, FileText, Globe, Loader2, Megaphone, Paperclip, ShieldCheck, Terminal, X as XIcon } from 'lucide-react'
+import { ArrowUp, BarChart3, Bot, Clock, FileText, Globe, Loader2, LoaderIcon, Megaphone, Mic, Paperclip, ShieldCheck, Terminal, X as XIcon } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { ModelSelector } from '@/components/model-selector'
 import type { ModelSelection } from '@/hooks/use-models'
 import { MemberAvatar } from '@/components/spaces/atoms'
+import { VoiceWaveform } from '@/components/chat-input-with-mentions'
+import { useVoiceMode } from '@/hooks/useVoiceMode'
+import { useVoiceInputAvailable } from '@/hooks/use-voice-available'
+import { CALL_VOICE_HOLDER, acquireVoice, releaseVoice, voiceOwnerId } from '@/lib/voice-ownership'
 import { caretContext, composerExtensions, composerMarkdown, type CaretContext } from '@/components/spaces/composer-editor'
 import { RichFormattingToolbar } from '@/components/spaces/composer-toolbar'
 import { isDirectImageUrl, useSpaceRefs } from '@/components/spaces/space-markdown'
@@ -424,6 +429,17 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     // --- send ----------------------------------------------------------------
     const mentioned = containsRowboatAddress(draft)
 
+    /** Per-turn agent options — attached whenever the outgoing text addresses @rowboat. */
+    const agentOptionsFor = (text: string): AgentOptions | undefined =>
+        containsRowboatAddress(text)
+            ? {
+                  ...(model ? { model: { provider: model.provider, model: model.model, ...(model.effort ? { effort: model.effort } : {}) } } : {}),
+                  permissionMode,
+                  ...(searchEnabled ? { searchEnabled: true } : {}),
+                  ...(codeMode ? { codeMode } : {}),
+              }
+            : undefined
+
     /** The one body builder — send and send-later produce identical wire text. */
     const buildBody = (raw: string): string => {
         const ready = attachments.filter((a) => a.status === 'done' && a.hash)
@@ -488,20 +504,93 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         if (!body) return
         // From the text actually going out — an /ask rewrite mentions @rowboat
         // even though the draft it came from didn't.
-        const agent: AgentOptions | undefined = containsRowboatAddress(raw)
-            ? {
-                  ...(model ? { model: { provider: model.provider, model: model.model, ...(model.effort ? { effort: model.effort } : {}) } } : {}),
-                  permissionMode,
-                  ...(searchEnabled ? { searchEnabled: true } : {}),
-                  ...(codeMode ? { codeMode } : {}),
-              }
-            : undefined
-        await onSend(body, agent)
+        await onSend(body, agentOptionsFor(raw))
         editor?.chain().clearContent().run()
         setDraft('')
         setAttachments([])
         setMentionOpen(false)
     }
+
+    // --- voice input ---------------------------------------------------------
+    // The assistant composer's dictation, verbatim: the mic swaps the box for
+    // a live waveform + interim transcript; ↵ (or the arrow) finalizes and
+    // posts the transcript as a message, ✕/esc discards it. The typed draft
+    // and staged attachments sit untouched underneath either way. The mic is
+    // one physical resource — acquireVoice makes starting here a clean steal
+    // from any other composer, and a live call is never stolen from.
+    const voice = useVoiceMode()
+    const voiceAvailable = useVoiceInputAvailable()
+    const voiceHolderId = `space-composer:${useId()}`
+    const [recording, setRecording] = useState(false)
+    const recordingRef = useRef(false)
+
+    const startRecording = () => {
+        if (voiceOwnerId() === CALL_VOICE_HOLDER) return
+        acquireVoice(voiceHolderId, () => {
+            // Stolen (another composer or a call took the mic): drop the
+            // capture without releasing — the thief owns it now.
+            voice.cancel()
+            setRecording(false)
+            recordingRef.current = false
+        })
+        setRecording(true)
+        recordingRef.current = true
+        void voice.start().then((result) => {
+            if (result === 'mic-denied') {
+                setRecording(false)
+                recordingRef.current = false
+                releaseVoice(voiceHolderId)
+                // App owns the OS-permission explainer dialog.
+                window.dispatchEvent(new CustomEvent('rowboat:permission-needed', { detail: { kind: 'microphone' } }))
+            }
+        })
+    }
+
+    const cancelRecording = () => {
+        voice.cancel()
+        setRecording(false)
+        recordingRef.current = false
+        releaseVoice(voiceHolderId)
+    }
+
+    const submitRecording = async () => {
+        // Already finalizing (a second ↵ while 'submitting') must not run
+        // submit twice — that would post the transcript twice.
+        if (!recordingRef.current || voice.state === 'submitting') return
+        const text = await voice.submit()
+        setRecording(false)
+        recordingRef.current = false
+        releaseVoice(voiceHolderId)
+        if (!text) return
+        const body = encodeMentions(replaceShortcodes(text), members)
+        if (body) await onSend(body, agentOptionsFor(text))
+    }
+
+    const submitRecordingRef = useRef(submitRecording)
+    const cancelRecordingRef = useRef(cancelRecording)
+
+    // ↵ submits the dictation, esc discards it — document-level while
+    // recording, the same keys the assistant composer honors.
+    useEffect(() => {
+        if (!recording) return
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Enter') {
+                e.preventDefault()
+                void submitRecordingRef.current()
+            } else if (e.key === 'Escape') {
+                e.preventDefault()
+                cancelRecordingRef.current()
+            }
+        }
+        document.addEventListener('keydown', handleKeyDown)
+        return () => document.removeEventListener('keydown', handleKeyDown)
+    }, [recording])
+
+    // Unmounting mid-recording (space/thread switch) must not keep the mic:
+    // drop the capture and free the ownership token.
+    useEffect(() => () => {
+        if (recordingRef.current) cancelRecordingRef.current()
+    }, [])
 
     // The editor's keydown: popover navigation first (it must beat every
     // editor keymap), then the send keys. Formatting chords live in the
@@ -599,6 +688,8 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         keydownRef.current = handleEditorKeyDown
         pasteRef.current = handleEditorPaste
         dropRef.current = editorDropGuard
+        submitRecordingRef.current = submitRecording
+        cancelRecordingRef.current = cancelRecording
     })
 
     return (
@@ -615,237 +706,293 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                         Drop to attach
                     </div>
                 )}
-                {showCommands && (
-                    <div className="absolute bottom-full left-0 right-0 z-20 mb-1.5 overflow-hidden rounded-2xl border-none bg-popover p-1.5 shadow-[var(--rowboat-shadow)]">
-                        {cmdCandidates.map((c, i) => (
-                            <button
-                                key={c.name}
-                                type="button"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={() => pickCommand(c)}
-                                className={cn('flex w-full items-baseline gap-2.5 rounded-lg px-3 py-2 text-left', i === cmdIndex ? 'bg-accent' : 'hover:bg-accent/60')}
-                            >
-                                <span className="shrink-0 font-mono text-sm font-medium">/{c.name}</span>
-                                {c.args && <span className="shrink-0 font-mono text-xs text-muted-foreground">{c.args}</span>}
-                                <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{c.hint}</span>
-                            </button>
-                        ))}
-                        <div className="px-3 pb-1 pt-1.5 text-[11px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
-                    </div>
-                )}
-                {!showCommands && activeCommand && !showMentions && (
-                    <div className="absolute bottom-full left-0 right-0 z-20 mb-1.5 rounded-2xl border-none bg-popover px-3 py-2 text-xs text-muted-foreground shadow-[var(--rowboat-shadow)]">
-                        <span className="font-mono text-sm font-medium text-foreground">/{activeCommand.name}</span>
-                        {activeCommand.args && <span className="font-mono text-sm"> {activeCommand.args}</span>} — {activeCommand.hint} · ↵ to run
-                    </div>
-                )}
-                {showEmoji && (
-                    <div className="absolute bottom-full left-2 z-20 mb-1 w-64 overflow-hidden rounded-lg border border-border bg-popover p-1 shadow-md">
-                        {emojiCandidates.map((c, i) => (
-                            <button
-                                key={c.n}
-                                type="button"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={() => pickEmoji(c)}
-                                className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1 text-left', i === emojiIndex ? 'bg-accent' : 'hover:bg-accent/60')}
-                            >
-                                <span className="text-base leading-none">{c.e}</span>
-                                <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">:{c.n}:</span>
-                            </button>
-                        ))}
-                        <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
-                    </div>
-                )}
-                {showMentions && (
-                    <div className="absolute bottom-full left-2 z-20 mb-1 w-72 overflow-hidden rounded-2xl border-none bg-popover p-1.5 shadow-[var(--rowboat-shadow)]">
-                        {candidates.map((c, i) => (
-                            <button
-                                key={c.id}
-                                type="button"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={() => pickCandidate(c)}
-                                className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left', i === mentionIndex ? 'bg-accent' : 'hover:bg-accent/60')}
-                            >
-                                {c.isAgent ? (
-                                    <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background"><Bot className="size-3.5" /></span>
-                                ) : c.isBroadcast ? (
-                                    <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><Megaphone className="size-3.5" /></span>
-                                ) : c.filePath ? (
-                                    <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><FileText className="size-3.5" /></span>
-                                ) : (
-                                    <MemberAvatar id={c.id} name={c.label} size="sm" className="size-6 text-[10px]" />
-                                )}
-                                <span className="min-w-0 flex-1">
-                                    <span className="block truncate text-[13px] font-medium">{c.label}</span>
-                                    {c.hint && <span className="block truncate text-[11px] text-muted-foreground">{c.hint}</span>}
-                                </span>
-                            </button>
-                        ))}
-                        <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
-                    </div>
-                )}
-                {/* The formatting bar rides the top edge, Slack-style. */}
-                <RichFormattingToolbar editor={editor} className="px-2 pt-1.5" />
-                {attachments.length > 0 && (
-                    <div className="flex flex-wrap items-center gap-1.5 px-2.5 pt-2">
-                        {attachments.map((a) => (
-                            <span
-                                key={a.id}
-                                title={a.status === 'error' ? a.error : `${a.name} · ${formatBytes(a.size)}`}
-                                className={cn(
-                                    'inline-flex max-w-56 items-center gap-1.5 rounded-lg border px-2 py-1 text-xs',
-                                    a.status === 'error' ? 'border-red-300 text-red-600 dark:border-red-800 dark:text-red-400' : 'border-border text-foreground/90',
-                                )}
-                            >
-                                {a.status === 'uploading' ? (
-                                    <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
-                                ) : refs && a.hash && isImageMime(a.mime) ? (
-                                    <img src={blobAppUrl({ orgId: refs.orgId, spaceId: refs.spaceId }, a.hash, { thumb: 64 })} alt="" className="size-5 shrink-0 rounded object-cover" />
-                                ) : (
-                                    <FileText className="size-3 shrink-0 text-muted-foreground" />
-                                )}
-                                <span className="truncate">{a.name}</span>
-                                <span className="shrink-0 text-[10px] text-muted-foreground">{a.status === 'uploading' ? 'uploading…' : a.status === 'error' ? 'failed' : formatBytes(a.size)}</span>
-                                <button
-                                    type="button"
-                                    onClick={() => removeAttachment(a.id)}
-                                    aria-label={`Remove ${a.name}`}
-                                    className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-                                >
-                                    <XIcon className="size-3" />
-                                </button>
-                            </span>
-                        ))}
-                    </div>
-                )}
-                {/* The rich input. What you see is what sends — the doc
-                    serializes back to wire markdown on every update. */}
-                <EditorContent editor={editor} className="space-composer" />
-                <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2">
-                    {refs && (
-                        <>
-                            <input
-                                ref={fileInputRef}
-                                type="file"
-                                multiple
-                                className="hidden"
-                                onChange={(e) => {
-                                    addFiles(Array.from(e.target.files ?? []))
-                                    e.target.value = ''
-                                }}
-                            />
-                            <button
-                                type="button"
-                                onClick={() => fileInputRef.current?.click()}
-                                title="Attach files (or paste / drop them)"
-                                className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
-                            >
-                                <Paperclip className="size-4" />
-                            </button>
-                        </>
-                    )}
-                    {onCreatePoll && (
+                {recording && (
+                    /* ── Recording bar (the assistant composer's, verbatim) ── */
+                    <div className="flex items-center gap-3 px-4 py-3">
                         <button
                             type="button"
-                            onClick={onCreatePoll}
-                            title="Create a poll"
-                            className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+                            onClick={cancelRecording}
+                            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                            aria-label="Cancel recording"
                         >
-                            <BarChart3 className="size-4" />
+                            <XIcon className="h-4 w-4" />
                         </button>
-                    )}
-                    <button
-                        type="button"
-                        onClick={insertRowboatChip}
-                        title="Address your Rowboat — it acts only when asked"
-                        className={cn(
-                            'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs',
-                            mentioned ? 'bg-foreground text-background' : 'bg-muted text-foreground/80 hover:bg-accent',
-                        )}
-                    >
-                        @rowboat
-                    </button>
-                    {mentioned && (
-                        <>
-                            <span className="mx-0.5 h-4 w-px bg-border" />
-                            <span className="text-[11px] text-muted-foreground">runs as your Rowboat</span>
-                            <ModelSelector value={model} onChange={setModel} defaultOption={{ label: 'Assistant model' }} effortSelectable />
-                            <button
-                                type="button"
-                                onClick={() => setPermissionMode((m) => (m === 'auto' ? 'manual' : 'auto'))}
-                                title={permissionMode === 'auto' ? 'Auto-permission on — click for manual approval prompts' : 'Manual approval prompts — click for auto-permission'}
+                        <div className="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
+                            <VoiceWaveform audioLevelsRef={voice.audioLevelsRef} />
+                            <div
                                 className={cn(
-                                    'flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors',
-                                    permissionMode === 'auto' ? 'bg-secondary text-foreground hover:bg-secondary/70' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                                    'min-h-5 truncate text-sm leading-5',
+                                    voice.interimText.trim() ? 'text-foreground' : 'text-muted-foreground',
                                 )}
                             >
-                                <ShieldCheck className="size-3.5 shrink-0" />
-                                <span>{permissionMode === 'auto' ? 'Auto' : 'Manual'}</span>
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => setSearchEnabled((v) => !v)}
-                                aria-pressed={searchEnabled}
-                                title="Web search"
-                                className={cn(
-                                    'flex h-7 shrink-0 items-center rounded-full border px-1.5 transition-colors',
-                                    searchEnabled
-                                        ? 'border-transparent bg-secondary text-foreground hover:bg-secondary/70'
-                                        : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground',
-                                )}
-                            >
-                                <Globe className="size-4 shrink-0" />
-                                {searchEnabled && <span className="ml-1.5 text-xs font-medium">Search</span>}
-                            </button>
-                            {codeModeAvailable && (
+                                {voice.interimText.trim() || (voice.state === 'submitting' ? 'Finalizing...' : 'Listening...')}
+                            </div>
+                        </div>
+                        <Button
+                            size="icon"
+                            onClick={() => void submitRecording()}
+                            disabled={voice.state === 'submitting'}
+                            className={cn(
+                                'h-7 w-7 shrink-0 rounded-full transition-all',
+                                voice.state !== 'submitting'
+                                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                                    : 'bg-muted text-muted-foreground',
+                            )}
+                        >
+                            {voice.state === 'submitting' ? (
+                                <LoaderIcon className="h-4 w-4 animate-spin" />
+                            ) : (
+                                <ArrowUp className="h-4 w-4" />
+                            )}
+                        </Button>
+                    </div>
+                )}
+                {/* The composer body stays mounted while recording — the TipTap doc
+                    keeps the typed draft — it just hides behind the bar above. */}
+                <div className={cn(recording && 'hidden')}>
+                    {showCommands && (
+                        <div className="absolute bottom-full left-0 right-0 z-20 mb-1.5 overflow-hidden rounded-2xl border-none bg-popover p-1.5 shadow-[var(--rowboat-shadow)]">
+                            {cmdCandidates.map((c, i) => (
                                 <button
+                                    key={c.name}
                                     type="button"
-                                    onClick={() => setCodeMode((m) => (m ? null : 'claude'))}
-                                    aria-pressed={!!codeMode}
-                                    title={codeMode ? 'Terminal on (Claude Code) — click to turn off' : 'Let it use the terminal / code tools'}
+                                    onMouseDown={(e) => e.preventDefault()}
+                                    onClick={() => pickCommand(c)}
+                                    className={cn('flex w-full items-baseline gap-2.5 rounded-lg px-3 py-2 text-left', i === cmdIndex ? 'bg-accent' : 'hover:bg-accent/60')}
+                                >
+                                    <span className="shrink-0 font-mono text-sm font-medium">/{c.name}</span>
+                                    {c.args && <span className="shrink-0 font-mono text-xs text-muted-foreground">{c.args}</span>}
+                                    <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{c.hint}</span>
+                                </button>
+                            ))}
+                            <div className="px-3 pb-1 pt-1.5 text-[11px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
+                        </div>
+                    )}
+                    {!showCommands && activeCommand && !showMentions && (
+                        <div className="absolute bottom-full left-0 right-0 z-20 mb-1.5 rounded-2xl border-none bg-popover px-3 py-2 text-xs text-muted-foreground shadow-[var(--rowboat-shadow)]">
+                            <span className="font-mono text-sm font-medium text-foreground">/{activeCommand.name}</span>
+                            {activeCommand.args && <span className="font-mono text-sm"> {activeCommand.args}</span>} — {activeCommand.hint} · ↵ to run
+                        </div>
+                    )}
+                    {showEmoji && (
+                        <div className="absolute bottom-full left-2 z-20 mb-1 w-64 overflow-hidden rounded-lg border border-border bg-popover p-1 shadow-md">
+                            {emojiCandidates.map((c, i) => (
+                                <button
+                                    key={c.n}
+                                    type="button"
+                                    onMouseDown={(e) => e.preventDefault()}
+                                    onClick={() => pickEmoji(c)}
+                                    className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1 text-left', i === emojiIndex ? 'bg-accent' : 'hover:bg-accent/60')}
+                                >
+                                    <span className="text-base leading-none">{c.e}</span>
+                                    <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">:{c.n}:</span>
+                                </button>
+                            ))}
+                            <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
+                        </div>
+                    )}
+                    {showMentions && (
+                        <div className="absolute bottom-full left-2 z-20 mb-1 w-72 overflow-hidden rounded-2xl border-none bg-popover p-1.5 shadow-[var(--rowboat-shadow)]">
+                            {candidates.map((c, i) => (
+                                <button
+                                    key={c.id}
+                                    type="button"
+                                    onMouseDown={(e) => e.preventDefault()}
+                                    onClick={() => pickCandidate(c)}
+                                    className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left', i === mentionIndex ? 'bg-accent' : 'hover:bg-accent/60')}
+                                >
+                                    {c.isAgent ? (
+                                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background"><Bot className="size-3.5" /></span>
+                                    ) : c.isBroadcast ? (
+                                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><Megaphone className="size-3.5" /></span>
+                                    ) : c.filePath ? (
+                                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><FileText className="size-3.5" /></span>
+                                    ) : (
+                                        <MemberAvatar id={c.id} name={c.label} size="sm" className="size-6 text-[10px]" />
+                                    )}
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block truncate text-[13px] font-medium">{c.label}</span>
+                                        {c.hint && <span className="block truncate text-[11px] text-muted-foreground">{c.hint}</span>}
+                                    </span>
+                                </button>
+                            ))}
+                            <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
+                        </div>
+                    )}
+                    {/* The formatting bar rides the top edge, Slack-style. */}
+                    <RichFormattingToolbar editor={editor} className="px-2 pt-1.5" />
+                    {attachments.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-1.5 px-2.5 pt-2">
+                            {attachments.map((a) => (
+                                <span
+                                    key={a.id}
+                                    title={a.status === 'error' ? a.error : `${a.name} · ${formatBytes(a.size)}`}
                                     className={cn(
-                                        'flex h-7 shrink-0 items-center rounded-full border px-1.5 transition-colors',
-                                        codeMode ? 'bg-secondary text-foreground border-transparent hover:bg-secondary/70' : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground',
+                                        'inline-flex max-w-56 items-center gap-1.5 rounded-lg border px-2 py-1 text-xs',
+                                        a.status === 'error' ? 'border-red-300 text-red-600 dark:border-red-800 dark:text-red-400' : 'border-border text-foreground/90',
                                     )}
                                 >
-                                    <Terminal className="size-4 shrink-0" />
-                                    {codeMode && <span className="ml-1.5 text-xs font-medium">Terminal</span>}
-                                </button>
-                            )}
-                        </>
+                                    {a.status === 'uploading' ? (
+                                        <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+                                    ) : refs && a.hash && isImageMime(a.mime) ? (
+                                        <img src={blobAppUrl({ orgId: refs.orgId, spaceId: refs.spaceId }, a.hash, { thumb: 64 })} alt="" className="size-5 shrink-0 rounded object-cover" />
+                                    ) : (
+                                        <FileText className="size-3 shrink-0 text-muted-foreground" />
+                                    )}
+                                    <span className="truncate">{a.name}</span>
+                                    <span className="shrink-0 text-[10px] text-muted-foreground">{a.status === 'uploading' ? 'uploading…' : a.status === 'error' ? 'failed' : formatBytes(a.size)}</span>
+                                    <button
+                                        type="button"
+                                        onClick={() => removeAttachment(a.id)}
+                                        aria-label={`Remove ${a.name}`}
+                                        className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                                    >
+                                        <XIcon className="size-3" />
+                                    </button>
+                                </span>
+                            ))}
+                        </div>
                     )}
-                    <div className="flex-1" />
-                    {onSchedule && (draft.trim() || attachments.some((a) => a.status === 'done')) && (
-                        <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
+                    {/* The rich input. What you see is what sends — the doc
+                        serializes back to wire markdown on every update. */}
+                    <EditorContent editor={editor} className="space-composer" />
+                    <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2">
+                        {refs && (
+                            <>
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    multiple
+                                    className="hidden"
+                                    onChange={(e) => {
+                                        addFiles(Array.from(e.target.files ?? []))
+                                        e.target.value = ''
+                                    }}
+                                />
                                 <button
                                     type="button"
-                                    title="Send later"
-                                    disabled={busy || uploading}
-                                    className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
+                                    onClick={() => fileInputRef.current?.click()}
+                                    title="Attach files (or paste / drop them)"
+                                    className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
                                 >
-                                    <Clock className="size-4" />
+                                    <Paperclip className="size-4" />
                                 </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                                {schedulePresets().map((p) => (
-                                    <DropdownMenuItem key={p.label} onClick={() => void scheduleDraft(p.at)}>
-                                        {p.label}
-                                    </DropdownMenuItem>
-                                ))}
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                    )}
-                    <button
-                        type="button"
-                        onClick={() => void send()}
-                        disabled={busy || uploading || (!draft.trim() && !attachments.some((a) => a.status === 'done'))}
-                        aria-label="Send"
-                        title={uploading ? 'Waiting for uploads…' : 'Send (↵ · Shift+↵ for a new line)'}
-                        className="inline-flex size-8 items-center justify-center rounded-full bg-foreground text-background disabled:opacity-30 transition-opacity"
-                    >
-                        {busy ? <Loader2 className="size-3.5 animate-spin" /> : <ArrowUp className="size-3.5" />}
-                    </button>
+                            </>
+                        )}
+                        {onCreatePoll && (
+                            <button
+                                type="button"
+                                onClick={onCreatePoll}
+                                title="Create a poll"
+                                className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+                            >
+                                <BarChart3 className="size-4" />
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            onClick={insertRowboatChip}
+                            title="Address your Rowboat — it acts only when asked"
+                            className={cn(
+                                'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs',
+                                mentioned ? 'bg-foreground text-background' : 'bg-muted text-foreground/80 hover:bg-accent',
+                            )}
+                        >
+                            @rowboat
+                        </button>
+                        {mentioned && (
+                            <>
+                                <span className="mx-0.5 h-4 w-px bg-border" />
+                                <span className="text-[11px] text-muted-foreground">runs as your Rowboat</span>
+                                <ModelSelector value={model} onChange={setModel} defaultOption={{ label: 'Assistant model' }} effortSelectable />
+                                <button
+                                    type="button"
+                                    onClick={() => setPermissionMode((m) => (m === 'auto' ? 'manual' : 'auto'))}
+                                    title={permissionMode === 'auto' ? 'Auto-permission on — click for manual approval prompts' : 'Manual approval prompts — click for auto-permission'}
+                                    className={cn(
+                                        'flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors',
+                                        permissionMode === 'auto' ? 'bg-secondary text-foreground hover:bg-secondary/70' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                                    )}
+                                >
+                                    <ShieldCheck className="size-3.5 shrink-0" />
+                                    <span>{permissionMode === 'auto' ? 'Auto' : 'Manual'}</span>
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setSearchEnabled((v) => !v)}
+                                    aria-pressed={searchEnabled}
+                                    title="Web search"
+                                    className={cn(
+                                        'flex h-7 shrink-0 items-center rounded-full border px-1.5 transition-colors',
+                                        searchEnabled
+                                            ? 'border-transparent bg-secondary text-foreground hover:bg-secondary/70'
+                                            : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground',
+                                    )}
+                                >
+                                    <Globe className="size-4 shrink-0" />
+                                    {searchEnabled && <span className="ml-1.5 text-xs font-medium">Search</span>}
+                                </button>
+                                {codeModeAvailable && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setCodeMode((m) => (m ? null : 'claude'))}
+                                        aria-pressed={!!codeMode}
+                                        title={codeMode ? 'Terminal on (Claude Code) — click to turn off' : 'Let it use the terminal / code tools'}
+                                        className={cn(
+                                            'flex h-7 shrink-0 items-center rounded-full border px-1.5 transition-colors',
+                                            codeMode ? 'bg-secondary text-foreground border-transparent hover:bg-secondary/70' : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground',
+                                        )}
+                                    >
+                                        <Terminal className="size-4 shrink-0" />
+                                        {codeMode && <span className="ml-1.5 text-xs font-medium">Terminal</span>}
+                                    </button>
+                                )}
+                            </>
+                        )}
+                        <div className="flex-1" />
+                        {onSchedule && (draft.trim() || attachments.some((a) => a.status === 'done')) && (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <button
+                                        type="button"
+                                        title="Send later"
+                                        disabled={busy || uploading}
+                                        className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
+                                    >
+                                        <Clock className="size-4" />
+                                    </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    {schedulePresets().map((p) => (
+                                        <DropdownMenuItem key={p.label} onClick={() => void scheduleDraft(p.at)}>
+                                            {p.label}
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        )}
+                        {voiceAvailable && (
+                            <button
+                                type="button"
+                                onClick={startRecording}
+                                aria-label="Voice input"
+                                title="Voice input"
+                                className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+                            >
+                                <Mic className="size-4" />
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            onClick={() => void send()}
+                            disabled={busy || uploading || (!draft.trim() && !attachments.some((a) => a.status === 'done'))}
+                            aria-label="Send"
+                            title={uploading ? 'Waiting for uploads…' : 'Send (↵ · Shift+↵ for a new line)'}
+                            className="inline-flex size-8 items-center justify-center rounded-full bg-foreground text-background disabled:opacity-30 transition-opacity"
+                        >
+                            {busy ? <Loader2 className="size-3.5 animate-spin" /> : <ArrowUp className="size-3.5" />}
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/apps/x/apps/renderer/src/hooks/use-voice-available.ts
+++ b/apps/x/apps/renderer/src/hooks/use-voice-available.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Whether voice input (push-to-talk STT) is configured: a local Deepgram key
+ * or a connected Rowboat account. The same probe App runs for the assistant
+ * composer's mic button, re-checked when sign-in state changes.
+ */
+export function useVoiceInputAvailable(): boolean {
+    const [available, setAvailable] = useState(false)
+    useEffect(() => {
+        let disposed = false
+        const probe = () => {
+            void Promise.all([
+                window.ipc.invoke('voice:getConfig', null),
+                window.ipc.invoke('oauth:getState', null),
+            ]).then(([config, oauthState]) => {
+                if (disposed) return
+                const rowboatConnected = oauthState.config?.rowboat?.connected ?? false
+                setAvailable(!!config.deepgram || rowboatConnected)
+            }).catch(() => {
+                if (!disposed) setAvailable(false)
+            })
+        }
+        probe()
+        const off = window.ipc.on('oauth:didConnect', probe)
+        return () => {
+            disposed = true
+            off()
+        }
+    }, [])
+    return available
+}

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -234,6 +234,7 @@ export const RPC_CHANNELS = [
   // voice:tts-chunk push channel (renderers filter by requestId).
   'voice:synthesizeStreamStart',
   'voice:synthesizeStreamCancel',
+  'voice:formatDictation',
   // Phase 5 (SEPARATION_PLAN.md): code-mode & terminal — the PTY lives with
   // core now (RFC Q13: the terminal shows the machine core runs on).
   // codeMode:provisionEngine stays client-local (sender-scoped progress).

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -30,6 +30,7 @@ import type { IAgentScheduleRepo } from '@x/core/dist/agent-schedule/repo.js';
 import type { IAgentScheduleStateRepo } from '@x/core/dist/agent-schedule/state-repo.js';
 import * as voice from '@x/core/dist/voice/voice.js';
 import { publishTtsChunk, subscribeTtsChunks } from '@x/core/dist/voice/tts-bus.js';
+import { formatDictation } from '@x/core/dist/voice/format_dictation.js';
 import { fetchLiveNote, listLiveNotes, setLiveNote, setLiveNoteActive, deleteLiveNote } from '@x/core/dist/knowledge/live-note/fileops.js';
 import { runningItemKeys } from '@x/core/dist/todo/runner.js';
 import { getSessionIndex as getTodoSessionIndex } from '@x/core/dist/todo/session-index.js';
@@ -1279,6 +1280,9 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
     },
     'voice:synthesize': async (args) => {
       return voice.synthesizeSpeech(args.text);
+    },
+    'voice:formatDictation': async (args) => {
+      return { text: await formatDictation(args.text) };
     },
     'live-note:run': async (args) => {
       const result = await runLiveNoteAgent(args.filePath, 'manual', args.context);

--- a/apps/x/packages/core/src/voice/format_dictation.ts
+++ b/apps/x/packages/core/src/voice/format_dictation.ts
@@ -1,0 +1,59 @@
+import { generateText } from 'ai';
+import { createLanguageModel } from '../models/models.js';
+import { getBackgroundTaskAgentModel, resolveProviderConfig } from '../models/defaults.js';
+import { directCallReasoningOptions } from '../models/reasoning.js';
+import { captureLlmUsage } from '../analytics/usage.js';
+import { withUseCase } from '../analytics/use_case.js';
+
+const SYSTEM_PROMPT = `You clean up voice-dictated text into a message ready to post in a team chat (Slack-style).
+
+Rules:
+- Remove filler ("um", "uh", "you know"), false starts, and stutter repeats
+- Fix punctuation, capitalization, and obvious transcription slips
+- Keep the person's words, tone, and meaning - do NOT summarize, rewrite, or add content
+- Keep @mentions exactly as they appear (e.g. "@rowboat")
+- Only break into paragraphs or a list when the speech clearly has that structure
+- Same language as the input
+- Output the cleaned message and nothing else`;
+
+// Past this the cleanup payoff shrinks while latency and cost grow — callers
+// post the raw transcript instead.
+const MAX_INPUT_CHARS = 6000;
+
+/**
+ * Clean a raw STT transcript into a postable chat message using the
+ * background-agents task model. Returns null when the input is empty or
+ * oversized, or the model produced nothing usable — callers fall back to
+ * the raw transcript. Model/provider errors propagate to the caller.
+ */
+export async function formatDictation(transcript: string): Promise<string | null> {
+    const text = transcript.trim();
+    if (!text || text.length > MAX_INPUT_CHARS) return null;
+
+    const { model: modelId, provider: providerName, effort } = await getBackgroundTaskAgentModel();
+    const providerConfig = await resolveProviderConfig(providerName);
+    const model = createLanguageModel(providerConfig, modelId);
+
+    // Reasoning models think by default and can starve the output cap — pin
+    // thinking to low; an explicit effort on the backgroundTask slot overrides
+    // (same posture as the chat-title call).
+    const reasoning = await directCallReasoningOptions(providerConfig.flavor, modelId, effort ?? 'low');
+    const result = await withUseCase({ useCase: 'copilot_chat', subUseCase: 'spaces_dictation_format' }, () => generateText({
+        model,
+        system: SYSTEM_PROMPT,
+        prompt: text,
+        maxOutputTokens: 4000,
+        ...reasoning,
+    }));
+
+    captureLlmUsage({
+        useCase: 'copilot_chat',
+        subUseCase: 'spaces_dictation_format',
+        model: modelId,
+        provider: providerName,
+        usage: result.usage,
+    });
+
+    const formatted = result.text.trim();
+    return formatted || null;
+}

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2626,6 +2626,14 @@ export const ipcSchemas = {
     req: z.object({ requestId: z.string() }),
     res: z.object({}),
   },
+  // Dictation cleanup: the Spaces composer sends the raw STT transcript and
+  // places the returned Slack-ready text (background-agents task model) into
+  // the input box as an editable draft. null = unusable input or no usable
+  // output — the caller falls back to the raw transcript.
+  'voice:formatDictation': {
+    req: z.object({ text: z.string() }),
+    res: z.object({ text: z.string().nullable() }),
+  },
   // Push channel: main → renderer with streaming TTS audio. `done: true`
   // (possibly with a final chunk) ends the stream; `error` aborts it.
   'voice:tts-chunk': {


### PR DESCRIPTION
## Summary
- Mic button + voice input on the Spaces composer (space stream and thread panes), reusing the assistant composer's dictation experience: live waveform, interim transcript, Enter/Escape keys, and the same mic-ownership store (acquireVoice) so composers, other surfaces, and live calls never fight over the mic.
- New cleanup pass: the raw STT transcript runs through the Background agents task model (models config) to strip filler ("um", false starts), fix punctuation, and produce a Slack-ready message. Strictly best-effort: any failure, empty result, or 15s timeout falls back to the raw transcript, so a dictation is never lost or blocked.
- Explicit endings on the recording bar: Stop (square button, Enter) finalizes and drops the cleaned text INTO the input box for review and editing - nothing auto-posts; Send (arrow, Cmd/Ctrl+Enter) finalizes and posts straight away. X / Escape discards.
- Plumbing: formatDictation() in core (modeled on the chat-title one-shot call, usage analytics included), new voice:formatDictation IPC channel wired in BOTH hosts (Electron main and rowboat-server), voice-availability probe hook, VoiceWaveform exported for reuse, and App-level listener so mic-denied surfaces the same macOS permission dialog.

## Test plan
- typecheck: shared, core, client, server, renderer, main - all pass
- tests: shared 309, core 835, server 27, renderer 508 - all pass
- Manual: dictate in a space and a thread; verify Stop lands cleaned text in the box (appending to a typed draft), Send posts directly, Escape discards, mic steal between composers cancels cleanly, and a configured-but-unreachable model still inserts the raw transcript after the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)