### PR TITLE
feat(spaces): edit a message in the composer's own editor

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { Editor } from '@tiptap/core'
 import { caretContext, composerExtensions, composerMarkdown } from './composer-editor'
+import { encodeMentions, resolveMentions } from '@/lib/spaces-presentation'
 
 // The composer's contract: what the editor holds serializes back to the
 // exact markdown the wire (and every downstream consumer: drafts, slash
@@ -93,6 +94,30 @@ describe('formatting commands produce wire markdown', () => {
         expect(e.getText()).toBe('a * b _c_')
         // Whatever escaping the serializer chose, it must parse back to the same text.
         expect(makeEditor(md).getText()).toBe('a * b _c_')
+    })
+})
+
+describe('inline message editor round trip', () => {
+    // The edit box seeds the editor with the posted body (mentions resolved to
+    // names) and saves what it serializes back (mentions re-encoded). Opening
+    // an edit and saving it untouched must reproduce the wire body exactly —
+    // otherwise editing rewrites messages nobody changed.
+    const members = [
+        { id: '01HXAMPLEULIDHARSH000000', displayName: 'Harsh' },
+        { id: '01HXAMPLEULIDRAMNIQUE000', displayName: 'Ramnique Singh' },
+    ]
+    const names = new Map(members.map((m) => [m.id, m.displayName]))
+    const bodies: [string, string][] = [
+        ['a mention', '@01HXAMPLEULIDHARSH000000 see a bunch of things like this'],
+        ['a multi-word mention', 'hey @01HXAMPLEULIDRAMNIQUE000 can you look?'],
+        ['two mentions and formatting', '@01HXAMPLEULIDHARSH000000 **please** ping @01HXAMPLEULIDRAMNIQUE000'],
+        ['@rowboat and @here keep their handles', '@rowboat summarise for @here'],
+        ['a mention mid-list', '- ask @01HXAMPLEULIDHARSH000000\n- then ship'],
+        ['an id cited in code stays literal', 'the id `@01HXAMPLEULIDHARSH000000` is the wire form'],
+    ]
+    it.each(bodies)('%s', (_name, body) => {
+        const editor = makeEditor(resolveMentions(body, names))
+        expect(encodeMentions(composerMarkdown(editor), members)).toBe(body)
     })
 })
 

