### PR TITLE
Improve assistant panels: resizing, multiple chats, and direct docking

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -10,12 +10,14 @@ import { cn, compactPath, parentPath } from '@/lib/utils';
 import { SPACES_ENABLED } from '@/lib/feature-flags';
 import { MarkdownEditor, type MarkdownEditorHandle } from './components/markdown-editor';
 import { ChatSidebar } from './components/chat-sidebar';
+import { AssistantPanels } from './components/assistant-panels';
+import { layoutAssistantPanels, restorePanelPreferences, type PanelSize } from './lib/assistant-panel-layout';
 import { AssistantChatDock } from './components/assistant-chat-dock';
-import { ASSISTANT_TABS_KEY, createAssistantTab, readAssistantPreference, restoreAssistantTabs, tabsAfterClose, writeAssistantPreference } from './lib/assistant-dock';
+import { ASSISTANT_TABS_KEY, assistantDockTabs, createAssistantTab, readAssistantPreference, replaceAssistantTab, restoreAssistantTabs, tabsAfterClose, writeAssistantPreference } from './lib/assistant-dock';
 import { useSessionChat } from '@/hooks/useSessionChat';
 import { subscribeSessionFeed } from '@/lib/session-chat/feed';
 import { ChatHeader } from './components/chat-header';
-import { ChatSessionPane, ChatSessionComposer, queuedMessageText } from './components/chat-session';
+import { queuedMessageText } from './components/chat-session';
 // Value import: the Home to-do surface mounts a standalone composer directly
 // (not tab-bound); chat tabs render theirs through ChatSessionComposer.
 import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from './components/chat-input-with-mentions';
@@ -92,7 +94,6 @@ import { LiveNoteSidebar } from '@/components/live-note-sidebar'
 import { BackgroundTaskDetail } from '@/components/background-task-detail'
 import { BrowserPane } from '@/components/browser-pane/BrowserPane'
 import { VersionHistoryPanel } from '@/components/version-history-panel'
-import { FileCardProvider } from '@/contexts/file-card-context'
 import { type ChatTab } from '@/components/tab-bar'
 import { CaffeinateToggle } from '@/components/caffeinate-toggle'
 import {
@@ -869,7 +870,7 @@ function ContentHeader({
 }
 
 function App() {
-  const { chatPanePlacement, chatPaneSize, assistantPresentation } = useTheme()
+  const { chatPanePlacement, chatPaneSize, assistantPresentation, setAssistantPresentation } = useTheme()
   const useBottomTabs = assistantPresentation === 'bottom-tabs'
   const isChatPaneInMiddle = chatPanePlacement === 'middle'
 
@@ -947,7 +948,7 @@ function App() {
   })
   const [graphStatus, setGraphStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
   const [graphError, setGraphError] = useState<string | null>(null)
-  const [isChatSidebarOpen, setIsChatSidebarOpen] = useState(true)
+  const [isChatSidebarOpen, setIsChatSidebarOpen] = useState(() => readAssistantPreference('rowboat-assistant-visible') !== 'false')
   const [isRightPaneMaximized, setIsRightPaneMaximized] = useState(false)
   // Middle-pane collapse animation. Animating its max-width from 100% is janky:
   // 100% is relative to the parent (far wider than the pane's real width), so the
@@ -1116,7 +1117,6 @@ function App() {
   const activeIsProcessing = sessionChat.chatState?.isProcessing ?? isProcessing
   const activeIsReasoning = sessionChat.chatState?.isReasoning ?? false
   const activeIsWaitingOnHuman = sessionChat.chatState?.isWaitingOnHuman ?? false
-  const activeIsWorking = activeIsProcessing && !activeIsWaitingOnHuman
   // (The in-flight-reply mirrors — pill response panel, fallback speech,
   // quick-ask state — read the HOVER session's store, declared above.)
   // A failed session load must be visible, not a blank chat.
@@ -1505,7 +1505,7 @@ function App() {
     })
   }, [voice, cancelPttForSteal])
 
-  const handlePromptSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => Promise<void>) | null>(null)
+  const handlePromptSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode, targetTabId?: string) => Promise<void>) | null>(null)
   // Companion sends (bar submits, call utterances) — filled once
   // handleHoverSubmit exists; early callers (startCall's PTT callback) fire
   // at event time, long after render.
