### PR TITLE
feat: add opt-in assistant bottom tabs

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -10,6 +10,8 @@ import { cn, compactPath, parentPath } from '@/lib/utils';
 import { SPACES_ENABLED } from '@/lib/feature-flags';
 import { MarkdownEditor, type MarkdownEditorHandle } from './components/markdown-editor';
 import { ChatSidebar } from './components/chat-sidebar';
+import { AssistantChatDock } from './components/assistant-chat-dock';
+import { ASSISTANT_TABS_KEY, createAssistantTab, readAssistantPreference, restoreAssistantTabs, tabsAfterClose, writeAssistantPreference } from './lib/assistant-dock';
 import { useSessionChat } from '@/hooks/useSessionChat';
 import { subscribeSessionFeed } from '@/lib/session-chat/feed';
 import { ChatHeader } from './components/chat-header';
@@ -867,7 +869,8 @@ function ContentHeader({
 }
 
 function App() {
-  const { chatPanePlacement, chatPaneSize } = useTheme()
+  const { chatPanePlacement, chatPaneSize, assistantPresentation } = useTheme()
+  const useBottomTabs = assistantPresentation === 'bottom-tabs'
   const isChatPaneInMiddle = chatPanePlacement === 'middle'
 
   type ShortcutPane = 'left' | 'right'
@@ -2405,7 +2408,7 @@ function App() {
               // session, exactly like a first composer send — no remount.
               t.id === pending.tabId ? { ...t, runId: boundSessionId } : t
             )))
-            void loadRunRef.current?.(boundSessionId)
+            if (activeChatTabIdRef.current === pending.tabId) void loadRunRef.current?.(boundSessionId)
           }
         }
       }
@@ -2597,7 +2600,11 @@ function App() {
   const [runs, setRuns] = useState<RunListItem[]>([])
 
   // Chat tab state
-  const [chatTabs, setChatTabs] = useState<ChatTab[]>(() => [{ id: 'default-chat-tab', runId: null, chatId: crypto.randomUUID() }])
+  const [chatTabs, setChatTabs] = useState<ChatTab[]>(() => {
+    const restored = useBottomTabs ? restoreAssistantTabs(readAssistantPreference(ASSISTANT_TABS_KEY)) : []
+    if (restored.length) return restored
+    return [{ id: 'default-chat-tab', runId: null, chatId: crypto.randomUUID() }]
+  })
   const chatTabsRef = useRef(chatTabs)
   chatTabsRef.current = chatTabs
   // A tab's current chat identity (see ChatTab.chatId). Session-scoped maps
@@ -2606,12 +2613,30 @@ function App() {
   const chatIdForTab = useCallback((tabId: string) => (
     chatTabsRef.current.find((t) => t.id === tabId)?.chatId ?? tabId
   ), [])
-  const [activeChatTabId] = useState('default-chat-tab')
+  const [activeChatTabId, setActiveChatTabId] = useState(() => {
+    const saved = readAssistantPreference('rowboat-assistant-active-tab')
+    if (useBottomTabs && saved && chatTabs.some((tab) => tab.id === saved)) return saved
+    return chatTabs[0].id
+  })
+  useEffect(() => {
+    if (!useBottomTabs) return
+    writeAssistantPreference(ASSISTANT_TABS_KEY, JSON.stringify(chatTabs))
+    writeAssistantPreference('rowboat-assistant-active-tab', activeChatTabId)
+  }, [chatTabs, useBottomTabs, activeChatTabId])
   const [chatViewStateByTab, setChatViewStateByTab] = useState<Record<string, ChatTabViewState>>({
     'default-chat-tab': createEmptyChatTabViewState(),
   })
   const chatViewStateByTabRef = useRef(chatViewStateByTab)
   const chatDraftsRef = useRef(new Map<string, string>())
+  const draftsRestoredRef = useRef(false)
+  if (!draftsRestoredRef.current) {
+    draftsRestoredRef.current = true
+    for (const tab of chatTabs) {
+      const draft = readAssistantPreference(`rowboat-assistant-draft:${tab.chatId}`)
+      if (draft) chatDraftsRef.current.set(tab.chatId, draft)
+    }
+  }
+  const creatingSessionByChatRef = useRef(new Map<string, Promise<{ sessionId: string }>>())
   // Per-tab selection (model + effort as ONE value) — the composer reports
   // every change (settings seed included) and reads it back on remount, so
   // a tab's selection survives tab switches for the life of the app.
@@ -2631,7 +2656,10 @@ function App() {
     } else {
       chatDraftsRef.current.delete(chatId)
     }
-  }, [chatIdForTab])
+    if (useBottomTabs) {
+      writeAssistantPreference(`rowboat-assistant-draft:${chatId}`, text || null)
+    }
+  }, [chatIdForTab, useBottomTabs])
   // Persist a run's work directory to its per-run sidecar config file. The agent
   // runtime reads this same file (config/workdir-<runId>.json) on each turn.
   const persistRunWorkDir = useCallback(async (runId: string, value: string | null) => {
@@ -2693,7 +2721,10 @@ function App() {
     })
   }, [])
   const getChatTabTitle = useCallback((tab: ChatTab) => {
-    if (!tab.runId) return 'New chat'
+    if (!tab.runId) {
+      const draft = chatDraftsRef.current.get(tab.chatId)?.trim()
+      return draft ? `Draft: ${draft.slice(0, 48)}` : 'New chat'
+    }
     return runs.find(r => r.id === tab.runId)?.title || '(Untitled chat)'
   }, [runs])
 
@@ -4084,6 +4115,13 @@ function App() {
     codeMode?: 'claude' | 'codex',
     permissionMode?: PermissionMode,
   ) => {
+    const submitTabId = activeChatTabIdRef.current
+    const submitTab = chatTabsRef.current.find((tab) => tab.id === submitTabId)
+    if (!submitTab) return
+    const isSubmitTabActive = () => activeChatTabIdRef.current === submitTabId
+      && chatTabsRef.current.find((tab) => tab.id === submitTabId)?.chatId === submitTab.chatId
+    const submittedSelection = selectionByTabRef.current.get(submitTab.chatId)
+    const submittedContext = buildMiddlePaneContext()
     if (activeIsProcessing && inCallRef.current) {
       // In-call input arrives at arbitrary moments — a hard
       // drop here silently ate utterances submitted while the previous turn
@@ -4093,7 +4131,6 @@ function App() {
       await stopRunRef.current?.()
     }
 
-    const submitTabId = activeChatTabIdRef.current
     const { text } = message
     const userMessage = text.trim()
     const hasAttachments = stagedAttachments.length > 0
@@ -4158,7 +4195,7 @@ function App() {
           })),
         ]
       : undefined
