### PR TITLE
Fix Space image previews and simplify file deletion

### DIFF
--- a/apps/x/apps/renderer/src/components/image-lightbox.tsx
+++ b/apps/x/apps/renderer/src/components/image-lightbox.tsx
@@ -178,7 +178,7 @@ export function ImageLightbox({
               if (event.key === 'ArrowRight' && navigation.index < navigation.count - 1) navigation.onNext()
             }
           }}
-          className="fixed inset-0 z-50 flex items-center justify-center outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+          className="titlebar-no-drag fixed inset-0 z-50 flex items-center justify-center outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
         >
           <DialogPrimitive.Title className="sr-only">{name}</DialogPrimitive.Title>
           <ZoomableImage
@@ -213,7 +213,8 @@ export function ImageLightbox({
               </div>
             </>
           )}
-          <div className="absolute right-4 top-4 flex items-center gap-1.5">
+          {/* Keep controls below Electron's 40px titlebar hit region. */}
+          <div className="titlebar-no-drag absolute right-4 top-14 flex items-center gap-1.5">
             {actions && <div className="flex items-center gap-3 text-xs" onClick={(event) => event.stopPropagation()}>{actions}</div>}
             {onDownload && <ImageOverlayButton label={`Download ${name}`} onClick={onDownload}>
               <Download className="h-3.5 w-3.5" />

--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -103,7 +103,7 @@ export function FileTree({ orgId, spaceId, entries, draftFolders = [], selectedP
 
     // Row actions. Rename/move edits the FULL path inline (folders are key
     // prefixes — typing a new prefix moves the file); the server's change
-    // event refreshes every pane. Delete asks for an optional reason.
+    // event refreshes every pane. Deleting confirms the move to Trash.
     const [renaming, setRenaming] = useState<{ path: string; value: string } | null>(null)
     const [deleting, setDeleting] = useState<spaces.SpacesAssetEntry | null>(null)
     const commitMove = async (entry: spaces.SpacesAssetEntry, toPath: string) => {
@@ -1018,14 +1018,12 @@ export function DeleteAssetDialog({ orgId, spaceId, entry, onClose, onDeleted }:
     onClose: () => void
     onDeleted?: () => void
 }) {
-    const [reason, setReason] = useState('')
     const [busy, setBusy] = useState(false)
     const confirm = async () => {
         setBusy(true)
         try {
             const res = await window.ipc.invoke('spaces:deleteAsset', {
                 orgId, spaceId, path: entry.path, baseVersion: entry.version,
-                ...(reason.trim() ? { reason: reason.trim() } : {}),
             })
             if (res.outcome === 'conflict') {
                 toast(`${entry.path} changed meanwhile — review and try again`, 'error')
@@ -1044,24 +1042,16 @@ export function DeleteAssetDialog({ orgId, spaceId, entry, onClose, onDeleted }:
         <Dialog open onOpenChange={(open) => !open && !busy && onClose()}>
             <DialogContent className="max-w-sm">
                 <DialogHeader>
-                    <DialogTitle className="text-sm">Delete <code className="font-mono text-[12px]">{entry.path}</code>?</DialogTitle>
+                    <DialogTitle className="break-words text-sm">Move “{entry.path}” to Trash?</DialogTitle>
                 </DialogHeader>
                 <div className="space-y-3">
                     <p className="text-xs text-muted-foreground">
-                        It moves to Trash — history stays, and anyone can restore it. The feed will show who deleted it and why.
+                        This removes the file from Space files for everyone. You can restore it from Trash.
                     </p>
-                    <Input
-                        value={reason}
-                        placeholder="Why? (optional — shows in the feed and history)"
-                        className="h-7 text-xs"
-                        disabled={busy}
-                        onChange={(e) => setReason(e.target.value)}
-                        onKeyDown={(e) => { if (e.key === 'Enter') void confirm() }}
-                    />
                     <div className="flex justify-end gap-2">
                         <Button variant="ghost" size="sm" className="h-7 text-xs" disabled={busy} onClick={onClose}>Cancel</Button>
                         <Button variant="destructive" size="sm" className="h-7 text-xs" disabled={busy} onClick={() => void confirm()}>
-                            {busy ? <Loader2 className="size-3 mr-1 animate-spin" /> : <Trash2 className="size-3 mr-1" />} Delete
+                            {busy ? <Loader2 className="size-3 mr-1 animate-spin" /> : <Trash2 className="size-3 mr-1" />} Move to Trash
                         </Button>
                     </div>
                 </div>

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { AttachmentColumn, SpaceMarkdown, SpaceNavProvider, SpaceRefsProvider } from './space-markdown'
+import { AttachmentColumn, BlobImage, SpaceMarkdown, SpaceNavProvider, SpaceRefsProvider } from './space-markdown'
 import { blobWireUrl } from '@/lib/spaces-presentation'
 
 const refs = { orgId: 'org', spaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', orgAddress: 'spaces.example.com' }
@@ -9,7 +9,7 @@ const secondHash = 'b'.repeat(64)
 const body = `Photos\n\n![First](${blobWireUrl(refs, firstHash, 'first.png')})\n\n![Second](${blobWireUrl(refs, secondHash, 'second.png')})\n\n![Third](https://example.com/third.png)`
 const invoke = vi.fn().mockResolvedValue({ saved: true })
 
-beforeEach(() => { Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } }); invoke.mockClear() })
+beforeEach(() => { Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } }); invoke.mockReset().mockResolvedValue({ saved: true }) })
 afterEach(cleanup)
 
 describe('Spaces message image carousel', () => {
@@ -121,5 +121,50 @@ describe('Space file attachments', () => {
         fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
         expect(await screen.findByRole('button', { name: 'Keep both' })).toBeEnabled()
         expect(screen.getByRole('textbox', { name: 'File name' })).toHaveValue('notes.txt')
+    })
+})
+
+
+describe.each(['carousel', 'standalone'] as const)('%s image preview actions', (kind) => {
+    const src = `app://space-blob/org/${refs.spaceId}/${secondHash}?name=second.png`
+    async function openPreview() {
+        if (kind === 'carousel') {
+            render(<SpaceRefsProvider refs={refs}><SpaceNavProvider onOpenFile={vi.fn()} onOpenAttachment={vi.fn()}><SpaceMarkdown body={body} /></SpaceNavProvider></SpaceRefsProvider>)
+        } else render(<BlobImage src={src} alt="Second" />)
+        fireEvent.click(await screen.findByRole('button', { name: 'Preview Second' }))
+        return screen.getByRole('dialog')
+    }
+
+    it('opens the save form and saves the selected image without dismissing the preview', async () => {
+        invoke.mockImplementation(async (channel) => channel === 'spaces:listAssets' ? { entries: [] } : { outcome: 'applied' })
+        const lightbox = await openPreview()
+        expect(lightbox).toHaveClass('titlebar-no-drag')
+        const action = within(lightbox).getByRole('button', { name: 'Save to space files' })
+        expect(action.parentElement?.parentElement).toHaveClass('titlebar-no-drag', 'top-14')
+        fireEvent.click(action)
+        const form = screen.getByRole('dialog', { name: 'Save to space files' })
+        const input = within(form).getByRole('textbox', { name: 'File name' })
+        expect(input).toHaveValue('second.png')
+        fireEvent.keyDown(input, { key: 'ArrowLeft' })
+        fireEvent.change(input, { target: { value: 'saved-photo.png' } })
+        fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+        await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Save to space files' })).not.toBeInTheDocument())
+        expect(invoke).toHaveBeenCalledWith('spaces:proposeChange', {
+            orgId: refs.orgId, spaceId: refs.spaceId,
+            input: { assetPath: 'saved-photo.png', baseVersion: 0, blob: secondHash, reason: 'saved from chat' },
+        })
+        expect(within(screen.getByRole('dialog')).getByRole('img', { name: 'Second' })).toBeVisible()
+    })
+
+    it('shows download failures and retries the selected image', async () => {
+        invoke.mockRejectedValueOnce(new Error('Could not fetch image')).mockResolvedValue({ saved: true })
+        const lightbox = await openPreview()
+        fireEvent.click(within(lightbox).getByRole('button', { name: 'Download' }))
+        expect(await within(lightbox).findByRole('alert')).toHaveTextContent('Could not fetch image')
+        fireEvent.click(within(lightbox).getByRole('button', { name: 'Download' }))
+        await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
+        expect(invoke).toHaveBeenLastCalledWith('spaces:saveBlob', { orgId: refs.orgId, spaceId: refs.spaceId, hash: secondHash, suggestedName: 'second.png' })
+        expect(within(lightbox).queryByRole('alert')).not.toBeInTheDocument()
+        expect(lightbox).toBeInTheDocument()
     })
 })

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
@@ -14,10 +14,11 @@ afterEach(cleanup)
 
 describe('Spaces message image carousel', () => {
     it('uses actual markdown tiles, opens the clicked image, and navigates only that message', async () => {
-        render(<SpaceRefsProvider refs={refs}>
+        const openAttachment = vi.fn()
+        render(<SpaceRefsProvider refs={refs}><SpaceNavProvider onOpenFile={vi.fn()} onOpenAttachment={openAttachment}>
             <SpaceMarkdown body={body} />
             <SpaceMarkdown body="![Other](https://example.com/other.png)" />
-        </SpaceRefsProvider>)
+        </SpaceNavProvider></SpaceRefsProvider>)
         fireEvent.click(await screen.findByRole('button', { name: 'Preview Second' }))
         const dialog = screen.getByRole('dialog')
         expect(within(dialog).getByRole('img', { name: 'Second' })).toBeInTheDocument()
@@ -41,6 +42,7 @@ describe('Spaces message image carousel', () => {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
         fireEvent.keyDown(screen.getByRole('button', { name: 'Preview Second' }), { key: 'Enter' })
         expect(screen.getByRole('status')).toHaveTextContent('2 of 3')
+        expect(openAttachment).not.toHaveBeenCalled()
     })
 
     it('includes pasted image URLs, skips files and failed images, and handles one image', async () => {
@@ -78,14 +80,18 @@ describe('Space file attachments', () => {
         expect(invoke).not.toHaveBeenCalled()
     })
 
-    it('routes uploaded images to the same panel when navigation is available', async () => {
+    it('keeps a single uploaded image in the lightbox with save and download actions', async () => {
         const openAttachment = vi.fn()
         render(<SpaceRefsProvider refs={refs}><SpaceNavProvider onOpenFile={vi.fn()} onOpenAttachment={openAttachment}>
             <SpaceMarkdown body={`![Photo](${blobWireUrl(refs, firstHash, 'photo.png')})`} />
         </SpaceNavProvider></SpaceRefsProvider>)
         fireEvent.click(await screen.findByRole('button', { name: 'Preview Photo' }))
-        expect(openAttachment).toHaveBeenCalledWith(expect.stringContaining(firstHash), 'photo.png')
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByRole('img', { name: 'Photo' })).toBeVisible()
+        expect(within(dialog).getByRole('button', { name: 'Download' })).toBeEnabled()
+        expect(within(dialog).getByRole('button', { name: 'Save to space files' })).toBeEnabled()
+        expect(screen.queryByRole('button', { name: 'Next image' })).not.toBeInTheDocument()
+        expect(openAttachment).not.toHaveBeenCalled()
     })
 
     it('previews in the panel, closes it, and hands saved files to the existing file view', async () => {

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -277,12 +277,10 @@ function SaveToSpaceDialog({ src, suggestedName, onSaved, onClose }: { src: stri
 }
 
 export function BlobImage({ src, alt }: { src: string; alt: string }) {
-    const openAttachment = useContext(AttachmentNavContext)
     const imageRef = useRef<HTMLImageElement>(null)
     const openGallery = useContext(MessageImageGalleryContext)
     const preview = () => {
-        if (openAttachment) openAttachment(src, new URL(src).searchParams.get('name') || alt || 'Image')
-        else if (openGallery && imageRef.current) openGallery(imageRef.current)
+        if (openGallery && imageRef.current) openGallery(imageRef.current)
         else setOpen(true)
     }
     const [open, setOpen] = useState(false)

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -143,11 +143,13 @@ function MessageImageGallery({ children }: { children: ReactNode }) {
 /** Source-specific actions always follow the currently selected image. */
 function SpaceImageActions({ src }: { src: string }) {
     const [saving, setSaving] = useState(false)
+    const [error, setError] = useState<string | null>(null)
     const [saveOpen, setSaveOpen] = useState(false)
     const parsed = parseBlobAppUrl(src)
     const save = async () => {
         if (saving) return
         setSaving(true)
+        setError(null)
         try {
             const res = parsed
                 ? await window.ipc.invoke('spaces:saveBlob', {
@@ -157,7 +159,7 @@ function SpaceImageActions({ src }: { src: string }) {
                 : await window.ipc.invoke('spaces:saveImageUrl', { url: src })
             if (res.saved) toast('Saved', 'success')
         } catch (err) {
-            toast(err instanceof Error ? err.message : 'Could not download', 'error')
+            setError(err instanceof Error ? err.message : 'Could not download')
         } finally {
             setSaving(false)
         }
@@ -172,6 +174,7 @@ function SpaceImageActions({ src }: { src: string }) {
             ) : (
                 <a href={src} target="_blank" rel="noreferrer" className="text-white/80 hover:text-white hover:underline">Open original</a>
             )}
+            {error && <p role="alert" className="absolute right-0 top-full mt-2 w-72 rounded-md bg-background p-3 text-xs text-destructive shadow-lg">{error}</p>}
             {saveOpen && <SaveToSpaceDialog src={src} onClose={() => setSaveOpen(false)} />}
         </>
     )
@@ -362,16 +365,7 @@ export function BlobImage({ src, alt }: { src: string; alt: string }) {
             {parsed && <button type="button" title="Save to space files" aria-label={`Save ${alt || 'image'} to space files`} onClick={() => setSaveOpen(true)} className="absolute bottom-3 right-3 rounded-md border border-border bg-background p-1.5 text-foreground shadow-sm hover:bg-accent"><FilePlus2 className="size-3.5" /></button>}
             </span>
             <ImageLightbox src={src} alt={alt} open={open} onOpenChange={setOpen}>
-                {parsed && (
-                    <>
-                        <button type="button" onClick={() => void save()} className="text-white/80 hover:text-white hover:underline">
-                            {saving ? 'Saving…' : 'Download'}
-                        </button>
-                        <button type="button" onClick={() => setSaveOpen(true)} className="text-white/80 hover:text-white hover:underline">
-                            Save to space files
-                        </button>
-                    </>
-                )}
+                <SpaceImageActions src={src} />
             </ImageLightbox>
             {saveOpen && <SaveToSpaceDialog src={src} onClose={() => setSaveOpen(false)} />}
         </>


### PR DESCRIPTION
Image attachments in Space messages were opening in the document side panel, bypassing the existing lightbox and per-message carousel. Restore gallery routing for images while other attachments continue to open in the document side panel.

The lightbox controls also overlapped Electron's 40px draggable titlebar hit region. Mark the lightbox as non-draggable and place its action controls below the titlebar so Download and Save to space files receive clicks. Share these actions between carousel and standalone previews and display download failures inline for retry.

Simplify the file deletion confirmation by removing the optional reason field and its request payload. Use “Move to Trash” for the title and action, and explain that the file is removed for everyone and can be restored from Trash.

Validation: all 10 space-markdown tests pass, covering carousel navigation, saving the selected image through the nested form, and download failure/retry in carousel and standalone previews. Renderer TypeScript check passes after the deletion-dialog change; git diff --check passes. Native Electron hit testing could not be verified in the available running app session.
