### PR TITLE
Add workspace document previews and editors to spaces

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -2367,7 +2367,10 @@ export function setupIpcHandlers() {
     },
     'spreadsheet:load': async (_event, args) => {
       const { loadSheetWindow } = await import('@x/core/dist/spreadsheet/spreadsheet.js');
-      const result = await loadSheetWindow(args.path, args.sheet, args.offset, args.limit);
+      const inputPath = args.space
+        ? await (await import('@x/core/dist/spaces/document-file.js')).materializeDocument(args.space.orgId, args.space.spaceId, args.path, args.space.version)
+        : args.path;
+      const result = await loadSheetWindow(inputPath, args.sheet, args.offset, args.limit);
       return {
         format: result.meta.format,
         sheets: result.meta.sheets,
@@ -2384,7 +2387,10 @@ export function setupIpcHandlers() {
     },
     'spreadsheet:find': async (_event, args) => {
       const { findInSheet } = await import('@x/core/dist/spreadsheet/spreadsheet.js');
-      return await findInSheet(args.path, args.sheet, args.query, args.maxMatches);
+      const inputPath = args.space
+        ? await (await import('@x/core/dist/spaces/document-file.js')).materializeDocument(args.space.orgId, args.space.spaceId, args.path, args.space.version)
+        : args.path;
+      return await findInSheet(inputPath, args.sheet, args.query, args.maxMatches);
     },
     'dialog:openDirectory': async (event, args) => {
       const win = BrowserWindow.fromWebContents(event.sender);

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -48,7 +48,7 @@ import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import container, { registerBrowserControlService, registerNotificationService, registerScreenPointerService, registerTextInsertService } from "@x/core/dist/di/container.js";
 import { forwardRpc } from "./rpc-forwarder.js";
-import { bounceAllLive } from "@x/core/dist/spaces/orgs.js";
+import { bounceAllLive, getClient as getSpaceClient } from "@x/core/dist/spaces/orgs.js";
 import type { CodeModeManager } from "@x/core/dist/code-mode/acp/manager.js";
 import type { ISessions } from "@x/core/dist/runtime/sessions/index.js";
 import { browserViewManager, BROWSER_PARTITION } from "./browser/view.js";
@@ -232,6 +232,33 @@ function registerAppProtocol() {
           return new Response("Forbidden", { status: 403 });
         }
       })();
+    }
+
+    // File-based URLs keep HTML's relative assets inside the same space.
+    if (url.host === "space-document") {
+      try {
+        const [orgId, spaceId, ...segments] = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+        if (!orgId || !spaceId || !segments.length || segments.some((part) => part === '..' || part.includes('/') || part.includes('\\'))) {
+          return new Response("Not Found", { status: 404 });
+        }
+        const assetPath = segments.join('/');
+        const asset = await getSpaceClient(orgId).readAsset(spaceId, assetPath);
+        const blob = asset.blob ? await spaceBlobCache.getBlob(orgId, spaceId, asset.blob.hash) : null;
+        const ext = path.extname(assetPath).toLowerCase();
+        const textTypes: Record<string, string> = {
+          '.html': 'text/html', '.htm': 'text/html', '.css': 'text/css',
+          '.js': 'text/javascript', '.json': 'application/json', '.svg': 'image/svg+xml',
+        };
+        return new Response(blob ? new Uint8Array(blob.bytes) : asset.content, {
+          headers: {
+            'content-type': textTypes[ext] ?? blob?.mime ?? 'text/plain',
+            'cache-control': 'no-cache',
+            'x-content-type-options': 'nosniff',
+          },
+        });
+      } catch {
+        return new Response("Not Found", { status: 404 });
+      }
     }
 
     // Space blobs: app://space-blob/<orgId>/<spaceId>/<hash>
@@ -479,7 +506,7 @@ function createWindow(options: { startHidden?: boolean } = {}) {
   // navigation untouched so the embeds keep working.
   win.webContents.on("will-frame-navigate", (event) => {
     if (event.isMainFrame) return;
-    if (!event.frame?.url.startsWith("app://workspace/")) return;
+    if (!event.frame?.url.startsWith("app://workspace/") && !event.frame?.url.startsWith("app://space-document/")) return;
     if (routeExternalNavigation(event.url)) event.preventDefault();
   });
 

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,3 +1,4 @@
+import { DocumentFileViewer } from '@/components/document-file-viewer'
 import * as React from 'react'
 import { Activity, useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
 import { workspace, quickAskShortcut, pttKey, type ipc } from '@x/shared';
@@ -21,14 +22,7 @@ import { ChatSessionPane, ChatSessionComposer, queuedMessageText } from './compo
 import { ChatInputWithMentions, type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from './components/chat-input-with-mentions';
 import { GraphView, type GraphEdge, type GraphNode } from '@/components/graph-view';
 import { BasesView, type BaseConfig, DEFAULT_BASE_CONFIG } from '@/components/bases-view';
-import { ImageFileViewer } from '@/components/image-file-viewer';
-import { VideoFileViewer } from '@/components/video-file-viewer';
-import { AudioFileViewer } from '@/components/audio-file-viewer';
-import { DocxFileViewer } from '@/components/docx-file-viewer';
-import { SpreadsheetFileViewer } from '@/components/spreadsheet-file-viewer';
-import { PptxEditor } from '@/components/pptx-editor';
 import { PersistentViewerCache } from '@/components/persistent-viewer-cache';
-import { UnsupportedFileViewer } from '@/components/unsupported-file-viewer';
 import { getViewerType, isCacheableViewerPath } from '@/lib/file-types';
 import {
   readFileAfterExternalChangesSettle,
@@ -7731,37 +7725,9 @@ function App() {
                       />
                     )}
                   </div>
-                ) : selectedPath && getViewerType(selectedPath) === 'image' ? (
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    <ImageFileViewer path={selectedPath} />
-                  </div>
-                ) : selectedPath && getViewerType(selectedPath) === 'video' ? (
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    <VideoFileViewer path={selectedPath} />
-                  </div>
-                ) : selectedPath && getViewerType(selectedPath) === 'audio' ? (
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    <AudioFileViewer path={selectedPath} />
-                  </div>
-                ) : selectedPath && getViewerType(selectedPath) === 'docx' ? (
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    <DocxFileViewer path={selectedPath} />
-                  </div>
-                ) : selectedPath && getViewerType(selectedPath) === 'spreadsheet' ? (
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    <SpreadsheetFileViewer path={selectedPath} />
-                  </div>
-                ) : selectedPath && getViewerType(selectedPath) === 'pptx' ? (
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    <PptxEditor
-                      key={selectedPath}
-                      path={selectedPath}
-                      onSlideChange={handleDeckSlideChange}
-                    />
-                  </div>
                 ) : (
                   <div className="flex-1 min-h-0 overflow-hidden">
-                    <UnsupportedFileViewer path={selectedPath} />
+                    <DocumentFileViewer path={selectedPath ?? ''} onSlideChange={handleDeckSlideChange} />
                   </div>
                 )
                 )}