-    setConversation((prev) => [...prev, {
+    if (isSubmitTabActive()) setConversation((prev) => [...prev, {
       id: userMessageId,
       role: 'user',
       content: userMessage,
@@ -4168,19 +4205,25 @@ function App() {
     setChatViewportAnchor(submitTabId, userMessageId)
 
     try {
-      let currentRunId = runId
+      let currentRunId = submitTab.runId
       let isNewRun = false
       let newRunCreatedAt: string | null = null
-      const selected = selectionByTabRef.current.get(chatIdForTab(submitTabId))
+      const selected = submittedSelection
       if (!currentRunId) {
-        const createdSession = await window.ipc.invoke('sessions:create', {})
+        let creation = creatingSessionByChatRef.current.get(submitTab.chatId)
+        if (!creation) {
+          creation = window.ipc.invoke('sessions:create', {})
+          creatingSessionByChatRef.current.set(submitTab.chatId, creation)
+          void creation.catch(() => creatingSessionByChatRef.current.delete(submitTab.chatId))
+        }
+        const createdSession = await creation
         currentRunId = createdSession.sessionId
         newRunCreatedAt = new Date().toISOString()
-        setRunId(currentRunId)
+        if (isSubmitTabActive()) setRunId(currentRunId)
         analytics.chatSessionCreated(currentRunId)
         // Update active chat tab's runId to the new run
         setChatTabs((prev) => prev.map((tab) => (
-          tab.id === submitTabId
+          tab.id === submitTabId && tab.chatId === submitTab.chatId
             ? { ...tab, runId: currentRunId }
             : tab
         )))
@@ -4345,7 +4388,7 @@ function App() {
           })
         }
 
-        const middlePaneContext = await buildMiddlePaneContext()
+        const middlePaneContext = await submittedContext
         sendResult = await sendSessionMessage({
           sessionId: currentRunId,
           input: {
@@ -4361,7 +4404,7 @@ function App() {
           searchEnabled: searchEnabled || undefined,
         })
       } else {
-        const middlePaneContext = await buildMiddlePaneContext()
+        const middlePaneContext = await submittedContext
         sendResult = await sendSessionMessage({
           sessionId: currentRunId,
           input: {
@@ -4382,7 +4425,7 @@ function App() {
       // this message yet — the pending chip above the composer represents it,
       // and the real bubble arrives via turn events when it is delivered.
       // Retract the optimistic bubble so it can't double-render.
-      if (sendResult.queued) {
+      if (sendResult.queued && isSubmitTabActive()) {
         setConversation((prev) => prev.filter((item) => item.id !== userMessageId))
       }
 
@@ -4408,11 +4451,15 @@ function App() {
   }
   handlePromptSubmitRef.current = handlePromptSubmit
 
-  const handleComposioConnected = useCallback((toolkitSlug: string) => {
+  const handleComposioConnected = useCallback((toolkitSlug: string, tabId = activeChatTabId) => {
     // Auto-send a continuation message when a Composio toolkit connects
     const name = composioDisplayNames[toolkitSlug] || toolkitSlug
+    if (tabId !== activeChatTabIdRef.current) {
+      toast(`${name} connected successfully`, { description: 'Return to the original chat to continue.' })
+      return
+    }
     handlePromptSubmitRef.current?.({ text: `${name} connected successfully.`, files: [] })
-  }, [])
+  }, [activeChatTabId])
 
   // The composer's stop state clears when the active turn settles.
   useEffect(() => {
@@ -4424,6 +4471,8 @@ function App() {
 
   const handleStop = useCallback(async () => {
     if (!runId) return
+    const stoppedTabId = activeChatTabIdRef.current
+    const stoppedChatId = chatIdForTab(stoppedTabId)
     setStopClickedAt(Date.now())
     setIsStopping(true)
     // Stopping the run must also silence it — the TTS queue holds segments
@@ -4441,10 +4490,10 @@ function App() {
         .filter(Boolean)
         .join('\n\n')
       if (drainedText) {
-        const draft = chatDraftsRef.current
-          .get(chatIdForTab(activeChatTabIdRef.current))
-          ?.trim()
-        setPresetMessage(draft ? `${draft}\n\n${drainedText}` : drainedText)
+        const draft = chatDraftsRef.current.get(stoppedChatId)?.trim()
+        const restored = draft ? `${draft}\n\n${drainedText}` : drainedText
+        chatDraftsRef.current.set(stoppedChatId, restored)
+        if (activeChatTabIdRef.current === stoppedTabId) setPresetMessage(restored)
       }
     } catch (error) {
       console.error('Failed to stop turn:', error)
@@ -4462,14 +4511,21 @@ function App() {
   }, [sessionChat])
 
   const handlePullQueued = useCallback(async (queueId: string) => {
+    const targetTabId = activeChatTabIdRef.current
+    const targetChatId = chatIdForTab(targetTabId)
     try {
       const removed = await sessionChat.removeQueued(queueId)
       const text = removed ? queuedMessageText(removed.message) : ''
-      if (text) setPresetMessage(text)
+      if (text) {
+        const draft = chatDraftsRef.current.get(targetChatId)?.trim()
+        const restored = draft ? `${draft}\n\n${text}` : text
+        chatDraftsRef.current.set(targetChatId, restored)
+        if (activeChatTabIdRef.current === targetTabId) setPresetMessage(restored)
+      }
     } catch (error) {
       console.error('Failed to pull back queued message:', error)
     }
-  }, [sessionChat])
+  }, [sessionChat, chatIdForTab])
 
   const handlePermissionResponse = useCallback(async (
     toolCallId: string,
@@ -4550,6 +4606,54 @@ function App() {
     selectionByTabRef.current.delete(chatIdForTab(activeChatTabIdRef.current))
   }, [setChatViewportAnchor])
 
+  const activateAssistantTab = useCallback((tab: ChatTab) => {
+    cancelRecordingIfActive()
+    setPresetMessage(chatDraftsRef.current.get(tab.chatId))
+    activeChatTabIdRef.current = tab.id
+    setActiveChatTabId(tab.id)
+    if (tab.runId) void loadRun(tab.runId)
+    else {
+      loadRunRequestIdRef.current += 1
+      setRunId(null)
+      setConversation([])
+      setCurrentAssistantMessage('')
+      setIsProcessing(false)
+      setIsStopping(false)
+      setPendingAskHumanRequests(new Map())
+      setAllPermissionRequests(new Map())
+      setPermissionResponses(new Map())
+      setAutoPermissionDecisions(new Map())
+    }
+  }, [cancelRecordingIfActive, loadRun])
+
+  useEffect(() => {
+    const initialTab = chatTabsRef.current.find((tab) => tab.id === activeChatTabIdRef.current)
+    if (initialTab?.runId) activateAssistantTab(initialTab)
+  }, [activateAssistantTab])
+
+  const addAssistantTab = useCallback((initialSelection?: ModelSelection | null) => {
+    const tab = createAssistantTab()
+    if (initialSelection) selectionByTabRef.current.set(tab.chatId, initialSelection)
+    setChatTabs((previous) => [...previous, tab])
+    activateAssistantTab(tab)
+    setIsChatSidebarOpen(true)
+  }, [activateAssistantTab])
+
+  const closeAssistantTab = useCallback((tabId: string) => {
+    const next = tabsAfterClose(chatTabsRef.current, tabId, activeChatTabIdRef.current)
+    if (!next.tabs.length) {
+      const blank = createAssistantTab()
+      setChatTabs([blank])
+      activateAssistantTab(blank)
+      setIsChatSidebarOpen(false)
+    } else {
+      setChatTabs(next.tabs)
+      if (tabId === activeChatTabIdRef.current) {
+        activateAssistantTab(next.tabs.find((tab) => tab.id === next.activeId)!)
+      }
+    }
+  }, [activateAssistantTab])
+
   // Bind the single chat surface to a session. THE one way any part of the
   // app points the chat at a conversation (recents, history, Home threads,
   // code sessions, quick-ask). No-ops when already bound; otherwise rebinds
@@ -4557,6 +4661,13 @@ function App() {
   const bindChatToRun = useCallback((rid: string) => {
     const active = chatTabsRef.current.find((t) => t.id === activeChatTabIdRef.current)
     if (active?.runId === rid) return
+    if (useBottomTabs || chatTabsRef.current.length > 1) {
+      const existing = chatTabsRef.current.find((tab) => tab.runId === rid)
+      const tab = existing ?? createAssistantTab(rid)
+      if (!existing) setChatTabs((previous) => [...previous, tab])
+      activateAssistantTab(tab)
+      return
+    }
     // Cancel any active dictation — its transcript belongs to the old chat.
     cancelRecordingIfActive()
     setChatTabs((prev) => prev.map((t) => (
@@ -4566,7 +4677,7 @@ function App() {
       t.id === activeChatTabIdRef.current ? { ...t, runId: rid, chatId: rid } : t
     )))
     void loadRun(rid)
-  }, [cancelRecordingIfActive, loadRun])
+  }, [cancelRecordingIfActive, loadRun, useBottomTabs, activateAssistantTab])
   bindChatToRunRef.current = bindChatToRun
 
   // A code session was selected in the Code view: bind the chat to it — the
@@ -4696,6 +4807,14 @@ function App() {
   }, [])
 
   const handleNewChatTab = useCallback(() => {
+    if (useBottomTabs || chatTabsRef.current.length > 1) {
+      addAssistantTab()
+      if (isCodeOpen) {
+        closeAllSections()
+        setExpandedFrom(currentViewState)
+      }
+      return
+    }
     // Single-chat model: reset the one conversation in place instead of
     // opening a new tab. Fresh chatId = fresh chat-session instance.
     setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId: crypto.randomUUID() }])
@@ -4706,7 +4825,7 @@ function App() {
     const from = currentViewState.type === 'chat' ? null : currentViewState
     closeAllSections()
     setExpandedFrom(from)
-  }, [dismissBrowserOverlay, handleNewChat, closeAllSections, currentViewState])
+  }, [dismissBrowserOverlay, handleNewChat, closeAllSections, currentViewState, useBottomTabs, addAssistantTab, isCodeOpen])
 
   // Sidebar variant: reset the chat in place without leaving file/graph context.
   // A caller with a selection already chosen for the fresh chat (the Home
@@ -4714,11 +4833,15 @@ function App() {
   // rebind commit — the remounted composer's initialSelection then shows the
   // same pair the sends will use, instead of racing the settings seed.
   const handleNewChatTabInSidebar = useCallback((initialSelection?: ModelSelection | null) => {
+    if (useBottomTabs || chatTabsRef.current.length > 1) {
+      addAssistantTab(initialSelection)
+      return
+    }
     const chatId = crypto.randomUUID()
     if (initialSelection) selectionByTabRef.current.set(chatId, initialSelection)
     setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId }])
     handleNewChat()
-  }, [handleNewChat])
+  }, [handleNewChat, useBottomTabs, addAssistantTab])
 
   // A chat was deleted (sessions:delete succeeded): drop it from the recents
   // list, and if it was the one on screen, reset the chat surface in place to
@@ -4732,8 +4855,12 @@ function App() {
     }
     const openTab = chatTabs.find((t) => t.runId === rid)
     if (!openTab) return
+    if (useBottomTabs || chatTabs.length > 1) {
+      closeAssistantTab(openTab.id)
+      return
+    }
     handleNewChatTabInSidebar()
-  }, [chatTabs, handleNewChatTabInSidebar])
+  }, [chatTabs, handleNewChatTabInSidebar, useBottomTabs, closeAssistantTab])
 
   // The companion's "+": a fresh COMPANION conversation for its next
   // question. The app window's chat is untouched.
@@ -5164,12 +5291,15 @@ function App() {
       case 'chat':
         if (view.runId) {
           bindChatToRun(view.runId)
+        } else if (useBottomTabs || chatTabsRef.current.length > 1) {
+          const current = chatTabsRef.current.find((tab) => tab.id === activeChatTabIdRef.current)
+          if (current?.runId) addAssistantTab()
         } else {
           handleNewChat()
         }
         return
     }
-  }, [closeAllSections, bindChatToRun, handleNewChat, isSpacesOpen])
+  }, [closeAllSections, bindChatToRun, handleNewChat, isSpacesOpen, useBottomTabs, addAssistantTab])
   applyViewStateRef.current = applyViewState
 
   const navigateToView = useCallback(async (nextView: ViewState) => {
@@ -5189,6 +5319,15 @@ function App() {
     setHistory(nextHistory)
     await applyViewState(nextView)
   }, [appendUnique, applyViewState, cancelRecordingIfActive, setHistory, isBrowserOpen, dismissBrowserOverlay])
+
+  const openAssistantRun = useCallback((sessionId: string) => {
+    if (useBottomTabs && !isCodeOpen) {
+      bindChatToRun(sessionId)
+      setIsChatSidebarOpen(true)
+    } else {
+      void navigateToView({ type: 'chat', runId: sessionId })
+    }
+  }, [useBottomTabs, isCodeOpen, bindChatToRun, navigateToView])
 
   // Move the maximized/full-screen chat into the right side pane: restore the
   // view we expanded from (or fall back to Home) and dock the chat on the right.
@@ -5824,6 +5963,11 @@ function App() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'l') {
         e.preventDefault()
+        if (useBottomTabs && !isCodeOpen && !isFullScreenChat) {
+          setIsChatSidebarOpen((open) => !open)
+          setIsRightPaneMaximized(false)
+          return
+        }
         if (isFullScreenChat && expandedFrom) {
           handleCloseFullScreenChat()
         } else {
@@ -5833,7 +5977,7 @@ function App() {
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [handleCloseFullScreenChat, isFullScreenChat, expandedFrom, navigateToFullScreenChat])
+  }, [handleCloseFullScreenChat, isFullScreenChat, expandedFrom, navigateToFullScreenChat, useBottomTabs, isCodeOpen])
 
   // Keyboard shortcut: Cmd+K / Ctrl+K opens the search palette (search-only).
   useEffect(() => {
@@ -6752,11 +6896,16 @@ function App() {
   // the workspace drawer at its edge. Before a session is picked the empty
   // state owns the pane and the chat stays out of the way.
   const codeChatMain = isCodeOpen && activeCodeSession !== null
+  const floatingAssistant = useBottomTabs && !isFullScreenChat && !isCodeOpen && !isBrowserOpen
+  const dockFullScreen = useBottomTabs && isFullScreenChat
+  const showAssistantDock = useBottomTabs && !isCodeOpen
   const chatPaneOpen = isCodeOpen ? codeChatMain : isChatSidebarOpen
-  const isRightPaneOnlyMode = isRightPaneContext && chatPaneOpen && isRightPaneMaximized
+  const isRightPaneOnlyMode = (isRightPaneContext || floatingAssistant) && chatPaneOpen && isRightPaneMaximized
   const shouldCollapseLeftPane = isRightPaneOnlyMode
   const nonChatPaneStyle = React.useMemo<React.CSSProperties>(() => {
     const style: React.CSSProperties = { maxWidth: insetMaxWidth }
+    if (dockFullScreen) return { display: 'none' }
+    if (floatingAssistant && !isRightPaneMaximized) return style
     if (!isRightPaneContext || !chatPaneOpen || isRightPaneMaximized) return style
     if (codeChatMain) {
       return { ...style, width: codeRailWidth, flex: '0 0 auto' }
@@ -6768,7 +6917,7 @@ function App() {
       return { ...style, width: DEFAULT_CHAT_PANE_WIDTH, flex: '0 0 auto' }
     }
     return style
-  }, [chatPaneSize, codeChatMain, codeRailWidth, chatPaneOpen, insetMaxWidth, isRightPaneContext, isRightPaneMaximized])
+  }, [chatPaneSize, codeChatMain, codeRailWidth, chatPaneOpen, insetMaxWidth, isRightPaneContext, isRightPaneMaximized, floatingAssistant, dockFullScreen])
   // Collapsing: pin max-width to the snapshot px (no transition) for one frame so it's
   // binding immediately (no flex jump), then animate to 0. Expanding goes back to 100%
   // — its non-binding range lands at the end of the range, where it isn't visible.
@@ -6857,7 +7006,7 @@ function App() {
     onOpenSpace: openSpace,
     activeSpace: isSpacesOpen ? spaceSelection : null,
     recentRuns: runs,
-    onOpenRun: (rid: string) => void navigateToView({ type: 'chat', runId: rid }),
+    onOpenRun: openAssistantRun,
     onRenameRun: (rid: string, title: string) => {
       void window.ipc.invoke('sessions:setTitle', { sessionId: rid, title })
         .then(() => setRuns((prev) => prev.map((r) => (r.id === rid ? { ...r, title } : r))))
@@ -6915,7 +7064,7 @@ function App() {
             <SidebarInset
               className={cn(
                 "overflow-hidden! min-h-0 min-w-0",
-                isRightPaneContext && isChatPaneInMiddle && "order-3",
+                isRightPaneContext && isChatPaneInMiddle && !(useBottomTabs && isBrowserOpen) && "order-3",
                 insetAnimateMaxWidth && "transition-[max-width] duration-200 ease-linear",
                 shouldCollapseLeftPane && "pointer-events-none select-none"
               )}
@@ -6942,7 +7091,7 @@ function App() {
                     recentRuns={runs}
                     activeRunId={runId}
                     sessionUsage={activeChatTabState.sessionUsage}
-                    onSelectRun={(rid) => void navigateToView({ type: 'chat', runId: rid })}
+                    onSelectRun={openAssistantRun}
                     onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
                   />
                 ) : (
@@ -7263,7 +7412,7 @@ function App() {
                       if (spaceSelection) void navigateToView({ type: 'spaces', orgId: spaceSelection.orgId, spaceId: spaceSelection.spaceId, rail })
                       else setRailSelection(rail)
                     }}
-                    onOpenSession={(sessionId) => void navigateToView({ type: 'chat', runId: sessionId })}
+                    onOpenSession={openAssistantRun}
                   />
                 </div>
                 </Activity>
@@ -7293,7 +7442,7 @@ function App() {
                     onNavigate={(path) => { void navigateToView({ type: 'workspace', path: path === WORKSPACE_ROOT ? undefined : path }) }}
                     onOpenNote={(path) => navigateToFile(path)}
                     onCreateWorkspace={async (name) => { await knowledgeActions.createWorkspace(name) }}
-                    onOpenRun={(rid) => void navigateToView({ type: 'chat', runId: rid })}
+                    onOpenRun={openAssistantRun}
                   />
                 </div>
                 </Activity>
@@ -7361,7 +7510,7 @@ function App() {
                     runs={runs}
                     currentRunId={runId}
                     processingRunIds={processingRunIds}
-                    onSelectRun={(rid) => void navigateToView({ type: 'chat', runId: rid })}
+                    onSelectRun={openAssistantRun}
                     onRenameRun={(rid, title) => {
                       void window.ipc.invoke('sessions:setTitle', { sessionId: rid, title })
                         .then(() => setRuns((prev) => prev.map((r) => (r.id === rid ? { ...r, title } : r))))
@@ -7592,7 +7741,7 @@ function App() {
                   />
                 </div>
               )}
-              {activeMiddle === 'chat' && (
+              {activeMiddle === 'chat' && !useBottomTabs && (
               <FileCardProvider onOpenKnowledgeFile={(path) => { navigateToFile(path) }} onOpenFile={(path) => { navigateToFile(path) }}>
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="relative min-h-0 flex-1">
@@ -7614,7 +7763,7 @@ function App() {
                         onPermissionResponse={handlePermissionResponse}
                         onAskHumanResponse={handleAskHumanResponse}
                         onCodePermissionResponse={handleCodePermissionResponse}
-                        onComposioConnected={handleComposioConnected}
+                        onComposioConnected={(slug) => handleComposioConnected(slug, tab.id)}
                         activeIsWorking={activeIsWorking}
                         activeIsProcessing={activeIsProcessing}
                         activeIsReasoning={activeIsReasoning}
@@ -7707,16 +7856,24 @@ function App() {
             {/* Chat pane - shown when viewing files/graph/code. Code sessions
                 bind this same assistant chat (a code session IS a chat
                 session) — there is no separate code chat surface. */}
-            {isRightPaneContext && (
+            {(isRightPaneContext || useBottomTabs) && (
               <CodeDiffOpenerProvider onOpenDiff={codeChatMain ? openCodeDiff : null}>
               <ChatSidebar
-                placement={chatPanePlacement}
+                floating={floatingAssistant && !isRightPaneMaximized}
+                keepMounted={useBottomTabs || chatTabs.length > 1}
+                onMinimize={showAssistantDock && !dockFullScreen ? () => {
+                  setIsChatSidebarOpen(false)
+                  setIsRightPaneMaximized(false)
+                  requestAnimationFrame(() => document.querySelector<HTMLButtonElement>(`[data-assistant-tab="${CSS.escape(activeChatTabId)}"]`)?.focus())
+                } : undefined}
+                onCloseTab={showAssistantDock ? () => closeAssistantTab(activeChatTabId) : undefined}
+                placement={useBottomTabs && isBrowserOpen ? 'right' : chatPanePlacement}
                 // Code mode: the chat fills whatever the rail and drawer leave.
                 paneSize={codeChatMain ? 'chat-bigger' : chatPaneSize}
-                className={isChatPaneInMiddle ? "order-2" : undefined}
+                className={cn(isChatPaneInMiddle && !(useBottomTabs && isBrowserOpen) && "order-2", showAssistantDock && !(floatingAssistant && !isRightPaneMaximized) && 'mb-11')}
                 defaultWidth={DEFAULT_CHAT_PANE_WIDTH}
-                isOpen={chatPaneOpen}
-                isMaximized={isRightPaneMaximized}
+                isOpen={dockFullScreen || chatPaneOpen}
+                isMaximized={dockFullScreen || isRightPaneMaximized}
                 chatTabs={chatTabs}
                 activeChatTabId={activeChatTabId}
                 getChatTabTitle={getChatTabTitle}
@@ -7724,7 +7881,7 @@ function App() {
                 recentRuns={runs}
                 onSelectRun={bindChatToRun}
                 onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
-                onOpenFullScreen={toggleRightPaneMaximize}
+                onOpenFullScreen={dockFullScreen ? undefined : toggleRightPaneMaximize}
                 onNavigateBack={() => { void navigateBack() }}
                 onNavigateForward={() => { void navigateForward() }}
                 canNavigateBack={canNavigateBack}
@@ -7817,6 +7974,26 @@ function App() {
               />
               </CodeDiffOpenerProvider>
             )}
+            {useBottomTabs && (
+              <AssistantChatDock
+                hidden={!showAssistantDock}
+                tabs={chatTabs}
+                activeId={activeChatTabId}
+                expanded={dockFullScreen || chatPaneOpen}
+                getTitle={getChatTabTitle}
+                onNew={addAssistantTab}
+                onClose={closeAssistantTab}
+                onSelect={(tab) => {
+                  if (tab.id === activeChatTabId && chatPaneOpen && !dockFullScreen) {
+                    setIsChatSidebarOpen(false)
+                    setIsRightPaneMaximized(false)
+                  } else {
+                    if (tab.id !== activeChatTabId) activateAssistantTab(tab)
+                    setIsChatSidebarOpen(true)
+                  }
+                }}
+              />
+            )}
             {/* Workspace drawer beside the code chat: changes, files or a
                 terminal — one of the chat header's buttons opens it. */}
             {codeChatMain && activeCodeSession && codePanel && (
@@ -7907,7 +8084,7 @@ function App() {
           onOpenChange={(o) => { setIsSearchOpen(o); if (!o) setSearchDefaultScope(undefined) }}
           defaultScope={searchDefaultScope}
           onSelectFile={navigateToFile}
-          onSelectRun={(id) => { void navigateToView({ type: 'chat', runId: id }) }}
+          onSelectRun={openAssistantRun}
         />
       </SidebarSectionProvider>
       <Toaster />

--- a/apps/x/apps/renderer/src/components/assistant-chat-dock.test.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-chat-dock.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AssistantChatDock } from './assistant-chat-dock'
+
+const sessions = vi.hoisted(() => new Map<string, { isProcessing: boolean; isWaitingOnHuman: boolean }>())
+vi.mock('@/hooks/useSessionChat', () => ({ useSessionChat: (sessionId: string) => ({ chatState: sessions.get(sessionId) }) }))
+vi.mock('@/lib/session-title', () => ({ useSessionTitle: () => undefined }))
+
+beforeEach(() => {
+  sessions.clear()
+  vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} })
+})
+afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+const tabs = [
+  { id: 'first', chatId: 'first', runId: 'first' },
+  { id: 'second', chatId: 'second', runId: 'second' },
+]
+const baseProps = { tabs, activeId: 'first', expanded: true, getTitle: (tab: { id: string }) => tab.id, onSelect: vi.fn(), onClose: vi.fn(), onNew: vi.fn() }
+
+describe('AssistantChatDock', () => {
+  it('keeps a single minimized tab compact instead of filling the dock', () => {
+    render(<AssistantChatDock {...baseProps} tabs={[tabs[0]]} expanded={false} />)
+    const tab = screen.getByRole('button', { name: 'first' })
+    expect(tab).toHaveAttribute('aria-expanded', 'false')
+    expect(tab.parentElement?.parentElement).toHaveClass('flex-[0_1_240px]')
+    expect(tab.parentElement?.parentElement).not.toHaveClass('flex-1')
+  })
+
+  it('opens, closes and creates tabs with separate accessible controls', () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const onNew = vi.fn()
+    render(<AssistantChatDock {...baseProps} onSelect={onSelect} onClose={onClose} onNew={onNew} />)
+    expect(screen.getByRole('button', { name: 'first' })).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'second' }))
+    expect(onSelect).toHaveBeenCalledWith(tabs[1])
+    fireEvent.click(screen.getByRole('button', { name: 'Close tab: second' }))
+    expect(onClose).toHaveBeenCalledWith('second')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'New assistant chat' }))
+    expect(onNew).toHaveBeenCalledOnce()
+    expect(onNew).toHaveBeenCalledWith()
+  })
+
+  it('marks background completion unread without opening it, then clears on reading', () => {
+    sessions.set('second', { isProcessing: true, isWaitingOnHuman: false })
+    const onSelect = vi.fn()
+    const { rerender } = render(<AssistantChatDock {...baseProps} onSelect={onSelect} />)
+    expect(screen.getByRole('button', { name: 'second — Working' })).toBeVisible()
+    sessions.set('second', { isProcessing: false, isWaitingOnHuman: false })
+    rerender(<AssistantChatDock {...baseProps} onSelect={onSelect} />)
+    expect(screen.getByRole('button', { name: 'second — Unread response' })).toBeVisible()
+    expect(onSelect).not.toHaveBeenCalled()
+    rerender(<AssistantChatDock {...baseProps} onSelect={onSelect} activeId="second" />)
+    expect(screen.getByRole('button', { name: 'second' })).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('shows pending input and keeps the active chat visible when tabs overflow', () => {
+    sessions.set('last', { isProcessing: true, isWaitingOnHuman: true })
+    const manyTabs = [...tabs, { id: 'third', chatId: 'third', runId: 'third' }, { id: 'last', chatId: 'last', runId: 'last' }]
+    render(<AssistantChatDock {...baseProps} tabs={manyTabs} activeId="last" />)
+    expect(screen.getByRole('button', { name: 'last — Needs your input' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'More chats (1)' })).toBeVisible()
+  })
+})

--- a/apps/x/apps/renderer/src/components/assistant-chat-dock.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-chat-dock.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronUp, Loader2, MessageCircle, Plus, X } from 'lucide-react'
+import { useSessionChat } from '@/hooks/useSessionChat'
+import { useSessionTitle } from '@/lib/session-title'
+import { cn } from '@/lib/utils'
+import type { ChatTab } from './tab-bar'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
+
+interface AssistantChatDockProps {
+  hidden?: boolean
+  tabs: ChatTab[]
+  activeId: string
+  expanded: boolean
+  getTitle: (tab: ChatTab) => string
+  onSelect: (tab: ChatTab) => void
+  onClose: (tabId: string) => void
+  onNew: () => void
+}
+
+function DockTab({ tab, active, expanded, title, onSelect, onClose, onStatus }: {
+  tab: ChatTab
+  active: boolean
+  expanded: boolean
+  title: string
+  onSelect: () => void
+  onClose: () => void
+  onStatus: (tabId: string, status: string) => void
+}) {
+  const session = useSessionChat(tab.runId)
+  const sessionTitle = useSessionTitle(tab.runId)
+  const working = session.chatState?.isProcessing ?? false
+  const waiting = session.chatState?.isWaitingOnHuman ?? false
+  const reading = active && expanded
+  const [activity, setActivity] = useState({ working, reading, unread: false })
+  if (activity.working !== working || activity.reading !== reading) {
+    setActivity({ working, reading, unread: reading ? false : activity.unread || (activity.working && !working) })
+  }
+  const unread = activity.unread && !reading
+  const status = waiting ? 'Needs your input' : working ? 'Working' : unread ? 'Unread response' : ''
+  useEffect(() => onStatus(tab.id, status), [onStatus, tab.id, status])
+  const label = sessionTitle ?? title
+  return (
+    <div className={cn('flex min-w-0 items-center rounded-t-lg border border-border bg-background shadow-sm', active && expanded && 'bg-accent')}>
+      <button
+        type="button"
+        data-assistant-tab={tab.id}
+        className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-tl-lg px-3 text-left text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={onSelect}
+        aria-expanded={active && expanded}
+        aria-label={`${label}${status ? ` — ${status}` : ''}`}
+        title={`${label}${status ? ` — ${status}` : ''}`}
+      >
+        {working && !waiting ? <Loader2 className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none" /> : <MessageCircle className="size-3.5 shrink-0" />}
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {(waiting || unread) && <span className="shrink-0 text-xs font-medium">{waiting ? '!' : '●'}</span>}
+        <span className="sr-only" role="status">{status}</span>
+      </button>
+      <button type="button" onClick={onClose} aria-label={`Close tab: ${label}`} title="Close tab — conversation stays in history" className="mr-1 flex size-7 shrink-0 items-center justify-center rounded hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring">
+        <X className="size-3.5" />
+      </button>
+    </div>
+  )
+}
+
+export function AssistantChatDock({ tabs, activeId, expanded, getTitle, onSelect, onClose, onNew, hidden = false }: AssistantChatDockProps) {
+  const dockRef = useRef<HTMLDivElement>(null)
+  const [capacity, setCapacity] = useState(3)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [statuses, setStatuses] = useState<Record<string, string>>({})
+  const onStatus = useCallback((tabId: string, status: string) => {
+    setStatuses((previous) => previous[tabId] === status ? previous : { ...previous, [tabId]: status })
+  }, [])
+  useEffect(() => {
+    const dock = dockRef.current
+    if (!dock) return
+    const observer = new ResizeObserver(() => setCapacity(Math.max(1, Math.floor((dock.clientWidth - 140) / 190))))
+    observer.observe(dock)
+    return () => observer.disconnect()
+  }, [])
+  const activeIndex = tabs.findIndex((tab) => tab.id === activeId)
+  const visibleIds = new Set(tabs.slice(0, capacity).map((tab) => tab.id))
+  if (activeIndex >= capacity) {
+    visibleIds.delete(tabs[capacity - 1]?.id)
+    visibleIds.add(activeId)
+  }
+  const overflow = tabs.filter((tab) => !visibleIds.has(tab.id))
+  return (
+    <div ref={dockRef} data-assistant-dock={hidden ? undefined : ''} role="region" aria-label="Assistant chats" hidden={hidden} className={cn('titlebar-no-drag pointer-events-none fixed bottom-0 right-3 z-30 h-11 w-[min(760px,calc(100vw-88px))] items-end justify-end gap-1.5', hidden ? 'hidden' : 'flex')}>
+      {tabs.map((tab) => (
+        <div key={tab.id} className={visibleIds.has(tab.id) ? 'pointer-events-auto min-w-0 flex-[0_1_240px]' : 'hidden'}>
+          <DockTab tab={tab} active={tab.id === activeId} expanded={expanded} title={getTitle(tab)} onSelect={() => onSelect(tab)} onClose={() => onClose(tab.id)} onStatus={onStatus} />
+        </div>
+      ))}
+      {overflow.length > 0 && (
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+          <DropdownMenuTrigger asChild>
+            <button type="button" className="pointer-events-auto flex h-10 shrink-0 items-center gap-1 rounded-t-lg border border-border bg-background px-3 text-xs hover:bg-accent" aria-label={`More chats (${overflow.length})`}>
+              <ChevronUp className="size-3.5" /> {overflow.length} more{overflow.some((tab) => statuses[tab.id] === 'Needs your input' || statuses[tab.id] === 'Unread response') ? ' ●' : ''}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="top" align="end" className="max-h-80 w-72 overflow-y-auto">
+            {overflow.map((tab) => (
+              <div key={tab.id} className="flex items-center">
+                <DropdownMenuItem className="min-w-0 flex-1" onSelect={() => { onSelect(tab); setMenuOpen(false) }}>
+                  <span className="min-w-0 truncate">{getTitle(tab)}{statuses[tab.id] ? ` — ${statuses[tab.id]}` : ''}</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem aria-label={`Close tab: ${getTitle(tab)}`} onSelect={(event) => { event.preventDefault(); onClose(tab.id) }}><X className="size-3.5" /></DropdownMenuItem>
+              </div>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      <button type="button" onClick={() => onNew()} aria-label="New assistant chat" title="New assistant chat" className="pointer-events-auto flex size-10 shrink-0 items-center justify-center rounded-t-lg border border-border bg-background hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"><Plus className="size-4" /></button>
+    </div>
+  )
+}

--- a/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -444,7 +444,8 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
     const left = Math.ceil(rect.left * zoomFactor)
     const top = Math.ceil(rect.top * zoomFactor)
     const right = Math.floor(clampedRightCss * zoomFactor)
-    const bottom = Math.floor(rect.bottom * zoomFactor)
+    const dock = el.ownerDocument.querySelector<HTMLElement>('[data-assistant-dock]')
+    const bottom = Math.floor(Math.min(rect.bottom, dock?.getBoundingClientRect().top ?? rect.bottom) * zoomFactor)
     const width = right - left
     const height = bottom - top
 

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -211,6 +211,7 @@ const CALL_PRESET_MENU: Array<{ preset: CallPreset; label: string; description: 
 ]
 
 interface ChatInputInnerProps {
+  draftKey?: string
   onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
   onStop?: () => void
   isProcessing: boolean
@@ -278,7 +279,10 @@ interface ChatInputInnerProps {
   focusSignal?: number
 }
 
+const attachmentsByDraft = new Map<string, StagedAttachment[]>()
+
 function ChatInputInner({
+  draftKey,
   onSubmit,
   onStop,
   isProcessing,
@@ -320,7 +324,12 @@ function ChatInputInner({
   // and stayed wrong after a rebind).
   const summonShortcut = useQuickAskShortcut()
   const summonShortcutLabel = quickAskShortcut.formatShortcut(summonShortcut.accelerator, isMac)
-  const [attachments, setAttachments] = useState<StagedAttachment[]>([])
+  const [attachments, setAttachments] = useState<StagedAttachment[]>(() => draftKey ? attachmentsByDraft.get(draftKey) ?? [] : [])
+  useEffect(() => {
+    if (!draftKey) return
+    if (attachments.length) attachmentsByDraft.set(draftKey, attachments)
+    else attachmentsByDraft.delete(draftKey)
+  }, [attachments, draftKey])
   const [focusNonce, setFocusNonce] = useState(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const canSubmit = (Boolean(message.trim()) || attachments.length > 0)
@@ -1495,6 +1504,7 @@ export function VoiceWaveform({ audioLevelsRef }: { audioLevelsRef?: React.Mutab
 }
 
 export interface ChatInputWithMentionsProps {
+  draftKey?: string
   knowledgeFiles: string[]
   recentFiles: string[]
   visibleFiles: string[]
@@ -1544,6 +1554,7 @@ export interface ChatInputWithMentionsProps {
 }
 
 export function ChatInputWithMentions({
+  draftKey,
   knowledgeFiles,
   recentFiles,
   visibleFiles,
@@ -1584,6 +1595,7 @@ export function ChatInputWithMentions({
   return (
     <PromptInputProvider knowledgeFiles={knowledgeFiles} recentFiles={recentFiles} visibleFiles={visibleFiles}>
       <ChatInputInner
+        draftKey={draftKey}
         onSubmit={onSubmit}
         onStop={onStop}
         isProcessing={isProcessing}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -391,6 +391,7 @@ export function ChatSessionComposer({
         </div>
       )}
       <ChatInputWithMentions
+        draftKey={tab.chatId}
         knowledgeFiles={knowledgeFiles}
         recentFiles={recentFiles}
         visibleFiles={visibleFiles}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
@@ -1,0 +1,56 @@
+import { useState, type ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ChatSidebar } from './chat-sidebar'
+
+vi.mock('@/components/ui/sidebar', () => ({ useSidebar: () => ({ state: 'collapsed' }) }))
+vi.mock('@/lib/tab-meta', () => ({ useTabMeta: () => ({}) }))
+vi.mock('@/components/chat-header', () => ({ ChatHeader: () => <div>Chat header</div> }))
+vi.mock('@/components/code/code-session-header', () => ({ CodeSessionHeader: () => null }))
+vi.mock('@/contexts/file-card-context', () => ({ FileCardProvider: ({ children }: { children: ReactNode }) => children }))
+vi.mock('@/components/chat-session', () => ({
+  ChatSessionPane: () => <div>Conversation</div>,
+  ChatSessionComposer: ({ tab, isActive }: { tab: { id: string }; isActive: boolean }) => {
+    const [text, setText] = useState('')
+    return <input aria-label={tab.id} hidden={!isActive} value={text} onChange={(event) => setText(event.target.value)} />
+  },
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} })
+})
+afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+const props = {
+  chatTabs: [{ id: 'first', chatId: 'first', runId: null }, { id: 'second', chatId: 'second', runId: null }],
+  activeChatTabId: 'first', getChatTabTitle: () => 'Chat', onNewChatTab: vi.fn(),
+  conversation: [], currentAssistantMessage: '', isProcessing: false, onSubmit: vi.fn(),
+  keepMounted: true, floating: true,
+}
+
+describe('floating ChatSidebar', () => {
+  it('preserves composer instances when minimized, switched and expanded', () => {
+    const { rerender } = render(<ChatSidebar {...props} isOpen />)
+    fireEvent.change(screen.getByLabelText('first'), { target: { value: 'Unsent draft' } })
+    rerender(<ChatSidebar {...props} isOpen={false} />)
+    expect(screen.getByLabelText('first')).toHaveValue('Unsent draft')
+    expect(screen.getByLabelText('first')).not.toBeVisible()
+    rerender(<ChatSidebar {...props} isOpen activeChatTabId="second" />)
+    fireEvent.change(screen.getByLabelText('second'), { target: { value: 'Independent draft' } })
+    rerender(<ChatSidebar {...props} isOpen floating={false} isMaximized />)
+    expect(screen.getByLabelText('first')).toHaveValue('Unsent draft')
+    expect(screen.getByLabelText('second')).toHaveValue('Independent draft')
+  })
+
+  it('minimizes via Escape without closing or stopping the conversation', () => {
+    const onMinimize = vi.fn()
+    const onCloseTab = vi.fn()
+    const onStop = vi.fn()
+    render(<ChatSidebar {...props} isOpen onMinimize={onMinimize} onCloseTab={onCloseTab} onStop={onStop} />)
+    fireEvent.keyDown(screen.getByLabelText('first'), { key: 'Escape' })
+    expect(onMinimize).toHaveBeenCalledOnce()
+    expect(onCloseTab).not.toHaveBeenCalled()
+    expect(onStop).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
+import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight, Minus, X } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { readAssistantPreference, writeAssistantPreference } from '@/lib/assistant-dock'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ChatHeader } from '@/components/chat-header'
 import { CodeSessionHeader, type CodeSessionHeaderProps } from '@/components/code/code-session-header'
@@ -53,6 +54,10 @@ function getInitialPaneWidth(defaultWidth: number): number {
 }
 
 interface ChatSidebarProps {
+  floating?: boolean
+  keepMounted?: boolean
+  onMinimize?: () => void
+  onCloseTab?: () => void
   defaultWidth?: number
   isOpen?: boolean
   isMaximized?: boolean
@@ -139,10 +144,14 @@ interface ChatSidebarProps {
   onStartCall?: (preset: CallPreset) => void
   onEndCall?: () => void
   callAvailable?: boolean
-  onComposioConnected?: (toolkitSlug: string) => void
+  onComposioConnected?: (toolkitSlug: string, tabId?: string) => void
 }
 
 export function ChatSidebar({
+  floating = false,
+  keepMounted = false,
+  onMinimize,
+  onCloseTab,
   defaultWidth = DEFAULT_WIDTH,
   isOpen = true,
   isMaximized = false,
@@ -227,6 +236,16 @@ export function ChatSidebar({
   const [width, setWidth] = useState(() => getInitialPaneWidth(defaultWidth))
   const [isResizing, setIsResizing] = useState(false)
   const [showContent, setShowContent] = useState(isOpen)
+  const [floatingSize, setFloatingSize] = useState(() => {
+    const fallback = { width: 460, height: 600 }
+    try {
+      const saved = JSON.parse(readAssistantPreference('rowboat-assistant-floating-size') ?? 'null')
+      if (Number.isFinite(saved?.width) && Number.isFinite(saved?.height)) {
+        return { width: Math.max(360, Math.min(900, saved.width)), height: Math.max(320, Math.min(1000, saved.height)) }
+      }
+    } catch { return fallback }
+    return fallback
+  })
   const [localPresetMessage, setLocalPresetMessage] = useState<string | undefined>(undefined)
 
   const paneRef = useRef<HTMLDivElement>(null)
@@ -258,12 +277,28 @@ export function ChatSidebar({
   }, [])
 
   useEffect(() => {
+    if (keepMounted) {
+      setShowContent(true)
+      return
+    }
     if (isOpen) {
       const timer = setTimeout(() => setShowContent(true), 150)
       return () => clearTimeout(timer)
     }
     setShowContent(false)
-  }, [isOpen])
+  }, [isOpen, keepMounted])
+
+  useEffect(() => {
+    if (!floating || !isOpen) return
+    const pane = paneRef.current
+    if (!pane) return
+    const observer = new ResizeObserver(() => {
+      const bounds = pane.getBoundingClientRect()
+      writeAssistantPreference('rowboat-assistant-floating-size', JSON.stringify({ width: bounds.width, height: bounds.height }))
+    })
+    observer.observe(pane)
+    return () => observer.disconnect()
+  }, [floating, isOpen])
 
   useEffect(() => {
     prevIsMaximizedRef.current = isMaximized
@@ -340,6 +375,15 @@ export function ChatSidebar({
     return chatTabStates[tabId] ?? emptyTabState
   }, [activeChatTabId, activeTabState, chatTabStates, emptyTabState])
   const paneStyle = useMemo<React.CSSProperties>(() => {
+    if (floating) {
+      return {
+        position: 'fixed', right: 12, bottom: 52, zIndex: 30,
+        width: floatingSize.width, height: floatingSize.height,
+        maxWidth: 'calc(100vw - 88px)', maxHeight: 'calc(100dvh - 108px)',
+        minWidth: 'min(360px, calc(100vw - 88px))', minHeight: 'min(320px, calc(100dvh - 108px))',
+        resize: 'both', display: isOpen ? undefined : 'none',
+      }
+    }
     if (!isOpen) {
       return { width: 0, flex: '0 0 auto' }
     }
@@ -352,23 +396,44 @@ export function ChatSidebar({
       return { width: 0, flex: '1 1 0' }
     }
     return { width, flex: '0 0 auto' }
-  }, [isOpen, isMaximized, paneSize, width])
+  }, [isOpen, isMaximized, paneSize, width, floating, floatingSize])
 
   return (
     <div
       ref={paneRef}
       data-chat-sidebar-root
+      role={floating ? 'region' : undefined}
+      aria-label={floating ? 'Assistant conversation' : undefined}
+      aria-hidden={!isOpen}
+      inert={!isOpen}
+      onKeyDown={(event) => {
+        if (floating && event.altKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
+          event.preventDefault()
+          const bounds = paneRef.current?.getBoundingClientRect()
+          if (bounds) setFloatingSize({
+            width: Math.max(360, Math.min(window.innerWidth - 88, bounds.width + (event.key === 'ArrowLeft' ? 20 : event.key === 'ArrowRight' ? -20 : 0))),
+            height: Math.max(320, Math.min(window.innerHeight - 108, bounds.height + (event.key === 'ArrowUp' ? 20 : event.key === 'ArrowDown' ? -20 : 0))),
+          })
+          return
+        }
+        if (event.key !== 'Escape' || event.defaultPrevented || !floating) return
+        if ((event.target as HTMLElement).closest('[role="dialog"], [role="menu"], [role="listbox"]')) return
+        event.preventDefault()
+        onMinimize?.()
+      }}
       onMouseDownCapture={onActivate}
       onFocusCapture={onActivate}
       className={cn(
         'relative flex min-w-0 flex-col overflow-hidden bg-background',
         isMiddlePlacement ? 'border-r border-border' : 'border-l border-border',
-        !isResizing && !justToggledMaximize && 'transition-[width] duration-200 ease-linear',
+        !floating && !isResizing && !justToggledMaximize && 'transition-[width] duration-200 ease-linear motion-reduce:transition-none',
+        floating && 'rounded-xl border border-border shadow-2xl',
         className
       )}
       style={paneStyle}
     >
-      {!isMaximized && isResizable && (
+      {floating && <span className="sr-only">Resize with Alt and arrow keys. Escape minimizes this chat.</span>}
+      {!floating && !isMaximized && isResizable && (
         <div
           onMouseDown={handleMouseDown}
           className={cn(
@@ -384,7 +449,7 @@ export function ChatSidebar({
       {showContent && (
         <>
           <header
-            className="titlebar-drag-region flex h-10 shrink-0 items-stretch border-b border-border bg-sidebar"
+            className={cn(floating ? 'titlebar-no-drag' : 'titlebar-drag-region', 'flex h-10 shrink-0 items-stretch border-b border-border bg-sidebar')}
             style={{
               paddingLeft: isMaximized ? (sidebarState === 'collapsed' ? collapsedLeftPaddingPx : 12) : undefined,
               paddingRight: isMaximized ? 12 : undefined,
@@ -444,16 +509,18 @@ export function ChatSidebar({
                     size="icon"
                     onClick={onOpenFullScreen}
                     className="titlebar-no-drag my-1 mr-2 h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
-                    aria-label={isMaximized ? 'Dock chat to side pane' : 'Expand chat'}
+                    aria-label={isMaximized ? (onMinimize ? 'Restore chat panel' : 'Dock chat to side pane') : 'Expand chat'}
                   >
                     {isMaximized
                       ? (isMiddlePlacement ? <ArrowLeft className="size-5" /> : <ArrowRight className="size-5" />)
                       : (isMiddlePlacement ? <ArrowRight className="size-5" /> : <ArrowLeft className="size-5" />)}
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">{isMaximized ? 'Dock to side pane' : 'Expand chat'}</TooltipContent>
+                <TooltipContent side="bottom">{isMaximized ? (onMinimize ? 'Restore chat panel' : 'Dock to side pane') : 'Expand chat'}</TooltipContent>
               </Tooltip>
             )}
+            {onMinimize && <Button variant="ghost" size="icon" onClick={onMinimize} className="titlebar-no-drag my-1 size-8 shrink-0" aria-label="Minimize chat" title="Minimize chat"><Minus className="size-4" /></Button>}
+            {onCloseTab && <Button variant="ghost" size="icon" onClick={onCloseTab} className="titlebar-no-drag my-1 mr-1 size-8 shrink-0" aria-label="Close chat tab" title="Close tab — conversation stays in history"><X className="size-4" /></Button>}
           </header>
 
           <FileCardProvider onOpenKnowledgeFile={onOpenKnowledgeFile ?? (() => {})} onOpenFile={onOpenFile}>
@@ -461,7 +528,7 @@ export function ChatSidebar({
               {/* Pane padding lives here, on the container — the shared chat pane renders identically on every surface. */}
               <div className="relative min-h-0 flex-1 px-3">
                 {chatTabs.map((tab) => {
-                  const isActive = tab.id === activeChatTabId
+                  const isActive = tab.id === activeChatTabId && isOpen
                   return (
                     <ChatSessionPane
                       // Keyed by chat identity — see App's chat panel key.
@@ -479,7 +546,7 @@ export function ChatSidebar({
                       activeIsProcessing={isProcessing}
                       activeIsReasoning={isReasoning}
                       onCodePermissionResponse={onCodePermissionResponse}
-                      onComposioConnected={onComposioConnected}
+                      onComposioConnected={(slug) => onComposioConnected?.(slug, tab.id)}
                       emptyStateVariant={pinnedToCodeSession ? 'code' : 'default'}
                       isCodeSession={!!(tab.runId && codeSessionLocks[tab.runId])}
                     />
@@ -487,11 +554,11 @@ export function ChatSidebar({
                 })}
               </div>
 
-              <div className="sticky bottom-0 z-10 bg-background pb-12 pt-0 shadow-lg">
+              <div className={cn('sticky bottom-0 z-10 bg-background pt-0 shadow-lg', floating ? 'pb-3' : 'pb-12')}>
                 <div className="pointer-events-none absolute inset-x-0 -top-6 h-6 bg-linear-to-t from-background to-transparent" />
                 <div className="mx-auto w-full max-w-4xl px-3">
                   {chatTabs.map((tab) => {
-                    const isActive = tab.id === activeChatTabId
+                    const isActive = tab.id === activeChatTabId && isOpen
                     return (
                       <ChatSessionComposer
                         // Composer instance per chat — see App's composer key.

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -423,7 +423,7 @@ function LaunchAtLoginSetting() {
 }
 
 function AppearanceSettings() {
-  const { theme, setTheme, chatPanePlacement, setChatPanePlacement, chatPaneSize, setChatPaneSize } = useTheme()
+  const { theme, setTheme, chatPanePlacement, setChatPanePlacement, chatPaneSize, setChatPaneSize, assistantPresentation, setAssistantPresentation } = useTheme()
 
   return (
     <div className="space-y-6">
@@ -458,7 +458,15 @@ function AppearanceSettings() {
         </div>
       </div>
       <div>
-        <h4 className="text-sm font-medium mb-3">Chat</h4>
+        <h4 className="text-sm font-medium mb-3">Assistant presentation</h4>
+        <div className="grid grid-cols-2 gap-3">
+          <ThemeOption label="Sidebar (default)" icon={PanelRight} isSelected={assistantPresentation === "sidebar"} onClick={() => setAssistantPresentation("sidebar")} />
+          <ThemeOption label="Bottom tabs" icon={MessageCircle} isSelected={assistantPresentation === "bottom-tabs"} onClick={() => setAssistantPresentation("bottom-tabs")} />
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Bottom tabs keep multiple chats within reach without resizing your workspace. Code keeps its workspace layout; the embedded browser uses a side-by-side chat.
+        </p>
+        <h4 className="mt-6 text-sm font-medium mb-3">Sidebar placement</h4>
         <p className="text-xs text-muted-foreground mb-4">
           Choose where chat sits when another pane is open
         </p>

--- a/apps/x/apps/renderer/src/contexts/theme-context.test.tsx
+++ b/apps/x/apps/renderer/src/contexts/theme-context.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider, useTheme } from './theme-context'
+
+function Preferences() {
+  const { assistantPresentation, setAssistantPresentation, chatPanePlacement, chatPaneSize } = useTheme()
+  return <>
+    <output aria-label="presentation">{assistantPresentation}</output>
+    <output aria-label="sidebar preferences">{chatPanePlacement} / {chatPaneSize}</output>
+    <button onClick={() => setAssistantPresentation('bottom-tabs')}>Use bottom tabs</button>
+    <button onClick={() => setAssistantPresentation('sidebar')}>Use sidebar</button>
+  </>
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+})
+afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+describe('assistant presentation preference', () => {
+  it('defaults to sidebar and ignores invalid saved modes', () => {
+    localStorage.setItem('rowboat-assistant-presentation', 'unsupported')
+    render(<ThemeProvider><Preferences /></ThemeProvider>)
+    expect(screen.getByLabelText('presentation')).toHaveTextContent('sidebar')
+  })
+
+  it('persists the opt-in mode without changing sidebar placement or size', () => {
+    localStorage.setItem('rowboat-chat-pane-placement', 'middle')
+    localStorage.setItem('rowboat-chat-pane-size', 'chat-equal')
+    const { unmount } = render(<ThemeProvider><Preferences /></ThemeProvider>)
+    fireEvent.click(screen.getByText('Use bottom tabs'))
+    expect(screen.getByLabelText('presentation')).toHaveTextContent('bottom-tabs')
+    unmount()
+    render(<ThemeProvider><Preferences /></ThemeProvider>)
+    expect(screen.getByLabelText('presentation')).toHaveTextContent('bottom-tabs')
+    fireEvent.click(screen.getByText('Use sidebar'))
+    expect(screen.getByLabelText('sidebar preferences')).toHaveTextContent('middle / chat-equal')
+    expect(localStorage.getItem('rowboat-assistant-presentation')).toBe('sidebar')
+  })
+})

--- a/apps/x/apps/renderer/src/contexts/theme-context.tsx
+++ b/apps/x/apps/renderer/src/contexts/theme-context.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import * as React from "react"
+import { readAssistantPreference, writeAssistantPreference } from '@/lib/assistant-dock'
 
 import { getSystemTheme, readStoredTheme, resolveTheme, THEME_STORAGE_KEY, type Theme } from "@/lib/theme"
 
 export type { Theme }
 export type ChatPanePlacement = "right" | "middle"
 export type ChatPaneSize = "chat-smaller" | "chat-equal" | "chat-bigger"
+export type AssistantPresentation = "sidebar" | "bottom-tabs"
 
 type ThemeContextProps = {
   theme: Theme
@@ -16,6 +18,8 @@ type ThemeContextProps = {
   setChatPanePlacement: (placement: ChatPanePlacement) => void
   chatPaneSize: ChatPaneSize
   setChatPaneSize: (size: ChatPaneSize) => void
+  assistantPresentation: AssistantPresentation
+  setAssistantPresentation: (presentation: AssistantPresentation) => void
 }
 
 const ThemeContext = React.createContext<ThemeContextProps | null>(null)
@@ -23,6 +27,7 @@ const ThemeContext = React.createContext<ThemeContextProps | null>(null)
 const STORAGE_KEY = THEME_STORAGE_KEY
 const CHAT_PANE_PLACEMENT_STORAGE_KEY = "rowboat-chat-pane-placement"
 const CHAT_PANE_SIZE_STORAGE_KEY = "rowboat-chat-pane-size"
+const ASSISTANT_PRESENTATION_STORAGE_KEY = "rowboat-assistant-presentation"
 
 function isChatPanePlacement(value: string | null): value is ChatPanePlacement {
   return value === "right" || value === "middle"
@@ -47,6 +52,13 @@ export function ThemeProvider({
   defaultTheme?: Theme
   children: React.ReactNode
 }) {
+  const [assistantPresentation, setAssistantPresentationState] = React.useState<AssistantPresentation>(() => {
+    return readAssistantPreference(ASSISTANT_PRESENTATION_STORAGE_KEY) === "bottom-tabs" ? "bottom-tabs" : "sidebar"
+  })
+  const setAssistantPresentation = React.useCallback((presentation: AssistantPresentation) => {
+    setAssistantPresentationState(presentation)
+    writeAssistantPreference(ASSISTANT_PRESENTATION_STORAGE_KEY, presentation)
+  }, [])
   const [theme, setThemeState] = React.useState<Theme>(() => readStoredTheme(defaultTheme))
   const [chatPanePlacement, setChatPanePlacementState] = React.useState<ChatPanePlacement>(() => {
     if (typeof window === "undefined") return "right"
@@ -123,8 +135,10 @@ export function ThemeProvider({
       setChatPanePlacement,
       chatPaneSize,
       setChatPaneSize,
+      assistantPresentation,
+      setAssistantPresentation,
     }),
-    [theme, resolvedTheme, setTheme, chatPanePlacement, setChatPanePlacement, chatPaneSize, setChatPaneSize]
+    [theme, resolvedTheme, setTheme, chatPanePlacement, setChatPanePlacement, chatPaneSize, setChatPaneSize, assistantPresentation, setAssistantPresentation]
   )
 
   return (

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
@@ -112,6 +112,24 @@ function delta(turnId: string, text: string): TurnBusEvent {
 }
 
 describe('useSessionChat', () => {
+  it('keeps captured actions bound to their original session after switching tabs', async () => {
+    const { deps, calls } = makeDeps()
+    const { result, rerender } = renderHook(({ sessionId }) => useSessionChat(sessionId, deps), {
+      initialProps: { sessionId: S1 as string | null },
+    })
+    await waitFor(() => expect(result.current.latestTurnId).toBe('turn-1'))
+    const original = result.current
+    rerender({ sessionId: null })
+    expect(result.current.chatState).toBeNull()
+    expect(result.current.queued).toEqual([])
+    await act(async () => {
+      await original.removeQueued('queue-1')
+      await original.stop()
+    })
+    expect(calls).toContainEqual({ method: 'removeQueued', args: [S1, 'queue-1'] })
+    expect(calls).toContainEqual({ method: 'stopTurn', args: ['turn-1'] })
+    expect(result.current.sessionId).toBeNull()
+  })
   it('seeds from the session, follows live events, and routes actions', async () => {
     const { deps, calls, emit, deltaSubs } = makeDeps()
     const { result } = renderHook(() => useSessionChat(S1, deps), { wrapper: StrictMode })

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.ts
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useSyncExternalStore } from 'react'
 import { ipcSessionsClient } from '@/lib/session-chat/client'
 import { subscribeTurnFeed } from '@/lib/turn-feed'
 import { subscribeSessionFeed } from '@/lib/session-chat/feed'
@@ -7,10 +7,19 @@ import { SessionChatStore, type SessionChatStoreDeps } from '@/lib/session-chat/
 // Declare "this window is watching turn X" so main forwards its deltas.
 // Fire-and-forget on both edges: a lost subscribe only degrades streaming
 // granularity (durable events still arrive), never correctness.
+const deltaSubscribers = new Map<string, number>()
+
 function subscribeDeltas(turnId: string): () => void {
-  void window.ipc.invoke('turns:subscribe', { turnId }).catch(() => undefined)
+  const count = deltaSubscribers.get(turnId) ?? 0
+  deltaSubscribers.set(turnId, count + 1)
+  if (count === 0) void window.ipc.invoke('turns:subscribe', { turnId }).catch(() => undefined)
   return () => {
-    void window.ipc.invoke('turns:unsubscribe', { turnId }).catch(() => undefined)
+    const remaining = (deltaSubscribers.get(turnId) ?? 1) - 1
+    if (remaining > 0) deltaSubscribers.set(turnId, remaining)
+    else {
+      deltaSubscribers.delete(turnId)
+      void window.ipc.invoke('turns:unsubscribe', { turnId }).catch(() => undefined)
+    }
   }
 }
 
@@ -28,15 +37,17 @@ export function useSessionChat(
   sessionId: string | null,
   deps: SessionChatStoreDeps = defaultDeps,
 ) {
-  const [store] = useState(() => new SessionChatStore(deps))
+  const binding = useMemo(() => ({ sessionId, store: new SessionChatStore(deps) }), [deps, sessionId])
+  const { store } = binding
   useEffect(() => store.connect(), [store])
   useEffect(() => {
-    void store.setSession(sessionId)
-  }, [store, sessionId])
+    void binding.store.setSession(binding.sessionId)
+  }, [binding])
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot)
   return useMemo(
     () => ({
       ...snapshot,
+      ...(snapshot.sessionId !== sessionId ? { sessionId, chatState: null, queued: [], error: null, loading: Boolean(sessionId) } : {}),
       sendMessage: store.sendMessage,
       sendOrQueueMessage: store.sendOrQueueMessage,
       editQueued: store.editQueued,
@@ -45,7 +56,7 @@ export function useSessionChat(
       answerAskHuman: store.answerAskHuman,
       stop: store.stop,
     }),
-    [snapshot, store],
+    [snapshot, store, sessionId],
   )
 }
 

--- a/apps/x/apps/renderer/src/lib/assistant-dock.test.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-dock.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { createAssistantTab, restoreAssistantTabs, tabsAfterClose } from './assistant-dock'
+
+describe('assistant dock tabs', () => {
+  it('creates independent draft identities and stable session identities', () => {
+    const first = createAssistantTab()
+    const second = createAssistantTab()
+    expect(first.id).not.toBe(second.id)
+    expect(first.chatId).not.toBe(second.chatId)
+    expect(first.runId).toBeNull()
+    expect(createAssistantTab('session').chatId).toBe('session')
+  })
+
+  it('restores validated tabs, including unsent drafts', () => {
+    const tabs = [createAssistantTab(), createAssistantTab('session')]
+    expect(restoreAssistantTabs(JSON.stringify(tabs))).toEqual(tabs)
+  })
+
+  it('ignores malformed storage and deduplicates identities', () => {
+    expect(restoreAssistantTabs('{')).toEqual([])
+    expect(restoreAssistantTabs('{}')).toEqual([])
+    expect(restoreAssistantTabs(null)).toEqual([])
+    const tab = createAssistantTab('session')
+    expect(restoreAssistantTabs(JSON.stringify([null, {}, tab, tab, { ...tab, id: 'other' }, { id: 1 }]))).toEqual([tab])
+  })
+
+  it('selects an adjacent chat only when the active tab closes', () => {
+    const tabs = [createAssistantTab(), createAssistantTab(), createAssistantTab()]
+    expect(tabsAfterClose(tabs, tabs[1].id, tabs[1].id).activeId).toBe(tabs[0].id)
+    expect(tabsAfterClose(tabs, tabs[0].id, tabs[0].id).activeId).toBe(tabs[1].id)
+    expect(tabsAfterClose(tabs, tabs[1].id, tabs[2].id).activeId).toBe(tabs[2].id)
+    expect(tabsAfterClose([tabs[0]], tabs[0].id, tabs[0].id)).toEqual({ tabs: [], activeId: null })
+    expect(tabsAfterClose(tabs, 'missing', tabs[0].id).tabs).toEqual(tabs)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/assistant-dock.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-dock.ts
@@ -1,0 +1,49 @@
+import type { ChatTab } from '@/components/tab-bar'
+
+export const ASSISTANT_TABS_KEY = 'rowboat-assistant-tabs'
+
+export function readAssistantPreference(key: string): string | null {
+  try { return localStorage.getItem(key) } catch { return null }
+}
+
+export function writeAssistantPreference(key: string, value: string | null): void {
+  try {
+    if (value === null) localStorage.removeItem(key)
+    else localStorage.setItem(key, value)
+  } catch { return }
+}
+
+export function createAssistantTab(runId: string | null = null): ChatTab {
+  return { id: crypto.randomUUID(), chatId: runId ?? crypto.randomUUID(), runId }
+}
+
+export function restoreAssistantTabs(raw: string | null): ChatTab[] {
+  try {
+    const parsed: unknown = JSON.parse(raw ?? 'null')
+    if (!Array.isArray(parsed)) return []
+    const ids = new Set<string>()
+    const chats = new Set<string>()
+    const runs = new Set<string>()
+    return parsed.filter((tab): tab is ChatTab => {
+      if (!tab || typeof tab !== 'object' || typeof tab.id !== 'string' || !tab.id
+        || typeof tab.chatId !== 'string' || !tab.chatId
+        || !(tab.runId === null || (typeof tab.runId === 'string' && tab.runId))
+        || ids.has(tab.id) || chats.has(tab.chatId) || (tab.runId && runs.has(tab.runId))) return false
+      ids.add(tab.id)
+      chats.add(tab.chatId)
+      if (tab.runId) runs.add(tab.runId)
+      return true
+    }).map(({ id, chatId, runId }) => ({ id, chatId, runId }))
+  } catch {
+    return []
+  }
+}
+
+export function tabsAfterClose(tabs: ChatTab[], tabId: string, activeId: string) {
+  const index = tabs.findIndex((tab) => tab.id === tabId)
+  const remaining = tabs.filter((tab) => tab.id !== tabId)
+  return {
+    tabs: remaining,
+    activeId: activeId === tabId ? remaining[Math.max(0, index - 1)]?.id ?? null : activeId,
+  }
+}

--- a/docs/assistant-bottom-tabs.md
+++ b/docs/assistant-bottom-tabs.md
@@ -1,0 +1,20 @@
+# Assistant bottom tabs
+
+Enable **Settings → Appearance → Assistant presentation → Bottom tabs**. Sidebar remains the default; its placement and size preferences are preserved.
+
+- Open several assistant conversations; click a bottom tab to expand it, or click the expanded tab again to minimize. Only one panel expands at a time. Excess tabs appear under **More chats**.
+- The floating panel does not resize ordinary workspace views. Resize using its corner, or Alt + arrow keys while focused inside the panel. Expand for a full-width conversation.
+- Escape or the minimize button tucks the panel away. Outside clicks leave it open. Completion never steals focus; tabs indicate working, unread replies, and requests for input.
+- Close silently removes a tab, not the saved conversation, and does not stop work. Reopen saved conversations from history. Use Stop in the conversation to stop a task.
+- Cmd/Ctrl+L toggles the panel while viewing another section. Cmd/Ctrl+N creates a new conversation.
+- Open tabs, the active tab, draft text, and floating dimensions are restored locally. Attachments remain available across presentation changes within the same app session; staged attachments are not restored after an app restart.
+
+## Native surfaces
+
+Code keeps its primary chat layout. The dock is hidden there. The embedded browser is an Electron native view above renderer content: it uses a side-by-side chat and reserves room for the bottom tabs instead of hiding the page behind an overlay.
+
+## Verification
+
+Run the renderer tests for `assistant-dock`, `assistant-chat-dock`, `chat-sidebar`, `useSessionChat`, and `session-chat/store`.
+
+For desktop QA, check email, files, Apps, Code, and the embedded browser at narrow and wide window sizes. Start work in two chats; minimize and switch while streaming; stop or answer a permission request in one and verify that the other continues. Check drafts, attachments, model selection, queues, focus, tab overflow, display zoom, and switching back to Sidebar.


### PR DESCRIPTION
## Summary
- Add an opt-in **Settings → Appearance → Assistant presentation → Bottom tabs** mode; keep Sidebar as the default.
- Support multiple assistant chats with one expandable/resizable panel, compact 240px tabs, overflow, working/unread/needs-input indicators, and silent tab closing.
- Preserve draft text, attachments within an app session, model selections and chat state across presentation changes; keep asynchronous actions bound to the originating session.
- Keep Code's primary chat layout intact and use a side-by-side fallback for the native embedded browser.

## Scope review
- One feature commit rebased onto current `main`; only assistant-related renderer changes, tests, and documentation (16 files).
- No dependency manifests, lockfiles, generated build artifacts, or unrelated backend changes.
- Includes the requested follow-ups: compact single-tab sizing and removal of the close toast/Undo popup.

## Validation
- Shared package rebuild passes.
- Renderer typecheck passes after rebase.
- All 541 renderer tests pass across 54 files after rebase.
- `git diff --check` passes; working tree is clean.

## Notes
- Closing a tab does not delete saved history or stop running work.
- Staged attachments survive presentation changes within the current app session, but are not restored after restarting the app.
- True overlays over the native browser are not implemented; the explicit side-by-side fallback keeps the browser usable.
