### PR TITLE
feat(x): offer changed model recommendations as a per-slot switch prompt

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -59,6 +59,7 @@ import { forwardRpc, shouldForwardChannel } from './rpc-forwarder.js';
 import { getPairingInfo, rotateKey as rotateServerKey, setLanEnabled as setServerLanEnabled, bridgeDeltaSubscribe, bridgeDeltaUnsubscribe, childServerMode, getConnectionInfo, connectRemoteServer, disconnectRemoteServer } from './server-host.js';
 import { testModelConnection, listModelsForProvider, generateOneShot } from '@x/core/dist/models/models.js';
 import { getImageModelCatalog, getModelCatalog } from '@x/core/dist/models/catalog.js';
+import { checkRecommendationUpdate, markRecommendationSeen, resolveRecommendationUpdate } from '@x/core/dist/models/recommendation-update.js';
 import { captureProviderConnected, captureProviderDisconnected } from '@x/core/dist/analytics/model-providers.js';
 import { getDefaultModelAndProvider } from '@x/core/dist/models/defaults.js';
 import { isSignedIn } from '@x/core/dist/account/account.js';
@@ -1613,6 +1614,16 @@ export function setupIpcHandlers() {
     'models:updateConfig': async (_event, args) => {
       const repo = container.resolve<IModelConfigRepo>('modelConfigRepo');
       await repo.updateConfig(args);
+      return { success: true };
+    },
+    'models:checkRecommendationUpdate': async () => {
+      return await checkRecommendationUpdate();
+    },
+    'models:resolveRecommendationUpdate': async (_event, args) => {
+      return await resolveRecommendationUpdate(args);
+    },
+    'models:markRecommendationSeen': async (_event, args) => {
+      await markRecommendationSeen(args.flavor);
       return { success: true };
     },
     'oauth:connect': async (_event, args) => {

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -87,6 +87,7 @@ import { splitFrontmatter, joinFrontmatter } from '@/lib/frontmatter'
 import { extractConferenceLink } from '@/lib/calendar-event'
 import { OnboardingModal } from '@/components/onboarding'
 import { ComposioGoogleMigrationModal } from '@/components/composio-google-migration-modal'
+import { ModelRecommendationUpdateModal, type RecommendationUpdate } from '@/components/model-recommendation-update-modal'
 import { CommandPalette, type CommandPaletteMention, type SearchType } from '@/components/search-dialog'
 import { LiveNoteSidebar } from '@/components/live-note-sidebar'
 import { BackgroundTaskDetail } from '@/components/background-task-detail'
@@ -1446,6 +1447,29 @@ function App() {
         }
       } catch (error) {
         console.error('[migration] check-composio-google failed:', error)
+      }
+    }
+    void run()
+    const cleanup = window.ipc.on('oauth:didConnect', (event) => {
+      if (event.provider === 'rowboat' && event.success) {
+        void run()
+      }
+    })
+    return cleanup
+  }, [])
+
+  // Recommendation-update prompt: checked at launch and again after a
+  // Rowboat sign-in (sign-in seeds the initial selection main-side and marks
+  // that version seen, so this only fires for a genuinely newer one). The
+  // check is idempotent — a version already answered returns shouldShow
+  // false — and never throws.
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const result = await window.ipc.invoke('models:checkRecommendationUpdate', null)
+        if (result.shouldShow) setRecommendationUpdate(result)
+      } catch (error) {
+        console.error('[models] checkRecommendationUpdate failed:', error)
       }
     }
     void run()
@@ -2850,6 +2874,8 @@ function App() {
 
   // One-time Composio→native Google migration modal
   const [showComposioGoogleMigration, setShowComposioGoogleMigration] = useState(false)
+  // The pending "Rowboat now recommends…" prompt, if any (see the modal).
+  const [recommendationUpdate, setRecommendationUpdate] = useState<RecommendationUpdate | null>(null)
 
   // Search state
   const [isSearchOpen, setIsSearchOpen] = useState(false)
@@ -8158,6 +8184,12 @@ function App() {
           void window.ipc.invoke('oauth:connect', { provider: 'google' })
         }}
       />
+      {!showOnboarding && (
+        <ModelRecommendationUpdateModal
+          update={recommendationUpdate}
+          onClose={() => setRecommendationUpdate(null)}
+        />
+      )}
       <GoogleDocPickerDialog
         open={googleDocPickerOpen}
         targetFolder={googleDocPickerTargetFolder}

