### PR TITLE
Add per-message image carousels to chat and Spaces

### DIFF
--- a/apps/x/apps/renderer/src/components/chat-message-attachments.test.tsx
+++ b/apps/x/apps/renderer/src/components/chat-message-attachments.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ChatMessageAttachments } from './chat-message-attachments'
+
+const image = (filename: string) => ({ path: `/tmp/${filename}`, filename, mimeType: 'image/png', thumbnailUrl: `data:image/png;base64,${filename}` })
+afterEach(cleanup)
+
+describe('message image carousel', () => {
+  it('opens the clicked image, navigates only message images, and resets zoom', () => {
+    render(<>
+      <ChatMessageAttachments attachments={[
+        image('first.png'),
+        { path: '/tmp/doc.pdf', filename: 'doc.pdf', mimeType: 'application/pdf' },
+        { ...image('frame.png'), isVideoFrame: true },
+        image('second.png'),
+        image('third.png'),
+      ]} />
+      <ChatMessageAttachments attachments={[image('other.png')]} />
+    </>)
+    fireEvent.click(screen.getByRole('button', { name: 'Preview second.png' }))
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByRole('img', { name: 'second.png' })).toBeInTheDocument()
+    expect(within(dialog).getByRole('status')).toHaveTextContent('2 of 3')
+    fireEvent.click(within(dialog).getByRole('img'))
+    expect(within(dialog).getByRole('img').style.transform).toContain('scale(2.5)')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Next image' }))
+    expect(within(dialog).getByRole('img', { name: 'third.png' }).style.transform).toContain('scale(1)')
+    expect(within(dialog).getByRole('button', { name: 'Next image' })).toBeDisabled()
+    fireEvent.keyDown(dialog, { key: 'ArrowRight' })
+    expect(within(dialog).getByRole('status')).toHaveTextContent('3 of 3')
+    fireEvent.keyDown(dialog, { key: 'ArrowLeft' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Previous image' }))
+    expect(within(dialog).getByRole('img', { name: 'first.png' })).toBeInTheDocument()
+    expect(within(dialog).getByRole('button', { name: 'Previous image' })).toBeDisabled()
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Preview second.png' }))
+    expect(within(screen.getByRole('dialog')).getByRole('status')).toHaveTextContent('2 of 3')
+  })
+
+  it('omits navigation for a single image and closes with the close button', () => {
+    render(<ChatMessageAttachments attachments={[image('only.png')]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Preview only.png' }))
+    expect(screen.queryByRole('button', { name: 'Next image' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Close image preview' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/apps/x/apps/renderer/src/components/chat-message-attachments.tsx
+++ b/apps/x/apps/renderer/src/components/chat-message-attachments.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
+import { ImageLightbox } from '@/components/image-lightbox'
 import type { MessageAttachment } from '@/lib/chat-conversation'
 import {
   type AttachmentIconKind,
@@ -39,47 +40,38 @@ function getAttachmentIcon(kind: AttachmentIconKind) {
   }
 }
 
-function ImageAttachmentPreview({ attachment }: { attachment: MessageAttachment }) {
-  const fallbackFileUrl = useMemo(() => toFileUrl(attachment.path), [attachment.path])
-  const [src, setSrc] = useState(attachment.thumbnailUrl || fallbackFileUrl)
-  const [triedBase64, setTriedBase64] = useState(Boolean(attachment.thumbnailUrl))
+function useAttachmentImage(attachment?: MessageAttachment) {
+  const path = attachment?.path
+  const thumbnailUrl = attachment?.thumbnailUrl
+  const mimeType = attachment?.mimeType
+  const fallbackFileUrl = useMemo(() => path ? toFileUrl(path) : '', [path])
+  const [loaded, setLoaded] = useState<{ path: string; src: string } | null>(null)
 
   useEffect(() => {
-    const nextSrc = attachment.thumbnailUrl || fallbackFileUrl
-    setSrc(nextSrc)
-    setTriedBase64(Boolean(attachment.thumbnailUrl))
-  }, [attachment.thumbnailUrl, fallbackFileUrl])
+    if (!path || thumbnailUrl) return
+    let cancelled = false
+    window.ipc.invoke('shell:readFileBase64', { path })
+      .then((result) => {
+        if (!cancelled) setLoaded({ path, src: `data:${result.mimeType || mimeType || 'image/*'};base64,${result.data}` })
+      })
+      .catch(() => { /* Keep the file URL if the read fails. */ })
+    return () => { cancelled = true }
+  }, [path, thumbnailUrl, mimeType])
 
-  const loadBase64 = useMemo(
-    () => async () => {
-      try {
-        const result = await window.ipc.invoke('shell:readFileBase64', { path: attachment.path })
-        const mimeType = result.mimeType || attachment.mimeType || 'image/*'
-        setSrc(`data:${mimeType};base64,${result.data}`)
-      } catch {
-        // Keep current src; fallback rendering (broken image icon) is better than crashing.
-      }
-    },
-    [attachment.mimeType, attachment.path]
-  )
+  return thumbnailUrl || (loaded?.path === path ? loaded?.src : undefined) || fallbackFileUrl
+}
 
-  useEffect(() => {
-    if (attachment.thumbnailUrl || triedBase64) return
-    setTriedBase64(true)
-    void loadBase64()
-  }, [attachment.thumbnailUrl, loadBase64, triedBase64])
-
+function ImageAttachmentPreview({ attachment, onOpen }: { attachment: MessageAttachment; onOpen: () => void }) {
+  const src = useAttachmentImage(attachment)
+  const name = getAttachmentDisplayName(attachment)
   return (
-    <img
-      src={src}
-      alt="Image attachment"
-      className="h-44 w-auto max-w-[300px] rounded-2xl border border-border/70 bg-muted object-cover"
-      onError={() => {
-        if (triedBase64) return
-        setTriedBase64(true)
-        void loadBase64()
-      }}
-    />
+    <button type="button" aria-label={`Preview ${name}`} onClick={onOpen} className="rounded-2xl cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+      <img
+        src={src}
+        alt={name}
+        className="h-44 w-auto max-w-[300px] rounded-2xl border border-border/70 bg-muted object-cover"
+      />
+    </button>
   )
 }
 
@@ -89,7 +81,7 @@ interface ChatMessageAttachmentsProps {
 }
 
 export function ChatMessageAttachments({ attachments, className }: ChatMessageAttachmentsProps) {
-  if (attachments.length === 0) return null
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
 
   const videoFrames = attachments.filter((attachment) => attachment.isVideoFrame)
   const imageAttachments = attachments.filter(
@@ -98,6 +90,12 @@ export function ChatMessageAttachments({ attachments, className }: ChatMessageAt
   const fileAttachments = attachments.filter(
     (attachment) => !attachment.isVideoFrame && !isImageMime(attachment.mimeType)
   )
+
+  const selected = selectedIndex === null ? undefined : imageAttachments[selectedIndex]
+  const selectedSrc = useAttachmentImage(selected)
+  const selectedName = selected ? getAttachmentDisplayName(selected) : ''
+
+  if (attachments.length === 0) return null
 
   return (
     <div className={cn('flex flex-col items-end gap-2', className)}>
@@ -116,10 +114,31 @@ export function ChatMessageAttachments({ attachments, className }: ChatMessageAt
       {imageAttachments.length > 0 && (
         <div className="flex flex-wrap justify-end gap-2">
           {imageAttachments.map((attachment, index) => (
-            <ImageAttachmentPreview key={`${attachment.path}-${index}`} attachment={attachment} />
+            <ImageAttachmentPreview key={`${attachment.path}-${index}`} attachment={attachment} onOpen={() => setSelectedIndex(index)} />
           ))}
         </div>
       )}
+      <ImageLightbox
+        open={Boolean(selected)}
+        onOpenChange={(open) => { if (!open) setSelectedIndex(null) }}
+        src={selectedSrc}
+        name={selectedName}
+        onDownload={() => {
+          const link = document.createElement('a')
+          link.href = selectedSrc
+          link.download = selectedName
+          document.body.appendChild(link)
+          link.click()
+          link.remove()
+        }}
+        onOpenInSystem={() => { if (selected) void window.ipc.invoke('shell:openPath', { path: selected.path }) }}
+        navigation={{
+          index: selectedIndex ?? 0,
+          count: imageAttachments.length,
+          onPrevious: () => setSelectedIndex((index) => index === null ? null : Math.max(0, index - 1)),
+          onNext: () => setSelectedIndex((index) => index === null ? null : Math.min(imageAttachments.length - 1, index + 1)),
+        }}
+      />
       {fileAttachments.length > 0 && (
         <div className="flex flex-wrap justify-end gap-2">
           {fileAttachments.map((attachment, index) => {

--- a/apps/x/apps/renderer/src/components/image-lightbox.tsx
+++ b/apps/x/apps/renderer/src/components/image-lightbox.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { Download, ExternalLink, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Download, ExternalLink, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const ZOOM_MAX = 8
@@ -138,9 +138,11 @@ interface ImageLightboxProps {
   /** Same src the inline image uses — already-loaded bytes, so no refetch. */
   src: string
   name: string
-  onDownload: () => void
-  onOpenInSystem: () => void
+  onDownload?: () => void
+  onOpenInSystem?: () => void
+  actions?: React.ReactNode
   onError?: () => void
+  navigation?: { index: number; count: number; onPrevious: () => void; onNext: () => void }
 }
 
 // Full-bleed image viewer for inline chat images. Built on the same Radix
@@ -156,6 +158,8 @@ export function ImageLightbox({
   onDownload,
   onOpenInSystem,
   onError,
+  navigation,
+  actions,
 }: ImageLightboxProps) {
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -164,22 +168,59 @@ export function ImageLightbox({
         <DialogPrimitive.Content
           aria-describedby={undefined}
           onClick={() => onOpenChange(false)}
+          onKeyDown={(event) => {
+            if (event.target instanceof Element && event.target.closest('[role="dialog"]') !== event.currentTarget) return
+            if (!navigation || event.altKey || event.ctrlKey || event.metaKey) return
+            if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+              event.preventDefault()
+              event.stopPropagation()
+              if (event.key === 'ArrowLeft' && navigation.index > 0) navigation.onPrevious()
+              if (event.key === 'ArrowRight' && navigation.index < navigation.count - 1) navigation.onNext()
+            }
+          }}
           className="fixed inset-0 z-50 flex items-center justify-center outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
         >
           <DialogPrimitive.Title className="sr-only">{name}</DialogPrimitive.Title>
           <ZoomableImage
+            key={src}
             src={src}
             alt={name}
             onError={onError}
             className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain"
           />
+          {navigation && navigation.count > 1 && (
+            <>
+              <button
+                type="button"
+                aria-label="Previous image"
+                disabled={navigation.index === 0}
+                onClick={(event) => { event.stopPropagation(); navigation.onPrevious() }}
+                className="absolute left-4 flex size-10 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80 disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+              >
+                <ChevronLeft className="size-6" />
+              </button>
+              <button
+                type="button"
+                aria-label="Next image"
+                disabled={navigation.index === navigation.count - 1}
+                onClick={(event) => { event.stopPropagation(); navigation.onNext() }}
+                className="absolute right-4 flex size-10 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80 disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+              >
+                <ChevronRight className="size-6" />
+              </button>
+              <div role="status" className="pointer-events-none absolute bottom-4 rounded-full bg-black/60 px-3 py-1.5 text-sm text-white">
+                {navigation.index + 1} of {navigation.count}
+              </div>
+            </>
+          )}
           <div className="absolute right-4 top-4 flex items-center gap-1.5">
-            <ImageOverlayButton label={`Download ${name}`} onClick={onDownload}>
+            {actions && <div className="flex items-center gap-3 text-xs" onClick={(event) => event.stopPropagation()}>{actions}</div>}
+            {onDownload && <ImageOverlayButton label={`Download ${name}`} onClick={onDownload}>
               <Download className="h-3.5 w-3.5" />
-            </ImageOverlayButton>
-            <ImageOverlayButton label={`Open ${name} in the system viewer`} onClick={onOpenInSystem}>
+            </ImageOverlayButton>}
+            {onOpenInSystem && <ImageOverlayButton label={`Open ${name} in the system viewer`} onClick={onOpenInSystem}>
               <ExternalLink className="h-3.5 w-3.5" />
-            </ImageOverlayButton>
+            </ImageOverlayButton>}
             <ImageOverlayButton label="Close image preview" onClick={() => onOpenChange(false)}>
               <X className="h-3.5 w-3.5" />
             </ImageOverlayButton>

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpaceMarkdown, SpaceRefsProvider } from './space-markdown'
+import { blobWireUrl } from '@/lib/spaces-presentation'
+
+const refs = { orgId: 'org', spaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', orgAddress: 'spaces.example.com' }
+const firstHash = 'a'.repeat(64)
+const secondHash = 'b'.repeat(64)
+const body = `Photos\n\n![First](${blobWireUrl(refs, firstHash, 'first.png')})\n\n![Second](${blobWireUrl(refs, secondHash, 'second.png')})\n\n![Third](https://example.com/third.png)`
+const invoke = vi.fn().mockResolvedValue({ saved: true })
+
+beforeEach(() => { Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } }); invoke.mockClear() })
+afterEach(cleanup)
+
+describe('Spaces message image carousel', () => {
+    it('uses actual markdown tiles, opens the clicked image, and navigates only that message', async () => {
+        render(<SpaceRefsProvider refs={refs}>
+            <SpaceMarkdown body={body} />
+            <SpaceMarkdown body="![Other](https://example.com/other.png)" />
+        </SpaceRefsProvider>)
+        fireEvent.click(await screen.findByRole('button', { name: 'Preview Second' }))
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByRole('img', { name: 'Second' })).toBeInTheDocument()
+        expect(within(dialog).getByRole('status')).toHaveTextContent('2 of 3')
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Download' }))
+        await waitFor(() => expect(invoke).toHaveBeenCalledWith('spaces:saveBlob', {
+            orgId: 'org', spaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', hash: secondHash, suggestedName: 'second.png',
+        }))
+        fireEvent.click(within(dialog).getByRole('img'))
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Next image' }))
+        expect(within(dialog).getByRole('img', { name: 'Third' }).style.transform).toContain('scale(1)')
+        expect(within(dialog).getByRole('button', { name: 'Next image' })).toBeDisabled()
+        expect(within(dialog).getByRole('link', { name: 'Open original' })).toHaveAttribute('href', 'https://example.com/third.png')
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Download' }))
+        await waitFor(() => expect(invoke).toHaveBeenCalledWith('spaces:saveImageUrl', { url: 'https://example.com/third.png' }))
+        fireEvent.keyDown(dialog, { key: 'ArrowLeft' })
+        fireEvent.keyDown(dialog, { key: 'ArrowLeft' })
+        expect(within(dialog).getByRole('img', { name: 'First' })).toBeInTheDocument()
+        expect(within(dialog).getByRole('button', { name: 'Previous image' })).toBeDisabled()
+        fireEvent.keyDown(dialog, { key: 'Escape' })
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        fireEvent.keyDown(screen.getByRole('button', { name: 'Preview Second' }), { key: 'Enter' })
+        expect(screen.getByRole('status')).toHaveTextContent('2 of 3')
+    })
+
+    it('includes pasted image URLs, skips files and failed images, and handles one image', async () => {
+        render(<SpaceMarkdown body={'![First](https://example.com/first.png)\n\nhttps://example.com/pasted.gif\n\n[Document](https://example.com/file.pdf)\n\n![Broken](https://example.com/broken.png)'} />)
+        fireEvent.error(await screen.findByRole('button', { name: 'Preview Broken' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Preview First' }))
+        expect(screen.getByRole('status')).toHaveTextContent('1 of 2')
+        fireEvent.keyDown(screen.getByRole('dialog'), { key: 'ArrowRight' })
+        expect(within(screen.getByRole('dialog')).getByRole('img')).toHaveAttribute('src', 'https://example.com/pasted.gif')
+        fireEvent.click(screen.getByRole('button', { name: 'Close image preview' }))
+        cleanup()
+        render(<SpaceMarkdown body="![Only](https://example.com/only.png)" />)
+        fireEvent.click(await screen.findByRole('button', { name: 'Preview Only' }))
+        expect(screen.queryByRole('button', { name: 'Next image' })).not.toBeInTheDocument()
+    })
+})

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -1,11 +1,11 @@
-import { createContext, memo, useContext, useMemo, useState, type ComponentProps, type CSSProperties, type ReactNode } from 'react'
+import { createContext, memo, useContext, useMemo, useRef, useState, type ComponentProps, type CSSProperties, type ReactNode } from 'react'
 import { Streamdown } from 'streamdown'
 import { Eye, FileDown, FilePlus2, FileText, Loader2 } from 'lucide-react'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { ZoomableImage } from '@/components/image-lightbox'
+import { ImageLightbox as SharedImageLightbox } from '@/components/image-lightbox'
 import { isTrustedDomain, linkDomain, trustDomain } from '@/lib/trusted-domains'
 import { toast } from '@/lib/toast'
 import { MemberProfilePopover } from '@/components/spaces/atoms'
@@ -97,12 +97,77 @@ function BlobLinkCard({ href, children }: { href: string; children?: ReactNode }
     )
 }
 
-/**
- * Discord-style viewer: the image large on a dimmed backdrop. Esc or a click
- * outside closes; scroll zooms, click toggles fit ⇄ zoomed, drag pans. The
- * row under the image carries the source-specific action (download for
- * blobs, open-original for external links).
- */
+/** One gallery per message, using rendered tile order (including pasted image URLs). */
+const MessageImageGalleryContext = createContext<((image: HTMLImageElement) => void) | null>(null)
+
+function MessageImageGallery({ children }: { children: ReactNode }) {
+    const container = useRef<HTMLDivElement>(null)
+    const [gallery, setGallery] = useState<{ images: { src: string; alt: string }[]; index: number } | null>(null)
+    const openImage = (image: HTMLImageElement) => {
+        const tiles = Array.from(container.current?.querySelectorAll<HTMLImageElement>('img[data-message-image]') ?? [])
+        const index = tiles.indexOf(image)
+        if (index < 0) return
+        setGallery({ images: tiles.map((tile) => ({ src: tile.src, alt: tile.alt })), index })
+    }
+    const selected = gallery?.images[gallery.index]
+    return (
+        <MessageImageGalleryContext.Provider value={openImage}>
+            <div ref={container}>{children}</div>
+            <SharedImageLightbox
+                open={Boolean(selected)}
+                onOpenChange={(open) => { if (!open) setGallery(null) }}
+                src={selected?.src ?? ''}
+                name={selected?.alt || 'Image'}
+                actions={selected && <SpaceImageActions key={selected.src} src={selected.src} />}
+                navigation={gallery ? {
+                    index: gallery.index,
+                    count: gallery.images.length,
+                    onPrevious: () => setGallery((current) => current && ({ ...current, index: Math.max(0, current.index - 1) })),
+                    onNext: () => setGallery((current) => current && ({ ...current, index: Math.min(current.images.length - 1, current.index + 1) })),
+                } : undefined}
+            />
+        </MessageImageGalleryContext.Provider>
+    )
+}
+
+/** Source-specific actions always follow the currently selected image. */
+function SpaceImageActions({ src }: { src: string }) {
+    const [saving, setSaving] = useState(false)
+    const [saveOpen, setSaveOpen] = useState(false)
+    const parsed = parseBlobAppUrl(src)
+    const save = async () => {
+        if (saving) return
+        setSaving(true)
+        try {
+            const res = parsed
+                ? await window.ipc.invoke('spaces:saveBlob', {
+                    ...parsed,
+                    suggestedName: new URL(src).searchParams.get('name') ?? undefined,
+                })
+                : await window.ipc.invoke('spaces:saveImageUrl', { url: src })
+            if (res.saved) toast('Saved', 'success')
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not download', 'error')
+        } finally {
+            setSaving(false)
+        }
+    }
+    return (
+        <>
+            <button type="button" disabled={saving} onClick={() => void save()} className="text-white/80 hover:text-white hover:underline">
+                {saving ? 'Saving…' : 'Download'}
+            </button>
+            {parsed ? (
+                <button type="button" onClick={() => setSaveOpen(true)} className="text-white/80 hover:text-white hover:underline">Save to space files</button>
+            ) : (
+                <a href={src} target="_blank" rel="noreferrer" className="text-white/80 hover:text-white hover:underline">Open original</a>
+            )}
+            {saveOpen && <SaveToSpaceDialog src={src} onClose={() => setSaveOpen(false)} />}
+        </>
+    )
+}
+
+/** Standalone tiles outside a message retain a single-image viewer. */
 function ImageLightbox({ src, alt, open, onOpenChange, children }: {
     src: string
     alt: string
@@ -110,18 +175,7 @@ function ImageLightbox({ src, alt, open, onOpenChange, children }: {
     onOpenChange: (open: boolean) => void
     children?: ReactNode
 }) {
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent
-                showCloseButton={false}
-                className="flex w-auto max-w-[92vw] flex-col items-center border-none bg-transparent p-0 shadow-none outline-none sm:max-w-[92vw]"
-            >
-                <DialogTitle className="sr-only">{alt || 'Image'}</DialogTitle>
-                <ZoomableImage src={src} alt={alt} className="max-h-[82vh] max-w-[92vw] rounded-lg object-contain" />
-                {children && <div className="flex items-center gap-3 self-start text-xs">{children}</div>}
-            </DialogContent>
-        </Dialog>
-    )
+    return <SharedImageLightbox src={src} name={alt || 'Image'} open={open} onOpenChange={onOpenChange} actions={children} />
 }
 
 /** An uploaded image in a message: inline preview, click to view, download from the viewer. */
@@ -208,6 +262,12 @@ function SaveToSpaceDialog({ src, onClose }: { src: string; onClose: () => void 
 }
 
 export function BlobImage({ src, alt }: { src: string; alt: string }) {
+    const imageRef = useRef<HTMLImageElement>(null)
+    const openGallery = useContext(MessageImageGalleryContext)
+    const preview = () => {
+        if (openGallery && imageRef.current) openGallery(imageRef.current)
+        else setOpen(true)
+    }
     const [open, setOpen] = useState(false)
     const [saveOpen, setSaveOpen] = useState(false)
     const [saving, setSaving] = useState(false)
@@ -249,9 +309,17 @@ export function BlobImage({ src, alt }: { src: string; alt: string }) {
                 <ContextMenuTrigger asChild>
                     <img
                         src={src}
+                        ref={imageRef}
+                        data-message-image
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`Preview ${alt || 'image'}`}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); preview() }
+                        }}
                         alt={alt}
                         loading="lazy"
-                        onClick={() => setOpen(true)}
+                        onClick={preview}
                         // The row has its own context menu — the image's wins here.
                         onContextMenu={(e) => e.stopPropagation()}
                         onLoad={() => setLoaded(true)}
@@ -260,7 +328,7 @@ export function BlobImage({ src, alt }: { src: string; alt: string }) {
                     />
                 </ContextMenuTrigger>
                 <ContextMenuContent>
-                    <ContextMenuItem onSelect={() => setOpen(true)}>
+                    <ContextMenuItem onSelect={preview}>
                         <Eye className="size-3.5 mr-2" /> View
                     </ContextMenuItem>
                     {parsed && (
@@ -314,6 +382,12 @@ function plainLabel(children: ReactNode): string | null {
  * images; a URL that never loads falls back to the plain link it came from.
  */
 function ExternalImage({ src, alt }: { src: string; alt: string }) {
+    const imageRef = useRef<HTMLImageElement>(null)
+    const openGallery = useContext(MessageImageGalleryContext)
+    const preview = () => {
+        if (openGallery && imageRef.current) openGallery(imageRef.current)
+        else setOpen(true)
+    }
     const [failed, setFailed] = useState(false)
     const [open, setOpen] = useState(false)
     const [saving, setSaving] = useState(false)
@@ -336,10 +410,18 @@ function ExternalImage({ src, alt }: { src: string; alt: string }) {
         <>
             <img
                 src={src}
+                ref={imageRef}
+                data-message-image
+                role="button"
+                tabIndex={0}
+                aria-label={`Preview ${alt || 'image'}`}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); preview() }
+                }}
                 alt={alt}
                 title={src}
                 loading="lazy"
-                onClick={() => setOpen(true)}
+                onClick={preview}
                 onError={() => setFailed(true)}
                 className={cn(TILE_CLASS, 'h-60 max-w-[360px]')}
             />
@@ -522,7 +604,9 @@ export const SpaceMarkdown = memo(function SpaceMarkdown({ body, className }: { 
     }, [body, refs, memberNames])
     return (
         <div className={cn(className)}>
-            <Streamdown components={spaceComponents}>{text}</Streamdown>
+            <MessageImageGallery key={text}>
+                <Streamdown components={spaceComponents}>{text}</Streamdown>
+            </MessageImageGallery>
         </div>
     )
 })

--- a/apps/x/apps/renderer/vite.config.ts
+++ b/apps/x/apps/renderer/vite.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
     excalidrawAssets(),
   ],
   resolve: {
+    // Linked workspace dependencies must share the renderer's React instance.
+    dedupe: ['react', 'react-dom'],
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },


### PR DESCRIPTION
Messages containing multiple images previously opened each image separately. Clicking an image now opens a carousel scoped to that message, with previous/next buttons, keyboard arrows, an image counter, and zoom reset between images.

Covers assistant-chat attachments and Spaces messages/thread replies, including uploaded images and pasted image URLs. Download and save actions follow the selected image. Also deduplicates React in Vite to prevent the blank startup screen caused by linked dependencies loading a second React instance.

Validation: 15 targeted tests pass, renderer TypeScript checking passes, and an isolated Electron startup check confirmed the home screen mounts after the React fix.