@@ -1533,10 +1533,11 @@ function App() {
 
   const handleSubmitRecording = useCallback(async () => {
     if (!isRecordingRef.current) return
+    const holder = voiceOwnerId()
+    const targetTabId = chatTabsRef.current.find((tab) => tab.chatId === holder)?.id
     const text = await voice.submit()
     setIsRecording(false)
     isRecordingRef.current = false
-    const holder = voiceOwnerId()
     if (holder && holder !== CALL_VOICE_HOLDER) releaseVoice(holder)
     if (text) {
       pendingVoiceInputRef.current = true
@@ -1544,8 +1545,8 @@ function App() {
       // started the recording, not blindly to the active chat.
       if (holder === HOME_VOICE_HOLDER) {
         handleHomeComposerSubmitRef.current?.({ text, files: [] })
-      } else {
-        handlePromptSubmitRef.current?.({ text, files: [] })
+      } else if (targetTabId) {
+        handlePromptSubmitRef.current?.({ text, files: [] }, undefined, undefined, undefined, undefined, undefined, targetTabId)
       }
     }
   }, [voice])
@@ -2618,6 +2619,22 @@ function App() {
     if (useBottomTabs && saved && chatTabs.some((tab) => tab.id === saved)) return saved
     return chatTabs[0].id
   })
+  const [savedAssistantLayout] = useState(() => restorePanelPreferences(readAssistantPreference('rowboat-assistant-panels')))
+  const [expandedAssistantTabs, setExpandedAssistantTabs] = useState<string[]>(savedAssistantLayout.expanded)
+  const [dockedAssistantTabId, setDockedAssistantTabId] = useState<string | null>(() => chatTabs.some((tab) => tab.id === savedAssistantLayout.docked) ? savedAssistantLayout.docked : null)
+  const [assistantPanelSizes, setAssistantPanelSizes] = useState<Record<string, PanelSize>>(savedAssistantLayout.sizes)
+  const [dockedAssistantWidth, setDockedAssistantWidth] = useState(DEFAULT_CHAT_PANE_WIDTH)
+  useEffect(() => {
+    const ids = new Set(chatTabs.map((tab) => tab.id))
+    writeAssistantPreference('rowboat-assistant-panels', JSON.stringify({ sizes: Object.fromEntries(Object.entries(assistantPanelSizes).filter(([id]) => ids.has(id))), expanded: expandedAssistantTabs.filter((id) => ids.has(id)), docked: dockedAssistantTabId }))
+    writeAssistantPreference('rowboat-assistant-visible', String(isChatSidebarOpen))
+  }, [assistantPanelSizes, expandedAssistantTabs, dockedAssistantTabId, isChatSidebarOpen, chatTabs])
+  const [assistantViewport, setAssistantViewport] = useState({ width: window.innerWidth, height: window.innerHeight })
+  useEffect(() => {
+    const resize = () => setAssistantViewport({ width: window.innerWidth, height: window.innerHeight })
+    window.addEventListener('resize', resize)
+    return () => window.removeEventListener('resize', resize)
+  }, [])
   useEffect(() => {
     if (!useBottomTabs) return
     writeAssistantPreference(ASSISTANT_TABS_KEY, JSON.stringify(chatTabs))
@@ -2637,6 +2654,7 @@ function App() {
     }
   }
   const creatingSessionByChatRef = useRef(new Map<string, Promise<{ sessionId: string }>>())
+  const previousChatIdentityByRunRef = useRef(new Map<string, string>())
   // Per-tab selection (model + effort as ONE value) — the composer reports
   // every change (settings seed included) and reads it back on remount, so
   // a tab's selection survives tab switches for the life of the app.
@@ -4114,15 +4132,20 @@ function App() {
     searchEnabled?: boolean,
     codeMode?: 'claude' | 'codex',
     permissionMode?: PermissionMode,
+    targetTabId?: string,
   ) => {
-    const submitTabId = activeChatTabIdRef.current
+    const submitTabId = targetTabId ?? activeChatTabIdRef.current
     const submitTab = chatTabsRef.current.find((tab) => tab.id === submitTabId)
     if (!submitTab) return
     const isSubmitTabActive = () => activeChatTabIdRef.current === submitTabId
       && chatTabsRef.current.find((tab) => tab.id === submitTabId)?.chatId === submitTab.chatId
     const submittedSelection = selectionByTabRef.current.get(submitTab.chatId)
+    const submittedWorkDir = workDirByTabRef.current[submitTabId] ?? null
     const submittedContext = buildMiddlePaneContext()
-    if (activeIsProcessing && inCallRef.current) {
+    const submitsToCall = inCallRef.current && submitTab.runId !== null && submitTab.runId === hoverRunIdRef.current
+    const submittedVoiceInput = pendingVoiceInputRef.current
+    pendingVoiceInputRef.current = false
+    if (isSubmitTabActive() && activeIsProcessing && submitsToCall) {
       // In-call input arrives at arbitrary moments — a hard
       // drop here silently ate utterances submitted while the previous turn
       // was still stopping (the PTT interrupt is async). Finish the stop and
@@ -4141,7 +4164,7 @@ function App() {
     // Video chat mode: drain the webcam frames buffered since the last send
     // so they ride along with this message as inline image parts.
     const marks = callTurnMarksRef.current
-    if (inCallRef.current && marks && marks.submit === undefined) {
+    if (submitsToCall && marks && marks.submit === undefined) {
       marks.submit = performance.now()
     }
 
@@ -4150,9 +4173,9 @@ function App() {
     // utterance — pendingVoiceInputRef is set just before submit) is spoken
     // even with the text panel open. Stamped per-turn so tucking or typing
     // mid-reply never flips an in-flight answer.
-    suppressSpeechTurnRef.current = inCallRef.current && !pendingVoiceInputRef.current
+    if (submitsToCall) suppressSpeechTurnRef.current = !submittedVoiceInput
 
-    if (inCallRef.current) {
+    if (submitsToCall) {
       // A new question supersedes whatever of the previous reply was still
       // unspoken — silence it and drop the frozen backlog so it never plays
       // over the new turn. (The overlay resets its segment list when the
@@ -4174,7 +4197,7 @@ function App() {
     // Frames ride along whenever screen capture is live — during calls, and
     // for quick-ask questions with the share toggle on.
     const videoFrames =
-      inCallRef.current || video.screenState === 'live' ? video.collectFrames() : []
+      submitsToCall || (!inCallRef.current && video.screenState === 'live') ? video.collectFrames() : []
 
     const userMessageId = `user-${Date.now()}`
     const displayAttachments: ChatMessage['attachments'] = hasAttachments || videoFrames.length > 0
@@ -4229,7 +4252,7 @@ function App() {
         )))
         // Flush this tab's pending work directory onto the freshly created run so
         // the agent picks it up on the first turn. Done before createMessage below.
-        const pendingWorkDir = workDirByTabRef.current[submitTabId] ?? null
+        const pendingWorkDir = submittedWorkDir
         if (pendingWorkDir) await persistRunWorkDir(currentRunId, pendingWorkDir)
         isNewRun = true
       }
@@ -4246,7 +4269,7 @@ function App() {
       // is dead air.
       const reasoningEffort =
         selected?.effort ??
-        (inCallRef.current && companionVoiceRef.current ? ('low' as const) : undefined)
+        (submitsToCall && companionVoiceRef.current ? ('low' as const) : undefined)
       // The runtime defaults omitted maxModelCalls to the global limit; the
       // chat-specific override is the UI's job to pass explicitly. A failed
       // settings read just falls back to the global limit.
@@ -4265,7 +4288,7 @@ function App() {
             ...(selected ? { model: { provider: selected.provider, model: selected.model } } : {}),
             composition: {
               workDirId: currentRunId,
-              ...(pendingVoiceInputRef.current ? { voiceInput: true } : {}),
+              ...(submittedVoiceInput ? { voiceInput: true } : {}),
               ...(ttsEnabledRef.current ? { voiceOutput: ttsModeRef.current } : {}),
               ...(searchEnabled ? { searchEnabled: true } : {}),
               // Code-session pins: a bound chat always carries the session's
@@ -4278,7 +4301,7 @@ function App() {
                     codeCwd: codeSessionLocksRef.current[currentRunId].cwd,
                   }
                 : (codeMode ? { codeMode } : {})),
-              ...((inCallRef.current && video.cameraOn) || video.screenState === 'live'
+              ...((submitsToCall && video.cameraOn) || (!inCallRef.current && video.screenState === 'live')
                 ? { videoMode: true }
                 : {}),
               ...(practiceModeRef.current ? { coachMode: true } : {}),
@@ -4399,7 +4422,7 @@ function App() {
           config: sendConfig,
         })
         analytics.chatMessageSent({
-          voiceInput: pendingVoiceInputRef.current || undefined,
+          voiceInput: submittedVoiceInput || undefined,
           voiceOutput: ttsEnabledRef.current ? ttsModeRef.current : undefined,
           searchEnabled: searchEnabled || undefined,
         })
@@ -4415,7 +4438,7 @@ function App() {
           config: sendConfig,
         })
         analytics.chatMessageSent({
-          voiceInput: pendingVoiceInputRef.current || undefined,
+          voiceInput: submittedVoiceInput || undefined,
           voiceOutput: ttsEnabledRef.current ? ttsModeRef.current : undefined,
           searchEnabled: searchEnabled || undefined,
         })
@@ -4428,8 +4451,6 @@ function App() {
       if (sendResult.queued && isSubmitTabActive()) {
         setConversation((prev) => prev.filter((item) => item.id !== userMessageId))
       }
-
-      pendingVoiceInputRef.current = false
 
       if (isNewRun) {
         const inferredTitle = inferRunTitleFromMessage(titleSource)
@@ -4607,8 +4628,8 @@ function App() {
   }, [setChatViewportAnchor])
 
   const activateAssistantTab = useCallback((tab: ChatTab) => {
-    cancelRecordingIfActive()
-    setPresetMessage(chatDraftsRef.current.get(tab.chatId))
+    setExpandedAssistantTabs((previous) => previous.includes(tab.id) ? previous : [...previous, tab.id])
+    setPresetMessage(undefined)
     activeChatTabIdRef.current = tab.id
     setActiveChatTabId(tab.id)
     if (tab.runId) void loadRun(tab.runId)
@@ -4624,7 +4645,7 @@ function App() {
       setPermissionResponses(new Map())
       setAutoPermissionDecisions(new Map())
     }
-  }, [cancelRecordingIfActive, loadRun])
+  }, [loadRun])
 
   useEffect(() => {
     const initialTab = chatTabsRef.current.find((tab) => tab.id === activeChatTabIdRef.current)
@@ -4639,7 +4660,34 @@ function App() {
     setIsChatSidebarOpen(true)
   }, [activateAssistantTab])
 
+  const changeAssistantPanelChat = useCallback((tabId: string, sessionId: string | null) => {
+    const current = chatTabsRef.current.find((tab) => tab.id === tabId)
+    if (!current || (sessionId !== null && current.runId === sessionId)) return
+    const existing = sessionId ? chatTabsRef.current.find((tab) => tab.runId === sessionId) : undefined
+    if (existing) {
+      activateAssistantTab(existing)
+      setIsChatSidebarOpen(true)
+      return
+    }
+    if (voiceOwnerId() === current.chatId) handleCancelRecording()
+    if (current.runId) previousChatIdentityByRunRef.current.set(current.runId, current.chatId)
+    const chatId = sessionId ? previousChatIdentityByRunRef.current.get(sessionId) ?? sessionId : crypto.randomUUID()
+    const replacement = { ...current, runId: sessionId, chatId }
+    setChatTabs((tabs) => replaceAssistantTab(tabs, tabId, sessionId, chatId))
+    setWorkDirByTab((previous) => ({ ...previous, [tabId]: null }))
+    setChatViewportAnchorByTab((previous) => {
+      const next = { ...previous }
+      delete next[tabId]
+      return next
+    })
+    activateAssistantTab(replacement)
+    setIsChatSidebarOpen(true)
+  }, [activateAssistantTab, handleCancelRecording])
+
   const closeAssistantTab = useCallback((tabId: string) => {
+    if (voiceOwnerId() === chatIdForTab(tabId)) handleCancelRecording()
+    setDockedAssistantTabId((previous) => previous === tabId ? null : previous)
+    setExpandedAssistantTabs((previous) => previous.filter((id) => id !== tabId))
     const next = tabsAfterClose(chatTabsRef.current, tabId, activeChatTabIdRef.current)
     if (!next.tabs.length) {
       const blank = createAssistantTab()
@@ -4652,7 +4700,7 @@ function App() {
         activateAssistantTab(next.tabs.find((tab) => tab.id === next.activeId)!)
       }
     }
-  }, [activateAssistantTab])
+  }, [activateAssistantTab, chatIdForTab, handleCancelRecording])
 
   // Bind the single chat surface to a session. THE one way any part of the
   // app points the chat at a conversation (recents, history, Home threads,
@@ -5342,6 +5390,27 @@ function App() {
     }
   }, [handleCloseFullScreenChat, navigateToView])
 
+  const toggleAssistantDock = (tab: ChatTab) => {
+    if (tab.id !== activeChatTabIdRef.current) activateAssistantTab(tab)
+    if (!useBottomTabs || dockedAssistantTabId === tab.id || isFullScreenChat) {
+      setAssistantPresentation('bottom-tabs')
+      setDockedAssistantTabId(null)
+      setExpandedAssistantTabs((previous) => [...previous.filter((id) => id !== tab.id), tab.id])
+    } else {
+      setDockedAssistantTabId(tab.id)
+    }
+    setIsChatSidebarOpen(true)
+    setIsRightPaneMaximized(false)
+    if (isFullScreenChat) pushChatToSidePane()
+  }
+
+  const minimizeAssistantTab = (tabId: string) => {
+    setExpandedAssistantTabs((previous) => previous.filter((id) => id !== tabId))
+    if (tabId === activeChatTabIdRef.current) setIsChatSidebarOpen(false)
+    setIsRightPaneMaximized(false)
+    requestAnimationFrame(() => document.querySelector<HTMLButtonElement>(`[data-assistant-tab="${CSS.escape(tabId)}"]`)?.focus())
+  }
+
   // Section entry points (sidebar items, deep links, the tour). Thin wrappers
   // over navigateToView so every entry records history — the old direct
   // state-twiddling versions didn't, which made Back skip whole sections.
@@ -5900,6 +5969,7 @@ function App() {
 
   const navigateToFullScreenChat = useCallback(() => {
     const current = currentViewStateRef.current
+    if (current.type === 'chat' && !isBrowserOpen) return
     // Only treat this as navigation when coming from another view
     if (current.type !== 'chat') {
       const nextHistory = {
@@ -5909,7 +5979,7 @@ function App() {
       setHistory(nextHistory)
     }
     handleOpenFullScreenChat()
-  }, [appendUnique, handleOpenFullScreenChat, setHistory])
+  }, [appendUnique, handleOpenFullScreenChat, setHistory, isBrowserOpen])
 
   // Handle image upload for the markdown editor
   const handleImageUpload = useCallback(async (file: File): Promise<string | null> => {
@@ -6878,11 +6948,6 @@ function App() {
     permissionResponses,
     autoPermissionDecisions,
   ])
-  const emptyChatTabState = React.useMemo<ChatTabViewState>(() => createEmptyChatTabViewState(), [])
-  const getChatTabStateForRender = useCallback((tabId: string): ChatTabViewState => {
-    if (tabId === activeChatTabId) return activeChatTabState
-    return chatViewStateByTab[tabId] ?? emptyChatTabState
-  }, [activeChatTabId, activeChatTabState, chatViewStateByTab, emptyChatTabState])
   const chatTabStatesForRender = React.useMemo(() => ({
     ...chatViewStateByTab,
     [activeChatTabId]: activeChatTabState,
@@ -6896,10 +6961,18 @@ function App() {
   // the workspace drawer at its edge. Before a session is picked the empty
   // state owns the pane and the chat stays out of the way.
   const codeChatMain = isCodeOpen && activeCodeSession !== null
-  const floatingAssistant = useBottomTabs && !isFullScreenChat && !isCodeOpen && !isBrowserOpen
-  const dockFullScreen = useBottomTabs && isFullScreenChat
-  const showAssistantDock = useBottomTabs && !isCodeOpen
-  const chatPaneOpen = isCodeOpen ? codeChatMain : isChatSidebarOpen
+  const floatingPanelsEnabled = useBottomTabs && !isFullScreenChat && !isCodeOpen && !isBrowserOpen
+  const dockedAssistantVisible = floatingPanelsEnabled && dockedAssistantTabId !== null && (dockedAssistantTabId !== activeChatTabId || isChatSidebarOpen)
+  const floatingAssistant = floatingPanelsEnabled && !dockedAssistantVisible
+  const dockFullScreen = isFullScreenChat
+  const fullScreenAssistantTabId = isFullScreenChat || isRightPaneMaximized ? activeChatTabId : null
+  const dockTabs = assistantDockTabs(chatTabs, dockedAssistantTabId, fullScreenAssistantTabId)
+  const showAssistantDock = useBottomTabs && !isCodeOpen && (fullScreenAssistantTabId === null || dockTabs.length > 0)
+  const chatPaneOpen = isCodeOpen ? codeChatMain : dockedAssistantVisible || isChatSidebarOpen
+  const assistantPanelBounds = layoutAssistantPanels([
+    ...expandedAssistantTabs.filter((id) => id !== dockedAssistantTabId && (id !== activeChatTabId || isChatSidebarOpen) && chatTabs.some((tab) => tab.id === id)),
+    ...(isChatSidebarOpen && activeChatTabId !== dockedAssistantTabId && !expandedAssistantTabs.includes(activeChatTabId) ? [activeChatTabId] : []),
+  ], assistantPanelSizes, assistantViewport, dockedAssistantVisible ? dockedAssistantWidth : 0, activeChatTabId)
   const isRightPaneOnlyMode = (isRightPaneContext || floatingAssistant) && chatPaneOpen && isRightPaneMaximized
   const shouldCollapseLeftPane = isRightPaneOnlyMode
   const nonChatPaneStyle = React.useMemo<React.CSSProperties>(() => {
@@ -7021,6 +7094,7 @@ function App() {
     onOpenEmail: (threadId?: string) => openEmailView(threadId),
     onOpenHome: () => void navigateToView({ type: 'home' }),
     onNewChat: handleNewChatTab,
+    onOpenAssistant: navigateToFullScreenChat,
     onToggleBrowser: handleToggleBrowser,
     onStartTour: () => setTourActive(true),
     meetingRecordingState: meetingTranscription.state,
@@ -7741,123 +7815,33 @@ function App() {
                   />
                 </div>
               )}
-              {activeMiddle === 'chat' && !useBottomTabs && (
-              <FileCardProvider onOpenKnowledgeFile={(path) => { navigateToFile(path) }} onOpenFile={(path) => { navigateToFile(path) }}>
-              <div className="flex min-h-0 flex-1 flex-col">
-                <div className="relative min-h-0 flex-1">
-                  {chatTabs.map((tab) => {
-                    const isActive = tab.id === activeChatTabId
-                    return (
-                      <ChatSessionPane
-                        // Keyed by CHAT identity: rebinding this tab to a
-                        // different session remounts the panel (fresh
-                        // scroll/DOM state); first-send runId binding does not.
-                        key={tab.chatId}
-                        tab={tab}
-                        isActive={isActive}
-                        tabState={getChatTabStateForRender(tab.id)}
-                        viewportAnchor={chatViewportAnchorByTab[tab.id]}
-                        onPickPrompt={setPresetMessage}
-                        isToolOpenForTab={isToolOpenForTab}
-                        setToolOpenForTab={setToolOpenForTab}
-                        onPermissionResponse={handlePermissionResponse}
-                        onAskHumanResponse={handleAskHumanResponse}
-                        onCodePermissionResponse={handleCodePermissionResponse}
-                        onComposioConnected={(slug) => handleComposioConnected(slug, tab.id)}
-                        activeIsWorking={activeIsWorking}
-                        activeIsProcessing={activeIsProcessing}
-                        activeIsReasoning={activeIsReasoning}
-                        isCodeSession={!!(tab.runId && codeSessionLocks[tab.runId])}
-                      />
-                    )
-                  })}
-                </div>
-
-                <div className="rowboat-composer-dock sticky bottom-0 z-10 bg-background pb-12 pt-2 shadow-lg">
-                  <div className="pointer-events-none absolute inset-x-0 -top-6 h-6 bg-linear-to-t from-background to-transparent" />
-                  <div className="mx-auto w-full max-w-4xl px-4">
-                    {chatTabs.map((tab) => {
-                      const isActive = tab.id === activeChatTabId
-                      return (
-                        <ChatSessionComposer
-                          // Composer instance per CHAT (see chat panel key
-                          // above): a rebound tab gets a fresh composer, so
-                          // attachments/toggles/selection can't leak across
-                          // sessions; first-send binding keeps the instance.
-                          key={tab.chatId}
-                          tab={tab}
-                          isActive={isActive}
-                          tabState={getChatTabStateForRender(tab.id)}
-                          knowledgeFiles={mentionableFiles}
-                          recentFiles={recentWikiFiles}
-                          visibleFiles={visibleKnowledgeFiles}
-                          onSubmit={handlePromptSubmit}
-                          onStop={handleStop}
-                          activeIsProcessing={activeIsProcessing}
-                          isStopping={isStopping}
-                          // The single session store follows the ACTIVE tab's
-                          // run — only that tab's composer shows its queue.
-                          queued={
-                            isActive && tab.runId && sessionChat.sessionId === tab.runId
-                              ? sessionChat.queued
-                              : undefined
-                          }
-                          onRemoveQueued={handleRemoveQueued}
-                          onPullQueued={handlePullQueued}
-                          presetMessage={presetMessage}
-                          onPresetMessageConsumed={() => setPresetMessage(undefined)}
-                          codeSessionLocks={codeSessionLocks}
-                          initialDraft={chatDraftsRef.current.get(tab.chatId)}
-                          onDraftChange={setChatDraftForTab}
-                          onSelectionChange={(t, selection) => {
-                            if (selection) {
-                              selectionByTabRef.current.set(t.chatId, selection)
-                            } else {
-                              selectionByTabRef.current.delete(t.chatId)
-                            }
-                          }}
-                          initialSelection={selectionByTabRef.current.get(tab.chatId) ?? null}
-                          // Last-turn restore: the single session store is
-                          // bound to the ACTIVE tab's run, so only that tab
-                          // gets a resolved value; others stay undefined
-                          // (loading) until activated. lastSelection is null
-                          // for a session with no turns (settings seed).
-                          restoredSelection={
-                            isActive && tab.runId
-                              && sessionChat.sessionId === tab.runId
-                              && sessionChat.chatState
-                              ? sessionChat.chatState.lastSelection
-                              : undefined
-                          }
-                          workDirByTab={workDirByTab}
-                          onWorkDirChange={setTabWorkDir}
-                          isRecording={isRecording}
-                          voiceOwner={voiceOwner}
-                          voice={voice}
-                          onStartRecording={handleStartRecording}
-                          onSubmitRecording={handleSubmitRecording}
-                          onCancelRecording={handleCancelRecording}
-                          voiceAvailable={voiceAvailable}
-                          inCall={inCall}
-                          callOnThisChat={callOnActiveChat}
-                          onStartCall={handleStartCall}
-                          onEndCall={endCall}
-                          ttsAvailable={ttsAvailable}
-                        />
-                      )
-                    })}
-                  </div>
-                </div>
-              </div>
-              </FileCardProvider>
-              )}
             </SidebarInset>
 
             {/* Chat pane - shown when viewing files/graph/code. Code sessions
                 bind this same assistant chat (a code session IS a chat
                 session) — there is no separate code chat surface. */}
-            {(isRightPaneContext || useBottomTabs) && (
+            {(
               <CodeDiffOpenerProvider onOpenDiff={codeChatMain ? openCodeDiff : null}>
+              <AssistantPanels
+                bounds={assistantPanelBounds}
+                allowDockControls={!isBrowserOpen && !isCodeOpen}
+                floatingEnabled={floatingPanelsEnabled && !isRightPaneMaximized}
+                dockedTabId={floatingPanelsEnabled && !isRightPaneMaximized ? dockedAssistantTabId : activeChatTabId}
+                onDockedWidthChange={setDockedAssistantWidth}
+                recordingChatId={voiceOwner}
+                callSessionId={inCall ? hoverRunId : null}
+                onResize={(tabId, size) => setAssistantPanelSizes((previous) => ({ ...previous, [tabId]: size }))}
+                onFocus={(tab) => {
+                  if (tab.id === activeChatTabIdRef.current) return
+                  activateAssistantTab(tab)
+                  setIsChatSidebarOpen(true)
+                }}
+                onMinimize={minimizeAssistantTab}
+                onClose={closeAssistantTab}
+                onToggleDock={toggleAssistantDock}
+                onChangeChat={changeAssistantPanelChat}
+                onSubmit={(tabId, message, mentions, attachments, search, code, permission) => { void handlePromptSubmit(message, mentions, attachments, search, code, permission, tabId) }}
+              >
               <ChatSidebar
                 floating={floatingAssistant && !isRightPaneMaximized}
                 keepMounted={useBottomTabs || chatTabs.length > 1}
@@ -7867,10 +7851,10 @@ function App() {
                   requestAnimationFrame(() => document.querySelector<HTMLButtonElement>(`[data-assistant-tab="${CSS.escape(activeChatTabId)}"]`)?.focus())
                 } : undefined}
                 onCloseTab={showAssistantDock ? () => closeAssistantTab(activeChatTabId) : undefined}
-                placement={useBottomTabs && isBrowserOpen ? 'right' : chatPanePlacement}
+                placement={useBottomTabs && !isCodeOpen ? 'right' : chatPanePlacement}
                 // Code mode: the chat fills whatever the rail and drawer leave.
                 paneSize={codeChatMain ? 'chat-bigger' : chatPaneSize}
-                className={cn(isChatPaneInMiddle && !(useBottomTabs && isBrowserOpen) && "order-2", showAssistantDock && !(floatingAssistant && !isRightPaneMaximized) && 'mb-11')}
+                className={cn(isChatPaneInMiddle && (!useBottomTabs || isCodeOpen) && "order-2", showAssistantDock && !(floatingAssistant && !isRightPaneMaximized) && 'mb-11')}
                 defaultWidth={DEFAULT_CHAT_PANE_WIDTH}
                 isOpen={dockFullScreen || chatPaneOpen}
                 isMaximized={dockFullScreen || isRightPaneMaximized}
@@ -7957,8 +7941,8 @@ function App() {
                 collapsedLeftPaddingPx={collapsedLeftPaddingPx}
                 // Gated on mic ownership: when another composer (Home, a
                 // call) owns the mic, the dock must not mirror the recording.
-                isRecording={isRecording && voiceOwner === chatIdForTab(activeChatTabId)}
-                recordingText={voiceOwner === chatIdForTab(activeChatTabId) ? voice.interimText : undefined}
+                isRecording={isRecording}
+                recordingText={voice.interimText}
                 recordingState={voice.state === 'submitting' ? 'stopping' : voice.state === 'connecting' ? 'connecting' : 'listening'}
                 audioLevelsRef={voice.audioLevelsRef}
                 onStartRecording={() => handleStartRecording(chatIdForTab(activeChatTabIdRef.current))}
@@ -7972,22 +7956,24 @@ function App() {
                 callAvailable={voiceAvailable && ttsAvailable}
                 onComposioConnected={handleComposioConnected}
               />
+              </AssistantPanels>
               </CodeDiffOpenerProvider>
             )}
             {useBottomTabs && (
               <AssistantChatDock
                 hidden={!showAssistantDock}
-                tabs={chatTabs}
+                tabs={dockTabs}
                 activeId={activeChatTabId}
                 expanded={dockFullScreen || chatPaneOpen}
+                expandedIds={floatingPanelsEnabled && !isRightPaneMaximized ? Object.keys(assistantPanelBounds) : undefined}
                 getTitle={getChatTabTitle}
                 onNew={addAssistantTab}
                 onClose={closeAssistantTab}
                 onSelect={(tab) => {
-                  if (tab.id === activeChatTabId && chatPaneOpen && !dockFullScreen) {
-                    setIsChatSidebarOpen(false)
-                    setIsRightPaneMaximized(false)
+                  if (assistantPanelBounds[tab.id] && floatingPanelsEnabled && !dockFullScreen) {
+                    minimizeAssistantTab(tab.id)
                   } else {
+                    setExpandedAssistantTabs((previous) => [...previous.filter((id) => id !== tab.id), tab.id])
                     if (tab.id !== activeChatTabId) activateAssistantTab(tab)
                     setIsChatSidebarOpen(true)
                   }

--- a/apps/x/apps/renderer/src/components/assistant-chat-dock.test.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-chat-dock.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AssistantChatDock } from './assistant-chat-dock'
 
 const sessions = vi.hoisted(() => new Map<string, { isProcessing: boolean; isWaitingOnHuman: boolean }>())
-vi.mock('@/hooks/useSessionChat', () => ({ useSessionChat: (sessionId: string) => ({ chatState: sessions.get(sessionId) }) }))
+vi.mock('@/hooks/useSessionChat', () => ({ useSessionChatStatus: (sessionId: string) => sessions.get(sessionId)?.isWaitingOnHuman ? 'waiting' : sessions.get(sessionId)?.isProcessing ? 'working' : 'idle' }))
 vi.mock('@/lib/session-title', () => ({ useSessionTitle: () => undefined }))
 
 beforeEach(() => {
@@ -19,6 +19,11 @@ const tabs = [
 const baseProps = { tabs, activeId: 'first', expanded: true, getTitle: (tab: { id: string }) => tab.id, onSelect: vi.fn(), onClose: vi.fn(), onNew: vi.fn() }
 
 describe('AssistantChatDock', () => {
+  it('reports multiple expanded panels independently of keyboard focus', () => {
+    render(<AssistantChatDock {...baseProps} expandedIds={['first', 'second']} />)
+    expect(screen.getByRole('button', { name: 'first' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('button', { name: 'second' })).toHaveAttribute('aria-expanded', 'true')
+  })
   it('keeps a single minimized tab compact instead of filling the dock', () => {
     render(<AssistantChatDock {...baseProps} tabs={[tabs[0]]} expanded={false} />)
     const tab = screen.getByRole('button', { name: 'first' })

--- a/apps/x/apps/renderer/src/components/assistant-chat-dock.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-chat-dock.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ChevronUp, Loader2, MessageCircle, Plus, X } from 'lucide-react'
-import { useSessionChat } from '@/hooks/useSessionChat'
+import { useSessionChatStatus } from '@/hooks/useSessionChat'
 import { useSessionTitle } from '@/lib/session-title'
 import { cn } from '@/lib/utils'
 import type { ChatTab } from './tab-bar'
@@ -11,6 +11,7 @@ interface AssistantChatDockProps {
   tabs: ChatTab[]
   activeId: string
   expanded: boolean
+  expandedIds?: string[]
   getTitle: (tab: ChatTab) => string
   onSelect: (tab: ChatTab) => void
   onClose: (tabId: string) => void
@@ -26,11 +27,11 @@ function DockTab({ tab, active, expanded, title, onSelect, onClose, onStatus }: 
   onClose: () => void
   onStatus: (tabId: string, status: string) => void
 }) {
-  const session = useSessionChat(tab.runId)
+  const sessionStatus = useSessionChatStatus(tab.runId)
   const sessionTitle = useSessionTitle(tab.runId)
-  const working = session.chatState?.isProcessing ?? false
-  const waiting = session.chatState?.isWaitingOnHuman ?? false
-  const reading = active && expanded
+  const working = sessionStatus === 'working' || sessionStatus === 'waiting'
+  const waiting = sessionStatus === 'waiting'
+  const reading = expanded
   const [activity, setActivity] = useState({ working, reading, unread: false })
   if (activity.working !== working || activity.reading !== reading) {
     setActivity({ working, reading, unread: reading ? false : activity.unread || (activity.working && !working) })
@@ -46,7 +47,7 @@ function DockTab({ tab, active, expanded, title, onSelect, onClose, onStatus }: 
         data-assistant-tab={tab.id}
         className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-tl-lg px-3 text-left text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         onClick={onSelect}
-        aria-expanded={active && expanded}
+        aria-expanded={expanded}
         aria-label={`${label}${status ? ` — ${status}` : ''}`}
         title={`${label}${status ? ` — ${status}` : ''}`}
       >
@@ -62,7 +63,7 @@ function DockTab({ tab, active, expanded, title, onSelect, onClose, onStatus }: 
   )
 }
 
-export function AssistantChatDock({ tabs, activeId, expanded, getTitle, onSelect, onClose, onNew, hidden = false }: AssistantChatDockProps) {
+export function AssistantChatDock({ tabs, activeId, expanded, expandedIds, getTitle, onSelect, onClose, onNew, hidden = false }: AssistantChatDockProps) {
   const dockRef = useRef<HTMLDivElement>(null)
   const [capacity, setCapacity] = useState(3)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -88,7 +89,7 @@ export function AssistantChatDock({ tabs, activeId, expanded, getTitle, onSelect
     <div ref={dockRef} data-assistant-dock={hidden ? undefined : ''} role="region" aria-label="Assistant chats" hidden={hidden} className={cn('titlebar-no-drag pointer-events-none fixed bottom-0 right-3 z-30 h-11 w-[min(760px,calc(100vw-88px))] items-end justify-end gap-1.5', hidden ? 'hidden' : 'flex')}>
       {tabs.map((tab) => (
         <div key={tab.id} className={visibleIds.has(tab.id) ? 'pointer-events-auto min-w-0 flex-[0_1_240px]' : 'hidden'}>
-          <DockTab tab={tab} active={tab.id === activeId} expanded={expanded} title={getTitle(tab)} onSelect={() => onSelect(tab)} onClose={() => onClose(tab.id)} onStatus={onStatus} />
+          <DockTab tab={tab} active={tab.id === activeId} expanded={expandedIds ? expandedIds.includes(tab.id) : tab.id === activeId && expanded} title={getTitle(tab)} onSelect={() => onSelect(tab)} onClose={() => onClose(tab.id)} onStatus={onStatus} />
         </div>
       ))}
       {overflow.length > 0 && (

--- a/apps/x/apps/renderer/src/components/assistant-panels.test.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-panels.test.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createEmptyChatTabViewState } from '@/lib/chat-conversation'
+import { AssistantPanels } from './assistant-panels'
+import { ChatSidebar, type ChatSidebarProps } from './chat-sidebar'
+
+const actions = vi.hoisted(() => ({
+  stop: vi.fn<(session: string) => Promise<never[]>>().mockResolvedValue([]),
+  remove: vi.fn<(session: string, id: string) => Promise<null>>().mockResolvedValue(null),
+  permission: vi.fn<(session: string, id: string, response: string) => Promise<void>>().mockResolvedValue(undefined),
+  answer: vi.fn<(session: string, id: string, response: string) => Promise<void>>().mockResolvedValue(undefined),
+}))
+vi.mock('@/hooks/useSessionChat', () => ({ useSessionChat: (sessionId: string) => ({ chatState: { ...createEmptyChatTabViewState(), currentAssistantMessage: sessionId }, queued: [], stop: () => actions.stop(sessionId), removeQueued: (id: string) => actions.remove(sessionId, id), respondToPermission: (id: string, response: string) => actions.permission(sessionId, id, response), answerAskHuman: (id: string, response: string) => actions.answer(sessionId, id, response) }) }))
+vi.mock('./chat-session', () => ({ queuedMessageText: () => '' }))
+vi.mock('./chat-sidebar', () => ({ ChatSidebar: (props: ChatSidebarProps) => {
+  const [draft, setDraft] = useState('')
+  return <section aria-label={props.activeChatTabId} hidden={!props.isOpen}>
+    <input aria-label={`Draft ${props.activeChatTabId}`} value={draft} onChange={(event) => setDraft(event.target.value)} />
+    <span>{props.currentAssistantMessage}</span>
+    <button onClick={() => props.onSubmit({ text: draft, files: [] })}>Send</button>
+    <button onClick={props.onStop}>Stop</button>
+    <button onClick={() => props.onPermissionResponse?.('permission', [], 'approve')}>Approve</button>
+    <button onClick={props.onToggleDock}>{props.floating ? 'Dock' : 'Undock'}</button>
+    <button onClick={() => props.onSelectRun?.('selected-session')}>Select chat</button>
+    <button onClick={props.onNewChatTab}>New chat</button>
+  </section>
+} }))
+
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+const tabs = [{ id: 'first', chatId: 'first', runId: 'session-first' }, { id: 'second', chatId: 'second', runId: 'session-second' }]
+const base = { chatTabs: tabs, activeChatTabId: 'first', getChatTabTitle: () => 'Chat', onNewChatTab: vi.fn(), conversation: [], currentAssistantMessage: '', isProcessing: false, onSubmit: vi.fn(), isOpen: true }
+const workspace = { floatingEnabled: true, dockedTabId: null, onDockedWidthChange: vi.fn(), bounds: { first: { width: 420, height: 600, right: 444 }, second: { width: 420, height: 600, right: 12 } }, onResize: vi.fn(), onFocus: vi.fn(), onMinimize: vi.fn(), onClose: vi.fn(), onToggleDock: vi.fn(), onSubmit: vi.fn(), onChangeChat: vi.fn() }
+
+describe('independent assistant panels', () => {
+  it('routes selector and new chat to the originating panel, not global new-tab actions', () => {
+    const onSelectRun = vi.fn()
+    render(<AssistantPanels {...workspace}><ChatSidebar {...base} onSelectRun={onSelectRun} /></AssistantPanels>)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Select chat' })[1])
+    expect(workspace.onChangeChat).toHaveBeenCalledWith('second', 'selected-session')
+    fireEvent.click(screen.getAllByRole('button', { name: 'New chat' })[1])
+    expect(workspace.onChangeChat).toHaveBeenCalledWith('second', null)
+    expect(base.onNewChatTab).not.toHaveBeenCalled()
+    expect(onSelectRun).not.toHaveBeenCalled()
+  })
+  it('retains both composers through minimize, docking and focus changes', () => {
+    const { rerender } = render(<AssistantPanels {...workspace}><ChatSidebar {...base} /></AssistantPanels>)
+    const first = screen.getByLabelText('Draft first')
+    const second = screen.getByLabelText('Draft second')
+    fireEvent.change(first, { target: { value: 'First draft' } })
+    fireEvent.change(second, { target: { value: 'Second draft' } })
+    rerender(<AssistantPanels {...workspace} bounds={{}}><ChatSidebar {...base} /></AssistantPanels>)
+    expect(first).not.toBeVisible()
+    rerender(<AssistantPanels {...workspace} dockedTabId="first"><ChatSidebar {...base} activeChatTabId="second" /></AssistantPanels>)
+    expect(screen.getByLabelText('Draft first')).toBe(first)
+    expect(screen.getByLabelText('Draft second')).toBe(second)
+    expect(first).toHaveValue('First draft')
+    expect(second).toHaveValue('Second draft')
+    expect(screen.getByRole('button', { name: 'Undock' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Dock' })).toBeVisible()
+  })
+
+  it('routes send, stop and permissions by panel identity, not focused chat', async () => {
+    render(<AssistantPanels {...workspace}><ChatSidebar {...base} /></AssistantPanels>)
+    fireEvent.change(screen.getByLabelText('Draft second'), { target: { value: 'Second question' } })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Send' })[1])
+    expect(workspace.onSubmit).toHaveBeenCalledWith('second', { text: 'Second question', files: [] })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Stop' })[1])
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve' })[1])
+    await waitFor(() => expect(actions.stop).toHaveBeenCalledWith('session-second'))
+    expect(actions.permission).toHaveBeenCalledWith('session-second', 'permission', 'allow')
+  })
+})

--- a/apps/x/apps/renderer/src/components/assistant-panels.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-panels.tsx
@@ -1,0 +1,98 @@
+import { useState, type ReactElement } from 'react'
+import { toast } from 'sonner'
+import { useSessionChat } from '@/hooks/useSessionChat'
+import { createEmptyChatTabViewState } from '@/lib/chat-conversation'
+import type { PanelSize } from '@/lib/assistant-panel-layout'
+import { ChatSidebar, type ChatSidebarProps } from './chat-sidebar'
+import { queuedMessageText } from './chat-session'
+import type { ChatTab } from './tab-bar'
+
+interface AssistantPanelsProps {
+  allowDockControls?: boolean
+  onDockedWidthChange: (width: number) => void
+  recordingChatId?: string | null
+  callSessionId?: string | null
+  floatingEnabled: boolean
+  dockedTabId: string | null
+  children: ReactElement<ChatSidebarProps>
+  bounds: Record<string, PanelSize & { right: number }>
+  onResize: (tabId: string, size: PanelSize) => void
+  onFocus: (tab: ChatTab) => void
+  onMinimize: (tabId: string) => void
+  onClose: (tabId: string) => void
+  onToggleDock: (tab: ChatTab) => void
+  onChangeChat: (tabId: string, sessionId: string | null) => void
+  onSubmit: (tabId: string, ...args: Parameters<ChatSidebarProps['onSubmit']>) => void
+}
+
+function SessionPanel({ tab, workspace, base }: { tab: ChatTab; workspace: Omit<AssistantPanelsProps, 'children'>; base: ChatSidebarProps }) {
+  const [restoredDraft, setRestoredDraft] = useState<string>()
+  const [stopping, setStopping] = useState(false)
+  const active = tab.id === base.activeChatTabId
+  const floating = workspace.floatingEnabled && tab.id !== workspace.dockedTabId
+  const expanded = floating ? Boolean(workspace.bounds[tab.id]) : tab.id === workspace.dockedTabId && base.isOpen
+  const session = useSessionChat(tab.runId, undefined, Boolean(expanded))
+  const state = session.chatState ?? createEmptyChatTabViewState()
+  const recording = workspace.recordingChatId === tab.chatId
+  const calling = Boolean(tab.runId && workspace.callSessionId === tab.runId)
+  const reportError = (error: unknown) => toast.error(error instanceof Error ? error.message : 'Chat action failed. Please try again.')
+  const restore = (text: string) => {
+    if (!text) return
+    const draft = base.getInitialDraft?.(tab.id)?.trim()
+    const next = draft ? `${draft}\n\n${text}` : text
+    base.onDraftChangeForTab?.(tab.id, next)
+    setRestoredDraft(next)
+  }
+  return <ChatSidebar
+    {...base}
+    {...state}
+    conversation={session.error ? [{ id: 'session-load-error', kind: 'error', message: `Failed to load chat: ${session.error}`, timestamp: 0 }] : state.conversation}
+    chatTabs={[tab]}
+    activeChatTabId={tab.id}
+    runId={tab.runId}
+    keepMounted
+    floating={floating}
+    className={floating ? undefined : base.className}
+    isOpen={expanded}
+    isFocused={active}
+    isMaximized={active && base.isMaximized}
+    floatingBounds={workspace.bounds[tab.id]}
+    onFloatingResize={(size) => workspace.onResize(tab.id, size)}
+    onDockedWidthChange={workspace.onDockedWidthChange}
+    onActivate={() => { if (!active) workspace.onFocus(tab); base.onActivate?.() }}
+    onToggleDock={!base.pinnedToCodeSession && workspace.allowDockControls !== false ? () => workspace.onToggleDock(tab) : undefined}
+    onMinimize={floating ? () => workspace.onMinimize(tab.id) : undefined}
+    onCloseTab={base.onCloseTab ? () => workspace.onClose(tab.id) : undefined}
+    onOpenFullScreen={base.onOpenFullScreen ? () => { workspace.onFocus(tab); base.onOpenFullScreen?.() } : undefined}
+    pinnedToCodeSession={active ? base.pinnedToCodeSession : null}
+    isProcessing={session.chatState?.isProcessing ?? false}
+    isReasoning={session.chatState?.isReasoning ?? false}
+    isWaitingOnHuman={session.chatState?.isWaitingOnHuman ?? false}
+    isStopping={active && calling ? base.isStopping : stopping}
+    queuedForActive={session.queued}
+    restoredSelectionForActive={session.chatState?.lastSelection}
+    presetMessage={restoredDraft ?? (active ? base.presetMessage : undefined)}
+    onPresetMessageConsumed={() => { setRestoredDraft(undefined); if (active) base.onPresetMessageConsumed?.() }}
+    onSubmit={(...args) => workspace.onSubmit(tab.id, ...args)}
+    onSelectRun={(sessionId) => workspace.onChangeChat(tab.id, sessionId)}
+    onNewChatTab={() => workspace.onChangeChat(tab.id, null)}
+    onStop={() => {
+      if (active && base.callOnThisChat) { base.onStop?.(); return }
+      setStopping(true)
+      void session.stop().then((entries) => restore(entries.map((entry) => queuedMessageText(entry.message)).filter(Boolean).join('\n\n'))).catch(reportError).finally(() => setStopping(false))
+    }}
+    onRemoveQueued={(id) => { void session.removeQueued(id).catch(reportError) }}
+    onPullQueued={(id) => { void session.removeQueued(id).then((entry) => restore(entry ? queuedMessageText(entry.message) : '')).catch(reportError) }}
+    onPermissionResponse={(id, _subflow, response) => { void session.respondToPermission(id, response === 'approve' ? 'allow' : 'deny').catch(reportError) }}
+    onAskHumanResponse={(id, _subflow, response) => { void session.answerAskHuman(id, response).catch(reportError) }}
+    isRecording={recording && base.isRecording}
+    recordingText={recording ? base.recordingText : undefined}
+    onStartRecording={() => { workspace.onFocus(tab); base.onStartRecording?.() }}
+    callOnThisChat={calling}
+    onStartCall={(preset) => { workspace.onFocus(tab); base.onStartCall?.(preset) }}
+  />
+}
+
+export function AssistantPanels({ children, ...workspace }: AssistantPanelsProps) {
+  return children.props.chatTabs.map((tab) => <SessionPanel key={tab.chatId} tab={tab} workspace={workspace} base={children.props} />)
+}

--- a/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -432,7 +432,7 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
 
     const zoomFactor = Math.max(window.electronUtils.getZoomFactor(), 0.01)
     const rect = el.getBoundingClientRect()
-    const chatSidebar = el.ownerDocument.querySelector<HTMLElement>('[data-chat-sidebar-root]')
+    const chatSidebar = el.ownerDocument.querySelector<HTMLElement>('[data-docked-chat]')
     const chatSidebarRect = chatSidebar?.getBoundingClientRect()
     const clampedRightCss = chatSidebarRect && chatSidebarRect.width > 0
       ? Math.min(rect.right, chatSidebarRect.left)
@@ -527,7 +527,7 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
     if (!el) return
 
     const sidebarInset = el.closest<HTMLElement>('[data-slot="sidebar-inset"]')
-    const chatSidebar = el.ownerDocument.querySelector<HTMLElement>('[data-chat-sidebar-root]')
+    const chatSidebar = el.ownerDocument.querySelector<HTMLElement>('[data-docked-chat]')
     const documentElement = el.ownerDocument.documentElement
 
     let pendingRaf: number | null = null

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -224,6 +224,7 @@ interface ChatInputInnerProps {
   allowSubmitWhileProcessing?: boolean
   isStopping?: boolean
   isActive: boolean
+  isFocused?: boolean
   presetMessage?: string
   onPresetMessageConsumed?: () => void
   runId?: string | null
@@ -289,6 +290,7 @@ function ChatInputInner({
   allowSubmitWhileProcessing = false,
   isStopping,
   isActive,
+  isFocused = isActive,
   presetMessage,
   onPresetMessageConsumed,
   runId,
@@ -738,6 +740,11 @@ function ChatInputInner({
     }
 
     const onDrop = (e: DragEvent) => {
+      const composer = e.target instanceof Element ? e.target.closest('[data-tour-id="chat-composer"]') : null
+      const panel = e.target instanceof Element ? e.target.closest<HTMLElement>('[data-assistant-chat]') : null
+      if (composer) {
+        if (composer !== composerRef.current) return
+      } else if (panel ? panel.dataset.assistantChat !== draftKey : !composerRef.current?.contains(document.activeElement)) return
       if (e.dataTransfer?.types?.includes('Files')) {
         e.preventDefault()
       }
@@ -757,16 +764,18 @@ function ChatInputInner({
       document.removeEventListener('dragover', onDragOver)
       document.removeEventListener('drop', onDrop)
     }
-  }, [addFiles, isActive])
+  }, [addFiles, isActive, draftKey])
 
   const visibleRecentWorkDirs = recentWorkDirs
     .filter((entry) => entry.path !== workDir)
     .slice(0, MAX_VISIBLE_RECENT_WORK_DIRS)
   const currentWorkDirLabel = effectiveWorkDir ? basename(effectiveWorkDir) || effectiveWorkDir : 'Not set'
   const currentWorkDirPath = effectiveWorkDir ? compactWorkDirPath(effectiveWorkDir) : ''
+  const composerRef = useRef<HTMLDivElement>(null)
 
   return (
     <div
+      ref={composerRef}
       data-tour-id="chat-composer"
       className={cn(
         // Composer: radius 24, raised surface; the ring is folded into
@@ -907,8 +916,8 @@ function ChatInputInner({
         <PromptInputTextarea
           placeholder={placeholder ?? 'Type your message...'}
           onKeyDown={handleKeyDown}
-          autoFocus={isActive}
-          focusTrigger={isActive ? `${runId ?? 'new'}:${focusNonce}:${focusSignal ?? 0}` : undefined}
+          autoFocus={isActive && isFocused}
+          focusTrigger={isActive && isFocused ? `${runId ?? 'new'}:${focusNonce}:${focusSignal ?? 0}` : undefined}
           className="min-h-6 rounded-none border-0 py-0 shadow-none focus-visible:ring-0"
         />
       </div>
@@ -1515,6 +1524,7 @@ export interface ChatInputWithMentionsProps {
   allowSubmitWhileProcessing?: boolean
   isStopping?: boolean
   isActive?: boolean
+  isFocused?: boolean
   presetMessage?: string
   onPresetMessageConsumed?: () => void
   runId?: string | null
@@ -1564,6 +1574,7 @@ export function ChatInputWithMentions({
   allowSubmitWhileProcessing,
   isStopping,
   isActive = true,
+  isFocused = isActive,
   presetMessage,
   onPresetMessageConsumed,
   runId,
@@ -1602,6 +1613,7 @@ export function ChatInputWithMentions({
         allowSubmitWhileProcessing={allowSubmitWhileProcessing}
         isStopping={isStopping}
         isActive={isActive}
+        isFocused={isFocused}
         presetMessage={presetMessage}
         onPresetMessageConsumed={onPresetMessageConsumed}
         runId={runId}

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -255,6 +255,7 @@ export function ChatSessionPane({
 }
 
 export interface ChatSessionComposerProps {
+  isFocused?: boolean
   tab: ChatTab
   isActive: boolean
   tabState: ChatTabViewState
@@ -327,6 +328,7 @@ export interface ChatSessionComposerProps {
 }
 
 export function ChatSessionComposer({
+  isFocused,
   tab,
   isActive,
   tabState,
@@ -405,6 +407,7 @@ export function ChatSessionComposer({
         </div>
       )}
       <ChatInputWithMentions
+        isFocused={isFocused ?? isActive}
         draftKey={tab.chatId}
         knowledgeFiles={knowledgeFiles}
         recentFiles={recentFiles}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@/components/chat-session', () => ({
 beforeEach(() => {
   localStorage.clear()
   vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} })
+  vi.stubGlobal('matchMedia', () => ({ matches: false }))
 })
 afterEach(() => { cleanup(); vi.unstubAllGlobals() })
 
@@ -30,6 +31,58 @@ const props = {
 }
 
 describe('floating ChatSidebar', () => {
+  it('resizes height, width and the corner with keyboard-accessible handles', () => {
+    const onFloatingResize = vi.fn()
+    render(<ChatSidebar {...props} floatingBounds={{ width: 420, height: 500, right: 12 }} onFloatingResize={onFloatingResize} />)
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize chat width' }), { key: 'ArrowLeft' })
+    expect(onFloatingResize).toHaveBeenLastCalledWith({ width: 430, height: 500 })
+    fireEvent.keyDown(screen.getByRole('separator', { name: 'Resize chat height' }), { key: 'ArrowUp', shiftKey: true })
+    expect(onFloatingResize).toHaveBeenLastCalledWith({ width: 420, height: 540 })
+    fireEvent.keyDown(screen.getByLabelText('first'), { key: 'ArrowLeft', altKey: true })
+    expect(onFloatingResize).toHaveBeenCalledTimes(2)
+  })
+
+  it('commits a pointer drag only when capture ends', () => {
+    vi.stubGlobal('PointerEvent', MouseEvent)
+    const onFloatingResize = vi.fn()
+    const { container } = render(<ChatSidebar {...props} onFloatingResize={onFloatingResize} />)
+    const pane = container.querySelector('[data-chat-sidebar-root]')!
+    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue(DOMRect.fromRect({ width: 400, height: 400 }))
+    const handle = screen.getByRole('separator', { name: 'Resize chat width and height' })
+    handle.setPointerCapture = vi.fn()
+    fireEvent.pointerDown(handle, { clientX: 100, clientY: 200 })
+    fireEvent.pointerMove(handle, { clientX: 20, clientY: 150 })
+    expect(onFloatingResize).not.toHaveBeenCalled()
+    fireEvent.lostPointerCapture(handle)
+    expect(onFloatingResize).toHaveBeenCalledWith({ width: 480, height: 450 })
+  })
+
+  it('animates expansion and minimizes accessibly without unmounting', () => {
+    const { container, rerender } = render(<ChatSidebar {...props} isOpen={false} />)
+    const pane = container.querySelector<HTMLElement>('[data-chat-sidebar-root]')!
+    const animation = { cancel: vi.fn(), onfinish: null as (() => void) | null }
+    pane.animate = vi.fn(() => animation as unknown as Animation)
+    rerender(<ChatSidebar {...props} isOpen />)
+    expect(pane.animate).toHaveBeenCalledWith(expect.any(Array), expect.objectContaining({ duration: 170 }))
+    rerender(<ChatSidebar {...props} isOpen={false} />)
+    expect(pane).toHaveAttribute('inert')
+    expect(pane).toHaveAttribute('aria-hidden', 'true')
+    expect(pane.animate).toHaveBeenLastCalledWith(expect.any(Array), expect.objectContaining({ duration: 130 }))
+    expect(screen.getByLabelText('first')).toBeInTheDocument()
+  })
+
+  it('respects reduced motion', () => {
+    vi.stubGlobal('matchMedia', () => ({ matches: true }))
+    const { container, rerender } = render(<ChatSidebar {...props} isOpen={false} />)
+    const pane = container.querySelector<HTMLElement>('[data-chat-sidebar-root]')!
+    pane.animate = vi.fn()
+    rerender(<ChatSidebar {...props} isOpen />)
+    expect(pane.animate).not.toHaveBeenCalled()
+    expect(pane.style.visibility).toBe('visible')
+    rerender(<ChatSidebar {...props} isOpen={false} />)
+    expect(pane.style.visibility).toBe('hidden')
+  })
+
   it('preserves composer instances when minimized, switched and expanded', () => {
     const { rerender } = render(<ChatSidebar {...props} isOpen />)
     fireEvent.change(screen.getByLabelText('first'), { target: { value: 'Unsent draft' } })

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight, Minus, X } from 'lucide-react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight, Minus, X, PanelRightClose, PanelsTopLeft } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { readAssistantPreference, writeAssistantPreference } from '@/lib/assistant-dock'
+import { clampPanelSize, type PanelSize } from '@/lib/assistant-panel-layout'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ChatHeader } from '@/components/chat-header'
 import { CodeSessionHeader, type CodeSessionHeaderProps } from '@/components/code/code-session-header'
@@ -53,7 +54,12 @@ function getInitialPaneWidth(defaultWidth: number): number {
   }
 }
 
-interface ChatSidebarProps {
+export interface ChatSidebarProps {
+  isFocused?: boolean
+  onDockedWidthChange?: (width: number) => void
+  floatingBounds?: PanelSize & { right: number }
+  onFloatingResize?: (size: PanelSize) => void
+  onToggleDock?: () => void
   floating?: boolean
   keepMounted?: boolean
   onMinimize?: () => void
@@ -148,6 +154,11 @@ interface ChatSidebarProps {
 }
 
 export function ChatSidebar({
+  isFocused = true,
+  onDockedWidthChange,
+  floatingBounds,
+  onFloatingResize,
+  onToggleDock,
   floating = false,
   keepMounted = false,
   onMinimize,
@@ -236,6 +247,7 @@ export function ChatSidebar({
   const [width, setWidth] = useState(() => getInitialPaneWidth(defaultWidth))
   const [isResizing, setIsResizing] = useState(false)
   const [showContent, setShowContent] = useState(isOpen)
+  const [animateContent, setAnimateContent] = useState(isOpen)
   const [floatingSize, setFloatingSize] = useState(() => {
     const fallback = { width: 460, height: 600 }
     try {
@@ -249,6 +261,9 @@ export function ChatSidebar({
   const [localPresetMessage, setLocalPresetMessage] = useState<string | undefined>(undefined)
 
   const paneRef = useRef<HTMLDivElement>(null)
+  const hasOpenedRef = useRef(isOpen)
+  const resizeRef = useRef<{ x: number; y: number; size: PanelSize; axis: 'width' | 'height' | 'both'; next: PanelSize } | null>(null)
+  const resizeFrame = useRef<number | null>(null)
   const startXRef = useRef(0)
   const startWidthRef = useRef(0)
   const prevIsMaximizedRef = useRef(isMaximized)
@@ -277,28 +292,94 @@ export function ChatSidebar({
   }, [])
 
   useEffect(() => {
-    if (keepMounted) {
+    if (keepMounted || isOpen) {
       setShowContent(true)
       return
-    }
-    if (isOpen) {
-      const timer = setTimeout(() => setShowContent(true), 150)
-      return () => clearTimeout(timer)
     }
     setShowContent(false)
   }, [isOpen, keepMounted])
 
-  useEffect(() => {
-    if (!floating || !isOpen) return
+  useLayoutEffect(() => {
     const pane = paneRef.current
     if (!pane) return
-    const observer = new ResizeObserver(() => {
-      const bounds = pane.getBoundingClientRect()
-      writeAssistantPreference('rowboat-assistant-floating-size', JSON.stringify({ width: bounds.width, height: bounds.height }))
-    })
+    if (!floating) { pane.style.visibility = isOpen ? 'visible' : 'hidden'; return }
+    if (!isOpen && !hasOpenedRef.current) { pane.style.visibility = 'hidden'; return }
+    if (isOpen) hasOpenedRef.current = true
+    if (!pane.animate || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      pane.style.visibility = isOpen ? 'visible' : 'hidden'
+      setAnimateContent(isOpen)
+      return
+    }
+    if (isOpen) setAnimateContent(true)
+    pane.style.visibility = 'visible'
+    const frames = [{ opacity: 0, transform: 'translateY(16px) scale(0.98)' }, { opacity: 1, transform: 'translateY(0) scale(1)' }]
+    const animation = pane.animate(isOpen ? frames : [...frames].reverse(), { duration: isOpen ? 170 : 130, easing: 'cubic-bezier(0.2, 0.8, 0.2, 1)' })
+    animation.onfinish = () => { pane.style.visibility = isOpen ? 'visible' : 'hidden'; setAnimateContent(isOpen) }
+    return () => animation.cancel()
+  }, [floating, isOpen])
+
+  useEffect(() => {
+    const pane = paneRef.current
+    if (!pane || floating || !isOpen || !onDockedWidthChange) return
+    const observer = new ResizeObserver(() => onDockedWidthChange(pane.getBoundingClientRect().width))
     observer.observe(pane)
     return () => observer.disconnect()
-  }, [floating, isOpen])
+  }, [floating, isOpen, onDockedWidthChange])
+
+  useEffect(() => () => { if (resizeFrame.current !== null) cancelAnimationFrame(resizeFrame.current) }, [])
+
+  const commitFloatingSize = (size: PanelSize) => {
+    setFloatingSize(size)
+    onFloatingResize?.(size)
+    writeAssistantPreference('rowboat-assistant-floating-size', JSON.stringify(size))
+  }
+
+  const resizeHandle = (axis: 'width' | 'height' | 'both') => (
+    <div
+      role="separator"
+      tabIndex={0}
+      aria-label={`Resize chat ${axis === 'both' ? 'width and height' : axis}`}
+      aria-orientation={axis === 'height' ? 'horizontal' : 'vertical'}
+      aria-valuenow={Math.round(axis === 'height' ? (floatingBounds ?? floatingSize).height : (floatingBounds ?? floatingSize).width)}
+      className={cn('titlebar-no-drag absolute z-40 touch-none hover:bg-primary/10 focus-visible:bg-primary/20', axis === 'width' ? 'left-0 top-2 bottom-2 w-2 cursor-ew-resize' : axis === 'height' ? 'top-0 left-2 right-2 h-2 cursor-ns-resize' : 'top-0 left-0 size-3 cursor-nwse-resize')}
+      onDoubleClick={() => commitFloatingSize(clampPanelSize({ width: 420, height: 600 }, { width: window.innerWidth, height: window.innerHeight }))}
+      onPointerDown={(event) => {
+        event.preventDefault()
+        const bounds = paneRef.current?.getBoundingClientRect()
+        if (!bounds) return
+        const size = { width: bounds.width, height: bounds.height }
+        resizeRef.current = { x: event.clientX, y: event.clientY, size, axis, next: size }
+        event.currentTarget.setPointerCapture(event.pointerId)
+      }}
+      onPointerMove={(event) => {
+        const drag = resizeRef.current
+        if (!drag) return
+        drag.next = clampPanelSize({ width: drag.size.width + (drag.axis !== 'height' ? drag.x - event.clientX : 0), height: drag.size.height + (drag.axis !== 'width' ? drag.y - event.clientY : 0) }, { width: window.innerWidth - (floatingBounds?.right ?? 12) + 12, height: window.innerHeight })
+        if (resizeFrame.current !== null) return
+        resizeFrame.current = requestAnimationFrame(() => {
+          resizeFrame.current = null
+          if (!paneRef.current || !resizeRef.current) return
+          paneRef.current.style.width = `${resizeRef.current.next.width}px`
+          paneRef.current.style.height = `${resizeRef.current.next.height}px`
+        })
+      }}
+      onLostPointerCapture={() => {
+        if (!resizeRef.current) return
+        commitFloatingSize(resizeRef.current.next)
+        resizeRef.current = null
+      }}
+      onPointerUp={(event) => event.currentTarget.releasePointerCapture(event.pointerId)}
+      onPointerCancel={(event) => event.currentTarget.releasePointerCapture(event.pointerId)}
+      onKeyDown={(event) => {
+        if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) return
+        event.preventDefault()
+        event.stopPropagation()
+        const size = floatingBounds ?? floatingSize
+        const step = event.shiftKey ? 40 : 10
+        commitFloatingSize(clampPanelSize({ width: size.width + (axis !== 'height' ? (event.key === 'ArrowLeft' ? step : event.key === 'ArrowRight' ? -step : 0) : 0), height: size.height + (axis !== 'width' ? (event.key === 'ArrowUp' ? step : event.key === 'ArrowDown' ? -step : 0) : 0) }, { width: window.innerWidth, height: window.innerHeight }))
+      }}
+    />
+  )
 
   useEffect(() => {
     prevIsMaximizedRef.current = isMaximized
@@ -377,15 +458,15 @@ export function ChatSidebar({
   const paneStyle = useMemo<React.CSSProperties>(() => {
     if (floating) {
       return {
-        position: 'fixed', right: 12, bottom: 52, zIndex: 30,
-        width: floatingSize.width, height: floatingSize.height,
+        position: 'fixed', right: floatingBounds?.right ?? 12, bottom: 52, zIndex: 30,
+        width: (floatingBounds ?? floatingSize).width, height: (floatingBounds ?? floatingSize).height,
         maxWidth: 'calc(100vw - 88px)', maxHeight: 'calc(100dvh - 108px)',
-        minWidth: 'min(360px, calc(100vw - 88px))', minHeight: 'min(320px, calc(100dvh - 108px))',
-        resize: 'both', display: isOpen ? undefined : 'none',
+        minWidth: 'min(320px, calc(100vw - 88px))', minHeight: 'min(280px, calc(100dvh - 108px))',
+        pointerEvents: isOpen ? undefined : 'none', transformOrigin: 'bottom right',
       }
     }
     if (!isOpen) {
-      return { width: 0, flex: '0 0 auto' }
+      return { width: 0, flex: '0 0 auto', borderWidth: 0 }
     }
     if (isMaximized) {
       // In maximize mode the pane should grow into the freed left space,
@@ -396,26 +477,20 @@ export function ChatSidebar({
       return { width: 0, flex: '1 1 0' }
     }
     return { width, flex: '0 0 auto' }
-  }, [isOpen, isMaximized, paneSize, width, floating, floatingSize])
+  }, [isOpen, isMaximized, paneSize, width, floating, floatingSize, floatingBounds])
 
   return (
     <div
       ref={paneRef}
       data-chat-sidebar-root
+      data-assistant-panel={activeChatTabId}
+      data-assistant-chat={chatTabs.find((tab) => tab.id === activeChatTabId)?.chatId}
+      data-docked-chat={isOpen && !floating ? '' : undefined}
       role={floating ? 'region' : undefined}
       aria-label={floating ? 'Assistant conversation' : undefined}
       aria-hidden={!isOpen}
       inert={!isOpen}
       onKeyDown={(event) => {
-        if (floating && event.altKey && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
-          event.preventDefault()
-          const bounds = paneRef.current?.getBoundingClientRect()
-          if (bounds) setFloatingSize({
-            width: Math.max(360, Math.min(window.innerWidth - 88, bounds.width + (event.key === 'ArrowLeft' ? 20 : event.key === 'ArrowRight' ? -20 : 0))),
-            height: Math.max(320, Math.min(window.innerHeight - 108, bounds.height + (event.key === 'ArrowUp' ? 20 : event.key === 'ArrowDown' ? -20 : 0))),
-          })
-          return
-        }
         if (event.key !== 'Escape' || event.defaultPrevented || !floating) return
         if ((event.target as HTMLElement).closest('[role="dialog"], [role="menu"], [role="listbox"]')) return
         event.preventDefault()
@@ -432,7 +507,8 @@ export function ChatSidebar({
       )}
       style={paneStyle}
     >
-      {floating && <span className="sr-only">Resize with Alt and arrow keys. Escape minimizes this chat.</span>}
+      {floating && <span className="sr-only">Use arrow keys on the resize handles to resize. Escape minimizes this chat.</span>}
+      {floating && <>{resizeHandle('width')}{resizeHandle('height')}{resizeHandle('both')}</>}
       {!floating && !isMaximized && isResizable && (
         <div
           onMouseDown={handleMouseDown}
@@ -501,6 +577,7 @@ export function ChatSidebar({
                 onOpenChatHistory={onOpenChatHistory}
               />
             )}
+            {onToggleDock && !pinnedToCodeSession && <Button variant="ghost" size="icon" onClick={onToggleDock} className="titlebar-no-drag my-1 size-8 shrink-0" aria-label={floating ? 'Dock chat' : 'Undock chat'} title={floating ? 'Dock chat to sidebar' : 'Undock chat into floating panel'}>{floating ? <PanelRightClose className="size-4" /> : <PanelsTopLeft className="size-4" />}</Button>}
             {onOpenFullScreen && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -528,7 +605,7 @@ export function ChatSidebar({
               {/* Pane padding lives here, on the container — the shared chat pane renders identically on every surface. */}
               <div className="relative min-h-0 flex-1 px-3">
                 {chatTabs.map((tab) => {
-                  const isActive = tab.id === activeChatTabId && isOpen
+                  const isActive = tab.id === activeChatTabId && (isOpen || (floating && animateContent))
                   return (
                     <ChatSessionPane
                       // Keyed by chat identity — see App's chat panel key.
@@ -558,13 +635,14 @@ export function ChatSidebar({
                 <div className="pointer-events-none absolute inset-x-0 -top-6 h-6 bg-linear-to-t from-background to-transparent" />
                 <div className="mx-auto w-full max-w-4xl px-3">
                   {chatTabs.map((tab) => {
-                    const isActive = tab.id === activeChatTabId && isOpen
+                    const isActive = tab.id === activeChatTabId && (isOpen || (floating && animateContent))
                     return (
                       <ChatSessionComposer
                         // Composer instance per chat — see App's composer key.
                         key={tab.chatId}
                         tab={tab}
                         isActive={isActive}
+                        isFocused={isFocused && isOpen}
                         tabState={getTabState(tab.id)}
                         knowledgeFiles={knowledgeFiles}
                         recentFiles={recentFiles}

--- a/apps/x/apps/renderer/src/components/code/workspace-drawer.tsx
+++ b/apps/x/apps/renderer/src/components/code/workspace-drawer.tsx
@@ -114,7 +114,7 @@ export function CodeWorkspaceDrawer({
 
   const maxAllowedWidth = useCallback(() => {
     const root = rootRef.current
-    const chat = root?.parentElement?.querySelector<HTMLElement>('[data-chat-sidebar-root]')
+    const chat = root?.parentElement?.querySelector<HTMLElement>('[data-docked-chat]')
     const chatWidth = chat?.getBoundingClientRect().width ?? 0
     const split = chatWidth + (root?.getBoundingClientRect().width ?? 0)
     if (split <= 0) return MAX_WIDTH
@@ -126,7 +126,7 @@ export function CodeWorkspaceDrawer({
   // chat. Shrink-only, so it can't fight the user's own resize.
   useEffect(() => {
     const root = rootRef.current
-    const chat = root?.parentElement?.querySelector<HTMLElement>('[data-chat-sidebar-root]')
+    const chat = root?.parentElement?.querySelector<HTMLElement>('[data-docked-chat]')
     if (!chat) return
     const clamp = () => setWidth((w) => Math.min(w, maxAllowedWidth()))
     clamp()

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -159,6 +159,7 @@ export type DockSidebarProps = {
   onOpenEmail?: (threadId?: string) => void
   onOpenHome?: () => void
   onNewChat?: () => void
+  onOpenAssistant?: () => void
   onToggleBrowser?: () => void
   /** Whether the browser overlay is up, for the Browser tile's running dot. */
   browserOpen?: boolean
@@ -555,6 +556,7 @@ export function DockSidebar({
   onOpenEmail,
   onOpenHome,
   onNewChat,
+  onOpenAssistant,
   onToggleBrowser,
   browserOpen = false,
   switcherOnly = false,
@@ -947,7 +949,7 @@ export function DockSidebar({
       // The top section: Assistant (resumes the most recent chat, falling
       // back to a fresh one — white tile) with Spaces right under it, then a
       // divider before the destinations.
-      ...(onOpenRun || onNewChat ? [
+      ...(onOpenAssistant || onOpenRun || onNewChat ? [
         {
           item: {
             key: 'assistant', label: 'Assistant', icon: MascotFaceIcon as unknown as LucideIcon,
@@ -955,7 +957,8 @@ export function DockSidebar({
             running: activeNav === 'assistant',
             onClick: () => {
               closeFlyouts()
-              if (lastChat && onOpenRun) onOpenRun(lastChat.id)
+              if (onOpenAssistant) onOpenAssistant()
+              else if (lastChat && onOpenRun) onOpenRun(lastChat.id)
               else onNewChat?.()
             },
           },
@@ -1094,7 +1097,7 @@ export function DockSidebar({
     knowledgeUpdatedLabel, knowledgeActions, onOpenApps, pinnedApps, onOpenApp,
     bgAgentsFailed, bgAgentsLabel, onToggleBrowser, browserOpen,
     switcherOnly, openLastSpace, onOpenChatHistory,
-    onNewChat, lastChat, onOpenRun,
+    onNewChat, onOpenAssistant, lastChat, onOpenRun,
     onOpenBgTasks, workspaceCount, totalSpacesUnread, totalSpaces, spacesOpen, chatsOpen,
     outOfCredits, hasOauthError, settingsStatus, settingsAlert,
   ])

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -423,7 +423,7 @@ function LaunchAtLoginSetting() {
 }
 
 function AppearanceSettings() {
-  const { theme, setTheme, chatPanePlacement, setChatPanePlacement, chatPaneSize, setChatPaneSize, assistantPresentation, setAssistantPresentation } = useTheme()
+  const { theme, setTheme, chatPanePlacement, setChatPanePlacement, chatPaneSize, setChatPaneSize } = useTheme()
 
   return (
     <div className="space-y-6">
@@ -458,15 +458,7 @@ function AppearanceSettings() {
         </div>
       </div>
       <div>
-        <h4 className="text-sm font-medium mb-3">Assistant presentation</h4>
-        <div className="grid grid-cols-2 gap-3">
-          <ThemeOption label="Sidebar (default)" icon={PanelRight} isSelected={assistantPresentation === "sidebar"} onClick={() => setAssistantPresentation("sidebar")} />
-          <ThemeOption label="Bottom tabs" icon={MessageCircle} isSelected={assistantPresentation === "bottom-tabs"} onClick={() => setAssistantPresentation("bottom-tabs")} />
-        </div>
-        <p className="mt-3 text-xs text-muted-foreground">
-          Bottom tabs keep multiple chats within reach without resizing your workspace. Code keeps its workspace layout; the embedded browser uses a side-by-side chat.
-        </p>
-        <h4 className="mt-6 text-sm font-medium mb-3">Sidebar placement</h4>
+        <h4 className="text-sm font-medium mb-3">Sidebar placement</h4>
         <p className="text-xs text-muted-foreground mb-4">
           Choose where chat sits when another pane is open
         </p>

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -210,6 +210,7 @@ type SidebarContentPanelProps = {
   onOpenEmail?: (threadId?: string) => void
   onOpenHome?: () => void
   onNewChat?: () => void
+  onOpenAssistant?: () => void
   onToggleBrowser?: () => void
   onVoiceNoteCreated?: (path: string) => void
   /** Starts the mascot-guided product tour. */
@@ -466,6 +467,7 @@ export function SidebarContentPanel({
   onOpenEmail,
   onOpenHome,
   onNewChat,
+  onOpenAssistant,
   onToggleBrowser,
   onVoiceNoteCreated,
   onStartTour,
@@ -854,7 +856,8 @@ export function SidebarContentPanel({
                 <SidebarMenuButton
                   isActive={activeNav === 'assistant'}
                   onClick={() => {
-                    if (lastChat && onOpenRun) onOpenRun(lastChat.id)
+                    if (onOpenAssistant) onOpenAssistant()
+                    else if (lastChat && onOpenRun) onOpenRun(lastChat.id)
                     else onNewChat?.()
                   }}
                 >

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.test.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { TurnBusEvent } from '@x/shared/src/turns.js'
 import type { SessionsClient } from '@/lib/session-chat/client'
 import {
@@ -168,6 +168,39 @@ describe('useSessionChat', () => {
       { method: 'respondToPermission', args: ['turn-2', 'tc1', 'deny', undefined] },
       { method: 'stopTurn', args: ['turn-2'] },
     ])
+  })
+
+  it('shares one seed and subscription across panels and the active chat', async () => {
+    const { deps, getUnsubscribed } = makeDeps()
+    const get = vi.spyOn(deps.client, 'get')
+    const first = renderHook(() => useSessionChat(S1, deps))
+    await waitFor(() => expect(first.result.current.latestTurnId).toBe('turn-1'))
+    const second = renderHook(() => useSessionChat(S1, deps))
+    expect(second.result.current.chatState).toBe(first.result.current.chatState)
+    expect(get).toHaveBeenCalledTimes(1)
+    first.unmount()
+    expect(getUnsubscribed()).toBe(0)
+    second.unmount()
+    expect(getUnsubscribed()).toBe(1)
+  })
+
+  it('keeps minimized sessions warm without rendering each streaming delta', async () => {
+    const { deps, emit } = makeDeps()
+    const get = vi.spyOn(deps.client, 'get')
+    const { result, rerender, unmount } = renderHook(({ live }) => useSessionChat(S1, deps, live), { initialProps: { live: true } })
+    await waitFor(() => expect(result.current.latestTurnId).toBe('turn-1'))
+    rerender({ live: false })
+    const frozen = result.current.chatState
+    act(() => {
+      emit(durable('turn-2', created('turn-2', S1, user('q2')), 1))
+      emit(durable('turn-2', requested('turn-2', 0), 2))
+      emit(delta('turn-2', 'Live answer'))
+    })
+    expect(result.current.chatState).toBe(frozen)
+    rerender({ live: true })
+    expect(result.current.chatState?.currentAssistantMessage).toBe('Live answer')
+    expect(get).toHaveBeenCalledTimes(1)
+    unmount()
   })
 
   it('unsubscribes from the feed on unmount (StrictMode double-mounts included)', async () => {

--- a/apps/x/apps/renderer/src/hooks/useSessionChat.ts
+++ b/apps/x/apps/renderer/src/hooks/useSessionChat.ts
@@ -30,20 +30,69 @@ const defaultDeps: SessionChatStoreDeps = {
   subscribeDeltas,
 }
 
+type Binding = { store: SessionChatStore; users: number; disconnect?: () => void; loaded: boolean }
+const bindings = new WeakMap<SessionChatStoreDeps, Map<string, Binding>>()
+
+function getBinding(deps: SessionChatStoreDeps, sessionId: string | null): Binding {
+  if (!sessionId) return { store: new SessionChatStore(deps), users: 0, loaded: false }
+  let sessions = bindings.get(deps)
+  if (!sessions) { sessions = new Map(); bindings.set(deps, sessions) }
+  let binding = sessions.get(sessionId)
+  if (!binding) {
+    binding = { store: new SessionChatStore(deps), users: 0, loaded: false }
+    sessions.set(sessionId, binding)
+  }
+  return binding
+}
+
 // Thin subscription over SessionChatStore — all logic (seeding, feed events,
 // reducer, overlay, action routing) lives in the store, which is unit-tested
 // without React. `deps` is injectable for tests.
-export function useSessionChat(
-  sessionId: string | null,
-  deps: SessionChatStoreDeps = defaultDeps,
-) {
-  const binding = useMemo(() => ({ sessionId, store: new SessionChatStore(deps) }), [deps, sessionId])
+function retainBinding(binding: Binding, sessionId: string | null, deps: SessionChatStoreDeps) {
   const { store } = binding
-  useEffect(() => store.connect(), [store])
-  useEffect(() => {
-    void binding.store.setSession(binding.sessionId)
-  }, [binding])
-  const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  if (sessionId) bindings.get(deps)?.set(sessionId, binding)
+  binding.users += 1
+  if (binding.users === 1) binding.disconnect = store.connect()
+  if (!binding.loaded) {
+    binding.loaded = true
+    void store.setSession(sessionId)
+  }
+  return () => {
+    binding.users -= 1
+    if (binding.users === 0) {
+      binding.disconnect?.()
+      binding.loaded = false
+      if (sessionId && bindings.get(deps)?.get(sessionId) === binding) bindings.get(deps)?.delete(sessionId)
+    }
+  }
+}
+
+function useSessionStore(sessionId: string | null, deps: SessionChatStoreDeps) {
+  const binding = useMemo(() => getBinding(deps, sessionId), [deps, sessionId])
+  const { store } = binding
+  useEffect(() => retainBinding(binding, sessionId, deps), [binding, sessionId, deps])
+  return store
+}
+
+const inactiveSubscribe = () => () => undefined
+
+export function useSessionChatStatus(sessionId: string | null) {
+  const store = useSessionStore(sessionId, defaultDeps)
+  const getStatus = () => {
+    const state = store.getSnapshot().chatState
+    return state?.isWaitingOnHuman ? 'waiting' : state?.isProcessing ? 'working' : 'idle'
+  }
+  return useSyncExternalStore(store.subscribe, getStatus)
+}
+
+export function useSessionChat(sessionId: string | null, deps: SessionChatStoreDeps = defaultDeps, live = true) {
+  const store = useSessionStore(sessionId, deps)
+  const getSnapshot = useMemo(() => {
+    if (live) return store.getSnapshot
+    const frozen = store.getSnapshot()
+    return () => frozen
+  }, [store, live])
+  const snapshot = useSyncExternalStore(live ? store.subscribe : inactiveSubscribe, getSnapshot)
   return useMemo(
     () => ({
       ...snapshot,

--- a/apps/x/apps/renderer/src/lib/assistant-dock.test.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-dock.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { createAssistantTab, restoreAssistantTabs, tabsAfterClose } from './assistant-dock'
+import { assistantDockTabs, createAssistantTab, replaceAssistantTab, restoreAssistantTabs, tabsAfterClose } from './assistant-dock'
 
 describe('assistant dock tabs', () => {
+  it('hides the full-screen chat without deleting it or hiding other chats', () => {
+    const tabs = [createAssistantTab(), createAssistantTab('other'), createAssistantTab('docked')]
+    expect(assistantDockTabs(tabs, tabs[2].id, tabs[0].id)).toEqual([tabs[1], tabs[2]])
+    expect(assistantDockTabs(tabs, tabs[2].id, null)).toEqual(tabs.slice(0, 2))
+    expect(tabs).toHaveLength(3)
+  })
+
+  it('replaces a conversation in place, preserving panel identity and other tabs', () => {
+    const tabs = [createAssistantTab('old'), createAssistantTab('other')]
+    const switched = replaceAssistantTab(tabs, tabs[0].id, 'selected', 'selected-identity')
+    expect(switched).toHaveLength(2)
+    expect(switched[0]).toEqual({ id: tabs[0].id, runId: 'selected', chatId: 'selected-identity' })
+    expect(switched[1]).toBe(tabs[1])
+    const fresh = replaceAssistantTab(switched, tabs[0].id, null, 'fresh-draft')
+    expect(fresh[0]).toEqual({ id: tabs[0].id, runId: null, chatId: 'fresh-draft' })
+    expect(replaceAssistantTab(tabs, 'closed-panel', 'selected', 'selected')).toEqual(tabs)
+  })
   it('creates independent draft identities and stable session identities', () => {
     const first = createAssistantTab()
     const second = createAssistantTab()

--- a/apps/x/apps/renderer/src/lib/assistant-dock.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-dock.ts
@@ -17,6 +17,14 @@ export function createAssistantTab(runId: string | null = null): ChatTab {
   return { id: crypto.randomUUID(), chatId: runId ?? crypto.randomUUID(), runId }
 }
 
+export function replaceAssistantTab(tabs: ChatTab[], tabId: string, runId: string | null, chatId: string) {
+  return tabs.map((tab) => tab.id === tabId ? { ...tab, runId, chatId } : tab)
+}
+
+export function assistantDockTabs(tabs: ChatTab[], dockedId: string | null, fullScreenId: string | null) {
+  return tabs.filter((tab) => tab.id !== (fullScreenId ?? dockedId))
+}
+
 export function restoreAssistantTabs(raw: string | null): ChatTab[] {
   try {
     const parsed: unknown = JSON.parse(raw ?? 'null')

--- a/apps/x/apps/renderer/src/lib/assistant-panel-layout.test.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-panel-layout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { clampPanelSize, layoutAssistantPanels, restorePanelPreferences } from './assistant-panel-layout'
+
+describe('assistant panel layout', () => {
+  it('keeps the focused panel reachable without moving panels that still fit', () => {
+    const viewport = { width: 1400, height: 900 }
+    expect(layoutAssistantPanels(['first', 'second'], {}, viewport, 0, 'first')).toEqual(layoutAssistantPanels(['first', 'second'], {}, viewport, 0, 'second'))
+    expect(Object.keys(layoutAssistantPanels(['first', 'second'], {}, { width: 800, height: 700 }, 0, 'first'))).toEqual(['first'])
+  })
+  it('tiles independent sizes without overlaps', () => {
+    const layout = layoutAssistantPanels(['first', 'second'], { first: { width: 360, height: 400 }, second: { width: 500, height: 650 } }, { width: 1400, height: 900 })
+    expect(layout.second).toEqual({ width: 500, height: 650, right: 12 })
+    expect(layout.first).toEqual({ width: 360, height: 400, right: 524 })
+  })
+  it('folds older panels on small windows and restores them as space returns', () => {
+    const ids = ['first', 'second', 'third']
+    expect(Object.keys(layoutAssistantPanels(ids, {}, { width: 800, height: 700 }))).toEqual(['third'])
+    expect(Object.keys(layoutAssistantPanels(ids, {}, { width: 1500, height: 900 }))).toEqual(['third', 'second', 'first'])
+  })
+  it('reserves the actual docked sidebar width', () => {
+    const layout = layoutAssistantPanels(['first', 'second'], {}, { width: 1400, height: 900 }, 460)
+    expect(layout.second.right).toBe(472)
+    expect(layout.first.right).toBe(904)
+  })
+  it('clamps tiny windows and invalid dimensions safely', () => {
+    expect(clampPanelSize({ width: Infinity, height: NaN }, { width: 1000, height: 800 })).toEqual({ width: 420, height: 600 })
+    expect(clampPanelSize({ width: 9999, height: 9999 }, { width: 300, height: 300 })).toEqual({ width: 212, height: 192 })
+    expect(layoutAssistantPanels(['first', 'first'], {}, { width: 1000, height: 800 })).toHaveProperty('first')
+  })
+  it('validates saved preferences rather than trusting local storage', () => {
+    expect(restorePanelPreferences('{broken')).toEqual({ sizes: {}, expanded: [], docked: null })
+    expect(restorePanelPreferences(JSON.stringify({ sizes: { good: { width: 400, height: 500 }, bad: { width: 'huge' } }, expanded: ['good', 123], docked: 'good' }))).toEqual({ sizes: { good: { width: 400, height: 500 } }, expanded: ['good'], docked: 'good' })
+  })
+})

--- a/apps/x/apps/renderer/src/lib/assistant-panel-layout.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-panel-layout.ts
@@ -1,0 +1,49 @@
+export interface PanelSize { width: number; height: number }
+export const DEFAULT_PANEL_SIZE: PanelSize = { width: 420, height: 600 }
+
+export function clampPanelSize(size: PanelSize, viewport: PanelSize): PanelSize {
+  const maxWidth = Math.max(0, viewport.width - 88)
+  const maxHeight = Math.max(0, viewport.height - 108)
+  return {
+    width: Math.min(maxWidth, Math.max(Math.min(320, maxWidth), Number.isFinite(size.width) ? size.width : DEFAULT_PANEL_SIZE.width)),
+    height: Math.min(maxHeight, Math.max(Math.min(280, maxHeight), Number.isFinite(size.height) ? size.height : DEFAULT_PANEL_SIZE.height)),
+  }
+}
+
+export function layoutAssistantPanels(ids: string[], sizes: Record<string, PanelSize>, viewport: PanelSize, reservedWidth = 0, preferredId?: string) {
+  const result: Record<string, PanelSize & { right: number }> = {}
+  const ordered = [...new Set(ids)].reverse()
+  const priority = preferredId && ordered.includes(preferredId) ? [preferredId, ...ordered.filter((id) => id !== preferredId)] : ordered
+  const selected = new Map<string, PanelSize>()
+  let used = 12 + reservedWidth
+  for (const id of priority) {
+    const size = clampPanelSize(sizes[id] ?? DEFAULT_PANEL_SIZE, { ...viewport, width: viewport.width - reservedWidth })
+    if (used + size.width > viewport.width - 64) continue
+    selected.set(id, size)
+    used += size.width + 12
+  }
+  let right = 12 + reservedWidth
+  for (const id of ordered) {
+    const size = selected.get(id)
+    if (!size) continue
+    result[id] = { ...size, right }
+    right += size.width + 12
+  }
+  return result
+}
+
+export function restorePanelPreferences(raw: string | null): { sizes: Record<string, PanelSize>; expanded: string[]; docked: string | null } {
+  const fallback = { sizes: {}, expanded: [], docked: null }
+  try {
+    const value = JSON.parse(raw ?? 'null')
+    if (!value || typeof value !== 'object') return fallback
+    const sizes: Record<string, PanelSize> = {}
+    if (value.sizes && typeof value.sizes === 'object') {
+      for (const [id, size] of Object.entries(value.sizes)) {
+        if (!size || typeof size !== 'object' || !('width' in size) || !('height' in size)) continue
+        if (typeof size.width === 'number' && typeof size.height === 'number' && Number.isFinite(size.width) && Number.isFinite(size.height)) sizes[id] = { width: size.width, height: size.height }
+      }
+    }
+    return { sizes, expanded: Array.isArray(value.expanded) ? value.expanded.filter((id: unknown): id is string => typeof id === 'string') : [], docked: typeof value.docked === 'string' ? value.docked : null }
+  } catch { return fallback }
+}

--- a/docs/assistant-bottom-tabs.md
+++ b/docs/assistant-bottom-tabs.md
@@ -1,13 +1,20 @@
 # Assistant bottom tabs
 
-Enable **Settings → Appearance → Assistant presentation → Bottom tabs**. Sidebar remains the default; its placement and size preferences are preserved.
+The sidebar remains the default. Use **Undock chat** in the chat header to move a conversation into a floating panel; **Dock chat** puts it back in the sidebar. There is no longer a presentation toggle in Settings. Existing bottom-tab preferences migrate automatically.
 
-- Open several assistant conversations; click a bottom tab to expand it, or click the expanded tab again to minimize. Only one panel expands at a time. Excess tabs appear under **More chats**.
-- The floating panel does not resize ordinary workspace views. Resize using its corner, or Alt + arrow keys while focused inside the panel. Expand for a full-width conversation.
+- The sidebar's **Assistant** destination always opens the full-screen assistant, preserving the current conversation or draft regardless of floating-panel preferences.
+- A full-screen or maximized conversation is omitted from the bottom dock while it owns the main view. Other conversations remain accessible; its tab returns when leaving full-screen mode. An otherwise empty dock is hidden.
+- The chat selector and **New chat** inside a panel replace that panel's conversation without changing its position or size. The bottom dock's **+** still opens an additional panel. Selecting a conversation already open elsewhere focuses its existing panel rather than duplicating it. Switching does not stop running work.
+
+- Multiple conversations can stay expanded side by side. Click a bottom tab to expand or minimize that conversation independently. Excess tabs appear under **More chats**.
+- Floating panels do not resize ordinary workspace views. Drag the top edge for height, left edge for width, or top-left corner for both. Focus a resize handle and use arrow keys (Shift for larger steps); double-click a handle to reset its size. Text-editing shortcuts remain untouched.
+- Panels fit the available viewport. Older panels fold when space runs out and return as space becomes available; the focused panel takes priority. A docked sidebar reserves its actual width, so floating chats can remain beside it. Expand temporarily for a full-width conversation.
 - Escape or the minimize button tucks the panel away. Outside clicks leave it open. Completion never steals focus; tabs indicate working, unread replies, and requests for input.
 - Close silently removes a tab, not the saved conversation, and does not stop work. Reopen saved conversations from history. Use Stop in the conversation to stop a task.
 - Cmd/Ctrl+L toggles the panel while viewing another section. Cmd/Ctrl+N creates a new conversation.
-- Open tabs, the active tab, draft text, and floating dimensions are restored locally. Attachments remain available across presentation changes within the same app session; staged attachments are not restored after an app restart.
+- Open tabs, the active tab, draft text, expanded panels, docking and per-panel dimensions are restored locally. Attachments remain available across presentation changes within the same app session; staged attachments are not restored after an app restart.
+- Sidebar, full-width and floating presentations reuse the same mounted composers and transcripts. Session subscriptions are shared; minimized transcripts stop rendering streaming deltas but their stores stay live. Reopening uses the current in-memory snapshot, not another history fetch.
+- Expand/minimize uses short opacity/transform animations, with immediate inertness on minimize and respect for reduced-motion preferences.
 
 ## Native surfaces
 
@@ -15,6 +22,6 @@ Code keeps its primary chat layout. The dock is hidden there. The embedded brows
 
 ## Verification
 
-Run the renderer tests for `assistant-dock`, `assistant-chat-dock`, `chat-sidebar`, `useSessionChat`, and `session-chat/store`.
+Run the renderer tests for `assistant-panel-layout`, `assistant-panels`, `assistant-dock`, `assistant-chat-dock`, `chat-sidebar`, `useSessionChat`, and `session-chat/store`.
 
-For desktop QA, check email, files, Apps, Code, and the embedded browser at narrow and wide window sizes. Start work in two chats; minimize and switch while streaming; stop or answer a permission request in one and verify that the other continues. Check drafts, attachments, model selection, queues, focus, tab overflow, display zoom, and switching back to Sidebar.
+For desktop QA, check email, files, Apps, Code, and the embedded browser at narrow and wide window sizes. Start work in two chats; minimize and switch while streaming; stop or answer a permission request in one and verify that the other continues. Check drafts, attachments, model selection, queues, dictation ownership, focus, tab overflow, display zoom, reduced motion, rapid toggles, pointer cancellation, docking and full-width restoration.


### PR DESCRIPTION
## Summary
- Add independently resizable floating assistant panels, shared warm session stores, and reduced-motion-aware expand/minimize animations.
- Replace the presentation setting with header dock/undock controls; preserve drafts, per-panel geometry, and independent chat actions.
- Make Assistant navigation open full-screen, omit the displayed full-screen chat from the dock, and switch conversations/new chats in place within a panel. The dock + button creates an additional panel.
- Preserve native Browser/Code layout safety and prevent cross-panel focus, file-drop, and voice-routing interference.

## Scope
One feature commit containing only assistant-panel implementation, associated tests, and documentation (21 files). No dependency or lockfile changes.

## Validation
- 564 renderer tests passed.
- Renderer typecheck passed.
- Targeted lint and git diff --check passed.
- Dependency and main builds passed during implementation.
- Existing chat-session lint errors remain unchanged.
- Desktop visual QA could not be completed because macOS Computer Use permissions were unavailable.