### PR TITLE
feat(x): keep space-thread sessions out of the chat list; history pane gets a Space chats tab

### DIFF
--- a/apps/x/apps/mobile/src/app/sessions/index.tsx
+++ b/apps/x/apps/mobile/src/app/sessions/index.tsx
@@ -1,7 +1,7 @@
 import { router, Stack, useFocusEffect } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
 import { Button, FlatList, Pressable, RefreshControl, StyleSheet, Text, useColorScheme, View } from 'react-native';
-import type { sessions as sessionsShared } from '@x/shared';
+import { sessions as sessionsShared } from '@x/shared';
 
 import * as analytics from '@/lib/analytics';
 import { StatusPill } from '@/components/status-pill';
@@ -23,7 +23,9 @@ export default function SessionsScreen() {
     try {
       const result = await sessions.list();
       setEntries(
-        [...result.sessions].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1)),
+        result.sessions
+          .filter(sessionsShared.isChatListSession)
+          .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1)),
       );
       setError(null);
     } catch (err) {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -111,6 +111,8 @@ import {
 } from '@/lib/chat-conversation'
 import { COMPOSIO_DISPLAY_NAMES as composioDisplayNames } from '@x/shared/src/composio.js'
 import { COMMAND_CENTER_CHAT_SENTINEL } from '@x/shared/src/home-threads.js'
+import { isChatListSession } from '@x/shared/src/sessions.js'
+import type { SessionOrigin, SpaceThreadOrigin } from '@x/shared/src/origins.js'
 import { AgentScheduleConfig } from '@x/shared/dist/agent-schedule.js'
 import { AgentScheduleState } from '@x/shared/dist/agent-schedule-state.js'
 import { toast } from "sonner"
@@ -2596,7 +2598,10 @@ function App() {
   }, [])
 
   // Runs history state
-  type RunListItem = { id: string; title?: string; createdAt: string; modifiedAt: string; agentId: string; useCase?: string }
+  // origin: what owns the session when something outside the runtime does
+  // (a space thread). Lists that show "your chats" filter on it via
+  // isChatListSession; lookups by id (tab titles, hover) use the full list.
+  type RunListItem = { id: string; title?: string; createdAt: string; modifiedAt: string; agentId: string; useCase?: string; origin?: SessionOrigin }
   const [runs, setRuns] = useState<RunListItem[]>([])
 
   // Chat tab state
@@ -3483,6 +3488,7 @@ function App() {
         createdAt: entry.createdAt,
         modifiedAt: entry.updatedAt,
         agentId: entry.lastAgentId ?? 'copilot',
+        ...(entry.origin ? { origin: entry.origin } : {}),
       })))
     } catch (err) {
       console.error('Failed to load sessions:', err)
@@ -3510,6 +3516,7 @@ function App() {
           createdAt: event.entry.createdAt,
           modifiedAt: event.entry.updatedAt,
           agentId: event.entry.lastAgentId ?? 'copilot',
+          ...(event.entry.origin ? { origin: event.entry.origin } : {}),
         }
         // Re-sort: chat-header slices the top of this list without sorting,
         // so it must stay newest-first like sessions:list.
@@ -3522,6 +3529,12 @@ function App() {
       })
     })
   }, [])
+
+  // The person's own chats — what every "recent chats" surface lists. Space
+  // threads and other owned sessions stay in `runs` (tab titles, the history
+  // pane's explicit filter) but out of these. One predicate, applied to the
+  // seed and to every feed event above, so seed and feed never disagree.
+  const chatRuns = useMemo(() => runs.filter(isChatListSession), [runs])
 
   const [bgTaskSummaries, setBgTaskSummaries] = useState<Array<{
     slug: string
@@ -4880,10 +4893,10 @@ function App() {
         activeTitle: hoverRunId
           ? (runs.find((r) => r.id === hoverRunId)?.title || '(Untitled chat)')
           : null,
-        recent: runs.slice(0, 10).map((r) => ({ id: r.id, title: r.title || '(Untitled chat)' })),
+        recent: chatRuns.slice(0, 10).map((r) => ({ id: r.id, title: r.title || '(Untitled chat)' })),
       })
       .catch(() => {})
-  }, [hoverRunId, runs])
+  }, [hoverRunId, runs, chatRuns])
 
   // The bar's chip switcher picked a chat: rebind the COMPANION to it. The
   // app window keeps showing whatever it was showing. The Command Center
@@ -7005,7 +7018,7 @@ function App() {
     onOpenApp: (folder: string) => { setAppInitialId(folder); setAppIdVersion((v) => v + 1); openAppsView() },
     onOpenSpace: openSpace,
     activeSpace: isSpacesOpen ? spaceSelection : null,
-    recentRuns: runs,
+    recentRuns: chatRuns,
     onOpenRun: openAssistantRun,
     onRenameRun: (rid: string, title: string) => {
       void window.ipc.invoke('sessions:setTitle', { sessionId: rid, title })
@@ -7088,7 +7101,7 @@ function App() {
                       return activeTab ? getChatTabTitle(activeTab) : 'New chat'
                     })()}
                     onNewChatTab={handleNewChatTab}
-                    recentRuns={runs}
+                    recentRuns={chatRuns}
                     activeRunId={runId}
                     sessionUsage={activeChatTabState.sessionUsage}
                     onSelectRun={openAssistantRun}
