### PR TITLE
Refine Spaces navigation and server switching

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { DocumentFileViewer } from '@/components/document-file-viewer'
+import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
 import * as React from 'react'
 import { Activity, useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
 import { workspace, quickAskShortcut, pttKey, type ipc } from '@x/shared';
@@ -37,7 +38,7 @@ import { BgTasksView } from '@/components/bg-tasks-view';
 import { AppsView } from '@/components/apps/apps-view';
 import { SpacesView, type SpaceSelection } from '@/components/spaces-view';
 import { railKey, type RailSelection } from '@/lib/spaces-selection';
-import { findSpace, useSpacesOrgs } from '@/hooks/use-spaces';
+import { findSpace, getSpacesOrgs, refreshSpacesOrgs, useSpacesOrgs } from '@/hooks/use-spaces';
 import { spaceDisplayName } from '@/lib/spaces-direct';
 import { EmailView } from '@/components/email-view';
 import { WorkspaceView } from '@/components/workspace-view';
@@ -4783,7 +4784,7 @@ function App() {
 
   // Header title for the current view (the tab strip is gone — the header
   // names where you are instead).
-  const { orgs: spacesOrgs } = useSpacesOrgs()
+  const { orgs: spacesOrgs, loading: spacesLoading } = useSpacesOrgs()
   const currentViewTitle = React.useMemo(() => {
     switch (currentViewState.type) {
       case 'home': return 'Home'
@@ -5313,7 +5314,7 @@ function App() {
         // through here. With the flag off, closeAllSections has already run,
         // so the app lands on the default full-screen chat.
         if (!SPACES_ENABLED) return
-        if (view.orgId && view.spaceId) setSpaceSelection({ orgId: view.orgId, spaceId: view.spaceId })
+        if (view.orgId) setSpaceSelection({ orgId: view.orgId, spaceId: view.spaceId ?? '' })
         setRailSelection(view.rail ?? { kind: 'general' })
         // Spaces carries its own conversation surface, so entering it
         // collapses the assistant chat pane by default; in-space navigation
@@ -5403,6 +5404,12 @@ function App() {
   const openSpace = useCallback((orgId: string, spaceId: string) => {
     void navigateToView({ type: 'spaces', orgId, spaceId })
   }, [navigateToView])
+
+  const openSpaces = useCallback(async () => {
+    if (spacesLoading) await refreshSpacesOrgs()
+    const target = resolveSpacesLocation(getSpacesOrgs(), spaceSelection ?? readLastSpace())
+    void navigateToView(target ? { type: 'spaces', ...target } : { type: 'spaces' })
+  }, [spacesLoading, spaceSelection, navigateToView])
 
   const openMeetingsView = useCallback(() => {
     void navigateToView({ type: 'meetings' })
@@ -7037,6 +7044,7 @@ function App() {
     onOpenApps: openAppsGrid,
     onOpenApp: (folder: string) => { setAppInitialId(folder); setAppIdVersion((v) => v + 1); openAppsView() },
     onOpenSpace: openSpace,
+    onOpenSpaces: () => { void openSpaces() },
     activeSpace: isSpacesOpen ? spaceSelection : null,
     recentRuns: chatRuns,
     onOpenRun: openAssistantRun,

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7045,7 +7045,7 @@ function App() {
     onOpenApp: (folder: string) => { setAppInitialId(folder); setAppIdVersion((v) => v + 1); openAppsView() },
     onOpenSpace: openSpace,
     onOpenSpaces: () => { void openSpaces() },
-    activeSpace: isSpacesOpen ? spaceSelection : null,
+    activeSpace: spaceSelection,
     recentRuns: chatRuns,
     onOpenRun: openAssistantRun,
     onRenameRun: (rid: string, title: string) => {

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
+
 import * as React from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
@@ -101,7 +103,7 @@ const RAIL_ICON_PX = 18
 
 /** The most recently opened space — App writes it on every space navigation;
     the ⌥Tab switcher lands there instead of opening the flyout. */
-export const LAST_SPACE_STORAGE_KEY = 'x:last-space'
+export { LAST_SPACE_STORAGE_KEY } from '@/lib/spaces-navigation'
 
 /** Where flyout panels (Chats / Spaces) sit, just right of the rail. */
 const DOCK_FLYOUT_LEFT_PX = DOCK_GUTTER_PX + 8
@@ -147,6 +149,7 @@ export type DockSidebarProps = {
   onOpenApp?: (folder: string) => void
   /** Open one space (org + space) in the Spaces view. */
   onOpenSpace?: (orgId: string, spaceId: string) => void
+  onOpenSpaces?: () => void
   /** The space currently open, for highlighting its flyout row. */
   activeSpace?: SpaceSelection
   recentRuns?: { id: string; title?: string; createdAt: string; modifiedAt?: string }[]
@@ -546,6 +549,7 @@ export function DockSidebar({
   onOpenApps,
   onOpenApp,
   onOpenSpace,
+  onOpenSpaces,
   activeSpace = null,
   recentRuns = [],
   onOpenRun,
@@ -888,22 +892,12 @@ export function DockSidebar({
   // (persisted by App), falling back to the first space anywhere; only when
   // there is none at all does it fall back to the flyout.
   const openLastSpace = useCallback((): boolean => {
-    let last: { orgId: string; spaceId: string } | null = null
-    try {
-      last = JSON.parse(window.localStorage.getItem(LAST_SPACE_STORAGE_KEY) ?? 'null') as { orgId: string; spaceId: string } | null
-    } catch { /* ignore */ }
-    const isValid = last != null
-      && orgs.some((o) => o.id === last.orgId && (o.spaces.some((s) => s.id === last.spaceId) || o.directs.some((s) => s.id === last.spaceId)))
-    const target = isValid && last
-      ? last
-      : (() => {
-        const org = orgs.find((o) => o.spaces.length > 0)
-        return org ? { orgId: org.id, spaceId: org.spaces[0].id } : null
-      })()
+    if (onOpenSpaces) { onOpenSpaces(); return true }
+    const target = resolveSpacesLocation(orgs, readLastSpace())
     if (!target) return false
     onOpenSpace?.(target.orgId, target.spaceId)
     return true
-  }, [orgs, onOpenSpace])
+  }, [orgs, onOpenSpace, onOpenSpaces])
 
   // ----- derived: meetings sublabel -----
   const previewEmail = emailThreads[0]

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -458,6 +458,8 @@ export function SidebarContentPanel({
   onOpenApps,
   onOpenApp,
   onOpenSpaces,
+  onOpenSpace,
+  activeSpace = null,
   recentRuns = [],
   onOpenRun,
   onRenameRun,
@@ -869,7 +871,7 @@ export function SidebarContentPanel({
         {/* Spaces returns to the last active server and space. */}
         {SPACES_ENABLED && (
           <>
-            <SpacesSidebarSection active={activeNav === 'spaces'} onOpenSpaces={() => onOpenSpaces?.()} />
+            <SpacesSidebarSection active={activeNav === 'spaces'} activeSpace={activeSpace} onOpenSpaces={() => onOpenSpaces?.()} onOpenSpace={(orgId, spaceId) => onOpenSpace?.(orgId, spaceId)} />
             <div className="mx-3 my-2 border-t border-border" />
           </>
         )}

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -197,6 +197,7 @@ type SidebarContentPanelProps = {
   onOpenApp?: (folder: string) => void
   /** Open one space (org + space) in the Spaces view. */
   onOpenSpace?: (orgId: string, spaceId: string) => void
+  onOpenSpaces?: () => void
   /** The space currently open, for highlighting its sidebar row. */
   activeSpace?: SpaceSelection
   onOpenAgent?: (slug: string) => void
@@ -456,8 +457,7 @@ export function SidebarContentPanel({
   onOpenBgTasks,
   onOpenApps,
   onOpenApp,
-  onOpenSpace,
-  activeSpace = null,
+  onOpenSpaces,
   recentRuns = [],
   onOpenRun,
   onRenameRun,
@@ -866,10 +866,10 @@ export function SidebarContentPanel({
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {/* Spaces — orgs and their spaces, with unread counts */}
+        {/* Spaces returns to the last active server and space. */}
         {SPACES_ENABLED && (
           <>
-            <SpacesSidebarSection activeSpace={activeSpace} onOpenSpace={(orgId, spaceId) => onOpenSpace?.(orgId, spaceId)} />
+            <SpacesSidebarSection active={activeNav === 'spaces'} onOpenSpaces={() => onOpenSpaces?.()} />
             <div className="mx-3 my-2 border-t border-border" />
           </>
         )}

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
@@ -29,13 +29,14 @@ beforeEach(() => { vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false, ad
 afterEach(() => { cleanup(); sessionStorage.clear(); vi.unstubAllGlobals() })
 
 describe('server and space navigation', () => {
-    it('shows only servers in the main sidebar and opens their first space', () => {
-        const onOpenSpace = vi.fn()
-        render(<SpacesSidebarSection activeSpace={null} onOpenSpace={onOpenSpace} />)
+    it('shows one Spaces entry and invokes the return-to-Spaces action', () => {
+        const onOpenSpaces = vi.fn()
+        render(<SidebarProvider><SpacesSidebarSection active={false} onOpenSpaces={onOpenSpaces} /></SidebarProvider>)
+        expect(screen.queryByText('Our server')).toBeNull()
         expect(screen.queryByText('main')).toBeNull()
         expect(screen.queryByText('Direct messages')).toBeNull()
-        fireEvent.click(screen.getByText('Our server'))
-        expect(onOpenSpace).toHaveBeenCalledWith('server', 'main')
+        fireEvent.click(screen.getByRole('button', { name: 'Spaces' }))
+        expect(onOpenSpaces).toHaveBeenCalledTimes(1)
     })
     it('nests three recent discussions, expands and collapses them, and folds DMs', () => {
         const onOpenDiscussion = vi.fn()
@@ -61,11 +62,10 @@ describe('server and space navigation', () => {
 })
 
 describe('server removal menus', () => {
-    it.each(['sidebar', 'rail'])('%s can cancel removal and then reopen and confirm', async (surface) => {
+    it('can cancel removal and then reopen and confirm from the rail', async () => {
         const invoke = vi.fn().mockResolvedValue({})
         vi.stubGlobal('ipc', { invoke })
-        if (surface === 'sidebar') render(<SpacesSidebarSection activeSpace={null} onOpenSpace={vi.fn()} />)
-        else render(<ServerOptionsMenu org={org} showArchived={false} onToggleArchived={vi.fn()} onMenuOpenChange={vi.fn()} />)
+        render(<ServerOptionsMenu org={org} showArchived={false} onToggleArchived={vi.fn()} onMenuOpenChange={vi.fn()} />)
         const openMenu = () => fireEvent.keyDown(screen.getByRole('button', { name: 'Server options' }), { key: 'Enter' })
         openMenu()
         expect(screen.queryByRole('menuitem', { name: 'New message' })).toBeNull()

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen, within, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpacesSidebarSection, ServerSpaceNavigation } from './spaces-sidebar-section'
+import { ServerOptionsMenu } from './spaces/server-options-menu'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+
+const { org, topics } = vi.hoisted(() => ({
+    org: {
+        id: 'server', name: 'Our server', memberId: 'me', directLabels: {},
+        spaces: [{ id: 'main', name: 'main' }, { id: 'founders', name: 'founders' }],
+        directs: Array.from({ length: 5 }, (_, i) => ({ id: `dm${i}`, name: `Person ${i}`, createdAt: `2026-09-0${i + 1}` })),
+    },
+    topics: [{ id: 'archived', rootMessageId: 'archived', title: 'Archived discussion', lastActivityAt: '2026-09-05', archived: true }, ...Array.from({ length: 4 }, (_, i) => ({ id: `topic${i}`, rootMessageId: `root${i}`, title: `Discussion ${i}`, lastActivityAt: `2026-09-0${i + 1}` }))],
+}))
+vi.mock('@/hooks/use-spaces', () => ({ useSpacesOrgs: () => ({ orgs: [org], loading: false, refresh: vi.fn() }), useSpaceFeed: () => ({ topics, loaded: true }), openSelfDirect: vi.fn() }))
+vi.mock('@/hooks/use-space-chat', () => ({ useSpacesUnreadCounts: () => new Map(), prefetchStream: vi.fn(), spaceLastActivityAt: () => null }))
+vi.mock('@/hooks/use-space-members', () => ({ prefetchMembers: vi.fn(), useSelfDisplayName: () => 'Me' }))
+vi.mock('@/components/spaces-view', () => ({ AddOrgDialog: () => null, OrgMonogram: () => null }))
+vi.mock('@/components/spaces/atoms', () => ({ MemberAvatar: () => null }))
+vi.mock('@/components/spaces/new-direct-dialog', () => ({ NewDirectDialog: () => null }))
+vi.mock('@/lib/spaces-direct', () => ({
+    directAvatarId: () => '', isSelfDirect: () => false, isSelfDirectUnsupported: () => false,
+    markSelfDirectUnsupported: vi.fn(), selfDirectFailureMessage: () => '', selfDirectRefused: () => false,
+    spaceDisplayName: (_org: unknown, dm: { name: string }) => dm.name,
+}))
+beforeEach(() => { vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }))) })
+afterEach(() => { cleanup(); sessionStorage.clear(); vi.unstubAllGlobals() })
+
+describe('server and space navigation', () => {
+    it('shows only servers in the main sidebar and opens their first space', () => {
+        const onOpenSpace = vi.fn()
+        render(<SpacesSidebarSection activeSpace={null} onOpenSpace={onOpenSpace} />)
+        expect(screen.queryByText('main')).toBeNull()
+        expect(screen.queryByText('Direct messages')).toBeNull()
+        fireEvent.click(screen.getByText('Our server'))
+        expect(onOpenSpace).toHaveBeenCalledWith('server', 'main')
+    })
+    it('nests three recent discussions, expands and collapses them, and folds DMs', () => {
+        const onOpenDiscussion = vi.fn()
+        render(<SidebarProvider><ServerSpaceNavigation org={org as unknown as OrgWithSpaces} spaceId="main" onOpenSpace={vi.fn()}
+            onOpenDiscussion={onOpenDiscussion} activeDiscussionCount={0} renderActiveDiscussions={() => null} /></SidebarProvider>)
+        const founders = screen.getByText('founders').closest('li')!
+        expect(within(founders).queryByText('Discussion 3')).toBeNull()
+        expect(screen.queryByLabelText('Expand #main')).toBeNull()
+        expect(screen.queryByText('No discussions yet')).toBeNull()
+        fireEvent.click(screen.getByLabelText('Expand #founders'))
+        expect(within(founders).queryByText('Discussion 0')).toBeNull()
+        fireEvent.click(within(founders).getByText('View all'))
+        fireEvent.click(within(founders).getByText('Discussion 0'))
+        expect(onOpenDiscussion).toHaveBeenCalledWith('founders', { kind: 'thread', rootMessageId: 'root0' })
+        fireEvent.click(screen.getByLabelText('Collapse #founders'))
+        expect(within(founders).queryByText('Discussion 3')).toBeNull()
+        expect(screen.queryByText('Person 0')).toBeNull()
+        fireEvent.click(screen.getByText('View all'))
+        expect(screen.getByText('Person 0')).toBeTruthy()
+        fireEvent.click(screen.getByText('Direct messages'))
+        expect(screen.queryByText('Person 0')).toBeNull()
+    })
+})
+
+describe('server removal menus', () => {
+    it.each(['sidebar', 'rail'])('%s can cancel removal and then reopen and confirm', async (surface) => {
+        const invoke = vi.fn().mockResolvedValue({})
+        vi.stubGlobal('ipc', { invoke })
+        if (surface === 'sidebar') render(<SpacesSidebarSection activeSpace={null} onOpenSpace={vi.fn()} />)
+        else render(<ServerOptionsMenu org={org} showArchived={false} onToggleArchived={vi.fn()} onMenuOpenChange={vi.fn()} />)
+        const openMenu = () => fireEvent.keyDown(screen.getByRole('button', { name: 'Server options' }), { key: 'Enter' })
+        openMenu()
+        expect(screen.queryByRole('menuitem', { name: 'New message' })).toBeNull()
+        expect(screen.queryByRole('menuitem', { name: 'New space' })).toBeNull()
+        expect(screen.queryByRole('menuitem', { name: 'Collapse spaces and DMs' })).toBeNull()
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Remove server' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+        expect(screen.queryByRole('alertdialog')).toBeNull()
+        expect(invoke).not.toHaveBeenCalled()
+        openMenu()
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Remove server' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+        await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+        expect(invoke).toHaveBeenCalledExactlyOnceWith('spaces:removeOrg', { orgId: 'server' })
+    })
+})
+
+it('shows archived discussions alongside live discussions, then hides only archived discussions', () => {
+    function Navigation() {
+        const [showArchived, setShowArchived] = useState(false)
+        return <SidebarProvider>
+            <ServerOptionsMenu org={org} showArchived={showArchived} onToggleArchived={() => setShowArchived((value) => !value)} onMenuOpenChange={() => {}} />
+            <ServerSpaceNavigation org={org as unknown as OrgWithSpaces} spaceId="main" onOpenSpace={vi.fn()}
+                onOpenDiscussion={vi.fn()} activeDiscussionCount={0} renderActiveDiscussions={() => null} showArchived={showArchived} />
+        </SidebarProvider>
+    }
+    render(<Navigation />)
+    fireEvent.click(screen.getByLabelText('Expand #founders'))
+    const founders = screen.getByText('founders').closest('li')!
+    fireEvent.click(within(founders).getByText('View all'))
+    expect(screen.queryByText('Archived discussion')).toBeNull()
+    const openMenu = () => fireEvent.keyDown(screen.getByRole('button', { name: 'Server options' }), { key: 'Enter' })
+    openMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Show Archived' }))
+    expect(screen.getByText('Archived discussion')).toBeTruthy()
+    expect(screen.getByText('Discussion 0')).toBeTruthy()
+    openMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Hide archived' }))
+    expect(screen.queryByText('Archived discussion')).toBeNull()
+    expect(screen.getByText('Discussion 0')).toBeTruthy()
+})

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SpacesSidebarSection, ServerSpaceNavigation } from './spaces-sidebar-section'
 import { ServerOptionsMenu } from './spaces/server-options-menu'
 import { SidebarProvider } from '@/components/ui/sidebar'
-import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 
 const { org, topics } = vi.hoisted(() => ({
     org: {
@@ -14,11 +14,11 @@ const { org, topics } = vi.hoisted(() => ({
     },
     topics: [{ id: 'archived', rootMessageId: 'archived', title: 'Archived discussion', lastActivityAt: '2026-09-05', archived: true }, ...Array.from({ length: 4 }, (_, i) => ({ id: `topic${i}`, rootMessageId: `root${i}`, title: `Discussion ${i}`, lastActivityAt: `2026-09-0${i + 1}` }))],
 }))
-vi.mock('@/hooks/use-spaces', () => ({ useSpacesOrgs: () => ({ orgs: [org], loading: false, refresh: vi.fn() }), useSpaceFeed: () => ({ topics, loaded: true }), openSelfDirect: vi.fn() }))
+vi.mock('@/hooks/use-spaces', () => ({ useSpacesOrgs: vi.fn(() => ({ orgs: [org], loading: false, refresh: vi.fn() })), useSpaceFeed: () => ({ topics, loaded: true }), openSelfDirect: vi.fn() }))
 vi.mock('@/hooks/use-space-chat', () => ({ useSpacesUnreadCounts: () => new Map(), prefetchStream: vi.fn(), spaceLastActivityAt: () => null }))
 vi.mock('@/hooks/use-space-members', () => ({ prefetchMembers: vi.fn(), useSelfDisplayName: () => 'Me' }))
 vi.mock('@/components/spaces-view', () => ({ AddOrgDialog: () => null, OrgMonogram: () => null }))
-vi.mock('@/components/spaces/atoms', () => ({ MemberAvatar: () => null }))
+vi.mock('@/components/spaces/atoms', () => ({ MemberAvatar: () => null, AddOrgDialog: () => null }))
 vi.mock('@/components/spaces/new-direct-dialog', () => ({ NewDirectDialog: () => null }))
 vi.mock('@/lib/spaces-direct', () => ({
     directAvatarId: () => '', isSelfDirect: () => false, isSelfDirectUnsupported: () => false,
@@ -29,14 +29,27 @@ beforeEach(() => { vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false, ad
 afterEach(() => { cleanup(); sessionStorage.clear(); vi.unstubAllGlobals() })
 
 describe('server and space navigation', () => {
-    it('shows one Spaces entry and invokes the return-to-Spaces action', () => {
+    it('shows nested server names and preserves the current location when returning to Spaces', () => {
         const onOpenSpaces = vi.fn()
-        render(<SidebarProvider><SpacesSidebarSection active={false} onOpenSpaces={onOpenSpaces} /></SidebarProvider>)
-        expect(screen.queryByText('Our server')).toBeNull()
+        render(<SidebarProvider><SpacesSidebarSection active={false} activeSpace={{ orgId: org.id, spaceId: 'founders' }} onOpenSpaces={onOpenSpaces} onOpenSpace={vi.fn()} /></SidebarProvider>)
+        expect(screen.getByText('Our server')).toHaveClass('font-medium')
+        expect(screen.getByText('Our server').closest('button')?.querySelector('svg')).toBeNull()
         expect(screen.queryByText('main')).toBeNull()
         expect(screen.queryByText('Direct messages')).toBeNull()
         fireEvent.click(screen.getByRole('button', { name: 'Spaces' }))
         expect(onOpenSpaces).toHaveBeenCalledTimes(1)
+        fireEvent.click(screen.getByText('Our server'))
+        expect(onOpenSpaces).toHaveBeenCalledTimes(2)
+    })
+    it('navigates to a different server when its name is clicked', () => {
+        const other = { ...org, id: 'other', name: 'Other server', spaces: [{ id: 'welcome', name: 'welcome' }] }
+        vi.mocked(useSpacesOrgs).mockReturnValueOnce({ orgs: [org, other] as unknown as OrgWithSpaces[], loading: false, refresh: vi.fn() })
+        const onOpenSpace = vi.fn()
+        render(<SidebarProvider><SpacesSidebarSection active activeSpace={{ orgId: org.id, spaceId: 'founders' }}
+            onOpenSpaces={vi.fn()} onOpenSpace={onOpenSpace} /></SidebarProvider>)
+        expect(screen.getByText('Other server')).toHaveClass('font-normal')
+        fireEvent.click(screen.getByText('Other server'))
+        expect(onOpenSpace).toHaveBeenCalledWith('other', 'welcome')
     })
     it('nests three recent discussions, expands and collapses them, and folds DMs', () => {
         const onOpenDiscussion = vi.fn()

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -1,36 +1,27 @@
-import { useEffect, useMemo, useState } from 'react'
-import { ChevronRight, Hash, Loader2, MessagesSquare, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { ChevronRight, CornerDownRight, Hash, Loader2, MessagesSquare, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
+import { RemoveServerDialog } from '@/components/spaces/remove-server-dialog'
 import {
-    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
-    AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
-import {
-    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger,
+    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
     ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { Input } from '@/components/ui/input'
 import { AddOrgDialog, OrgMonogram, type SpaceSelection } from '@/components/spaces-view'
-import { openSelfDirect, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
+import { openSelfDirect, useSpaceFeed, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { prefetchStream, spaceLastActivityAt, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
 import { MemberAvatar } from '@/components/spaces/atoms'
 import { NewDirectDialog } from '@/components/spaces/new-direct-dialog'
 import { directAvatarId, isSelfDirect, isSelfDirectUnsupported, markSelfDirectUnsupported, selfDirectFailureMessage, selfDirectRefused, spaceDisplayName } from '@/lib/spaces-direct'
 import { prefetchMembers, useSelfDisplayName } from '@/hooks/use-space-members'
-import { bumpSpaceUse, readSpaceUse, spaceUseKey } from '@/lib/space-usage'
+import { bumpSpaceUse } from '@/lib/space-usage'
+import type { RailSelection } from '@/lib/spaces-selection'
 import { toast } from '@/lib/toast'
 
-/** The fold: how many spaces the section shows before "Show all". */
-const MAX_VISIBLE_SPACES = 5
-/** DMs fold too, by recency — the people you talk to stay in view. */
-const MAX_VISIBLE_DIRECTS = 5
-
-// The sidebar's SPACES section (design: "App shell scope planning"): every
-// org this install is signed into, its spaces underneath with unread counts,
-// and a Sign in chip on an org that can't be reached.
+const MAX_VISIBLE_DIRECTS = 3
 
 export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
     activeSpace: SpaceSelection
@@ -40,30 +31,6 @@ export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
     const unread = useSpacesUnreadCounts()
     const [expanded, setExpanded] = useState(true)
     const [addOrgOpen, setAddOrgOpen] = useState(false)
-    // Top-5 fold: the section shows the most-opened spaces; the rest sit
-    // behind "Show all" (Gmail's Spaces treatment). Per-session toggle.
-    const [showAll, setShowAll] = useState(false)
-    const totalSpaces = orgs.reduce((n, o) => n + o.spaces.length, 0)
-    const folded = !showAll && totalSpaces > MAX_VISIBLE_SPACES
-    let visibleSpaceKeys: ReadonlySet<string> | null = null
-    if (folded) {
-        const counts = readSpaceUse()
-        const ranked = orgs
-            .flatMap((o) => o.spaces.map((sp) => ({ key: spaceUseKey(o.id, sp.id), count: counts[spaceUseKey(o.id, sp.id)] ?? 0 })))
-            .sort((a, b) => b.count - a.count)
-            .slice(0, MAX_VISIBLE_SPACES)
-            .map((r) => r.key)
-        const keys = new Set(ranked)
-        // The open space never falls below the fold.
-        if (activeSpace) {
-            const activeKey = spaceUseKey(activeSpace.orgId, activeSpace.spaceId)
-            if (!keys.has(activeKey)) {
-                keys.delete(ranked[ranked.length - 1]!)
-                keys.add(activeKey)
-            }
-        }
-        visibleSpaceKeys = keys
-    }
     const openSpace = (orgId: string, spaceId: string) => {
         bumpSpaceUse(orgId, spaceId)
         onOpenSpace(orgId, spaceId)
@@ -114,19 +81,10 @@ export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
                                     org={org}
                                     activeSpace={activeSpace}
                                     unread={unread}
-                                    visibleSpaceKeys={visibleSpaceKeys}
                                     onOpenSpace={openSpace}
                                     onChanged={() => void refresh()}
                                 />
                             ))}
-                            {totalSpaces > MAX_VISIBLE_SPACES && (
-                                <SidebarMenuItem>
-                                    <SidebarMenuButton onClick={() => setShowAll((v) => !v)} className="pl-6 text-muted-foreground">
-                                        <ChevronRight className={cn('size-3.5 shrink-0 transition-transform', showAll && 'rotate-90')} />
-                                        <span className="flex-1 truncate">{showAll ? 'Show less' : `Show all ${totalSpaces} spaces`}</span>
-                                    </SidebarMenuButton>
-                                </SidebarMenuItem>
-                            )}
                         </SidebarMenu>
                     )
                 )}
@@ -136,22 +94,25 @@ export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
     )
 }
 
-function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onChanged }: {
+function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, renderDiscussions, showArchived = false, activeDiscussionCount }: {
     org: OrgWithSpaces
     activeSpace: SpaceSelection
     unread: Map<string, number>
-    /** Non-null while folded: only these org/space keys render. */
-    visibleSpaceKeys?: ReadonlySet<string> | null
+    rail?: boolean
+    showArchived?: boolean
+    activeDiscussionCount?: number
+    renderDiscussions?: (spaceId: string) => ReactNode
     onOpenSpace: (orgId: string, spaceId: string) => void
     onChanged: () => void
 }) {
+    const [directsCollapsed, setDirectsCollapsed] = useState(() => sessionStorage.getItem(`spaces:directsCollapsed:${org.id}`) === 'true')
     const [creating, setCreating] = useState(false)
     const [newName, setNewName] = useState('')
     // Rename-in-place: the row's label becomes an input (same shape as create).
     const [renamingId, setRenamingId] = useState<string | null>(null)
     const [renameValue, setRenameValue] = useState('')
     const [newDirectOpen, setNewDirectOpen] = useState(false)
-    const [showAllDirects, setShowAllDirects] = useState(false)
+    const [showAllDirects, setShowAllDirects] = useState(() => sessionStorage.getItem(`spaces:directsExpanded:${org.id}`) === 'true')
     const [confirmRemove, setConfirmRemove] = useState(false)
     // A dead OAuth session shows as a gentle "Sign in again" (org.authError, from core);
     // an unreachable org shows Retry.
@@ -238,8 +199,18 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
         <>
             <SidebarMenuItem>
                 <div className="group/org flex h-7 items-center gap-1.5 rounded-md pl-6 pr-2 text-[11.5px] text-muted-foreground" title={`You are ${org.memberId}`}>
+                    {rail ? (
+                        <button type="button" onClick={() => setCreating(true)} className="flex flex-1 items-center gap-1.5 text-left hover:text-foreground">
+                            <Plus className="size-3.5" /> New space
+                        </button>
+                    ) : <>
                     <OrgMonogram org={org} size="sm" />
-                    <span className="flex-1 truncate">{org.name}</span>
+                    <button type="button" className={cn('flex-1 truncate text-left hover:text-foreground', activeSpace?.orgId === org.id && 'font-semibold text-foreground')}
+                        aria-current={!rail && activeSpace?.orgId === org.id ? 'page' : undefined}
+                        onClick={() => onOpenSpace(org.id, activeSpace?.orgId === org.id ? activeSpace.spaceId : (org.spaces[0]?.id ?? org.directs[0]?.id ?? ''))}>
+                        {org.name}
+                    </button>
+                    </>}
                     {needsSignIn ? (
                         <button
                             type="button"
@@ -260,7 +231,7 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                             Retry
                         </button>
                     ) : null}
-                    <DropdownMenu>
+                    {!rail && <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                             <button
                                 type="button"
@@ -270,14 +241,7 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                                 <MoreVertical className="size-3.5" />
                             </button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent side="right" align="start">
-                            <DropdownMenuItem onClick={() => setCreating(true)}>
-                                <Plus className="mr-2 size-3.5" /> New space
-                            </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => setNewDirectOpen(true)}>
-                                <MessagesSquare className="mr-2 size-3.5" /> New message
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
+                        <DropdownMenuContent side="right" align="start" onCloseAutoFocus={(event) => { if (confirmRemove) event.preventDefault() }}>
                             <DropdownMenuItem
                                 className="text-destructive focus:text-destructive"
                                 onClick={() => setConfirmRemove(true)}
@@ -285,93 +249,67 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                                 <Trash2 className="mr-2 size-3.5" /> Remove server
                             </DropdownMenuItem>
                         </DropdownMenuContent>
-                    </DropdownMenu>
-                    <AlertDialog open={confirmRemove} onOpenChange={setConfirmRemove}>
-                        <AlertDialogContent>
-                            <AlertDialogHeader>
-                                <AlertDialogTitle>Remove {org.name}?</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                    This only removes the server from this device — you can rejoin with an invite link.
-                                </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter>
-                                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                <AlertDialogAction
-                                    className="bg-destructive text-white hover:bg-destructive/90"
-                                    onClick={() => {
-                                        setConfirmRemove(false)
-                                        void window.ipc.invoke('spaces:removeOrg', { orgId: org.id }).then(onChanged)
-                                    }}
-                                >
-                                    Remove
-                                </AlertDialogAction>
-                            </AlertDialogFooter>
-                        </AlertDialogContent>
-                    </AlertDialog>
+                    </DropdownMenu>}
+                    <RemoveServerDialog org={org} open={confirmRemove} onOpenChange={setConfirmRemove} onRemoved={onChanged} />
                 </div>
             </SidebarMenuItem>
-            {org.spaces.filter((space) => !visibleSpaceKeys || visibleSpaceKeys.has(spaceUseKey(org.id, space.id))).map((space) => {
+            {rail && org.spaces.map((space) => {
                 const active = activeSpace?.orgId === org.id && activeSpace.spaceId === space.id
                 const count = unread.get(`${org.id}/${space.id}`) ?? 0
                 if (renamingId === space.id) {
-                    return (
-                        <SidebarMenuItem key={space.id}>
-                            <div className="flex items-center gap-1 py-0.5 pl-9 pr-2">
-                                <Input
-                                    autoFocus
-                                    value={renameValue}
-                                    className="h-7 text-xs"
-                                    onChange={(e) => setRenameValue(e.target.value)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === 'Enter') void renameSpace(space.id)
-                                        if (e.key === 'Escape') setRenamingId(null)
-                                    }}
-                                    onBlur={() => void renameSpace(space.id)}
-                                />
-                            </div>
-                        </SidebarMenuItem>
-                    )
+                    return <SidebarMenuItem key={space.id}>
+                        <div className="flex items-center gap-1 py-0.5 pl-9 pr-2">
+                            <Input autoFocus value={renameValue} className="h-7 text-xs"
+                                onChange={(event) => setRenameValue(event.target.value)}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') void renameSpace(space.id)
+                                    if (event.key === 'Escape') setRenamingId(null)
+                                }} onBlur={() => void renameSpace(space.id)} />
+                        </div>
+                    </SidebarMenuItem>
                 }
                 return (
-                    <SidebarMenuItem key={space.id}>
-                        <ContextMenu>
-                            <ContextMenuTrigger asChild>
-                                <SidebarMenuButton
-                                    isActive={active}
-                                    onClick={() => onOpenSpace(org.id, space.id)}
-                                    // Hover = intent: warm the cached tail + roster and
-                                    // start the refresh, so the click paints instantly.
-                                    onMouseEnter={() => {
-                                        prefetchStream(org.id, space.id)
-                                        prefetchMembers(org.id, space.id)
-                                    }}
-                                    className="pl-9"
-                                >
-                                    {/* A space is a channel — # says so. */}
-                                    <Hash className="size-3.5 shrink-0 text-muted-foreground" />
-                                    <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
-                                    {count > 0 && (
-                                        <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
-                                    )}
-                                </SidebarMenuButton>
-                            </ContextMenuTrigger>
-                            <ContextMenuContent>
-                                <ContextMenuItem
-                                    onClick={() => {
-                                        setRenameValue(space.name)
-                                        setRenamingId(space.id)
-                                    }}
-                                >
-                                    <Pencil className="mr-2 size-3.5" /> Rename space
-                                </ContextMenuItem>
-                            </ContextMenuContent>
-                        </ContextMenu>
-                    </SidebarMenuItem>
+                        <CollapsibleSpace key={space.id} orgId={org.id} spaceId={space.id} name={space.name}
+                        showArchived={showArchived} countOverride={active ? activeDiscussionCount : undefined}
+                        discussions={() => renderDiscussions?.(space.id)}>
+                            <ContextMenu>
+                                <ContextMenuTrigger asChild>
+                                    <SidebarMenuButton
+                                        isActive={active}
+                                        onClick={() => onOpenSpace(org.id, space.id)}
+                                        // Hover = intent: warm the cached tail + roster and
+                                        // start the refresh, so the click paints instantly.
+                                        onMouseEnter={() => {
+                                            prefetchStream(org.id, space.id)
+                                            prefetchMembers(org.id, space.id)
+                                        }}
+                                        className="min-w-0 flex-1 pl-1"
+                                    >
+                                        {/* A space is a channel — # says so. */}
+                                        <Hash className="size-3.5 shrink-0 text-muted-foreground" />
+                                        <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>{space.name}</span>
+                                        {count > 0 && (
+                                            <span className="shrink-0 text-[11px] font-semibold tabular-nums text-foreground/80">{count}</span>
+                                        )}
+                                    </SidebarMenuButton>
+                                </ContextMenuTrigger>
+                                <ContextMenuContent>
+                                    <ContextMenuItem
+                                        onClick={() => {
+                                            setRenameValue(space.name)
+                                            setRenamingId(space.id)
+                                        }}
+                                    >
+                                        <Pencil className="mr-2 size-3.5" /> Rename space
+                                    </ContextMenuItem>
+                                </ContextMenuContent>
+                            </ContextMenu>
+                    </CollapsibleSpace>
                 )
             })}
-            {org.spaces.length === 0 && !org.error && !creating && (
+            {rail && org.spaces.length === 0 && !org.error && !creating && (
                 <SidebarMenuItem>
-                    <SidebarMenuButton onClick={() => setCreating(true)} className="pl-9 text-muted-foreground">
+                    <SidebarMenuButton onClick={() => setCreating(true)} className="pl-6 text-muted-foreground">
                         <Plus className="size-3.5 shrink-0" />
                         <span className="flex-1 truncate text-xs">Create the first space</span>
                     </SidebarMenuButton>
@@ -380,14 +318,15 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
             {/* Direct messages: the org's people you talk to, most recent first.
                 A DM is a space with a two-person roster (contract 2026-09-07);
                 the row is the person, not a channel. */}
-            {!org.error && (
+            {rail && !org.error && (
                 <SidebarMenuItem>
-                    <div className="flex h-6 items-end pl-9 pr-2 text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                    <button type="button" aria-expanded={!directsCollapsed} onClick={() => setDirectsCollapsed((v) => { sessionStorage.setItem(`spaces:directsCollapsed:${org.id}`, String(!v)); return !v })} className="flex h-8 w-full items-center gap-1.5 px-2 text-xs font-medium text-muted-foreground">
+                        <ChevronRight className={cn("size-3.5", !directsCollapsed && "rotate-90")} />
                         <span className="truncate">Direct messages</span>
-                    </div>
+                    </button>
                 </SidebarMenuItem>
             )}
-            {!org.error && visibleDirects.map((dm) => {
+            {rail && !directsCollapsed && !org.error && visibleDirects.map((dm) => {
                 const active = activeSpace?.orgId === org.id && activeSpace.spaceId === dm.id
                 const count = unread.get(`${org.id}/${dm.id}`) ?? 0
                 const self = isSelfDirect(dm, org.memberId)
@@ -402,7 +341,7 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                                 prefetchStream(org.id, dm.id)
                                 prefetchMembers(org.id, dm.id)
                             }}
-                            className="pl-9"
+                            className="pl-6"
                         >
                             <MemberAvatar id={other} name={label} size="sm" className="size-4 rounded-[3px] text-[8px]" />
                             <span className={cn('flex-1 truncate', count > 0 && !active && 'font-medium text-foreground')}>
@@ -417,11 +356,11 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                 )
             })}
             {/* Not created yet: the same row, waiting for its first click. */}
-            {!org.error && !selfDm && (
+            {rail && !directsCollapsed && !org.error && !selfDm && (
                 <SidebarMenuItem>
                     <SidebarMenuButton
                         onClick={() => void openSelf()}
-                        className={cn('pl-9', selfUnsupported && 'opacity-50')}
+                        className={cn('pl-6', selfUnsupported && 'opacity-50')}
                         title={selfUnsupported
                             ? `Notes to self need a newer server — ${org.name} hasn't been updated yet`
                             : 'Notes to self — only you (and your agent) can see this'}
@@ -434,17 +373,17 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
                     </SidebarMenuButton>
                 </SidebarMenuItem>
             )}
-            {!org.error && directs.length > MAX_VISIBLE_DIRECTS && (
+            {rail && !directsCollapsed && !org.error && directs.length > MAX_VISIBLE_DIRECTS && (
                 <SidebarMenuItem>
-                    <SidebarMenuButton onClick={() => setShowAllDirects((v) => !v)} className="pl-9 text-muted-foreground">
+                    <SidebarMenuButton onClick={() => setShowAllDirects((v) => { sessionStorage.setItem(`spaces:directsExpanded:${org.id}`, String(!v)); return !v })} className="pl-6 text-muted-foreground">
                         <ChevronRight className={cn('size-3.5 shrink-0 transition-transform', showAllDirects && 'rotate-90')} />
-                        <span className="flex-1 truncate text-xs">{showAllDirects ? 'Show less' : `Show all ${directs.length}`}</span>
+                        <span className="flex-1 truncate text-xs">{showAllDirects ? 'Show less' : 'View all'}</span>
                     </SidebarMenuButton>
                 </SidebarMenuItem>
             )}
-            {!org.error && (
+            {rail && !org.error && (
                 <SidebarMenuItem>
-                    <SidebarMenuButton onClick={() => setNewDirectOpen(true)} className="pl-9 text-muted-foreground">
+                    <SidebarMenuButton onClick={() => setNewDirectOpen(true)} className="pl-6 text-muted-foreground">
                         <Plus className="size-3.5 shrink-0" />
                         <span className="flex-1 truncate text-xs">New message</span>
                     </SidebarMenuButton>
@@ -476,4 +415,79 @@ function OrgRows({ org, activeSpace, unread, visibleSpaceKeys, onOpenSpace, onCh
             )}
         </>
     )
+}
+
+/** Server navigation lives above the selected space's existing files pane. */
+export function ServerSpaceNavigation({ org, spaceId, onOpenSpace, onOpenDiscussion, renderActiveDiscussions, activeDiscussionCount, showArchived = false }: {
+    org: OrgWithSpaces
+    spaceId: string
+    onOpenSpace: (orgId: string, spaceId: string) => void
+    onOpenDiscussion: (spaceId: string, selection: RailSelection) => void
+    renderActiveDiscussions: (limit: number) => ReactNode
+    activeDiscussionCount: number
+    showArchived?: boolean
+}) {
+    const { refresh } = useSpacesOrgs()
+    const unread = useSpacesUnreadCounts()
+    return <SidebarMenu>
+        <OrgRows org={org} activeSpace={{ orgId: org.id, spaceId }} unread={unread} rail showArchived={showArchived} activeDiscussionCount={activeDiscussionCount}
+            onOpenSpace={onOpenSpace} onChanged={() => void refresh()}
+            renderDiscussions={(id) => <SpaceDiscussions orgId={org.id} spaceId={id}
+                active={id === spaceId} activeCount={activeDiscussionCount} showArchived={showArchived} renderActive={renderActiveDiscussions}
+                onSelect={(selection) => onOpenDiscussion(id, selection)} />} />
+    </SidebarMenu>
+}
+
+function SpaceDiscussions({ orgId, spaceId, active, activeCount, renderActive, onSelect, showArchived }: {
+    orgId: string
+    spaceId: string
+    active: boolean
+    activeCount: number
+    showArchived: boolean
+    renderActive: (limit: number) => ReactNode
+    onSelect: (selection: RailSelection) => void
+}) {
+    const feed = useSpaceFeed(orgId, spaceId)
+    const foldKey = `spaces:discussionsExpanded:${orgId}/${spaceId}`
+    const [showAll, setShowAll] = useState(() => sessionStorage.getItem(foldKey) === 'true')
+    const topics = feed.topics.filter((topic) => showArchived || !topic.archived).sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt))
+    const count = active ? activeCount : topics.length
+    return <div className="ml-3 border-l border-border pl-1">
+        {active ? renderActive(showAll ? Infinity : 3) : (showAll ? topics : topics.slice(0, 3)).map((topic) => (
+            <button key={topic.id} type="button" onClick={() => onSelect({ kind: 'thread', rootMessageId: topic.rootMessageId })}
+                title={topic.title} className={cn('flex h-8 w-full items-center gap-2 rounded px-2 text-left text-[13px] hover:bg-accent/50', topic.archived && 'opacity-60')}>
+                <CornerDownRight className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate">{topic.title}</span>
+            </button>
+        ))}
+        {count > 3 && <button type="button" className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground" onClick={() => setShowAll((value) => { sessionStorage.setItem(foldKey, String(!value)); return !value })}>
+            {showAll ? 'Show less' : 'View all'}
+        </button>}
+    </div>
+}
+
+function CollapsibleSpace({ orgId, spaceId, name, showArchived, countOverride, discussions, children }: {
+    orgId: string
+    spaceId: string
+    name: string
+    showArchived: boolean
+    countOverride?: number
+    discussions: () => ReactNode
+    children: ReactNode
+}) {
+    const feed = useSpaceFeed(orgId, spaceId)
+    const key = `spaces:spaceExpanded:${orgId}/${spaceId}`
+    const [expanded, setExpanded] = useState(() => sessionStorage.getItem(key) === 'true')
+    const count = countOverride ?? feed.topics.filter((topic) => showArchived || !topic.archived).length
+    return <SidebarMenuItem>
+        <div className="flex items-center">
+            {count > 0 ? <button type="button" aria-label={`${expanded ? 'Collapse' : 'Expand'} #${name}`} aria-expanded={expanded}
+                className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent"
+                onClick={() => setExpanded((value) => { sessionStorage.setItem(key, String(!value)); return !value })}>
+                <ChevronRight className={cn('size-3.5', expanded && 'rotate-90')} />
+            </button> : <span className="w-5.5 shrink-0" />}
+            {children}
+        </div>
+        {count > 0 && expanded && discussions()}
+    </SidebarMenuItem>
 }

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { ChevronRight, CornerDownRight, Hash, MessagesSquare, Pencil, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
+import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuAction, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
 import {
     ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger,
 } from '@/components/ui/context-menu'
@@ -9,19 +9,25 @@ import { Input } from '@/components/ui/input'
 import { type SpaceSelection } from '@/components/spaces-view'
 import { openSelfDirect, useSpaceFeed, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { prefetchStream, spaceLastActivityAt, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
-import { MemberAvatar } from '@/components/spaces/atoms'
+import { AddOrgDialog, MemberAvatar } from '@/components/spaces/atoms'
 import { NewDirectDialog } from '@/components/spaces/new-direct-dialog'
 import { directAvatarId, isSelfDirect, isSelfDirectUnsupported, markSelfDirectUnsupported, selfDirectFailureMessage, selfDirectRefused, spaceDisplayName } from '@/lib/spaces-direct'
 import { prefetchMembers, useSelfDisplayName } from '@/hooks/use-space-members'
+import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
 import type { RailSelection } from '@/lib/spaces-selection'
 import { toast } from '@/lib/toast'
 
 const MAX_VISIBLE_DIRECTS = 3
 
-export function SpacesSidebarSection({ active, onOpenSpaces }: {
+export function SpacesSidebarSection({ active, activeSpace, onOpenSpaces, onOpenSpace }: {
     active: boolean
+    activeSpace: SpaceSelection
     onOpenSpaces: () => void
+    onOpenSpace: (orgId: string, spaceId: string) => void
 }) {
+    const { orgs, refresh } = useSpacesOrgs()
+    const [addOrgOpen, setAddOrgOpen] = useState(false)
+    const current = resolveSpacesLocation(orgs, activeSpace ?? readLastSpace())
     return <SidebarGroup className="pt-0">
         <SidebarGroupContent>
             <SidebarMenu>
@@ -30,9 +36,30 @@ export function SpacesSidebarSection({ active, onOpenSpaces }: {
                         <MessagesSquare className="size-4 shrink-0" />
                         <span>Spaces</span>
                     </SidebarMenuButton>
+                    <SidebarMenuAction type="button" showOnHover aria-label="Add a server" title="Add a server"
+                        onClick={() => setAddOrgOpen(true)}>
+                        <Plus />
+                    </SidebarMenuAction>
+                    {orgs.length > 0 && <SidebarMenu className="ml-4 w-auto gap-0 border-l border-sidebar-border pl-2">
+                        {orgs.map((org) => {
+                            const selected = current?.orgId === org.id
+                            return <SidebarMenuItem key={org.id}>
+                                <SidebarMenuButton
+                                    aria-current={active && selected ? 'page' : undefined}
+                                    className="h-7 text-[13px]"
+                                    onClick={() => {
+                                        if (selected) onOpenSpaces()
+                                        else onOpenSpace(org.id, org.spaces[0]?.id ?? org.directs[0]?.id ?? '')
+                                    }}>
+                                    <span className={cn('truncate', selected ? 'font-medium text-sidebar-foreground' : 'font-normal text-muted-foreground')}>{org.name}</span>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                        })}
+                    </SidebarMenu>}
                 </SidebarMenuItem>
             </SidebarMenu>
         </SidebarGroupContent>
+        <AddOrgDialog open={addOrgOpen} onOpenChange={setAddOrgOpen} onAdded={() => void refresh()} />
     </SidebarGroup>
 }
 

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -1,104 +1,45 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import { ChevronRight, CornerDownRight, Hash, Loader2, MessagesSquare, MoreVertical, Pencil, Plus, Trash2 } from 'lucide-react'
+import { ChevronRight, CornerDownRight, Hash, MessagesSquare, Pencil, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
-import { RemoveServerDialog } from '@/components/spaces/remove-server-dialog'
-import {
-    DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import {
     ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { Input } from '@/components/ui/input'
-import { AddOrgDialog, OrgMonogram, type SpaceSelection } from '@/components/spaces-view'
+import { type SpaceSelection } from '@/components/spaces-view'
 import { openSelfDirect, useSpaceFeed, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 import { prefetchStream, spaceLastActivityAt, useSpacesUnreadCounts } from '@/hooks/use-space-chat'
 import { MemberAvatar } from '@/components/spaces/atoms'
 import { NewDirectDialog } from '@/components/spaces/new-direct-dialog'
 import { directAvatarId, isSelfDirect, isSelfDirectUnsupported, markSelfDirectUnsupported, selfDirectFailureMessage, selfDirectRefused, spaceDisplayName } from '@/lib/spaces-direct'
 import { prefetchMembers, useSelfDisplayName } from '@/hooks/use-space-members'
-import { bumpSpaceUse } from '@/lib/space-usage'
 import type { RailSelection } from '@/lib/spaces-selection'
 import { toast } from '@/lib/toast'
 
 const MAX_VISIBLE_DIRECTS = 3
 
-export function SpacesSidebarSection({ activeSpace, onOpenSpace }: {
-    activeSpace: SpaceSelection
-    onOpenSpace: (orgId: string, spaceId: string) => void
+export function SpacesSidebarSection({ active, onOpenSpaces }: {
+    active: boolean
+    onOpenSpaces: () => void
 }) {
-    const { orgs, loading, refresh } = useSpacesOrgs()
-    const unread = useSpacesUnreadCounts()
-    const [expanded, setExpanded] = useState(true)
-    const [addOrgOpen, setAddOrgOpen] = useState(false)
-    const openSpace = (orgId: string, spaceId: string) => {
-        bumpSpaceUse(orgId, spaceId)
-        onOpenSpace(orgId, spaceId)
-    }
-
-    return (
-        <SidebarGroup className="flex flex-col pt-0">
-            <SidebarGroupContent>
-                <div className="group/spaces-head flex items-center pr-1.5">
-                    <button
-                        type="button"
-                        data-tour-id="nav-spaces"
-                        onClick={() => setExpanded((v) => !v)}
-                        className="flex h-8 flex-1 items-center gap-2.5 rounded-md px-2.5 text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                    >
+    return <SidebarGroup className="pt-0">
+        <SidebarGroupContent>
+            <SidebarMenu>
+                <SidebarMenuItem>
+                    <SidebarMenuButton data-tour-id="nav-spaces" isActive={active} onClick={onOpenSpaces}>
                         <MessagesSquare className="size-4 shrink-0" />
-                        <span className="flex-1 truncate text-left">Spaces</span>
-                        <ChevronRight className={cn('size-3.5 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')} />
-                    </button>
-                    <button
-                        type="button"
-                        aria-label="Add a server"
-                        title="Add a server"
-                        onClick={() => setAddOrgOpen(true)}
-                        className="flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/spaces-head:opacity-100"
-                    >
-                        <Plus className="size-3.5" />
-                    </button>
-                </div>
-                {expanded && (
-                    loading ? (
-                        <div className="flex items-center gap-2 pl-6 pr-4 pb-2 text-[11.5px] text-muted-foreground">
-                            <Loader2 className="size-3 animate-spin" /> Loading…
-                        </div>
-                    ) : orgs.length === 0 ? (
-                        <button
-                            type="button"
-                            onClick={() => setAddOrgOpen(true)}
-                            className="pl-6 pr-4 pb-2 text-left text-[11.5px] italic text-muted-foreground hover:text-foreground"
-                        >
-                            Add a server to see its spaces here.
-                        </button>
-                    ) : (
-                        <SidebarMenu>
-                            {orgs.map((org) => (
-                                <OrgRows
-                                    key={org.id}
-                                    org={org}
-                                    activeSpace={activeSpace}
-                                    unread={unread}
-                                    onOpenSpace={openSpace}
-                                    onChanged={() => void refresh()}
-                                />
-                            ))}
-                        </SidebarMenu>
-                    )
-                )}
-            </SidebarGroupContent>
-            <AddOrgDialog open={addOrgOpen} onOpenChange={setAddOrgOpen} onAdded={() => void refresh()} />
-        </SidebarGroup>
-    )
+                        <span>Spaces</span>
+                    </SidebarMenuButton>
+                </SidebarMenuItem>
+            </SidebarMenu>
+        </SidebarGroupContent>
+    </SidebarGroup>
 }
 
-function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, renderDiscussions, showArchived = false, activeDiscussionCount }: {
+function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, renderDiscussions, showArchived = false, activeDiscussionCount }: {
     org: OrgWithSpaces
     activeSpace: SpaceSelection
     unread: Map<string, number>
-    rail?: boolean
     showArchived?: boolean
     activeDiscussionCount?: number
     renderDiscussions?: (spaceId: string) => ReactNode
@@ -113,7 +54,6 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
     const [renameValue, setRenameValue] = useState('')
     const [newDirectOpen, setNewDirectOpen] = useState(false)
     const [showAllDirects, setShowAllDirects] = useState(() => sessionStorage.getItem(`spaces:directsExpanded:${org.id}`) === 'true')
-    const [confirmRemove, setConfirmRemove] = useState(false)
     // A dead OAuth session shows as a gentle "Sign in again" (org.authError, from core);
     // an unreachable org shows Retry.
     const needsSignIn = !!org.authError
@@ -199,18 +139,9 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
         <>
             <SidebarMenuItem>
                 <div className="group/org flex h-7 items-center gap-1.5 rounded-md pl-6 pr-2 text-[11.5px] text-muted-foreground" title={`You are ${org.memberId}`}>
-                    {rail ? (
-                        <button type="button" onClick={() => setCreating(true)} className="flex flex-1 items-center gap-1.5 text-left hover:text-foreground">
-                            <Plus className="size-3.5" /> New space
-                        </button>
-                    ) : <>
-                    <OrgMonogram org={org} size="sm" />
-                    <button type="button" className={cn('flex-1 truncate text-left hover:text-foreground', activeSpace?.orgId === org.id && 'font-semibold text-foreground')}
-                        aria-current={!rail && activeSpace?.orgId === org.id ? 'page' : undefined}
-                        onClick={() => onOpenSpace(org.id, activeSpace?.orgId === org.id ? activeSpace.spaceId : (org.spaces[0]?.id ?? org.directs[0]?.id ?? ''))}>
-                        {org.name}
+                    <button type="button" onClick={() => setCreating(true)} className="flex flex-1 items-center gap-1.5 text-left hover:text-foreground">
+                        <Plus className="size-3.5" /> New space
                     </button>
-                    </>}
                     {needsSignIn ? (
                         <button
                             type="button"
@@ -231,29 +162,10 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
                             Retry
                         </button>
                     ) : null}
-                    {!rail && <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <button
-                                type="button"
-                                aria-label="Server options"
-                                className="flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/org:opacity-100 data-[state=open]:opacity-100"
-                            >
-                                <MoreVertical className="size-3.5" />
-                            </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent side="right" align="start" onCloseAutoFocus={(event) => { if (confirmRemove) event.preventDefault() }}>
-                            <DropdownMenuItem
-                                className="text-destructive focus:text-destructive"
-                                onClick={() => setConfirmRemove(true)}
-                            >
-                                <Trash2 className="mr-2 size-3.5" /> Remove server
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>}
-                    <RemoveServerDialog org={org} open={confirmRemove} onOpenChange={setConfirmRemove} onRemoved={onChanged} />
+
                 </div>
             </SidebarMenuItem>
-            {rail && org.spaces.map((space) => {
+            {org.spaces.map((space) => {
                 const active = activeSpace?.orgId === org.id && activeSpace.spaceId === space.id
                 const count = unread.get(`${org.id}/${space.id}`) ?? 0
                 if (renamingId === space.id) {
@@ -307,7 +219,7 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
                     </CollapsibleSpace>
                 )
             })}
-            {rail && org.spaces.length === 0 && !org.error && !creating && (
+            {org.spaces.length === 0 && !org.error && !creating && (
                 <SidebarMenuItem>
                     <SidebarMenuButton onClick={() => setCreating(true)} className="pl-6 text-muted-foreground">
                         <Plus className="size-3.5 shrink-0" />
@@ -318,7 +230,7 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
             {/* Direct messages: the org's people you talk to, most recent first.
                 A DM is a space with a two-person roster (contract 2026-09-07);
                 the row is the person, not a channel. */}
-            {rail && !org.error && (
+            {!org.error && (
                 <SidebarMenuItem>
                     <button type="button" aria-expanded={!directsCollapsed} onClick={() => setDirectsCollapsed((v) => { sessionStorage.setItem(`spaces:directsCollapsed:${org.id}`, String(!v)); return !v })} className="flex h-8 w-full items-center gap-1.5 px-2 text-xs font-medium text-muted-foreground">
                         <ChevronRight className={cn("size-3.5", !directsCollapsed && "rotate-90")} />
@@ -326,7 +238,7 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
                     </button>
                 </SidebarMenuItem>
             )}
-            {rail && !directsCollapsed && !org.error && visibleDirects.map((dm) => {
+            {!directsCollapsed && !org.error && visibleDirects.map((dm) => {
                 const active = activeSpace?.orgId === org.id && activeSpace.spaceId === dm.id
                 const count = unread.get(`${org.id}/${dm.id}`) ?? 0
                 const self = isSelfDirect(dm, org.memberId)
@@ -356,7 +268,7 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
                 )
             })}
             {/* Not created yet: the same row, waiting for its first click. */}
-            {rail && !directsCollapsed && !org.error && !selfDm && (
+            {!directsCollapsed && !org.error && !selfDm && (
                 <SidebarMenuItem>
                     <SidebarMenuButton
                         onClick={() => void openSelf()}
@@ -373,7 +285,7 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
                     </SidebarMenuButton>
                 </SidebarMenuItem>
             )}
-            {rail && !directsCollapsed && !org.error && directs.length > MAX_VISIBLE_DIRECTS && (
+            {!directsCollapsed && !org.error && directs.length > MAX_VISIBLE_DIRECTS && (
                 <SidebarMenuItem>
                     <SidebarMenuButton onClick={() => setShowAllDirects((v) => { sessionStorage.setItem(`spaces:directsExpanded:${org.id}`, String(!v)); return !v })} className="pl-6 text-muted-foreground">
                         <ChevronRight className={cn('size-3.5 shrink-0 transition-transform', showAllDirects && 'rotate-90')} />
@@ -381,7 +293,7 @@ function OrgRows({ org, activeSpace, unread, onOpenSpace, onChanged, rail, rende
                     </SidebarMenuButton>
                 </SidebarMenuItem>
             )}
-            {rail && !org.error && (
+            {!org.error && (
                 <SidebarMenuItem>
                     <SidebarMenuButton onClick={() => setNewDirectOpen(true)} className="pl-6 text-muted-foreground">
                         <Plus className="size-3.5 shrink-0" />
@@ -430,7 +342,7 @@ export function ServerSpaceNavigation({ org, spaceId, onOpenSpace, onOpenDiscuss
     const { refresh } = useSpacesOrgs()
     const unread = useSpacesUnreadCounts()
     return <SidebarMenu>
-        <OrgRows org={org} activeSpace={{ orgId: org.id, spaceId }} unread={unread} rail showArchived={showArchived} activeDiscussionCount={activeDiscussionCount}
+        <OrgRows org={org} activeSpace={{ orgId: org.id, spaceId }} unread={unread} showArchived={showArchived} activeDiscussionCount={activeDiscussionCount}
             onOpenSpace={onOpenSpace} onChanged={() => void refresh()}
             renderDiscussions={(id) => <SpaceDiscussions orgId={org.id} spaceId={id}
                 active={id === spaceId} activeCount={activeDiscussionCount} showArchived={showArchived} renderActive={renderActiveDiscussions}

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -16,8 +16,8 @@ import { FileColumn, TrashDialog, UploadFilesDialog } from '@/components/spaces/
 import { GeneralStream } from '@/components/spaces/general-stream'
 import { ScheduledDialog } from '@/components/spaces/scheduled-dialog'
 import { SelectionCopy } from '@/components/spaces/selection-copy'
-import { ServerOptionsMenu } from '@/components/spaces/server-options-menu'
 import { ServerSwitcher } from '@/components/spaces/server-switcher'
+import { ServerOptionsMenu } from '@/components/spaces/server-options-menu'
 import { ServerSpaceNavigation } from '@/components/spaces-sidebar-section'
 import { SpaceRail } from '@/components/spaces/space-rail'
 import { SpaceSearch } from '@/components/spaces/space-search'
@@ -160,9 +160,14 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
             onSelect({ orgId, spaceId })
             onRailSelect({ kind: 'general' })
         }
-        return <div className="flex min-h-0 flex-1">
+        return <div className="spaces-surface flex min-h-0 flex-1 flex-col">
+            <header className="spaces-header flex shrink-0 items-center gap-2 border-b border-border">
+                <ServerSwitcher org={selectedOrg} onOpenSpace={openSpace} />
+            </header>
+            <div className="flex min-h-0 flex-1">
             <aside className="w-64 shrink-0 overflow-y-auto border-r border-border bg-[var(--rowboat-panel-soft)] p-2">
-                <div className="flex items-center"><ServerSwitcher org={selectedOrg} onOpenSpace={openSpace} />
+                <div className="flex h-8 items-center">
+                    <span className="flex-1 px-1 text-[13px] font-semibold text-muted-foreground">Spaces</span>
                     <ServerOptionsMenu org={selectedOrg} showArchived={emptyShowArchived} onToggleArchived={() => setEmptyShowArchived((value) => !value)} onMenuOpenChange={() => {}} />
                 </div>
                 <ServerSpaceNavigation org={selectedOrg} spaceId="" onOpenSpace={openSpace}
@@ -170,6 +175,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
             </aside>
             <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
                 {selectedOrg.error ? 'This server is unreachable. Retry or sign in from the server options.' : 'Create a space to start a conversation.'}
+            </div>
             </div>
         </div>
     }
@@ -688,18 +694,15 @@ function SpacePane({ org, space, selection, onSelect, onSwitchSpace, onOpenSessi
             {/* One per pane — covers the stream and thread panes alike. */}
             {active && <SelectionCopy />}
             <header className="spaces-header flex shrink-0 items-center gap-2 border-b border-border">
-                {/* Left: the org's mark, then # the space. Hover it for what the
-                    old identity card said — server name, who you are. The address
-                    is deliberately absent (decision 2026-09-07: names are the
-                    identity; the address is plumbing). Inviting lives with the
-                    members; nothing here repeats it. */}
+                <ServerSwitcher org={org} onOpenSpace={onSwitchSpace} />
+                <span aria-hidden="true" className="shrink-0 text-muted-foreground/50">/</span>
+                {/* The space breadcrumb retains its identity hover card. */}
                 <HoverCard openDelay={200} closeDelay={150}>
                     <HoverCardTrigger asChild>
                         <button
                             type="button"
-                            className="flex h-9 max-w-[320px] shrink-0 items-center gap-2 rounded-md pl-1 pr-2 hover:bg-accent/60 data-[state=open]:bg-accent/60"
+                            className="flex h-9 min-w-0 max-w-[320px] shrink items-center gap-2 rounded-md pl-1 pr-2 hover:bg-accent/60 data-[state=open]:bg-accent/60"
                         >
-                            <OrgMonogram org={org} />
                             <span className={cn('flex min-w-0 items-center', isDirect ? 'gap-1.5' : 'gap-0.5')}>
                                 {isDirect
                                     ? <MemberAvatar id={directOtherId} name={spaceTitle} size="sm" />

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -16,6 +16,9 @@ import { FileColumn, TrashDialog, UploadFilesDialog } from '@/components/spaces/
 import { GeneralStream } from '@/components/spaces/general-stream'
 import { ScheduledDialog } from '@/components/spaces/scheduled-dialog'
 import { SelectionCopy } from '@/components/spaces/selection-copy'
+import { ServerOptionsMenu } from '@/components/spaces/server-options-menu'
+import { ServerSwitcher } from '@/components/spaces/server-switcher'
+import { ServerSpaceNavigation } from '@/components/spaces-sidebar-section'
 import { SpaceRail } from '@/components/spaces/space-rail'
 import { SpaceSearch } from '@/components/spaces/space-search'
 import { railKey, type RailSelection } from '@/lib/spaces-selection'
@@ -107,6 +110,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
 }) {
     const { orgs, loading, refresh } = useSpacesOrgs()
     const [addOrgOpen, setAddOrgOpen] = useState(false)
+    const [emptyShowArchived, setEmptyShowArchived] = useState(false)
 
     const selectedOrg = selection ? (orgs.find((o) => o.id === selection.orgId) ?? null) : null
     const selectedSpace = selection && selectedOrg ? (findSpace(selectedOrg, selection.spaceId) ?? null) : null
@@ -115,11 +119,11 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
     useEffect(() => {
         if (loading) return
         if (selectedOrg && selectedSpace) return
-        const first = orgs.find((o) => o.spaces.length > 0)
-        const space = first?.spaces[0]
+        const first = selectedOrg ?? orgs.find((o) => o.spaces.length > 0 || o.directs.length > 0)
+        const space = first?.spaces[0] ?? first?.directs[0]
         if (first && space) {
             if (!selection || selection.orgId !== first.id || selection.spaceId !== space.id) onSelect({ orgId: first.id, spaceId: space.id })
-        } else if (selection) {
+        } else if (selection && !selectedOrg) {
             onSelect(null)
         }
     }, [loading, orgs, selection, selectedOrg, selectedSpace, onSelect])
@@ -140,15 +144,34 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
                 space={selectedSpace}
                 selection={railSelection}
                 onSelect={onRailSelect}
-                onSwitchSpace={(orgId, spaceId) => {
+                onSwitchSpace={(orgId, spaceId, next = { kind: 'general' }) => {
                     onSelect({ orgId, spaceId })
                     // The old space's rail selection means nothing over there.
-                    onRailSelect({ kind: 'general' })
+                    onRailSelect(next)
                 }}
                 onOpenSession={onOpenSession}
                 active={active}
             />
         )
+    }
+
+    if (selectedOrg) {
+        const openSpace = (orgId: string, spaceId: string) => {
+            onSelect({ orgId, spaceId })
+            onRailSelect({ kind: 'general' })
+        }
+        return <div className="flex min-h-0 flex-1">
+            <aside className="w-64 shrink-0 overflow-y-auto border-r border-border bg-[var(--rowboat-panel-soft)] p-2">
+                <div className="flex items-center"><ServerSwitcher org={selectedOrg} onOpenSpace={openSpace} />
+                    <ServerOptionsMenu org={selectedOrg} showArchived={emptyShowArchived} onToggleArchived={() => setEmptyShowArchived((value) => !value)} onMenuOpenChange={() => {}} />
+                </div>
+                <ServerSpaceNavigation org={selectedOrg} spaceId="" onOpenSpace={openSpace}
+                    onOpenDiscussion={() => {}} activeDiscussionCount={0} renderActiveDiscussions={() => null} />
+            </aside>
+            <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
+                {selectedOrg.error ? 'This server is unreachable. Retry or sign in from the server options.' : 'Create a space to start a conversation.'}
+            </div>
+        </div>
     }
 
     return (
@@ -188,13 +211,13 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
 // One space: header across the top, then the space rail | the selected thing
 // ---------------------------------------------------------------------------
 
-function SpacePane({ org, space, selection, onSelect, onOpenSession, active = true }: {
+function SpacePane({ org, space, selection, onSelect, onSwitchSpace, onOpenSession, active = true }: {
     org: OrgWithSpaces
     space: spaces.Space
     selection: RailSelection
     onSelect: (selection: RailSelection) => void
     /** The quick switcher can land on another space entirely. */
-    onSwitchSpace: (orgId: string, spaceId: string) => void
+    onSwitchSpace: (orgId: string, spaceId: string, selection?: RailSelection) => void
     onOpenSession?: (sessionId: string) => void
     /** False while the Spaces view is kept mounted but hidden. */
     active?: boolean
@@ -874,6 +897,15 @@ function SpacePane({ org, space, selection, onSelect, onOpenSession, active = tr
 
             <div ref={paneRef} className="flex-1 min-h-0 flex">
                 <SpaceRail
+                    org={org}
+                    onOpenSpace={(orgId, spaceId) => {
+                        if (orgId === org.id && spaceId === space.id) select({ kind: 'general' })
+                        else onSwitchSpace(orgId, spaceId)
+                    }}
+                    onOpenDiscussion={(spaceId, next) => {
+                        if (spaceId === space.id) select(next)
+                        else onSwitchSpace(org.id, spaceId, next)
+                    }}
                     orgId={org.id}
                     spaceId={space.id}
                     selfMemberId={org.memberId}

--- a/apps/x/apps/renderer/src/components/spaces/atoms.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/atoms.tsx
@@ -187,10 +187,11 @@ export function Segmented<T extends string>({ value, options, onChange, size = '
 }
 
 
-export function AddOrgDialog({ open, onOpenChange, onAdded }: {
+export function AddOrgDialog({ open, onOpenChange, onAdded, initialAction }: {
     open: boolean
     onOpenChange: (open: boolean) => void
-    onAdded: () => void
+    onAdded: (orgId: string, spaceId?: string) => void
+    initialAction?: 'create' | 'join'
 }) {
     // One dialog, two doors: paste an invite link (resolve pre-auth, then
     // join with a system-browser sign-in), or name a new server on the
@@ -226,7 +227,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
             toast(`Created ${org.name} — you're the admin`, 'success')
             onOpenChange(false)
             setOrgName('')
-            onAdded()
+            onAdded(org.id)
         } catch (err) {
             toast(err instanceof Error ? err.message : 'Could not create the server', 'error')
         } finally {
@@ -262,7 +263,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
             onOpenChange(false)
             setInviteUrl('')
             setPreview(null)
-            onAdded()
+            onAdded(org.id, space.id)
         } catch (err) {
             toast(err instanceof Error ? err.message : 'Could not join', 'error')
         } finally {
@@ -278,7 +279,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
             const { org } = await window.ipc.invoke('spaces:addOrg', { baseUrl: baseUrl.trim(), memberId: memberId.trim() })
             toast(`Signed into ${org.name} as ${org.memberId}`, 'success')
             onOpenChange(false)
-            onAdded()
+            onAdded(org.id)
         } catch (err) {
             toast(err instanceof Error ? err.message : 'Could not reach the server', 'error')
         } finally {
@@ -290,7 +291,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-md">
                 <DialogHeader>
-                    <DialogTitle>{mode === 'dev' ? 'Add a dev server' : 'Add a server'}</DialogTitle>
+                    <DialogTitle>{mode === 'dev' ? 'Add a dev server' : initialAction === 'create' ? 'Create a server' : initialAction === 'join' ? 'Join a server' : 'Add a server'}</DialogTitle>
                     <DialogDescription>
                         {mode === 'dev'
                             ? 'Dev sign-in against a stub Harbor (run pnpm dev in apps/harbor/packages/server).'
@@ -304,7 +305,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
                             <p className="text-xs text-muted-foreground">Paste an invite link someone sent you.</p>
                             <div className="mt-1.5 flex items-center gap-2">
                                 <Input
-                                    autoFocus
+                                    autoFocus={initialAction !== 'create'}
                                     value={inviteUrl}
                                     onChange={(e) => void resolvePreview(e.target.value)}
                                     placeholder="https://org.example/join/…"
@@ -333,6 +334,7 @@ export function AddOrgDialog({ open, onOpenChange, onAdded }: {
                             <p className="text-xs text-muted-foreground">Free — you name it and you’re its admin.</p>
                             <div className="mt-1.5 flex items-center gap-2">
                                 <Input
+                                    autoFocus={initialAction === 'create'}
                                     value={orgName}
                                     onChange={(e) => setOrgName(e.target.value)}
                                     placeholder="Acme, book club, just me…"

--- a/apps/x/apps/renderer/src/components/spaces/remove-server-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/remove-server-dialog.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog'
+import { toast } from '@/lib/toast'
+
+export function RemoveServerDialog({ org, open, onOpenChange, onRemoved }: {
+    org: { id: string; name: string }
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onRemoved: () => void
+}) {
+    const [removing, setRemoving] = useState(false)
+    const remove = async () => {
+        if (removing) return
+        setRemoving(true)
+        try {
+            await window.ipc.invoke('spaces:removeOrg', { orgId: org.id })
+            onOpenChange(false)
+            onRemoved()
+        } catch (error) {
+            toast(error instanceof Error ? error.message : 'Could not remove the server', 'error')
+        } finally {
+            setRemoving(false)
+        }
+    }
+    return <AlertDialog open={open} onOpenChange={(next) => { if (!removing) onOpenChange(next) }}>
+        <AlertDialogContent>
+            <AlertDialogHeader>
+                <AlertDialogTitle>Remove {org.name}?</AlertDialogTitle>
+                <AlertDialogDescription>This only removes the server from this device — you can rejoin with an invite link.</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+                <AlertDialogCancel disabled={removing}>Cancel</AlertDialogCancel>
+                <AlertDialogAction disabled={removing} className="bg-destructive text-white hover:bg-destructive/90"
+                    onClick={(event) => { event.preventDefault(); void remove() }}>
+                    {removing ? 'Removing…' : 'Remove'}
+                </AlertDialogAction>
+            </AlertDialogFooter>
+        </AlertDialogContent>
+    </AlertDialog>
+}

--- a/apps/x/apps/renderer/src/components/spaces/server-options-menu.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/server-options-menu.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { Archive, MoreHorizontal, Trash2 } from 'lucide-react'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { useSpacesOrgs } from '@/hooks/use-spaces'
+import { RemoveServerDialog } from './remove-server-dialog'
+
+export function ServerOptionsMenu({ org, showArchived, onToggleArchived, onMenuOpenChange }: {
+    org: { id: string; name: string }
+    showArchived: boolean
+    onToggleArchived: () => void
+    onMenuOpenChange: (open: boolean) => void
+}) {
+    const { refresh } = useSpacesOrgs()
+    const [menuOpen, setMenuOpen] = useState(false)
+    const [confirmRemove, setConfirmRemove] = useState(false)
+    return <>
+        <DropdownMenu open={menuOpen} onOpenChange={(open) => { setMenuOpen(open); onMenuOpenChange(open) }}>
+            <DropdownMenuTrigger asChild>
+                <button type="button" aria-label="Server options" className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground">
+                    <MoreHorizontal className="size-3.5" />
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onCloseAutoFocus={(event) => { if (confirmRemove) event.preventDefault() }}>
+                <DropdownMenuItem onSelect={onToggleArchived}><Archive className="mr-2 size-3.5" />{showArchived ? 'Hide archived' : 'Show Archived'}</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="text-destructive focus:text-destructive" onSelect={(event) => {
+                    event.preventDefault()
+                    setMenuOpen(false)
+                    setConfirmRemove(true)
+                    onMenuOpenChange(true)
+                }}><Trash2 className="mr-2 size-3.5" />Remove server</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+        <RemoveServerDialog org={org} open={confirmRemove} onOpenChange={(open) => { setConfirmRemove(open); onMenuOpenChange(open) }} onRemoved={() => void refresh()} />
+    </>
+}

--- a/apps/x/apps/renderer/src/components/spaces/server-switcher.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/server-switcher.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ServerSwitcher } from './server-switcher'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+
+const { servers } = vi.hoisted(() => ({ servers: [
+    { id: 'one', name: 'Rowboat', address: 'one.test', spaces: [{ id: 'main' }], directs: [] },
+    { id: 'two', name: 'Founders', address: 'two.test', spaces: [{ id: 'main' }], directs: [] },
+    { id: 'empty', name: 'New server', address: 'new.test', spaces: [], directs: [] },
+] }))
+vi.mock('@/hooks/use-spaces', () => ({
+    useSpacesOrgs: () => ({ orgs: servers, refresh: async () => {} }),
+    getSpacesOrgs: () => servers,
+}))
+vi.mock('@/components/spaces/atoms', () => ({
+    OrgMonogram: () => <span>RS</span>,
+    AddOrgDialog: ({ open, initialAction, onAdded }: { open: boolean; initialAction: string; onAdded: (id: string, spaceId?: string) => void }) =>
+        open ? <button onClick={() => onAdded('two', 'invited-space')}>Complete {initialAction}</button> : null,
+}))
+afterEach(cleanup)
+function setup() {
+    const onOpenSpace = vi.fn()
+    render(<ServerSwitcher org={servers[0] as unknown as OrgWithSpaces} onOpenSpace={onOpenSpace} />)
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Switch server: Rowboat' }), { key: 'Enter' })
+    return onOpenSpace
+}
+describe('ServerSwitcher', () => {
+    it('switches servers even when their space IDs match', () => {
+        const onOpenSpace = setup()
+        fireEvent.click(screen.getByRole('menuitem', { name: /Founders/ }))
+        expect(onOpenSpace).toHaveBeenCalledWith('two', 'main')
+    })
+    it('allows selecting an empty server', () => {
+        const onOpenSpace = setup()
+        fireEvent.click(screen.getByRole('menuitem', { name: /New server/ }))
+        expect(onOpenSpace).toHaveBeenCalledWith('empty', '')
+    })
+    it.each(['create', 'join'])('opens the %s flow and navigates after success', async (action) => {
+        const onOpenSpace = setup()
+        fireEvent.click(screen.getByRole('menuitem', { name: action === 'create' ? 'Create a server' : 'Join a server' }))
+        fireEvent.click(screen.getByText(`Complete ${action}`))
+        await waitFor(() => expect(onOpenSpace).toHaveBeenCalledWith('two', 'invited-space'))
+    })
+})

--- a/apps/x/apps/renderer/src/components/spaces/server-switcher.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/server-switcher.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { Check, ChevronsUpDown, LogIn, Plus } from 'lucide-react'
+import { AddOrgDialog, OrgMonogram } from '@/components/spaces/atoms'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { getSpacesOrgs, useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
+
+export function ServerSwitcher({ org, onOpenSpace, onMenuOpenChange }: {
+    org: OrgWithSpaces
+    onOpenSpace: (orgId: string, spaceId: string) => void
+    onMenuOpenChange?: (open: boolean) => void
+}) {
+    const { orgs, refresh } = useSpacesOrgs()
+    const [menuOpen, setMenuOpen] = useState(false)
+    const [action, setAction] = useState<'create' | 'join' | null>(null)
+    const openServer = (server: OrgWithSpaces, spaceId?: string) => {
+        onOpenSpace(server.id, spaceId ?? server.spaces[0]?.id ?? server.directs[0]?.id ?? '')
+    }
+
+    return <>
+        <DropdownMenu open={menuOpen} onOpenChange={(open) => { setMenuOpen(open); onMenuOpenChange?.(open || action !== null) }}>
+            <DropdownMenuTrigger asChild>
+                <button type="button" aria-label={`Switch server: ${org.name}`}
+                    className="flex h-12 min-w-0 flex-1 items-center gap-2.5 rounded-lg px-2 text-left hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                    <OrgMonogram org={org} className="size-8 rounded-lg text-xs font-medium" />
+                    <span className="min-w-0 flex-1 truncate text-[15px] font-semibold">{org.name}</span>
+                    <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" sideOffset={4} className="w-64">
+                {orgs.map((server) => <DropdownMenuItem key={server.id}
+                    onSelect={() => { if (server.id !== org.id) openServer(server) }}>
+                    <OrgMonogram org={server} />
+                    <span className="min-w-0 flex-1 truncate">{server.name}</span>
+                    {server.id === org.id && <Check className="size-4 shrink-0" aria-label="Active server" />}
+                </DropdownMenuItem>)}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={(event) => { event.preventDefault(); setMenuOpen(false); setAction('create'); onMenuOpenChange?.(true) }}><Plus className="size-4" /> Create a server</DropdownMenuItem>
+                <DropdownMenuItem onSelect={(event) => { event.preventDefault(); setMenuOpen(false); setAction('join'); onMenuOpenChange?.(true) }}><LogIn className="size-4" /> Join a server</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+        <AddOrgDialog key={action ?? 'closed'} open={action !== null} initialAction={action ?? undefined}
+            onOpenChange={(open) => { if (!open) { setAction(null); onMenuOpenChange?.(false) } }}
+            onAdded={(orgId, spaceId) => {
+                void refresh().then(() => {
+                    const added = getSpacesOrgs().find((server) => server.id === orgId)
+                    if (added) openServer(added, spaceId)
+                })
+            }} />
+    </>
+}

--- a/apps/x/apps/renderer/src/components/spaces/server-switcher.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/server-switcher.tsx
@@ -19,10 +19,16 @@ export function ServerSwitcher({ org, onOpenSpace, onMenuOpenChange }: {
     return <>
         <DropdownMenu open={menuOpen} onOpenChange={(open) => { setMenuOpen(open); onMenuOpenChange?.(open || action !== null) }}>
             <DropdownMenuTrigger asChild>
-                <button type="button" aria-label={`Switch server: ${org.name}`}
-                    className="flex h-12 min-w-0 flex-1 items-center gap-2.5 rounded-lg px-2 text-left hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
-                    <OrgMonogram org={org} className="size-8 rounded-lg text-xs font-medium" />
-                    <span className="min-w-0 flex-1 truncate text-[15px] font-semibold">{org.name}</span>
+                <button type="button" aria-label={`Switch server: ${org.name}`} title={orgs.length > 1 ? 'Switch server · more servers available' : 'Switch server'}
+                    className="flex h-9 min-w-0 max-w-64 shrink items-center gap-2 rounded-md px-1.5 text-left hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                    <span className="relative isolate flex size-7 shrink-0 items-start justify-start">
+                        {orgs.length > 1 && <span aria-hidden="true" className="pointer-events-none absolute inset-0">
+                            <span className="absolute left-1 top-1 size-6 rounded-md border border-foreground/20 bg-muted" />
+                            <span className="absolute left-0.5 top-0.5 size-6 rounded-md border border-foreground/25 bg-muted" />
+                        </span>}
+                        <OrgMonogram org={org} className="relative size-6 rounded-md text-[10px] font-medium" />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-sm font-semibold">{org.name}</span>
                     <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
                 </button>
             </DropdownMenuTrigger>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -15,7 +15,6 @@ import { toast } from '@/lib/toast'
 import { SecondaryRail, type SecondaryRailContext } from '@/components/secondary-rail'
 import { FileTree } from '@/components/spaces/files-tab'
 import { ServerOptionsMenu } from '@/components/spaces/server-options-menu'
-import { ServerSwitcher } from '@/components/spaces/server-switcher'
 import { ServerSpaceNavigation } from '@/components/spaces-sidebar-section'
 import { refreshSpaceFeed, type OrgWithSpaces } from '@/hooks/use-spaces'
 import type { NotifyLevel, SpaceNotifyHandle } from '@/hooks/use-spaces-notify'
@@ -228,7 +227,7 @@ export function SpaceRail({
         <div ref={bodyRef} className={cn('spaces-navigation flex h-full min-h-0 flex-col', resizing && 'select-none')}>
             <section style={chatStyle} className="group/section flex min-h-0 flex-col">
                 <div className="flex shrink-0 items-center gap-0.5 px-2 py-1">
-                    <ServerSwitcher org={org} onOpenSpace={onOpenSpace} onMenuOpenChange={onMenuOpenChange} />
+                    <span className="min-w-0 flex-1 px-1 text-[13px] font-semibold text-muted-foreground">Spaces</span>
                     <ServerOptionsMenu org={org} showArchived={showArchived} onToggleArchived={() => setShowArchived((value) => { sessionStorage.setItem(archivedKey, String(!value)); return !value })} onMenuOpenChange={onMenuOpenChange} />
                     {/* Docked: close. Peeked: the lock — dock it. Same spot, flipped glyph. */}
                     <button

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState, type ReactNode } from 'react'
-import { Archive, ArchiveRestore, ArrowLeft, Bell, BellOff, Bot, Check, CornerDownRight, FileText, FolderPlus, MessageSquare, MessageSquareOff, MessagesSquare, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
+import { Archive, ArchiveRestore, Bell, BellOff, Bot, Check, CornerDownRight, FileText, FolderPlus, MessageSquareOff, MessagesSquare, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
 import { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import {
@@ -14,7 +14,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { toast } from '@/lib/toast'
 import { SecondaryRail, type SecondaryRailContext } from '@/components/secondary-rail'
 import { FileTree } from '@/components/spaces/files-tab'
-import { refreshSpaceFeed } from '@/hooks/use-spaces'
+import { ServerOptionsMenu } from '@/components/spaces/server-options-menu'
+import { ServerSwitcher } from '@/components/spaces/server-switcher'
+import { ServerSpaceNavigation } from '@/components/spaces-sidebar-section'
+import { refreshSpaceFeed, type OrgWithSpaces } from '@/hooks/use-spaces'
 import type { NotifyLevel, SpaceNotifyHandle } from '@/hooks/use-spaces-notify'
 import type { SpacePresence, StreamState } from '@/hooks/use-space-chat'
 import { prefetchThread, STREAM_READ_KEY } from '@/hooks/use-space-chat'
@@ -24,26 +27,9 @@ import { formatFeedTime, resolveMentions } from '@/lib/spaces-presentation'
 import { getTopicLastReadAt } from '@/lib/spaces-read-state'
 import type { RailSelection } from '@/lib/spaces-selection'
 
-// The space's edge rail: one collapsible strip carrying the same sidebar on
-// every surface. Two stacked panes, each with its own scroll — Chat
-// (Messages, then the discussions) on top and Files (the tree; boards are
-// files at whiteboards/<name>.excalidraw and live there with a pen icon)
-// pinned to the bottom. They split the height 60/40 until the divider is
-// dragged (then the Files height sticks, persisted); collapsing either
-// (click its label) hands the whole height to the other. No counts, no
-// filter chips, no search box — ⌘K searches, bold + dot mark unread, and
-// archived discussions get their own view (Chat's ⋯ menu → back row).
-// Each pane's actions sit on its label and appear on hover anywhere in the
-// pane. The Discussions section lists ONLY
-// deliberate topic annotations (annotation model): threads someone gave a
-// goal. Plain reply chains stay behind their chips in the stream — the rail
-// holds intentions, not accidents.
-//
-// The rail chrome (docked width + drag-resize, the collapsed sliver, the
-// hover peek drawer) is the shared SecondaryRail shell — Email's filter
-// rail uses the same one. This file owns only what's IN the rail. The
-// shell sidebar contracts to the dock while in Spaces, so this is THE
-// sidebar here.
+// Server spaces and their nested discussions, then DMs, share the upper
+// scrolling pane. The selected space's files retain their resizable lower
+// pane. SecondaryRail owns docking, resizing, and the hover drawer.
 
 const NOTIFY_CHOICES: { level: NotifyLevel; label: string }[] = [
     { level: 'all', label: 'All messages' },
@@ -51,7 +37,7 @@ const NOTIFY_CHOICES: { level: NotifyLevel; label: string }[] = [
     { level: 'mute', label: 'Muted' },
 ]
 
-type RailSection = 'chat' | 'files'
+type RailSection = 'files'
 /** Collapsed sections persist like the rail's own pin. */
 const COLLAPSED_KEY = 'spaces:railCollapsed'
 /** A dragged Files height persists too (null = the 60/40 default). */
@@ -62,9 +48,12 @@ const FILES_MIN = 96
 const CHAT_MIN = 120
 
 export function SpaceRail({
-    orgId, spaceId, selfMemberId, stream, topics, changeSets, entries, draftFolders, presence, unreadPaths, notify, selection, onSelect, onCreateFile, onCreateBoard, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
+    org, onOpenSpace, onOpenDiscussion, orgId, spaceId, selfMemberId, stream, topics, changeSets, entries, draftFolders, presence, unreadPaths, notify, selection, onSelect, onCreateFile, onCreateBoard, onUploadFiles, onOpenTrash, onAddFolder, onRemoveFolder,
     open, onTogglePin,
 }: {
+    org: OrgWithSpaces
+    onOpenSpace: (orgId: string, spaceId: string) => void
+    onOpenDiscussion: (spaceId: string, selection: RailSelection) => void
     orgId: string
     spaceId: string
     selfMemberId: string
@@ -97,9 +86,9 @@ export function SpaceRail({
     const [creatingFile, setCreatingFile] = useState<{ prefix: string } | null>(null)
     const [creatingFolder, setCreatingFolder] = useState(false)
     const [creatingBoard, setCreatingBoard] = useState(false)
-    // Chat shows the live discussions, or — via its ⋯ menu — the archived
-    // ones as a view of their own with a back row.
-    const [chatView, setChatView] = useState<'live' | 'archived'>('live')
+    // Archived discussions can be included alongside live discussions.
+    const archivedKey = `spaces:showArchived:${orgId}`
+    const [showArchived, setShowArchived] = useState(() => sessionStorage.getItem(archivedKey) === 'true')
     const uploadInputRef = useRef<HTMLInputElement | null>(null)
 
     // Resizable panes: null = the 60/40 default until the divider is dragged;
@@ -199,9 +188,7 @@ export function SpaceRail({
     const byActivity = (a: { topic: spaces.TopicListing }, b: { topic: spaces.TopicListing }) => b.topic.lastActivityAt.localeCompare(a.topic.lastActivityAt)
     const titled = topics.map((t) => ({ topic: t, title: resolveMentions(t.title, memberNames) }))
     const liveRows = titled.filter((x) => !x.topic.archived).sort(byActivity)
-    const archivedRows = titled.filter((x) => x.topic.archived).sort(byActivity)
-    const archivedView = chatView === 'archived'
-    const topicRows = archivedView ? archivedRows : liveRows
+    const topicRows = showArchived ? titled.sort(byActivity) : liveRows
 
     const selectedRootId = selection.kind === 'thread' ? selection.rootMessageId : null
     // A board is a file in the same tree, so either selection kind highlights its row.
@@ -222,12 +209,11 @@ export function SpaceRail({
         topics.filter((t) => !t.archived && isUnread(t) && effectiveLevel(t.rootMessageId) !== 'mute').length + (generalBadge > 0 ? 1 : 0)
     const badge = unreadTopics + unreadPaths.size
 
-    const chatCollapsed = collapsed.has('chat')
     const filesCollapsed = collapsed.has('files')
-    const bothOpen = !chatCollapsed && !filesCollapsed
+    const bothOpen = !filesCollapsed
     // A collapsed pane is just its label; the other takes everything left.
     // With both open, a dragged Files height wins over the 60/40 default.
-    const chatStyle: React.CSSProperties = chatCollapsed ? { flex: '0 0 auto' } : !bothOpen || filesHeight !== null ? { flex: '1 1 0%' } : { flex: '60 1 0%' }
+    const chatStyle: React.CSSProperties = !bothOpen || filesHeight !== null ? { flex: '1 1 0%' } : { flex: '60 1 0%' }
     const filesStyle: React.CSSProperties = filesCollapsed
         ? { flex: '0 0 auto' }
         : !bothOpen
@@ -241,29 +227,9 @@ export function SpaceRail({
     const renderBody = ({ togglePin, onMenuOpenChange }: SecondaryRailContext) => (
         <div ref={bodyRef} className={cn('spaces-navigation flex h-full min-h-0 flex-col', resizing && 'select-none')}>
             <section style={chatStyle} className="group/section flex min-h-0 flex-col">
-                <SectionHeader label="Chat" collapsed={chatCollapsed} count={liveRows.length} onToggle={() => toggleSection('chat')}>
-                    <DropdownMenu onOpenChange={onMenuOpenChange}>
-                        <DropdownMenuTrigger asChild>
-                            <button
-                                type="button"
-                                aria-label="Chat options"
-                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/section:opacity-100 data-[state=open]:opacity-100"
-                            >
-                                <MoreHorizontal className="size-3.5" />
-                            </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                            {archivedView ? (
-                                <DropdownMenuItem onClick={() => setChatView('live')}>
-                                    <ArrowLeft className="size-3.5 mr-2" /> Back to chat
-                                </DropdownMenuItem>
-                            ) : (
-                                <DropdownMenuItem onClick={() => setChatView('archived')}>
-                                    <Archive className="size-3.5 mr-2" /> View archived{archivedRows.length > 0 ? ` (${archivedRows.length})` : ''}
-                                </DropdownMenuItem>
-                            )}
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                <div className="flex shrink-0 items-center gap-0.5 px-2 py-1">
+                    <ServerSwitcher org={org} onOpenSpace={onOpenSpace} onMenuOpenChange={onMenuOpenChange} />
+                    <ServerOptionsMenu org={org} showArchived={showArchived} onToggleArchived={() => setShowArchived((value) => { sessionStorage.setItem(archivedKey, String(!value)); return !value })} onMenuOpenChange={onMenuOpenChange} />
                     {/* Docked: close. Peeked: the lock — dock it. Same spot, flipped glyph. */}
                     <button
                         type="button"
@@ -273,40 +239,12 @@ export function SpaceRail({
                     >
                         {open ? <PanelLeftClose className="size-3.5" /> : <PanelLeftOpen className="size-3.5" />}
                     </button>
-                </SectionHeader>
-                {!chatCollapsed && (
+                </div>
                     <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2">
-                        {archivedView ? (
-                            <button
-                                type="button"
-                                onClick={() => setChatView('live')}
-                                title="Back to chat"
-                                className="flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px] text-foreground/90 hover:bg-accent/50"
-                            >
-                                <ArrowLeft className="size-3.5 shrink-0 text-muted-foreground" />
-                                <span className="flex-1 truncate font-medium">Archived</span>
-                                {archivedRows.length > 0 && <span className="text-[11px] tabular-nums text-muted-foreground">{archivedRows.length}</span>}
-                            </button>
-                        ) : (
-                            <button
-                                type="button"
-                                aria-current={selection.kind === 'general' ? 'page' : undefined}
-                                onClick={() => onSelect({ kind: 'general' })}
-                                className={cn(
-                                    'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
-                                    selection.kind === 'general' ? 'bg-[var(--stream-mention-wash)] font-semibold text-[var(--stream-link)]' : 'text-foreground/90 hover:bg-accent/50',
-                                )}
-                            >
-                                <MessageSquare className="size-3.5 shrink-0 text-muted-foreground" />
-                                <span className={cn('flex-1 truncate', generalBadge > 0 && selection.kind !== 'general' && 'font-semibold')}>Messages</span>
-                                {generalBadge > 0 && selection.kind !== 'general' && (
-                                    <span className="text-[11px] font-semibold tabular-nums">{generalBadge}</span>
-                                )}
-                                {(presence.typing.get('') ?? []).length > 0 && <span className="size-1.5 rounded-full bg-[var(--rowboat-success)]" title="someone is typing" />}
-                            </button>
-                        )}
-
-                        {topicRows.map(({ topic, title }) => {
+                        <ServerSpaceNavigation org={org} spaceId={spaceId} onOpenSpace={onOpenSpace}
+                            onOpenDiscussion={onOpenDiscussion} activeDiscussionCount={topicRows.length} showArchived={showArchived}
+                            renderActiveDiscussions={(limit) => <>
+                        {topicRows.slice(0, limit).map(({ topic, title }) => {
                             const active = topic.rootMessageId === selectedRootId
                             const muted = effectiveLevel(topic.rootMessageId) === 'mute'
                             // Muted topics don't clamor: no bold, no dot,
@@ -463,13 +401,10 @@ export function SpaceRail({
                                 </div>
                             )
                         })}
-                        {topicRows.length === 0 && (
-                            <div className="px-2 py-2 text-xs text-muted-foreground">
-                                {archivedView ? 'Nothing archived.' : 'No discussions yet — give a thread a goal to put it here.'}
-                            </div>
-                        )}
+
+                            </>}
+                        />
                     </div>
-                )}
             </section>
 
             <section
@@ -631,6 +566,7 @@ function SectionHeader({ label, collapsed, count, onToggle, children }: {
             <button
                 type="button"
                 onClick={onToggle}
+                aria-expanded={!collapsed}
                 title={collapsed ? `Show ${label.toLowerCase()}` : `Hide ${label.toLowerCase()}`}
                 className="flex h-full min-w-0 flex-1 items-center gap-1.5 text-left text-[13px] font-semibold text-muted-foreground hover:text-foreground"
             >

--- a/apps/x/apps/renderer/src/lib/spaces-navigation.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-navigation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { resolveSpacesLocation } from './spaces-navigation'
+
+const orgs = [
+    { id: 'first', spaces: [{ id: 'main' }], directs: [] },
+    { id: 'second', spaces: [{ id: 'founders' }, { id: 'design' }], directs: [{ id: 'dm' }] },
+    { id: 'empty', spaces: [], directs: [] },
+] as unknown as OrgWithSpaces[]
+
+describe('returning to Spaces', () => {
+    it.each(['design', 'dm'])('restores the saved location %s instead of the first server', (spaceId) => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'second', spaceId })).toEqual({ orgId: 'second', spaceId })
+    })
+    it('keeps the previous server when its saved space was removed', () => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'second', spaceId: 'removed' })).toEqual({ orgId: 'second', spaceId: 'founders' })
+    })
+    it.each([null, {}, 'invalid', { orgId: 'removed', spaceId: 'gone' }])('chooses an available server for invalid saved state %j', (saved) => {
+        expect(resolveSpacesLocation(orgs, saved)).toEqual({ orgId: 'first', spaceId: 'main' })
+    })
+    it('keeps an empty selected server available for creating a space', () => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'empty', spaceId: '' })).toEqual({ orgId: 'empty', spaceId: '' })
+    })
+    it('returns no location before joining the first server', () => {
+        expect(resolveSpacesLocation([], null)).toBeNull()
+    })
+})

--- a/apps/x/apps/renderer/src/lib/spaces-navigation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-navigation.ts
@@ -1,0 +1,22 @@
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+
+export const LAST_SPACE_STORAGE_KEY = 'x:last-space'
+
+type SpaceLocation = { orgId: string; spaceId: string }
+
+/** Restore a valid location, preferring another space on the same server if it was deleted. */
+export function resolveSpacesLocation(orgs: OrgWithSpaces[], previous: unknown): SpaceLocation | null {
+    const saved = previous && typeof previous === 'object' && 'orgId' in previous && 'spaceId' in previous
+        && typeof previous.orgId === 'string' && typeof previous.spaceId === 'string' ? { orgId: previous.orgId, spaceId: previous.spaceId } : null
+    const previousOrg = saved ? orgs.find((org) => org.id === saved.orgId) : undefined
+    if (previousOrg && saved && [...previousOrg.spaces, ...previousOrg.directs].some((space) => space.id === saved.spaceId)) {
+        return { orgId: previousOrg.id, spaceId: saved.spaceId }
+    }
+    const org = previousOrg ?? orgs.find((org) => org.spaces.length > 0 || org.directs.length > 0) ?? orgs[0]
+    return org ? { orgId: org.id, spaceId: org.spaces[0]?.id ?? org.directs[0]?.id ?? '' } : null
+}
+
+export function readLastSpace(): unknown {
+    try { return JSON.parse(localStorage.getItem(LAST_SPACE_STORAGE_KEY) ?? 'null') }
+    catch { return null }
+}


### PR DESCRIPTION
Spaces navigation now keeps server names in the main sidebar and lists each server's spaces, nested discussions, and DMs in the side rail above the existing files pane. Clicking Spaces returns to the last valid server and space, including DMs; selecting a server changes the active server. The active server is subtly emphasized, and the hover add-server action sits inside the Spaces row highlight.

The section breadcrumb includes a server dropdown with a layered badge for multiple servers and create/join actions. Discussions start collapsed, show up to three with View all, and omit expansion controls when empty. Show Archived includes archived discussions alongside live ones. Server removal uses a shared confirmation flow with cancellation and error handling.

Validation:
- Targeted sidebar, server switcher, navigation, and secondary rail tests passed.
- Renderer TypeScript checks passed.
- Targeted lint and git diff checks passed.