--- a/apps/x/apps/renderer/src/components/audio-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/audio-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { useEffect, useState } from 'react'
 import { ExternalLinkIcon, FileAudioIcon } from 'lucide-react'
 
@@ -13,13 +14,14 @@ function basename(path: string): string {
 }
 
 export function AudioFileViewer({ path }: AudioFileViewerProps) {
+  const source = useFileViewerSource()
   const [state, setState] = useState<State>('loading')
 
   useEffect(() => {
     setState('loading')
   }, [path])
 
-  const src = `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`
+  const src = source.url(path)
 
   if (state === 'error') {
     return (
@@ -30,7 +32,7 @@ export function AudioFileViewer({ path }: AudioFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >

--- a/apps/x/apps/renderer/src/components/document-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/document-file-viewer.tsx
@@ -1,0 +1,28 @@
+import { getViewerType } from '@/lib/file-types'
+import { HtmlFileViewer } from './html-file-viewer'
+import { PdfFileViewer } from './pdf-file-viewer'
+import { ImageFileViewer } from './image-file-viewer'
+import { VideoFileViewer } from './video-file-viewer'
+import { AudioFileViewer } from './audio-file-viewer'
+import { DocxFileViewer } from './docx-file-viewer'
+import { SpreadsheetFileViewer } from './spreadsheet-file-viewer'
+import { PptxEditor } from './pptx-editor'
+import { UnsupportedFileViewer } from './unsupported-file-viewer'
+
+/** Shared format routing; storage is supplied by FileViewerSourceContext. */
+export function DocumentFileViewer({ path, onSlideChange }: {
+  path: string
+  onSlideChange?: (slideNumber: number, slideCount: number) => void
+}) {
+  switch (getViewerType(path)) {
+    case 'html': return <HtmlFileViewer path={path} />
+    case 'pdf': return <PdfFileViewer path={path} />
+    case 'image': return <ImageFileViewer path={path} />
+    case 'video': return <VideoFileViewer path={path} />
+    case 'audio': return <AudioFileViewer path={path} />
+    case 'docx': return <DocxFileViewer path={path} />
+    case 'spreadsheet': return <SpreadsheetFileViewer path={path} />
+    case 'pptx': return <PptxEditor key={path} path={path} onSlideChange={onSlideChange} />
+    default: return <UnsupportedFileViewer path={path} />
+  }
+}

--- a/apps/x/apps/renderer/src/components/docx-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/docx-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react'
 import {
   CloudDownloadIcon,
@@ -64,9 +65,11 @@ function baseName(path: string): string {
 }
 
 export function DocxFileViewer({ path }: DocxFileViewerProps) {
+  const source = useFileViewerSource()
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [buffer, setBuffer] = useState<ArrayBuffer | null>(null)
   const [saveState, setSaveState] = useState<SaveState>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [reloadNonce, setReloadNonce] = useState(0)
   const [link, setLink] = useState<GoogleDocLink | null>(null)
   const [syncing, setSyncing] = useState<'up' | 'down' | null>(null)
@@ -90,7 +93,7 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
 
     ;(async () => {
       try {
-        const result = await window.ipc.invoke('workspace:readFile', { path, encoding: 'base64' })
+        const result = await source.read({ path, encoding: 'base64' })
         if (cancelled) return
         setBuffer(base64ToArrayBuffer(result.data))
         setLoadState('ready')
@@ -106,17 +109,22 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
       cancelled = true
       if (armTimerRef.current) clearTimeout(armTimerRef.current)
     }
-  }, [path, reloadNonce])
+  }, [path, reloadNonce, source])
+
+  useEffect(() => source.subscribe?.(() => {
+    if (!dirtyRef.current && !savingRef.current) setReloadNonce((n) => n + 1)
+  }), [source])
 
   // Is this file linked to a Google Doc? Drives the sync bar.
   useEffect(() => {
     let cancelled = false
     setLink(null)
+    if (!source.workspace) return
     void window.ipc.invoke('google-docs:getLink', { path })
       .then((res) => { if (!cancelled) setLink(res.link) })
       .catch((err) => { console.error('Failed to read Google Doc link:', err) })
     return () => { cancelled = true }
-  }, [path])
+  }, [path, source])
 
   // Serialize the current document and write it back to disk.
   const persist = useCallback(async () => {
@@ -125,10 +133,12 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
     savingRef.current = true
     dirtyRef.current = false
     setSaveState('saving')
+    setSaveError(null)
+    let failed = false
     try {
       const out = await editor.save()
       if (out) {
-        await window.ipc.invoke('workspace:writeFile', {
+        await source.write({
           path,
           data: arrayBufferToBase64(out),
           opts: { encoding: 'base64' },
@@ -136,16 +146,18 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
       }
       setSaveState('saved')
     } catch (err) {
+      failed = true
+      setSaveError(err instanceof Error ? err.message.replace(/^ETag mismatch: /, '') : 'Could not save document')
       console.error('Failed to save docx:', err)
       dirtyRef.current = true
       setSaveState('error')
     } finally {
       savingRef.current = false
       // A change landed while we were saving — flush it.
-      if (dirtyRef.current) scheduleSave()
+      if (dirtyRef.current && !failed) scheduleSave()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [path])
+  }, [path, source])
 
   const scheduleSave = () => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
@@ -165,7 +177,7 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
       if (dirtyRef.current) void persist()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [path])
+  }, [path, source])
 
   // Write any pending edits to disk before a sync-up so we push the latest.
   const flushPendingSave = useCallback(async () => {
@@ -235,7 +247,7 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
         <p className="max-w-md text-xs">The file may be corrupted or not a valid Word document.</p>
         <button
           type="button"
-          onClick={() => { void window.ipc.invoke('shell:openPath', { path }) }}
+          onClick={() => { void source.open({ path }) }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >
           <ExternalLinkIcon className="size-3.5" />
@@ -247,6 +259,19 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
 
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden">
+      {saveError && (
+        <div role="alert" className="flex shrink-0 items-center gap-3 border-b border-border px-3 py-2 text-xs">
+          <span className="min-w-0 flex-1">{saveError}</span>
+          <button type="button" onClick={() => { void persist() }} className="shrink-0 underline">Retry save</button>
+          <button type="button" onClick={() => {
+            if (!window.confirm('Discard your unsaved edits and reload the latest document?')) return
+            if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+            dirtyRef.current = false
+            setSaveError(null)
+            setReloadNonce((n) => n + 1)
+          }} className="shrink-0 underline">Discard edits and reload</button>
+        </div>
+      )}
       {link && (
         <div className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/30 px-3 py-1.5 text-xs">
           <GoogleDocsIcon className="size-4 shrink-0" />

--- a/apps/x/apps/renderer/src/components/file-viewer-source.tsx
+++ b/apps/x/apps/renderer/src/components/file-viewer-source.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from 'react'
+import type { ipc } from '@x/shared'
+
+type Channel<K extends keyof ipc.IPCChannels> = (args: ipc.IPCChannels[K]['req']) => Promise<ipc.IPCChannels[K]['res']>
+
+/** Storage operations shared by workspace and space document viewers. */
+export interface FileViewerSource {
+  url: (path: string) => string
+  read: Channel<'workspace:readFile'>
+  write: Channel<'workspace:writeFile'>
+  stat: Channel<'workspace:stat'>
+  open: Channel<'shell:openPath'>
+  exportCopy: Channel<'workspace:exportCopy'>
+  loadSheet: Channel<'spreadsheet:load'>
+  findCells: Channel<'spreadsheet:find'>
+  subscribe?: (listener: () => void) => () => void
+  notifyChanged?: (version: number) => void
+  workspace: boolean
+}
+
+const workspaceSource: FileViewerSource = {
+  url: (path) => `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`,
+  read: (args) => window.ipc.invoke('workspace:readFile', args),
+  write: (args) => window.ipc.invoke('workspace:writeFile', args),
+  stat: (args) => window.ipc.invoke('workspace:stat', args),
+  open: (args) => window.ipc.invoke('shell:openPath', args),
+  exportCopy: (args) => window.ipc.invoke('workspace:exportCopy', args),
+  loadSheet: (args) => window.ipc.invoke('spreadsheet:load', args),
+  findCells: (args) => window.ipc.invoke('spreadsheet:find', args),
+  workspace: true,
+}
+
+export const FileViewerSourceContext = createContext<FileViewerSource>(workspaceSource)
+export const useFileViewerSource = () => useContext(FileViewerSourceContext)

--- a/apps/x/apps/renderer/src/components/html-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/html-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { useEffect, useMemo, useState } from 'react'
 import { AlertCircleIcon, ExternalLinkIcon, FileTextIcon, Loader2Icon } from 'lucide-react'
 
@@ -14,15 +15,11 @@ interface HtmlFileViewerProps {
   path: string
 }
 
-function toAppWorkspaceUrl(path: string): string {
-  const segments = path.split('/').filter(Boolean).map((seg) => encodeURIComponent(seg))
-  return `app://workspace/${segments.join('/')}`
-}
-
 export function HtmlFileViewer({ path }: HtmlFileViewerProps) {
+  const source = useFileViewerSource()
   const [state, setState] = useState<ViewerState>({ kind: 'loading' })
   const [iframeLoaded, setIframeLoaded] = useState(false)
-  const iframeSrc = useMemo(() => toAppWorkspaceUrl(path), [path])
+  const iframeSrc = useMemo(() => source.url(path), [path, source])
 
   useEffect(() => {
     let cancelled = false
@@ -31,7 +28,7 @@ export function HtmlFileViewer({ path }: HtmlFileViewerProps) {
 
     ;(async () => {
       try {
-        const stat = await window.ipc.invoke('workspace:stat', { path })
+        const stat = await source.stat({ path })
         if (cancelled) return
         if (stat.kind !== 'file') {
           setState({ kind: 'error', message: 'Selected path is not a file.' })
@@ -56,7 +53,7 @@ export function HtmlFileViewer({ path }: HtmlFileViewerProps) {
     return () => {
       cancelled = true
     }
-  }, [path])
+  }, [path, source])
 
   if (state.kind === 'error') {
     return (
@@ -89,7 +86,7 @@ export function HtmlFileViewer({ path }: HtmlFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >

--- a/apps/x/apps/renderer/src/components/image-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/image-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { useEffect, useState } from 'react'
 import { ExternalLinkIcon, FileImageIcon, Loader2Icon } from 'lucide-react'
 
@@ -8,13 +9,14 @@ interface ImageFileViewerProps {
 type State = 'loading' | 'loaded' | 'error'
 
 export function ImageFileViewer({ path }: ImageFileViewerProps) {
+  const source = useFileViewerSource()
   const [state, setState] = useState<State>('loading')
 
   useEffect(() => {
     setState('loading')
   }, [path])
 
-  const src = `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`
+  const src = source.url(path)
 
   if (state === 'error') {
     return (
@@ -25,7 +27,7 @@ export function ImageFileViewer({ path }: ImageFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >

--- a/apps/x/apps/renderer/src/components/pdf-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/pdf-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { useEffect, useState } from 'react'
 import { ExternalLinkIcon, FileTextIcon, Loader2Icon } from 'lucide-react'
 
@@ -8,13 +9,14 @@ interface PdfFileViewerProps {
 type State = 'loading' | 'ready' | 'error'
 
 export function PdfFileViewer({ path }: PdfFileViewerProps) {
+  const source = useFileViewerSource()
   const [state, setState] = useState<State>('loading')
 
   useEffect(() => {
     setState('loading')
   }, [path])
 
-  const src = `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`
+  const src = source.url(path)
 
   if (state === 'error') {
     return (
@@ -24,7 +26,7 @@ export function PdfFileViewer({ path }: PdfFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import {
   Component,
   useCallback,
@@ -210,6 +211,7 @@ function textSignature(paras: readonly { runs: readonly { text: string }[] }[]):
 }
 
 export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
+  const source = useFileViewerSource()
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [baseDeck, setBaseDeck] = useState<SlideDeck | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
@@ -269,11 +271,11 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
   if (fileSyncRef.current === null) {
     fileSyncRef.current = createDeckFileSync({
       read: async () => {
-        const res = await window.ipc.invoke('workspace:readFile', { path, encoding: 'base64' })
+        const res = await source.read({ path, encoding: 'base64' })
         return { data: res.data, etag: res.etag, stat: { mtimeMs: res.stat.mtimeMs, size: res.stat.size } }
       },
       write: async (data, expectedEtag) => {
-        const res = await window.ipc.invoke('workspace:writeFile', {
+        const res = await source.write({
           path,
           data,
           opts: { encoding: 'base64', ...(expectedEtag !== null ? { expectedEtag } : {}) },
@@ -282,7 +284,7 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
       },
       stat: async () => {
         try {
-          const s = await window.ipc.invoke('workspace:stat', { path })
+          const s = await source.stat({ path })
           return { mtimeMs: s.mtimeMs, size: s.size }
         } catch {
           return null
@@ -375,7 +377,7 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
       void savePipeline.flush()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [path])
+  }, [path, source])
 
   // App.tsx keys this component by path, so a different file is a fresh mount.
   useEffect(() => {
@@ -533,6 +535,8 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
       externalSignalBusyRef.current = false
     }
   }, [fileSync, savePipeline, reloadFromDisk])
+
+  useEffect(() => source.subscribe?.(() => { void handleExternalSignal() }), [source, handleExternalSignal])
 
   // The workspace watcher only covers allowlisted roots, so assistant deck
   // tools additionally announce their writes via this window event (App.tsx).
@@ -1445,14 +1449,14 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
   // ---------------------------------------------------------------- render
 
   const openExternally = useCallback(() => {
-    void window.ipc.invoke('shell:openPath', { path })
-  }, [path])
+    void source.open({ path })
+  }, [path, source])
 
   /** Saves a copy elsewhere. Flushes first so the copy has the latest edits. */
   const exportCopy = useCallback(async () => {
     try {
       await savePipeline.flush()
-      const result = await window.ipc.invoke('workspace:exportCopy', { path })
+      const result = await source.exportCopy({ path })
       if (result.error) {
         toast.error(`Could not export a copy: ${result.error}`)
         return
@@ -1466,7 +1470,7 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
       const message = err instanceof Error ? err.message : String(err)
       toast.error('Could not export a copy.', { description: message })
     }
-  }, [path, savePipeline])
+  }, [path, savePipeline, source])
 
   if (loadState === 'error') return <FailurePanel path={path} onOpen={openExternally} />
 

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -1,5 +1,6 @@
 import '@/styles/spaces.css'
 import { ThreadResizeHandle, THREAD_DEFAULT_WIDTH, THREAD_MIN_WIDTH, THREAD_DIVIDER_WIDTH, STREAM_MIN_WIDTH } from '@/components/spaces/thread-resize-handle'
+import { getViewerType } from '@/lib/file-types'
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { Bell, BellOff, Check, Clock, Columns2, Copy, FileText, FolderOpen, Hash, Link as LinkIcon, Loader2, MoreHorizontal, PenTool, Plus, Users } from 'lucide-react'
 import { spaces } from '@x/shared'
@@ -1005,7 +1006,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                                 />
                             </Suspense>
                         ) : centerPath ? (
-                            <div className={cn('flex min-w-0 min-h-0 flex-1', !split && 'mx-auto max-w-[880px]')}>
+                            <div className={cn('flex min-w-0 min-h-0 flex-1', !split && !getViewerType(centerPath) && 'mx-auto max-w-[880px]')}>
                                 <FileColumn
                                     key={centerPath}
                                     org={org}

--- a/apps/x/apps/renderer/src/components/spaces/document-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/document-viewer.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import type { spaces } from '@x/shared'
+import { DocumentFileViewer } from '@/components/document-file-viewer'
+import { FileViewerSourceContext } from '@/components/file-viewer-source'
+import { createSpaceFileSource } from '@/lib/space-file-source'
+
+export function SpaceDocumentViewer({ orgId, spaceId, asset, onChanged }: {
+  orgId: string
+  spaceId: string
+  asset: spaces.ReadAssetResult
+  onChanged: () => void
+}) {
+  // Host keys by file identity, preserving editor drafts across version updates.
+  const [source] = useState(() => createSpaceFileSource(orgId, spaceId, asset, onChanged))
+  useEffect(() => {
+    source.notifyChanged?.(asset.version)
+  }, [asset.version, source])
+  return (
+    <FileViewerSourceContext.Provider value={source}>
+      <DocumentFileViewer path={asset.path} />
+    </FileViewerSourceContext.Provider>
+  )
+}

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -1,3 +1,7 @@
+import { splitFrontmatter, joinFrontmatter } from '@/lib/frontmatter'
+import { MarkdownEditor } from '@/components/markdown-editor'
+import { SpaceDocumentViewer } from './document-viewer'
+import { getViewerType } from '@/lib/file-types'
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ArrowLeft, Check, Clock, Download, Eye, FileText, Folder, FolderOpen, History, Image as ImageIcon, Loader2, MoreHorizontal, Pencil, PenTool, Plus, RotateCcw, Trash2, Upload, X } from 'lucide-react'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@/components/ui/context-menu'
@@ -14,7 +18,7 @@ import { RichMarkdownViewer } from '@/components/rich-markdown-viewer'
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { MemberText } from '@/components/spaces/member-text'
 import {
-    attributionLabel, blobAppUrl, buildFileTree, formatBytes, formatFeedTime, isImageMime,
+    attributionLabel, blobAppUrl, blobWireUrl, buildFileTree, formatBytes, formatFeedTime, isImageMime,
     parseAssetWireUrl, parseBlobAppUrl, resolveSpaceLink, rewriteBlobLinks, rewriteRelativeImages, toggleTaskAt,
     type FileTreeNode,
 } from '@/lib/spaces-presentation'
@@ -24,9 +28,8 @@ import { uploadInputFor } from '@/lib/spaces-upload'
 
 // Files: the tree (README first) and the file column — rendered file
 // with one-tap checkboxes, Edit → draft→apply (merged / conflict handled),
-// History with diffs. Binary files (uploads, spec §6) render a preview or a
-// download card instead of the editor; Replace is the binary "edit" (a new
-// upload proposed at the same path against the current version).
+// History with diffs. Supported documents reuse the workspace viewers/editors;
+// other binary files retain the download card and versioned Replace action.
 
 // ---------------------------------------------------------------------------
 // Files rail — the space's tree, README first, unread dots on moved files
@@ -804,12 +807,42 @@ export function FileColumn({ org, space, path, entries = [], memberNames, refres
             )}
             <div className="flex-1 min-h-0 flex">
                 <div className="flex-1 min-w-0 min-h-0 overflow-y-auto">
-                    {draft ? (
+                    {draft && /\.md$/i.test(path) ? (
+                        <MarkdownEditor
+                            content={splitFrontmatter(draft.text).body}
+                            frontmatter={splitFrontmatter(draft.text).raw}
+                            onFrontmatterChange={(raw) => setDraft({ ...draft, text: joinFrontmatter(raw, splitFrontmatter(draft.text).body), conflict: null })}
+                            onChange={(text) => setDraft({ ...draft, text: joinFrontmatter(splitFrontmatter(draft.text).raw, text), conflict: null })}
+                            onExport={async (format) => {
+                                try {
+                                    await window.ipc.invoke('export:note', { markdown: draft.text, format, title: fileName })
+                                } catch (err) {
+                                    toast(err instanceof Error ? err.message : 'Could not export', 'error')
+                                }
+                            }}
+                            onImageUpload={async (file) => {
+                                const uploaded = await window.ipc.invoke('spaces:uploadBlob', {
+                                    orgId: org.id, spaceId: space.id, name: file.name,
+                                    ...(await uploadInputFor(file)),
+                                    ...(file.type ? { mime: file.type } : {}),
+                                })
+                                return blobWireUrl(wireRefs, uploaded.blob.hash, file.name)
+                            }}
+                        />
+                    ) : draft ? (
                         <Textarea
                             value={draft.text}
                             spellCheck={false}
                             className="w-full h-full min-h-full rounded-none border-0 font-mono text-sm resize-none focus-visible:ring-0 px-5 py-4"
                             onChange={(e) => setDraft({ ...draft, text: e.target.value, conflict: null })}
+                        />
+                    ) : asset && getViewerType(path) ? (
+                        <SpaceDocumentViewer
+                            key={`${org.id}:${space.id}:${path}:${['docx', 'pptx'].includes(getViewerType(path)!) ? 'editor' : asset.version}`}
+                            orgId={org.id}
+                            spaceId={space.id}
+                            asset={asset}
+                            onChanged={onChanged}
                         />
                     ) : blob ? (
                         <div className="p-5">

--- a/apps/x/apps/renderer/src/components/spreadsheet-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/spreadsheet-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   CheckIcon,
@@ -68,6 +69,7 @@ function formatCell(value: string | number | boolean | null): string {
 }
 
 export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
+  const source = useFileViewerSource()
   const [data, setData] = useState<SpreadsheetLoadResult | null>(null)
   const [activeSheet, setActiveSheet] = useState<string | null>(() => viewStateByPath.get(path)?.sheet ?? null)
   const [page, setPage] = useState(() => viewStateByPath.get(path)?.page ?? 0)
@@ -105,7 +107,7 @@ export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
     setFindQuery('')
     setFindResult(null)
     setError(null)
-  }, [path])
+  }, [path, source])
 
   useEffect(() => {
     const requestId = ++requestIdRef.current
@@ -113,7 +115,7 @@ export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
     setLoading(true)
     void (async () => {
       try {
-        const result = await window.ipc.invoke('spreadsheet:load', {
+        const result = await source.loadSheet({
           path,
           sheet: activeSheet ?? undefined,
           offset: headerRows + page * PAGE_SIZE,
@@ -143,7 +145,7 @@ export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
     return () => {
       cancelled = true
     }
-  }, [path, activeSheet, page, headerRows, version])
+  }, [path, activeSheet, page, headerRows, version, source])
 
   // Remember where the user is so reopening this file restores the position.
   useEffect(() => {
@@ -208,7 +210,7 @@ export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
     const timer = setTimeout(() => {
       void (async () => {
         try {
-          const res = await window.ipc.invoke('spreadsheet:find', { path, sheet, query })
+          const res = await source.findCells({ path, sheet, query })
           if (cancelled) return
           setFindResult({ sheet: res.activeSheet, matches: res.matches, total: res.total })
           setFindIndex(0)
@@ -330,7 +332,7 @@ export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
         >
@@ -503,7 +505,7 @@ export function SpreadsheetFileViewer({ path }: SpreadsheetFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent"
         >

--- a/apps/x/apps/renderer/src/components/video-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/video-file-viewer.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerSource } from './file-viewer-source'
 import { useEffect, useState } from 'react'
 import { ExternalLinkIcon, FileVideoIcon } from 'lucide-react'
 
@@ -8,13 +9,14 @@ interface VideoFileViewerProps {
 type State = 'loading' | 'ready' | 'error'
 
 export function VideoFileViewer({ path }: VideoFileViewerProps) {
+  const source = useFileViewerSource()
   const [state, setState] = useState<State>('loading')
 
   useEffect(() => {
     setState('loading')
   }, [path])
 
-  const src = `app://workspace/${path.split('/').map(encodeURIComponent).join('/')}`
+  const src = source.url(path)
 
   if (state === 'error') {
     return (
@@ -27,7 +29,7 @@ export function VideoFileViewer({ path }: VideoFileViewerProps) {
         <button
           type="button"
           onClick={() => {
-            void window.ipc.invoke('shell:openPath', { path })
+            void source.open({ path })
           }}
           className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >

--- a/apps/x/apps/renderer/src/lib/space-file-source.test.ts
+++ b/apps/x/apps/renderer/src/lib/space-file-source.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { spaces } from '@x/shared'
+import { createSpaceFileSource } from './space-file-source'
+
+const blob = { hash: 'a'.repeat(64), size: 4, mime: 'application/octet-stream' }
+const asset = (path = 'report.docx', version = 3) => ({ path, version, content: '', blob, recentHistory: [] }) as spaces.ReadAssetResult
+const invoke = vi.fn()
+beforeEach(() => {
+  window.ipc = { ...window.ipc, invoke } as typeof window.ipc
+  invoke.mockReset()
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer })))
+})
+function handlers(result: unknown) {
+  invoke.mockImplementation(async (channel) => {
+    if (channel === 'spaces:readAsset') return asset()
+    if (channel === 'spaces:uploadBlob') return { blob: { ...blob, hash: 'b'.repeat(64) } }
+    if (channel === 'spaces:proposeChange') return result
+    throw new Error(`Unexpected channel ${channel}`)
+  })
+}
+describe('space document storage', () => {
+  it('reads binary bytes and advances the Word edit base after successful saves', async () => {
+    handlers({ outcome: 'applied', version: 4 })
+    const changed = vi.fn()
+    const source = createSpaceFileSource('org', 'space', asset(), changed)
+    expect(await source.read({ path: 'report.docx', encoding: 'base64' })).toMatchObject({ data: 'AQIDBA==', etag: '3' })
+    await source.write({ path: 'report.docx', data: 'BQ==', opts: { encoding: 'base64' } })
+    expect(invoke).toHaveBeenLastCalledWith('spaces:proposeChange', expect.objectContaining({ input: expect.objectContaining({ baseVersion: 3, blob: 'b'.repeat(64) }) }))
+    await source.write({ path: 'report.docx', data: 'Bg==', opts: { encoding: 'base64' } })
+    expect(invoke).toHaveBeenLastCalledWith('spaces:proposeChange', expect.objectContaining({ input: expect.objectContaining({ baseVersion: 4 }) }))
+    expect(changed).toHaveBeenCalledTimes(2)
+  })
+  it('keeps the old edit base on conflict so retry cannot overwrite concurrent changes', async () => {
+    handlers({ outcome: 'conflict', currentVersion: 8 })
+    const changed = vi.fn()
+    const source = createSpaceFileSource('org', 'space', asset(), changed)
+    for (let i = 0; i < 2; i++) await expect(source.write({ path: 'report.docx', data: 'AA==', opts: { encoding: 'base64' } })).rejects.toThrow('ETag mismatch')
+    expect(invoke.mock.calls.filter(([channel]) => channel === 'spaces:proposeChange').map(([, args]) => args.input.baseVersion)).toEqual([3, 3])
+    expect(changed).not.toHaveBeenCalled()
+  })
+  it('uses the PowerPoint snapshot etag even after a newer read', async () => {
+    handlers({ outcome: 'applied', version: 4 })
+    const source = createSpaceFileSource('org', 'space', asset('slides.pptx'), vi.fn())
+    await source.read({ path: 'slides.pptx', encoding: 'base64' })
+    await source.write({ path: 'slides.pptx', data: 'AA==', opts: { encoding: 'base64', expectedEtag: '2' } })
+    expect(invoke).toHaveBeenLastCalledWith('spaces:proposeChange', expect.objectContaining({ input: expect.objectContaining({ assetPath: 'slides.pptx', baseVersion: 2 }) }))
+  })
+  it('pins spreadsheet paging and search to the same space and version', async () => {
+    invoke.mockResolvedValue({})
+    const source = createSpaceFileSource('org', 'space', asset('budget.xlsx'), vi.fn())
+    await source.loadSheet({ path: 'budget.xlsx', offset: 500, limit: 500 })
+    await source.findCells({ path: 'budget.xlsx', query: 'Total' })
+    for (const [, args] of invoke.mock.calls) expect(args.space).toEqual({ orgId: 'org', spaceId: 'space', version: 3 })
+  })
+  it('notifies editors about external versions but ignores their own save echo', async () => {
+    handlers({ outcome: 'applied', version: 4 })
+    const source = createSpaceFileSource('org', 'space', asset(), vi.fn())
+    const listener = vi.fn()
+    const unsubscribe = source.subscribe!(listener)
+    source.notifyChanged!(3)
+    await source.write({ path: 'report.docx', data: 'AA==', opts: { encoding: 'base64' } })
+    source.notifyChanged!(4)
+    expect(listener).not.toHaveBeenCalled()
+    source.notifyChanged!(5)
+    expect(listener).toHaveBeenCalledOnce()
+    unsubscribe()
+    source.notifyChanged!(6)
+    expect(listener).toHaveBeenCalledOnce()
+  })
+  it('uses encoded space URLs for HTML and blob URLs for media', () => {
+    expect(createSpaceFileSource('org', 'space', asset('web/my page.html'), vi.fn()).url('')).toBe('app://space-document/org/space/web/my%20page.html')
+    expect(createSpaceFileSource('org', 'space', asset('report.pdf'), vi.fn()).url('')).toBe(`app://space-blob/org/space/${blob.hash}`)
+  })
+})

--- a/apps/x/apps/renderer/src/lib/space-file-source.ts
+++ b/apps/x/apps/renderer/src/lib/space-file-source.ts
@@ -1,0 +1,85 @@
+import type { spaces } from '@x/shared'
+import type { FileViewerSource } from '@/components/file-viewer-source'
+import { blobAppUrl } from './spaces-presentation'
+import { getViewerType } from './file-types'
+
+function base64(bytes: Uint8Array): string {
+  let text = ''
+  for (let i = 0; i < bytes.length; i += 0x8000) text += String.fromCharCode(...bytes.subarray(i, i + 0x8000))
+  return btoa(text)
+}
+
+/** One instance per open document; only successful reads/writes advance its edit base. */
+export function createSpaceFileSource(
+  orgId: string,
+  spaceId: string,
+  initial: spaces.ReadAssetResult,
+  onChanged: () => void,
+): FileViewerSource {
+  const path = initial.path
+  const name = path.split('/').pop() ?? path
+  const listeners = new Set<() => void>()
+  let snapshot = initial
+  const readAsset = () => window.ipc.invoke('spaces:readAsset', { orgId, spaceId, path })
+  const statOf = (asset: spaces.ReadAssetResult, size?: number) => ({
+    kind: 'file' as const,
+    size: size ?? asset.blob?.size ?? new TextEncoder().encode(asset.content).length,
+    // Versions are monotonic and identify changes even if timestamps coincide.
+    mtimeMs: asset.version,
+    ctimeMs: 0,
+  })
+  const download = async () => {
+    const asset = await readAsset()
+    if (!asset.blob) throw new Error('This document has no downloadable blob')
+    return window.ipc.invoke('spaces:saveBlob', { orgId, spaceId, hash: asset.blob.hash, suggestedName: name })
+  }
+  return {
+    workspace: false,
+    subscribe: (listener) => { listeners.add(listener); return () => { listeners.delete(listener) } },
+    notifyChanged: (version) => { if (version !== snapshot.version) for (const listener of listeners) listener() },
+    url: () => getViewerType(path) === 'html'
+      ? `app://space-document/${[orgId, spaceId, ...path.split('/')].map(encodeURIComponent).join('/')}`
+      : initial.blob
+      ? blobAppUrl({ orgId, spaceId }, initial.blob.hash)
+      : `data:text/html;charset=utf-8,${encodeURIComponent(initial.content)}`,
+    read: async ({ encoding = 'utf8' }) => {
+      const asset = await readAsset()
+      let bytes: Uint8Array
+      if (asset.blob) {
+        const response = await fetch(blobAppUrl({ orgId, spaceId }, asset.blob.hash))
+        if (!response.ok) throw new Error('Could not load document')
+        bytes = new Uint8Array(await response.arrayBuffer())
+      } else bytes = new TextEncoder().encode(asset.content)
+      snapshot = asset
+      return { path, encoding, data: encoding === 'base64' ? base64(bytes) : new TextDecoder().decode(bytes), stat: statOf(asset, bytes.length), etag: String(asset.version) }
+    },
+    write: async ({ data, opts }) => {
+      const baseVersion = opts?.expectedEtag !== undefined
+        ? Number(opts.expectedEtag)
+        : getViewerType(path) === 'pptx' ? (await readAsset()).version : snapshot.version
+      const uploaded = await window.ipc.invoke('spaces:uploadBlob', {
+        orgId, spaceId, name, bytes: opts?.encoding === 'base64' ? data : base64(new TextEncoder().encode(data)),
+        ...(snapshot.blob ? { mime: snapshot.blob.mime } : {}),
+      })
+      const result = await window.ipc.invoke('spaces:proposeChange', {
+        orgId, spaceId,
+        input: { assetPath: path, baseVersion, blob: uploaded.blob.hash, reason: `Edit ${name}` },
+      })
+      if (result.outcome === 'conflict') throw new Error('ETag mismatch: Someone changed this document. Reload to see their changes before saving.')
+      snapshot = { ...snapshot, version: result.version, blob: uploaded.blob }
+      onChanged()
+      return { path, etag: String(result.version), stat: statOf(snapshot) }
+    },
+    stat: async () => statOf(await readAsset()),
+    open: async () => {
+      const result = await download()
+      return result.saved && result.path ? window.ipc.invoke('shell:openPath', { path: result.path }) : {}
+    },
+    exportCopy: async () => {
+      const result = await download()
+      return { saved: result.saved, dest: result.path }
+    },
+    loadSheet: (args) => window.ipc.invoke('spreadsheet:load', { ...args, space: { orgId, spaceId, version: initial.version } }),
+    findCells: (args) => window.ipc.invoke('spreadsheet:find', { ...args, space: { orgId, spaceId, version: initial.version } }),
+  }
+}

--- a/apps/x/packages/core/src/spaces/document-file.ts
+++ b/apps/x/packages/core/src/spaces/document-file.ts
@@ -1,0 +1,14 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { getClient } from './orgs.js';
+import { getBlob, writeBlobFile } from './blob-cache.js';
+
+/** Immutable named snapshot for parsers that require a filesystem path. */
+export async function materializeDocument(orgId: string, spaceId: string, assetPath: string, version: number): Promise<string> {
+    const asset = await getClient(orgId).readAsset(spaceId, assetPath, version);
+    const bytes = asset.blob
+        ? (await getBlob(orgId, spaceId, asset.blob.hash)).bytes
+        : Buffer.from(asset.content, 'utf8');
+    const hash = createHash('sha256').update(bytes).digest('hex');
+    return writeBlobFile(hash, path.basename(assetPath), bytes);
+}

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2456,6 +2456,7 @@ export const ipcSchemas = {
   'spreadsheet:load': {
     req: z.object({
       path: z.string(),
+      space: z.object({ orgId: z.string(), spaceId: z.string(), version: z.number().int().min(1) }).optional(),
       sheet: z.string().optional(),
       offset: z.number().int().min(0),
       limit: z.number().int().min(1).max(1000),
@@ -2484,6 +2485,7 @@ export const ipcSchemas = {
   'spreadsheet:find': {
     req: z.object({
       path: z.string(),
+      space: z.object({ orgId: z.string(), spaceId: z.string(), version: z.number().int().min(1) }).optional(),
       sheet: z.string().optional(),
       query: z.string(),
       maxMatches: z.number().int().min(1).max(5000).optional(),


### PR DESCRIPTION
Spaces previously rendered text as Markdown and offered image previews or downloads for uploaded documents. This change reuses the workspace viewers and editors so space files support Word and PowerPoint editing, PDF and spreadsheet viewing, HTML previews, and image/audio/video playback.

A shared file-access layer keeps workspace storage as the default and routes space editor saves through versioned changes with conflict protection. Spreadsheet paging and search use immutable snapshots; HTML previews resolve relative assets within the space. Markdown files use the existing rich editor with frontmatter preservation, image uploads, and export. Document editors can use the available pane width.

Validation:
- 52 targeted tests passed, including space save/conflict handling, spreadsheet snapshot routing, refresh notifications, PowerPoint editing, and space links.
- Shared, core, renderer, and main-process TypeScript checks passed.
- `git diff --check` passed.
- Targeted lint found the existing `react-hooks/set-state-in-effect` issue in `html-file-viewer.tsx`; no new lint findings in the checked components.
- No manual Electron UI verification performed.