--- a/apps/x/apps/renderer/src/components/spaces/composer-toolbar.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer-toolbar.tsx
@@ -186,9 +186,10 @@ export function FormattingToolbar({ textareaRef, value, onChange, onCaret, class
 }
 
 // ---------------------------------------------------------------------------
-// The same bar, driven by the rich composer's TipTap editor: real commands
-// with pressed states instead of string transforms. (The message editor's
-// textarea still uses FormattingToolbar above.)
+// The same bar, driven by a TipTap editor: real commands with pressed states
+// instead of string transforms. Both mention surfaces — the composer and the
+// inline message editor — use this one; FormattingToolbar above is the
+// textarea-era version, now without a caller.
 // ---------------------------------------------------------------------------
 
 type RichToolKey = 'bold' | 'italic' | 'strike' | 'ordered' | 'bullet' | 'quote' | 'code' | 'codeblock'

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import type { EditorView } from '@tiptap/pm/view'
 import { uploadInputFor } from '@/lib/spaces-upload'
-import { ArrowUp, BarChart3, Bot, Clock, FileText, Globe, Loader2, LoaderIcon, Megaphone, Mic, Paperclip, ShieldCheck, Square, Terminal, X as XIcon } from 'lucide-react'
+import { ArrowUp, BarChart3, Clock, FileText, Globe, Loader2, LoaderIcon, Mic, Paperclip, ShieldCheck, Square, Terminal, X as XIcon } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -11,19 +11,19 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { ModelSelector } from '@/components/model-selector'
 import type { ModelSelection } from '@/hooks/use-models'
-import { MemberAvatar } from '@/components/spaces/atoms'
 import { VoiceWaveform } from '@/components/chat-input-with-mentions'
 import { useVoiceMode } from '@/hooks/useVoiceMode'
 import { useVoiceInputAvailable } from '@/hooks/use-voice-available'
 import { CALL_VOICE_HOLDER, acquireVoice, releaseVoice, voiceOwnerId } from '@/lib/voice-ownership'
 import { caretContext, composerExtensions, composerMarkdown, type CaretContext } from '@/components/spaces/composer-editor'
 import { RichFormattingToolbar } from '@/components/spaces/composer-toolbar'
+import { MentionMenu, useMentionAutocomplete } from '@/components/spaces/mention-autocomplete'
 import { isDirectImageUrl, useSpaceRefs } from '@/components/spaces/space-markdown'
 import '@/styles/space-composer.css'
 import { noteEmojiUsed, replaceShortcodes, searchEmoji, type EmojiEntry } from '@/lib/emoji-data'
 import { containsRowboatAddress } from '@/lib/spaces-mentions'
 import { schedulePresets } from '@/lib/spaces-schedule'
-import { blobAppUrl, blobWireUrl, encodeMentions, encodeSpaceLinkTarget, formatBytes, isImageMime } from '@/lib/spaces-presentation'
+import { blobAppUrl, blobWireUrl, encodeMentions, formatBytes, isImageMime, mentionEndingAtCaret } from '@/lib/spaces-presentation'
 import { toast } from '@/lib/toast'
 
 // The space composer. A plain message box — Enter sends, Shift+Enter breaks a
@@ -60,19 +60,6 @@ export interface AgentOptions {
     searchEnabled?: boolean
     codeMode?: 'claude' | 'codex'
 }
-
-interface MentionCandidate {
-    id: string
-    label: string
-    hint?: string
-    isAgent?: boolean
-    isBroadcast?: boolean
-    /** A file suggestion — picking it inserts a plain markdown link to the path. */
-    filePath?: string
-}
-
-// "/" so typing into a folder ("@design/sc…") keeps the file query alive.
-const MENTION_RE = /(^|[\s([{])@([\w./-]*)$/
 
 /** A pane-provided slash command; `args` absent = picking it runs immediately. */
 export interface SlashCommand {
@@ -160,9 +147,8 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     const keydownRef = useRef<(view: EditorView, event: KeyboardEvent) => boolean>(() => false)
     const pasteRef = useRef<(event: ClipboardEvent) => boolean>(() => false)
     const dropRef = useRef<(event: DragEvent) => boolean>(() => false)
-    /** Where the caret sits (text-before-caret + doc position) — drives the autocompletes. */
+    /** Where the caret sits (text-before-caret + doc position) — drives the :emoji: autocomplete. */
     const [context, setContext] = useState<CaretContext | null>(null)
-    const [mentionOpen, setMentionOpen] = useState(false)
 
     const editor = useEditor({
         // The getter runs inside Placeholder's decoration pass (post-render,
@@ -177,10 +163,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         },
         onUpdate: ({ editor: ed }) => {
             setDraft(composerMarkdown(ed))
-            const ctx = caretContext(ed)
-            setContext(ctx)
-            // Open on "@" at a word start; stay open while the query grows.
-            setMentionOpen(!!ctx && MENTION_RE.test(ctx.text))
+            setContext(caretContext(ed))
             onTypeRef.current?.()
         },
         onSelectionUpdate: ({ editor: ed }) => setContext(caretContext(ed)),
@@ -317,47 +300,12 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     }, [editor, seed, appliedSeed])
 
     // --- @ autocomplete ------------------------------------------------------
-    const [mentionIndex, setMentionIndex] = useState(0)
-    const mentionMatch = useMemo(() => {
-        if (!mentionOpen || !context) return null
-        const m = MENTION_RE.exec(context.text)
-        if (!m) return null
-        const query = m[2] ?? ''
-        return { query: query.toLowerCase(), from: context.from - query.length - 1, to: context.from }
-    }, [context, mentionOpen])
-    const candidates = useMemo<MentionCandidate[]>(() => {
-        if (!mentionMatch) return []
-        const q = mentionMatch.query
-        const people: MentionCandidate[] = []
-        if ('rowboat'.startsWith(q)) people.push({ id: 'rowboat', label: 'rowboat', hint: 'your agent — acts only when asked', isAgent: true })
-        if ('here'.startsWith(q)) people.push({ id: 'here', label: 'here', hint: 'notify everyone online', isBroadcast: true })
-        for (const m of members) {
-            const hay = `${m.id} ${m.displayName}`.toLowerCase()
-            if (!q || hay.includes(q)) people.push({ id: m.id, label: m.displayName, ...(m.id === selfMemberId ? { hint: 'you' } : {}) })
-        }
-        // Files join once a query exists (a bare "@" is a people gesture);
-        // picking one inserts a markdown link, not a mention.
-        const files: MentionCandidate[] = q
-            ? entries
-                  .filter((e) => e.state !== 'deleted' && e.path.toLowerCase().includes(q))
-                  .slice(0, 4)
-                  .map((e) => ({
-                      id: `file:${e.path}`,
-                      label: e.path.split('/').pop() ?? e.path,
-                      ...(e.path.includes('/') ? { hint: e.path } : {}),
-                      filePath: e.path,
-                  }))
-            : []
-        return [...people.slice(0, 8 - files.length), ...files]
-    }, [mentionMatch, members, entries, selfMemberId])
-    // Reset the highlighted row whenever the query changes (adjust-on-change, not an effect).
-    const mentionQuery = mentionMatch?.query ?? null
-    const [lastQuery, setLastQuery] = useState<string | null>(null)
-    if (mentionQuery !== lastQuery) {
-        setLastQuery(mentionQuery)
-        setMentionIndex(0)
-    }
-    const showMentions = mentionOpen && !!mentionMatch && candidates.length > 0
+    // The shared hook (same popup the inline message editor uses) — it rides
+    // the editor's own events, so no wiring through onUpdate here. The menu
+    // portals out and measures against the box, hence the element in state.
+    const [box, setBox] = useState<HTMLDivElement | null>(null)
+    const mention = useMentionAutocomplete(editor, { members, entries, ...(selfMemberId ? { selfMemberId } : {}) })
+    const showMentions = mention.show
 
     // --- :emoji: autocomplete ------------------------------------------------
     // ":fi" at the caret offers 🔥 etc.; a completed ":fire:" left as text
@@ -417,24 +365,6 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         }
     }
 
-    // The draft shows the person's name; send() encodes it back to the wire
-    // address @<memberId> (what notifications and agent invocation scan for).
-    // A file becomes a live link to the space path — standard markdown on the
-    // wire. Inserted as literal nodes, never re-parsed as markdown.
-    const pickCandidate = (c: MentionCandidate) => {
-        if (!mentionMatch || !editor) return
-        const chain = editor.chain().focus().deleteRange({ from: mentionMatch.from, to: mentionMatch.to })
-        if (c.filePath) {
-            chain.insertContent([
-                { type: 'text', text: c.filePath, marks: [{ type: 'link', attrs: { href: encodeSpaceLinkTarget(c.filePath) } }] },
-                { type: 'text', text: ' ' },
-            ]).run()
-        } else {
-            chain.insertContent({ type: 'text', text: `@${c.label} ` }).run()
-        }
-        setMentionOpen(false)
-    }
-
     const insertRowboatChip = () => {
         if (!editor) return
         const { $from, empty } = editor.state.selection
@@ -486,7 +416,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         editor?.chain().clearContent().run()
         setDraft('')
         setAttachments([])
-        setMentionOpen(false)
+        mention.close()
     }
 
     const send = async (textOverride?: string) => {
@@ -525,7 +455,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         editor?.chain().clearContent().run()
         setDraft('')
         setAttachments([])
-        setMentionOpen(false)
+        mention.close()
     }
 
     // --- voice input ---------------------------------------------------------
@@ -682,25 +612,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                 return true
             }
         }
-        if (showMentions) {
-            if (e.key === 'ArrowDown') {
-                setMentionIndex((i) => (i + 1) % candidates.length)
-                return true
-            }
-            if (e.key === 'ArrowUp') {
-                setMentionIndex((i) => (i - 1 + candidates.length) % candidates.length)
-                return true
-            }
-            if (e.key === 'Enter' || e.key === 'Tab') {
-                const c = candidates[mentionIndex]
-                if (c) pickCandidate(c)
-                return true
-            }
-            if (e.key === 'Escape') {
-                setMentionOpen(false)
-                return true
-            }
-        }
+        if (mention.onKeyDown(e)) return true
         if (showEmoji) {
             if (e.key === 'ArrowDown') {
                 setEmojiIndex((i) => (i + 1) % emojiCandidates.length)
@@ -719,6 +631,18 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                 setEmojiDismissed(true)
                 return true
             }
+        }
+        if (e.key === 'Backspace' && editor) {
+            // A mention deletes as one unit (the Discord behavior): with the
+            // caret right at the end of "@Name", the whole token goes, not
+            // the last letter. caretContext bows out for range selections and
+            // code — a cited @Name still edits character by character.
+            const ctx = caretContext(editor)
+            const start = ctx ? mentionEndingAtCaret(ctx.text, members.map((m) => m.displayName)) : null
+            if (ctx && start !== null) {
+                return editor.chain().focus().deleteRange({ from: ctx.from - (ctx.text.length - start), to: ctx.from }).run()
+            }
+            return false
         }
         if (e.key !== 'Enter') return false
         // ⌘Enter always sends — even from inside a code fence.
@@ -763,6 +687,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     return (
         <div className="px-3 pb-3 pt-1 shrink-0">
             <div
+                ref={setBox}
                 className="relative rounded-2xl border border-border bg-background shadow-[0_8px_24px_rgb(0_0_0_/_0.04)]"
                 onDragEnter={onDragEnter}
                 onDragOver={(e) => { if (refs && dragHasFiles(e)) e.preventDefault() }}
@@ -877,33 +802,10 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
                             <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
                         </div>
                     )}
