### PR TITLE
Preview Space attachments in the file panel and resolve duplicate uploads

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -2367,7 +2367,9 @@ export function setupIpcHandlers() {
     },
     'spreadsheet:load': async (_event, args) => {
       const { loadSheetWindow } = await import('@x/core/dist/spreadsheet/spreadsheet.js');
-      const inputPath = args.space
+      const inputPath = args.attachment
+        ? await (await import('@x/core/dist/spaces/document-file.js')).materializeAttachment(args.attachment.orgId, args.attachment.spaceId, args.attachment.hash, args.path)
+        : args.space
         ? await (await import('@x/core/dist/spaces/document-file.js')).materializeDocument(args.space.orgId, args.space.spaceId, args.path, args.space.version)
         : args.path;
       const result = await loadSheetWindow(inputPath, args.sheet, args.offset, args.limit);
@@ -2387,7 +2389,9 @@ export function setupIpcHandlers() {
     },
     'spreadsheet:find': async (_event, args) => {
       const { findInSheet } = await import('@x/core/dist/spreadsheet/spreadsheet.js');
-      const inputPath = args.space
+      const inputPath = args.attachment
+        ? await (await import('@x/core/dist/spaces/document-file.js')).materializeAttachment(args.attachment.orgId, args.attachment.spaceId, args.attachment.hash, args.path)
+        : args.space
         ? await (await import('@x/core/dist/spaces/document-file.js')).materializeDocument(args.space.orgId, args.space.spaceId, args.path, args.space.version)
         : args.path;
       return await findInSheet(inputPath, args.sheet, args.query, args.maxMatches);

--- a/apps/x/apps/renderer/src/components/docx-file-viewer.tsx
+++ b/apps/x/apps/renderer/src/components/docx-file-viewer.tsx
@@ -129,7 +129,7 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
   // Serialize the current document and write it back to disk.
   const persist = useCallback(async () => {
     const editor = editorRef.current
-    if (!editor || savingRef.current) return
+    if (source.readOnly || !editor || savingRef.current) return
     savingRef.current = true
     dirtyRef.current = false
     setSaveState('saving')
@@ -165,7 +165,7 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
   }
 
   const handleChange = () => {
-    if (!armedRef.current) return
+    if (source.readOnly || !armedRef.current) return
     dirtyRef.current = true
     scheduleSave()
   }
@@ -330,10 +330,10 @@ export function DocxFileViewer({ path }: DocxFileViewerProps) {
             key={`${path}:${reloadNonce}`}
             ref={editorRef}
             documentBuffer={buffer}
-            mode="editing"
+            mode={source.readOnly ? 'viewing' : 'editing'}
             documentName={baseName(path)}
             documentNameEditable={false}
-            onChange={handleChange}
+            onChange={source.readOnly ? undefined : handleChange}
             onError={(err) => { console.error('docx editor error:', err) }}
             className="flex-1 min-h-0"
           />

--- a/apps/x/apps/renderer/src/components/file-viewer-source.tsx
+++ b/apps/x/apps/renderer/src/components/file-viewer-source.tsx
@@ -15,6 +15,8 @@ export interface FileViewerSource {
   findCells: Channel<'spreadsheet:find'>
   subscribe?: (listener: () => void) => () => void
   notifyChanged?: (version: number) => void
+  /** Immutable attachments use the same viewers without editing controls. */
+  readOnly?: boolean
   workspace: boolean
 }
 

--- a/apps/x/apps/renderer/src/components/pptx-editor.test.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.test.tsx
@@ -5,6 +5,8 @@ import { synthesizeDeckFromOutline } from '@x/shared/dist/pptx/generate.js'
 import { DECK_PALETTES } from '@x/shared/dist/pptx/new-deck.js'
 import { UserMessageContext } from '@x/shared/dist/message.js'
 import { getViewerType } from '@/lib/file-types'
+import { FileViewerSourceContext } from './file-viewer-source'
+import { createSpaceAttachmentSource } from '@/lib/space-attachment-source'
 import { PptxEditor } from './pptx-editor'
 
 // The editor announces failures through sonner; the conflict paths must NOT
@@ -530,5 +532,23 @@ describe('deck context reported to the host', () => {
 
   it('is inert for a non-pptx path', () => {
     expect(getViewerType('knowledge/A.md')).not.toBe('pptx')
+  })
+})
+
+
+describe('PowerPoint message attachment preview', () => {
+  it('navigates slides without exposing editing controls or writing the attachment', async () => {
+    const bytes = Uint8Array.from(atob(await deckBase64('Beta')), (c) => c.charCodeAt(0))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => bytes.buffer }))
+    try {
+      const source = createSpaceAttachmentSource(`app://space-blob/org/space/${'a'.repeat(64)}`, 'slides.pptx')
+      const write = vi.spyOn(source, 'write')
+      render(<FileViewerSourceContext.Provider value={source}><PptxEditor path="slides.pptx" /></FileViewerSourceContext.Provider>)
+      expect(await screen.findByText('1 of 3')).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: 'Next slide' }))
+      expect(screen.getByText('2 of 3')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Add slide' })).not.toBeInTheDocument()
+      expect(write).not.toHaveBeenCalled()
+    } finally { cleanup(); vi.unstubAllGlobals() }
   })
 })

--- a/apps/x/apps/renderer/src/components/pptx-editor.tsx
+++ b/apps/x/apps/renderer/src/components/pptx-editor.tsx
@@ -391,7 +391,7 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
         // preserve it byte-for-byte — repair the package once, on open.
         try {
           const upgraded = await upgradeGeneratedDeck(bytes)
-          if (upgraded && !cancelled) {
+          if (upgraded && !cancelled && !source.readOnly) {
             // Guarded like every other write: if the assistant touched the
             // file between our read and this repair, keep opening as-is and
             // let the conflict banner sort it out.
@@ -1489,6 +1489,19 @@ export function PptxEditor({ path, onSlideChange }: PptxEditorProps) {
         <PresentationIcon className="size-6" />
         <p className="text-sm font-medium text-foreground">{baseName(path)}</p>
         <p className="max-w-md text-xs">This presentation has no slides.</p>
+      </div>
+    )
+  }
+
+  if (source.readOnly) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex items-center justify-center gap-3 border-b border-border p-2 text-xs">
+          <button type="button" disabled={currentIndex === 0} onClick={() => setActiveIndex(currentIndex - 1)}>Previous slide</button>
+          <span>{currentIndex + 1} of {deck.slides.length}</span>
+          <button type="button" disabled={currentIndex === deck.slides.length - 1} onClick={() => setActiveIndex(currentIndex + 1)}>Next slide</button>
+        </div>
+        {slide && <div className="min-h-0 flex-1 overflow-auto p-4"><SlideThumbnail slide={slide} sizeEmu={deck.slideSizeEmu} widthPx={800} /></div>}
       </div>
     )
   }

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -28,7 +28,7 @@ import { useSpaceNotifyPrefs, type NotifyLevel } from '@/hooks/use-spaces-notify
 import { requestJump } from '@/lib/spaces-jump'
 import { chord } from '@/lib/shortcut'
 import { SpaceMembersProvider, SpaceProfilesProvider } from '@/components/spaces/member-text'
-import { SpaceNavProvider, SpaceRefsProvider } from '@/components/spaces/space-markdown'
+import { AttachmentColumn, SpaceNavProvider, SpaceRefsProvider } from '@/components/spaces/space-markdown'
 import { artifactsForThread, threadLabelOf } from '@/lib/spaces-conventions'
 import { isUnreadChange, resolveMentions } from '@/lib/spaces-presentation'
 import { markRead, markTopicRead } from '@/lib/spaces-read-state'