--- a/apps/x/apps/renderer/src/components/model-recommendation-update-modal.test.tsx
+++ b/apps/x/apps/renderer/src/components/model-recommendation-update-modal.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ModelRecommendationUpdateModal, type RecommendationUpdate } from './model-recommendation-update-modal'
+
+// Same preload stub pattern as the other renderer tests: invoke routes by
+// channel through a per-test handler map.
+let handlers: Record<string, (args: unknown) => Promise<unknown>> = {}
+const invokes: Array<{ channel: string; args: unknown }> = []
+
+;(window as unknown as { ipc: unknown }).ipc = {
+  on: () => () => undefined,
+  invoke: (channel: string, args: unknown) => {
+    invokes.push({ channel, args })
+    const handler = handlers[channel]
+    return handler ? handler(args) : Promise.reject(new Error(`no handler: ${channel}`))
+  },
+}
+
+const UPDATE: RecommendationUpdate = {
+  shouldShow: true,
+  flavor: 'rowboat',
+  providerId: 'rowboat',
+  hash: 'abc',
+  assistantModel: { provider: 'rowboat', model: 'google/gemini-3.5-flash' },
+  rows: [
+    {
+      slot: 'assistantModel',
+      current: { provider: 'rowboat', model: 'google/gemini-3.5-flash' },
+      recommended: { provider: 'rowboat', model: 'Auto' },
+    },
+    { slot: 'knowledgeGraph', current: null, recommended: { provider: 'rowboat', model: 'Auto-background' } },
+    { slot: 'chatTitle', current: { provider: 'rowboat', model: 'lite' }, recommended: null },
+  ],
+}
+
+afterEach(() => { cleanup() })
+
+beforeEach(() => {
+  handlers = {}
+  invokes.length = 0
+  handlers['models:resolveRecommendationUpdate'] = async (args) => ({
+    applied: (args as { apply: string[] }).apply,
+  })
+})
+
+describe('ModelRecommendationUpdateModal', () => {
+  it('renders one checked row per slot, with inherit rows spelled out', () => {
+    render(<ModelRecommendationUpdateModal update={UPDATE} onClose={() => {}} />)
+    expect(screen.getByRole('checkbox', { name: 'Assistant' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Knowledge graph' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Chat titles' })).toBeChecked()
+    // knowledgeGraph's current and chatTitle's recommended both inherit.
+    expect(screen.getAllByText('Same as Assistant')).toHaveLength(2)
+    expect(screen.getByTitle('Same as Assistant (google/gemini-3.5-flash)')).toBeInTheDocument()
+    expect(screen.getByText('Auto')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Switch to recommended models?' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Switch' })).toBeEnabled()
+  })
+
+  it('applies exactly the checked slots and closes', async () => {
+    const onClose = vi.fn()
+    render(<ModelRecommendationUpdateModal update={UPDATE} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Knowledge graph' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Switch' }))
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(invokes).toEqual([{
+      channel: 'models:resolveRecommendationUpdate',
+      args: { flavor: 'rowboat', hash: 'abc', apply: ['assistantModel', 'chatTitle'] },
+    }])
+  })
+
+  it('"Not Now" answers with no slots', async () => {
+    const onClose = vi.fn()
+    render(<ModelRecommendationUpdateModal update={UPDATE} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Not Now' }))
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(invokes).toEqual([{
+      channel: 'models:resolveRecommendationUpdate',
+      args: { flavor: 'rowboat', hash: 'abc', apply: [] },
+    }])
+  })
+
+  it('the group checkbox toggles every task row', () => {
+    render(<ModelRecommendationUpdateModal update={UPDATE} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Background tasks' }))
+    expect(screen.getByRole('checkbox', { name: 'Knowledge graph' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Chat titles' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Assistant' })).toBeChecked()
+    expect(screen.getByRole('button', { name: 'Switch' })).toBeEnabled()
+    expect(screen.getByText(/Tasks you don't switch keep following the Assistant/)).toBeInTheDocument()
+    // With every row unchecked there is nothing to switch.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Assistant' }))
+    expect(screen.getByRole('button', { name: 'Switch' })).toBeDisabled()
+  })
+
+  it('renders nothing without a pending update', () => {
+    const { container } = render(<ModelRecommendationUpdateModal update={null} onClose={() => {}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/x/apps/renderer/src/components/model-recommendation-update-modal.tsx
+++ b/apps/x/apps/renderer/src/components/model-recommendation-update-modal.tsx
@@ -1,0 +1,277 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { ArrowRight } from "lucide-react"
+import { toast } from "sonner"
+import type { IPCChannels } from "@x/shared/dist/ipc.js"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { providerDisplayNames, type ModelSelection } from "@/components/model-selector"
+import { TASK_SLOTS } from "@/components/settings/task-slots"
+
+/** The pending update as served by models:checkRecommendationUpdate. */
+export type RecommendationUpdate = Extract<
+  IPCChannels["models:checkRecommendationUpdate"]["res"],
+  { shouldShow: true }
+>
+type Row = RecommendationUpdate["rows"][number]
+type SlotKey = Row["slot"]
+
+const TASK_LABELS: Record<string, string> = Object.fromEntries(TASK_SLOTS.map((t) => [t.key, t.label]))
+
+function choiceLabel(choice: ModelSelection): string {
+  return choice.effort ? `${choice.model} · ${choice.effort} effort` : choice.model
+}
+
+/**
+ * "Switch to recommended models": the per-slot diff between the backend's
+ * current recommendation for the provider serving the assistant and the
+ * saved config, offered once per recommendation version. Every row is a
+ * checkbox (all checked by default); Switch writes the checked slots, Not
+ * Now writes nothing. Both — and closing the dialog any other way — answer
+ * the prompt for this version, so it does not return until the backend's
+ * recommendation changes again. The write itself happens main-side
+ * (models:resolveRecommendationUpdate), which re-derives the rows before
+ * applying so a stale dialog cannot clobber an edit made while it was open.
+ *
+ * Checkboxes, not switches: nothing changes until Switch is pressed, and a
+ * switch promises an immediate effect. Copy follows the Apple dialog
+ * pattern — a verb-led title, one plain sentence of context, and a primary
+ * button that repeats the title's verb.
+ */
+export function ModelRecommendationUpdateModal({
+  update,
+  onClose,
+}: {
+  update: RecommendationUpdate | null
+  onClose: () => void
+}) {
+  const [checked, setChecked] = useState<Set<SlotKey>>(new Set())
+  const [busy, setBusy] = useState(false)
+  // Whether this update has been answered (apply / not now). Closing the
+  // dialog without answering — Escape, overlay click — counts as Not now.
+  const answered = useRef(false)
+
+  useEffect(() => {
+    if (!update) return
+    setChecked(new Set(update.rows.map((r) => r.slot)))
+    setBusy(false)
+    answered.current = false
+  }, [update])
+
+  const assistantRow = useMemo(() => update?.rows.find((r) => r.slot === "assistantModel") ?? null, [update])
+  const taskRows = useMemo(() => update?.rows.filter((r) => r.slot !== "assistantModel") ?? [], [update])
+
+  if (!update) return null
+
+  const providerName = providerDisplayNames[update.flavor] || update.flavor
+  const currentAssistant = update.assistantModel
+  // Inherit rows show "Same as Assistant"; the resolved model rides in the tooltip.
+  const inheritNow = "Same as Assistant"
+  const inheritNowTitle = `Same as Assistant (${choiceLabel(currentAssistant)})`
+  const tasksChecked = taskRows.filter((r) => checked.has(r.slot)).length
+  const assistantChecked = assistantRow ? checked.has("assistantModel") : false
+  const someTasksUnchecked = tasksChecked < taskRows.length
+
+  const toggle = (slot: SlotKey, on: boolean) => {
+    setChecked((prev) => {
+      const next = new Set(prev)
+      if (on) next.add(slot)
+      else next.delete(slot)
+      return next
+    })
+  }
+
+  const toggleAllTasks = (on: boolean) => {
+    setChecked((prev) => {
+      const next = new Set(prev)
+      for (const row of taskRows) {
+        if (on) next.add(row.slot)
+        else next.delete(row.slot)
+      }
+      return next
+    })
+  }
+
+  const resolve = async (apply: SlotKey[]) => {
+    if (answered.current) return
+    answered.current = true
+    setBusy(true)
+    try {
+      const result = await window.ipc.invoke("models:resolveRecommendationUpdate", {
+        flavor: update.flavor,
+        hash: update.hash,
+        apply,
+      })
+      if (result.applied.length > 0) {
+        window.dispatchEvent(new Event("models-config-changed"))
+        toast.success(
+          result.applied.length === 1 ? "Switched to the recommended model" : "Switched to the recommended models",
+        )
+      }
+    } catch (error) {
+      console.error("[models] Could not resolve the recommendation update:", error)
+      if (apply.length > 0) toast.error("Couldn't switch models. You can change them in Settings.")
+    } finally {
+      setBusy(false)
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) void resolve([])
+      }}
+    >
+      <DialogContent className="w-[min(30rem,calc(100%-2rem))] max-w-lg p-0 gap-0 overflow-hidden rounded-xl">
+        <div className="p-6 pb-0">
+          <DialogHeader className="space-y-1.5">
+            <DialogTitle className="text-lg font-semibold">Switch to recommended models?</DialogTitle>
+            <DialogDescription className="text-sm leading-relaxed">
+              Rowboat has new recommendations for {providerName}. Choose the models you&apos;d like
+              to switch.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="px-6 pt-4 space-y-4">
+          {assistantRow && (
+            <RowLine
+              id="rec-assistant"
+              label="Assistant"
+              current={assistantRow.current ? choiceLabel(assistantRow.current) : inheritNow}
+              currentTitle={assistantRow.current ? undefined : inheritNowTitle}
+              recommended={assistantRow.recommended ? choiceLabel(assistantRow.recommended) : "Same as Assistant"}
+              checked={assistantChecked}
+              disabled={busy}
+              onChange={(on) => toggle("assistantModel", on)}
+            />
+          )}
+
+          {taskRows.length > 0 && (
+            <div className="space-y-2">
+              <label className="flex items-center gap-2.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  aria-label="Background tasks"
+                  className="size-4 shrink-0 cursor-pointer accent-[#2383E2]"
+                  checked={tasksChecked === taskRows.length}
+                  ref={(el) => {
+                    if (el) el.indeterminate = tasksChecked > 0 && tasksChecked < taskRows.length
+                  }}
+                  disabled={busy}
+                  onChange={(e) => toggleAllTasks(e.target.checked)}
+                />
+                <span className="text-sm font-medium">
+                  Background tasks
+                  <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                    {taskRows.length === 1 ? "1 model" : `${taskRows.length} models`}
+                  </span>
+                </span>
+              </label>
+              <div className="ml-6 space-y-2 border-l pl-3.5">
+                {taskRows.map((row) => (
+                  <RowLine
+                    key={row.slot}
+                    id={`rec-${row.slot}`}
+                    label={TASK_LABELS[row.slot] ?? row.slot}
+                    current={row.current ? choiceLabel(row.current) : inheritNow}
+                    currentTitle={row.current ? undefined : inheritNowTitle}
+                    recommended={row.recommended ? choiceLabel(row.recommended) : "Same as Assistant"}
+                    checked={checked.has(row.slot)}
+                    disabled={busy}
+                    onChange={(on) => toggle(row.slot, on)}
+                  />
+                ))}
+              </div>
+              {assistantChecked && someTasksUnchecked && (
+                <p className="ml-6 text-[11px] text-muted-foreground">
+                  Tasks you don&apos;t switch keep following the Assistant, so they&apos;ll use the new
+                  Assistant model.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 px-6 py-4 mt-6 border-t bg-muted/30">
+          <Button variant="ghost" size="sm" disabled={busy} onClick={() => void resolve([])}>
+            Not Now
+          </Button>
+          <Button
+            size="sm"
+            disabled={busy || checked.size === 0}
+            onClick={() => void resolve(update.rows.map((r) => r.slot).filter((s) => checked.has(s)))}
+          >
+            Switch
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RowLine({
+  id,
+  label,
+  current,
+  currentTitle,
+  recommended,
+  checked,
+  disabled,
+  onChange,
+}: {
+  id: string
+  label: string
+  current: string
+  currentTitle?: string
+  recommended: string
+  checked: boolean
+  disabled: boolean
+  onChange: (on: boolean) => void
+}) {
+  return (
+    <label htmlFor={id} className="flex items-start gap-2.5 cursor-pointer">
+      <input
+        id={id}
+        type="checkbox"
+        aria-label={label}
+        className="mt-[3px] size-4 shrink-0 cursor-pointer accent-[#2383E2]"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span className="min-w-0 flex-1 space-y-1">
+        <span className="block text-sm font-medium">{label}</span>
+        <span className="flex items-center gap-1.5 min-w-0">
+          <Pill tone="current" title={currentTitle ?? current}>{current}</Pill>
+          <ArrowRight className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+          <Pill tone="next" title={recommended}>{recommended}</Pill>
+        </span>
+      </span>
+    </label>
+  )
+}
+
+function Pill({ tone, title, children }: { tone: "current" | "next"; title: string; children: string }) {
+  return (
+    <span
+      title={title}
+      className={
+        tone === "next"
+          ? "inline-block max-w-[14rem] truncate rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+          : "inline-block max-w-[14rem] truncate rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+      }
+    >
+      {children}
+    </span>
+  )
+}

--- a/apps/x/apps/renderer/src/components/settings/model-selection-section.tsx
+++ b/apps/x/apps/renderer/src/components/settings/model-selection-section.tsx
@@ -2,12 +2,15 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { ModelSelector, providerDisplayNames, type ModelRef, type ModelSelection } from "@/components/model-selector"
 import { useModels, type ModelPickerGroup } from "@/hooks/use-models"
+import { TASK_SLOTS, type TaskKey } from "@/components/settings/task-slots"
 
 // The unified model-selection surface (signed-in and BYOK alike): ONE
 // required Assistant model plus per-task overrides that default to
 // "Same as Assistant". No "Auto" rows — every choice is an explicit model;
-// recommendation logic only ever picks INITIAL models at provider-connect
-// time, never appears as a dropdown option. The Image model is the one
+// recommendation logic picks INITIAL models at provider-connect time and
+// otherwise only reaches the config through the explicit update prompt
+// (model-recommendation-update-modal) — never a dropdown option. The Image
+// model is the one
 // slot outside that inheritance: it can't inherit the assistant (a text
 // model), so it's its own explicit pick — or unset, which turns image
 // generation off.
@@ -23,24 +26,6 @@ interface ImageProviderEntry {
   models: string[]
 }
 
-type TaskKey =
-  | "backgroundTask"
-  | "subagent"
-  | "knowledgeGraph"
-  | "meetingNotes"
-  | "liveNoteAgent"
-  | "autoPermissionDecision"
-  | "chatTitle"
-
-const TASKS: Array<{ key: TaskKey; label: string; description: string }> = [
-  { key: "backgroundTask", label: "Background agents", description: "Scheduled and event-driven agents that run without a chat" },
-  { key: "subagent", label: "Subagents", description: "Workers the assistant spawns during a chat" },
-  { key: "knowledgeGraph", label: "Knowledge graph", description: "Note creation, email classification, knowledge sync" },
-  { key: "meetingNotes", label: "Meeting notes", description: "Meeting summaries and prep briefs" },
-  { key: "liveNoteAgent", label: "Live notes", description: "Self-updating notes and their routing" },
-  { key: "autoPermissionDecision", label: "Permission checks", description: "Auto-approval of safe tool calls" },
-  { key: "chatTitle", label: "Chat titles", description: "Naming chats from the first message" },
-]
 
 function refLabel(ref: ModelRef): string {
   return `${providerDisplayNames[ref.provider] || ref.provider} · ${ref.model}`
@@ -195,7 +180,7 @@ export function ModelSelectionSection({ dialogOpen }: { dialogOpen: boolean }) {
           </p>
         </div>
         <div className="grid grid-cols-2 gap-x-4 gap-y-4">
-          {TASKS.map(({ key, label, description }) => {
+          {TASK_SLOTS.map(({ key, label, description }) => {
             const override = taskModels[key] ?? null
             const inheritText = key === "subagent"
               ? "Uses the spawning chat's model"

--- a/apps/x/apps/renderer/src/components/settings/providers-section.tsx
+++ b/apps/x/apps/renderer/src/components/settings/providers-section.tsx
@@ -413,6 +413,10 @@ function AddProviderDialog({ open, onOpenChange, connectedIds, isRowboatConnecte
           taskOverridesSeeded: Object.keys(taskModels).length,
           source: analyticsSource,
         })
+        // The user has now been offered this version of the recommendation:
+        // the update prompt waits for the next one. Awaited BEFORE the
+        // config-changed event so a re-check can't race ahead of the marker.
+        await window.ipc.invoke("models:markRecommendationSeen", { flavor }).catch(() => {})
       }
       for (const warning of testRes.warnings ?? []) {
         toast.warning(warning, { duration: 12000 })

--- a/apps/x/apps/renderer/src/components/settings/task-slots.ts
+++ b/apps/x/apps/renderer/src/components/settings/task-slots.ts
@@ -1,0 +1,22 @@
+// The per-task model override slots as the settings UI names them. Shared
+// by the model-selection section and the recommendation-update prompt so
+// both label a slot the same way. Keys mirror shared/models.ts TaskModels.
+
+export type TaskKey =
+  | "backgroundTask"
+  | "subagent"
+  | "knowledgeGraph"
+  | "meetingNotes"
+  | "liveNoteAgent"
+  | "autoPermissionDecision"
+  | "chatTitle"
+
+export const TASK_SLOTS: Array<{ key: TaskKey; label: string; description: string }> = [
+  { key: "backgroundTask", label: "Background agents", description: "Scheduled and event-driven agents that run without a chat" },
+  { key: "subagent", label: "Subagents", description: "Workers the assistant spawns during a chat" },
+  { key: "knowledgeGraph", label: "Knowledge graph", description: "Note creation, email classification, knowledge sync" },
+  { key: "meetingNotes", label: "Meeting notes", description: "Meeting summaries and prep briefs" },
+  { key: "liveNoteAgent", label: "Live notes", description: "Self-updating notes and their routing" },
+  { key: "autoPermissionDecision", label: "Permission checks", description: "Auto-approval of safe tool calls" },
+  { key: "chatTitle", label: "Chat titles", description: "Naming chats from the first message" },
+]

--- a/apps/x/packages/core/src/models/recommendation-update.test.ts
+++ b/apps/x/packages/core/src/models/recommendation-update.test.ts
@@ -1,0 +1,199 @@
+import { rmSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The recommendation-update prompt's state machine: when a prompt is
+ * offered, what apply/dismiss write, and that a version is offered once.
+ */
+
+const workDir = vi.hoisted(() =>
+    `${process.env.TMPDIR?.replace(/\/$/, '') ?? '/tmp'}/rec-update-test-${process.pid}-${Math.random().toString(36).slice(2)}`,
+);
+
+const mocks = vi.hoisted(() => ({
+    getConfig: vi.fn(async (): Promise<unknown> => ({ version: 2, providers: {} })),
+    updateConfig: vi.fn<(patch: unknown) => Promise<void>>(async () => {}),
+    getRowboatConfig: vi.fn(async (): Promise<unknown> => ({ modelRecommendations: {} })),
+    getModelCatalog: vi.fn(async (): Promise<unknown> => ({ providers: [], defaultModel: null })),
+    capture: vi.fn(),
+}));
+
+vi.mock('../config/config.js', () => ({ WorkDir: workDir }));
+vi.mock('../config/rowboat.js', () => ({ getRowboatConfig: mocks.getRowboatConfig }));
+vi.mock('../analytics/posthog.js', () => ({ capture: mocks.capture }));
+vi.mock('./catalog.js', () => ({ getModelCatalog: mocks.getModelCatalog }));
+vi.mock('../di/container.js', () => ({
+    default: { resolve: () => ({ getConfig: mocks.getConfig, updateConfig: mocks.updateConfig }) },
+}));
+
+import { checkRecommendationUpdate, markRecommendationSeen, resolveRecommendationUpdate } from './recommendation-update.js';
+
+const statePath = path.join(workDir, 'config', 'model-recommendations.json');
+
+const RECS = {
+    rowboat: {
+        assistantModel: 'Auto',
+        taskModels: { knowledgeGraph: 'Auto-background', chatTitle: 'Auto-background' },
+    },
+    openai: 'gpt-5.4',
+};
+
+function serveConfig(cfg: Record<string, unknown>): void {
+    mocks.getConfig.mockImplementation(async () => ({ version: 2, providers: {}, ...cfg }));
+}
+
+function serveCatalog(providerId: string, models: string[], status: 'ok' | 'error' = 'ok'): void {
+    mocks.getModelCatalog.mockImplementation(async () => ({
+        providers: [{ id: providerId, flavor: providerId, status, models: models.map((id) => ({ id })) }],
+        defaultModel: null,
+    }));
+}
+
+async function readState(): Promise<Record<string, string>> {
+    return JSON.parse(await fs.readFile(statePath, 'utf8')).seen;
+}
+
+beforeEach(async () => {
+    await fs.mkdir(path.dirname(statePath), { recursive: true });
+    mocks.getConfig.mockReset();
+    mocks.updateConfig.mockReset();
+    mocks.capture.mockReset();
+    mocks.getRowboatConfig.mockImplementation(async () => ({ modelRecommendations: RECS }));
+    serveConfig({ assistantModel: { provider: 'rowboat', model: 'google/gemini-3.5-flash' } });
+    serveCatalog('rowboat', ['Auto', 'Auto-background', 'google/gemini-3.5-flash']);
+});
+
+afterEach(async () => {
+    await fs.rm(workDir, { recursive: true, force: true });
+});
+
+process.on('exit', () => {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+});
+
+describe('checkRecommendationUpdate', () => {
+    it('offers the per-slot diff for the assistant\'s provider', async () => {
+        const result = await checkRecommendationUpdate();
+        expect(result.shouldShow).toBe(true);
+        if (!result.shouldShow) return;
+        expect(result.flavor).toBe('rowboat');
+        expect(result.providerId).toBe('rowboat');
+        expect(result.rows.map((r) => r.slot)).toEqual(['assistantModel', 'knowledgeGraph', 'chatTitle']);
+        expect(mocks.capture).toHaveBeenCalledWith('llm_recommendation_update_shown', expect.objectContaining({ flavor: 'rowboat', row_count: 3 }));
+    });
+
+    it('resolves a BYOK provider\'s flavor through the providers map', async () => {
+        serveConfig({
+            providers: { openai: { flavor: 'openai', apiKey: 'k' } },
+            assistantModel: { provider: 'openai', model: 'gpt-4.1' },
+        });
+        serveCatalog('openai', ['gpt-4.1', 'gpt-5.4']);
+        const result = await checkRecommendationUpdate();
+        expect(result).toMatchObject({ shouldShow: true, flavor: 'openai', rows: [{ slot: 'assistantModel' }] });
+    });
+
+    it('is quiet with no assistant, no recommendation for the flavor, or a failed listing', async () => {
+        serveConfig({});
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+
+        serveConfig({ providers: { ollama: { flavor: 'ollama' } }, assistantModel: { provider: 'ollama', model: 'llama3' } });
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+
+        serveConfig({ assistantModel: { provider: 'rowboat', model: 'google/gemini-3.5-flash' } });
+        serveCatalog('rowboat', [], 'error');
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+        // A failed listing leaves no marker so the next launch retries.
+        await expect(fs.readFile(statePath, 'utf8')).rejects.toThrow();
+    });
+
+    it('records a recommendation the config already matches as seen', async () => {
+        serveConfig({
+            assistantModel: { provider: 'rowboat', model: 'Auto' },
+            taskModels: {
+                knowledgeGraph: { provider: 'rowboat', model: 'Auto-background' },
+                chatTitle: { provider: 'rowboat', model: 'Auto-background' },
+            },
+        });
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+        expect(Object.keys(await readState())).toEqual(['rowboat']);
+    });
+
+    it('never throws: a failing config fetch is a quiet no-show', async () => {
+        mocks.getRowboatConfig.mockRejectedValue(new Error('offline'));
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+    });
+});
+
+describe('resolveRecommendationUpdate', () => {
+    it('applies exactly the checked slots and records the version as seen', async () => {
+        const shown = await checkRecommendationUpdate();
+        if (!shown.shouldShow) throw new Error('expected a prompt');
+
+        const result = await resolveRecommendationUpdate({ flavor: 'rowboat', hash: shown.hash, apply: ['assistantModel', 'chatTitle'] });
+        expect(result.applied).toEqual(['assistantModel', 'chatTitle']);
+        expect(mocks.updateConfig).toHaveBeenCalledWith({
+            assistantModel: { provider: 'rowboat', model: 'Auto' },
+            taskModels: { chatTitle: { provider: 'rowboat', model: 'Auto-background' } },
+        });
+        expect(await readState()).toEqual({ rowboat: shown.hash });
+        expect(mocks.capture).toHaveBeenCalledWith('llm_recommendation_update_applied', expect.objectContaining({
+            applied_slots: ['assistantModel', 'chatTitle'],
+        }));
+
+        // The same version is not offered again, even though the unchecked
+        // knowledgeGraph slot still differs.
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+    });
+
+    it('"Not now" writes nothing but still records the version', async () => {
+        const shown = await checkRecommendationUpdate();
+        if (!shown.shouldShow) throw new Error('expected a prompt');
+
+        const result = await resolveRecommendationUpdate({ flavor: 'rowboat', hash: shown.hash, apply: [] });
+        expect(result.applied).toEqual([]);
+        expect(mocks.updateConfig).not.toHaveBeenCalled();
+        expect(await readState()).toEqual({ rowboat: shown.hash });
+        expect(mocks.capture).toHaveBeenCalledWith('llm_recommendation_update_dismissed', expect.anything());
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+    });
+
+    it('re-derives rows at apply time so a stale dialog cannot clobber a newer edit', async () => {
+        const shown = await checkRecommendationUpdate();
+        if (!shown.shouldShow) throw new Error('expected a prompt');
+
+        // The user set the assistant to the recommendation by hand while the
+        // dialog was open: that slot no longer has a row.
+        serveConfig({ assistantModel: { provider: 'rowboat', model: 'Auto' } });
+        const result = await resolveRecommendationUpdate({ flavor: 'rowboat', hash: shown.hash, apply: ['assistantModel', 'knowledgeGraph'] });
+        expect(result.applied).toEqual(['knowledgeGraph']);
+        expect(mocks.updateConfig).toHaveBeenCalledWith({
+            taskModels: { knowledgeGraph: { provider: 'rowboat', model: 'Auto-background' } },
+        });
+    });
+
+    it('applies nothing when the recommendation version no longer matches', async () => {
+        const result = await resolveRecommendationUpdate({ flavor: 'rowboat', hash: 'stale', apply: ['assistantModel'] });
+        expect(result.applied).toEqual([]);
+        expect(mocks.updateConfig).not.toHaveBeenCalled();
+    });
+});
+
+describe('markRecommendationSeen', () => {
+    it('suppresses the prompt for the current version only', async () => {
+        await markRecommendationSeen('rowboat');
+        expect(await checkRecommendationUpdate()).toEqual({ shouldShow: false });
+
+        // A changed backend recommendation is a new version.
+        mocks.getRowboatConfig.mockImplementation(async () => ({
+            modelRecommendations: { ...RECS, rowboat: { assistantModel: 'Auto', taskModels: {} } },
+        }));
+        expect(await checkRecommendationUpdate()).toMatchObject({ shouldShow: true, rows: [{ slot: 'assistantModel' }] });
+    });
+
+    it('is a no-op for a flavor without a recommendation', async () => {
+        await markRecommendationSeen('ollama');
+        await expect(fs.readFile(statePath, 'utf8')).rejects.toThrow();
+    });
+});

--- a/apps/x/packages/core/src/models/recommendation-update.ts
+++ b/apps/x/packages/core/src/models/recommendation-update.ts
@@ -1,0 +1,208 @@
+import fs from "fs/promises";
+import path from "path";
+import { z } from "zod";
+import { ModelSelection } from "@x/shared/dist/models.js";
+import {
+    computeRecommendationRows,
+    patchForSlots,
+    recommendationHash,
+    type RecommendationRow,
+    type RecommendationSlotKey,
+} from "@x/shared/dist/recommendation-update.js";
+import type { ModelRecommendations } from "@x/shared/dist/rowboat-account.js";
+import container from "../di/container.js";
+import { WorkDir } from "../config/config.js";
+import { getRowboatConfig } from "../config/rowboat.js";
+import { capture } from "../analytics/posthog.js";
+import { IModelConfigRepo } from "./repo.js";
+import { getModelCatalog } from "./catalog.js";
+
+/**
+ * The "Rowboat now recommends…" prompt: when the backend's recommendation
+ * for the provider serving the assistant model changes, offer the user the
+ * per-slot diff once, and never again for that version of the
+ * recommendation.
+ *
+ * State is one marker per flavor — `seen[flavor] = hash` — in a small file
+ * beside models.json (a UI-flow marker, not model config). The hash is the
+ * content hash of the flavor's recommendation (shared/recommendation-update),
+ * so the prompt reappears only when the recommendation itself changes; a
+ * backend rollback hashes to a value already answered and stays quiet.
+ *
+ * `seen` is written on apply, on dismiss, and when a provider is first
+ * connected (its initial selection already applied this version), so a
+ * user who connected and then deliberately changed their model is not
+ * nagged about the recommendation they already saw. A user who predates
+ * this marker gets one prompt on their next launch if their config differs
+ * — that is the intended catch-up.
+ *
+ * The check needs the provider's live model list (a recommendation the
+ * provider does not list produces no row); a provider whose listing failed
+ * yields no prompt and no marker, so the next launch retries.
+ */
+
+const STATE_FILE = path.join(WorkDir, "config", "model-recommendations.json");
+
+const State = z.object({
+    seen: z.record(z.string(), z.string()).default({}),
+});
+type State = z.infer<typeof State>;
+
+async function loadState(): Promise<State> {
+    try {
+        return State.parse(JSON.parse(await fs.readFile(STATE_FILE, "utf8")));
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException | null)?.code !== "ENOENT") {
+            console.warn("[models] Could not read model-recommendations.json; treating as empty:", err);
+        }
+        return { seen: {} };
+    }
+}
+
+async function saveState(state: State): Promise<void> {
+    await fs.mkdir(path.dirname(STATE_FILE), { recursive: true });
+    const tmp = `${STATE_FILE}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(state, null, 2));
+    await fs.rename(tmp, STATE_FILE);
+}
+
+async function markSeen(flavor: string, hash: string): Promise<void> {
+    const state = await loadState();
+    if (state.seen[flavor] === hash) return;
+    await saveState({ seen: { ...state.seen, [flavor]: hash } });
+}
+
+async function currentRecommendations(): Promise<ModelRecommendations | undefined> {
+    return (await getRowboatConfig().catch(() => null))?.modelRecommendations;
+}
+
+/**
+ * Record that the user has been offered this flavor's current
+ * recommendation — called at the seeding moment (provider connect / Rowboat
+ * sign-in), where initial selection just applied it. Best-effort: a failure
+ * here means at worst one extra prompt later.
+ */
+export async function markRecommendationSeen(flavor: string): Promise<void> {
+    try {
+        const hash = recommendationHash(await currentRecommendations(), flavor);
+        if (hash) await markSeen(flavor, hash);
+    } catch (error) {
+        console.warn(`[models] Could not record recommendation as seen for ${flavor}:`, error);
+    }
+}
+
+export type RecommendationUpdate = {
+    flavor: string;
+    providerId: string;
+    hash: string;
+    /** The assistant as saved now — renders "Same as Assistant (X)" for inherit rows. */
+    assistantModel: z.infer<typeof ModelSelection>;
+    rows: RecommendationRow[];
+};
+
+export type RecommendationUpdateCheck =
+    | { shouldShow: false }
+    | ({ shouldShow: true } & RecommendationUpdate);
+
+/**
+ * The pending update for the assistant's provider, or nothing. Pure with
+ * respect to state except in one case: a recommendation the config already
+ * matches is recorded as seen so the catalog isn't re-listed on every
+ * launch for a prompt that can never appear.
+ */
+async function computeUpdate(): Promise<RecommendationUpdate | null> {
+    const repo = container.resolve<IModelConfigRepo>("modelConfigRepo");
+    const cfg = await repo.getConfig().catch(() => null);
+    const assistantModel = cfg?.assistantModel;
+    if (!cfg || !assistantModel) return null;
+
+    const providerId = assistantModel.provider;
+    const flavor = providerId === "rowboat" || providerId === "codex"
+        ? providerId
+        : cfg.providers[providerId]?.flavor;
+    if (!flavor) return null;
+
+    const recommendations = await currentRecommendations();
+    const hash = recommendationHash(recommendations, flavor);
+    if (!hash) return null;
+
+    const state = await loadState();
+    if (state.seen[flavor] === hash) return null;
+
+    const catalog = await getModelCatalog();
+    const entry = catalog.providers.find((p) => p.id === providerId);
+    if (!entry || entry.status !== "ok") return null;
+
+    const rows = computeRecommendationRows({
+        providerId,
+        flavor,
+        availableModelIds: entry.models.map((m) => m.id),
+        recommendations,
+        assistantModel,
+        taskModels: cfg.taskModels ?? {},
+    });
+    if (rows.length === 0) {
+        await markSeen(flavor, hash);
+        return null;
+    }
+    return { flavor, providerId, hash, assistantModel, rows };
+}
+
+export async function checkRecommendationUpdate(): Promise<RecommendationUpdateCheck> {
+    try {
+        const update = await computeUpdate();
+        if (!update) return { shouldShow: false };
+        capture("llm_recommendation_update_shown", {
+            flavor: update.flavor,
+            recommendation_hash: update.hash,
+            row_count: update.rows.length,
+            slots: update.rows.map((r) => r.slot),
+        });
+        return { shouldShow: true, ...update };
+    } catch (error) {
+        // Best-effort: the prompt must never break launch.
+        console.warn("[models] Recommendation update check failed:", error);
+        return { shouldShow: false };
+    }
+}
+
+/**
+ * The user's answer to the prompt: `apply` lists the checked slots (empty =
+ * "Not now"). Rows are recomputed from a fresh config + catalog read and
+ * only checked slots still proposing the same change are written, so a
+ * stale dialog can't clobber an edit made while it was open. The flavor's
+ * hash is recorded as seen either way.
+ */
+export async function resolveRecommendationUpdate(args: {
+    flavor: string;
+    hash: string;
+    apply: RecommendationSlotKey[];
+}): Promise<{ applied: RecommendationSlotKey[] }> {
+    const applied: RecommendationSlotKey[] = [];
+    try {
+        if (args.apply.length > 0) {
+            const update = await computeUpdate();
+            if (update && update.flavor === args.flavor && update.hash === args.hash) {
+                const patch = patchForSlots(update.rows, args.apply);
+                if (patch.assistantModel || patch.taskModels) {
+                    const repo = container.resolve<IModelConfigRepo>("modelConfigRepo");
+                    await repo.updateConfig(patch);
+                    for (const row of update.rows) {
+                        if (args.apply.includes(row.slot)) applied.push(row.slot);
+                    }
+                }
+            }
+        }
+    } finally {
+        await markSeen(args.flavor, args.hash).catch((error) => {
+            console.warn(`[models] Could not record recommendation as seen for ${args.flavor}:`, error);
+        });
+    }
+    capture(applied.length > 0 ? "llm_recommendation_update_applied" : "llm_recommendation_update_dismissed", {
+        flavor: args.flavor,
+        recommendation_hash: args.hash,
+        requested_slots: args.apply,
+        applied_slots: applied,
+    });
+    return { applied };
+}

--- a/apps/x/packages/core/src/models/rowboat-selection.ts
+++ b/apps/x/packages/core/src/models/rowboat-selection.ts
@@ -5,6 +5,7 @@ import { getRowboatConfig } from "../config/rowboat.js";
 import { selectInitialModel, selectInitialTaskModels } from "./initial-selection.js";
 import { normalizeModelRecommendation } from "@x/shared/dist/rowboat-account.js";
 import { capture } from "../analytics/posthog.js";
+import { markRecommendationSeen } from "./recommendation-update.js";
 
 /**
  * Model-selection hooks for the Rowboat sign-in lifecycle. Signing in is
@@ -13,8 +14,9 @@ import { capture } from "../analytics/posthog.js";
  *
  * - Connect with no saved assistant → pick an initial model (backend
  *   recommendation if the gateway lists it, else the first listed model)
- *   and save it. A saved assistant is NEVER replaced — recommendations only
- *   ever choose the initial model.
+ *   and save it. A saved assistant is NEVER replaced silently — after this
+ *   moment a changed recommendation only reaches the config through the
+ *   explicit update prompt (recommendation-update.ts).
  * - Connect with no saved image model → seed the gateway's image model.
  *   Its own guard, not the assistant's: the image model cannot inherit the
  *   assistant (a text model), so a BYOK user who already has an assistant
@@ -58,6 +60,9 @@ async function seedAssistantModel(repo: IModelConfigRepo, cfg: Config | null): P
                 },
                 ...(Object.keys(taskModels).length > 0 ? { taskModels } : {}),
             });
+            // The user has now been offered this version of the
+            // recommendation; the update prompt waits for the next one.
+            await markRecommendationSeen("rowboat");
             // Measures recommendation quality: hit = the backend's pick was
             // in the gateway list; miss = first-listed fallback.
             capture("llm_initial_model_selected", {

--- a/apps/x/packages/shared/src/initial-selection.ts
+++ b/apps/x/packages/shared/src/initial-selection.ts
@@ -26,7 +26,9 @@ import {
  * selection. It must never run over an existing choice: after initial setup
  * the saved model configuration is the source of truth, and changes to the
  * recommendations or to the provider's list order must not silently replace
- * what the user picked.
+ * what the user picked. A CHANGED recommendation reaches an existing config
+ * only through the explicit per-slot update prompt (recommendation-update.ts),
+ * offered once per recommendation version.
  *
  * Pure functions by design: callers supply the provider's available models
  * (from the unified catalog / a live probe) and the recommendations map

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -21,6 +21,7 @@ import { UserMessage, UserMessageContent } from './message.js';
 import { RequestedAgent, type TurnBusEvent, type TurnEvent } from './turns.js';
 import type { QueuedSessionMessage, SessionBusEvent, SessionIndexEntry, SessionState } from './sessions.js';
 import { RowboatApiConfig } from './rowboat-account.js';
+import { RecommendationRowSchema, RecommendationSlot } from './recommendation-update.js';
 import { ZListToolkitsResponse } from './composio.js';
 import { AppSummarySchema, RegistryRecordSchema, RowboatAppManifestSchema } from './rowboat-app.js';
 import { BrowserStateSchema, DisplayMediaRequestSchema, HttpAuthRequestSchema } from './browser-control.js';
@@ -1026,6 +1027,49 @@ export const ipcSchemas = {
     res: z.object({
       success: z.literal(true),
     }),
+  },
+  // The "Rowboat now recommends…" prompt (core/models/recommendation-update):
+  // the per-slot diff between the backend's current recommendation for the
+  // provider serving the assistant model and the saved config, offered once
+  // per recommendation version. shouldShow false = nothing pending (no
+  // assistant, no recommendation for its flavor, already answered, config
+  // already matches, or the provider's list failed to load).
+  'models:checkRecommendationUpdate': {
+    req: z.null(),
+    res: z.union([
+      z.object({ shouldShow: z.literal(false) }),
+      z.object({
+        shouldShow: z.literal(true),
+        flavor: z.string(),
+        providerId: z.string(),
+        // Content hash of the recommendation the rows were computed from;
+        // echoed back on resolve so a stale dialog can't apply over edits.
+        hash: z.string(),
+        // The assistant as saved now, for rendering inherit rows.
+        assistantModel: ModelSelection,
+        rows: z.array(RecommendationRowSchema),
+      }),
+    ]),
+  },
+  // The user's answer: `apply` = the checked slots (empty = "Not now").
+  // Rows are recomputed main-side before writing; the recommendation is
+  // recorded as seen either way. `applied` = the slots actually written.
+  'models:resolveRecommendationUpdate': {
+    req: z.object({
+      flavor: z.string(),
+      hash: z.string(),
+      apply: z.array(RecommendationSlot),
+    }),
+    res: z.object({
+      applied: z.array(RecommendationSlot),
+    }),
+  },
+  // Record the flavor's current recommendation as seen — the renderer's
+  // provider-connect flow calls this right after seeding the initial
+  // selection (the Rowboat sign-in path does the same main-side).
+  'models:markRecommendationSeen': {
+    req: z.object({ flavor: z.string() }),
+    res: z.object({ success: z.literal(true) }),
   },
   'oauth:connect': {
     req: z.object({

--- a/apps/x/packages/shared/src/recommendation-update.test.ts
+++ b/apps/x/packages/shared/src/recommendation-update.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+    computeRecommendationRows,
+    patchForSlots,
+    recommendationHash,
+    type RecommendationRowsInput,
+} from "./recommendation-update.js";
+import { RowboatApiConfig } from "./rowboat-account.js";
+
+describe("recommendationHash", () => {
+    it("hashes the legacy bare-string and object wire shapes identically", () => {
+        expect(recommendationHash({ openai: "gpt-5.4" }, "openai"))
+            .toBe(recommendationHash({ openai: { assistantModel: "gpt-5.4" } }, "openai"));
+        expect(recommendationHash({ openai: "gpt-5.4" }, "openai"))
+            .toBe(recommendationHash({ openai: { assistantModel: { model: "gpt-5.4" } } }, "openai"));
+    });
+
+    it("is independent of task key order", () => {
+        const a = { rowboat: { assistantModel: "Auto", taskModels: { chatTitle: "lite", subagent: "lite" } } };
+        const b = { rowboat: { assistantModel: "Auto", taskModels: { subagent: "lite", chatTitle: "lite" } } };
+        expect(recommendationHash(a, "rowboat")).toBe(recommendationHash(b, "rowboat"));
+    });
+
+    it("changes when the model, effort, or a task recommendation changes", () => {
+        const base = recommendationHash({ openai: "gpt-5.4" }, "openai");
+        expect(recommendationHash({ openai: "gpt-5.5" }, "openai")).not.toBe(base);
+        expect(recommendationHash({ openai: { assistantModel: { model: "gpt-5.4", effort: "high" } } }, "openai")).not.toBe(base);
+        expect(recommendationHash({ openai: { assistantModel: "gpt-5.4", taskModels: { chatTitle: "gpt-5.4-mini" } } }, "openai")).not.toBe(base);
+    });
+
+    it("treats an unrecognized effort as Auto once the wire shape is parsed", () => {
+        const schema = RowboatApiConfig.shape.modelRecommendations;
+        const lenient = schema.parse({ openai: { assistantModel: { model: "gpt-5.4", effort: "minimal" } } });
+        expect(recommendationHash(lenient, "openai")).toBe(recommendationHash({ openai: "gpt-5.4" }, "openai"));
+    });
+
+    it("is null for a flavor with no recommendation", () => {
+        expect(recommendationHash({ openai: "gpt-5.4" }, "ollama")).toBeNull();
+        expect(recommendationHash(undefined, "openai")).toBeNull();
+    });
+});
+
+describe("computeRecommendationRows", () => {
+    const rowboatRecs = {
+        rowboat: {
+            assistantModel: "Auto",
+            taskModels: { knowledgeGraph: "Auto-background", chatTitle: "Auto-background", subagent: "Auto-background" },
+        },
+    };
+    const listed = ["Auto", "Auto-background", "google/gemini-3.5-flash", "google/gemini-3.5-flash-lite"];
+
+    function input(overrides: Partial<RecommendationRowsInput> = {}): RecommendationRowsInput {
+        return {
+            providerId: "rowboat",
+            flavor: "rowboat",
+            availableModelIds: listed,
+            recommendations: rowboatRecs,
+            assistantModel: { provider: "rowboat", model: "google/gemini-3.5-flash" },
+            taskModels: {},
+            ...overrides,
+        };
+    }
+
+    it("proposes the assistant and every differing task slot", () => {
+        const rows = computeRecommendationRows(input());
+        expect(rows.map((r) => r.slot)).toEqual(["assistantModel", "knowledgeGraph", "chatTitle", "subagent"]);
+        expect(rows[0]).toEqual({
+            slot: "assistantModel",
+            current: { provider: "rowboat", model: "google/gemini-3.5-flash" },
+            recommended: { provider: "rowboat", model: "Auto" },
+        });
+        expect(rows[1]).toEqual({
+            slot: "knowledgeGraph",
+            current: null,
+            recommended: { provider: "rowboat", model: "Auto-background" },
+        });
+    });
+
+    it("is empty when the config already matches", () => {
+        const rows = computeRecommendationRows(input({
+            assistantModel: { provider: "rowboat", model: "Auto" },
+            taskModels: {
+                knowledgeGraph: { provider: "rowboat", model: "Auto-background" },
+                chatTitle: { provider: "rowboat", model: "Auto-background" },
+                subagent: { provider: "rowboat", model: "Auto-background" },
+            },
+        }));
+        expect(rows).toEqual([]);
+    });
+
+    it("treats a task recommendation equal to the recommended assistant as inherit", () => {
+        const recs = { openai: { assistantModel: "gpt-5.4", taskModels: { chatTitle: "gpt-5.4" } } };
+        const rows = computeRecommendationRows(input({
+            providerId: "openai",
+            flavor: "openai",
+            availableModelIds: ["gpt-5.4", "gpt-5.4-mini"],
+            recommendations: recs,
+            assistantModel: { provider: "openai", model: "gpt-5.4" },
+            taskModels: { chatTitle: { provider: "openai", model: "gpt-5.4-mini" } },
+        }));
+        expect(rows).toEqual([{
+            slot: "chatTitle",
+            current: { provider: "openai", model: "gpt-5.4-mini" },
+            recommended: null,
+        }]);
+    });
+
+    it("skips recommendations the provider does not list instead of proposing inherit", () => {
+        const rows = computeRecommendationRows(input({ availableModelIds: ["google/gemini-3.5-flash", "Auto"] }));
+        expect(rows.map((r) => r.slot)).toEqual(["assistantModel"]);
+    });
+
+    it("leaves task overrides pinned to another provider alone", () => {
+        const rows = computeRecommendationRows(input({
+            taskModels: { knowledgeGraph: { provider: "ollama", model: "llama3" } },
+        }));
+        expect(rows.map((r) => r.slot)).toEqual(["assistantModel", "chatTitle", "subagent"]);
+    });
+
+    it("compares effort as part of the choice", () => {
+        const recs = { openai: { assistantModel: { model: "gpt-5.4", effort: "high" as const } } };
+        const rows = computeRecommendationRows(input({
+            providerId: "openai",
+            flavor: "openai",
+            availableModelIds: ["gpt-5.4"],
+            recommendations: recs,
+            assistantModel: { provider: "openai", model: "gpt-5.4" },
+        }));
+        expect(rows).toEqual([{
+            slot: "assistantModel",
+            current: { provider: "openai", model: "gpt-5.4" },
+            recommended: { provider: "openai", model: "gpt-5.4", effort: "high" },
+        }]);
+    });
+
+    it("is empty when the assistant is on a different provider or the flavor has no recommendation", () => {
+        expect(computeRecommendationRows(input({ assistantModel: { provider: "openai", model: "gpt-5.4" } }))).toEqual([]);
+        expect(computeRecommendationRows(input({ flavor: "ollama" }))).toEqual([]);
+    });
+});
+
+describe("patchForSlots", () => {
+    const rows = computeRecommendationRows({
+        providerId: "rowboat",
+        flavor: "rowboat",
+        availableModelIds: ["Auto", "Auto-background", "old", "lite"],
+        recommendations: { rowboat: { assistantModel: "Auto", taskModels: { chatTitle: "Auto-background", subagent: "Auto" } } },
+        assistantModel: { provider: "rowboat", model: "old" },
+        taskModels: { subagent: { provider: "rowboat", model: "lite" } },
+    });
+
+    it("writes only the checked slots; a checked inherit row clears the override", () => {
+        expect(patchForSlots(rows, ["assistantModel", "subagent"])).toEqual({
+            assistantModel: { provider: "rowboat", model: "Auto" },
+            taskModels: { subagent: null },
+        });
+    });
+
+    it("ignores slots that have no row", () => {
+        expect(patchForSlots(rows, ["knowledgeGraph"])).toEqual({});
+        expect(patchForSlots(rows, [])).toEqual({});
+    });
+});

--- a/apps/x/packages/shared/src/recommendation-update.ts
+++ b/apps/x/packages/shared/src/recommendation-update.ts
@@ -1,0 +1,197 @@
+import { z } from "zod";
+import { ModelSelection, TaskModels } from "./models.js";
+import {
+    normalizeModelRecommendation,
+    type ModelRecommendations,
+    type NormalizedModelRecommendation,
+    type RecommendedModelChoice,
+} from "./rowboat-account.js";
+
+/**
+ * Recommendation UPDATES: the pure half of the "Rowboat now recommends…"
+ * prompt (core/models/recommendation-update.ts owns state and IPC).
+ *
+ * Initial selection (initial-selection.ts) seeds a provider's models once,
+ * at connect time. After that the saved config is the source of truth and
+ * a changed backend recommendation must never be applied silently. This
+ * module turns a changed recommendation into an explicit, per-slot
+ * proposal the user can accept row by row:
+ *
+ * - `recommendationHash` identifies one flavor's recommendation by CONTENT
+ *   (normalized, so the legacy bare-string and object wire shapes hash the
+ *   same). The prompt is offered once per hash: the user's accept/dismiss
+ *   is recorded against it, and a backend rollback hashes back to a value
+ *   they already answered.
+ * - `computeRecommendationRows` diffs the recommendation against the saved
+ *   config for the provider currently serving the assistant, one row per
+ *   slot that would change. Task slots pointing at a DIFFERENT provider are
+ *   left alone (the recommendation is about this provider's slots, not a
+ *   nudge to move providers); a recommended model the provider does not
+ *   list produces no row (a stale hint, same rule as initial selection).
+ * - `patchForSlots` turns the rows the user checked into a config patch.
+ */
+
+export const RecommendationSlot = z.enum([
+    "assistantModel",
+    "knowledgeGraph",
+    "meetingNotes",
+    "liveNoteAgent",
+    "autoPermissionDecision",
+    "chatTitle",
+    "backgroundTask",
+    "subagent",
+]);
+export type RecommendationSlotKey = z.infer<typeof RecommendationSlot>;
+
+const TASK_SLOTS = Object.keys(TaskModels.shape) as Array<keyof z.infer<typeof TaskModels>>;
+// Compile-time guard: every task slot is a recommendation slot and vice versa.
+type _TaskSlotsCovered = Exclude<keyof z.infer<typeof TaskModels>, RecommendationSlotKey> extends never ? true : never;
+type _NoExtraSlots = Exclude<RecommendationSlotKey, "assistantModel" | keyof z.infer<typeof TaskModels>> extends never ? true : never;
+const _slotGuards: [_TaskSlotsCovered, _NoExtraSlots] = [true, true];
+void _slotGuards;
+
+type Selection = z.infer<typeof ModelSelection>;
+
+export interface RecommendationRow {
+    slot: RecommendationSlotKey;
+    /** What the slot resolves to now; null on a task slot = inherits the assistant. */
+    current: Selection | null;
+    /** What the recommendation proposes; null on a task slot = inherit the assistant. */
+    recommended: Selection | null;
+}
+
+export const RecommendationRowSchema = z.object({
+    slot: RecommendationSlot,
+    current: ModelSelection.nullable(),
+    recommended: ModelSelection.nullable(),
+});
+
+/**
+ * Content hash of one flavor's recommendation in canonical form; null when
+ * the flavor has none. FNV-1a over a key-sorted JSON encoding — this only
+ * needs to be stable and collision-free across the handful of values a
+ * backend will ever serve, not cryptographic.
+ */
+export function recommendationHash(
+    recommendations: ModelRecommendations | undefined,
+    flavor: string,
+): string | null {
+    const normalized = normalizeModelRecommendation(recommendations, flavor);
+    if (!normalized) return null;
+    const canonical = JSON.stringify({
+        assistantModel: canonicalChoice(normalized.assistantModel),
+        taskModels: Object.keys(normalized.taskModels).sort().map((key) => [
+            key,
+            canonicalChoice(normalized.taskModels[key]!),
+        ]),
+    });
+    return fnv1a(canonical);
+}
+
+function canonicalChoice(choice: RecommendedModelChoice): [string, string] {
+    return [choice.model, choice.effort ?? ""];
+}
+
+function fnv1a(input: string): string {
+    // 32-bit FNV-1a, two passes with different offsets folded into one
+    // 16-hex-char string, so a one-character change flips both halves.
+    let h1 = 0x811c9dc5;
+    let h2 = 0x050c5d1f;
+    for (let i = 0; i < input.length; i++) {
+        const c = input.charCodeAt(i);
+        h1 = Math.imul(h1 ^ c, 0x01000193) >>> 0;
+        h2 = Math.imul(h2 ^ c, 0x01000193) >>> 0;
+    }
+    return h1.toString(16).padStart(8, "0") + h2.toString(16).padStart(8, "0");
+}
+
+export interface RecommendationRowsInput {
+    /** Provider INSTANCE id the assistant model points at. */
+    providerId: string;
+    /** That provider's flavor (keys the recommendations map). */
+    flavor: string;
+    /** The provider's live model list; a recommendation outside it is ignored. */
+    availableModelIds: string[];
+    recommendations: ModelRecommendations | undefined;
+    assistantModel: Selection;
+    taskModels: Partial<Record<keyof z.infer<typeof TaskModels>, Selection | null | undefined>>;
+}
+
+export function computeRecommendationRows(input: RecommendationRowsInput): RecommendationRow[] {
+    const { providerId, flavor, availableModelIds, assistantModel, taskModels } = input;
+    if (assistantModel.provider !== providerId) return [];
+    const rec = normalizeModelRecommendation(input.recommendations, flavor);
+    if (!rec) return [];
+
+    const rows: RecommendationRow[] = [];
+    const listed = new Set(availableModelIds);
+
+    if (listed.has(rec.assistantModel.model)) {
+        const recommended = toSelection(providerId, rec.assistantModel);
+        if (!sameChoice(assistantModel, recommended)) {
+            rows.push({ slot: "assistantModel", current: assistantModel, recommended });
+        }
+    }
+
+    for (const key of TASK_SLOTS) {
+        const current = taskModels[key] ?? null;
+        // An override on another provider is a deliberate choice outside
+        // this recommendation's scope.
+        if (current && current.provider !== providerId) continue;
+        const proposal = taskProposal(rec, key, listed, providerId);
+        if (proposal === "unusable") continue;
+        if (current === null && proposal === null) continue;
+        if (current && proposal && sameChoice(current, proposal)) continue;
+        rows.push({ slot: key, current, recommended: proposal });
+    }
+
+    return rows;
+}
+
+/**
+ * What the recommendation says a task slot should be: an explicit
+ * override, `null` = inherit the assistant (the task is absent from the
+ * recommendation, or equals its assistant pick — the same rule initial
+ * selection applies), or "unusable" when the recommended model is not in
+ * the provider's list.
+ */
+function taskProposal(
+    rec: NormalizedModelRecommendation,
+    key: keyof z.infer<typeof TaskModels>,
+    listed: Set<string>,
+    providerId: string,
+): Selection | null | "unusable" {
+    const choice = rec.taskModels[key];
+    if (!choice) return null;
+    if (choice.model === rec.assistantModel.model && choice.effort === rec.assistantModel.effort) return null;
+    if (!listed.has(choice.model)) return "unusable";
+    return toSelection(providerId, choice);
+}
+
+function toSelection(providerId: string, choice: RecommendedModelChoice): Selection {
+    return { provider: providerId, model: choice.model, ...(choice.effort ? { effort: choice.effort } : {}) };
+}
+
+function sameChoice(a: Selection, b: Selection): boolean {
+    return a.provider === b.provider && a.model === b.model && (a.effort ?? undefined) === (b.effort ?? undefined);
+}
+
+export interface RecommendationPatch {
+    assistantModel?: Selection;
+    taskModels?: Partial<Record<keyof z.infer<typeof TaskModels>, Selection | null>>;
+}
+
+/** The config patch that applies exactly the checked rows (null = clear the override so it inherits). */
+export function patchForSlots(rows: RecommendationRow[], slots: RecommendationSlotKey[]): RecommendationPatch {
+    const wanted = new Set(slots);
+    const patch: RecommendationPatch = {};
+    for (const row of rows) {
+        if (!wanted.has(row.slot)) continue;
+        if (row.slot === "assistantModel") {
+            if (row.recommended) patch.assistantModel = row.recommended;
+            continue;
+        }
+        patch.taskModels = { ...(patch.taskModels ?? {}), [row.slot]: row.recommended };
+    }
+    return patch;
+}

--- a/apps/x/packages/shared/src/rowboat-account.ts
+++ b/apps/x/packages/shared/src/rowboat-account.ts
@@ -38,8 +38,10 @@ export const RowboatApiConfig = z.object({
   // intended model differs; for rowboat they reproduce the pre-v2 curated
   // lite-tier task models so plan credits aren't burned by background
   // services). Hints for the INITIAL selection when a provider is first
-  // connected — never a catalog, and never applied over a saved choice
-  // (see shared/initial-selection.ts). The bare-string form is the legacy
+  // connected — never a catalog, and never applied silently over a saved
+  // choice (see shared/initial-selection.ts; a later change is offered
+  // through the explicit update prompt, shared/recommendation-update.ts).
+  // The bare-string form is the legacy
   // wire shape, accepted so backend deploy order and rollback are
   // non-events. Local/custom flavors are intentionally absent: the API
   // can't know which models exist in a user's environment. Optional so


### PR DESCRIPTION
## Summary

Backend model recommendations were only consulted once, at first provider connect. When the backend changes a recommendation, existing users never hear about it.

This adds a **"Switch to recommended models?"** dialog, offered once per recommendation version. It lists one checkbox row per slot that would change (Assistant, plus task slots grouped under Background tasks), each rendered as `current → recommended` pills. **Switch** writes only the checked slots; **Not Now** writes nothing. Either way that version is never offered again until the backend changes it.

No backend changes. The wire shape of `/v1/config` is untouched.

## Design

- **Version = content hash.** A flavor's recommendation is identified by an FNV-1a hash of its normalized form (`shared/recommendation-update.ts`), so the legacy bare-string and object wire shapes hash the same and a backend rollback hashes back to an already-answered value.
- **State = `seen[flavor] = hash`** in `config/model-recommendations.json`, written on Switch, on Not Now, and at the seeding moment (Rowboat sign-in main-side; BYOK connect via `models:markRecommendationSeen`, awaited before `models-config-changed` so a re-check can't race the marker).
- **Scope = the assistant's provider.** Task overrides pinned to another provider are left alone. A recommended model the provider doesn't list produces no row. A task recommendation equal to the recommended assistant means inherit, so switching that row clears the override.
- **Resolve re-derives rows** from a fresh config + catalog read before writing, so a stale dialog can't clobber an edit made while it was open. A hash mismatch applies nothing but still marks the version seen.
- **Triggers:** app mount and Rowboat sign-in success. Deliberately not `models-config-changed`, so the dialog never pops over Settings.
- **Catch-up:** users who predate the marker get one prompt at next launch if their config differs from the current recommendation. This is intended, but it does mean most current Rowboat users will see the dialog once after this ships.
- **Checkboxes, not switches:** nothing changes until Switch is pressed, and a switch promises an immediate effect.

## Files

- `packages/shared/src/recommendation-update.ts` — hash, per-slot diff, patch builder (pure)
- `packages/core/src/models/recommendation-update.ts` — state file, check, resolve, mark-seen; PostHog `llm_recommendation_update_shown/applied/dismissed`
- IPC: `models:checkRecommendationUpdate`, `models:resolveRecommendationUpdate`, `models:markRecommendationSeen`
- `apps/renderer/src/components/model-recommendation-update-modal.tsx` — the dialog
- `apps/renderer/src/components/settings/task-slots.ts` — task labels extracted from the settings section so both surfaces name slots identically
- Seeding sites (`rowboat-selection.ts`, add-provider dialog) now mark the version seen; doc comments on "never applied over a saved choice" sharpened to "never applied silently"

## Testing

- 14 shared, 11 core, 5 renderer unit tests added; full shared / core / renderer suites pass.
- Renderer typecheck and lint clean on touched files.
- **Not yet live-verified in the running app.** To force the prompt locally: delete `config/model-recommendations.json` in the work dir and make sure the assistant model differs from the backend recommendation.

## Deferred

- Image model in recommendations (still the `ROWBOAT_IMAGE_MODEL` constant)
- A per-recommendation `reason` string from the backend to render in the dialog
- Tracking recommendation-sourced vs user-chosen selections for silent follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVufEECnpHz7Ez2LWE5QqE