@@ -7511,6 +7524,9 @@ function App() {
                     currentRunId={runId}
                     processingRunIds={processingRunIds}
                     onSelectRun={openAssistantRun}
+                    onOpenSpaceThread={(origin: SpaceThreadOrigin) => {
+                      void navigateToView({ type: 'spaces', orgId: origin.orgId, spaceId: origin.spaceId, rail: { kind: 'thread', rootMessageId: origin.threadRootId } })
+                    }}
                     onRenameRun={(rid, title) => {
                       void window.ipc.invoke('sessions:setTitle', { sessionId: rid, title })
                         .then(() => setRuns((prev) => prev.map((r) => (r.id === rid ? { ...r, title } : r))))
@@ -7878,7 +7894,7 @@ function App() {
                 activeChatTabId={activeChatTabId}
                 getChatTabTitle={getChatTabTitle}
                 onNewChatTab={() => handleNewChatTabInSidebar()}
-                recentRuns={runs}
+                recentRuns={chatRuns}
                 onSelectRun={bindChatToRun}
                 onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
                 onOpenFullScreen={dockFullScreen ? undefined : toggleRightPaneMaximize}

--- a/apps/x/apps/renderer/src/components/chat-history-view.tsx
+++ b/apps/x/apps/renderer/src/components/chat-history-view.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useMemo, useState } from 'react'
-import { ExternalLink, MoreVertical, Pencil, SearchIcon, SquarePen, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ExternalLink, MessagesSquare, MoreVertical, Pencil, SearchIcon, SquarePen, Trash2 } from 'lucide-react'
+import type { SessionOrigin, SpaceThreadOrigin } from '@x/shared/src/origins.js'
+import { isChatListSession } from '@x/shared/src/sessions.js'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -26,6 +28,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { formatRelativeTime } from '@/lib/relative-time'
+import { findSpace, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 
 type Run = {
   id: string
@@ -33,9 +36,12 @@ type Run = {
   createdAt: string
   modifiedAt: string
   agentId: string
+  /** Set when something outside the runtime owns the session (a space thread). */
+  origin?: SessionOrigin
 }
 
 type ChatHistoryViewProps = {
+  /** EVERY session, owned or not — this pane is where owned sessions become reachable. */
   runs: Run[]
   currentRunId?: string | null
   processingRunIds?: Set<string>
@@ -45,6 +51,166 @@ type ChatHistoryViewProps = {
   onDeleteRun: (runId: string) => Promise<void> | void
   onNewChat?: () => void
   onOpenSearch?: () => void
+  /** Jump to the thread that owns a space-thread session. */
+  onOpenSpaceThread?: (origin: SpaceThreadOrigin) => void
+}
+
+// ---------------------------------------------------------------------------
+// Two lists, never merged: the person's own assistant chats, and Mentions —
+// the sessions the @rowboat mention machinery owns, one per space thread.
+// The header tab picks which; in Mentions the chips narrow to one space.
+// Names come from the live org roster when it is loaded (renames, DM display
+// names) and fall back to what the session recorded at creation.
+// ---------------------------------------------------------------------------
+
+type HistoryTab = 'chats' | 'mentions'
+
+const HISTORY_TAB_KEY = 'chat-history.tab'
+
+function readHistoryTab(): HistoryTab {
+  try {
+    return localStorage.getItem(HISTORY_TAB_KEY) === 'mentions' ? 'mentions' : 'chats'
+  } catch {
+    return 'chats'
+  }
+}
+
+function spaceKey(origin: SpaceThreadOrigin): string {
+  return `${origin.orgId}/${origin.spaceId}`
+}
+
+/** A stable hue per space so its chip reads the same everywhere in the list. */
+function spaceHue(key: string): number {
+  let h = 0
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0
+  return h % 360
+}
+
+interface SpaceFacet {
+  key: string
+  origin: SpaceThreadOrigin
+  /** Space name, or the other person's name for a DM. */
+  label: string
+  orgName?: string
+  isDirect: boolean
+  count: number
+  latestMs: number
+}
+
+function resolveSpace(origin: SpaceThreadOrigin, orgs: OrgWithSpaces[]): Pick<SpaceFacet, 'label' | 'orgName' | 'isDirect'> {
+  const org = orgs.find((o) => o.id === origin.orgId)
+  if (!org) return { label: origin.spaceName, isDirect: false }
+  const space = findSpace(org, origin.spaceId)
+  const isDirect = org.directs.some((s) => s.id === origin.spaceId)
+  const label = isDirect
+    ? (org.directLabels[origin.spaceId] ?? space?.name ?? origin.spaceName)
+    : (space?.name ?? origin.spaceName)
+  return { label, orgName: org.name, isDirect }
+}
+
+function SpaceDot({ hue, className }: { hue: number; className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('inline-block size-2 shrink-0 rounded-full', className)}
+      style={{ backgroundColor: `hsl(${hue} 62% 52%)` }}
+    />
+  )
+}
+
+/** The chip on a row: which space (and DM-ness) a thread session belongs to, and whose org. */
+function SpaceChip({ facet }: { facet: SpaceFacet }) {
+  return (
+    <span
+      className="inline-flex max-w-[280px] shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-muted/50 px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+      title={facet.orgName ? `${facet.label} · ${facet.orgName}` : facet.label}
+    >
+      <SpaceDot hue={spaceHue(facet.key)} />
+      {facet.isDirect && <span className="text-muted-foreground/70">DM</span>}
+      <span className="truncate text-foreground/80">{facet.label}</span>
+      {facet.orgName && <span className="truncate text-muted-foreground/70">· {facet.orgName}</span>}
+    </span>
+  )
+}
+
+/** The header's view picker — two lists, one shown at a time. */
+function HistoryTabs({
+  value,
+  mentionCount,
+  onChange,
+}: {
+  value: HistoryTab
+  mentionCount: number
+  onChange: (tab: HistoryTab) => void
+}) {
+  const tab = (id: HistoryTab, label: string, count?: number) => {
+    const selected = value === id
+    return (
+      <button
+        type="button"
+        role="tab"
+        aria-selected={selected}
+        onClick={() => onChange(id)}
+        className={cn(
+          'inline-flex h-7 items-center gap-1.5 rounded-md px-3 text-[13px] font-medium transition-colors',
+          selected
+            ? 'bg-background text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5)]'
+            : 'text-muted-foreground hover:text-foreground',
+        )}
+      >
+        {label}
+        {count !== undefined && (
+          <span className={cn('rounded-full px-1.5 py-px text-[11px] tabular-nums', selected ? 'bg-muted text-muted-foreground' : 'bg-muted/60 text-muted-foreground')}>
+            {count}
+          </span>
+        )}
+      </button>
+    )
+  }
+  return (
+    <div role="tablist" aria-label="History view" className="inline-flex items-center gap-0.5 rounded-lg bg-muted p-0.5">
+      {tab('chats', 'Assistant chats')}
+      {tab('mentions', 'Space chats', mentionCount)}
+    </div>
+  )
+}
+
+/** A filter chip in the facet row: one space, its org, and its thread count. */
+function FacetChip({
+  facet,
+  selected,
+  onClick,
+}: {
+  facet: SpaceFacet
+  selected: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={cn(
+        'inline-flex max-w-[260px] items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] transition-colors',
+        selected
+          ? 'border-foreground/80 bg-foreground text-background'
+          : 'border-border/70 bg-background text-foreground hover:bg-accent',
+      )}
+    >
+      <SpaceDot hue={spaceHue(facet.key)} className={cn(selected && 'ring-1 ring-background/60')} />
+      {facet.isDirect && <span className={cn('text-[10px] uppercase tracking-wide', selected ? 'text-background/70' : 'text-muted-foreground')}>DM</span>}
+      <span className="truncate font-medium">{facet.label}</span>
+      {facet.orgName && (
+        <span className={cn('truncate', selected ? 'text-background/70' : 'text-muted-foreground')}>· {facet.orgName}</span>
+      )}
+      <span className={cn('tabular-nums', selected ? 'text-background/70' : 'text-muted-foreground')}>{facet.count}</span>
+    </button>
+  )
+}
+
+function recencyMs(run: Run): number {
+  const ms = new Date(run.modifiedAt).getTime()
+  return Number.isNaN(ms) ? 0 : ms
 }
 
 export function ChatHistoryView({
@@ -57,18 +223,68 @@ export function ChatHistoryView({
   onDeleteRun,
   onNewChat,
   onOpenSearch,
+  onOpenSpaceThread,
 }: ChatHistoryViewProps) {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameDraft, setRenameDraft] = useState('')
+  const [tab, setTab] = useState<HistoryTab>(readHistoryTab)
+  // Mentions only: narrow to one space (its facet key); null = every space.
+  const [spaceFilter, setSpaceFilter] = useState<string | null>(null)
+  const { orgs } = useSpacesOrgs()
 
-  const sortedRuns = useMemo(() => {
-    return [...runs].sort((a, b) => {
-      const at = new Date(a.modifiedAt).getTime()
-      const bt = new Date(b.modifiedAt).getTime()
-      return (Number.isNaN(bt) ? 0 : bt) - (Number.isNaN(at) ? 0 : at)
-    })
-  }, [runs])
+  useEffect(() => {
+    try {
+      localStorage.setItem(HISTORY_TAB_KEY, tab)
+    } catch {
+      // per-viewer convenience only
+    }
+  }, [tab])
+
+  const sortedRuns = useMemo(() => [...runs].sort((a, b) => recencyMs(b) - recencyMs(a)), [runs])
+
+  const chatRuns = useMemo(() => sortedRuns.filter(isChatListSession), [sortedRuns])
+  const threadRuns = useMemo(
+    () => sortedRuns.filter((r): r is Run & { origin: SpaceThreadOrigin } => r.origin?.kind === 'space_thread'),
+    [sortedRuns],
+  )
+
+  // One facet per space, from the sessions' own metadata: busiest first.
+  const facets = useMemo(() => {
+    const byKey = new Map<string, SpaceFacet>()
+    for (const run of threadRuns) {
+      const key = spaceKey(run.origin)
+      const existing = byKey.get(key)
+      if (existing) {
+        existing.count += 1
+        existing.latestMs = Math.max(existing.latestMs, recencyMs(run))
+        continue
+      }
+      byKey.set(key, { key, origin: run.origin, ...resolveSpace(run.origin, orgs), count: 1, latestMs: recencyMs(run) })
+    }
+    return [...byKey.values()].sort((a, b) => b.count - a.count || b.latestMs - a.latestMs || a.label.localeCompare(b.label))
+  }, [threadRuns, orgs])
+  const facetByKey = useMemo(() => new Map(facets.map((f) => [f.key, f])), [facets])
+
+  const hasThreads = threadRuns.length > 0
+  // The Mentions tab only exists once there is something to list; a remembered
+  // "mentions" pick with nothing to show falls back to chats.
+  const showMentions = tab === 'mentions' && hasThreads
+  // A filter whose space vanished (last thread deleted) reads as "all spaces"
+  // — derived, so no effect has to reset state.
+  const activeFacet = showMentions && spaceFilter ? facetByKey.get(spaceFilter) ?? null : null
+  const effectiveFilter = activeFacet ? activeFacet.key : null
+
+  const visibleRuns = useMemo(() => {
+    if (!showMentions) return chatRuns
+    if (activeFacet) return threadRuns.filter((r) => spaceKey(r.origin) === activeFacet.key)
+    return threadRuns
+  }, [showMentions, chatRuns, activeFacet, threadRuns])
+
+  const changeTab = useCallback((next: HistoryTab) => {
+    setTab(next)
+    setSpaceFilter(null)
+  }, [])
 
   const handleConfirmDelete = useCallback(async () => {
     if (!pendingDeleteId) return
@@ -90,12 +306,34 @@ export function ChatHistoryView({
     onRenameRun?.(runId, title)
   }, [renameDraft, runs, onRenameRun])
 
+  const plural = (n: number, one: string, many: string) => `${n} ${n === 1 ? one : many}`
+  const subtitle = (() => {
+    if (activeFacet) {
+      const where = activeFacet.isDirect ? `your DM with ${activeFacet.label}` : activeFacet.label
+      const org = activeFacet.orgName ? ` (${activeFacet.orgName})` : ''
+      return `${plural(activeFacet.count, 'thread', 'threads')} where Rowboat was mentioned in ${where}${org}, newest first.`
+    }
+    if (showMentions) {
+      return `${plural(threadRuns.length, 'thread', 'threads')} where Rowboat was mentioned across your spaces, newest first.`
+    }
+    if (chatRuns.length === 0) return 'Every conversation you have with the assistant shows up here.'
+    return `${plural(chatRuns.length, 'conversation', 'conversations')} with the assistant, newest first.`
+  })()
+
+  const emptyMessage = activeFacet
+    ? 'No threads in this space yet.'
+    : hasThreads && !showMentions
+      ? 'No assistant chats yet. The Space chats tab lists the conversations Rowboat had inside your spaces.'
+      : 'No chats yet.'
+
   return (
     <div className="flex h-full flex-col overflow-hidden bg-[#f8f8f9] dark:bg-[#0b0b0d]">
       <div className="mx-auto w-full max-w-[1120px] shrink-0 px-[30px] pt-[34px] pb-5">
         <div className="flex items-center justify-between gap-4">
           <h1 className="text-[24px] font-[650] tracking-[-0.02em] text-[#0d0e11] dark:text-[#f4f5f7]">Chat history</h1>
           <div className="flex items-center gap-2">
+            {hasThreads && <HistoryTabs value={showMentions ? 'mentions' : 'chats'} mentionCount={threadRuns.length} onChange={changeTab} />}
+            {hasThreads && <span className="mx-1 h-5 w-px bg-border/70" aria-hidden="true" />}
             {onOpenSearch && (
               <button
                 type="button"
@@ -114,30 +352,58 @@ export function ChatHistoryView({
             )}
           </div>
         </div>
-        <p className="mt-1 text-[14px] text-black/50 dark:text-white/[0.52]">
-          {sortedRuns.length === 0
-            ? 'Every conversation you have shows up here.'
-            : `${sortedRuns.length} ${sortedRuns.length === 1 ? 'conversation' : 'conversations'}, newest first.`}
-        </p>
+        <p className="mt-1 text-[14px] text-black/50 dark:text-white/[0.52]">{subtitle}</p>
+
+        {showMentions && facets.length > 1 && (
+          <div className="mt-4 flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by space">
+            <button
+              type="button"
+              onClick={() => setSpaceFilter(null)}
+              aria-pressed={effectiveFilter === null}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] font-medium transition-colors',
+                effectiveFilter === null
+                  ? 'border-foreground/80 bg-foreground text-background'
+                  : 'border-border/70 bg-background text-foreground hover:bg-accent',
+              )}
+            >
+              All spaces
+            </button>
+            <span className="mx-1 h-4 w-px bg-border/70" aria-hidden="true" />
+            {facets.map((facet) => (
+              <FacetChip
+                key={facet.key}
+                facet={facet}
+                selected={effectiveFilter === facet.key}
+                onClick={() => setSpaceFilter((prev) => (prev === facet.key ? null : facet.key))}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[1120px] px-[30px] pb-12">
-          {sortedRuns.length === 0 ? (
+          {visibleRuns.length === 0 ? (
             <div className="rounded-xl border border-dashed border-border px-6 py-10 text-center text-sm text-muted-foreground">
-              No chats yet.
+              {emptyMessage}
             </div>
           ) : (
             <div className="overflow-hidden rounded-xl border border-border/60 bg-card">
               <div className="flex items-center border-b border-border/60 bg-muted/30 px-4 py-3 text-[13px] text-muted-foreground">
-                <div className="min-w-0 flex-1">Title</div>
+                <div className="min-w-0 flex-1">{showMentions ? 'Thread' : 'Conversation'}</div>
                 <div className="w-28 shrink-0 text-right">Last modified</div>
                 <div className="w-7 shrink-0" />
               </div>
 
-              {sortedRuns.map((run) => {
+              {visibleRuns.map((run) => {
                 const isActive = currentRunId === run.id
                 const isProcessing = processingRunIds?.has(run.id)
+                const threadOrigin = run.origin?.kind === 'space_thread' ? run.origin : null
+                const facet = threadOrigin ? facetByKey.get(spaceKey(threadOrigin)) ?? null : null
+                const openThread = threadOrigin && onOpenSpaceThread
+                  ? () => onOpenSpaceThread(threadOrigin)
+                  : null
                 return (
                   <ContextMenu key={run.id}>
                     <ContextMenuTrigger asChild>
@@ -177,11 +443,12 @@ export function ChatHistoryView({
                                   onSelectRun(run.id)
                                 }
                               }}
-                              className="flex w-full items-center px-4 py-2.5 text-left text-sm"
+                              className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm"
                             >
                               <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-                                {run.title || '(Untitled chat)'}
+                                {run.title || (threadOrigin ? '(Untitled thread)' : '(Untitled chat)')}
                               </span>
+                              {facet && <SpaceChip facet={facet} />}
                               <span className="w-28 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
                                 {formatRelativeTime(run.modifiedAt)}
                               </span>
@@ -198,16 +465,20 @@ export function ChatHistoryView({
                                   <MoreVertical className="size-4" />
                                 </button>
                               </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end" className="w-48">
-                                {onOpenInNewTab && (
-                                  <>
-                                    <DropdownMenuItem onClick={() => onOpenInNewTab(run.id)}>
-                                      <ExternalLink className="mr-2 size-4" />
-                                      Open in new tab
-                                    </DropdownMenuItem>
-                                    <DropdownMenuSeparator />
-                                  </>
+                              <DropdownMenuContent align="end" className="w-52">
+                                {openThread && (
+                                  <DropdownMenuItem onClick={openThread}>
+                                    <MessagesSquare className="mr-2 size-4" />
+                                    Open thread in space
+                                  </DropdownMenuItem>
                                 )}
+                                {onOpenInNewTab && (
+                                  <DropdownMenuItem onClick={() => onOpenInNewTab(run.id)}>
+                                    <ExternalLink className="mr-2 size-4" />
+                                    Open in new tab
+                                  </DropdownMenuItem>
+                                )}
+                                {(openThread || onOpenInNewTab) && <DropdownMenuSeparator />}
                                 {onRenameRun && (
                                   <DropdownMenuItem onClick={() => startRename(run)}>
                                     <Pencil className="mr-2 size-4" />
@@ -229,16 +500,20 @@ export function ChatHistoryView({
                         )}
                       </div>
                     </ContextMenuTrigger>
-                    <ContextMenuContent className="w-48">
-                      {onOpenInNewTab && (
-                        <>
-                          <ContextMenuItem onClick={() => onOpenInNewTab(run.id)}>
-                            <ExternalLink className="mr-2 size-4" />
-                            Open in new tab
-                          </ContextMenuItem>
-                          <ContextMenuSeparator />
-                        </>
+                    <ContextMenuContent className="w-52">
+                      {openThread && (
+                        <ContextMenuItem onClick={openThread}>
+                          <MessagesSquare className="mr-2 size-4" />
+                          Open thread in space
+                        </ContextMenuItem>
                       )}
+                      {onOpenInNewTab && (
+                        <ContextMenuItem onClick={() => onOpenInNewTab(run.id)}>
+                          <ExternalLink className="mr-2 size-4" />
+                          Open in new tab
+                        </ContextMenuItem>
+                      )}
+                      {(openThread || onOpenInNewTab) && <ContextMenuSeparator />}
                       {onRenameRun && (
                         <ContextMenuItem onClick={() => startRename(run)}>
                           <Pencil className="mr-2 size-4" />
@@ -268,7 +543,9 @@ export function ChatHistoryView({
           <DialogHeader>
             <DialogTitle>Delete chat</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this chat?
+              {runs.find((r) => r.id === pendingDeleteId)?.origin?.kind === 'space_thread'
+                ? 'Are you sure you want to delete this thread’s conversation? The next @rowboat mention in the thread starts a fresh one.'
+                : 'Are you sure you want to delete this chat?'}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/apps/x/packages/core/docs/session-design.md
+++ b/apps/x/packages/core/docs/session-design.md
@@ -116,6 +116,7 @@ interface SessionCreated extends BaseSessionEvent {
   type: "session_created";
   schemaVersion: 1;
   title?: string;
+  origin?: SessionOrigin; // what owns the session, when something does
 }
 
 interface SessionTurnAppended extends BaseSessionEvent {
@@ -140,6 +141,15 @@ type SessionEvent =
 `turn_appended` deliberately denormalizes `agentId` and `model` from the
 turn so the index can fold from session files without opening turn files.
 The turn file remains authoritative for the turn's actual configuration.
+
+`origin` (a `SessionOrigin`, `@x/shared/origins.ts`) names the thing
+outside the runtime that owns the conversation as a whole — a space thread
+today. It is set once at creation and never changes; the runtime records it
+and never reads it. It is distinct from the per-input `InputOrigin` on turn
+events: a space-thread session outlives any single mention, and a person can
+chat in it directly, so ownership must not be derived from the latest turn.
+Sessions created before the field existed carry none and read as a person's
+own chats; the log is append-only, so they are not retrofitted.
 
 The session file never mirrors turn outcomes. Turn lifecycle facts live only
 in turn files; deriving "is this session busy/suspended/failed" reads the
@@ -204,6 +214,7 @@ Rules:
 interface SessionIndexEntry {
   sessionId: string;
   title?: string;
+  origin?: SessionOrigin; // folded from session_created (section 5)
   createdAt: string;
   updatedAt: string;
   turnCount: number;
@@ -226,6 +237,13 @@ the same derivation everywhere: terminal event kind if present, else
 `idle`. Whether a turn is *actively processing right now* is not in the
 index; it is ephemeral bus state (`turn-processing-start/end`), per the turn
 specification.
+
+The index and `sessions:list` carry every session, owned or not. Hiding
+owned sessions from a person's chat list is an edge concern: each list
+applies `isChatListSession(entry)` (`@x/shared/sessions.ts`) to both the
+`sessions:list` seed and every `index-changed` event, so a filtered list and
+its live feed cannot disagree. A server-side filter argument belongs with
+pagination, if that non-goal is ever revisited.
 
 ### 8.2 Startup scan
 
@@ -264,7 +282,7 @@ interface SendMessageConfig {
 }
 
 interface ISessions {
-  createSession(input?: { title?: string }): Promise<string>;
+  createSession(input?: { title?: string; origin?: SessionOrigin }): Promise<string>;
   listSessions(): SessionIndexEntry[];
   getSession(sessionId: string): Promise<SessionState>;
   getTurn(turnId: string): Promise<Turn>; // passthrough to turn runtime

--- a/apps/x/packages/core/src/runtime/sessions/api.ts
+++ b/apps/x/packages/core/src/runtime/sessions/api.ts
@@ -1,7 +1,7 @@
 import type { z } from "zod";
 import type { UseCase } from "@x/shared/dist/analytics.js";
 import type { UserMessage } from "@x/shared/dist/message.js";
-import type { InputOrigin } from "@x/shared/dist/origins.js";
+import type { InputOrigin, SessionOrigin } from "@x/shared/dist/origins.js";
 import type {
     QueuedSessionMessage,
     SessionIndexEntry,
@@ -47,7 +47,10 @@ export interface ISessions {
     // each session's latest turn for status). Must run before listSessions.
     initialize(): Promise<void>;
 
-    createSession(input?: { title?: string }): Promise<string>;
+    // origin: what owns the session when something outside the runtime
+    // does (a space thread). Main-process callers only — the renderer's
+    // sessions:create contract deliberately accepts title alone.
+    createSession(input?: { title?: string; origin?: SessionOrigin }): Promise<string>;
     listSessions(): SessionIndexEntry[];
     getSession(sessionId: string): Promise<SessionState>;
     getTurn(turnId: string): Promise<Turn>;

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -368,6 +368,23 @@ describe("createSession and listing", () => {
             expect.objectContaining({ kind: "index-changed", sessionId }),
         ]);
     });
+
+    it("stamps a session origin on session_created and folds it into the index entry", async () => {
+        const { sessions, repo } = makeSessions();
+        const origin = {
+            kind: "space_thread" as const,
+            orgId: "org-1",
+            spaceId: "space-1",
+            threadRootId: "root-1",
+            spaceName: "Roadboard",
+        };
+        const sessionId = await sessions.createSession({ title: "SSO first?", origin });
+        const [created] = await (repo as InMemorySessionRepo).read(sessionId);
+        expect(created).toEqual(expect.objectContaining({ type: "session_created", origin }));
+        expect(sessions.listSessions()).toEqual([
+            expect.objectContaining({ sessionId, title: "SSO first?", origin }),
+        ]);
+    });
 });
 
 describe("sendMessage (13.3)", () => {

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type { UserMessage } from "@x/shared/dist/message.js";
+import type { SessionOrigin } from "@x/shared/dist/origins.js";
 import {
     type QueuedSessionMessage,
     SessionCreated,
@@ -168,7 +169,7 @@ export class SessionsImpl implements ISessions {
         return deriveTurnStatus(reduceTurn(turn.events));
     }
 
-    async createSession(input?: { title?: string }): Promise<string> {
+    async createSession(input?: { title?: string; origin?: SessionOrigin }): Promise<string> {
         const sessionId = await this.idGenerator.next();
         const event = SessionCreated.parse({
             type: "session_created",
@@ -176,6 +177,7 @@ export class SessionsImpl implements ISessions {
             sessionId,
             ts: this.clock.now(),
             ...(input?.title === undefined ? {} : { title: input.title }),
+            ...(input?.origin === undefined ? {} : { origin: input.origin }),
         });
         await this.sessionRepo.create(event);
         this.publishEntry(sessionIndexEntry(reduceSession([event]), "none"));

--- a/apps/x/packages/core/src/runtime/tools/domains/app.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/app.ts
@@ -15,6 +15,7 @@ import { searchThreads } from "../../../knowledge/email/dispatcher.js";
 import { formatTimestampForModel } from "@x/shared/dist/time.js";
 import { listTasks as listBackgroundTasks } from "../../../background-tasks/fileops.js";
 import type { ISessions } from "../../sessions/api.js";
+import { isChatListSession } from "@x/shared/dist/sessions.js";
 import { BuiltinToolsSchema } from "../types.js";
 
 
@@ -139,6 +140,7 @@ export const appNavigationTools: z.infer<typeof BuiltinToolsSchema> = {
                             case 'chat-history': {
                                 const sessions = container.resolve<ISessions>('sessions')
                                     .listSessions()
+                                    .filter(isChatListSession)
                                     .slice(0, limit)
                                     .map((s) => ({
                                         sessionId: s.sessionId,

--- a/apps/x/packages/core/src/spaces/topic-agent.test.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildInvocationMessage, mentionOrigin } from './topic-agent.js';
+import { buildInvocationMessage, mentionOrigin, threadOrigin } from './topic-agent.js';
 
 const input = {
     orgId: 'org-1',
@@ -46,6 +46,18 @@ describe('mentionOrigin', () => {
             spaceId: '01M07B68G1BQFP70TX5RPHJX89',
             threadRootId: '01M07ROOTAAAAAAAAAAAAAAAA1',
             messageId: '01M07MSGAAAAAAAAAAAAAAAAA1',
+        });
+    });
+});
+
+describe('threadOrigin', () => {
+    it('identifies the thread and carries the space name as a display fallback — no message id', () => {
+        expect(threadOrigin(input)).toEqual({
+            kind: 'space_thread',
+            orgId: 'org-1',
+            spaceId: '01M07B68G1BQFP70TX5RPHJX89',
+            threadRootId: '01M07ROOTAAAAAAAAAAAAAAAA1',
+            spaceName: 'Roadboard',
         });
     });
 });

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { ISessions } from '../runtime/sessions/api.js';
-import type { SpaceMentionOrigin } from '@x/shared/dist/origins.js';
+import type { SpaceMentionOrigin, SpaceThreadOrigin } from '@x/shared/dist/origins.js';
 import { deriveTurnStatus, reduceTurn } from '@x/shared/dist/turns.js';
 import { WorkDir } from '../config/config.js';
 import { spacesMcpServerNameFor } from './orgs.js';
@@ -22,8 +22,13 @@ import { spacesMcpServerNameFor } from './orgs.js';
 //   starts, or on the input_added when it steers a live one, and the
 //   agent-activity feed (agent-activity.ts) turns those events into the
 //   room's "Rowboat is working" chip and lease. The session is user-openable
-//   (thread pane + chat sidebar), so the person's own chat turns there carry
+//   (thread pane + history pane), so the person's own chat turns there carry
 //   no origin and never light the chip.
+// - The session itself carries a space_thread SESSION origin (org, space,
+//   thread root, space name) on its session_created, so every chat list
+//   keeps it out of the person's own chats (isChatListSession) and the
+//   history pane can group it under its space. Its title is the thread's
+//   label alone — the space is metadata, not a title prefix.
 
 const REGISTRY_FILE = path.join(WorkDir, 'config', 'spaces_topic_sessions.json');
 
@@ -124,6 +129,17 @@ export function mentionOrigin(input: Pick<InvokeTopicAgentInput, 'orgId' | 'spac
   };
 }
 
+/** The origin the thread's SESSION carries — set once at creation (pure; tested). */
+export function threadOrigin(input: Pick<InvokeTopicAgentInput, 'orgId' | 'spaceId' | 'threadRootId' | 'spaceName'>): SpaceThreadOrigin {
+  return {
+    kind: 'space_thread',
+    orgId: input.orgId,
+    spaceId: input.spaceId,
+    threadRootId: input.threadRootId,
+    spaceName: input.spaceName,
+  };
+}
+
 function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
@@ -152,7 +168,8 @@ export async function invokeTopicAgent(input: InvokeTopicAgentInput): Promise<In
   }
   if (!sessionId) {
     sessionId = await sessions.createSession({
-      title: truncate(`${input.spaceName}: ${input.threadLabel}`, 100),
+      title: truncate(input.threadLabel, 100),
+      origin: threadOrigin(input),
     });
     registry.sessions[key] = sessionId;
     writeRegistry(registry);

--- a/apps/x/packages/shared/src/origins.ts
+++ b/apps/x/packages/shared/src/origins.ts
@@ -27,3 +27,27 @@ export type SpaceMentionOrigin = z.infer<typeof SpaceMentionOrigin>;
 
 export const InputOrigin = z.discriminatedUnion("kind", [SpaceMentionOrigin]);
 export type InputOrigin = z.infer<typeof InputOrigin>;
+
+// Where a SESSION came from: the thing outside the runtime that owns the
+// conversation as a whole (a space thread today; a todo item, a channel
+// sender, ... later). Distinct from InputOrigin, which identifies one
+// message: a space-thread session outlives any single mention, and a person
+// can chat in it directly, so the stamp lives on session_created — set once,
+// stable for the session's life — and is folded into the session index so
+// every chat list can hide or group these sessions without opening turn
+// files. The runtime records it and never reads it (see
+// isChatListSession in sessions.ts for the one consumer contract).
+export const SpaceThreadOrigin = z.object({
+    kind: z.literal("space_thread"),
+    orgId: z.string(),
+    spaceId: z.string(),
+    threadRootId: z.string(),
+    // Display fallback captured at creation. Readers prefer the live space
+    // name when the org is loaded; this keeps the row legible when it is
+    // not (org signed out, space deleted).
+    spaceName: z.string(),
+});
+export type SpaceThreadOrigin = z.infer<typeof SpaceThreadOrigin>;
+
+export const SessionOrigin = z.discriminatedUnion("kind", [SpaceThreadOrigin]);
+export type SessionOrigin = z.infer<typeof SessionOrigin>;

--- a/apps/x/packages/shared/src/sessions.test.ts
+++ b/apps/x/packages/shared/src/sessions.test.ts
@@ -5,6 +5,7 @@ import {
     SessionCreated,
     SessionEvent,
     SessionTurnAppended,
+    isChatListSession,
     reduceSession,
     sessionIndexEntry,
 } from "./sessions.js";
@@ -13,6 +14,13 @@ type SEvent = z.infer<typeof SessionEvent>;
 
 const SESSION_ID = "2026-07-02T09-00-00Z-0000042-000";
 const MODEL = { provider: "openai", model: "gpt-test" };
+const SPACE_ORIGIN = {
+    kind: "space_thread" as const,
+    orgId: "org-1",
+    spaceId: "space-1",
+    threadRootId: "root-1",
+    spaceName: "Roadboard",
+};
 
 function sessionCreated(
     overrides: Partial<z.infer<typeof SessionCreated>> = {},
@@ -197,5 +205,23 @@ describe("sessionIndexEntry", () => {
         expect(entry.turnCount).toBe(0);
         expect(entry.lastAgentId).toBeUndefined();
         expect(entry.latestTurnStatus).toBe("none");
+    });
+
+    it("carries the session origin from session_created into the entry, absent otherwise", () => {
+        const owned = sessionIndexEntry(
+            reduceSession([sessionCreated({ title: "SSO first?", origin: SPACE_ORIGIN })]),
+            "none",
+        );
+        expect(owned.origin).toEqual(SPACE_ORIGIN);
+        const own = sessionIndexEntry(reduceSession([sessionCreated()]), "none");
+        expect("origin" in own).toBe(false);
+    });
+});
+
+describe("isChatListSession", () => {
+    it("keeps a person's own chats and drops sessions something else owns", () => {
+        expect(isChatListSession({})).toBe(true);
+        expect(isChatListSession({ origin: undefined })).toBe(true);
+        expect(isChatListSession({ origin: SPACE_ORIGIN })).toBe(false);
     });
 });

--- a/apps/x/packages/shared/src/sessions.ts
+++ b/apps/x/packages/shared/src/sessions.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { UserMessage } from "./message.js";
-import type { InputOrigin } from "./origins.js";
+import { SessionOrigin, type InputOrigin } from "./origins.js";
 import { ModelDescriptor, type TurnStatus } from "./turns.js";
 
 // Durable session contract for the session layer (see
@@ -18,6 +18,9 @@ export const SessionCreated = z.object({
     sessionId: z.string(),
     ts: z.string(),
     title: z.string().optional(),
+    // What owns this conversation, when something outside the runtime does
+    // (a space thread). Absent for a person's own chats. See origins.ts.
+    origin: SessionOrigin.optional(),
 });
 
 // agentId/model are denormalized from the turn so the session index can fold
@@ -67,6 +70,7 @@ export interface SessionTurnRef {
 export interface SessionState {
     definition: z.infer<typeof SessionCreated>;
     title?: string;
+    origin?: SessionOrigin;
     turns: SessionTurnRef[];
     latestTurnId?: string;
     createdAt: string;
@@ -94,6 +98,7 @@ export function reduceSession(
     const state: SessionState = {
         definition: first,
         title: first.title,
+        ...(first.origin === undefined ? {} : { origin: first.origin }),
         turns: [],
         createdAt: first.ts,
         updatedAt: first.ts,
@@ -156,6 +161,9 @@ export type SessionLatestTurnStatus = "none" | TurnStatus;
 export interface SessionIndexEntry {
     sessionId: string;
     title?: string;
+    // Denormalized from session_created so lists can filter and group
+    // without reading session files. Absent = a person's own chat.
+    origin?: SessionOrigin;
     createdAt: string;
     updatedAt: string;
     turnCount: number;
@@ -218,6 +226,7 @@ export function sessionIndexEntry(
     return {
         sessionId: state.definition.sessionId,
         title: state.title,
+        ...(state.origin === undefined ? {} : { origin: state.origin }),
         createdAt: state.createdAt,
         updatedAt: state.updatedAt,
         turnCount: state.turns.length,
@@ -226,4 +235,15 @@ export function sessionIndexEntry(
         latestTurnId: state.latestTurnId,
         latestTurnStatus,
     };
+}
+
+// The ONE rule every chat list applies (sidebar, dock, chat header, quick-ask
+// switcher, mobile, the agent's chat-history read view): sessions owned by
+// something outside the runtime stay out of the default list and are reached
+// from their owner (the space thread) or from the history pane's explicit
+// filter. sessions:list and the index-changed feed still carry every session
+// — this predicate is applied at the edge, on the seed and on each feed
+// event alike, so the two paths cannot disagree.
+export function isChatListSession(entry: Pick<SessionIndexEntry, "origin">): boolean {
+    return entry.origin === undefined;
 }


### PR DESCRIPTION
## Why

Every `@rowboat` mention in a space creates one session per thread. Those sessions showed up in the primary sidebar next to the person's own chats, titled `"Space: thread label"`, and there was no way to tell them apart or keep them out.

## What

**Session-level origin (shared + core)**
- New `SessionOrigin` union in `origins.ts` with one member, `space_thread` (org, space, thread root, space name as display fallback). Optional on `session_created`; folded into `SessionIndexEntry.origin`. Schema version unchanged.
- Kept distinct from the per-input `InputOrigin`: a thread session outlives any one mention and a person can chat in it directly, so ownership must not derive from the latest turn.
- `createSession` accepts `origin` (main-process callers only; the renderer's `sessions:create` contract still takes a title alone). `invokeTopicAgent` stamps it and titles the session with the thread label alone.
- `isChatListSession(entry)` in `sessions.ts` is the one predicate every chat list applies. `sessions:list` and the `index-changed` feed still carry every session; the filter runs at the edge on the seed and on each feed event, so the two paths cannot disagree.

**Lists (renderer, mobile, agent tool)**
- Sidebar, dock, chat header, quick-ask switcher, the mobile list and the agent's chat-history read view show only the person's chats. Tab titles and hover lookups still use the full list.

**History pane**
- Header tab: **Assistant chats | Space chats** (two lists, never merged; last pick remembered; tab appears only once a space chat exists).
- Space chats: per-space filter chips (shown when threads span more than one space), row chips reading `Space · Org` or `DM Name · Org`, live names from the org roster with fallback to what the session recorded, and an **Open thread in space** action that deep-links to the thread rail.

**Docs**
- `session-design.md` covers the origin field, the edge-filter rule, and the no-retrofit decision.

## Decisions to be aware of
- Sessions created before this change carry no origin and stay visible in the sidebar with their old titles until retention removes them. The log is append-only, so they are not retrofitted.
- A server-side filter argument on `sessions:list` is deferred until pagination (a stated non-goal) is revisited; the two belong together.

## Verification
- shared: 311 tests pass; core: 842 pass (one file, `spaces/client.test.ts`, fails only where `@rowboat/harbor` is not built — environmental); renderer: 541 pass.
- Typecheck clean for shared, core, client, renderer, main. ESLint clean on changed files.
- Manually tested by @ramnique in the app (tabs + org chips iteration came from that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bYqU3dzDScvoxYzDrJJ28