@@ -344,10 +344,10 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     // ------------------------------------------------------------------
     const memoryKey = `${org.id}/${space.id}`
     const [docPath, setDocPath] = useState<string | null>(() => {
-        if (selection.kind === 'file' || selection.kind === 'whiteboard') return selection.path
+        if (selection.kind === 'file' || selection.kind === 'whiteboard' || selection.kind === 'attachment') return selection.path
         return columnMemory.get(memoryKey)?.docPath ?? null
     })
-    const [chatOpen, setChatOpen] = useState(() => columnMemory.get(memoryKey)?.chatOpen ?? true)
+    const [chatOpen, setChatOpen] = useState(() => selection.kind === 'attachment' || (columnMemory.get(memoryKey)?.chatOpen ?? true))
     useEffect(() => {
         columnMemory.set(memoryKey, { docPath, chatOpen })
     }, [memoryKey, docPath, chatOpen])
@@ -502,7 +502,8 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     // right; anything from Chat reopens the left — and, narrow, closes the
     // doc so the chat actually shows.
     const placeSelection = (next: RailSelection) => {
-        if (next.kind === 'file' || next.kind === 'whiteboard') {
+        if (next.kind === 'file' || next.kind === 'whiteboard' || next.kind === 'attachment') {
+            if (next.kind === 'attachment') setChatOpen(true)
             setDocPath(next.path)
         } else {
             setChatOpen(true)
@@ -557,7 +558,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     // rail stays where it is — it is a sidebar, not a flyout.
     const select = (next: RailSelection) => {
         onSelect(next)
-        analytics.spacesTabViewed(next.kind === 'general' ? 'general' : next.kind === 'file' ? 'files' : next.kind === 'whiteboard' ? 'whiteboard' : 'topics')
+        analytics.spacesTabViewed(next.kind === 'general' ? 'general' : (next.kind === 'file' || next.kind === 'attachment') ? 'files' : next.kind === 'whiteboard' ? 'whiteboard' : 'topics')
         placeSelection(next)
     }
     const openFile = (path: string) => select({ kind: 'file', path })
@@ -607,7 +608,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     const chatContextRef = useRef<string | null>(null)
     if (selection.kind === 'thread') chatContextRef.current = selection.rootMessageId
     else if (selection.kind === 'general') chatContextRef.current = null
-    else if (selection.kind === 'file' && selection.fromThreadRootId) chatContextRef.current = selection.fromThreadRootId
+    else if ((selection.kind === 'file' || selection.kind === 'attachment') && selection.fromThreadRootId) chatContextRef.current = selection.fromThreadRootId
     const chatRootId = chatContextRef.current
 
     const threadBesideStream = !!chatRootId && !docOpen && !threadExpanded && conversationWidth >= 840
@@ -629,7 +630,7 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
         }
         setDocPath(null)
         setChatOpen(true)
-        if (selection.kind === 'file' || selection.kind === 'whiteboard') {
+        if (selection.kind === 'file' || selection.kind === 'whiteboard' || selection.kind === 'attachment') {
             onSelect(chatRootId ? { kind: 'thread', rootMessageId: chatRootId } : { kind: 'general' })
         }
     }
@@ -647,16 +648,19 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
     const crumbLabel = crumbLabelRaw === null ? null : resolveMentions(crumbLabelRaw, memberNames)
 
     // Files picked (rail Upload button) or dropped on the tree, awaiting the
-    // destination-folder dialog. Prefill the open file's folder when there is one.
+    // upload confirmation. Default to Space files; choosing a folder is optional.
     const [uploadFiles, setUploadFiles] = useState<File[] | null>(null)
     const [trashOpen, setTrashOpen] = useState(false)
-    const uploadDefaultFolder = centerPath?.includes('/') ? centerPath.slice(0, centerPath.lastIndexOf('/')) : ''
 
     return (
         <SpaceMembersProvider members={memberNames}>
         <SpaceProfilesProvider members={members} here={hereSet} selfId={org.memberId}>
         <SpaceRefsProvider refs={{ orgId: org.id, orgAddress: org.address, spaceId: space.id }}>
-        <SpaceNavProvider onOpenFile={openFile}>
+        <SpaceNavProvider onOpenFile={openFile} onOpenAttachment={(src, name) => {
+            const url = new URL(src)
+            url.searchParams.set('name', name)
+            select({ kind: 'attachment', path: url.href, ...(chatRootId ? { fromThreadRootId: chatRootId } : {}) })
+        }}>
         <div className="spaces-surface relative flex-1 min-h-0 flex flex-col">
             {/* One per pane — covers the stream and thread panes alike. */}
             {active && <SelectionCopy />}
@@ -983,7 +987,12 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                         className={cn('min-w-0 min-h-0 flex', docAnim || (split && !anim) ? 'shrink-0 overflow-hidden' : 'flex-1')}
                     >
                     <div style={docAnim ? { width: docAnim.width } : undefined} className={cn('flex min-w-0 min-h-0', docAnim ? 'shrink-0' : 'flex-1', !split && !boardPath && 'justify-center')}>
-                        {boardPath ? (
+                        {docRender.startsWith('app://space-blob/') ? (
+                            <AttachmentColumn key={docRender} src={docRender} onDismiss={closeDoc} onSaved={(path) => {
+                                setRefreshTick((tick) => tick + 1)
+                                select({ kind: 'file', path, ...(chatRootId ? { fromThreadRootId: chatRootId } : {}) })
+                            }} />
+                        ) : boardPath ? (
                             // Keyed by path so switching boards remounts a fresh collab session.
                             <Suspense
                                 fallback={
@@ -1044,7 +1053,6 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
                     space={space}
                     files={uploadFiles}
                     entries={entries}
-                    defaultFolder={uploadDefaultFolder}
                     onClose={() => setUploadFiles(null)}
                     onDone={() => setRefreshTick((t) => t + 1)}
                 />

--- a/apps/x/apps/renderer/src/components/spaces/blob-preview.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/blob-preview.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BlobPreview } from './blob-preview'
+
+vi.mock('@eigenpal/docx-editor-react', () => ({ DocxEditor: ({ mode }: { mode: string }) => <div data-testid="word-mode">{mode}</div> }))
+
+const src = `app://space-blob/org/space/${'a'.repeat(64)}`
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('Attachment preview', () => {
+    it('uses the shared PDF viewer with the original attachment URL', async () => {
+        render(<BlobPreview src={src} name="report.pdf" />)
+        const frame = await screen.findByTitle('PDF preview')
+        expect(frame).toHaveAttribute('src', src)
+        fireEvent.load(frame)
+        expect(screen.queryByText('Loading PDF…')).not.toBeInTheDocument()
+    })
+
+    it('uses the existing Word editor in viewing mode for attachments', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2]).buffer }))
+        render(<BlobPreview src={src} name="report.docx" />)
+        expect(await screen.findByTestId('word-mode')).toHaveTextContent('viewing')
+    })
+
+    it('reports failed text loads instead of leaving a loading indicator', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+        render(<BlobPreview src={src} name="report.txt" />)
+        await waitFor(() => expect(screen.getByText(/Could not load this preview/)).toBeInTheDocument())
+        expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
+})

--- a/apps/x/apps/renderer/src/components/spaces/blob-preview.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/blob-preview.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { DocumentFileViewer } from '@/components/document-file-viewer'
+import { FileViewerSourceContext } from '@/components/file-viewer-source'
+import { createSpaceAttachmentSource } from '@/lib/space-attachment-source'
+import { getViewerType } from '@/lib/file-types'
+
+/** Preview the original attachment, independently of any entry in space files. */
+export function BlobPreview({ src, name }: { src: string; name: string }) {
+    const source = useMemo(() => createSpaceAttachmentSource(src, name), [src, name])
+    if (getViewerType(name)) return (
+        <FileViewerSourceContext.Provider value={source}>
+            <div className="h-full min-h-0 flex-1 overflow-hidden"><DocumentFileViewer key={src} path={name} /></div>
+        </FileViewerSourceContext.Provider>
+    )
+    return <TextAttachmentPreview src={src} />
+}
+
+function TextAttachmentPreview({ src }: { src: string }) {
+    const [content, setContent] = useState<{ text?: string; truncated: boolean } | null>(null)
+    const [error, setError] = useState(false)
+    useEffect(() => {
+        const controller = new AbortController()
+        setContent(null)
+        setError(false)
+        void (async () => {
+            try {
+                const response = await fetch(src, { signal: controller.signal })
+                if (!response.ok) throw new Error('Could not load attachment')
+                const blob = await response.blob()
+                const mime = blob.type.split(';')[0] ?? ''
+                const isText = mime.startsWith('text/') || ['application/json', 'application/xml', 'application/javascript'].includes(mime)
+                const text = isText ? await blob.slice(0, 1_000_000).text() : undefined
+                if (controller.signal.aborted) return
+                setContent({ text, truncated: isText && blob.size > 1_000_000 })
+            } catch {
+                if (!controller.signal.aborted) setError(true)
+            }
+        })()
+        return () => controller.abort()
+    }, [src])
+    if (error) return <p className="p-6 text-sm text-muted-foreground">Could not load this preview. Close and reopen to try again, or download the file.</p>
+    if (!content) return <div role="status" className="flex items-center gap-2 p-6 text-sm"><Loader2 className="size-4 animate-spin" /> Loading preview…</div>
+    if (content.text !== undefined) return <div>{content.truncated && <p className="px-4 text-xs text-muted-foreground">Showing the first 1 MB. Download to read the full file.</p>}<pre className="overflow-auto whitespace-pre-wrap break-words p-4 text-xs">{content.text}</pre></div>
+    return <p className="p-6 text-sm text-muted-foreground">Preview isn’t available for this file type. Download it to open it on your device.</p>
+}

--- a/apps/x/apps/renderer/src/components/spaces/file-conflict.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/file-conflict.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { spaces } from '@x/shared'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { UploadFilesDialog } from './files-tab'
+import { SpaceMarkdown, SpaceRefsProvider } from './space-markdown'
+import { availableCopyPath } from './file-conflict'
+import { blobWireUrl } from '@/lib/spaces-presentation'
+
+vi.mock('@/components/markdown-editor', () => ({ MarkdownEditor: () => null }))
+vi.mock('@/components/rich-markdown-viewer', () => ({ RichMarkdownViewer: () => null }))
+
+const refs = { orgId: 'org', spaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', orgAddress: 'spaces.example.com' }
+const hash = 'a'.repeat(64)
+const invoke = vi.fn()
+let entries: { path: string; version: number }[]
+let proposals: { assetPath: string; baseVersion: number }[]
+let responses: unknown[]
+beforeEach(() => {
+    entries = [{ path: 'report.pdf', version: 3 }, { path: 'report (1).pdf', version: 1 }]
+    proposals = []
+    responses = []
+    invoke.mockReset().mockImplementation(async (channel, args) => {
+        if (channel === 'spaces:listAssets') return { entries }
+        if (channel === 'spaces:uploadBlob') return { blob: { hash } }
+        if (channel === 'spaces:proposeChange') {
+            proposals.push(args.input)
+            if (responses.length) {
+                const response = responses.shift()
+                if (response instanceof Error) throw response
+                return response
+            }
+            entries = [...entries.filter((entry) => entry.path !== args.input.assetPath), { path: args.input.assetPath, version: args.input.baseVersion + 1 }]
+            return { outcome: 'applied', version: args.input.baseVersion + 1 }
+        }
+        throw new Error(`Unexpected channel ${channel}`)
+    })
+    Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+})
+afterEach(cleanup)
+
+async function start(kind: 'upload' | 'attachment', files = [new File(['data'], 'report.pdf')]) {
+    if (kind === 'upload') {
+        render(<UploadFilesDialog org={{ id: 'org' } as OrgWithSpaces} space={{ id: refs.spaceId, name: 'Team' } as spaces.Space} files={files} entries={[]} onDone={vi.fn()} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByRole('button', { name: /^Upload(?: \d+ files)?$/ }))
+    } else {
+        render(<SpaceRefsProvider refs={refs}><SpaceMarkdown body={`[report.pdf](${blobWireUrl(refs, hash, 'report.pdf')})`} /></SpaceRefsProvider>)
+        fireEvent.click(await screen.findByRole('button', { name: 'Save to space files' }))
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+    }
+}
+
+describe.each(['upload', 'attachment'] as const)('%s duplicate resolution', (kind) => {
+    it('offers choices before writing and keeps both using the next available name', async () => {
+        await start(kind)
+        fireEvent.click(await screen.findByRole('button', { name: 'Keep both' }))
+        await waitFor(() => expect(proposals).toHaveLength(1))
+        expect(proposals[0]).toMatchObject({ assetPath: 'report (2).pdf', baseVersion: 0 })
+    })
+    it('replaces only the approved version, retaining its path and history', async () => {
+        await start(kind)
+        const replace = await screen.findByRole('button', { name: 'Replace' })
+        expect(proposals).toHaveLength(0)
+        fireEvent.click(replace)
+        await waitFor(() => expect(proposals).toHaveLength(1))
+        expect(proposals[0]).toMatchObject({ assetPath: 'report.pdf', baseVersion: 3 })
+    })
+    it('cancels without uploading or changing the existing file', async () => {
+        await start(kind)
+        await screen.findByRole('button', { name: 'Keep both' })
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+        await waitFor(() => expect(screen.queryByRole('button', { name: 'Keep both' })).not.toBeInTheDocument())
+        expect(proposals).toHaveLength(0)
+        expect(invoke).not.toHaveBeenCalledWith('spaces:uploadBlob', expect.anything())
+    })
+    it('asks again when another user changes the file after the replacement decision', async () => {
+        responses = [{ outcome: 'conflict', currentVersion: 4 }]
+        await start(kind)
+        fireEvent.click(await screen.findByRole('button', { name: 'Replace' }))
+        expect(await screen.findByText(/changed while saving/)).toBeVisible()
+        expect(proposals).toHaveLength(1)
+        expect(proposals[0].baseVersion).toBe(3)
+        fireEvent.click(screen.getByRole('button', { name: 'Replace' }))
+        await waitFor(() => expect(proposals).toHaveLength(2))
+        expect(proposals[1].baseVersion).toBe(4)
+    })
+    it('resolves a collision that appears after the initial name check', async () => {
+        entries = []
+        responses = [{ outcome: 'conflict', currentVersion: 1 }]
+        await start(kind)
+        expect(await screen.findByText(/changed while saving/)).toBeVisible()
+        fireEvent.click(screen.getByRole('button', { name: 'Keep both' }))
+        await waitFor(() => expect(proposals).toHaveLength(2))
+        expect(proposals[0]).toMatchObject({ assetPath: 'report.pdf', baseVersion: 0 })
+        expect(proposals[1]).toMatchObject({ assetPath: 'report (1).pdf', baseVersion: 0 })
+    })
+    it('keeps save failures visible after choosing a resolution', async () => {
+        responses = [new Error('Could not save file')]
+        await start(kind)
+        fireEvent.click(await screen.findByRole('button', { name: 'Keep both' }))
+        expect(await screen.findByRole('alert')).toHaveTextContent('Could not save file')
+        expect(screen.getByRole('button', { name: kind === 'upload' ? /^Upload$/ : /^Save$/ })).toBeEnabled()
+    })
+    it('shows lookup failures inline and allows retry', async () => {
+        invoke.mockRejectedValueOnce(new Error('Connection lost'))
+        await start(kind)
+        expect(await screen.findByRole('alert')).toHaveTextContent('Connection lost')
+        expect(screen.getByRole('button', { name: kind === 'upload' ? /^Upload$/ : /^Save$/ })).toBeEnabled()
+    })
+})
+
+it('resolves duplicate names within the same upload batch', async () => {
+    entries = []
+    await start('upload', [new File(['one'], 'report.pdf'), new File(['two'], 'report.pdf')])
+    fireEvent.click(await screen.findByRole('button', { name: 'Keep both' }))
+    await waitFor(() => expect(proposals).toHaveLength(2))
+    expect(proposals.map((p) => [p.assetPath, p.baseVersion])).toEqual([['report.pdf', 0], ['report (1).pdf', 0]])
+})
+
+it('numbers copies in their folder and preserves extensions', () => {
+    expect(availableCopyPath('design/report.pdf', new Set(['design/report (1).pdf']))).toBe('design/report (2).pdf')
+    expect(availableCopyPath('README', new Set())).toBe('README (1)')
+    expect(availableCopyPath('folder/.env', new Set())).toBe('folder/.env (1)')
+})

--- a/apps/x/apps/renderer/src/components/spaces/file-conflict.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/file-conflict.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+type Choice = 'keep' | 'replace' | 'cancel'
+type Conflict = { path: string; version: number; changed: boolean }
+
+export function availableCopyPath(path: string, occupied: ReadonlySet<string>): string {
+    const slash = path.lastIndexOf('/')
+    const dot = path.lastIndexOf('.')
+    const split = dot > slash + 1 ? dot : path.length
+    const stem = path.slice(0, split)
+    const extension = path.slice(split)
+    for (let n = 1; ; n++) {
+        const candidate = `${stem} (${n})${extension}`
+        if (!occupied.has(candidate)) return candidate
+    }
+}
+
+/** Both upload entry points use the same explicit, version-checked decisions. */
+export function useSpaceFileSave(orgId: string, spaceId: string) {
+    const [conflict, setConflict] = useState<Conflict | null>(null)
+    const pending = useRef<((choice: Choice) => void) | null>(null)
+    useEffect(() => () => { pending.current?.('cancel') }, [])
+    const choose = (choice: Choice) => {
+        const resolve = pending.current
+        pending.current = null
+        setConflict(null)
+        resolve?.(choice)
+    }
+    const ask = (value: Conflict) => new Promise<Choice>((resolve) => {
+        pending.current = resolve
+        setConflict(value)
+    })
+    const list = async () => (await window.ipc.invoke('spaces:listAssets', { orgId, spaceId })).entries.filter((entry) => entry.state !== 'deleted')
+    const save = async ({ path, getBlob, reason }: { path: string; getBlob: () => Promise<string>; reason: string }): Promise<string | null> => {
+        const entries = await list()
+        const occupied = new Set(entries.map((entry) => entry.path))
+        const existing = entries.find((entry) => entry.path === path)
+        let collision: Conflict | null = existing ? { path, version: existing.version, changed: false } : null
+        let destination = path
+        let baseVersion = 0
+        let hash: string | undefined
+        for (;;) {
+            if (collision) {
+                const choice = await ask(collision)
+                if (choice === 'cancel') return null
+                if (choice === 'replace') {
+                    // Pin to the version the user approved, never a refreshed head.
+                    baseVersion = collision.version
+                } else {
+                    occupied.add(collision.path)
+                    for (const entry of await list()) occupied.add(entry.path)
+                    destination = availableCopyPath(path, occupied)
+                    baseVersion = 0
+                }
+            }
+            hash ??= await getBlob()
+            const result = await window.ipc.invoke('spaces:proposeChange', {
+                orgId, spaceId,
+                input: { assetPath: destination, baseVersion, blob: hash, reason },
+            })
+            if (result.outcome !== 'conflict') return destination
+            collision = { path: destination, version: result.currentVersion, changed: true }
+            // A concurrent write requires a new decision, including for numbered copies.
+        }
+    }
+    return { save, conflict, choose }
+}
+
+export function FileConflictNotice({ conflict, onChoose }: { conflict: Conflict; onChoose: (choice: Choice) => void }) {
+    return (
+        <div role="alert" className="space-y-3 rounded-md border border-border bg-muted/40 p-3 text-xs">
+            <p className="break-words font-medium">“{conflict.path}” {conflict.changed ? 'changed while saving. Choose how to continue.' : 'already exists in this folder.'}</p>
+            <p className="text-muted-foreground">Keep both saves a numbered copy. Replace saves a new version and preserves the existing file’s history.</p>
+            <div className="flex flex-wrap gap-2">
+                <Button size="sm" onClick={() => onChoose('keep')}>Keep both</Button>
+                <Button size="sm" variant="outline" onClick={() => onChoose('replace')}>Replace</Button>
+                <Button size="sm" variant="ghost" onClick={() => onChoose('cancel')}>Cancel</Button>
+            </div>
+        </div>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -1,3 +1,4 @@
+import { FileConflictNotice, useSpaceFileSave } from './file-conflict'
 import { splitFrontmatter, joinFrontmatter } from '@/lib/frontmatter'
 import { MarkdownEditor } from '@/components/markdown-editor'
 import { SpaceDocumentViewer } from './document-viewer'
@@ -1152,7 +1153,8 @@ export function TrashDialog({ org, space, onClose }: {
 interface UploadRow {
     file: File
     name: string
-    status: 'pending' | 'uploading' | 'done' | 'error'
+    status: 'pending' | 'uploading' | 'done' | 'error' | 'cancelled'
+    savedPath?: string
     error?: string
 }
 
@@ -1167,43 +1169,39 @@ export function UploadFilesDialog({ org, space, files, entries, defaultFolder, o
     onDone: () => void
 }) {
     const [folder, setFolder] = useState(defaultFolder ?? '')
+    const [choosingFolder, setChoosingFolder] = useState(false)
     const [rows, setRows] = useState<UploadRow[]>(files.map((file) => ({ file, name: file.name, status: 'pending' })))
     const [running, setRunning] = useState(false)
+    const fileSave = useSpaceFileSave(org.id, space.id)
+    const uploadedHashes = useRef(new Map<File, string>())
 
     const cleanFolder = folder.trim().replace(/^\/+|\/+$/g, '')
     const destFor = (name: string) => (cleanFolder ? `${cleanFolder}/${name}` : name)
-    const existing = useMemo(() => new Map(entries.map((e) => [e.path, e.version])), [entries])
 
     const upload = async () => {
         setRunning(true)
         let failed = 0
         for (const [i, row] of rows.entries()) {
-            if (row.status === 'done') continue
-            setRows((prev) => prev.map((r, j) => (j === i ? { ...r, status: 'uploading' } : r)))
+            if (row.status === 'done' || row.status === 'cancelled') continue
+            setRows((prev) => prev.map((r, j) => (j === i ? { ...r, status: 'uploading', error: undefined } : r)))
             try {
-                const uploaded = await window.ipc.invoke('spaces:uploadBlob', {
-                    orgId: org.id,
-                    spaceId: space.id,
-                    ...(await uploadInputFor(row.file)),
-                    name: row.name,
-                    ...(row.file.type ? { mime: row.file.type } : {}),
-                })
-                const dest = destFor(row.name)
-                const result = await window.ipc.invoke('spaces:proposeChange', {
-                    orgId: org.id,
-                    spaceId: space.id,
-                    input: {
-                        assetPath: dest,
-                        // Existing path = replace against its current head; new = create.
-                        baseVersion: existing.get(dest) ?? 0,
-                        blob: uploaded.blob.hash,
-                        reason: `upload ${row.name}`,
+                const savedPath = await fileSave.save({
+                    path: destFor(row.name),
+                    reason: `upload ${row.name}`,
+                    getBlob: async () => {
+                        const cached = uploadedHashes.current.get(row.file)
+                        if (cached) return cached
+                        const uploaded = await window.ipc.invoke('spaces:uploadBlob', {
+                            orgId: org.id, spaceId: space.id,
+                            ...(await uploadInputFor(row.file)), name: row.name,
+                            ...(row.file.type ? { mime: row.file.type } : {}),
+                        })
+                        uploadedHashes.current.set(row.file, uploaded.blob.hash)
+                        return uploaded.blob.hash
                     },
                 })
-                if (result.outcome === 'conflict') {
-                    throw new Error(`someone changed ${dest} meanwhile — try again`)
-                }
-                setRows((prev) => prev.map((r, j) => (j === i ? { ...r, status: 'done' } : r)))
+                setRows((prev) => prev.map((r, j) => (j === i ? { ...r, status: savedPath ? 'done' : 'cancelled', savedPath: savedPath ?? undefined, error: undefined } : r)))
+                if (savedPath) onDone()
             } catch (err) {
                 failed += 1
                 const message = err instanceof Error ? err.message : 'upload failed'
@@ -1212,8 +1210,6 @@ export function UploadFilesDialog({ org, space, files, entries, defaultFolder, o
         }
         setRunning(false)
         if (failed === 0) {
-            toast(rows.length === 1 ? `Uploaded ${destFor(rows[0]!.name)}` : `Uploaded ${rows.length} files`, 'success')
-            onDone()
             onClose()
         }
     }
@@ -1225,16 +1221,23 @@ export function UploadFilesDialog({ org, space, files, entries, defaultFolder, o
                     <DialogTitle className="text-sm">Upload to {space.name}</DialogTitle>
                 </DialogHeader>
                 <div className="space-y-3">
-                    <label className="block text-xs text-muted-foreground">
-                        Folder <span className="text-muted-foreground/70">(optional — e.g. design/screens; created by the upload)</span>
-                        <Input
-                            value={folder}
-                            placeholder="(space root)"
-                            className="mt-1 h-7 text-xs font-mono"
-                            disabled={running}
-                            onChange={(e) => setFolder(e.target.value)}
-                        />
-                    </label>
+                    <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                        <span>Upload to: {cleanFolder || 'Space files'}</span>
+                        <button type="button" disabled={running || rows.some((row) => row.status === 'done')} onClick={() => setChoosingFolder((value) => !value)} className="shrink-0 underline">Change folder</button>
+                    </div>
+                    {choosingFolder && (
+                        <label className="block text-xs text-muted-foreground">
+                            Folder (optional)
+                            <Input value={folder} placeholder="Leave blank for Space files" className="mt-1 h-7 text-xs" disabled={running || rows.some((row) => row.status === 'done')} onChange={(e) => setFolder(e.target.value)} list="space-upload-folders" />
+                            <datalist id="space-upload-folders">
+                                {[...new Set(entries.flatMap((entry) => {
+                                    const parts = entry.path.split('/')
+                                    return parts.slice(0, -1).map((_, index) => parts.slice(0, index + 1).join('/'))
+                                }))].sort().map((path) => <option key={path} value={path} />)}
+                            </datalist>
+                            <span className="mt-1 block">Choose an existing folder or type a new folder name.</span>
+                        </label>
+                    )}
                     <div className="max-h-56 space-y-1 overflow-y-auto">
                         {rows.map((row, i) => (
                             <div key={i} className="flex items-center gap-2 rounded-md border border-border px-2 py-1.5 text-xs">
@@ -1248,23 +1251,21 @@ export function UploadFilesDialog({ org, space, files, entries, defaultFolder, o
                                     <FileText className="size-3.5 shrink-0 text-muted-foreground" />
                                 )}
                                 <span className="min-w-0 flex-1">
-                                    <span className="block truncate font-mono">{destFor(row.name)}</span>
-                                    {row.error && <span className="block truncate text-red-500">{row.error}</span>}
+                                    <span className="block truncate font-mono">{row.savedPath ?? destFor(row.name)}{row.status === 'cancelled' ? ' — cancelled' : ''}</span>
+                                    {row.error && <span role="alert" className="block break-words text-red-500">{row.error}</span>}
                                 </span>
                                 <span className="shrink-0 text-muted-foreground">{formatBytes(row.file.size)}</span>
-                                {existing.has(destFor(row.name)) && row.status === 'pending' && (
-                                    <span className="shrink-0 rounded bg-amber-100 px-1 text-[10px] text-amber-700 dark:bg-amber-950 dark:text-amber-400">replaces v{existing.get(destFor(row.name))}</span>
-                                )}
                             </div>
                         ))}
                     </div>
-                    <div className="flex justify-end gap-2">
+                    {fileSave.conflict && <FileConflictNotice conflict={fileSave.conflict} onChoose={fileSave.choose} />}
+                    {!fileSave.conflict && <div className="flex justify-end gap-2">
                         <Button variant="ghost" size="sm" className="h-7 text-xs" disabled={running} onClick={onClose}>Cancel</Button>
                         <Button size="sm" className="h-7 text-xs" disabled={running || rows.length === 0} onClick={() => void upload()}>
                             {running ? <Loader2 className="size-3 mr-1 animate-spin" /> : <Upload className="size-3 mr-1" />}
                             Upload {rows.length === 1 ? '' : `${rows.length} files`}
                         </Button>
-                    </div>
+                    </div>}
                 </div>
             </DialogContent>
         </Dialog>

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { SpaceMarkdown, SpaceRefsProvider } from './space-markdown'
+import { AttachmentColumn, SpaceMarkdown, SpaceNavProvider, SpaceRefsProvider } from './space-markdown'
 import { blobWireUrl } from '@/lib/spaces-presentation'
 
 const refs = { orgId: 'org', spaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', orgAddress: 'spaces.example.com' }
@@ -55,5 +55,65 @@ describe('Spaces message image carousel', () => {
         render(<SpaceMarkdown body="![Only](https://example.com/only.png)" />)
         fireEvent.click(await screen.findByRole('button', { name: 'Preview Only' }))
         expect(screen.queryByRole('button', { name: 'Next image' })).not.toBeInTheDocument()
+    })
+})
+
+describe('Space file attachments', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: async () => new Blob(['hello'], { type: 'text/plain' }) }))
+        vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:attachment')
+        vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    })
+    afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+    it('routes attachment clicks to the document panel without opening a modal', async () => {
+        const openAttachment = vi.fn()
+        render(<SpaceRefsProvider refs={refs}><SpaceNavProvider onOpenFile={vi.fn()} onOpenAttachment={openAttachment}>
+            <SpaceMarkdown body={`Conversation stays visible\n\n[notes.txt](${blobWireUrl(refs, firstHash, 'notes.txt')})`} />
+        </SpaceNavProvider></SpaceRefsProvider>)
+        fireEvent.click(await screen.findByRole('button', { name: 'notes.txt' }))
+        expect(openAttachment).toHaveBeenCalledWith(expect.stringContaining(firstHash), 'notes.txt')
+        expect(screen.getByText('Conversation stays visible')).toBeVisible()
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        expect(invoke).not.toHaveBeenCalled()
+    })
+
+    it('routes uploaded images to the same panel when navigation is available', async () => {
+        const openAttachment = vi.fn()
+        render(<SpaceRefsProvider refs={refs}><SpaceNavProvider onOpenFile={vi.fn()} onOpenAttachment={openAttachment}>
+            <SpaceMarkdown body={`![Photo](${blobWireUrl(refs, firstHash, 'photo.png')})`} />
+        </SpaceNavProvider></SpaceRefsProvider>)
+        fireEvent.click(await screen.findByRole('button', { name: 'Preview Photo' }))
+        expect(openAttachment).toHaveBeenCalledWith(expect.stringContaining(firstHash), 'photo.png')
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('previews in the panel, closes it, and hands saved files to the existing file view', async () => {
+        invoke.mockImplementation(async (channel) => channel === 'spaces:listAssets' ? { entries: [] } : { outcome: 'applied' })
+        const onSaved = vi.fn()
+        const onDismiss = vi.fn()
+        render(<AttachmentColumn src={`app://space-blob/org/${refs.spaceId}/${firstHash}?name=notes.txt`} onSaved={onSaved} onDismiss={onDismiss} />)
+        expect(await screen.findByText('hello')).toBeInTheDocument()
+        expect(screen.getByRole('region', { name: 'Attachment preview' })).toBeInTheDocument()
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Close attachment preview' }))
+        expect(onDismiss).toHaveBeenCalledOnce()
+        fireEvent.click(screen.getByRole('button', { name: 'Save to space files' }))
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+        await waitFor(() => expect(onSaved).toHaveBeenCalledWith('notes.txt'))
+        expect(invoke).toHaveBeenCalledWith('spaces:proposeChange', {
+            orgId: refs.orgId, spaceId: refs.spaceId,
+            input: { assetPath: 'notes.txt', baseVersion: 0, blob: firstHash, reason: 'saved from chat' },
+        })
+        expect(invoke).not.toHaveBeenCalledWith('spaces:saveBlob', expect.anything())
+    })
+
+    it('keeps the save dialog open when the filename conflicts', async () => {
+        invoke.mockImplementation(async (channel) => channel === 'spaces:listAssets' ? { entries: [{ path: 'notes.txt', version: 1 }] } : { outcome: 'conflict', currentVersion: 1 })
+        render(<SpaceRefsProvider refs={refs}><SpaceMarkdown body={`[notes.txt](${blobWireUrl(refs, firstHash, 'notes.txt')})`} /></SpaceRefsProvider>)
+        fireEvent.click(await screen.findByRole('button', { name: 'Save to space files' }))
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+        expect(await screen.findByRole('button', { name: 'Keep both' })).toBeEnabled()
+        expect(screen.getByRole('textbox', { name: 'File name' })).toHaveValue('notes.txt')
     })
 })

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -1,6 +1,8 @@
+import { FileConflictNotice, useSpaceFileSave } from './file-conflict'
 import { createContext, memo, useContext, useMemo, useRef, useState, type ComponentProps, type CSSProperties, type ReactNode } from 'react'
+import { BlobPreview } from '@/components/spaces/blob-preview'
 import { Streamdown } from 'streamdown'
-import { Eye, FileDown, FilePlus2, FileText, Loader2 } from 'lucide-react'
+import { Eye, FileDown, FilePlus2, FileText, Loader2, X } from 'lucide-react'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -29,7 +31,7 @@ import {
 //      walker; fix-it-once rule from the mention sweep),
 //   2. blobs — the org's canonical https blob links rewrite to app://space-blob
 //      (served by main through the content-addressed cache), images render
-//      inline, non-image blob links render as a download card, and
+//      inline, non-image blob links render as a preview card, and
 //   3. file links — a relative link in a message points at a space file
 //      (resolved from the root; plain markdown on the wire), as does the
 //      contract's canonical …/f/<path> form; both open in the file pane.
@@ -46,16 +48,20 @@ export function useSpaceRefs(): SpaceRefs | null {
     return useContext(SpaceRefsContext)
 }
 
+const AttachmentNavContext = createContext<((src: string, name: string) => void) | null>(null)
+
 const SpaceNavContext = createContext<((path: string) => void) | null>(null)
 
 /** Mounted beside SpaceRefsProvider — lets any rendered file link open the file pane. */
-export function SpaceNavProvider({ onOpenFile, children }: { onOpenFile: (path: string) => void; children: ReactNode }) {
-    return <SpaceNavContext.Provider value={onOpenFile}>{children}</SpaceNavContext.Provider>
+export function SpaceNavProvider({ onOpenFile, onOpenAttachment, children }: { onOpenFile: (path: string) => void; onOpenAttachment?: (src: string, name: string) => void; children: ReactNode }) {
+    return <SpaceNavContext.Provider value={onOpenFile}><AttachmentNavContext.Provider value={onOpenAttachment ?? null}>{children}</AttachmentNavContext.Provider></SpaceNavContext.Provider>
 }
 
-/** An attached non-image file inside a message: name + download on tap. */
+/** Attachments preview on tap; saving to space files keeps the original link intact. */
 function BlobLinkCard({ href, children }: { href: string; children?: ReactNode }) {
     const parsed = parseBlobAppUrl(href)
+    const openAttachment = useContext(AttachmentNavContext)
+    const [saveOpen, setSaveOpen] = useState(false)
     const [saving, setSaving] = useState(false)
     if (!parsed) return null
     const suggestedName = (() => {
@@ -85,15 +91,19 @@ function BlobLinkCard({ href, children }: { href: string; children?: ReactNode }
         }
     }
     return (
-        <button
-            type="button"
-            onClick={() => void save()}
-            title="Download"
-            className="my-0.5 inline-flex max-w-full items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground/90 hover:border-foreground/30"
-        >
-            {saving ? <Loader2 className="size-3.5 shrink-0 animate-spin" /> : <FileDown className="size-3.5 shrink-0 text-muted-foreground" />}
-            <span className="truncate">{children}</span>
-        </button>
+        <>
+            <span className="my-0.5 inline-flex max-w-full items-center rounded-lg border border-border bg-background text-xs font-medium text-foreground/90">
+                <button type="button" onClick={() => openAttachment?.(href, suggestedName || 'Attachment')} title="Preview file" className="inline-flex min-w-0 items-center gap-1.5 px-2.5 py-1.5 hover:bg-accent">
+                    <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                    <span className="truncate">{children}</span>
+                </button>
+                <button type="button" onClick={() => setSaveOpen(true)} title="Save to space files" aria-label="Save to space files" className="shrink-0 p-2 hover:bg-accent"><FilePlus2 className="size-3.5" /></button>
+                <button type="button" disabled={saving} onClick={() => void save()} title="Download" aria-label="Download" className="shrink-0 p-2 hover:bg-accent">
+                    {saving ? <Loader2 className="size-3.5 animate-spin" /> : <FileDown className="size-3.5" />}
+                </button>
+            </span>
+            {saveOpen && <SaveToSpaceDialog src={href} suggestedName={suggestedName} onClose={() => setSaveOpen(false)} />}
+        </>
     )
 }
 
@@ -198,12 +208,11 @@ function tileStyle(dims: { width: number; height: number } | null): CSSPropertie
 }
 
 /**
- * Promote a chat image into the space's files — the record. The bytes are
+ * Promote a chat attachment into the space's files. The bytes are
  * already in the org's blob store; saving is one proposeChange referencing
- * the hash. baseVersion 0 = create: an occupied path fails with the server's
- * conflict error rather than silently overwriting someone's file.
+ * the hash. Duplicate names use the same explicit choices as direct uploads.
  */
-function SaveToSpaceDialog({ src, onClose }: { src: string; onClose: () => void }) {
+function SaveToSpaceDialog({ src, suggestedName, onSaved, onClose }: { src: string; suggestedName?: string; onSaved?: (path: string) => void; onClose: () => void }) {
     const parsed = parseBlobAppUrl(src)
     const suggested = (() => {
         try {
@@ -212,60 +221,68 @@ function SaveToSpaceDialog({ src, onClose }: { src: string; onClose: () => void 
             return ''
         }
     })()
-    const [path, setPath] = useState(suggested || (parsed ? `image-${parsed.hash.slice(0, 8)}.png` : ''))
+    const [path, setPath] = useState(suggested || suggestedName || (parsed ? `attachment-${parsed.hash.slice(0, 8)}` : ''))
     const [saving, setSaving] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const fileSave = useSpaceFileSave(parsed?.orgId ?? '', parsed?.spaceId ?? '')
     if (!parsed) return null
     const save = async () => {
         const cleaned = path.split('/').filter((s) => s && s !== '.' && s !== '..').join('/')
-        if (!cleaned || saving) return
+        if (saving) return
+        if (!cleaned) { setError('Enter a file name.'); return }
         setSaving(true)
+        setError(null)
         try {
-            await window.ipc.invoke('spaces:proposeChange', {
-                orgId: parsed.orgId,
-                spaceId: parsed.spaceId,
-                input: { assetPath: cleaned, baseVersion: 0, blob: parsed.hash, reason: 'saved from chat' },
-            })
+            const savedPath = await fileSave.save({ path: cleaned, getBlob: async () => parsed.hash, reason: 'saved from chat' })
+            if (!savedPath) { onClose(); return }
             toast('Saved to space files', 'success')
+            onSaved?.(savedPath)
             onClose()
         } catch (err) {
-            toast(err instanceof Error ? err.message : 'Could not save to space files', 'error')
+            setError(err instanceof Error ? err.message : 'Could not save to space files')
         } finally {
             setSaving(false)
         }
     }
     return (
-        <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+        <Dialog open onOpenChange={(o) => { if (!o && !saving) onClose() }}>
             <DialogContent className="sm:max-w-md">
                 <DialogTitle>Save to space files</DialogTitle>
                 <div className="text-sm text-muted-foreground">
-                    The image becomes a file in this space — in the file tree for everyone, versioned like any other file.
+                    Save this attachment in Files for everyone in the space. It will still be available in this message.
                 </div>
                 <input
                     autoFocus
                     value={path}
-                    onChange={(e) => setPath(e.target.value)}
+                    onChange={(e) => { setPath(e.target.value); setError(null) }}
                     onKeyDown={(e) => {
                         if (e.key === 'Enter') void save()
                     }}
-                    placeholder="folder/name.png"
+                    aria-label="File name"
+                    disabled={saving}
+                    placeholder="File name"
                     className="w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs outline-none focus:border-foreground/30"
                 />
-                <div className="flex justify-end gap-2">
-                    <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+                {error && <p role="alert" className="text-xs text-red-500">{error}</p>}
+                {fileSave.conflict && <FileConflictNotice conflict={fileSave.conflict} onChoose={fileSave.choose} />}
+                {!fileSave.conflict && <div className="flex justify-end gap-2">
+                    <Button variant="ghost" size="sm" disabled={saving} onClick={onClose}>Cancel</Button>
                     <Button size="sm" disabled={saving} onClick={() => void save()}>
                         {saving ? <Loader2 className="mr-1 size-3.5 animate-spin" /> : null} Save
                     </Button>
-                </div>
+                </div>}
             </DialogContent>
         </Dialog>
     )
 }
 
 export function BlobImage({ src, alt }: { src: string; alt: string }) {
+    const openAttachment = useContext(AttachmentNavContext)
     const imageRef = useRef<HTMLImageElement>(null)
     const openGallery = useContext(MessageImageGalleryContext)
     const preview = () => {
-        if (openGallery && imageRef.current) openGallery(imageRef.current)
+        if (openAttachment) openAttachment(src, new URL(src).searchParams.get('name') || alt || 'Image')
+        else if (openGallery && imageRef.current) openGallery(imageRef.current)
         else setOpen(true)
     }
     const [open, setOpen] = useState(false)
@@ -305,6 +322,7 @@ export function BlobImage({ src, alt }: { src: string; alt: string }) {
     }
     return (
         <>
+            <span className="relative inline-block align-top">
             <ContextMenu>
                 <ContextMenuTrigger asChild>
                     <img
@@ -343,6 +361,8 @@ export function BlobImage({ src, alt }: { src: string; alt: string }) {
                     )}
                 </ContextMenuContent>
             </ContextMenu>
+            {parsed && <button type="button" title="Save to space files" aria-label={`Save ${alt || 'image'} to space files`} onClick={() => setSaveOpen(true)} className="absolute bottom-3 right-3 rounded-md border border-border bg-background p-1.5 text-foreground shadow-sm hover:bg-accent"><FilePlus2 className="size-3.5" /></button>}
+            </span>
             <ImageLightbox src={src} alt={alt} open={open} onOpenChange={setOpen}>
                 {parsed && (
                     <>
@@ -610,3 +630,33 @@ export const SpaceMarkdown = memo(function SpaceMarkdown({ body, className }: { 
         </div>
     )
 })
+
+
+/** Attachment content occupies the same document column as saved space files. */
+export function AttachmentColumn({ src, onDismiss, onSaved }: { src: string; onDismiss: () => void; onSaved: (path: string) => void }) {
+    const name = new URL(src).searchParams.get('name') || 'Attachment'
+    const [saveOpen, setSaveOpen] = useState(false)
+    const [downloading, setDownloading] = useState(false)
+    const download = async () => {
+        const parsed = parseBlobAppUrl(src)
+        if (!parsed || downloading) return
+        setDownloading(true)
+        try {
+            await window.ipc.invoke('spaces:saveBlob', { ...parsed, suggestedName: name })
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not download', 'error')
+        } finally { setDownloading(false) }
+    }
+    return (
+        <section aria-label="Attachment preview" className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2 text-xs text-muted-foreground">
+                <span className="min-w-0 flex-1 truncate font-mono text-foreground/80" title={name}>{name}</span>
+                <button type="button" onClick={() => setSaveOpen(true)} className="flex shrink-0 items-center gap-1 hover:text-foreground"><FilePlus2 className="size-3" /> Save to space files</button>
+                <button type="button" disabled={downloading} onClick={() => void download()} className="flex shrink-0 items-center gap-1 hover:text-foreground"><FileDown className="size-3" /> Download</button>
+                <button type="button" aria-label="Close attachment preview" onClick={onDismiss} className="rounded p-1 hover:bg-accent hover:text-foreground"><X className="size-3.5" /></button>
+            </div>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-auto"><BlobPreview src={src} name={name} /></div>
+            {saveOpen && <SaveToSpaceDialog src={src} suggestedName={name} onSaved={onSaved} onClose={() => setSaveOpen(false)} />}
+        </section>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -507,6 +507,9 @@ export function SpaceRail({
                             </button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => uploadInputRef.current?.click()}>
+                                <Upload className="size-3.5 mr-2" /> Upload files…
+                            </DropdownMenuItem>
                             <DropdownMenuItem onClick={() => { setCreatingBoard(false); setCreatingFile({ prefix: '' }) }}>
                                 <FileText className="size-3.5 mr-2" /> New file
                             </DropdownMenuItem>
@@ -515,9 +518,6 @@ export function SpaceRail({
                             </DropdownMenuItem>
                             <DropdownMenuItem onClick={() => { setCreatingFile(null); setCreatingFolder(false); setCreatingBoard(true) }}>
                                 <PenTool className="size-3.5 mr-2" /> New board
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => uploadInputRef.current?.click()}>
-                                <Upload className="size-3.5 mr-2" /> Upload files…
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>

--- a/apps/x/apps/renderer/src/lib/space-attachment-source.test.ts
+++ b/apps/x/apps/renderer/src/lib/space-attachment-source.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSpaceAttachmentSource } from './space-attachment-source'
+
+const hash = 'a'.repeat(64)
+const src = `app://space-blob/org/space/${hash}`
+const invoke = vi.fn()
+beforeEach(() => {
+  window.ipc = { ...window.ipc, invoke } as typeof window.ipc
+  invoke.mockReset()
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer }))
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('message attachment document storage', () => {
+  it('reads an immutable attachment without looking up or creating an asset', async () => {
+    const source = createSpaceAttachmentSource(src, 'notes.docx')
+    expect(source.readOnly).toBe(true)
+    expect(await source.read({ path: 'notes.docx', encoding: 'base64' })).toMatchObject({ data: 'AQIDBA==', etag: hash })
+    expect(await source.stat({ path: 'notes.docx' })).toMatchObject({ size: 4 })
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(invoke).not.toHaveBeenCalled()
+    await expect(source.write({ path: 'notes.docx', data: 'changed' })).rejects.toThrow('Save this attachment')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+  it('pins spreadsheet paging and search to the attachment hash', async () => {
+    invoke.mockResolvedValue({})
+    const source = createSpaceAttachmentSource(src, 'budget.xlsx')
+    await source.loadSheet({ path: 'budget.xlsx', offset: 500, limit: 500 })
+    await source.findCells({ path: 'budget.xlsx', query: 'Total' })
+    for (const [, args] of invoke.mock.calls) {
+      expect(args.attachment).toEqual({ orgId: 'org', spaceId: 'space', hash })
+      expect(args.space).toBeUndefined()
+    }
+  })
+})

--- a/apps/x/apps/renderer/src/lib/space-attachment-source.ts
+++ b/apps/x/apps/renderer/src/lib/space-attachment-source.ts
@@ -1,0 +1,39 @@
+import type { FileViewerSource } from '@/components/file-viewer-source'
+import { parseBlobAppUrl } from './spaces-presentation'
+
+/** The original message attachment is immutable, even after it is saved to Files. */
+export function createSpaceAttachmentSource(src: string, name: string): FileViewerSource {
+  const attachment = parseBlobAppUrl(src)
+  if (!attachment) throw new Error('Invalid attachment URL')
+  let loaded: Promise<ArrayBuffer> | undefined
+  const readBytes = () => loaded ??= fetch(src).then(async (response) => {
+    if (!response.ok) throw new Error('Could not load attachment')
+    return response.arrayBuffer()
+  }).catch((error) => { loaded = undefined; throw error })
+  const stat = async () => ({ kind: 'file' as const, size: (await readBytes()).byteLength, mtimeMs: 0, ctimeMs: 0 })
+  const download = () => window.ipc.invoke('spaces:saveBlob', { ...attachment, suggestedName: name })
+  return {
+    workspace: false,
+    readOnly: true,
+    url: () => src,
+    stat,
+    read: async ({ path, encoding = 'utf8' }) => {
+      const bytes = new Uint8Array(await readBytes())
+      let data: string
+      if (encoding === 'base64') {
+        let binary = ''
+        for (let i = 0; i < bytes.length; i += 0x8000) binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000))
+        data = btoa(binary)
+      } else data = new TextDecoder().decode(bytes)
+      return { path, encoding, data, stat: await stat(), etag: attachment.hash }
+    },
+    write: async () => { throw new Error('Save this attachment to Space files to edit it.') },
+    open: async () => {
+      const result = await download()
+      return result.saved && result.path ? window.ipc.invoke('shell:openPath', { path: result.path }) : {}
+    },
+    exportCopy: async () => { const result = await download(); return { saved: result.saved, dest: result.path } },
+    loadSheet: (args) => window.ipc.invoke('spreadsheet:load', { ...args, attachment }),
+    findCells: (args) => window.ipc.invoke('spreadsheet:find', { ...args, attachment }),
+  }
+}

--- a/apps/x/apps/renderer/src/lib/spaces-selection.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-selection.ts
@@ -9,6 +9,8 @@ export type RailSelection =
     | { kind: 'thread'; rootMessageId: string }
     /** `fromThreadRootId` = opened from a thread (an artifact link) — the file view shows a crumb back to it. */
     | { kind: 'file'; path: string; fromThreadRootId?: string }
+    /** Original message blob URL, including its display name. */
+    | { kind: 'attachment'; path: string; fromThreadRootId?: string }
     /** A shared board, full-bleed. `path` is its asset path (whiteboards/<name>.excalidraw). */
     | { kind: 'whiteboard'; path: string }
 
@@ -16,6 +18,7 @@ export type RailSelection =
 export function railKey(sel: RailSelection | undefined): string {
     if (!sel || sel.kind === 'general') return 'general'
     if (sel.kind === 'thread') return `thread:${sel.rootMessageId}`
+    if (sel.kind === 'attachment') return `attachment:${sel.path}`
     if (sel.kind === 'whiteboard') return `whiteboard:${sel.path}`
     return `file:${sel.path}`
 }

--- a/apps/x/packages/core/src/spaces/document-file.ts
+++ b/apps/x/packages/core/src/spaces/document-file.ts
@@ -12,3 +12,9 @@ export async function materializeDocument(orgId: string, spaceId: string, assetP
     const hash = createHash('sha256').update(bytes).digest('hex');
     return writeBlobFile(hash, path.basename(assetPath), bytes);
 }
+
+/** Message attachments need no asset entry to use the same document parsers. */
+export async function materializeAttachment(orgId: string, spaceId: string, hash: string, name: string): Promise<string> {
+    const { bytes } = await getBlob(orgId, spaceId, hash);
+    return writeBlobFile(hash, path.basename(name), bytes);
+}

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -2457,6 +2457,7 @@ export const ipcSchemas = {
     req: z.object({
       path: z.string(),
       space: z.object({ orgId: z.string(), spaceId: z.string(), version: z.number().int().min(1) }).optional(),
+      attachment: z.object({ orgId: z.string(), spaceId: z.string(), hash: z.string().regex(/^[a-f0-9]{64}$/) }).optional(),
       sheet: z.string().optional(),
       offset: z.number().int().min(0),
       limit: z.number().int().min(1).max(1000),
@@ -2486,6 +2487,7 @@ export const ipcSchemas = {
     req: z.object({
       path: z.string(),
       space: z.object({ orgId: z.string(), spaceId: z.string(), version: z.number().int().min(1) }).optional(),
+      attachment: z.object({ orgId: z.string(), spaceId: z.string(), hash: z.string().regex(/^[a-f0-9]{64}$/) }).optional(),
       sheet: z.string().optional(),
       query: z.string(),
       maxMatches: z.number().int().min(1).max(5000).optional(),


### PR DESCRIPTION
Space message attachments now open in the existing resizable document panel, keeping the conversation alongside the preview. Users can save attachments to Space files and continue into the existing file viewing/editing experience. Message links keep pointing to their original content.

- Reuse the shared Word, PowerPoint, spreadsheet, HTML, PDF, and media viewers for attachments; Word and PowerPoint attachment previews are read-only.
- Put Upload files first and default uploads to Space files, with optional folder selection.
- Add inline Keep both / Replace / Cancel choices to direct uploads and attachment saves. Keep both chooses an available numbered filename; Replace preserves history and checks the approved version. Concurrent changes require another decision, and errors remain visible inline for retry.

Validation: targeted attachment, document-source, and PowerPoint tests passed during implementation; the final duplicate-resolution and message-preview run passed all 22 tests. Renderer and main typechecks, shared compilation, and the core production build passed. Diff checked against main; no dependency installation artifacts are included.
