### PR TITLE
feat(spaces): open the agent chat behind a Rowboat reply, landing on its turn

### DIFF
--- a/apps/x/apps/main/src/spaces/ipc.ts
+++ b/apps/x/apps/main/src/spaces/ipc.ts
@@ -10,6 +10,7 @@ import { getDndUntil, getNotifyPrefs, setDndUntil, setNotifyPref } from '@x/core
 import { cancelScheduled, listScheduled, scheduleItem } from '@x/core/dist/spaces/scheduler.js';
 import { invokeTopicAgent, stopTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
 import { onSpaceAgentActivity, startSpaceAgentActivity } from '@x/core/dist/spaces/agent-activity.js';
+import { resolveResponseSession, startSpaceResponseIndex } from '@x/core/dist/spaces/response-index.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
 import { fetchLinkPreview } from './link-preview.js';
 
@@ -63,6 +64,7 @@ type SpacesHandlers = {
   'spaces:endPoll': InvokeHandler<'spaces:endPoll'>;
   'spaces:invokeRowboat': InvokeHandler<'spaces:invokeRowboat'>;
   'spaces:topicSession': InvokeHandler<'spaces:topicSession'>;
+  'spaces:responseSession': InvokeHandler<'spaces:responseSession'>;
   'spaces:stopRowboat': InvokeHandler<'spaces:stopRowboat'>;
   'spaces:getNotifyPrefs': InvokeHandler<'spaces:getNotifyPrefs'>;
   'spaces:setNotifyPref': InvokeHandler<'spaces:setNotifyPref'>;
@@ -103,6 +105,9 @@ orgs.onMemberFrame((orgId, frame) => broadcastSpacesEvent({ orgId, frame }));
 // can be sent.
 onSpaceAgentActivity((event) => broadcastSpacesEvent(event));
 void startSpaceAgentActivity().catch((err) => console.error('[spaces] agent activity feed failed to start:', err));
+// The per-response index ("which run posted this reply"): same bus, its own
+// consumer — see core/spaces/response-index.
+void startSpaceResponseIndex().catch((err) => console.error('[spaces] response index failed to start:', err));
 
 function broadcastSpacesEvent(event: spacesShared.SpacesBusEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -393,6 +398,8 @@ export const spacesIpcHandlers: SpacesHandlers = {
   'spaces:topicSession': async (_event, args) => ({
     sessionId: topicSessionId(args.orgId, args.spaceId, args.threadRootId),
   }),
+
+  'spaces:responseSession': async (_event, args) => resolveResponseSession(args),
 
   'spaces:stopRowboat': async (_event, args) => stopTopicAgent(args),
 

--- a/apps/x/apps/renderer/src/components/ai-elements/conversation.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/conversation.tsx
@@ -36,6 +36,10 @@ export type ConversationProps = ComponentProps<"div"> & {
   scrollMemoryKey?: string;
   anchorMessageId?: string | null;
   anchorRequestKey?: number;
+  /** Deep link: pin this item's row near the viewport top once it renders
+   * (lib/chat-scroll.ts requestJump). Each new jumpRequestKey re-applies. */
+  jumpMessageId?: string | null;
+  jumpRequestKey?: number;
   children?: ReactNode;
 };
 
@@ -44,6 +48,8 @@ export const Conversation = ({
   scrollMemoryKey,
   anchorMessageId = null,
   anchorRequestKey,
+  jumpMessageId = null,
+  jumpRequestKey,
   children,
   className,
   ...props
@@ -108,6 +114,19 @@ export const Conversation = ({
     // it exactly once when the row appears.
     controller.requestSendAnchor(anchorMessageId);
   }, [anchorRequestKey, anchorMessageId, scrollMode, controller]);
+
+  // A deep link (Spaces' "Open agent chat" on a reply, landing on the run
+  // that wrote it). Unlike the send anchor, a mount-time request IS applied:
+  // the pane usually mounts because of the jump, and the controller keeps it
+  // pending until the transcript renders the row.
+  const appliedJumpKeyRef = useRef<number | undefined>(undefined);
+  useLayoutEffect(() => {
+    if (jumpRequestKey === undefined || jumpRequestKey === appliedJumpKeyRef.current) {
+      return;
+    }
+    appliedJumpKeyRef.current = jumpRequestKey;
+    if (jumpMessageId) controller.requestJump(jumpMessageId);
+  }, [jumpRequestKey, jumpMessageId, controller]);
 
   const scrollToBottom = useCallback(() => {
     controller.jumpToLatest("smooth");

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -29,6 +29,7 @@ import { ChatInputWithMentions, type CallPreset, type PermissionMode, type Stage
 import { type ChatTab } from './tab-bar'
 import { useReportTabMeta } from '@/lib/tab-meta'
 import { useSessionTitle } from '@/lib/session-title'
+import { consumeChatJump, usePendingChatJump } from '@/lib/chat-jump'
 import {
   type ChatTabViewState,
   type ChatViewportAnchorState,
@@ -129,6 +130,17 @@ export function ChatSessionPane({
   const askBatchTotal = askBatchMaxRef.current
   const currentAsk = pendingAsks[0]
 
+  // A deep link into this session (lib/chat-jump.ts): claim it once the pane
+  // is mounted for that session and hand it to the Conversation; the scroll
+  // controller pins the row when the transcript renders it.
+  const pendingJump = usePendingChatJump(tab.runId)
+  const [jump, setJump] = React.useState<{ messageId: string; key: number } | null>(null)
+  React.useEffect(() => {
+    if (!pendingJump || !tab.runId) return
+    const messageId = consumeChatJump(tab.runId)
+    if (messageId) setJump((prev) => ({ messageId, key: (prev?.key ?? 0) + 1 }))
+  }, [pendingJump, tab.runId])
+
   const tabHasConversation = tabState.conversation.length > 0 || tabState.currentAssistantMessage
   // Store-backed chats stream through synthetic conversation items that carry
   // their durable ids (turn-view.ts), so completion updates the mounted nodes
@@ -162,6 +174,8 @@ export function ChatSessionPane({
         scrollMemoryKey={tab.chatId}
         anchorMessageId={viewportAnchor?.messageId}
         anchorRequestKey={viewportAnchor?.requestKey}
+        jumpMessageId={jump?.messageId}
+        jumpRequestKey={jump?.key}
         className="relative flex-1"
       >
         <ConversationContent className={tabConversationContentClassName}>

--- a/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/general-stream.tsx
@@ -22,6 +22,7 @@ import { formatScheduleTime, parseRemindArgs } from '@/lib/spaces-schedule'
 import { getTopicLastReadAt, markRead, markTopicRead } from '@/lib/spaces-read-state'
 import { toggleSaved, useSaved } from '@/lib/spaces-saved'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
+import { openResponseChat } from '@/lib/spaces-response-chat'
 import { toast } from '@/lib/toast'
 import * as analytics from '@/lib/analytics'
 import { containsRowboatAddress } from '@/lib/spaces-mentions'
@@ -234,6 +235,11 @@ export function GeneralStream({
         } catch {
             toast('Could not open the agent chat', 'error')
         }
+    }
+
+    // "Open agent chat" on one of your Rowboat's posts: the run that wrote it.
+    const openResponse = (message: spaces.Message) => {
+        if (onOpenSession) void openResponseChat({ orgId: org.id, spaceId: space.id, message, onOpenSession })
     }
 
     // The working strip's stop square: cancel your Rowboat's run right here.
@@ -612,6 +618,7 @@ export function GeneralStream({
                 onOpenThread={onOpenThread}
                 onPrefetchThread={(id) => prefetchThread(org.id, space.id, id)}
                 onOpenAgentChat={onOpenSession ? (id) => void openAgentChat(id) : undefined}
+                onOpenResponseChat={onOpenSession ? openResponse : undefined}
                 onStopAgent={(id) => void stopAgent(id)}
                 onReplyInThread={replyInThread}
                 onAskRowboat={askRowboat}

--- a/apps/x/apps/renderer/src/components/spaces/message-row.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/message-row.tsx
@@ -130,7 +130,7 @@ export interface ThreadRowData {
 }
 
 function MessageRowImpl({
-    message, memberNames, continuation, thread, onOpenThread, onPrefetchThread, onOpenAgentChat, onStopAgent, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onQuoteReply, onForward, onToggleSave, saved, onRetryFailed, onDiscardFailed, onVotePoll, onRemovePollVote, onEndPoll, dense, selfMemberId,
+    message, memberNames, continuation, thread, onOpenThread, onPrefetchThread, onOpenAgentChat, onOpenResponseChat, onStopAgent, onReplyInThread, onAskRowboat, onCopyLink, onReact, onDelete, onEdit, onQuoteReply, onForward, onToggleSave, saved, onRetryFailed, onDiscardFailed, onVotePoll, onRemovePollVote, onEndPoll, dense, selfMemberId,
 }: {
     message: spaces.Message & { pending?: boolean; failed?: boolean }
     memberNames: Map<string, string>
@@ -144,6 +144,13 @@ function MessageRowImpl({
     onPrefetchThread?: (rootMessageId: string) => void
     /** Opens the thread's agent session in the chat view (working strip's "Open chat"). */
     onOpenAgentChat?: (rootMessageId: string) => void
+    /**
+     * Opens the run that posted THIS message (the viewer's own Rowboat's
+     * reply), landing on its turn — the "via Rowboat" label and the menu's
+     * "Open agent chat". Offered only on the viewer's own agent posts: the
+     * session lives on this machine, nobody else's.
+     */
+    onOpenResponseChat?: (message: spaces.Message) => void
     /** Stops the viewer's own Rowboat working this thread (working strip's stop square). */
     onStopAgent?: (rootMessageId: string) => void
     onReplyInThread?: (message: spaces.Message) => void
@@ -255,6 +262,7 @@ function MessageRowImpl({
     const canSave = !!onToggleSave && !deleted && !unconfirmed
     const canQuote = !!onQuoteReply && !deleted && !unconfirmed && !!messageText
     const canForward = !!onForward && !deleted && !unconfirmed
+    const canOpenResponseChat = !!onOpenResponseChat && viaAgent && !deleted && !unconfirmed && selfMemberId === message.author.memberId
 
     const row = (
         <div
@@ -282,9 +290,22 @@ function MessageRowImpl({
                             <button type="button" className="cursor-pointer text-[15px] font-extrabold leading-[22px] text-foreground hover:underline">{name}</button>
                         </MemberProfilePopover>
                         {viaAgent && (
-                            <span className="text-muted-foreground">
-                                via {message.author.agentName ?? 'agent'}{message.author.actingMode === 'scheduled' ? ', scheduled' : ''}
-                            </span>
+                            canOpenResponseChat ? (
+                                // Your own Rowboat's post: the label is the subtle way in
+                                // to the run that wrote it (the ⋯ menu has it too).
+                                <button
+                                    type="button"
+                                    onClick={() => onOpenResponseChat!(message)}
+                                    title="Open the agent chat that wrote this"
+                                    className="cursor-pointer text-muted-foreground hover:text-[var(--stream-link)] hover:underline"
+                                >
+                                    via {message.author.agentName ?? 'agent'}{message.author.actingMode === 'scheduled' ? ', scheduled' : ''}
+                                </button>
+                            ) : (
+                                <span className="text-muted-foreground">
+                                    via {message.author.agentName ?? 'agent'}{message.author.actingMode === 'scheduled' ? ', scheduled' : ''}
+                                </span>
+                            )
                         )}
                         <span title={formatFullTimestamp(message.postedAt)} className="text-muted-foreground">{formatFeedTime(message.postedAt)}</span>
                     </div>
@@ -476,7 +497,7 @@ function MessageRowImpl({
                             <Bot className="size-3.5" />
                         </button>
                     )}
-                    {(onCopyLink || canDelete || canEdit || canQuote || canForward || canPin || canSave) && (
+                    {(onCopyLink || canDelete || canEdit || canQuote || canForward || canPin || canSave || canOpenResponseChat) && (
                         <DropdownMenu onOpenChange={setMenuOpen}>
                             <DropdownMenuTrigger asChild>
                                 <button type="button" title="More" className={cn('inline-flex size-7 items-center justify-center rounded-md text-muted-foreground', ICON_HOVER)}>
@@ -484,6 +505,11 @@ function MessageRowImpl({
                                 </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className={MENU_HIGHLIGHT}>
+                                {canOpenResponseChat && (
+                                    <DropdownMenuItem onClick={() => onOpenResponseChat!(message)}>
+                                        <Bot className="size-3.5 mr-2" /> Open agent chat
+                                    </DropdownMenuItem>
+                                )}
                                 {canQuote && (
                                     <DropdownMenuItem onClick={() => onQuoteReply!(message)}>
                                         <Quote className="size-3.5 mr-2" /> Quote reply

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -27,6 +27,7 @@ import { formatScheduleTime, parseRemindArgs } from '@/lib/spaces-schedule'
 import { getTopicLastReadAt, markTopicRead } from '@/lib/spaces-read-state'
 import { toggleSaved, useSaved } from '@/lib/spaces-saved'
 import { maybeInvokeRowboat } from '@/lib/spaces-rowboat'
+import { openResponseChat } from '@/lib/spaces-response-chat'
 import { toast } from '@/lib/toast'
 import * as analytics from '@/lib/analytics'
 import { containsRowboatAddress } from '@/lib/spaces-mentions'
@@ -546,6 +547,12 @@ export function ThreadPane({
         }
     }
 
+    // "Open agent chat" on one of your Rowboat's replies: the run that wrote
+    // it, not merely the thread's session (see lib/spaces-response-chat.ts).
+    const openResponse = (message: spaces.Message) => {
+        if (onOpenSession) void openResponseChat({ orgId: org.id, spaceId: space.id, message, onOpenSession })
+    }
+
     // Whether an agent session exists for this thread — powers the header's
     // persistent "Chat" link (the working chip only exists while a turn runs).
     const [hasSession, setHasSession] = useState(false)
@@ -605,6 +612,7 @@ export function ThreadPane({
                 onForward={setForwarding}
                 onToggleSave={toggleSave}
                 saved={savedIds.has(message.id)}
+                onOpenResponseChat={onOpenSession ? openResponse : undefined}
                 onRetryFailed={retryFailed}
                 onDiscardFailed={discardFailed}
                 onVotePoll={(m, answerIds) => void votePoll(m, answerIds)}

--- a/apps/x/apps/renderer/src/lib/chat-jump.ts
+++ b/apps/x/apps/renderer/src/lib/chat-jump.ts
@@ -1,0 +1,58 @@
+import { useSyncExternalStore } from 'react'
+
+// Deep link into a chat: "open session S and land on message M". Navigation
+// is the caller's job (openAssistantRun); the landing is this module's — a
+// pending jump the session's pane consumes once it is mounted for that
+// session, then hands to the scroll controller, which pins the row when the
+// transcript renders it (lib/chat-scroll.ts requestJump). Module state, not
+// just an event: the pane may mount AFTER the request fires — the same
+// posture as lib/spaces-jump.ts for message rows in a space.
+
+export interface ChatJumpTarget {
+    sessionId: string
+    /** A conversation item id — a user row is `${turnId}:user` or `${turnId}:user:${inputIndex}`. */
+    messageId: string
+}
+
+/** The user-row item id for a turn's input (mirrors lib/session-chat/turn-view.ts). */
+export function turnInputMessageId(turnId: string, inputIndex?: number): string {
+    return typeof inputIndex === 'number' ? `${turnId}:user:${inputIndex}` : `${turnId}:user`
+}
+
+let pending: ChatJumpTarget | null = null
+const listeners = new Set<() => void>()
+
+export function requestChatJump(target: ChatJumpTarget): void {
+    pending = target
+    for (const l of listeners) l()
+}
+
+/** The pane for `sessionId` claims its jump (null = nothing pending for it). */
+export function consumeChatJump(sessionId: string): string | null {
+    if (!pending || pending.sessionId !== sessionId) return null
+    const id = pending.messageId
+    pending = null
+    return id
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+function snapshot(): ChatJumpTarget | null {
+    return pending
+}
+
+/** The pending jump, when it targets `sessionId`; re-renders the caller when one arrives. */
+export function usePendingChatJump(sessionId: string | null): ChatJumpTarget | null {
+    const current = useSyncExternalStore(subscribe, snapshot, snapshot)
+    return current && sessionId && current.sessionId === sessionId ? current : null
+}
+
+/** Test seam. */
+export function resetChatJump(): void {
+    pending = null
+}

--- a/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.test.ts
@@ -3,6 +3,7 @@ import {
   ANCHOR_TAIL_HEADROOM_PX,
   AT_BOTTOM_EPSILON_PX,
   ChatScrollController,
+  JUMP_DEADLINE_MS,
   NEAR_BOTTOM_PX,
   SEND_ANCHOR_PEEK_PX,
   resetChatScrollMemory,
@@ -773,5 +774,72 @@ describe('ChatScrollController — subscription and cleanup', () => {
     expect(controller.snapshot().following).toBe(true)
     h.grow(100)
     expect(h.container.scrollTop).toBe(h.maxTop())
+  })
+})
+
+describe('ChatScrollController — deep link (requestJump)', () => {
+  const TARGET = 1800 - SEND_ANCHOR_PEEK_PX
+
+  it('pins an existing row near the viewport top and stops following', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    addUserRow(h, 'turn-1:user', 1800)
+    expect(controller.snapshot().following).toBe(true)
+
+    controller.requestJump('turn-1:user')
+    expect(h.container.scrollTop).toBe(TARGET)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('waits for a row that renders later (the transcript is still loading)', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    controller.requestJump('turn-1:user')
+    expect(h.container.scrollTop).toBe(h.maxTop())
+
+    // Streaming/loading growth before the row lands keeps the live edge.
+    h.grow(300)
+    expect(h.container.scrollTop).toBe(h.maxTop())
+
+    addUserRow(h, 'turn-1:user', 1800)
+    triggerResize()
+    expect(h.container.scrollTop).toBe(TARGET)
+    expect(controller.snapshot().following).toBe(false)
+  })
+
+  it('never falls back to the last user row: a row that never appears does nothing', () => {
+    const h = createHarness()
+    const controller = attach(h)
+    addUserRow(h, 'other:user', 1800)
+    controller.requestJump('turn-9:user')
+    triggerResize()
+    expect(h.container.scrollTop).toBe(h.maxTop())
+    expect(controller.snapshot().following).toBe(true)
+  })
+
+  it("the reader's own scroll cancels a pending jump", () => {
+    const h = createHarness()
+    const controller = attach(h)
+    controller.requestJump('turn-1:user')
+    h.wheel(-100)
+    h.scrollTo(200)
+    addUserRow(h, 'turn-1:user', 1800)
+    triggerResize()
+    expect(h.container.scrollTop).toBe(200)
+  })
+
+  it('gives up after JUMP_DEADLINE_MS', () => {
+    vi.useFakeTimers()
+    try {
+      const h = createHarness()
+      const controller = attach(h)
+      controller.requestJump('turn-1:user')
+      vi.advanceTimersByTime(JUMP_DEADLINE_MS + 1)
+      addUserRow(h, 'turn-1:user', 1800)
+      triggerResize()
+      expect(h.container.scrollTop).toBe(h.maxTop())
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/x/apps/renderer/src/lib/chat-scroll.ts
+++ b/apps/x/apps/renderer/src/lib/chat-scroll.ts
@@ -87,6 +87,11 @@ export const ANCHOR_TAIL_HEADROOM_PX = 128
  * queued message that will start a later turn — repositioning for it out of
  * the blue would be a yank, not navigation. */
 const SEND_ANCHOR_DEADLINE_MS = 3000
+/** A jump into a chat that is still loading (a Spaces reply's "Open agent
+ * chat" lands before the session's transcript renders) waits this long for
+ * its row. Longer than the send deadline: the whole transcript loads, not
+ * one round-trip. */
+export const JUMP_DEADLINE_MS = 15_000
 
 /** Keys that scroll a container when it (or a non-editable descendant) has
  * focus. */
@@ -135,6 +140,16 @@ export interface ChatScrollOptions {
   memoryKey?: string
 }
 
+/** A brief highlight on a deep-linked row so the eye finds it (no-op where
+ * the Web Animations API is missing, e.g. jsdom). */
+function flashRow(row: HTMLElement): void {
+  if (typeof row.animate !== 'function') return
+  row.animate(
+    [{ backgroundColor: 'rgba(250, 204, 21, 0.3)' }, { backgroundColor: 'transparent' }],
+    { duration: 1800, easing: 'ease-out' }
+  )
+}
+
 export class ChatScrollController {
   private mode: ChatScrollMode
   private memoryKey?: string
@@ -174,6 +189,11 @@ export class ChatScrollController {
     baselineUserRowId: string | null
     deadline: number
   } | null = null
+
+  // A deep link into the transcript (requestJump): pins the named row near
+  // the viewport top once it exists. Unlike a send anchor it has no
+  // last-user-row fallback — a jump to a row that never appears does nothing.
+  private pendingJump: { messageId: string; deadline: number } | null = null
 
   // In-flight smooth scroll to the live edge (jump button): growth re-targets
   // the animation instead of fighting it with instant writes.
@@ -232,6 +252,7 @@ export class ChatScrollController {
     this.els = null
     this.restore = null
     this.pendingSendAnchor = null
+    this.pendingJump = null
     this.smoothPending = false
   }
 
@@ -253,6 +274,7 @@ export class ChatScrollController {
     if (!els) return
     this.restore = null
     this.pendingSendAnchor = null
+    this.pendingJump = null
     this.following = true
     const top = this.maxTop()
     if (behavior === 'smooth' && typeof els.container.scrollTo === 'function') {
@@ -290,6 +312,37 @@ export class ChatScrollController {
       deadline: now() + SEND_ANCHOR_DEADLINE_MS,
     }
     this.trySendAnchor()
+  }
+
+  /**
+   * Deep link: pin the given message near the viewport top as soon as its row
+   * exists (now, or when a loading transcript renders it — resize ticks
+   * retry until JUMP_DEADLINE_MS). Reading-position restore and any pending
+   * send anchor yield to it; the reader's own scroll cancels it.
+   */
+  requestJump(messageId: string): void {
+    if (!this.els) return
+    this.restore = null
+    this.pendingSendAnchor = null
+    this.pendingJump = { messageId, deadline: now() + JUMP_DEADLINE_MS }
+    this.tryJump()
+  }
+
+  private tryJump(): void {
+    const pending = this.pendingJump
+    const els = this.els
+    if (!pending || !els) return
+    if (now() > pending.deadline) {
+      this.pendingJump = null
+      return
+    }
+    const row = els.content.querySelector<HTMLElement>(
+      `[data-message-id="${pending.messageId}"]`
+    )
+    if (!row) return
+    this.pendingJump = null
+    this.applyAnchorToElement(row, pending.messageId)
+    flashRow(row)
   }
 
   /**
@@ -395,15 +448,17 @@ export class ChatScrollController {
         if (distance > AT_BOTTOM_EPSILON_PX) {
           this.following = false
           this.cancelSmooth()
-          // The reader took over before a pending send reposition landed —
-          // applying it late would be a yank.
+          // The reader took over before a pending send reposition (or deep
+          // link) landed — applying it late would be a yank.
           this.pendingSendAnchor = null
+          this.pendingJump = null
         }
       } else if (attributed && distance <= NEAR_BOTTOM_PX) {
         // A downward user gesture back into the near-bottom band resumes
         // following.
         this.following = true
         this.pendingSendAnchor = null
+        this.pendingJump = null
       } else if (distance <= AT_BOTTOM_EPSILON_PX && this.spacerHeight === 0) {
         // Unattributed downward arrivals engage only at the true live edge:
         // that's a scrollbar dragged to the very end (scrollbars emit no
@@ -474,8 +529,10 @@ export class ChatScrollController {
 
   private handleResize = (): void => {
     if (!this.els) return
-    // A resize tick is exactly when a just-sent message's row lands.
+    // A resize tick is exactly when a just-sent message's row lands — or a
+    // loading transcript's rows, for a pending deep link.
     this.trySendAnchor()
+    this.tryJump()
     this.maintainAnchorSpacer()
     if (this.restore) {
       if (now() > this.restore.deadline) {

--- a/apps/x/apps/renderer/src/lib/spaces-response-chat.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-response-chat.ts
@@ -1,0 +1,37 @@
+import type { spaces } from '@x/shared'
+import { requestChatJump, turnInputMessageId } from '@/lib/chat-jump'
+import { toast } from '@/lib/toast'
+
+// "Open agent chat" on one of the viewer's own Rowboat posts: resolve the run
+// that wrote it (core/spaces/response-index via spaces:responseSession) and
+// open the session landing on that run's input. A recorded link whose
+// session is gone says so — it never falls through to the thread's session,
+// which by then is a fresh one (the registry recreates on demand) and would
+// open the wrong conversation. Only an UNRECORDED post (from before the
+// index existed) falls back to the thread's session, unanchored.
+export async function openResponseChat(input: {
+    orgId: string
+    spaceId: string
+    message: spaces.Message
+    onOpenSession: (sessionId: string) => void
+}): Promise<void> {
+    const { orgId, spaceId, message, onOpenSession } = input
+    try {
+        const res = await window.ipc.invoke('spaces:responseSession', { orgId, spaceId, messageId: message.id })
+        if (res.status === 'found') {
+            requestChatJump({ sessionId: res.sessionId, messageId: turnInputMessageId(res.turnId, res.inputIndex) })
+            onOpenSession(res.sessionId)
+            return
+        }
+        if (res.status === 'gone') {
+            toast('The agent chat that wrote this reply is no longer available', 'info')
+            return
+        }
+        const threadRootId = message.threadRoot ?? message.id
+        const { sessionId } = await window.ipc.invoke('spaces:topicSession', { orgId, spaceId, threadRootId })
+        if (sessionId) onOpenSession(sessionId)
+        else toast('No agent chat recorded for this reply', 'info')
+    } catch {
+        toast('Could not open the agent chat', 'error')
+    }
+}

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -308,6 +308,7 @@ export const RPC_CHANNELS = [
   'spaces:endPoll',
   'spaces:invokeRowboat',
   'spaces:topicSession',
+  'spaces:responseSession',
   'spaces:stopRowboat',
   'spaces:subscribeSpace',
   'spaces:unsubscribeSpace',

--- a/apps/x/apps/server/src/spaces-deps.ts
+++ b/apps/x/apps/server/src/spaces-deps.ts
@@ -7,6 +7,7 @@ import { getDndUntil, getNotifyPrefs, setDndUntil, setNotifyPref } from '@x/core
 import { cancelScheduled, listScheduled, scheduleItem } from '@x/core/dist/spaces/scheduler.js';
 import { invokeTopicAgent, stopTopicAgent, topicSessionId } from '@x/core/dist/spaces/topic-agent.js';
 import { onSpaceAgentActivity, startSpaceAgentActivity } from '@x/core/dist/spaces/agent-activity.js';
+import { resolveResponseSession, startSpaceResponseIndex } from '@x/core/dist/spaces/response-index.js';
 import { fetchLinkPreview } from '@x/core/dist/spaces/link-preview.js';
 import { SpacesClient } from '@x/core/dist/spaces/client.js';
 import { openExternalUrl } from '@x/core/dist/auth/url-opener.js';
@@ -44,6 +45,9 @@ function emitSpacesEvent(event: spacesShared.SpacesBusEvent): void {
 // can be sent.
 onSpaceAgentActivity((event) => emitSpacesEvent(event));
 void startSpaceAgentActivity().catch((err) => console.error('[spaces] agent activity feed failed to start:', err));
+// The per-response index ("which run posted this reply"): same bus, its own
+// consumer — see core/spaces/response-index.
+void startSpaceResponseIndex().catch((err) => console.error('[spaces] response index failed to start:', err));
 
 // Keyed by org/space; each entry remembers WHICH live client it subscribed
 // on. A re-auth (orgs.upsertOAuthOrg) closes and replaces the org's client —
@@ -78,7 +82,7 @@ type SpacesRpcChannel =
   | 'spaces:listStream' | 'spaces:listThread' | 'spaces:linkPreview' | 'spaces:postMessage' | 'spaces:createTopic'
   | 'spaces:manageTopic' | 'spaces:reactToMessage'
   | 'spaces:deleteMessage' | 'spaces:editMessage' | 'spaces:votePoll' | 'spaces:endPoll'
-  | 'spaces:invokeRowboat' | 'spaces:topicSession' | 'spaces:stopRowboat'
+  | 'spaces:invokeRowboat' | 'spaces:topicSession' | 'spaces:responseSession' | 'spaces:stopRowboat'
   | 'spaces:subscribeSpace' | 'spaces:unsubscribeSpace' | 'spaces:presence' | 'spaces:whiteboard'
   | 'spaces:bounceLive'
   | 'spaces:getNotifyPrefs' | 'spaces:setNotifyPref' | 'spaces:getDnd' | 'spaces:setDnd'
@@ -328,6 +332,8 @@ export const spacesRpcHandlers: SpacesHandlers = {
   'spaces:topicSession': async (args) => ({
     sessionId: topicSessionId(args.orgId, args.spaceId, args.threadRootId),
   }),
+
+  'spaces:responseSession': async (args) => resolveResponseSession(args),
 
   'spaces:stopRowboat': async (args) => stopTopicAgent(args),
 

--- a/apps/x/packages/core/src/spaces/response-index.test.ts
+++ b/apps/x/packages/core/src/spaces/response-index.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { TurnBusEvent } from '@x/shared/dist/turns.js';
+import { MAX_LINKS, SpaceResponseIndexer, linkKey, postedMessageId, type ResponseLinkStore } from './response-index.js';
+
+const origin = (threadRootId: string, orgId = 'org-1', spaceId = 'space-1') => ({
+  kind: 'space_mention' as const,
+  orgId,
+  spaceId,
+  threadRootId,
+  messageId: `mention-${threadRootId}`,
+});
+
+function harness() {
+  let file: { version: 1; links: Record<string, { sessionId: string; turnId: string; inputIndex?: number }> } = { version: 1, links: {} };
+  let writes = 0;
+  const store: ResponseLinkStore = {
+    read: () => ({ version: 1, links: { ...file.links } }),
+    write: (index) => {
+      file = index;
+      writes += 1;
+    },
+  };
+  const indexer = new SpaceResponseIndexer(store, (orgId) => (orgId === 'org-1' ? 'spaces-org-1' : null));
+  const turn = (turnId: string, event: Record<string, unknown>, sessionId = 'sess-1'): TurnBusEvent =>
+    ({ turnId, sessionId, event }) as unknown as TurnBusEvent;
+  const mcpOutput = (messageId: string, threadRoot?: string) => ({
+    success: true,
+    serverName: 'spaces-org-1',
+    toolName: 'post_message',
+    result: {
+      content: [{ type: 'text', text: JSON.stringify({ messageId, ...(threadRoot ? { threadRoot } : {}) }) }],
+      structuredContent: { messageId, ...(threadRoot ? { threadRoot } : {}) },
+    },
+  });
+  const post = (turnId: string, toolCallId: string, args: Record<string, unknown>, serverName = 'spaces-org-1') =>
+    turn(turnId, {
+      type: 'tool_invocation_requested',
+      toolCallId,
+      toolId: 'executeMcpTool',
+      toolName: 'executeMcpTool',
+      execution: 'sync',
+      input: { serverName, toolName: 'post_message', arguments: args },
+    });
+  const result = (turnId: string, toolCallId: string, output: unknown, isError = false) =>
+    turn(turnId, { type: 'tool_result', toolCallId, toolName: 'executeMcpTool', source: 'sync', result: { output, isError } });
+  return { indexer, turn, post, result, mcpOutput, links: () => file.links, writes: () => writes };
+}
+
+describe('postedMessageId', () => {
+  it('prefers structuredContent, falls back to the JSON text block', () => {
+    expect(postedMessageId({ success: true, result: { structuredContent: { messageId: 'm1' } } })).toBe('m1');
+    expect(postedMessageId({ success: true, result: { content: [{ type: 'text', text: '{"messageId":"m2"}' }] } })).toBe('m2');
+  });
+
+  it('yields nothing for failures, error results, or non-JSON text', () => {
+    expect(postedMessageId({ success: false, error: 'nope' })).toBeNull();
+    expect(postedMessageId({ success: true, result: { isError: true, content: [{ type: 'text', text: '{"messageId":"m"}' }] } })).toBeNull();
+    expect(postedMessageId({ success: true, result: { content: [{ type: 'text', text: 'not json' }] } })).toBeNull();
+    expect(postedMessageId(null)).toBeNull();
+  });
+});
+
+describe('SpaceResponseIndexer', () => {
+  it('links the receipt of a mention-created turn to the turn (creating input)', () => {
+    const h = harness();
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    h.indexer.handleTurnEvent(h.post('t1', 'call-1', { spaceId: 'space-1', threadRoot: 'root-1', body: 'Done.' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'call-1', h.mcpOutput('reply-1', 'root-1')));
+    expect(h.links()).toEqual({ [linkKey('org-1', 'space-1', 'reply-1')]: { sessionId: 'sess-1', turnId: 't1' } });
+    expect(h.indexer.link('org-1', 'space-1', 'reply-1')).toEqual({ sessionId: 'sess-1', turnId: 't1' });
+    expect(h.indexer.link('org-1', 'space-1', 'other')).toBeNull();
+  });
+
+  it('attributes a post to the steered input whose thread it answers', () => {
+    const h = harness();
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'input_added', inputIndex: 2, origin: origin('root-2') }));
+    h.indexer.handleTurnEvent(h.post('t1', 'call-a', { spaceId: 'space-1', threadRoot: 'root-2', body: 'second' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'call-a', h.mcpOutput('reply-b', 'root-2')));
+    h.indexer.handleTurnEvent(h.post('t1', 'call-b', { spaceId: 'space-1', threadRoot: 'root-1', body: 'first' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'call-b', h.mcpOutput('reply-a', 'root-1')));
+    expect(h.links()).toEqual({
+      [linkKey('org-1', 'space-1', 'reply-b')]: { sessionId: 'sess-1', turnId: 't1', inputIndex: 2 },
+      [linkKey('org-1', 'space-1', 'reply-a')]: { sessionId: 'sess-1', turnId: 't1' },
+    });
+  });
+
+  it('falls back to the first mention for a post outside any mentioned thread (a new root)', () => {
+    const h = harness();
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'input_added', inputIndex: 1, origin: origin('root-1') }));
+    h.indexer.handleTurnEvent(h.post('t1', 'call-1', { spaceId: 'space-1', body: 'announcement' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'call-1', h.mcpOutput('root-new')));
+    expect(h.links()).toEqual({ [linkKey('org-1', 'space-1', 'root-new')]: { sessionId: 'sess-1', turnId: 't1', inputIndex: 1 } });
+  });
+
+  it('ignores turns without a mention origin, other MCP servers, other tools, and failed posts', () => {
+    const h = harness();
+    // no origin → the person chatting in the thread's session
+    h.indexer.handleTurnEvent(h.turn('t0', { type: 'turn_created' }));
+    h.indexer.handleTurnEvent(h.post('t0', 'c0', { spaceId: 'space-1', body: 'x' }));
+    h.indexer.handleTurnEvent(h.result('t0', 'c0', h.mcpOutput('m0')));
+
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    // another server
+    h.indexer.handleTurnEvent(h.post('t1', 'c1', { spaceId: 'space-1', body: 'x' }, 'some-other-mcp'));
+    h.indexer.handleTurnEvent(h.result('t1', 'c1', h.mcpOutput('m1')));
+    // another tool on the org server
+    h.indexer.handleTurnEvent(
+      h.turn('t1', {
+        type: 'tool_invocation_requested',
+        toolCallId: 'c2',
+        toolId: 'executeMcpTool',
+        toolName: 'executeMcpTool',
+        execution: 'sync',
+        input: { serverName: 'spaces-org-1', toolName: 'read_thread', arguments: { spaceId: 'space-1', rootMessageId: 'root-1' } },
+      }),
+    );
+    h.indexer.handleTurnEvent(h.result('t1', 'c2', { success: true, result: { structuredContent: { messageId: 'm2' } } }));
+    // a post the org refused
+    h.indexer.handleTurnEvent(h.post('t1', 'c3', { spaceId: 'space-1', threadRoot: 'root-1', body: 'x' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'c3', { success: false, error: 'Failed to execute MCP tool: forbidden' }));
+    // a runtime error result
+    h.indexer.handleTurnEvent(h.post('t1', 'c4', { spaceId: 'space-1', threadRoot: 'root-1', body: 'x' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'c4', 'permission denied', true));
+
+    expect(h.links()).toEqual({});
+    expect(h.writes()).toBe(0);
+  });
+
+  it('forgets a settled turn: a late result for it records nothing', () => {
+    const h = harness();
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    h.indexer.handleTurnEvent(h.post('t1', 'c1', { spaceId: 'space-1', threadRoot: 'root-1', body: 'x' }));
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'turn_cancelled' }));
+    h.indexer.handleTurnEvent(h.result('t1', 'c1', h.mcpOutput('m1')));
+    expect(h.links()).toEqual({});
+  });
+
+  it('caps the file at MAX_LINKS, dropping the oldest', () => {
+    const h = harness();
+    h.indexer.handleTurnEvent(h.turn('t1', { type: 'turn_created', origin: origin('root-1') }));
+    for (let i = 0; i < MAX_LINKS + 3; i++) {
+      h.indexer.handleTurnEvent(h.post('t1', `c${i}`, { spaceId: 'space-1', threadRoot: 'root-1', body: 'x' }));
+      h.indexer.handleTurnEvent(h.result('t1', `c${i}`, h.mcpOutput(`m${i}`)));
+    }
+    const keys = Object.keys(h.links());
+    expect(keys).toHaveLength(MAX_LINKS);
+    expect(keys[0]).toBe(linkKey('org-1', 'space-1', 'm3'));
+    expect(keys[keys.length - 1]).toBe(linkKey('org-1', 'space-1', `m${MAX_LINKS + 2}`));
+  });
+});

--- a/apps/x/packages/core/src/spaces/response-index.ts
+++ b/apps/x/packages/core/src/spaces/response-index.ts
@@ -1,0 +1,269 @@
+import fs from 'fs';
+import path from 'path';
+import type { TurnBusEvent } from '@x/shared/dist/turns.js';
+import type { SpaceMentionOrigin } from '@x/shared/dist/origins.js';
+import { WorkDir } from '../config/config.js';
+import { spacesMcpServerNameFor } from './orgs.js';
+
+// "Which run wrote this reply?" — the per-response half of the space ↔ agent
+// linkage. topic-agent.ts's registry answers "which session does this THREAD
+// use" (one per thread, recreated when deleted), which is right for the
+// working chip and the thread header's Chat link but cannot point at the
+// exact turn behind one agent post, and silently re-points old posts at a
+// fresh session once the original is gone.
+//
+// This module watches the turn bus for the agent's post_message calls made
+// inside a mention-originated turn, and records feed message id → (session,
+// turn, input) locally, next to the registry. The org never sees a session
+// id: sessions are local to the machine whose Rowboat ran, so nobody else
+// could resolve one anyway (when agents move into Harbor the org will know
+// the run itself and can stamp provenance on the message then).
+//
+// Recognition is structural, not textual: a tool_invocation_requested for
+// executeMcpTool whose server is the mention's org and whose inner tool is
+// post_message, paired by toolCallId with its tool_result carrying the new
+// message's id. The runtime knows nothing of this — same posture as
+// agent-activity.ts.
+
+const INDEX_FILE = path.join(WorkDir, 'config', 'spaces_response_sessions.json');
+/** Insertion-ordered cap; the oldest links fall off first. */
+export const MAX_LINKS = 2000;
+
+export interface SpaceResponseLink {
+  sessionId: string;
+  turnId: string;
+  /**
+   * The input inside the turn that carried the mention this post answers:
+   * absent = the turn's creating input, N = the Nth input_added (a mention
+   * steered into a live turn). The renderer's user-row ids follow the same
+   * shape (`${turnId}:user` / `${turnId}:user:${N}`), so this is what the
+   * chat view scrolls to.
+   */
+  inputIndex?: number;
+}
+
+interface IndexFile {
+  version: 1;
+  links: Record<string, SpaceResponseLink>;
+}
+
+export interface ResponseLinkStore {
+  read(): IndexFile;
+  write(index: IndexFile): void;
+}
+
+export function linkKey(orgId: string, spaceId: string, messageId: string): string {
+  return `${orgId}/${spaceId}/${messageId}`;
+}
+
+const fileStore: ResponseLinkStore = {
+  read() {
+    try {
+      if (!fs.existsSync(INDEX_FILE)) return { version: 1, links: {} };
+      const raw = JSON.parse(fs.readFileSync(INDEX_FILE, 'utf-8')) as Partial<IndexFile>;
+      return { version: 1, links: raw.links ?? {} };
+    } catch {
+      return { version: 1, links: {} };
+    }
+  },
+  write(index) {
+    const dir = path.dirname(INDEX_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(INDEX_FILE, JSON.stringify(index, null, 2));
+  },
+};
+
+function mentionOrigin(event: unknown): SpaceMentionOrigin | null {
+  const origin = (event as { origin?: { kind?: string } }).origin;
+  return origin?.kind === 'space_mention' ? (origin as SpaceMentionOrigin) : null;
+}
+
+interface TrackedInput {
+  origin: SpaceMentionOrigin;
+  inputIndex?: number;
+}
+
+interface TrackedTurn {
+  sessionId: string;
+  /** Mention inputs the turn accepted, in arrival order. */
+  inputs: TrackedInput[];
+}
+
+interface PendingPost {
+  turnId: string;
+  orgId: string;
+  spaceId: string;
+  threadRoot: string | null;
+}
+
+/**
+ * Pull the posted message id out of executeMcpTool's output. The MCP result
+ * carries the org's `{ messageId, threadRoot? }` both as structuredContent
+ * and as a JSON text block; either is accepted (pure; tested).
+ */
+export function postedMessageId(output: unknown): string | null {
+  const o = output as { success?: boolean; result?: unknown } | null;
+  if (!o || o.success === false) return null;
+  const result = o.result as
+    | { isError?: boolean; structuredContent?: { messageId?: unknown }; content?: Array<{ type?: string; text?: string }> }
+    | null
+    | undefined;
+  if (!result || result.isError) return null;
+  const structured = result.structuredContent?.messageId;
+  if (typeof structured === 'string' && structured) return structured;
+  for (const part of result.content ?? []) {
+    if (part.type !== 'text' || typeof part.text !== 'string') continue;
+    try {
+      const parsed = JSON.parse(part.text) as { messageId?: unknown };
+      if (typeof parsed.messageId === 'string' && parsed.messageId) return parsed.messageId;
+    } catch {
+      // not JSON — keep looking
+    }
+  }
+  return null;
+}
+
+/**
+ * The bus consumer. Pure apart from the injected store and server-name
+ * lookup (tested); the module-level instance below wires the real ones.
+ */
+export class SpaceResponseIndexer {
+  private readonly running = new Map<string, TrackedTurn>();
+  private readonly pendingPosts = new Map<string, PendingPost>();
+
+  constructor(
+    private readonly store: ResponseLinkStore,
+    private readonly serverNameFor: (orgId: string) => string | null,
+  ) {}
+
+  handleTurnEvent(busEvent: TurnBusEvent): void {
+    const event = busEvent.event as { type?: string };
+    switch (event.type) {
+      case 'turn_created':
+      case 'input_added': {
+        const origin = mentionOrigin(event);
+        if (!origin) return;
+        let turn = this.running.get(busEvent.turnId);
+        if (!turn) {
+          turn = { sessionId: busEvent.sessionId ?? '', inputs: [] };
+          this.running.set(busEvent.turnId, turn);
+        }
+        const inputIndex = event.type === 'input_added' ? (event as { inputIndex?: number }).inputIndex : undefined;
+        turn.inputs.push({ origin, ...(typeof inputIndex === 'number' ? { inputIndex } : {}) });
+        return;
+      }
+      case 'tool_invocation_requested': {
+        const turn = this.running.get(busEvent.turnId);
+        if (!turn) return;
+        const e = event as { toolCallId: string; toolName: string; input?: unknown };
+        if (e.toolName !== 'executeMcpTool') return;
+        const input = e.input as { serverName?: unknown; toolName?: unknown; arguments?: { spaceId?: unknown; threadRoot?: unknown } } | null;
+        if (!input || input.toolName !== 'post_message' || typeof input.serverName !== 'string') return;
+        const spaceId = input.arguments?.spaceId;
+        if (typeof spaceId !== 'string') return;
+        // The org whose MCP server this call targets — one of the mention
+        // origins' orgs (a turn steered from two orgs is theoretical, but
+        // matching by server name keeps the attribution honest either way).
+        const orgId = [...new Set(turn.inputs.map((i) => i.origin.orgId))].find((id) => this.serverNameFor(id) === input.serverName);
+        if (!orgId) return;
+        const threadRoot = typeof input.arguments?.threadRoot === 'string' ? input.arguments.threadRoot : null;
+        this.pendingPosts.set(e.toolCallId, { turnId: busEvent.turnId, orgId, spaceId, threadRoot });
+        return;
+      }
+      case 'tool_result': {
+        const e = event as { toolCallId: string; result?: { output?: unknown; isError?: boolean } };
+        const post = this.pendingPosts.get(e.toolCallId);
+        if (!post) return;
+        this.pendingPosts.delete(e.toolCallId);
+        if (e.result?.isError) return;
+        const messageId = postedMessageId(e.result?.output);
+        if (!messageId) return;
+        const turn = this.running.get(post.turnId);
+        if (!turn) return;
+        // The input this post answers: the mention in the same thread, else
+        // the turn's first mention (a root post, or a thread the agent chose).
+        const input =
+          turn.inputs.find((i) => i.origin.spaceId === post.spaceId && i.origin.threadRootId === post.threadRoot) ?? turn.inputs[0];
+        this.record(linkKey(post.orgId, post.spaceId, messageId), {
+          sessionId: turn.sessionId,
+          turnId: post.turnId,
+          ...(input && typeof input.inputIndex === 'number' ? { inputIndex: input.inputIndex } : {}),
+        });
+        return;
+      }
+      case 'turn_completed':
+      case 'turn_failed':
+      case 'turn_cancelled': {
+        this.running.delete(busEvent.turnId);
+        for (const [id, post] of this.pendingPosts) {
+          if (post.turnId === busEvent.turnId) this.pendingPosts.delete(id);
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  link(orgId: string, spaceId: string, messageId: string): SpaceResponseLink | null {
+    return this.store.read().links[linkKey(orgId, spaceId, messageId)] ?? null;
+  }
+
+  private record(key: string, link: SpaceResponseLink): void {
+    const index = this.store.read();
+    // Re-insert at the end so a rewrite counts as recent for the cap.
+    delete index.links[key];
+    index.links[key] = link;
+    const keys = Object.keys(index.links);
+    if (keys.length > MAX_LINKS) {
+      for (const stale of keys.slice(0, keys.length - MAX_LINKS)) delete index.links[stale];
+    }
+    this.store.write(index);
+  }
+}
+
+// --- the process-wide instance ----------------------------------------------
+
+const indexer = new SpaceResponseIndexer(fileStore, spacesMcpServerNameFor);
+
+let started: Promise<void> | null = null;
+
+/** Subscribe the indexer to the turn bus. Idempotent; hosts call it at boot next to startSpaceAgentActivity. */
+export function startSpaceResponseIndex(): Promise<void> {
+  if (started) return started;
+  started = (async () => {
+    const { lazyResolve } = await import('../di/lazy-resolve.js');
+    const turnEventBus = await lazyResolve<{ subscribeAll(listener: (event: TurnBusEvent) => void): () => void }>('turnEventBus');
+    turnEventBus.subscribeAll((event) => indexer.handleTurnEvent(event));
+  })();
+  started.catch(() => {
+    started = null; // let a later call retry
+  });
+  return started;
+}
+
+export type ResponseSessionResolution =
+  /** The run that posted this message; the renderer opens the session at its input. */
+  | { status: 'found'; sessionId: string; turnId: string; inputIndex?: number }
+  /** A link exists but its session was deleted since — say so, never fall through to a recreated one. */
+  | { status: 'gone' }
+  /** Nothing recorded: a post from before this index existed, or not this member's Rowboat. */
+  | { status: 'unknown' };
+
+/** The message-row "Open agent chat" resolution. */
+export async function resolveResponseSession(input: {
+  orgId: string;
+  spaceId: string;
+  messageId: string;
+}): Promise<ResponseSessionResolution> {
+  const link = indexer.link(input.orgId, input.spaceId, input.messageId);
+  if (!link) return { status: 'unknown' };
+  const { lazyResolve } = await import('../di/lazy-resolve.js');
+  const sessions = await lazyResolve<{ getSession(sessionId: string): Promise<unknown> }>('sessions');
+  try {
+    await sessions.getSession(link.sessionId);
+  } catch {
+    return { status: 'gone' };
+  }
+  return { status: 'found', ...link };
+}

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -83,7 +83,8 @@ function writeRegistry(registry: Registry): void {
 
 /**
  * The thread's session, if one has been created — the renderer's "open the
- * agent session" affordance when no live activity record names it.
+ * agent session" affordance when no live activity record names it. Thread-
+ * level only: the run behind ONE agent post is response-index.ts's job.
  */
 export function topicSessionId(orgId: string, spaceId: string, threadRootId: string): string | null {
   return readRegistry().sessions[registryKey(orgId, spaceId, threadRootId)] ?? null;

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3986,6 +3986,20 @@ export const ipcSchemas = {
     req: z.object({ orgId: z.string(), spaceId: z.string(), threadRootId: z.string() }),
     res: z.object({ sessionId: z.string().nullable() }),
   },
+  // The run behind ONE agent-posted message (core/spaces/response-index):
+  // the message row's "Open agent chat". found = open the session at that
+  // input; gone = the link's session was deleted since (say so, never fall
+  // through to the thread's recreated session); unknown = nothing recorded
+  // (pre-index post, or not this member's Rowboat) — the caller may fall
+  // back to spaces:topicSession.
+  'spaces:responseSession': {
+    req: z.object({ orgId: z.string(), spaceId: z.string(), messageId: z.string() }),
+    res: z.discriminatedUnion('status', [
+      z.object({ status: z.literal('found'), sessionId: z.string(), turnId: z.string(), inputIndex: z.number().int().optional() }),
+      z.object({ status: z.literal('gone') }),
+      z.object({ status: z.literal('unknown') }),
+    ]),
+  },
   // The stop square on the working chip: cancel the thread session's live
   // turn without leaving the space. Invoker-only by construction — the
   // topic→session registry is local, so only the member whose Rowboat runs


### PR DESCRIPTION
## What

A Rowboat post in a space now links back to the run that wrote it, after the fact. On your own agent posts, the "via Rowboat" label is clickable and the ⋯ menu gains **Open agent chat**. Clicking opens the session scrolled to the exact input that produced the reply (a steered mention lands on its steered input).

## Design

- **Per-response, stored locally.** The org's message schema is untouched: a session id is only resolvable on the author's machine, so org-side metadata would be an opaque token for everyone else. When agents move into Harbor as jobs, the org can stamp run provenance itself and this index retires.
- **Registry stays the thread-level fallback.** `spaces_topic_sessions.json` (one session per thread) still powers the working chip and the thread header's Chat link. It can't point at a specific turn and silently re-points old posts at a fresh session after deletion, which is what this fixes.
- **A gone session says so.** `found | gone | unknown` — a recorded link whose session was deleted never falls through to the recreated thread session (wrong conversation). Only pre-index posts fall back to the thread session, unanchored.

## How

- `core/spaces/response-index.ts` — turn-bus consumer (same `subscribeAll` posture as agent-activity). Pairs a `tool_invocation_requested` for `executeMcpTool → post_message` on the mention org's server with its `tool_result` by toolCallId; records `org/space/messageId → {sessionId, turnId, inputIndex?}` in `config/spaces_response_sessions.json`, capped at 2000.
- IPC `spaces:responseSession`, registered in Electron main and the server host (`channels.ts` + `spaces-deps.ts`).
- Renderer deep link: `lib/chat-jump.ts` (pending target, spaces-jump idiom) → `ChatSessionPane` consumes → `Conversation` `jumpMessageId`/`jumpRequestKey` → `ChatScrollController.requestJump`, which pins the `${turnId}:user[:${inputIndex}]` row near the viewport top once the transcript renders it (15s deadline, no last-user-row fallback, the reader's own scroll cancels, brief flash).

## Tests

- 8 new indexer tests (creating vs steered input attribution, root-post fallback, other servers/tools/failed posts ignored, settled-turn forgetting, cap).
- 5 new scroll-controller tests for `requestJump` (existing row, late row, missing row, user-scroll cancel, deadline).
- Full renderer suite (546), shared suite (309), core spaces tests pass; renderer/main/server typecheck clean.
- Live-verified: mention @rowboat, wait for the reply, click the label → chat opens scrolled to that turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn1URjmaU9j6h5WDzJ8xhH