-                    {showMentions && (
-                        <div className="absolute bottom-full left-2 z-20 mb-1 w-72 overflow-hidden rounded-2xl border-none bg-popover p-1.5 shadow-[var(--rowboat-shadow)]">
-                            {candidates.map((c, i) => (
-                                <button
-                                    key={c.id}
-                                    type="button"
-                                    onMouseDown={(e) => e.preventDefault()}
-                                    onClick={() => pickCandidate(c)}
-                                    className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left', i === mentionIndex ? 'bg-accent' : 'hover:bg-accent/60')}
-                                >
-                                    {c.isAgent ? (
-                                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background"><Bot className="size-3.5" /></span>
-                                    ) : c.isBroadcast ? (
-                                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><Megaphone className="size-3.5" /></span>
-                                    ) : c.filePath ? (
-                                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><FileText className="size-3.5" /></span>
-                                    ) : (
-                                        <MemberAvatar id={c.id} name={c.label} size="sm" className="size-6 text-[10px]" />
-                                    )}
-                                    <span className="min-w-0 flex-1">
-                                        <span className="block truncate text-[13px] font-medium">{c.label}</span>
-                                        {c.hint && <span className="block truncate text-[11px] text-muted-foreground">{c.hint}</span>}
-                                    </span>
-                                </button>
-                            ))}
-                            <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
-                        </div>
+                    {/* Portalled, so the recording guard is explicit — the
+                        `hidden` wrapper above can't reach it. */}
+                    {!recording && mention.show && (
+                        <MentionMenu anchor={box} candidates={mention.candidates} index={mention.index} onPick={mention.pick} />
                     )}
                     {/* The formatting bar rides the top edge, Slack-style. */}
                     <RichFormattingToolbar editor={editor} className="px-2 pt-1.5" />

--- a/apps/x/apps/renderer/src/components/spaces/edit-box.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/edit-box.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { spaces } from '@x/shared'
+import { MessageEditBox } from './edit-box'
+import { SpaceProfilesProvider } from './member-text'
+
+// The inline editor mounts a real TipTap instance, a portalled mention menu
+// and a layout-effect placement pass. These pin that it comes up clean and
+// renders the body it was handed — the app-level check this can't do is
+// whether it *looks* right, but a crash or an empty box shows up here.
+
+afterEach(cleanup)
+
+const member = (id: string, displayName: string) => ({ id, displayName, role: 'member' }) as unknown as spaces.Member
+
+function mount(initial: string, onChange = vi.fn()) {
+    const utils = render(
+        <SpaceProfilesProvider members={[member('01HAAA', 'Harsh')]} here={new Set()} selfId="01HAAA">
+            <MessageEditBox initial={initial} onChange={onChange} onSave={vi.fn()} onCancel={vi.fn()} />
+        </SpaceProfilesProvider>,
+    )
+    return { ...utils, onChange }
+}
+
+describe('MessageEditBox', () => {
+    it('mounts with the body already in the editor', () => {
+        mount('hello @Harsh')
+        expect(document.querySelector('.ProseMirror')?.textContent).toBe('hello @Harsh')
+    })
+
+    it('emits the baseline once on mount, so an untouched draft compares equal', () => {
+        const { onChange } = mount('hello @Harsh')
+        expect(onChange).toHaveBeenCalledWith('hello @Harsh')
+    })
+
+    it('keeps the composer surface: the formatting bar and the growth cap', () => {
+        mount('hi')
+        expect(screen.getByLabelText(/Bold/i)).toBeTruthy()
+        // The edit variant lifts the composer's 10rem cap to half the window.
+        expect(document.querySelector('.space-composer.space-composer-edit')).toBeTruthy()
+    })
+
+    it('shows no mention menu until an @ is typed', () => {
+        mount('hello @Harsh')
+        expect(document.querySelector('[data-slot="mention-menu"]')).toBeNull()
+    })
+
+    it('renders an empty body without crashing (an image-only message)', () => {
+        mount('')
+        expect(document.querySelector('.ProseMirror')?.textContent).toBe('')
+    })
+})

--- a/apps/x/apps/renderer/src/components/spaces/edit-box.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/edit-box.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import type { EditorView } from '@tiptap/pm/view'
+import { caretContext, composerExtensions, composerMarkdown } from '@/components/spaces/composer-editor'
+import { RichFormattingToolbar } from '@/components/spaces/composer-toolbar'
+import { MentionMenu, useMentionAutocomplete } from '@/components/spaces/mention-autocomplete'
+import { useSpaceProfiles } from '@/components/spaces/member-text'
+import { mentionEndingAtCaret } from '@/lib/spaces-presentation'
+import '@/styles/space-composer.css'
+
+/**
+ * The inline message editor — the composer's surface (same TipTap nodes,
+ * markdown input rules, toolbar and @mention popup) minus the send-only
+ * machinery (attachments, slash commands, drafts, scheduling). Enter saves,
+ * Shift+Enter breaks a line, Escape cancels; members come from the space's
+ * profiles context. The host owns the draft string (onChange fires with the
+ * doc's markdown on every edit) and renders its own Save/Cancel row; extra
+ * rows inside the bordered box (image thumbnails) ride in as children.
+ */
+export function MessageEditBox({ initial, onChange, onSave, onCancel, children }: {
+    /** The starting markdown — mentions already resolved to display names. */
+    initial: string
+    /**
+     * Fires with the doc's markdown on every edit, and once on mount with the
+     * editor's own serialization of `initial` — TipTap normalizes markdown as
+     * it parses, so that first value is the baseline an untouched draft
+     * compares equal to.
+     */
+    onChange: (markdown: string) => void
+    onSave: () => void
+    onCancel: () => void
+    children?: ReactNode
+}) {
+    const { byId, selfId } = useSpaceProfiles()
+    const members = useMemo(() => [...byId.values()], [byId])
+    // The menu anchors to this box; state (not a ref) so it re-renders once
+    // the node exists and the menu can measure against it.
+    const [box, setBox] = useState<HTMLDivElement | null>(null)
+    const keydownRef = useRef<(view: EditorView, event: KeyboardEvent) => boolean>(() => false)
+    const onChangeRef = useRef(onChange)
+    const editor = useEditor({
+        extensions: composerExtensions(() => 'Add a message'),
+        content: initial,
+        autofocus: 'end',
+        editorProps: {
+            handleKeyDown: (view, event) => keydownRef.current(view, event),
+        },
+        onUpdate: ({ editor: ed }) => onChangeRef.current(composerMarkdown(ed)),
+    })
+    const mention = useMentionAutocomplete(editor, { members, ...(selfId ? { selfMemberId: selfId } : {}) })
+
+    const handleKeyDown = (view: EditorView, e: KeyboardEvent): boolean => {
+        if (mention.onKeyDown(e)) return true
+        if (e.key === 'Escape') {
+            onCancel()
+            return true
+        }
+        if (e.key === 'Backspace' && editor) {
+            // A mention deletes as one unit (the Discord behavior, same as
+            // the composer); caretContext bows out for selections and code.
+            const ctx = caretContext(editor)
+            const start = ctx ? mentionEndingAtCaret(ctx.text, members.map((m) => m.displayName)) : null
+            if (ctx && start !== null) {
+                return editor.chain().focus().deleteRange({ from: ctx.from - (ctx.text.length - start), to: ctx.from }).run()
+            }
+            return false
+        }
+        if (e.key === 'Enter') {
+            // ⌘Enter saves from anywhere, even inside a code fence — the
+            // composer's ⌘Enter-always-sends rule.
+            if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+                onSave()
+                return true
+            }
+            if (!e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !view.composing) {
+                // Inside a code fence Enter breaks the line (the composer's
+                // posture); everywhere else it saves.
+                if (view.state.selection.$from.parent.type.name === 'codeBlock') return false
+                onSave()
+                return true
+            }
+        }
+        return false
+    }
+
+    // Callbacks read through refs, re-pointed after every render, so the
+    // create-once editor always sees current state (the composer's pattern).
+    useEffect(() => {
+        keydownRef.current = handleKeyDown
+        onChangeRef.current = onChange
+    })
+
+    // The baseline, once the editor exists: what `initial` serializes back to
+    // untouched. onUpdate never fires for the initial content.
+    useEffect(() => {
+        if (editor) onChangeRef.current(composerMarkdown(editor))
+    }, [editor])
+
+    return (
+        <div ref={setBox} className="rounded-2xl border border-border bg-background">
+            {mention.show && <MentionMenu anchor={box} candidates={mention.candidates} index={mention.index} onPick={mention.pick} />}
+            <RichFormattingToolbar editor={editor} className="px-2 pt-1.5" />
+            <EditorContent editor={editor} className="space-composer space-composer-edit" />
+            {children}
+        </div>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/mention-autocomplete.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/mention-autocomplete.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { Editor } from '@tiptap/core'
+import { Bot, FileText, Megaphone } from 'lucide-react'
+import type { spaces } from '@x/shared'
+import { cn } from '@/lib/utils'
+import { MemberAvatar } from '@/components/spaces/atoms'
+import { caretContext, type CaretContext } from '@/components/spaces/composer-editor'
+import { encodeSpaceLinkTarget } from '@/lib/spaces-presentation'
+
+// The @ autocomplete behind every mention surface — the composer and the
+// inline message editor. The hook owns the popup's whole lifecycle off the
+// editor's own events; the host renders <MentionMenu> inside its relative
+// box and routes keydowns through onKeyDown ahead of its other bindings.
+
+export interface MentionCandidate {
+    id: string
+    label: string
+    hint?: string
+    isAgent?: boolean
+    isBroadcast?: boolean
+    /** A file suggestion — picking it inserts a plain markdown link to the path. */
+    filePath?: string
+}
+
+// "/" so typing into a folder ("@design/sc…") keeps the file query alive.
+export const MENTION_RE = /(^|[\s([{])@([\w./-]*)$/
+
+export function useMentionAutocomplete(editor: Editor | null, { members = [], entries = [], selfMemberId }: {
+    /** Space members — the people the popup offers. */
+    members?: readonly spaces.Member[]
+    /** Space files — the same popup offers them once a query exists. */
+    entries?: readonly spaces.SpacesAssetEntry[]
+    selfMemberId?: string
+}) {
+    /** Where the caret sits (text-before-caret + doc position) — what the trigger matches against. */
+    const [context, setContext] = useState<CaretContext | null>(null)
+    const [open, setOpen] = useState(false)
+    const [index, setIndex] = useState(0)
+
+    // Open on "@" at a word start; stay open while the query grows. A plain
+    // caret move only retargets the match — clicking beside an "@word" that
+    // is already text must not pop the menu.
+    useEffect(() => {
+        if (!editor) return
+        const onUpdate = ({ editor: ed }: { editor: Editor }) => {
+            const ctx = caretContext(ed)
+            setContext(ctx)
+            setOpen(!!ctx && MENTION_RE.test(ctx.text))
+        }
+        const onSelectionUpdate = ({ editor: ed }: { editor: Editor }) => setContext(caretContext(ed))
+        editor.on('update', onUpdate)
+        editor.on('selectionUpdate', onSelectionUpdate)
+        return () => {
+            editor.off('update', onUpdate)
+            editor.off('selectionUpdate', onSelectionUpdate)
+        }
+    }, [editor])
+
+    const match = useMemo(() => {
+        if (!open || !context) return null
+        const m = MENTION_RE.exec(context.text)
+        if (!m) return null
+        const query = m[2] ?? ''
+        return { query: query.toLowerCase(), from: context.from - query.length - 1, to: context.from }
+    }, [context, open])
+
+    const candidates = useMemo<MentionCandidate[]>(() => {
+        if (!match) return []
+        const q = match.query
+        const people: MentionCandidate[] = []
+        if ('rowboat'.startsWith(q)) people.push({ id: 'rowboat', label: 'rowboat', hint: 'your agent — acts only when asked', isAgent: true })
+        if ('here'.startsWith(q)) people.push({ id: 'here', label: 'here', hint: 'notify everyone online', isBroadcast: true })
+        for (const m of members) {
+            const hay = `${m.id} ${m.displayName}`.toLowerCase()
+            if (!q || hay.includes(q)) people.push({ id: m.id, label: m.displayName, ...(m.id === selfMemberId ? { hint: 'you' } : {}) })
+        }
+        // Files join once a query exists (a bare "@" is a people gesture);
+        // picking one inserts a markdown link, not a mention.
+        const files: MentionCandidate[] = q
+            ? entries
+                  .filter((e) => e.state !== 'deleted' && e.path.toLowerCase().includes(q))
+                  .slice(0, 4)
+                  .map((e) => ({
+                      id: `file:${e.path}`,
+                      label: e.path.split('/').pop() ?? e.path,
+                      ...(e.path.includes('/') ? { hint: e.path } : {}),
+                      filePath: e.path,
+                  }))
+            : []
+        return [...people.slice(0, 8 - files.length), ...files]
+    }, [match, members, entries, selfMemberId])
+
+    // Reset the highlighted row whenever the query changes (adjust-on-change, not an effect).
+    const query = match?.query ?? null
+    const [lastQuery, setLastQuery] = useState<string | null>(null)
+    if (query !== lastQuery) {
+        setLastQuery(query)
+        setIndex(0)
+    }
+    const show = open && !!match && candidates.length > 0
+
+    // The draft shows the person's name; send/save encodes it back to the
+    // wire address @<memberId> (what notifications and agent invocation scan
+    // for). A file becomes a live link to the space path — standard markdown
+    // on the wire. Inserted as literal nodes, never re-parsed as markdown.
+    const pick = (c: MentionCandidate) => {
+        if (!match || !editor) return
+        const chain = editor.chain().focus().deleteRange({ from: match.from, to: match.to })
+        if (c.filePath) {
+            chain.insertContent([
+                { type: 'text', text: c.filePath, marks: [{ type: 'link', attrs: { href: encodeSpaceLinkTarget(c.filePath) } }] },
+                { type: 'text', text: ' ' },
+            ]).run()
+        } else {
+            chain.insertContent({ type: 'text', text: `@${c.label} ` }).run()
+        }
+        setOpen(false)
+    }
+
+    /** Arrow/Enter/Tab/Escape while the menu shows; true = consumed. */
+    const onKeyDown = (e: KeyboardEvent): boolean => {
+        if (!show) return false
+        if (e.key === 'ArrowDown') {
+            setIndex((i) => (i + 1) % candidates.length)
+            return true
+        }
+        if (e.key === 'ArrowUp') {
+            setIndex((i) => (i - 1 + candidates.length) % candidates.length)
+            return true
+        }
+        if (e.key === 'Enter' || e.key === 'Tab') {
+            const c = candidates[index]
+            if (c) pick(c)
+            return true
+        }
+        if (e.key === 'Escape') {
+            setOpen(false)
+            return true
+        }
+        return false
+    }
+
+    return { show, candidates, index, pick, onKeyDown, close: () => setOpen(false) }
+}
+
+/**
+ * The dropdown. Anchored just above the host's box — but portalled and
+ * fixed-positioned, because the inline editor lives inside the stream's
+ * scroll container, which would clip an absolutely-positioned menu at its
+ * top edge. Flips below the box when there isn't room above.
+ */
+export function MentionMenu({ anchor, candidates, index, onPick }: {
+    /** The host's bordered box — the menu hugs its top-left. */
+    anchor: HTMLElement | null
+    candidates: readonly MentionCandidate[]
+    index: number
+    onPick: (c: MentionCandidate) => void
+}) {
+    const menuRef = useRef<HTMLDivElement | null>(null)
+    // Placement writes straight to the node instead of going through state:
+    // a scroll handler that setState'd would re-render the menu on every
+    // scroll event AND land a frame late, so the menu would visibly lag the
+    // box it is pinned to. Direct writes happen in the same frame as the
+    // scroll. Measured, not estimated — the row count drives the height.
+    useLayoutEffect(() => {
+        const place = () => {
+            const el = menuRef.current
+            const box = anchor?.getBoundingClientRect()
+            if (!el || !box) return
+            const gap = 4
+            const menu = el.getBoundingClientRect()
+            const above = box.top - gap - menu.height
+            const left = Math.max(8, Math.min(box.left + 8, window.innerWidth - menu.width - 8))
+            const top = above >= 8 ? above : Math.max(8, Math.min(box.bottom + gap, window.innerHeight - menu.height - 8))
+            el.style.left = `${left}px`
+            el.style.top = `${top}px`
+            // Revealed only once placed — the first paint is already correct
+            // (a layout effect runs before it), so there is no flash at 0,0.
+            el.style.visibility = 'visible'
+        }
+        place()
+        // Capture phase: the stream scrolls, not the window.
+        window.addEventListener('scroll', place, true)
+        window.addEventListener('resize', place)
+        return () => {
+            window.removeEventListener('scroll', place, true)
+            window.removeEventListener('resize', place)
+        }
+    }, [anchor, candidates.length])
+
+    return createPortal(
+        <div
+            ref={menuRef}
+            data-slot="mention-menu"
+            // left/top/visibility are owned by place() above. React never
+            // rewrites them: this object is value-identical on every render,
+            // so the style diff is empty and the imperative values stand.
+            style={{ position: 'fixed', visibility: 'hidden' }}
+            className="z-50 w-72 overflow-hidden rounded-2xl border-none bg-popover p-1.5 shadow-[var(--rowboat-shadow)]"
+        >
+            {candidates.map((c, i) => (
+                <button
+                    key={c.id}
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => onPick(c)}
+                    className={cn('flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left', i === index ? 'bg-accent' : 'hover:bg-accent/60')}
+                >
+                    {c.isAgent ? (
+                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background"><Bot className="size-3.5" /></span>
+                    ) : c.isBroadcast ? (
+                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><Megaphone className="size-3.5" /></span>
+                    ) : c.filePath ? (
+                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"><FileText className="size-3.5" /></span>
+                    ) : (
+                        <MemberAvatar id={c.id} name={c.label} size="sm" className="size-6 text-[10px]" />
+                    )}
+                    <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[13px] font-medium">{c.label}</span>
+                        {c.hint && <span className="block truncate text-[11px] text-muted-foreground">{c.hint}</span>}
+                    </span>
+                </button>
+            ))}
+            <div className="px-2 pb-0.5 pt-1 text-[10.5px] text-muted-foreground/80">↑↓ · ↵ or ⇥ to pick · esc</div>
+        </div>,
+        document.body,
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -1,7 +1,8 @@
-import { memo, useRef, useState } from 'react'
-import { Bookmark, BookmarkCheck, Bot, ChevronRight, Copy, Forward, Link as LinkIcon, Loader2, MessageSquare, MessageSquareText, MoreHorizontal, Pencil, Pin, PinOff, Quote, SmilePlus, Square, Trash2 } from 'lucide-react'
+import { memo, useState } from 'react'
+import { Bookmark, BookmarkCheck, Bot, ChevronRight, Copy, Forward, Link as LinkIcon, Loader2, MessageSquare, MessageSquareText, MoreHorizontal, Pencil, Pin, PinOff, Quote, SmilePlus, Square, Trash2, X } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import {
     ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuSub,
     ContextMenuSubContent, ContextMenuSubTrigger, ContextMenuTrigger,
@@ -10,16 +11,18 @@ import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
-import { Textarea } from '@/components/ui/textarea'
 import { MemberAvatar, MemberProfilePopover } from '@/components/spaces/atoms'
-import { FormattingToolbar } from '@/components/spaces/composer-toolbar'
+import { MessageEditBox } from '@/components/spaces/edit-box'
 import { EmojiPickerPopover } from '@/components/spaces/emoji-picker'
 import { MessageLinkPreview } from '@/components/spaces/link-preview-card'
 import { PollCard } from '@/components/spaces/poll-card'
-import { SpaceMarkdown } from '@/components/spaces/space-markdown'
+import { SpaceMarkdown, useSpaceRefs } from '@/components/spaces/space-markdown'
 import { frequentEmoji, noteEmojiUsed } from '@/lib/emoji-data'
 import { PIN_EMOJI } from '@/lib/spaces-corpus'
-import { formatFeedTime, formatFullTimestamp, resolveMentions } from '@/lib/spaces-presentation'
+import {
+    blobAppUrl, encodeMentions, formatFeedTime, formatFullTimestamp, joinImageEmbeds,
+    parseBlobAppUrl, resolveMentions, rewriteBlobLinks, splitImageEmbeds, type ImageEmbed,
+} from '@/lib/spaces-presentation'
 import { toast } from '@/lib/toast'
 
 // One message in a stream (general or a thread). Consecutive messages by the
@@ -185,13 +188,45 @@ function MessageRowImpl({
     const canDelete = !!onDelete && !deleted && !unconfirmed && selfMemberId === message.author.memberId
     // Poll messages are immutable once posted (the org refuses too).
     const canEdit = !!onEdit && !deleted && !unconfirmed && !message.poll && selfMemberId === message.author.memberId
-    // The inline editor: null = not editing; a string = the draft body.
-    const [editDraft, setEditDraft] = useState<string | null>(null)
-    const editRef = useRef<HTMLTextAreaElement | null>(null)
+    // The inline editor: null = not editing. Images live beside the text, not
+    // in it — the box edits prose while the embeds show as removable
+    // thumbnails (the Slack model); split/joinImageEmbeds carry the round trip.
+    // `initial` seeds the editor once; `text` is its live markdown; `baseline`
+    // is what an untouched draft serializes to (see MessageEditBox.onChange).
+    const [edit, setEdit] = useState<{ initial: string; text: string; images: ImageEmbed[]; baseline: string | null } | null>(null)
+    const refs = useSpaceRefs()
+    // A thumbnail address for an extracted embed: the org's blob links render
+    // through the app:// cache (their https wire form doesn't), anything
+    // external is its own src.
+    const editThumbSrc = (url: string): string => {
+        if (!refs) return url
+        const parsed = parseBlobAppUrl(rewriteBlobLinks(url, refs))
+        return parsed ? blobAppUrl(parsed, parsed.hash, { thumb: 128 }) : url
+    }
+    // The editor shows people, the wire stores ids: mentions resolve to names
+    // on open and encode back on save — the same trip the composer's send
+    // path makes, so editing "@Name …" round-trips to "@<memberId> …".
+    const beginEdit = () => {
+        const { text, images } = splitImageEmbeds(message.body)
+        const resolved = resolveMentions(text, memberNames)
+        setEdit({ initial: resolved, text: resolved, images, baseline: null })
+    }
     const commitEdit = () => {
-        const text = (editDraft ?? '').trim()
-        setEditDraft(null)
-        if (text && text !== message.body) onEdit!(message, text)
+        if (!edit) return
+        const members = [...memberNames].map(([id, displayName]) => ({ id, displayName }))
+        const body = joinImageEmbeds(encodeMentions(edit.text, members), edit.images)
+        setEdit(null)
+        if (!body || body === message.body) return
+        // A no-change save must never rewrite the message, and the assembled
+        // body alone can't tell: the editor normalizes markdown, legacy inline
+        // images move to the tile row, mentions re-encode. Compare the parts
+        // instead — text against the editor's own baseline, images by url.
+        const orig = splitImageEmbeds(message.body)
+        const untouched = edit.baseline !== null
+            && edit.text === edit.baseline
+            && edit.images.length === orig.images.length
+            && edit.images.every((img, i) => img.url === orig.images[i]?.url)
+        if (!untouched) onEdit!(message, body)
     }
     const showActions = !deleted && !unconfirmed && !!(onReplyInThread || onAskRowboat || onCopyLink || onReact || canDelete)
     // While the emoji picker or the ⋯ menu is open the hover-revealed chrome
@@ -254,29 +289,37 @@ function MessageRowImpl({
                         <span title={formatFullTimestamp(message.postedAt)} className="text-muted-foreground">{formatFeedTime(message.postedAt)}</span>
                     </div>
                 )}
-                {editDraft !== null ? (
+                {edit !== null ? (
                     <div className="mt-1">
-                        <FormattingToolbar textareaRef={editRef} value={editDraft} onChange={setEditDraft} className="mb-1" />
-                        <Textarea
-                            ref={editRef}
-                            autoFocus
-                            value={editDraft}
-                            onChange={(e) => setEditDraft(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' && !e.shiftKey) {
-                                    e.preventDefault()
-                                    commitEdit()
-                                } else if (e.key === 'Escape') {
-                                    setEditDraft(null)
-                                }
-                            }}
-                            className="min-h-16 text-sm"
-                        />
-                        <div className="mt-1 flex items-center gap-2 text-xs">
-                            <button type="button" onClick={commitEdit} className="rounded-md bg-foreground px-2 py-0.5 font-medium text-background hover:opacity-90">Save</button>
-                            <button type="button" onClick={() => setEditDraft(null)} className="text-muted-foreground hover:text-foreground">Cancel</button>
-                            <span className="text-muted-foreground/70">Enter to save · Esc to cancel</span>
-                        </div>
+                        <MessageEditBox
+                            initial={edit.initial}
+                            onChange={(text) => setEdit((e) => (e ? { ...e, text, baseline: e.baseline ?? text } : e))}
+                            onSave={commitEdit}
+                            onCancel={() => setEdit(null)}
+                        >
+                            {edit.images.length > 0 && (
+                                <div className="flex flex-wrap items-center gap-1.5 px-2.5 pb-1 pt-1">
+                                    {edit.images.map((img, i) => (
+                                        <span key={`${img.url}-${i}`} className="group/edit-thumb relative">
+                                            <img src={editThumbSrc(img.url)} alt={img.alt} title={img.alt} className="size-16 rounded-lg border border-border object-cover" />
+                                            <button
+                                                type="button"
+                                                onClick={() => setEdit({ ...edit, images: edit.images.filter((_, j) => j !== i) })}
+                                                aria-label={`Remove ${img.alt || 'image'}`}
+                                                className="absolute -right-1.5 -top-1.5 hidden rounded-full border border-border bg-background p-0.5 text-muted-foreground shadow-xs hover:text-foreground group-hover/edit-thumb:block"
+                                            >
+                                                <X className="size-3" />
+                                            </button>
+                                        </span>
+                                    ))}
+                                </div>
+                            )}
+                            <div className="flex items-center gap-2 px-2 pb-2 pt-1 text-xs">
+                                <span className="text-muted-foreground/70">Enter to save · Esc to cancel</span>
+                                <Button variant="outline" size="sm" className="ml-auto" onClick={() => setEdit(null)}>Cancel</Button>
+                                <Button size="sm" disabled={!edit.text.trim() && edit.images.length === 0} onClick={commitEdit}>Save</Button>
+                            </div>
+                        </MessageEditBox>
                     </div>
                 ) : deleted ? (
                     <div className="text-sm italic leading-relaxed text-muted-foreground">This message was deleted</div>
@@ -464,7 +507,7 @@ function MessageRowImpl({
                                     </DropdownMenuItem>
                                 )}
                                 {canEdit && (
-                                    <DropdownMenuItem onClick={() => setEditDraft(message.body)}>
+                                    <DropdownMenuItem onClick={beginEdit}>
                                         <Pencil className="size-3.5 mr-2" /> Edit message
                                     </DropdownMenuItem>
                                 )}
@@ -552,7 +595,7 @@ function MessageRowImpl({
                     </ContextMenuItem>
                 )}
                 {canEdit && (
-                    <ContextMenuItem onSelect={() => setEditDraft(message.body)}>
+                    <ContextMenuItem onSelect={beginEdit}>
                         <Pencil className="size-3.5 mr-2" /> Edit message
                     </ContextMenuItem>
                 )}

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.test.ts
@@ -12,6 +12,9 @@ import {
     formatFeedTime,
     initials,
     isUnreadChange,
+    joinImageEmbeds,
+    mentionEndingAtCaret,
+    splitImageEmbeds,
     orgMonogram,
     parseAssetWireUrl,
     parseBlobAppUrl,
@@ -234,6 +237,12 @@ describe('mentions — compose names, wire ids', () => {
             .toBe('hey **@Ramnique Singh**')
     })
 
+    it('resolve then encode round-trips a wire body — the inline editor trip', () => {
+        const names = new Map(members.map((m) => [m.id, m.displayName]))
+        const body = '@01HXAMPLEULIDRAMNIQUE0000 see a bunch of things like this'
+        expect(encodeMentions(resolveMentions(body, names), members)).toBe(body)
+    })
+
     it('resolveMentions renders names without markup — for titles, crumbs, reasons', () => {
         const names = new Map(members.map((m) => [m.id, m.displayName]))
         expect(resolveMentions('ask @01HXAMPLEULIDHARSH000000 about it', names))
@@ -241,6 +250,25 @@ describe('mentions — compose names, wire ids', () => {
         expect(resolveMentions('`@01HXAMPLEULIDHARSH000000` in code, @unknown alone', names))
             .toBe('`@01HXAMPLEULIDHARSH000000` in code, @unknown alone')
         expect(resolveMentions('@rowboat plan this', names)).toBe('@rowboat plan this')
+    })
+
+    it('mentionEndingAtCaret finds the whole token backspace should take', () => {
+        const names = members.map((m) => m.displayName)
+        expect(mentionEndingAtCaret('ping @Harsh', names)).toBe(5)
+        expect(mentionEndingAtCaret('@Harsh', names)).toBe(0)
+        expect(mentionEndingAtCaret('(@harsh', names)).toBe(1) // boundary + case-insensitive
+        expect(mentionEndingAtCaret('hey @Ramnique Singh', names)).toBe(4) // the full long name, whole
+        expect(mentionEndingAtCaret('@rowboat', [])).toBe(0)
+        expect(mentionEndingAtCaret('@here', [])).toBe(0)
+    })
+
+    it('mentionEndingAtCaret stays out of non-mentions', () => {
+        const names = members.map((m) => m.displayName)
+        expect(mentionEndingAtCaret('email@Harsh', names)).toBeNull() // no boundary before @
+        expect(mentionEndingAtCaret('ping @Hars', names)).toBeNull() // caret mid-name
+        expect(mentionEndingAtCaret('ping @Harsh ', names)).toBeNull() // caret past the token
+        expect(mentionEndingAtCaret('`@Harsh', names)).toBeNull() // an opening cite, not an address
+        expect(mentionEndingAtCaret('@Nobody', names)).toBeNull()
     })
 })
 
@@ -332,5 +360,46 @@ describe('separateImageParagraphs — old messages get the tile-row layout too',
         expect(separateImageParagraphs(inline)).toBe(inline)
         const fenced = '```\ntext\n![x](y.png)\n```'
         expect(separateImageParagraphs(fenced)).toBe(fenced)
+    })
+})
+
+describe('splitImageEmbeds / joinImageEmbeds — the inline editor round trip', () => {
+    const img = (n: string) => `![${n}](https://org.example/s/${'A'.repeat(26)}/b/${'a'.repeat(64)}?name=${n})`
+    it('a composer-shaped body round-trips byte-identical', () => {
+        const body = `some text\n\n${img('a.png')}\n${img('b.png')}`
+        const { text, images } = splitImageEmbeds(body)
+        expect(text).toBe('some text')
+        expect(images.map((i) => i.alt)).toEqual(['a.png', 'b.png'])
+        expect(joinImageEmbeds(text, images)).toBe(body)
+    })
+    it('an image-only body leaves the text empty', () => {
+        const body = img('a.png')
+        const { text, images } = splitImageEmbeds(body)
+        expect(text).toBe('')
+        expect(images).toHaveLength(1)
+        expect(joinImageEmbeds(text, images)).toBe(body)
+    })
+    it('removing every image leaves just the text', () => {
+        const { text } = splitImageEmbeds(`keep me\n\n${img('a.png')}`)
+        expect(joinImageEmbeds(text, [])).toBe('keep me')
+    })
+    it('inline images move to trailing lines; interleaved text collapses cleanly', () => {
+        const { text, images } = splitImageEmbeds(`before\n${img('a.png')}\nafter`)
+        expect(text).toBe('before\nafter')
+        expect(joinImageEmbeds(text, images)).toBe(`before\nafter\n\n${img('a.png')}`)
+    })
+    it('embeds inside code regions stay literal text', () => {
+        const fenced = '```\n![x](y.png)\n```'
+        const { text, images } = splitImageEmbeds(fenced)
+        expect(images).toHaveLength(0)
+        expect(text).toBe(fenced)
+        const cite = 'see `![x](y.png)` for the syntax'
+        expect(splitImageEmbeds(cite).text).toBe(cite)
+    })
+    it('a markdown title suffix survives the round trip', () => {
+        const body = `![a](https://x.example/a.png "hover text")`
+        const { images } = splitImageEmbeds(body)
+        expect(images[0]!.url).toBe('https://x.example/a.png')
+        expect(joinImageEmbeds('', images)).toBe(body)
     })
 })

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.ts
@@ -303,6 +303,25 @@ export function encodeMentions(body: string, members: readonly { id: string; dis
         .join('')
 }
 
+/**
+ * Where a mention token ending exactly at the caret starts: for "ping @Name"
+ * with the caret right after the name, the index of its "@" — null when the
+ * caret isn't at the end of a known mention. Backspace handlers use this to
+ * delete the whole token in one press (the Discord behavior). Matching
+ * mirrors encodeMentions — a boundary before the "@", case-insensitive —
+ * and the @rowboat and @here handles count too.
+ */
+export function mentionEndingAtCaret(textBeforeCaret: string, names: readonly string[]): number | null {
+    for (const name of new Set(['rowboat', 'here', ...names])) {
+        if (!name) continue
+        const start = textBeforeCaret.length - name.length - 1
+        if (start < 0 || textBeforeCaret[start] !== '@') continue
+        if (textBeforeCaret.slice(start + 1).toLowerCase() !== name.toLowerCase()) continue
+        if (start === 0 || /[\s([{]/.test(textBeforeCaret[start - 1]!)) return start
+    }
+    return null
+}
+
 // ---------------------------------------------------------------------------
 // File links — plain relative markdown links resolve against the space's file
 // tree (GitHub README semantics): in a file, against the file's own folder; in
@@ -427,6 +446,62 @@ export function separateImageParagraphs(body: string): string {
         out.push(line)
     }
     return out.join('\n')
+}
+
+/** One `![alt](url)` embed lifted out of a body by splitImageEmbeds. */
+export interface ImageEmbed {
+    alt: string
+    url: string
+    /** The optional markdown title suffix (` "…"`), kept verbatim for reassembly. */
+    title?: string
+}
+
+/**
+ * Pull the image embeds out of a body for the inline editor: the text edits
+ * bare in the textarea, the images ride below it as thumbnails (the Slack
+ * model). Code regions are cites — an embed inside one stays literal text.
+ * joinImageEmbeds reassembles the shape the composer sends: text, blank
+ * line, one image per line.
+ */
+export function splitImageEmbeds(body: string): { text: string; images: ImageEmbed[] } {
+    const images: ImageEmbed[] = []
+    const out: string[] = []
+    let fence: string | null = null
+    for (const line of body.split('\n')) {
+        const fenceMark = line.match(/^\s*(```+|~~~+)/)?.[1]
+        if (fenceMark) {
+            if (fence === null) fence = fenceMark[0]!
+            else if (fenceMark[0] === fence) fence = null
+            out.push(line)
+            continue
+        }
+        if (fence !== null) {
+            out.push(line)
+            continue
+        }
+        // Inline code spans are cites too — split them out, lift embeds only
+        // from the literal segments.
+        const stripped = line
+            .split(/(`[^`\n]*`)/g)
+            .map((seg, i) => {
+                if (i % 2 === 1) return seg
+                return seg.replace(/!\[([^\]]*)\]\(([^()\s]+)(\s+"[^"]*")?\)/g, (_m, alt: string, url: string, title?: string) => {
+                    images.push({ alt, url, ...(title ? { title } : {}) })
+                    return ''
+                })
+            })
+            .join('')
+        // A line that was only embeds disappears with its newline — no phantom
+        // paragraph break where the image sat. Anything else keeps its place.
+        if (stripped.trim() === '' && line.trim() !== '') continue
+        out.push(stripped.replace(/[^\S\n]+$/, ''))
+    }
+    return { text: out.join('\n').replace(/\n{3,}/g, '\n\n').trim(), images }
+}
+
+export function joinImageEmbeds(text: string, images: ImageEmbed[]): string {
+    const lines = images.map((i) => `![${i.alt}](${i.url}${i.title ?? ''})`)
+    return [text.trim(), lines.join('\n')].filter(Boolean).join('\n\n')
 }
 
 /**

--- a/apps/x/apps/renderer/src/styles/space-composer.css
+++ b/apps/x/apps/renderer/src/styles/space-composer.css
@@ -7,6 +7,12 @@
   overflow-y: auto;
 }
 
+/* The inline message editor grows further than the send box — Slack's cap:
+   half the window, then the box scrolls internally. */
+.space-composer.space-composer-edit {
+  max-height: 50vh;
+}
+
 .space-composer .ProseMirror {
   outline: none;
   min-height: 2.25rem;


### PR DESCRIPTION
Editing a message dropped you into a bare textarea holding raw wire markdown - `@01HXAMPLEULID...` ids instead of names, image URLs inline with the prose, no mention popup, no formatting bar with real commands. This makes the edit box the composer's surface.

## What changed

- **`edit-box.tsx`** - `MessageEditBox`: the composer's editor (same TipTap nodes, markdown input rules, toolbar, `@` popup) minus the send-only machinery (attachments, slash commands, drafts, scheduling). Enter saves, Shift+Enter breaks a line, Escape cancels, Cmd+Enter saves from anywhere including inside a code fence.
- **`mention-autocomplete.tsx`** - the `@` autocomplete lifted out of `composer.tsx` into a hook + menu shared by both surfaces. The menu portals to `document.body` and places itself against the host box: absolutely positioned, it got clipped by the stream's scroll container when the editor sat mid-feed. Placement writes straight to the node so it does not lag the box on scroll.
- **Mentions round trip** - names on open, wire ids on save, the same trip the composer's send path makes. Backspace with the caret at the end of a mention takes the whole token (`mentionEndingAtCaret`), the Discord behavior.
- **Images** - they edit as removable thumbnails beside the prose rather than as markdown inside it (`splitImageEmbeds` / `joinImageEmbeds`, the Slack model). Embeds inside code regions stay literal text.
- **No-op saves stay no-ops** - the editor normalizes markdown, legacy inline images move to the tile row and mentions re-encode, so the assembled body alone cannot tell. `MessageEditBox` reports a baseline on mount (its own serialization of the seed) and the save compares text against that plus images by url.
- **`space-composer.css`** - the edit variant grows to half the window before it scrolls internally; the send box keeps its smaller cap.
- **`composer-toolbar.tsx`** - `FormattingToolbar` (the textarea-era string-transform bar) is now caller-less; comment updated to say so rather than removing it in this PR.

## Rebased onto main (voice input, #992)

#992 landed voice dictation in the same `composer.tsx` and conflicted with this branch's mention extraction. Resolved by taking main's composer wholesale and re-applying the extraction on top, so all of the voice work is intact. One decision the merge forced:

- The mention menu used to live inside the wrapper that #992 hides while recording (`<div className={cn(recording && 'hidden')}>`). Now that the menu portals to `document.body`, that wrapper can no longer hide it, so the render is explicitly gated on `!recording`. Same behavior as before, just no longer implicit.

## Testing

`vitest` - full renderer suite green: **528 tests across 50 files**, including #992's voice tests.

New coverage:
- editor round trips: seeding with a resolved body and saving untouched reproduces the wire body byte-identically (mentions, multi-word names, `@rowboat`/`@here`, formatting, list items, ids cited in code).
- `mentionEndingAtCaret` - the token backspace should take, and the non-mentions it must stay out of.
- `splitImageEmbeds`/`joinImageEmbeds` - composer-shaped bodies, image-only bodies, interleaved text, code regions, markdown title suffixes.
- `MessageEditBox` mount: comes up with the body in the editor, emits the baseline once, keeps the formatting bar and the growth cap, no menu until an `@` is typed, empty body does not crash.

`tsc -b` clean (after `npm run deps` - #992 added a `voice:formatDictation` channel to `@x/shared`, so a stale build fails the renderer typecheck). `eslint` on the touched files reports one `react-refresh/only-export-components` on `mention-autocomplete.tsx` (hook + component in one file) - the same pattern 29 existing files in this renderer already use, including `space-markdown.tsx` and `member-text.tsx`.

Not covered by tests: whether it *looks* right in the running app - that needs a real space. The mention menu's placement against a scrolling stream, and the composer's menu while the recording bar is up, are the two spots worth a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)