### PR TITLE
feat(x): add app-wide and embedded browser context menus

### DIFF
--- a/apps/x/apps/main/src/browser/context-menu.ts
+++ b/apps/x/apps/main/src/browser/context-menu.ts
@@ -1,0 +1,76 @@
+import type { ContextMenuParams, MenuItemConstructorOptions, WebContents } from 'electron';
+
+export function buildBrowserContextMenu(
+  wc: WebContents,
+  params: ContextMenuParams,
+  actions: { openTab: (url: string) => void; copyText: (text: string) => void },
+): MenuItemConstructorOptions[] {
+  const menu: MenuItemConstructorOptions[] = [];
+  // Keep commands bound to the original contents even if the active tab changes.
+  const command = (run: () => void) => () => {
+    if (wc.isDestroyed()) return;
+    wc.focus();
+    run();
+  };
+  const group = (items: MenuItemConstructorOptions[]) => {
+    if (menu.length) menu.push({ type: 'separator' });
+    menu.push(...items);
+  };
+  const canOpen = (url: string) => /^https?:\/\//i.test(url);
+  const canSaveImage = (url: string) => canOpen(url) || /^blob:https?:\/\//i.test(url) || /^data:image\//i.test(url);
+  const { editFlags } = params;
+
+  if (params.isEditable) {
+    group([
+      { label: 'Undo', enabled: editFlags.canUndo, click: command(() => wc.undo()) },
+      { label: 'Redo', enabled: editFlags.canRedo, click: command(() => wc.redo()) },
+    ]);
+    group([
+      { label: 'Cut', enabled: editFlags.canCut, click: command(() => wc.cut()) },
+      { label: 'Copy', enabled: editFlags.canCopy, click: command(() => wc.copy()) },
+      { label: 'Paste', enabled: editFlags.canPaste, click: command(() => wc.paste()) },
+      { label: 'Paste as plain text', enabled: editFlags.canPaste, click: command(() => wc.pasteAndMatchStyle()) },
+      { label: 'Select all', enabled: editFlags.canSelectAll, click: command(() => wc.selectAll()) },
+    ]);
+  } else if (params.selectionText) {
+    group([{ label: 'Copy', enabled: editFlags.canCopy, click: () => actions.copyText(params.selectionText) }]);
+  }
+
+  if (params.linkURL) {
+    group([
+      { label: 'Open link in new tab', enabled: canOpen(params.linkURL), click: () => {
+        if (canOpen(params.linkURL)) actions.openTab(params.linkURL);
+      } },
+      { label: 'Copy link address', click: () => actions.copyText(params.linkURL) },
+    ]);
+  }
+
+  if (params.mediaType === 'image') {
+    group([
+      { label: 'Open image in new tab', enabled: canOpen(params.srcURL), click: () => {
+        if (canOpen(params.srcURL)) actions.openTab(params.srcURL);
+      } },
+      { label: 'Save image as…', enabled: canSaveImage(params.srcURL), click: command(() => {
+        // Download through the originating page's session. Electron supplies the
+        // native save dialog and preserves the original image format.
+        if (canSaveImage(params.srcURL)) wc.downloadURL(params.srcURL);
+      }) },
+      { label: 'Copy image', enabled: params.hasImageContents, click: command(() => wc.copyImageAt(params.x, params.y)) },
+      { label: 'Copy image address', enabled: !!params.srcURL, click: () => actions.copyText(params.srcURL) },
+    ]);
+  }
+
+  if (!params.isEditable && !params.selectionText && !params.linkURL && params.mediaType === 'none') {
+    group([
+      { label: 'Back', enabled: wc.navigationHistory.canGoBack(), click: command(() => {
+        if (wc.navigationHistory.canGoBack()) wc.navigationHistory.goBack();
+      }) },
+      { label: 'Forward', enabled: wc.navigationHistory.canGoForward(), click: command(() => {
+        if (wc.navigationHistory.canGoForward()) wc.navigationHistory.goForward();
+      }) },
+      { label: 'Reload', click: command(() => wc.reload()) },
+    ]);
+  }
+  group([{ label: 'Copy page address', click: () => actions.copyText(params.pageURL) }]);
+  return menu;
+}

--- a/apps/x/apps/main/src/browser/ipc.ts
+++ b/apps/x/apps/main/src/browser/ipc.ts
@@ -60,8 +60,8 @@ export const browserIpcHandlers: BrowserHandlers = {
   'browser:forward': async () => {
     return browserViewManager.forward();
   },
-  'browser:reload': async () => {
-    browserViewManager.reload();
+  'browser:reload': async (_event, args) => {
+    browserViewManager.reload(args?.tabId);
     return { ok: true };
   },
   'browser:getState': async () => {

--- a/apps/x/apps/main/src/browser/view.ts
+++ b/apps/x/apps/main/src/browser/view.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
-import { BrowserWindow, WebContentsView, desktopCapturer, session, shell, type Session, type WebContents } from 'electron';
+import { BrowserWindow, Menu, WebContentsView, clipboard, desktopCapturer, session, shell, type Session, type WebContents } from 'electron';
 import type {
   BrowserPageElement,
   BrowserPageSnapshot,
@@ -10,6 +10,7 @@ import type {
   HttpAuthRequest,
 } from '@x/shared/dist/browser-control.js';
 import { normalizeNavigationTarget } from './navigation.js';
+import { buildBrowserContextMenu } from './context-menu.js';
 import {
   buildClickScript,
   buildFocusScript,
@@ -419,6 +420,15 @@ export class BrowserViewManager extends EventEmitter {
   private wireEvents(tab: BrowserTab): void {
     const { id: tabId, view } = tab;
     const wc = view.webContents;
+
+    wc.on('context-menu', (_event, params) => {
+      const window = this.window;
+      if (!window || window.isDestroyed() || wc.isDestroyed() || !this.visible || this.attachedTabId !== tabId) return;
+      Menu.buildFromTemplate(buildBrowserContextMenu(wc, params, {
+        openTab: (url) => { void this.newTab(url); },
+        copyText: (text) => clipboard.writeText(text),
+      })).popup({ window });
+    });
 
     // The app's ⌥/⌃+Tab section switcher must keep working while this tab
     // holds keyboard focus — guest keystrokes never reach the app renderer's
@@ -975,8 +985,8 @@ export class BrowserViewManager extends EventEmitter {
     return { ok: true };
   }
 
-  reload(): void {
-    const activeTab = this.getActiveTab();
+  reload(tabId?: string): void {
+    const activeTab = tabId ? this.tabs.get(tabId) : this.getActiveTab();
     if (!activeTab) return;
     this.invalidateSnapshot(activeTab.id);
     activeTab.view.webContents.reload();

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -89,7 +89,8 @@ import { BackgroundTaskDetail } from '@/components/background-task-detail'
 import { BrowserPane } from '@/components/browser-pane/BrowserPane'
 import { VersionHistoryPanel } from '@/components/version-history-panel'
 import { FileCardProvider } from '@/contexts/file-card-context'
-import { type ChatTab } from '@/components/tab-bar'
+import { TabBar, type ChatTab } from '@/components/tab-bar'
+import { closeTabs } from '@/lib/close-tabs'
 import { CaffeinateToggle } from '@/components/caffeinate-toggle'
 import {
   type ChatMessage,
@@ -878,6 +879,13 @@ function App() {
 
   // File browser state (for Knowledge section)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [openFilePaths, setOpenFilePaths] = useState<string[]>([])
+  const openFilePathsRef = useRef(openFilePaths)
+  openFilePathsRef.current = openFilePaths
+  const fileTabNavigationRef = useRef(0)
+  useEffect(() => {
+    if (selectedPath) setOpenFilePaths((prev) => prev.includes(selectedPath) ? prev : [...prev, selectedPath])
+  }, [selectedPath])
   const [, setFileContent] = useState<string>('')
   const [editorContent, setEditorContent] = useState<string>('')
   const editorContentRef = useRef<string>('')
@@ -2815,13 +2823,16 @@ function App() {
       permissionResponses: new Map(permissionResponses),
       autoPermissionDecisions: new Map(autoPermissionDecisions),
     }
-    setChatViewStateByTab((prev) => ({ ...prev, [activeChatTabId]: snapshot }))
+    const liveSnapshot = sessionChat.sessionId === runId && sessionChat.chatState
+      ? { runId, ...sessionChat.chatState } : snapshot
+    setChatViewStateByTab((prev) => ({ ...prev, [activeChatTabId]: liveSnapshot }))
   }, [
     activeChatTabId,
     runId,
     conversation,
     currentAssistantMessage,
     sessionChat.chatState,
+    sessionChat.sessionId,
     pendingAskHumanRequests,
     allPermissionRequests,
     permissionResponses,
@@ -3131,6 +3142,18 @@ function App() {
         return []
       })()
       const selectedPathAtEvent = selectedPathRef.current
+      if (event.type === 'moved') {
+        const movedPath = (path: string) => path === event.from || path.startsWith(`${event.from}/`)
+          ? event.to + path.slice(event.from.length) : path
+        setOpenFilePaths((prev) => [...new Set(prev.map(movedPath))])
+        if (selectedPathAtEvent && selectedPathAtEvent.startsWith(`${event.from}/`)) setSelectedPath(movedPath(selectedPathAtEvent))
+      } else if (event.type === 'deleted') {
+        setOpenFilePaths((prev) => prev.filter((path) => path !== event.path && !path.startsWith(`${event.path}/`)))
+        if (selectedPathAtEvent && (selectedPathAtEvent === event.path || selectedPathAtEvent.startsWith(`${event.path}/`))) {
+          setSelectedPath(null)
+          setIsKnowledgeViewOpen(true)
+        }
+      }
 
       // Initial hydration owns its read until editorPath/baseline are ready.
       // Record every Markdown event so that loader can detect an in-flight
@@ -4613,7 +4636,7 @@ function App() {
     setIsBrowserOpen(false)
   }, [])
 
-  const handleNewChat = useCallback(() => {
+  const handleNewChat = useCallback((preserveDraft = false) => {
     // Invalidate any in-flight run loads (rapid switching can otherwise "pop" old conversations back in)
     loadRunRequestIdRef.current += 1
     setConversation([])
@@ -4636,8 +4659,10 @@ function App() {
     // A brand-new chat starts with no work directory and restarts its
     // selection from the settings pair (the composer re-seeds when its
     // runId prop drops to null; clearing here keeps the map in lockstep).
-    setWorkDirByTab(prev => ({ ...prev, [activeChatTabIdRef.current]: null }))
-    selectionByTabRef.current.delete(chatIdForTab(activeChatTabIdRef.current))
+    if (!preserveDraft) {
+      setWorkDirByTab(prev => ({ ...prev, [activeChatTabIdRef.current]: null }))
+      selectionByTabRef.current.delete(chatIdForTab(activeChatTabIdRef.current))
+    }
   }, [setChatViewportAnchor])
 
   const activateAssistantTab = useCallback((tab: ChatTab) => {
@@ -4688,11 +4713,36 @@ function App() {
     }
   }, [activateAssistantTab])
 
-  // Bind the single chat surface to a session. THE one way any part of the
-  // app points the chat at a conversation (recents, history, Home threads,
-  // code sessions, quick-ask). No-ops when already bound; otherwise rebinds
-  // with a fresh chat identity (remounts pane + composer, drops drafts).
+  const switchChatTab = useCallback((tabId: string) => {
+    const tab = chatTabsRef.current.find((entry) => entry.id === tabId)
+    if (!tab || tabId === activeChatTabIdRef.current) return
+    activateAssistantTab(tab)
+  }, [activateAssistantTab])
+
+  const closeChatTabs = useCallback((ids: string[]) => {
+    const next = closeTabs(chatTabsRef.current, activeChatTabIdRef.current, ids, (tab) => tab.id)
+    if (!next.activeId) return // Keep one chat, matching the tab strip's close rules.
+    switchChatTab(next.activeId)
+    chatTabsRef.current = next.tabs
+    setChatTabs(next.tabs)
+  }, [switchChatTab])
+
+  const createChatTab = useCallback(() => {
+    cancelRecordingIfActive()
+    const id = crypto.randomUUID()
+    const tab: ChatTab = { id, runId: null, chatId: id }
+    chatTabsRef.current = [...chatTabsRef.current, tab]
+    setChatTabs(chatTabsRef.current)
+    activeChatTabIdRef.current = id
+    setActiveChatTabId(id)
+    handleNewChat()
+    return tab
+  }, [cancelRecordingIfActive, handleNewChat])
+
+  // Reuse an existing session tab, or open a new one without replacing a draft.
   const bindChatToRun = useCallback((rid: string) => {
+    const existing = chatTabsRef.current.find((tab) => tab.runId === rid)
+    if (existing) { switchChatTab(existing.id); return }
     const active = chatTabsRef.current.find((t) => t.id === activeChatTabIdRef.current)
     if (active?.runId === rid) return
     if (useBottomTabs || chatTabsRef.current.length > 1) {
@@ -4704,14 +4754,16 @@ function App() {
     }
     // Cancel any active dictation — its transcript belongs to the old chat.
     cancelRecordingIfActive()
+    if (active?.runId || (active && chatDraftsRef.current.get(active.chatId))) createChatTab()
+    const targetTabId = activeChatTabIdRef.current
     setChatTabs((prev) => prev.map((t) => (
       // Rebinding to a different session = a different chat identity — but a
       // DETERMINISTIC one (the session id), so switching A→B→A restores A's
       // draft/selection instead of silently dropping half-typed input.
-      t.id === activeChatTabIdRef.current ? { ...t, runId: rid, chatId: rid } : t
+      t.id === targetTabId ? { ...t, runId: rid, chatId: rid } : t
     )))
     void loadRun(rid)
-  }, [cancelRecordingIfActive, loadRun, useBottomTabs, activateAssistantTab])
+  }, [cancelRecordingIfActive, loadRun, switchChatTab, createChatTab, useBottomTabs, activateAssistantTab])
   bindChatToRunRef.current = bindChatToRun
 
   // A code session was selected in the Code view: bind the chat to it — the
@@ -4849,19 +4901,17 @@ function App() {
       }
       return
     }
-    // Single-chat model: reset the one conversation in place instead of
-    // opening a new tab. Fresh chatId = fresh chat-session instance.
-    setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId: crypto.randomUUID() }])
+    // A fresh tab keeps the other conversations and drafts available.
+    createChatTab()
     dismissBrowserOverlay()
-    handleNewChat()
     // "New chat" opens the full-screen chat; remember where we came from so
     // closing it can restore the section.
     const from = currentViewState.type === 'chat' ? null : currentViewState
     closeAllSections()
     setExpandedFrom(from)
-  }, [dismissBrowserOverlay, handleNewChat, closeAllSections, currentViewState, useBottomTabs, addAssistantTab, isCodeOpen])
+  }, [dismissBrowserOverlay, closeAllSections, currentViewState, createChatTab, useBottomTabs, addAssistantTab, isCodeOpen])
 
-  // Sidebar variant: reset the chat in place without leaving file/graph context.
+  // Sidebar variant: add a chat without leaving file/graph context.
   // A caller with a selection already chosen for the fresh chat (the Home
   // composer handoff) passes it here so the map entry exists BEFORE the
   // rebind commit — the remounted composer's initialSelection then shows the
@@ -4871,11 +4921,9 @@ function App() {
       addAssistantTab(initialSelection)
       return
     }
-    const chatId = crypto.randomUUID()
+    const { chatId } = createChatTab()
     if (initialSelection) selectionByTabRef.current.set(chatId, initialSelection)
-    setChatTabs([{ id: activeChatTabIdRef.current, runId: null, chatId }])
-    handleNewChat()
-  }, [handleNewChat, useBottomTabs, addAssistantTab])
+  }, [createChatTab, useBottomTabs, addAssistantTab])
 
   // A chat was deleted (sessions:delete succeeded): drop it from the recents
   // list, and if it was the one on screen, reset the chat surface in place to
@@ -4893,8 +4941,9 @@ function App() {
       closeAssistantTab(openTab.id)
       return
     }
-    handleNewChatTabInSidebar()
-  }, [chatTabs, handleNewChatTabInSidebar, useBottomTabs, closeAssistantTab])
+    if (chatTabs.length === 1) createChatTab()
+    closeChatTabs([openTab.id])
+  }, [chatTabs, createChatTab, closeChatTabs, useBottomTabs, closeAssistantTab])
 
   // The companion's "+": a fresh COMPANION conversation for its next
   // question. The app window's chat is untouched.
@@ -5478,6 +5527,46 @@ function App() {
   const navigateToFile = useCallback((path: string) => {
     void navigateToView({ type: 'file', path })
   }, [navigateToView])
+
+  const saveTabMarkdown = useCallback(async (paths: string[]) => {
+    for (const path of paths) {
+      if (!path.endsWith('.md')) continue
+      const content = editorContentByPathRef.current.get(path)
+      const baseline = initialContentByPathRef.current.get(path)
+      if (content === undefined || baseline === undefined || content === baseline) continue
+      await window.ipc.invoke('workspace:writeFile', {
+        path, data: joinFrontmatter(frontmatterByPathRef.current.get(path) ?? null, content),
+      })
+      setInitialContentForPath(path, content)
+    }
+  }, [setInitialContentForPath])
+
+  const switchFileTab = useCallback((path: string) => {
+    const request = ++fileTabNavigationRef.current
+    void (async () => {
+      try {
+        await saveTabMarkdown(selectedPathRef.current ? [selectedPathRef.current] : [])
+        if (request !== fileTabNavigationRef.current) return
+        navigateToFile(path)
+      } catch { toast.error('Could not save the current file; tab kept open') }
+    })()
+  }, [saveTabMarkdown, navigateToFile])
+
+  const closeFileTabs = useCallback((paths: string[]) => {
+    ++fileTabNavigationRef.current // A close supersedes an in-flight tab switch.
+    void (async () => {
+      try {
+        await saveTabMarkdown(paths)
+        const next = closeTabs(openFilePathsRef.current, selectedPathRef.current, paths, (path) => path)
+        openFilePathsRef.current = next.tabs
+        setOpenFilePaths(next.tabs)
+        if (next.activeId !== selectedPathRef.current) {
+          if (next.activeId) navigateToFile(next.activeId)
+          else void navigateToView({ type: 'knowledge-view', mode: 'files' })
+        }
+      } catch { toast.error('Could not save files; tabs kept open') }
+    })()
+  }, [saveTabMarkdown, navigateToFile, navigateToView])
 
   // Deep-link handler kept in a ref so the useEffect below can register the
   // IPC listener (and run the one-time pending-link drain) just once on mount,
@@ -6895,7 +6984,7 @@ function App() {
   // The active chat's view state, backed by the sessions hook (legacy
   // standalone states remain only as the pre-load fallback until stage 7).
   const activeChatTabState = React.useMemo<ChatTabViewState>(() => (
-    sessionChat.chatState
+    sessionChat.sessionId === runId && sessionChat.chatState
       ? { runId, ...sessionChat.chatState }
       : {
           runId,
@@ -6909,6 +6998,7 @@ function App() {
         }
   ), [
     runId,
+    sessionChat.sessionId,
     sessionChat.chatState,
     sessionLoadErrorItems,
     conversation,
@@ -7135,9 +7225,19 @@ function App() {
                     onSelectRun={openAssistantRun}
                     onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
                   />
+                ) : currentViewState.type === 'file' && selectedPath ? (
+                  <TabBar
+                    tabs={openFilePaths.includes(selectedPath) ? openFilePaths : [...openFilePaths, selectedPath]}
+                    activeTabId={selectedPath}
+                    getTabId={(path) => path}
+                    getTabTitle={(path) => path.split('/').pop() ?? path}
+                    onSwitchTab={switchFileTab}
+                    onCloseTab={(path) => closeFileTabs([path])}
+                    onCloseTabs={closeFileTabs}
+                    layout="scroll"
+                    allowSingleTabClose
+                  />
                 ) : (
-                  // No tabs: the header names the section (or open file). It is
-                  // part of the titlebar drag region — static text drags fine.
                   <div className="flex min-w-0 flex-1 items-center self-center">
                     <span className="truncate text-sm font-medium text-foreground/80">
                       {currentViewTitle}
@@ -7760,6 +7860,11 @@ function App() {
               {activeMiddle === 'chat' && !useBottomTabs && (
               <FileCardProvider onOpenKnowledgeFile={(path) => { navigateToFile(path) }} onOpenFile={(path) => { navigateToFile(path) }}>
               <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex h-9 shrink-0 border-b border-border">
+                  <TabBar tabs={chatTabs} activeTabId={activeChatTabId} getTabId={(tab) => tab.id}
+                    getTabTitle={getChatTabTitle} onSwitchTab={switchChatTab}
+                    onCloseTab={(id) => closeChatTabs([id])} onCloseTabs={closeChatTabs} layout="scroll" />
+                </div>
                 <div className="relative min-h-0 flex-1">
                   {chatTabs.map((tab) => {
                     const isActive = tab.id === activeChatTabId
@@ -7891,6 +7996,8 @@ function App() {
                 isOpen={dockFullScreen || chatPaneOpen}
                 isMaximized={dockFullScreen || isRightPaneMaximized}
                 chatTabs={chatTabs}
+                onSwitchChatTab={switchChatTab}
+                onCloseChatTabs={closeChatTabs}
                 activeChatTabId={activeChatTabId}
                 getChatTabTitle={getChatTabTitle}
                 onNewChatTab={() => handleNewChatTabInSidebar()}

--- a/apps/x/apps/renderer/src/components/bg-task-menu-items.test.tsx
+++ b/apps/x/apps/renderer/src/components/bg-task-menu-items.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { BgTaskMenuItems } from './bg-task-menu-items'
+
+afterEach(cleanup)
+
+function setup({ active = true, busy = false, updating = false, context = true } = {}) {
+    const callbacks = {
+        onOpen: vi.fn(), onDetails: vi.fn(), onToggleActive: vi.fn(), onRun: vi.fn(), onDelete: vi.fn(),
+    }
+    const contents = <BgTaskMenuItems {...callbacks} context={context} active={active} busy={busy} updating={updating} />
+    if (context) {
+        render(
+            <table><tbody><ContextMenu>
+                <ContextMenuTrigger asChild>
+                    <tr><td><button onClick={callbacks.onOpen}>Task row</button></td></tr>
+                </ContextMenuTrigger>
+                <ContextMenuContent>{contents}</ContextMenuContent>
+            </ContextMenu></tbody></table>,
+        )
+        fireEvent.contextMenu(screen.getByRole('button', { name: 'Task row' }), { button: 2 })
+    } else {
+        render(<DropdownMenu>
+            <DropdownMenuTrigger>Options</DropdownMenuTrigger>
+            <DropdownMenuContent>{contents}</DropdownMenuContent>
+        </DropdownMenu>)
+        fireEvent.keyDown(screen.getByRole('button', { name: 'Options' }), { key: 'ArrowDown' })
+    }
+    return callbacks
+}
+
+describe('background task menus', () => {
+    it.each([true, false])('uses the same actions for context=%s', (context) => {
+        setup({ context })
+        expect(screen.getAllByRole('menuitem').map((item) => item.textContent?.trim())).toEqual([
+            'Open task', 'View details', 'Pause', 'Run now', 'Delete task',
+        ])
+    })
+
+    it.each([
+        ['Open task', 'onOpen'], ['View details', 'onDetails'], ['Pause', 'onToggleActive'],
+        ['Run now', 'onRun'], ['Delete task', 'onDelete'],
+    ] as const)('routes %s without triggering other actions', (label, action) => {
+        const callbacks = setup()
+        expect(callbacks.onOpen).not.toHaveBeenCalled()
+        fireEvent.click(screen.getByRole('menuitem', { name: label }))
+        for (const [name, callback] of Object.entries(callbacks)) {
+            expect(callback).toHaveBeenCalledTimes(name === action ? 1 : 0)
+        }
+    })
+
+    it('offers Resume and manual Run now for a paused task', () => {
+        const { onToggleActive } = setup({ active: false })
+        expect(screen.queryByRole('menuitem', { name: 'Pause' })).toBeNull()
+        expect(screen.getByRole('menuitem', { name: 'Run now' })).not.toHaveAttribute('aria-disabled')
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Resume' }))
+        expect(onToggleActive).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([{ busy: true }, { updating: true }])('disables conflicting actions for %j', (state) => {
+        const { onToggleActive, onRun } = setup(state)
+        for (const name of ['Pause', 'Run now']) {
+            const item = screen.getByRole('menuitem', { name })
+            expect(item).toHaveAttribute('aria-disabled', 'true')
+            fireEvent.click(item)
+        }
+        expect(onToggleActive).not.toHaveBeenCalled()
+        expect(onRun).not.toHaveBeenCalled()
+        expect(screen.getByRole('menuitem', { name: 'View details' })).not.toHaveAttribute('aria-disabled')
+    })
+})

--- a/apps/x/apps/renderer/src/components/bg-task-menu-items.tsx
+++ b/apps/x/apps/renderer/src/components/bg-task-menu-items.tsx
@@ -1,0 +1,32 @@
+import { FolderOpen, Info, Pause, Play, Trash2 } from 'lucide-react'
+import { ContextMenuItem, ContextMenuSeparator } from '@/components/ui/context-menu'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
+
+export function BgTaskMenuItems({ context = false, active, busy, updating, onOpen, onDetails, onToggleActive, onRun, onDelete }: {
+    context?: boolean
+    active: boolean
+    busy: boolean
+    updating: boolean
+    onOpen: () => void
+    onDetails: () => void
+    onToggleActive: () => void
+    onRun: () => void
+    onDelete: () => void
+}) {
+    const Item = context ? ContextMenuItem : DropdownMenuItem
+    const Separator = context ? ContextMenuSeparator : DropdownMenuSeparator
+    return (
+        <>
+            <Item onSelect={onOpen}><FolderOpen className="size-3.5" /> Open task</Item>
+            <Item onSelect={onDetails}><Info className="size-3.5" /> View details</Item>
+            <Separator />
+            <Item disabled={busy || updating} onSelect={onToggleActive}>
+                {active ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
+                {active ? 'Pause' : 'Resume'}
+            </Item>
+            <Item disabled={busy || updating} onSelect={onRun}><Play className="size-3.5" /> Run now</Item>
+            <Separator />
+            <Item variant="destructive" onSelect={onDelete}><Trash2 className="size-3.5" /> Delete task</Item>
+        </>
+    )
+}

--- a/apps/x/apps/renderer/src/components/bg-tasks-view.tsx
+++ b/apps/x/apps/renderer/src/components/bg-tasks-view.tsx
@@ -4,7 +4,7 @@ import {
     ListChecks, Play, Square, Loader2, Trash2, Plus, X, AlertCircle,
     Repeat, Clock, Zap, ChevronLeft, ChevronDown, ChevronRight,
     Pencil, Check, PanelRightClose, PanelRightOpen, Sparkles,
-    Code2, FolderOpen, LayoutTemplate, MoreVertical, Info,
+    Code2, FolderOpen, LayoutTemplate, MoreVertical,
 } from 'lucide-react'
 import type { BackgroundTask, BackgroundTaskSummary, Triggers } from '@x/shared/dist/background-task.js'
 import { Button } from '@/components/ui/button'
@@ -14,10 +14,10 @@ import { Textarea } from '@/components/ui/textarea'
 import {
     DropdownMenu,
     DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { BgTaskMenuItems } from '@/components/bg-task-menu-items'
 import {
     Dialog,
     DialogContent,
@@ -1751,6 +1751,8 @@ export function BgTasksView({ onCreateWithCopilot, onEditWithCopilot, initialSlu
     // as `LiveNotesView` uses for its toggle / stop buttons.
     const [updatingSlugs, setUpdatingSlugs] = useState<Set<string>>(new Set())
     const [stoppingSlugs, setStoppingSlugs] = useState<Set<string>>(new Set())
+    const [startingSlugs, setStartingSlugs] = useState<Set<string>>(new Set())
+    const startingSlugsRef = useRef(new Set<string>())
     const [detailsTask, setDetailsTask] = useState<BackgroundTaskSummary | null>(null)
     const [deleteTarget, setDeleteTarget] = useState<BackgroundTaskSummary | null>(null)
     const [deleting, setDeleting] = useState(false)
@@ -1801,6 +1803,22 @@ export function BgTasksView({ onCreateWithCopilot, onEditWithCopilot, initialSlu
             })
         }
     }, [])
+
+    const handleRunNow = useCallback(async (slug: string) => {
+        if (startingSlugsRef.current.has(slug) || agentStatus.get(slug)?.status === 'running') return
+        startingSlugsRef.current.add(slug)
+        setStartingSlugs(new Set(startingSlugsRef.current))
+        try {
+            analytics.bgAgentRunClicked()
+            const result = await window.ipc.invoke('bg-task:run', { slug })
+            if (!result.success) toast(result.error ?? 'Run failed', 'error')
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Run failed', 'error')
+        } finally {
+            startingSlugsRef.current.delete(slug)
+            setStartingSlugs(new Set(startingSlugsRef.current))
+        }
+    }, [agentStatus])
 
     const handleStop = useCallback(async (slug: string) => {
         setStoppingSlugs(prev => new Set(prev).add(slug))
@@ -1921,112 +1939,119 @@ export function BgTasksView({ onCreateWithCopilot, onEditWithCopilot, initialSlu
                                     const isStopping = stoppingSlugs.has(task.slug)
                                     const hasError = !isRunning && !!task.lastRunError
                                     const instructionsPreview = task.instructions.split('\n')[0].trim()
+                                    const menuProps = {
+                                        active: task.active,
+                                        busy: isRunning || isStopping || startingSlugs.has(task.slug),
+                                        updating: isUpdating,
+                                        onOpen: () => setSelectedSlug(task.slug),
+                                        onDetails: () => setDetailsTask(task),
+                                        onToggleActive: () => { void handleToggleActive(task.slug, !task.active) },
+                                        onRun: () => { void handleRunNow(task.slug) },
+                                        onDelete: () => setDeleteTarget(task),
+                                    }
                                     return (
-                                        <tr
-                                            key={task.slug}
-                                            className={`border-b border-border/50 last:border-b-0 transition-colors ${isRunning ? 'bg-primary/5' : 'hover:bg-muted/20'}`}
-                                        >
-                                            <td className="px-4 py-3 align-top">
-                                                <div className="flex min-w-0 flex-col gap-1">
-                                                    <div className="flex items-center gap-1.5">
-                                                        {hasError && (
-                                                            <AlertCircle
-                                                                className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
-                                                                aria-label="Last run failed"
-                                                            >
-                                                                <title>Last run failed: {task.lastRunError}</title>
-                                                            </AlertCircle>
-                                                        )}
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => setSelectedSlug(task.slug)}
-                                                            className="truncate text-left text-sm font-medium text-foreground hover:text-primary"
-                                                            title={task.name}
-                                                        >
-                                                            {task.name}
-                                                        </button>
-                                                    </div>
-                                                    <div className="truncate font-mono text-[11px] text-muted-foreground">
-                                                        {task.slug}
-                                                    </div>
-                                                    {instructionsPreview && (
-                                                        <div className="truncate text-xs text-muted-foreground/80" title={task.instructions}>
-                                                            {instructionsPreview}
+                                        <ContextMenu key={task.slug}>
+                                            <ContextMenuTrigger asChild>
+                                                <tr
+                                                    className={`border-b border-border/50 last:border-b-0 transition-colors ${isRunning ? 'bg-primary/5' : 'hover:bg-muted/20'}`}
+                                                >
+                                                    <td className="px-4 py-3 align-top">
+                                                        <div className="flex min-w-0 flex-col gap-1">
+                                                            <div className="flex items-center gap-1.5">
+                                                                {hasError && (
+                                                                    <AlertCircle
+                                                                        className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+                                                                        aria-label="Last run failed"
+                                                                    >
+                                                                        <title>Last run failed: {task.lastRunError}</title>
+                                                                    </AlertCircle>
+                                                                )}
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => setSelectedSlug(task.slug)}
+                                                                    className="truncate text-left text-sm font-medium text-foreground hover:text-primary"
+                                                                    title={task.name}
+                                                                >
+                                                                    {task.name}
+                                                                </button>
+                                                            </div>
+                                                            <div className="truncate font-mono text-[11px] text-muted-foreground">
+                                                                {task.slug}
+                                                            </div>
+                                                            {instructionsPreview && (
+                                                                <div className="truncate text-xs text-muted-foreground/80" title={task.instructions}>
+                                                                    {instructionsPreview}
+                                                                </div>
+                                                            )}
+                                                            {hasError && task.lastRunError && (
+                                                                <div className="truncate text-xs text-amber-600 dark:text-amber-400" title={task.lastRunError}>
+                                                                    {task.lastRunError}
+                                                                </div>
+                                                            )}
                                                         </div>
-                                                    )}
-                                                    {hasError && task.lastRunError && (
-                                                        <div className="truncate text-xs text-amber-600 dark:text-amber-400" title={task.lastRunError}>
-                                                            {task.lastRunError}
-                                                        </div>
-                                                    )}
-                                                </div>
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-foreground/80">
-                                                {summarizeSchedule(task.triggers)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-foreground/80">
-                                                {formatLastRanLabel(task.lastRunAt)}
-                                            </td>
-                                            <td className="px-4 py-3">
-                                                {isRunning ? (
-                                                    <div className="flex flex-wrap items-center gap-2">
-                                                        <span className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-foreground animate-pulse">
-                                                            <Loader2 className="size-3 animate-spin" />
-                                                            Updating
-                                                        </span>
-                                                        <Button
-                                                            variant="destructive"
-                                                            size="sm"
-                                                            onClick={() => handleStop(task.slug)}
-                                                            disabled={isStopping}
-                                                            className="h-auto gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium"
-                                                        >
-                                                            {isStopping ? <Loader2 className="size-3 animate-spin" /> : <Square className="size-3" />}
-                                                            Stop
-                                                        </Button>
-                                                    </div>
-                                                ) : (
-                                                    <div className="flex items-center gap-3">
-                                                        <Switch
-                                                            checked={task.active}
-                                                            onCheckedChange={(checked) => { void handleToggleActive(task.slug, checked) }}
-                                                            disabled={isUpdating}
-                                                        />
-                                                        <span className="min-w-16 text-xs font-medium text-foreground/80">
-                                                            {task.active ? 'Active' : 'Inactive'}
-                                                        </span>
-                                                        {isUpdating && (
-                                                            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                                                    </td>
+                                                    <td className="px-4 py-3 text-sm text-foreground/80">
+                                                        {summarizeSchedule(task.triggers)}
+                                                    </td>
+                                                    <td className="px-4 py-3 text-sm text-foreground/80">
+                                                        {formatLastRanLabel(task.lastRunAt)}
+                                                    </td>
+                                                    <td className="px-4 py-3">
+                                                        {isRunning ? (
+                                                            <div className="flex flex-wrap items-center gap-2">
+                                                                <span className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-foreground animate-pulse">
+                                                                    <Loader2 className="size-3 animate-spin" />
+                                                                    Updating
+                                                                </span>
+                                                                <Button
+                                                                    variant="destructive"
+                                                                    size="sm"
+                                                                    onClick={() => handleStop(task.slug)}
+                                                                    disabled={isStopping}
+                                                                    className="h-auto gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium"
+                                                                >
+                                                                    {isStopping ? <Loader2 className="size-3 animate-spin" /> : <Square className="size-3" />}
+                                                                    Stop
+                                                                </Button>
+                                                            </div>
+                                                        ) : (
+                                                            <div className="flex items-center gap-3">
+                                                                <Switch
+                                                                    checked={task.active}
+                                                                    onCheckedChange={(checked) => { void handleToggleActive(task.slug, checked) }}
+                                                                    disabled={isUpdating}
+                                                                />
+                                                                <span className="min-w-16 text-xs font-medium text-foreground/80">
+                                                                    {task.active ? 'Active' : 'Inactive'}
+                                                                </span>
+                                                                {isUpdating && (
+                                                                    <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                                                                )}
+                                                            </div>
                                                         )}
-                                                    </div>
-                                                )}
-                                            </td>
-                                            <td className="px-2 py-3">
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger asChild>
-                                                        <button
-                                                            type="button"
-                                                            className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-                                                            aria-label={`Options for ${task.name}`}
-                                                        >
-                                                            <MoreVertical className="size-4" />
-                                                        </button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent align="end" className="w-44">
-                                                        <DropdownMenuItem onClick={() => setDetailsTask(task)}>
-                                                            <Info className="size-3.5" /> View details
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuSeparator />
-                                                        <DropdownMenuItem
-                                                            variant="destructive"
-                                                            onClick={() => setDeleteTarget(task)}
-                                                        >
-                                                            <Trash2 className="size-3.5" /> Delete task
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
-                                            </td>
-                                        </tr>
+                                                    </td>
+                                                    <td className="px-2 py-3">
+                                                        <DropdownMenu>
+                                                            <DropdownMenuTrigger asChild>
+                                                                <button
+                                                                    type="button"
+                                                                    className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                                                                    aria-label={`Options for ${task.name}`}
+                                                                >
+                                                                    <MoreVertical className="size-4" />
+                                                                </button>
+                                                            </DropdownMenuTrigger>
+                                                            <DropdownMenuContent align="end" className="w-44">
+                                                                <BgTaskMenuItems {...menuProps} />
+                                                            </DropdownMenuContent>
+                                                        </DropdownMenu>
+                                                    </td>
+                                                </tr>
+                                            </ContextMenuTrigger>
+                                            <ContextMenuContent className="w-44">
+                                                <BgTaskMenuItems context {...menuProps} />
+                                            </ContextMenuContent>
+                                        </ContextMenu>
                                     )
                                 })}
                             </tbody>

--- a/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -22,6 +22,8 @@ declare module 'react' {
 import type { DisplayMediaRequest, DisplayMediaSource, HttpAuthRequest } from '@x/shared/dist/browser-control.js'
 
 import { BrowserTabRail } from '@/components/browser-pane/browser-tab-rail'
+import { closeOtherBrowserTabs } from '@/components/browser-pane/browser-tab-actions'
+import { toast } from '@/lib/toast'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -595,6 +597,22 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
     void window.ipc.invoke('browser:closeTab', { tabId })
   }, [])
 
+  const handleCloseOtherTabs = useCallback((tabId: string) => {
+    void closeOtherBrowserTabs(tabId).catch((error) => {
+      toast(error instanceof Error ? error.message : 'Could not close browser tabs', 'error')
+    })
+  }, [])
+
+  const handleReloadTab = useCallback((tabId: string) => {
+    void window.ipc.invoke('browser:reload', { tabId }).catch(() => toast('Could not reload tab', 'error'))
+  }, [])
+
+  const handleDuplicateTab = useCallback((url: string) => {
+    void window.ipc.invoke('browser:newTab', { url }).then((result) => {
+      if (!result.ok) toast(result.error ?? 'Could not duplicate tab', 'error')
+    }).catch(() => toast('Could not duplicate tab', 'error'))
+  }, [])
+
   const toggleRail = useCallback(() => {
     const next = !railOpen
     localStorage.setItem('browser:railOpen', next ? '1' : '0')
@@ -634,6 +652,9 @@ export function BrowserPane({ onClose, forceHidden = false }: BrowserPaneProps) 
         onTogglePin={toggleRail}
         onSwitchTab={handleSwitchTab}
         onCloseTab={handleCloseTab}
+        onCloseOtherTabs={handleCloseOtherTabs}
+        onReloadTab={handleReloadTab}
+        onDuplicateTab={handleDuplicateTab}
         onNewTab={handleNewTab}
       />
 

--- a/apps/x/apps/renderer/src/components/browser-pane/browser-tab-actions.ts
+++ b/apps/x/apps/renderer/src/components/browser-pane/browser-tab-actions.ts
@@ -1,0 +1,14 @@
+export async function closeOtherBrowserTabs(keepTabId: string): Promise<void> {
+  // Read current native state: the rail's rendered list may already be stale.
+  const state = await window.ipc.invoke('browser:getState', null)
+  if (!state.tabs.some((tab) => tab.id === keepTabId)) return
+  if (state.activeTabId !== keepTabId) {
+    const switched = await window.ipc.invoke('browser:switchTab', { tabId: keepTabId })
+    if (!switched.ok) throw new Error('Could not activate the tab to keep')
+  }
+  for (const tab of state.tabs) {
+    if (tab.id === keepTabId) continue
+    const closed = await window.ipc.invoke('browser:closeTab', { tabId: tab.id })
+    if (!closed.ok) throw new Error('Could not close a browser tab')
+  }
+}

--- a/apps/x/apps/renderer/src/components/browser-pane/browser-tab-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/browser-tab-rail.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BrowserTabRail } from './browser-tab-rail'
+import { closeOtherBrowserTabs } from './browser-tab-actions'
+import type { BrowserTabState } from '@x/shared/dist/browser-control.js'
+
+vi.mock('@/lib/toast', () => ({ toast: vi.fn() }))
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+const originalIpc = Object.getOwnPropertyDescriptor(window, 'ipc')
+afterEach(() => {
+  cleanup()
+  if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  else Reflect.deleteProperty(navigator, 'clipboard')
+  if (originalIpc) Object.defineProperty(window, 'ipc', originalIpc)
+  else Reflect.deleteProperty(window, 'ipc')
+})
+
+const tabs: BrowserTabState[] = ['First', 'Second', 'Third'].map((title) => ({
+  id: title, title, url: `https://example.com/${title}`, favicon: null,
+  canGoBack: false, canGoForward: false, loading: false,
+}))
+
+function setup(items = tabs) {
+  const callbacks = {
+    onTogglePin: vi.fn(), onSwitchTab: vi.fn(), onCloseTab: vi.fn(), onCloseOtherTabs: vi.fn(), onNewTab: vi.fn(),
+    onReloadTab: vi.fn(), onDuplicateTab: vi.fn(),
+  }
+  render(<BrowserTabRail {...callbacks} tabs={items} activeTabId="First" open />)
+  return callbacks
+}
+
+describe('browser tab menus', () => {
+  it.each(['Close tab', 'Close other tabs'])('targets the inactive tab for %s without switching on right-click', (name) => {
+    const callbacks = setup()
+    fireEvent.contextMenu(screen.getByTitle('Second'), { button: 2 })
+    expect(callbacks.onSwitchTab).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('menuitem', { name }))
+    expect(name === 'Close tab' ? callbacks.onCloseTab : callbacks.onCloseOtherTabs).toHaveBeenCalledExactlyOnceWith('Second')
+    expect(callbacks.onSwitchTab).not.toHaveBeenCalled()
+  })
+
+  it('disables closing the last tab and copying an empty URL', () => {
+    const callbacks = setup([{ ...tabs[0], url: '' }])
+    fireEvent.contextMenu(screen.getByTitle('First'), { button: 2 })
+    for (const name of ['Close tab', 'Close other tabs', 'Copy URL', 'Duplicate tab']) {
+      const item = screen.getByRole('menuitem', { name })
+      expect(item).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(item)
+    }
+    expect(callbacks.onCloseTab).not.toHaveBeenCalled()
+    expect(callbacks.onCloseOtherTabs).not.toHaveBeenCalled()
+  })
+
+  it('copies the clicked tab URL', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    setup()
+    fireEvent.contextMenu(screen.getByTitle('Second'), { button: 2 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy URL' }))
+    expect(writeText).toHaveBeenCalledExactlyOnceWith(tabs[1].url)
+  })
+
+  it.each(['Reload', 'Duplicate tab'])('routes %s for the inactive tab', (name) => {
+    const callbacks = setup()
+    fireEvent.contextMenu(screen.getByTitle('Second'), { button: 2 })
+    fireEvent.click(screen.getByRole('menuitem', { name }))
+    expect(name === 'Reload' ? callbacks.onReloadTab : callbacks.onDuplicateTab)
+      .toHaveBeenCalledExactlyOnceWith(name === 'Reload' ? 'Second' : tabs[1].url)
+    expect(callbacks.onSwitchTab).not.toHaveBeenCalled()
+  })
+})
+
+describe('closing other native browser tabs', () => {
+  function mockIpc(activeTabId = 'First', switched = true) {
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'browser:getState') return { activeTabId, tabs }
+      return { ok: channel === 'browser:switchTab' ? switched : true }
+    })
+    Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+    return invoke
+  }
+
+  it('activates the surviving tab before sequentially closing the others', async () => {
+    const invoke = mockIpc()
+    await closeOtherBrowserTabs('Second')
+    expect(invoke.mock.calls).toEqual([
+      ['browser:getState', null],
+      ['browser:switchTab', { tabId: 'Second' }],
+      ['browser:closeTab', { tabId: 'First' }],
+      ['browser:closeTab', { tabId: 'Third' }],
+    ])
+  })
+
+  it('does not close anything if the requested survivor no longer exists', async () => {
+    const invoke = mockIpc()
+    await closeOtherBrowserTabs('Gone')
+    expect(invoke).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops if activating the surviving tab fails', async () => {
+    const invoke = mockIpc('First', false)
+    await expect(closeOtherBrowserTabs('Second')).rejects.toThrow('Could not activate')
+    expect(invoke.mock.calls.map(([channel]) => channel)).toEqual(['browser:getState', 'browser:switchTab'])
+  })
+})

--- a/apps/x/apps/renderer/src/components/browser-pane/browser-tab-rail.tsx
+++ b/apps/x/apps/renderer/src/components/browser-pane/browser-tab-rail.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
-import { Globe, Loader2, PanelLeftClose, Plus, X } from 'lucide-react'
+import { Copy, Globe, Loader2, PanelLeftClose, Plus, X } from 'lucide-react'
 
 import type { BrowserTabState } from '@x/shared/dist/browser-control.js'
 
 import { cn } from '@/lib/utils'
+import { toast } from '@/lib/toast'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@/components/ui/context-menu'
 
 // The browser's edge rail: vertical tabs, following the Spaces rail pattern
 // (spaces/space-rail.tsx) — a plain sticky sidebar that collapses to a 28px
@@ -60,6 +62,9 @@ export function BrowserTabRail({
   onTogglePin,
   onSwitchTab,
   onCloseTab,
+  onCloseOtherTabs,
+  onReloadTab,
+  onDuplicateTab,
   onNewTab,
 }: {
   tabs: BrowserTabState[]
@@ -68,8 +73,19 @@ export function BrowserTabRail({
   onTogglePin: () => void
   onSwitchTab: (tabId: string) => void
   onCloseTab: (tabId: string) => void
+  onCloseOtherTabs: (tabId: string) => void
+  onReloadTab: (tabId: string) => void
+  onDuplicateTab: (url: string) => void
   onNewTab: () => void
 }) {
+  const copyUrl = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url)
+      toast('URL copied', 'success')
+    } catch {
+      toast('Could not copy URL', 'error')
+    }
+  }
   return (
     <aside
       style={{ width: open ? RAIL_OPEN_WIDTH : RAIL_STRIP_WIDTH, transition: 'width 200ms cubic-bezier(0.2,0,0,1)' }}
@@ -135,35 +151,55 @@ export function BrowserTabRail({
             {tabs.map((tab) => {
               const title = getBrowserTabTitle(tab)
               return (
-                <button
-                  key={tab.id}
-                  type="button"
-                  onClick={() => onSwitchTab(tab.id)}
-                  title={title}
-                  className={cn(
-                    'group/tab flex h-8 w-full shrink-0 items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
-                    tab.id === activeTabId
-                      ? 'bg-accent font-medium text-foreground'
-                      : 'text-foreground/90 hover:bg-accent/50',
-                  )}
-                >
-                  <TabFavicon tab={tab} />
-                  <span className="min-w-0 flex-1 truncate">{title}</span>
-                  {/* Main refuses to close the last tab, so don't offer it (same as the old strip). */}
-                  {tabs.length > 1 && (
-                    <span
-                      role="button"
-                      aria-label="Close tab"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        onCloseTab(tab.id)
-                      }}
-                      className="flex shrink-0 items-center justify-center rounded-sm p-0.5 opacity-0 transition-all group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10"
+                <ContextMenu key={tab.id}>
+                  <ContextMenuTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => onSwitchTab(tab.id)}
+                      title={title}
+                      className={cn(
+                        'group/tab flex h-8 w-full shrink-0 items-center gap-2 rounded-md px-2 text-left text-[13.5px]',
+                        tab.id === activeTabId
+                          ? 'bg-accent font-medium text-foreground'
+                          : 'text-foreground/90 hover:bg-accent/50',
+                      )}
                     >
-                      <X className="size-3" />
-                    </span>
-                  )}
-                </button>
+                      <TabFavicon tab={tab} />
+                      <span className="min-w-0 flex-1 truncate">{title}</span>
+                      {/* Main refuses to close the last tab, so don't offer it (same as the old strip). */}
+                      {tabs.length > 1 && (
+                        <span
+                          role="button"
+                          aria-label="Close tab"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onCloseTab(tab.id)
+                          }}
+                          className="flex shrink-0 items-center justify-center rounded-sm p-0.5 opacity-0 transition-all group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10"
+                        >
+                          <X className="size-3" />
+                        </span>
+                      )}
+                    </button>
+                  </ContextMenuTrigger>
+                  <ContextMenuContent>
+                    <ContextMenuItem onSelect={() => onReloadTab(tab.id)}>Reload</ContextMenuItem>
+                    <ContextMenuItem
+                      disabled={!tab.url.trim() || /^(javascript:|file:\/\/|chrome:\/\/|chrome-extension:\/\/)/i.test(tab.url.trim())}
+                      onSelect={() => onDuplicateTab(tab.url)}
+                    >Duplicate tab</ContextMenuItem>
+                    <ContextMenuItem disabled={!tab.url.trim()} onSelect={() => { void copyUrl(tab.url) }}>
+                      <Copy /> Copy URL
+                    </ContextMenuItem>
+                    <ContextMenuSeparator />
+                    <ContextMenuItem disabled={tabs.length <= 1} onSelect={() => onCloseTab(tab.id)}>
+                      Close tab
+                    </ContextMenuItem>
+                    <ContextMenuItem disabled={tabs.length <= 1} onSelect={() => onCloseOtherTabs(tab.id)}>
+                      Close other tabs
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
               )
             })}
             <button

--- a/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChatSidebar } from './chat-sidebar'
 
 vi.mock('@/components/ui/sidebar', () => ({ useSidebar: () => ({ state: 'collapsed' }) }))
-vi.mock('@/lib/tab-meta', () => ({ useTabMeta: () => ({}) }))
+vi.mock('@/lib/tab-meta', () => ({ useTabMeta: () => ({}), useAllTabMeta: () => new Map() }))
 vi.mock('@/components/chat-header', () => ({ ChatHeader: () => <div>Chat header</div> }))
 vi.mock('@/components/code/code-session-header', () => ({ CodeSessionHeader: () => null }))
 vi.mock('@/contexts/file-card-context', () => ({ FileCardProvider: ({ children }: { children: ReactNode }) => children }))
@@ -25,6 +25,7 @@ afterEach(() => { cleanup(); vi.unstubAllGlobals() })
 const props = {
   chatTabs: [{ id: 'first', chatId: 'first', runId: null }, { id: 'second', chatId: 'second', runId: null }],
   activeChatTabId: 'first', getChatTabTitle: () => 'Chat', onNewChatTab: vi.fn(),
+  onSwitchChatTab: vi.fn(), onCloseChatTabs: vi.fn(),
   conversation: [], currentAssistantMessage: '', isProcessing: false, onSubmit: vi.fn(),
   keepMounted: true, floating: true,
 }

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -9,7 +9,7 @@ import { ChatHeader } from '@/components/chat-header'
 import { CodeSessionHeader, type CodeSessionHeaderProps } from '@/components/code/code-session-header'
 import { type PromptInputMessage, type FileMention } from '@/components/ai-elements/prompt-input'
 import { FileCardProvider } from '@/contexts/file-card-context'
-import { type ChatTab } from '@/components/tab-bar'
+import { TabBar, type ChatTab } from '@/components/tab-bar'
 import { type CallPreset, type PermissionMode, type StagedAttachment, type ModelSelection } from '@/components/chat-input-with-mentions'
 import { ChatSessionPane, ChatSessionComposer } from '@/components/chat-session'
 import type { QueuedSessionMessage } from '@x/shared/src/sessions.js'
@@ -65,6 +65,8 @@ interface ChatSidebarProps {
   paneSize?: ChatPaneSize
   className?: string
   chatTabs: ChatTab[]
+  onSwitchChatTab: (tabId: string) => void
+  onCloseChatTabs: (tabIds: string[]) => void
   activeChatTabId: string
   getChatTabTitle: (tab: ChatTab) => string
   onNewChatTab: () => void
@@ -159,6 +161,8 @@ export function ChatSidebar({
   paneSize = 'chat-smaller',
   className,
   chatTabs,
+  onSwitchChatTab,
+  onCloseChatTabs,
   activeChatTabId,
   getChatTabTitle,
   onNewChatTab,
@@ -522,6 +526,12 @@ export function ChatSidebar({
             {onMinimize && <Button variant="ghost" size="icon" onClick={onMinimize} className="titlebar-no-drag my-1 size-8 shrink-0" aria-label="Minimize chat" title="Minimize chat"><Minus className="size-4" /></Button>}
             {onCloseTab && <Button variant="ghost" size="icon" onClick={onCloseTab} className="titlebar-no-drag my-1 mr-1 size-8 shrink-0" aria-label="Close chat tab" title="Close tab — conversation stays in history"><X className="size-4" /></Button>}
           </header>
+
+          <div className="flex h-9 shrink-0 border-b border-border">
+            <TabBar tabs={chatTabs} activeTabId={activeChatTabId} getTabId={(tab) => tab.id}
+              getTabTitle={getChatTabTitle} onSwitchTab={onSwitchChatTab}
+              onCloseTab={(id) => onCloseChatTabs([id])} onCloseTabs={onCloseChatTabs} layout="scroll" />
+          </div>
 
           <FileCardProvider onOpenKnowledgeFile={onOpenKnowledgeFile ?? (() => {})} onOpenFile={onOpenFile}>
             <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/x/apps/renderer/src/components/code/file-tree.test.tsx
+++ b/apps/x/apps/renderer/src/components/code/file-tree.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CodeFileTree } from './file-tree'
+
+vi.mock('@/lib/toast', () => ({ toast: vi.fn() }))
+const originalIpc = Object.getOwnPropertyDescriptor(window, 'ipc')
+afterEach(() => {
+  cleanup()
+  if (originalIpc) Object.defineProperty(window, 'ipc', originalIpc)
+  else Reflect.deleteProperty(window, 'ipc')
+})
+
+async function setup() {
+  const invoke = vi.fn(async (_channel: string, args: { relPath: string }) => ({ entries:
+    args.relPath === '.' ? [{ name: 'src', kind: 'dir' }] : [{ name: 'app.ts', kind: 'file' }],
+  }))
+  Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+  const onSelectFile = vi.fn()
+  render(<CodeFileTree sessionId="session" selectedPath={null} onSelectFile={onSelectFile} />)
+  await screen.findByRole('button', { name: 'src' })
+  return { invoke, onSelectFile }
+}
+
+describe('code file-tree menus', () => {
+  it('expands a folder and opens a nested file without opening on right-click', async () => {
+    const { onSelectFile } = await setup()
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'src' }), { button: 2 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Expand folder' }))
+    const file = await screen.findByRole('button', { name: 'app.ts' })
+    fireEvent.contextMenu(file, { button: 2 })
+    expect(onSelectFile).not.toHaveBeenCalled()
+    expect(screen.queryByRole('menuitem', { name: 'Refresh files' })).toBeNull()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open file' }))
+    expect(onSelectFile).toHaveBeenCalledExactlyOnceWith('src/app.ts')
+  })
+  it('refreshes a folder using the current session and relative path', async () => {
+    const { invoke } = await setup()
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'src' }), { button: 2 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Refresh folder' }))
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('codeSession:readdir', { sessionId: 'session', relPath: 'src' }))
+  })
+})

--- a/apps/x/apps/renderer/src/components/code/file-tree.tsx
+++ b/apps/x/apps/renderer/src/components/code/file-tree.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ChevronDown, ChevronRight, FileText, Folder } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { toast } from '@/lib/toast'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
 
 interface TreeEntry {
   name: string
@@ -21,12 +23,17 @@ export function CodeFileTree({
   const [childrenByDir, setChildrenByDir] = useState<Record<string, TreeEntry[]>>({})
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [error, setError] = useState<string | null>(null)
+  const sessionRef = useRef(sessionId)
+  sessionRef.current = sessionId
 
   const loadDir = useCallback(async (relPath: string) => {
     try {
       const res = await window.ipc.invoke('codeSession:readdir', { sessionId, relPath })
+      if (sessionRef.current !== sessionId) return
       setChildrenByDir((prev) => ({ ...prev, [relPath]: res.entries }))
+      setError(null)
     } catch (err) {
+      if (sessionRef.current !== sessionId) return
       setError(err instanceof Error ? err.message : 'Failed to read directory')
     }
   }, [sessionId])
@@ -39,13 +46,13 @@ export function CodeFileTree({
   }, [loadDir])
 
   const toggleDir = (relPath: string) => {
+    if (!expanded.has(relPath) && !childrenByDir[relPath]) void loadDir(relPath)
     setExpanded((prev) => {
       const next = new Set(prev)
       if (next.has(relPath)) {
         next.delete(relPath)
       } else {
         next.add(relPath)
-        if (!childrenByDir[relPath]) void loadDir(relPath)
       }
       return next
     })
@@ -62,40 +69,73 @@ export function CodeFileTree({
         const isOpen = expanded.has(childPath)
         return (
           <div key={childPath}>
-            <button
-              type="button"
-              onClick={() => toggleDir(childPath)}
-              className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-muted"
-              style={{ paddingLeft: depth * 12 + 8 }}
-            >
-              {isOpen ? <ChevronDown className="size-3 shrink-0" /> : <ChevronRight className="size-3 shrink-0" />}
-              <Folder className="size-3.5 shrink-0 text-muted-foreground" />
-              <span className="truncate">{entry.name}</span>
-            </button>
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => toggleDir(childPath)}
+                  className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-muted"
+                  style={{ paddingLeft: depth * 12 + 8 }}
+                >
+                  {isOpen ? <ChevronDown className="size-3 shrink-0" /> : <ChevronRight className="size-3 shrink-0" />}
+                  <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{entry.name}</span>
+                </button>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem onSelect={() => toggleDir(childPath)}>{isOpen ? 'Collapse folder' : 'Expand folder'}</ContextMenuItem>
+                <ContextMenuItem onSelect={() => { void loadDir(childPath) }}>Refresh folder</ContextMenuItem>
+                <ContextMenuItem onSelect={() => { void copyPath(childPath) }}>Copy relative path</ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
             {isOpen && renderDir(childPath, depth + 1)}
           </div>
         )
       }
       return (
-        <button
-          key={childPath}
-          type="button"
-          onClick={() => onSelectFile(childPath)}
-          className={cn(
-            'flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-muted',
-            selectedPath === childPath && 'bg-muted font-medium',
-          )}
-          style={{ paddingLeft: depth * 12 + 22 }}
-        >
-          <FileText className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="truncate">{entry.name}</span>
-        </button>
+        <ContextMenu key={childPath}>
+          <ContextMenuTrigger asChild>
+            <button
+              type="button"
+              onClick={() => onSelectFile(childPath)}
+              className={cn(
+                'flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs hover:bg-muted',
+                selectedPath === childPath && 'bg-muted font-medium',
+              )}
+              style={{ paddingLeft: depth * 12 + 22 }}
+            >
+              <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{entry.name}</span>
+            </button>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem onSelect={() => onSelectFile(childPath)}>Open file</ContextMenuItem>
+            <ContextMenuItem onSelect={() => { void copyPath(childPath) }}>Copy relative path</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
       )
     })
   }
 
-  if (error) {
-    return <div className="p-3 text-xs text-destructive">{error}</div>
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div className="min-h-full overflow-auto py-1">
+          {error ? <div className="p-3 text-xs text-destructive">{error}</div> : renderDir('.', 0)}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={() => { void loadDir('.') }}>Refresh files</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+async function copyPath(path: string) {
+  try {
+    await navigator.clipboard.writeText(path)
+    toast('Path copied', 'success')
+  } catch {
+    toast('Could not copy path', 'error')
   }
-  return <div className="overflow-auto py-1">{renderDir('.', 0)}</div>
 }

--- a/apps/x/apps/renderer/src/components/code/session-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/code/session-rail.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CodeSession } from '@x/shared/src/code-sessions.js'
+import { SessionRail } from './session-rail'
+import type { CodeAgentsStatus } from './code-agent-status'
+import type { ProjectRow } from './use-code-sessions'
+
+afterEach(() => { cleanup(); localStorage.clear() })
+
+const project: ProjectRow = {
+  project: { id: 'project', name: 'Example', path: '/Example', addedAt: '2026-09-08T00:00:00Z' },
+  git: { isGitRepo: true, branch: 'main', hasCommits: true, dirtyCount: 0, root: '/Example', subpath: '' },
+}
+const session: CodeSession = {
+  id: 'session', projectId: 'project', title: 'Fix rendering', agent: 'codex',
+  cwd: '/Example', createdAt: '2026-09-08T00:00:00Z',
+}
+const ready: CodeAgentsStatus = {
+  claude: { installed: true, signedIn: true },
+  codex: { installed: true, signedIn: true },
+}
+
+function setup(done = false, agentsStatus: CodeAgentsStatus | null = ready) {
+  const target = { ...session, ...(done ? { doneAt: '2026-09-08T01:00:00Z' } : {}) }
+  const callbacks = {
+    onSelectSession: vi.fn(), onAddProject: vi.fn(), onRemoveProject: vi.fn(),
+    onNewSession: vi.fn(), onSetDone: vi.fn(), onDeleteSession: vi.fn(),
+  }
+  localStorage.setItem('x:code-done-open', '1')
+  render(<SessionRail
+    {...callbacks}
+    projects={[project]}
+    sessions={[target]}
+    statusOf={() => 'working'}
+    agentsStatus={agentsStatus}
+    selectedSessionId={null}
+  />)
+  return { ...callbacks, target }
+}
+
+function openSessionMenu() {
+  fireEvent.contextMenu(screen.getByText(session.title), { button: 2 })
+}
+
+function openProjectMenu() {
+  fireEvent.contextMenu(screen.getByText('Example'), { button: 2 })
+}
+
+describe('code rail context menus', () => {
+  it.each([false, true])('updates done=%s on the clicked session without selecting it', (done) => {
+    const { onSetDone, onSelectSession, target } = setup(done)
+    openSessionMenu()
+    expect(onSelectSession).not.toHaveBeenCalled()
+    expect(screen.queryByRole('menuitem', { name: 'New session' })).toBeNull()
+    fireEvent.click(screen.getByRole('menuitem', { name: done ? 'Reopen' : 'Mark as done' }))
+    expect(onSetDone).toHaveBeenCalledExactlyOnceWith(target, !done)
+    expect(onSelectSession).not.toHaveBeenCalled()
+  })
+
+  it('routes deletion through the existing parent confirmation callback', () => {
+    const { onDeleteSession, onSelectSession, target } = setup()
+    openSessionMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete session' }))
+    expect(onDeleteSession).toHaveBeenCalledExactlyOnceWith(target)
+    expect(onSelectSession).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['New session', undefined], ['New Claude Code session', 'claude'], ['New Codex session', 'codex'],
+  ] as const)('creates %s in the clicked project without collapsing it', (name, agent) => {
+    const { onNewSession } = setup()
+    openProjectMenu()
+    expect(screen.getByRole('button', { name: 'Collapse project', hidden: true })).toBeTruthy()
+    fireEvent.click(screen.getByRole('menuitem', { name }))
+    expect(onNewSession.mock.calls).toEqual([agent ? ['project', agent] : ['project']])
+  })
+
+  it('disables agents that are missing or signed out', () => {
+    const { onNewSession } = setup(false, {
+      claude: { installed: false, signedIn: false },
+      codex: { installed: true, signedIn: false },
+    })
+    openProjectMenu()
+    for (const name of ['New Claude Code session', 'New Codex session']) {
+      const item = screen.getByRole('menuitem', { name })
+      expect(item).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(item)
+    }
+    expect(onNewSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps explicit agent choices enabled while status is loading', () => {
+    setup(false, null)
+    openProjectMenu()
+    expect(screen.getByRole('menuitem', { name: 'New Codex session' })).not.toHaveAttribute('aria-disabled')
+  })
+
+  it('removes the clicked project through its existing handler', () => {
+    const { onRemoveProject } = setup()
+    openProjectMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remove project' }))
+    expect(onRemoveProject).toHaveBeenCalledExactlyOnceWith('project')
+  })
+
+  it('keeps keyboard actions in the three-dot menu from selecting the session', () => {
+    const { onSelectSession, onSetDone, target } = setup()
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Session actions' }), { key: 'ArrowDown' })
+    fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Mark as done' }), { key: 'Enter' })
+    expect(onSetDone).toHaveBeenCalledExactlyOnceWith(target, true)
+    expect(onSelectSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/components/code/session-rail.tsx
+++ b/apps/x/apps/renderer/src/components/code/session-rail.tsx
@@ -24,6 +24,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { projectLabel, type ProjectRow } from './use-code-sessions'
 import { AGENT_LABEL, isAgentReady, type CodeAgentsStatus } from './code-agent-status'
 
@@ -31,6 +34,60 @@ import { AGENT_LABEL, isAgentReady, type CodeAgentsStatus } from './code-agent-s
 // cap, never a deletion policy.
 const DONE_VISIBLE_LIMIT = 25
 const DONE_OPEN_STORAGE_KEY = 'x:code-done-open'
+
+// Both menu entry points use the same actions and availability rules.
+function SessionMenuItems({ context = false, done, onSetDone, onDelete }: {
+  context?: boolean
+  done: boolean
+  onSetDone: (done: boolean) => void
+  onDelete: () => void
+}) {
+  const Item = context ? ContextMenuItem : DropdownMenuItem
+  const Separator = context ? ContextMenuSeparator : DropdownMenuSeparator
+  const Icon = done ? RotateCcw : Check
+  return (
+    <>
+      <Item onSelect={() => onSetDone(!done)}>
+        <Icon className="size-4" /> {done ? 'Reopen' : 'Mark as done'}
+      </Item>
+      <Separator />
+      <Item onSelect={onDelete}>
+        <Trash2 className="size-4" /> Delete session
+      </Item>
+    </>
+  )
+}
+
+function ProjectMenuItems({ context = false, projectId, agentsStatus, onNewSession, onRemoveProject }: {
+  context?: boolean
+  projectId: string
+  agentsStatus: CodeAgentsStatus | null
+  onNewSession: (projectId: string, agent?: CodingAgent) => void
+  onRemoveProject: (projectId: string) => void
+}) {
+  const Item = context ? ContextMenuItem : DropdownMenuItem
+  const Separator = context ? ContextMenuSeparator : DropdownMenuSeparator
+  return (
+    <>
+      <Item onSelect={() => onNewSession(projectId)}>
+        <Plus className="size-4" /> New session
+      </Item>
+      {(['claude', 'codex'] as CodingAgent[]).map((agent) => (
+        <Item
+          key={agent}
+          disabled={agentsStatus !== null && !isAgentReady(agentsStatus, agent)}
+          onSelect={() => onNewSession(projectId, agent)}
+        >
+          <span className="size-4" /> New {AGENT_LABEL[agent]} session
+        </Item>
+      ))}
+      <Separator />
+      <Item onSelect={() => onRemoveProject(projectId)}>
+        <Trash2 className="size-4" /> Remove project
+      </Item>
+    </>
+  )
+}
 
 function readDoneOpen(): boolean {
   if (typeof window === 'undefined') return false
@@ -92,81 +149,81 @@ function SessionRow({
   const ToggleIcon = done ? RotateCcw : Check
   const toggleLabel = done ? 'Reopen' : 'Mark as done'
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      title={`${session.title}\n${AGENT_LABEL[session.agent] ?? session.agent}${worktree ? ` · ${worktree.branch}` : ''}`}
-      className={cn(
-        'group relative mt-0.5 flex cursor-pointer items-start gap-2.5 rounded-lg py-1.5 pl-2.5 pr-1.5',
-        indent && 'ml-3',
-        selected ? 'bg-accent text-foreground' : 'hover:bg-accent/60',
-      )}
-      onClick={onSelect}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onSelect()
-        }
-      }}
-    >
-      <StatusDot status={done ? 'idle' : status} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <span className={cn('min-w-0 flex-1 truncate text-[13px] leading-5', selected ? 'font-medium' : 'text-foreground/90')}>
-            {prefix && <span className="text-muted-foreground">{prefix} · </span>}
-            {session.title}
-          </span>
-          {/* The time's slot is exactly as wide as the hover actions, so the
-              actions replace the time — never the title beside it. */}
-          <span className="w-12 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground/70 transition-opacity group-hover:opacity-0 group-has-[[data-state=open]]:opacity-0">
-            {when}
-          </span>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          role="button"
+          tabIndex={0}
+          title={`${session.title}\n${AGENT_LABEL[session.agent] ?? session.agent}${worktree ? ` · ${worktree.branch}` : ''}`}
+          className={cn(
+            'group relative mt-0.5 flex cursor-pointer items-start gap-2.5 rounded-lg py-1.5 pl-2.5 pr-1.5',
+            indent && 'ml-3',
+            selected ? 'bg-accent text-foreground' : 'hover:bg-accent/60',
+          )}
+          onClick={onSelect}
+          onKeyDown={(e) => {
+            if (e.target !== e.currentTarget) return
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onSelect()
+            }
+          }}
+        >
+          <StatusDot status={done ? 'idle' : status} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <span className={cn('min-w-0 flex-1 truncate text-[13px] leading-5', selected ? 'font-medium' : 'text-foreground/90')}>
+                {prefix && <span className="text-muted-foreground">{prefix} · </span>}
+                {session.title}
+              </span>
+              {/* The time's slot is exactly as wide as the hover actions, so the
+                  actions replace the time — never the title beside it. */}
+              <span className="w-12 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground/70 transition-opacity group-hover:opacity-0 group-has-[[data-state=open]]:opacity-0">
+                {when}
+              </span>
+            </div>
+            <div className="truncate text-[11px] leading-4 text-muted-foreground/70">{detail}</div>
+          </div>
+          {/* Hover actions sit in the time's reserved slot so the card never
+              reflows and nothing overlaps the text. */}
+          <div className="absolute right-1.5 top-1 flex items-center opacity-0 transition-opacity group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => { e.stopPropagation(); onSetDone(!done) }}
+                  aria-label={toggleLabel}
+                >
+                  <ToggleIcon className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{toggleLabel}</TooltipContent>
+            </Tooltip>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 shrink-0 p-0 text-muted-foreground"
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label="Session actions"
+                >
+                  <MoreHorizontal className="size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
+                <SessionMenuItems done={done} onSetDone={onSetDone} onDelete={onDelete} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
-        <div className="truncate text-[11px] leading-4 text-muted-foreground/70">{detail}</div>
-      </div>
-      {/* Hover actions sit in the time's reserved slot so the card never
-          reflows and nothing overlaps the text. */}
-      <div className="absolute right-1.5 top-1 flex items-center opacity-0 transition-opacity group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-foreground"
-              onClick={(e) => { e.stopPropagation(); onSetDone(!done) }}
-              aria-label={toggleLabel}
-            >
-              <ToggleIcon className="size-3.5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{toggleLabel}</TooltipContent>
-        </Tooltip>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 w-6 shrink-0 p-0 text-muted-foreground"
-              onClick={(e) => e.stopPropagation()}
-              aria-label="Session actions"
-            >
-              <MoreHorizontal className="size-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-            <DropdownMenuItem onClick={() => onSetDone(!done)}>
-              <ToggleIcon className="size-4" />
-              {toggleLabel}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onDelete}>
-              <Trash2 className="size-4" />
-              Delete session
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <SessionMenuItems context done={done} onSetDone={onSetDone} onDelete={onDelete} />
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 
@@ -281,88 +338,75 @@ export function SessionRail({
             : projectSessions
           return (
             <div key={project.id} className="mb-2">
-              <div className="group flex h-8 items-center gap-1 rounded-lg pl-1 pr-1 hover:bg-accent/60">
-                <button
-                  type="button"
-                  onClick={() => toggleCollapsed(project.id)}
-                  className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 hover:text-foreground"
-                  aria-label={isCollapsed ? 'Expand project' : 'Collapse project'}
-                >
-                  {isCollapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
-                </button>
-                {/* Deliberate hover delay — the full path is reference info,
-                    not something that should pop up on a passing cursor. */}
-                <Tooltip delayDuration={1000}>
-                  <TooltipTrigger asChild>
+              <ContextMenu>
+                <ContextMenuTrigger asChild>
+                  <div className="group flex h-8 items-center gap-1 rounded-lg pl-1 pr-1 hover:bg-accent/60">
                     <button
                       type="button"
                       onClick={() => toggleCollapsed(project.id)}
-                      className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                      className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 hover:text-foreground"
+                      aria-label={isCollapsed ? 'Expand project' : 'Collapse project'}
                     >
-                      <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1 truncate text-[13px] font-medium" dir="rtl">
-                        {/* Right-to-left truncation: when the label doesn't fit,
-                            the leaf folder — the part that tells packages apart —
-                            survives and the ellipsis eats the root end. */}
-                        <span dir="ltr">
-                          {label}
-                          {parentHint && (
-                            <span className="ml-1.5 font-normal text-muted-foreground/60">
-                              {compactPath(parentHint, 22)}
-                            </span>
-                          )}
-                        </span>
-                      </span>
+                      {isCollapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
                     </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" className="max-w-[420px] break-all font-mono text-xs">
-                    {project.path}
-                  </TooltipContent>
-                </Tooltip>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 w-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
-                  onClick={() => onNewSession(project.id)}
-                  title="New session"
-                >
-                  <Plus className="size-3.5" />
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
+                    {/* Deliberate hover delay — the full path is reference info,
+                        not something that should pop up on a passing cursor. */}
+                    <Tooltip delayDuration={1000}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => toggleCollapsed(project.id)}
+                          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                        >
+                          <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />
+                          <span className="min-w-0 flex-1 truncate text-[13px] font-medium" dir="rtl">
+                            {/* Right-to-left truncation: when the label doesn't fit,
+                                the leaf folder — the part that tells packages apart —
+                                survives and the ellipsis eats the root end. */}
+                            <span dir="ltr">
+                              {label}
+                              {parentHint && (
+                                <span className="ml-1.5 font-normal text-muted-foreground/60">
+                                  {compactPath(parentHint, 22)}
+                                </span>
+                              )}
+                            </span>
+                          </span>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="max-w-[420px] break-all font-mono text-xs">
+                        {project.path}
+                      </TooltipContent>
+                    </Tooltip>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+                      className="h-6 w-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+                      onClick={() => onNewSession(project.id)}
+                      title="New session"
                     >
-                      <MoreHorizontal className="size-3.5" />
+                      <Plus className="size-3.5" />
                     </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
-                    <DropdownMenuItem onClick={() => onNewSession(project.id)}>
-                      <Plus className="size-4" />
-                      New session
-                    </DropdownMenuItem>
-                    {/* The explicit picks — the plain entry (and the + button)
-                        take the agent you last worked with. */}
-                    {(['claude', 'codex'] as CodingAgent[]).map((agent) => (
-                      <DropdownMenuItem
-                        key={agent}
-                        disabled={agentsStatus !== null && !isAgentReady(agentsStatus, agent)}
-                        onClick={() => onNewSession(project.id, agent)}
-                      >
-                        <span className="size-4" />
-                        New {AGENT_LABEL[agent]} session
-                      </DropdownMenuItem>
-                    ))}
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onClick={() => onRemoveProject(project.id)}>
-                      <Trash2 className="size-4" />
-                      Remove project
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+                        >
+                          <MoreHorizontal className="size-3.5" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start">
+                        <ProjectMenuItems projectId={project.id} agentsStatus={agentsStatus} onNewSession={onNewSession} onRemoveProject={onRemoveProject} />
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ProjectMenuItems context projectId={project.id} agentsStatus={agentsStatus} onNewSession={onNewSession} onRemoveProject={onRemoveProject} />
+                </ContextMenuContent>
+              </ContextMenu>
               {!isCollapsed && projectSessions.length === 0 && (
                 <button
                   type="button"

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -1,3 +1,4 @@
+import { SidebarChatContextMenu } from "./sidebar-chat-context-menu"
 "use client"
 
 import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
@@ -1622,17 +1623,25 @@ function ChatsFlyout({
               </div>
             ) : (
               <>
-                <button
-                  type="button"
-                  onClick={() => onOpenRun?.(chat.id)}
-                  className="flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left text-[13.5px] text-foreground/90 hover:bg-accent"
+                <SidebarChatContextMenu
+                  pinned={pinnedChatIds.includes(chat.id)}
+                  onOpen={onOpenRun ? () => onOpenRun(chat.id) : undefined}
+                  onTogglePin={() => onTogglePin(chat.id)}
+                  onRename={onRenameRun ? () => { setRenameDraft(chat.title || ''); setRenamingChatId(chat.id) } : undefined}
+                  onRequestDelete={onRequestDelete ? () => onRequestDelete(chat.id, chat.title || '(Untitled chat)') : undefined}
                 >
-                  <MessageSquare className="size-4 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1 truncate pr-5">{chat.title || '(Untitled chat)'}</span>
-                  {pinnedChatIds.includes(chat.id) && (
-                    <Pin className="size-3 shrink-0 text-muted-foreground/70 transition-opacity group-hover/chat-row:opacity-0" />
-                  )}
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => onOpenRun?.(chat.id)}
+                    className="flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left text-[13.5px] text-foreground/90 hover:bg-accent"
+                  >
+                    <MessageSquare className="size-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1 truncate pr-5">{chat.title || '(Untitled chat)'}</span>
+                    {pinnedChatIds.includes(chat.id) && (
+                      <Pin className="size-3 shrink-0 text-muted-foreground/70 transition-opacity group-hover/chat-row:opacity-0" />
+                    )}
+                  </button>
+                </SidebarChatContextMenu>
                 {onRenameRun && (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/apps/x/apps/renderer/src/components/email-thread-context-menu.test.tsx
+++ b/apps/x/apps/renderer/src/components/email-thread-context-menu.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EmailThreadContextMenu } from './email-thread-context-menu'
+
+afterEach(cleanup)
+
+function setup({ unread = true, section = 'important', categorizing = true }: {
+  unread?: boolean
+  section?: 'important' | 'other' | null
+  categorizing?: boolean
+} = {}) {
+  const actions = {
+    onMarkRead: vi.fn().mockResolvedValue(undefined),
+    onSetImportance: vi.fn().mockResolvedValue(undefined),
+    onSetCategory: vi.fn().mockResolvedValue(undefined),
+    onArchive: vi.fn().mockResolvedValue(undefined),
+    onTrash: vi.fn().mockResolvedValue(undefined),
+  }
+  const onOpen = vi.fn()
+  render(
+    <EmailThreadContextMenu
+      {...actions}
+      threadId="clicked-thread"
+      unread={unread}
+      section={section}
+      category="newsletter"
+      labels={[
+        { id: 'newsletter', name: 'News', kind: 'builtin' },
+        { id: 'customer', name: 'Customer', kind: 'custom' },
+      ]}
+      onSetCategory={categorizing ? actions.onSetCategory : undefined}
+    >
+      <div><button onClick={onOpen}>Email row</button></div>
+    </EmailThreadContextMenu>,
+  )
+  fireEvent.contextMenu(screen.getByRole('button', { name: 'Email row' }), { button: 2 })
+  return { ...actions, onOpen }
+}
+
+describe('email thread context menu', () => {
+  it.each([true, false])('toggles read state for unread=%s without opening the thread', (unread) => {
+    const { onMarkRead, onOpen } = setup({ unread })
+    expect(onOpen).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('menuitem', { name: unread ? 'Mark as read' : 'Mark as unread' }))
+    expect(onMarkRead).toHaveBeenCalledExactlyOnceWith('clicked-thread', unread)
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it.each(['important', 'other'] as const)('toggles importance from %s', (section) => {
+    const { onSetImportance } = setup({ section })
+    fireEvent.click(screen.getByRole('menuitem', { name: section === 'important' ? 'Mark as not important' : 'Mark as important' }))
+    expect(onSetImportance).toHaveBeenCalledExactlyOnceWith('clicked-thread', section === 'important' ? 'other' : 'important')
+  })
+
+  it('omits unavailable importance and category actions', () => {
+    setup({ section: null, categorizing: false })
+    expect(screen.queryByRole('menuitem', { name: /important/ })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Category' })).toBeNull()
+  })
+
+  it.each(['Archive', 'Delete'])('routes %s to the existing handler for the clicked thread', (name) => {
+    const { onArchive, onTrash, onOpen } = setup()
+    fireEvent.click(screen.getByRole('menuitem', { name }))
+    expect(name === 'Archive' ? onArchive : onTrash).toHaveBeenCalledExactlyOnceWith('clicked-thread')
+    expect(name === 'Archive' ? onTrash : onArchive).not.toHaveBeenCalled()
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('shows the selected category and supports custom labels', async () => {
+    const { onSetCategory } = setup()
+    fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Category' }), { key: 'ArrowRight' })
+    expect(await screen.findByRole('menuitemradio', { name: 'News' })).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Customer' }))
+    expect(onSetCategory).toHaveBeenCalledExactlyOnceWith('clicked-thread', 'customer')
+  })
+
+  it('keeps menu typeahead from reaching document-level inbox shortcuts', () => {
+    setup()
+    const shortcut = vi.fn()
+    document.addEventListener('keydown', shortcut)
+    try {
+      fireEvent.keyDown(screen.getByRole('menuitem', { name: 'Archive' }), { key: 'e' })
+      expect(shortcut).not.toHaveBeenCalled()
+    } finally {
+      document.removeEventListener('keydown', shortcut)
+    }
+  })
+})

--- a/apps/x/apps/renderer/src/components/email-thread-context-menu.tsx
+++ b/apps/x/apps/renderer/src/components/email-thread-context-menu.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react'
+import { Archive, CheckCheck, Mail, Star, StarOff, Trash2 } from 'lucide-react'
+import type { EmailLabelInfo } from '@/lib/email-labels'
+import {
+  ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuRadioGroup,
+  ContextMenuRadioItem, ContextMenuSeparator, ContextMenuSub,
+  ContextMenuSubContent, ContextMenuSubTrigger, ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+
+export function EmailThreadContextMenu({
+  children, threadId, unread, category, section, labels,
+  onMarkRead, onSetImportance, onSetCategory, onArchive, onTrash,
+}: {
+  children: ReactNode
+  threadId: string
+  unread: boolean
+  category?: string | null
+  section: 'important' | 'other' | null
+  labels: EmailLabelInfo[]
+  onMarkRead: (threadId: string, read?: boolean) => Promise<void>
+  onSetImportance: (threadId: string, importance: 'important' | 'other') => Promise<void>
+  onSetCategory?: (threadId: string, category: string) => Promise<void>
+  onArchive: (threadId: string) => Promise<void>
+  onTrash: (threadId: string) => Promise<void>
+}) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      {/* Menu typeahead must not trigger the inbox's document-level shortcuts. */}
+      <ContextMenuContent className="font-sans" onKeyDown={(event) => event.stopPropagation()}>
+        <ContextMenuItem onSelect={() => { void onMarkRead(threadId, unread) }}>
+          {unread ? <CheckCheck /> : <Mail />}
+          {unread ? 'Mark as read' : 'Mark as unread'}
+        </ContextMenuItem>
+        {section && (
+          <ContextMenuItem onSelect={() => { void onSetImportance(threadId, section === 'important' ? 'other' : 'important') }}>
+            {section === 'important' ? <StarOff /> : <Star />}
+            {section === 'important' ? 'Mark as not important' : 'Mark as important'}
+          </ContextMenuItem>
+        )}
+        {onSetCategory && labels.length > 0 && (
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>Category</ContextMenuSubTrigger>
+            <ContextMenuSubContent className="font-sans" onKeyDown={(event) => event.stopPropagation()}>
+              <ContextMenuRadioGroup value={category ?? ''} onValueChange={(value) => { void onSetCategory(threadId, value) }}>
+                {labels.map((label) => (
+                  <ContextMenuRadioItem key={label.id} value={label.id}>{label.name}</ContextMenuRadioItem>
+                ))}
+              </ContextMenuRadioGroup>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        )}
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={() => { void onArchive(threadId) }}>
+          <Archive /> Archive
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem variant="destructive" onSelect={() => { void onTrash(threadId) }}>
+          <Trash2 /> Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/x/apps/renderer/src/components/email-view.tsx
+++ b/apps/x/apps/renderer/src/components/email-view.tsx
@@ -12,6 +12,7 @@ import { prepareEmailHtml, splitPlainTextQuote, stripQuotedReplyText, QUOTED_CLA
 import { BUILTIN_LABELS, labelNameFor, orderedCategoryIds, type EmailLabelInfo } from '@/lib/email-labels'
 import { replyReadyThreads } from '@/lib/email-reply-ready'
 import { EmailRail, type EmailRailSelection } from '@/components/email-rail'
+import { EmailThreadContextMenu } from '@/components/email-thread-context-menu'
 import { useTheme } from '@/contexts/theme-context'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { Button } from '@/components/ui/button'
@@ -2381,68 +2382,81 @@ const ThreadRow = memo(function ThreadRow({
   }
   return (
     <div className={cn('gmail-row-group', !isMounted && 'gmail-row-group-cv', isLeaving && 'gmail-row-group-leaving')}>
-      <div
-        className={cn('gmail-row-shell', isSelected && 'gmail-row-shell-selected')}
-        data-thread-id={thread.threadId}
-        onMouseEnter={() => onHoverIn(thread)}
-        onMouseLeave={onHoverOut}
+      <EmailThreadContextMenu
+        threadId={thread.threadId}
+        unread={isUnread}
+        category={thread.category}
+        section={section}
+        labels={labels}
+        onMarkRead={onMarkRead}
+        onSetImportance={onSetImportance}
+        onSetCategory={onSetCategory}
+        onArchive={onArchive}
+        onTrash={onTrash}
       >
-        <button
-          type="button"
-          className={cn('gmail-row', isSelected && 'gmail-row-selected', isUnread && 'gmail-row-unread', isFocused && 'gmail-row-focused')}
-          onClick={() => onToggle(thread)}
+        <div
+          className={cn('gmail-row-shell', isSelected && 'gmail-row-shell-selected')}
+          data-thread-id={thread.threadId}
+          onMouseEnter={() => onHoverIn(thread)}
+          onMouseLeave={onHoverOut}
         >
-          <span className="gmail-row-dot" aria-hidden />
-          <span className="gmail-row-sender">{extractName(latest?.from || thread.from)}</span>
-          <span className="gmail-row-content">
-            <strong>{thread.summary || thread.subject || '(No subject)'}</strong>
-            <span>{thread.summary ? thread.subject : snippet(thread.preview || latest?.body || thread.latest_email)}</span>
-            {categoryChip && <span className="gmail-row-chip">{categoryChip}</span>}
-            {chip && <span className={cn('gmail-row-chip', chipWaiting ? 'gmail-row-chip-waiting' : 'gmail-row-chip-ready')}>{chip}</span>}
-          </span>
-          <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
-        </button>
-        <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
-          {section && (
+          <button
+            type="button"
+            className={cn('gmail-row', isSelected && 'gmail-row-selected', isUnread && 'gmail-row-unread', isFocused && 'gmail-row-focused')}
+            onClick={() => onToggle(thread)}
+          >
+            <span className="gmail-row-dot" aria-hidden />
+            <span className="gmail-row-sender">{extractName(latest?.from || thread.from)}</span>
+            <span className="gmail-row-content">
+              <strong>{thread.summary || thread.subject || '(No subject)'}</strong>
+              <span>{thread.summary ? thread.subject : snippet(thread.preview || latest?.body || thread.latest_email)}</span>
+              {categoryChip && <span className="gmail-row-chip">{categoryChip}</span>}
+              {chip && <span className={cn('gmail-row-chip', chipWaiting ? 'gmail-row-chip-waiting' : 'gmail-row-chip-ready')}>{chip}</span>}
+            </span>
+            <span className="gmail-row-date">{formatInboxTime(latest?.date || thread.date)}</span>
+          </button>
+          <div className="gmail-row-actions" onMouseDown={stop} onClick={stop}>
+            {section && (
+              <button
+                type="button"
+                className="gmail-row-action"
+                title={section === 'important' ? 'Not important — teach the classifier' : 'Important — teach the classifier'}
+                aria-label={section === 'important' ? 'Mark as not important' : 'Mark as important'}
+                onClick={(e) => { stop(e); void onSetImportance(thread.threadId, section === 'important' ? 'other' : 'important') }}
+              >
+                {section === 'important' ? <StarOff size={15} /> : <Star size={15} />}
+              </button>
+            )}
             <button
               type="button"
               className="gmail-row-action"
-              title={section === 'important' ? 'Not important — teach the classifier' : 'Important — teach the classifier'}
-              aria-label={section === 'important' ? 'Mark as not important' : 'Mark as important'}
-              onClick={(e) => { stop(e); void onSetImportance(thread.threadId, section === 'important' ? 'other' : 'important') }}
+              title={isUnread ? 'Mark as read' : 'Mark as unread'}
+              aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
+              onClick={(e) => { stop(e); void onMarkRead(thread.threadId, isUnread) }}
             >
-              {section === 'important' ? <StarOff size={15} /> : <Star size={15} />}
+              {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
             </button>
-          )}
-          <button
-            type="button"
-            className="gmail-row-action"
-            title={isUnread ? 'Mark as read' : 'Mark as unread'}
-            aria-label={isUnread ? 'Mark as read' : 'Mark as unread'}
-            onClick={(e) => { stop(e); void onMarkRead(thread.threadId, isUnread) }}
-          >
-            {isUnread ? <CheckCheck size={15} /> : <Mail size={15} />}
-          </button>
-          <button
-            type="button"
-            className="gmail-row-action"
-            title="Archive"
-            aria-label="Archive"
-            onClick={(e) => { stop(e); void onArchive(thread.threadId) }}
-          >
-            <Archive size={15} />
-          </button>
-          <button
-            type="button"
-            className="gmail-row-action gmail-row-action-danger"
-            title="Delete"
-            aria-label="Delete"
-            onClick={(e) => { stop(e); void onTrash(thread.threadId) }}
-          >
-            <Trash2 size={15} />
-          </button>
+            <button
+              type="button"
+              className="gmail-row-action"
+              title="Archive"
+              aria-label="Archive"
+              onClick={(e) => { stop(e); void onArchive(thread.threadId) }}
+            >
+              <Archive size={15} />
+            </button>
+            <button
+              type="button"
+              className="gmail-row-action gmail-row-action-danger"
+              title="Delete"
+              aria-label="Delete"
+              onClick={(e) => { stop(e); void onTrash(thread.threadId) }}
+            >
+              <Trash2 size={15} />
+            </button>
+          </div>
         </div>
-      </div>
+      </EmailThreadContextMenu>
       {/* Drop the detail as soon as the row starts leaving — the collapse
           keyframe assumes row height, and the thread is being removed anyway. */}
       {isMounted && !isLeaving && (

--- a/apps/x/apps/renderer/src/components/file-list-context-menu.test.tsx
+++ b/apps/x/apps/renderer/src/components/file-list-context-menu.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FileListContextMenu } from './file-list-context-menu'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from './ui/context-menu'
+
+afterEach(cleanup)
+describe('file-list empty-space menu', () => {
+  it('calls the current folder creation action', () => {
+    const onSelect = vi.fn()
+    render(<FileListContextMenu actions={[{ label: 'New folder', onSelect }]}><div data-testid="empty" /></FileListContextMenu>)
+    fireEvent.contextMenu(screen.getByTestId('empty'), { button: 2 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'New folder' }))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+  it('gives a nested file menu priority over blank-space actions', () => {
+    render(<FileListContextMenu actions={[{ label: 'New folder', onSelect: vi.fn() }]}><div>
+      <ContextMenu><ContextMenuTrigger asChild><button>File</button></ContextMenuTrigger>
+        <ContextMenuContent><ContextMenuItem>Rename</ContextMenuItem></ContextMenuContent>
+      </ContextMenu>
+    </div></FileListContextMenu>)
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'File' }), { button: 2 })
+    expect(screen.getByRole('menuitem', { name: 'Rename' })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: 'New folder' })).toBeNull()
+  })
+  it('preserves input context menus', () => {
+    render(<FileListContextMenu actions={[{ label: 'New folder', onSelect: vi.fn() }]}><div><input aria-label="Name" /></div></FileListContextMenu>)
+    const event = new MouseEvent('contextmenu', { button: 2, bubbles: true, cancelable: true })
+    fireEvent(screen.getByRole('textbox'), event)
+    expect(event.defaultPrevented).toBe(false)
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+})

--- a/apps/x/apps/renderer/src/components/file-list-context-menu.tsx
+++ b/apps/x/apps/renderer/src/components/file-list-context-menu.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+
+export function FileListContextMenu({ children, actions, onOpenChange }: {
+  children: ReactNode
+  actions: { label: string; onSelect: () => void; disabled?: boolean }[]
+  onOpenChange?: (open: boolean) => void
+}) {
+  return (
+    <ContextMenu onOpenChange={onOpenChange}>
+      <ContextMenuTrigger asChild onContextMenuCapture={(event) => {
+        // Leave editor and input menus to their own controls.
+        if (event.target instanceof Element && event.target.closest('input, textarea, [contenteditable="true"]')) event.stopPropagation()
+      }} onContextMenu={(event) => {
+        if (event.defaultPrevented) return // An item's own menu takes priority.
+        if (event.target instanceof Element && event.target.closest('button, a')) event.preventDefault()
+      }}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {actions.map((action) => <ContextMenuItem key={action.label} disabled={action.disabled} onSelect={action.onSelect}>{action.label}</ContextMenuItem>)}
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/x/apps/renderer/src/components/knowledge-view.tsx
+++ b/apps/x/apps/renderer/src/components/knowledge-view.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { FileListContextMenu } from '@/components/file-list-context-menu'
 import {
   ChevronRight,
   Copy,
@@ -232,6 +233,11 @@ export function KnowledgeView({
           {basisContent}
         </div>
       ) : (
+      <FileListContextMenu actions={[
+        { label: 'New note', onSelect: () => actions.createNote(currentFolder?.path) },
+        { label: 'New folder', onSelect: () => { void actions.createFolder(currentFolder?.path).then(setRenameTarget).catch(() => {}) } },
+        { label: 'Add Google Doc', onSelect: () => actions.addGoogleDoc(currentFolder?.path) },
+      ]}>
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[1120px] px-[30px] py-6">
           {currentFolder ? (
@@ -299,6 +305,7 @@ export function KnowledgeView({
           />
         </div>
       </div>
+      </FileListContextMenu>
       )}
     </div>
   )

--- a/apps/x/apps/renderer/src/components/meeting-context-menu.test.tsx
+++ b/apps/x/apps/renderer/src/components/meeting-context-menu.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { MeetingEventContextMenu, MeetingNoteContextMenu } from './meeting-context-menu'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({ toast: vi.fn() }))
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  else Reflect.deleteProperty(navigator, 'clipboard')
+})
+
+function clipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+  return writeText
+}
+
+function eventMenu({ links = true, captureDisabled = false } = {}) {
+  const onCapture = vi.fn()
+  render(<Popover>
+    <MeetingEventContextMenu
+      conferenceLink={links ? 'https://meet.google.com/example' : null}
+      calendarLink={links ? 'https://calendar.google.com/event' : null}
+      captureDisabled={captureDisabled}
+      onCapture={onCapture}
+    >
+      <PopoverTrigger asChild><button>Meeting</button></PopoverTrigger>
+    </MeetingEventContextMenu>
+    <PopoverContent>Meeting details</PopoverContent>
+  </Popover>)
+  fireEvent.contextMenu(screen.getByRole('button', { name: 'Meeting' }), { button: 2 })
+  return onCapture
+}
+
+describe('meeting context menus', () => {
+  it.each([['Join & take notes', true], ['Take notes', false]] as const)('routes %s without opening the details popover', (name, openConference) => {
+    const onCapture = eventMenu()
+    expect(screen.queryByText('Meeting details')).toBeNull()
+    fireEvent.click(screen.getByRole('menuitem', { name }))
+    expect(onCapture).toHaveBeenCalledExactlyOnceWith(openConference)
+    expect(screen.queryByText('Meeting details')).toBeNull()
+  })
+
+  it('omits link actions for an event without links', () => {
+    eventMenu({ links: false })
+    expect(screen.getAllByRole('menuitem')).toHaveLength(1)
+    expect(screen.getByRole('menuitem', { name: 'Take notes' })).toBeTruthy()
+  })
+
+  it('disables capture while busy but keeps links usable', () => {
+    const onCapture = eventMenu({ captureDisabled: true })
+    for (const name of ['Join & take notes', 'Take notes']) {
+      const item = screen.getByRole('menuitem', { name })
+      expect(item).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(item)
+    }
+    expect(onCapture).not.toHaveBeenCalled()
+    expect(screen.getByRole('menuitem', { name: 'Open in Google Calendar' })).not.toHaveAttribute('aria-disabled')
+  })
+
+  it('opens the event calendar URL', () => {
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    eventMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open in Google Calendar' }))
+    expect(open).toHaveBeenCalledExactlyOnceWith('https://calendar.google.com/event', '_blank')
+  })
+
+  it('copies the conference URL', async () => {
+    const writeText = clipboard()
+    eventMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy meeting link' }))
+    expect(writeText).toHaveBeenCalledExactlyOnceWith('https://meet.google.com/example')
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('Copied to clipboard', 'success'))
+  })
+
+  it.each(['Open note', 'Copy path'])('supports %s on saved note table rows', (name) => {
+    const onOpen = vi.fn()
+    const writeText = clipboard()
+    const path = 'knowledge/Meetings/2026-09-08/Standup.md'
+    render(<table><tbody><MeetingNoteContextMenu path={path} onOpen={onOpen}>
+      <tr><td><button onClick={onOpen}>Standup</button></td></tr>
+    </MeetingNoteContextMenu></tbody></table>)
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Standup' }), { button: 2 })
+    expect(onOpen).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('menuitem', { name }))
+    if (name === 'Copy path') {
+      expect(writeText).toHaveBeenCalledExactlyOnceWith(path)
+      expect(onOpen).not.toHaveBeenCalled()
+    } else {
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(writeText).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/apps/x/apps/renderer/src/components/meeting-context-menu.tsx
+++ b/apps/x/apps/renderer/src/components/meeting-context-menu.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react'
+import { Calendar, Copy, FileText, Mic, Video } from 'lucide-react'
+import { toast } from '@/lib/toast'
+import {
+  ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+
+async function copy(value: string) {
+  try {
+    await navigator.clipboard.writeText(value)
+    toast('Copied to clipboard', 'success')
+  } catch {
+    toast('Could not copy to clipboard', 'error')
+  }
+}
+
+export function MeetingEventContextMenu({ children, conferenceLink, calendarLink, captureDisabled, onCapture }: {
+  children: ReactNode
+  conferenceLink: string | null
+  calendarLink?: string | null
+  captureDisabled: boolean
+  onCapture: (openConference: boolean) => void
+}) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        {conferenceLink && (
+          <ContextMenuItem disabled={captureDisabled} onSelect={() => onCapture(true)}>
+            <Video /> Join & take notes
+          </ContextMenuItem>
+        )}
+        <ContextMenuItem disabled={captureDisabled} onSelect={() => onCapture(false)}>
+          <Mic /> Take notes
+        </ContextMenuItem>
+        {(calendarLink || conferenceLink) && <ContextMenuSeparator />}
+        {calendarLink && (
+          <ContextMenuItem onSelect={() => { window.open(calendarLink, '_blank') }}>
+            <Calendar /> Open in Google Calendar
+          </ContextMenuItem>
+        )}
+        {conferenceLink && (
+          <ContextMenuItem onSelect={() => { void copy(conferenceLink) }}>
+            <Copy /> Copy meeting link
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+export function MeetingNoteContextMenu({ children, path, onOpen }: {
+  children: ReactNode
+  path: string
+  onOpen: () => void
+}) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={onOpen}><FileText /> Open note</ContextMenuItem>
+        <ContextMenuItem onSelect={() => { void copy(path) }}><Copy /> Copy path</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/x/apps/renderer/src/components/meetings-view.tsx
+++ b/apps/x/apps/renderer/src/components/meetings-view.tsx
@@ -4,6 +4,7 @@ import { Calendar, ChevronDown, ChevronRight, Clock, ExternalLink, FileText, Loa
 import { Streamdown } from 'streamdown'
 
 import { Button } from '@/components/ui/button'
+import { MeetingEventContextMenu, MeetingNoteContextMenu } from '@/components/meeting-context-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { formatRelativeTime } from '@/lib/relative-time'
@@ -564,7 +565,7 @@ function InlineMeetingPrep({ event, onOpenNote }: { event: UpcomingEvent; onOpen
   )
 }
 
-function UpcomingEvents({ onOpenNote }: { onOpenNote: (path: string) => void }) {
+function UpcomingEvents({ onOpenNote, captureDisabled }: { onOpenNote: (path: string) => void; captureDisabled: boolean }) {
   const [events, setEvents] = useState<UpcomingEvent[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -754,6 +755,7 @@ function UpcomingEvents({ onOpenNote }: { onOpenNote: (path: string) => void }) 
                 isToday={day.dateKey === todayKey}
                 prepEventId={prepEventId}
                 onOpenNote={onOpenNote}
+                captureDisabled={captureDisabled}
               />
             ))}
           </div>
@@ -764,7 +766,7 @@ function UpcomingEvents({ onOpenNote }: { onOpenNote: (path: string) => void }) 
   )
 }
 
-function UpcomingDayCard({ day, isToday, prepEventId, onOpenNote }: { day: DayGroup; isToday: boolean; prepEventId: string | null; onOpenNote: (path: string) => void }) {
+function UpcomingDayCard({ day, isToday, prepEventId, onOpenNote, captureDisabled }: { day: DayGroup; isToday: boolean; prepEventId: string | null; onOpenNote: (path: string) => void; captureDisabled: boolean }) {
   const dayNum = day.date.getDate()
   const month = day.date.toLocaleDateString([], { month: 'short' })
   const weekday = day.date.toLocaleDateString([], { weekday: 'short' })
@@ -801,6 +803,7 @@ function UpcomingDayCard({ day, isToday, prepEventId, onOpenNote }: { day: DayGr
             isLast={idx === count - 1}
             isPrepTarget={ev.id === prepEventId}
             onOpenNote={onOpenNote}
+            captureDisabled={captureDisabled}
           />
         ))
       )}
@@ -816,7 +819,7 @@ function NowBadge() {
   )
 }
 
-function UpcomingEventItem({ event, isLast, isPrepTarget, onOpenNote }: { event: UpcomingEvent; isLast: boolean; isPrepTarget: boolean; onOpenNote: (path: string) => void }) {
+function UpcomingEventItem({ event, isLast, isPrepTarget, onOpenNote, captureDisabled }: { event: UpcomingEvent; isLast: boolean; isPrepTarget: boolean; onOpenNote: (path: string) => void; captureDisabled: boolean }) {
   const [open, setOpen] = useState(false)
   // The next meeting auto-expands its prep; any other meeting with attendees
   // can be expanded on demand via the Prep toggle (resolves lazily on open).
@@ -831,71 +834,78 @@ function UpcomingEventItem({ event, isLast, isPrepTarget, onOpenNote }: { event:
   return (
     <div className={cn(!isLast && 'border-b')}>
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <div
-          role="button"
-          tabIndex={0}
-          title={titleAndLocation}
-          className={cn(
-            'group flex w-full cursor-pointer items-center gap-4 px-5 py-3 text-left transition-colors',
-            showPrep && 'border-b',
-            isNow ? 'bg-muted' : 'hover:bg-muted/50',
-          )}
-        >
-          <span className="shrink-0 text-[13px] tabular-nums text-muted-foreground" style={{ width: 118 }}>
-            {formatEventTimeRangeCompact(event)}
-          </span>
-          <span className="flex min-w-0 flex-1 flex-col">
-            <span className="flex items-center gap-2">
-              <span className="truncate text-sm font-semibold text-foreground">
-                {event.summary}
-              </span>
-              {isNow ? <NowBadge /> : null}
-            </span>
-            {subtitle ? (
-              <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
-                {platform ? <Video className="size-3.5 shrink-0" /> : <MapPin className="size-3.5 shrink-0" />}
-                <span className="truncate">{subtitle}</span>
-              </span>
-            ) : null}
-          </span>
-          <div className="flex shrink-0 items-center gap-2">
-            {prepEligible ? (
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); setPrepOpen((v) => !v) }}
-                onMouseDown={(e) => e.stopPropagation()}
-                aria-expanded={prepOpen}
-                title={prepOpen ? 'Hide prep' : 'Show meeting prep'}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
-                  prepOpen ? 'bg-accent text-foreground' : 'bg-background text-foreground hover:bg-accent',
-                )}
-              >
-                <Sparkles className="size-3.5" />
-                Prep
-                <ChevronDown className={cn('size-3 transition-transform', prepOpen && 'rotate-180')} />
-              </button>
-            ) : null}
-            {event.conferenceLink ? (
-              <SplitJoinButton
-                onJoinAndNotes={() => triggerMeetingCapture(event, true)}
-                onNotesOnly={() => triggerMeetingCapture(event, false)}
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={(e) => { e.stopPropagation(); triggerMeetingCapture(event, false) }}
-                onMouseDown={(e) => e.stopPropagation()}
-                className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-              >
-                <Mic className="size-3.5" />
-                Take notes
-              </button>
+      <MeetingEventContextMenu
+        conferenceLink={event.conferenceLink}
+        calendarLink={event.htmlLink}
+        captureDisabled={captureDisabled}
+        onCapture={(openConference) => triggerMeetingCapture(event, openConference)}
+      >
+        <PopoverTrigger asChild>
+          <div
+            role="button"
+            tabIndex={0}
+            title={titleAndLocation}
+            className={cn(
+              'group flex w-full cursor-pointer items-center gap-4 px-5 py-3 text-left transition-colors',
+              showPrep && 'border-b',
+              isNow ? 'bg-muted' : 'hover:bg-muted/50',
             )}
+          >
+            <span className="shrink-0 text-[13px] tabular-nums text-muted-foreground" style={{ width: 118 }}>
+              {formatEventTimeRangeCompact(event)}
+            </span>
+            <span className="flex min-w-0 flex-1 flex-col">
+              <span className="flex items-center gap-2">
+                <span className="truncate text-sm font-semibold text-foreground">
+                  {event.summary}
+                </span>
+                {isNow ? <NowBadge /> : null}
+              </span>
+              {subtitle ? (
+                <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  {platform ? <Video className="size-3.5 shrink-0" /> : <MapPin className="size-3.5 shrink-0" />}
+                  <span className="truncate">{subtitle}</span>
+                </span>
+              ) : null}
+            </span>
+            <div className="flex shrink-0 items-center gap-2">
+              {prepEligible ? (
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setPrepOpen((v) => !v) }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  aria-expanded={prepOpen}
+                  title={prepOpen ? 'Hide prep' : 'Show meeting prep'}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
+                    prepOpen ? 'bg-accent text-foreground' : 'bg-background text-foreground hover:bg-accent',
+                  )}
+                >
+                  <Sparkles className="size-3.5" />
+                  Prep
+                  <ChevronDown className={cn('size-3 transition-transform', prepOpen && 'rotate-180')} />
+                </button>
+              ) : null}
+              {event.conferenceLink ? (
+                <SplitJoinButton
+                  onJoinAndNotes={() => triggerMeetingCapture(event, true)}
+                  onNotesOnly={() => triggerMeetingCapture(event, false)}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); triggerMeetingCapture(event, false) }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                >
+                  <Mic className="size-3.5" />
+                  Take notes
+                </button>
+              )}
+            </div>
           </div>
-        </div>
-      </PopoverTrigger>
+        </PopoverTrigger>
+      </MeetingEventContextMenu>
       <EventDetailsPopover event={event} onClose={() => setOpen(false)} />
     </Popover>
     {showPrep ? <InlineMeetingPrep event={event} onOpenNote={onOpenNote} /> : null}
@@ -1271,7 +1281,7 @@ export function MeetingsView({ onOpenNote, onTakeMeetingNotes, meetingState, mee
       </div>
       <div className="flex-1 overflow-auto">
         <div className="mx-auto w-full max-w-[1120px] px-[30px] pb-12">
-        <UpcomingEvents onOpenNote={onOpenNote} />
+        <UpcomingEvents onOpenNote={onOpenNote} captureDisabled={isBusy || isRecording} />
         <div className="pt-6">
         {loading ? (
           <div className="flex items-center justify-center py-10">
@@ -1307,21 +1317,23 @@ export function MeetingsView({ onOpenNote, onTakeMeetingNotes, meetingState, mee
               </thead>
               <tbody>
                 {notes.map((note) => (
-                  <tr key={note.path} className="border-b border-border/50 last:border-b-0 hover:bg-muted/20">
-                    <td className="px-4 py-3 align-top">
-                      <button
-                        type="button"
-                        onClick={() => { analytics.meetingNoteOpened(); onOpenNote(note.path) }}
-                        className="block w-full min-w-0 text-left text-sm font-medium text-foreground hover:underline"
-                      >
-                        <span className="block truncate">{note.name}</span>
-                      </button>
-                    </td>
-                    <td className="px-4 py-3 align-top text-sm text-muted-foreground">{note.dateLabel}</td>
-                    <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                      {note.mtimeMs > 0 ? (formatRelativeTime(new Date(note.mtimeMs).toISOString()) || '—') : '—'}
-                    </td>
-                  </tr>
+                  <MeetingNoteContextMenu key={note.path} path={note.path} onOpen={() => { analytics.meetingNoteOpened(); onOpenNote(note.path) }}>
+                    <tr className="border-b border-border/50 last:border-b-0 hover:bg-muted/20">
+                      <td className="px-4 py-3 align-top">
+                        <button
+                          type="button"
+                          onClick={() => { analytics.meetingNoteOpened(); onOpenNote(note.path) }}
+                          className="block w-full min-w-0 text-left text-sm font-medium text-foreground hover:underline"
+                        >
+                          <span className="block truncate">{note.name}</span>
+                        </button>
+                      </td>
+                      <td className="px-4 py-3 align-top text-sm text-muted-foreground">{note.dateLabel}</td>
+                      <td className="px-4 py-3 align-top text-sm text-muted-foreground">
+                        {note.mtimeMs > 0 ? (formatRelativeTime(new Date(note.mtimeMs).toISOString()) || '—') : '—'}
+                      </td>
+                    </tr>
+                  </MeetingNoteContextMenu>
                 ))}
               </tbody>
             </table>

--- a/apps/x/apps/renderer/src/components/message-context-menu.test.tsx
+++ b/apps/x/apps/renderer/src/components/message-context-menu.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MessageContextMenu } from './message-context-menu'
+import { toast } from '@/lib/toast'
+
+vi.mock('@/lib/toast', () => ({ toast: vi.fn() }))
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+afterEach(() => {
+  window.getSelection()?.removeAllRanges()
+  cleanup()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  else Reflect.deleteProperty(navigator, 'clipboard')
+})
+
+function setup() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+  render(<>
+    <MessageContextMenu text="Hello **world**"><div data-testid="message">Hello world</div></MessageContextMenu>
+    <div data-testid="other">Other message</div>
+  </>)
+  return writeText
+}
+
+function select(node: HTMLElement, start: number, end: number) {
+  const range = document.createRange()
+  range.setStart(node.firstChild!, start)
+  range.setEnd(node.firstChild!, end)
+  window.getSelection()?.removeAllRanges()
+  window.getSelection()?.addRange(range)
+}
+
+describe('message context menu', () => {
+  it('copies the source message, including markdown', async () => {
+    const writeText = setup()
+    fireEvent.contextMenu(screen.getByTestId('message'), { button: 2 })
+    expect(screen.queryByRole('menuitem', { name: 'Copy selected text' })).toBeNull()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy message' }))
+    expect(writeText).toHaveBeenCalledExactlyOnceWith('Hello **world**')
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('Copied to clipboard', 'success'))
+  })
+
+  it('copies the selection captured before the menu takes focus', () => {
+    const writeText = setup()
+    select(screen.getByTestId('message'), 6, 11)
+    fireEvent.contextMenu(screen.getByTestId('message'), { button: 2 })
+    window.getSelection()?.removeAllRanges()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy selected text' }))
+    expect(writeText).toHaveBeenCalledExactlyOnceWith('world')
+  })
+
+  it('ignores text selected in a different message', () => {
+    setup()
+    select(screen.getByTestId('other'), 0, 5)
+    fireEvent.contextMenu(screen.getByTestId('message'), { button: 2 })
+    expect(screen.queryByRole('menuitem', { name: 'Copy selected text' })).toBeNull()
+  })
+
+  it('reports clipboard failures', async () => {
+    const writeText = setup()
+    writeText.mockRejectedValue(new Error('Clipboard unavailable'))
+    fireEvent.contextMenu(screen.getByTestId('message'), { button: 2 })
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy message' }))
+    await waitFor(() => expect(toast).toHaveBeenCalledWith('Could not copy to clipboard', 'error'))
+  })
+
+  it('preserves the editing menu for embedded text inputs', () => {
+    render(<MessageContextMenu text="message"><div><textarea aria-label="Editor" /></div></MessageContextMenu>)
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 })
+    fireEvent(screen.getByRole('textbox'), event)
+    expect(event.defaultPrevented).toBe(false)
+    expect(screen.queryByRole('menuitem')).toBeNull()
+  })
+})

--- a/apps/x/apps/renderer/src/components/message-context-menu.tsx
+++ b/apps/x/apps/renderer/src/components/message-context-menu.tsx
@@ -1,0 +1,54 @@
+import { useState, type ReactNode } from 'react'
+import { Copy } from 'lucide-react'
+import { toast } from '@/lib/toast'
+import {
+  ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+
+export function MessageContextMenu({ text, children }: { text: string; children: ReactNode }) {
+  const [selectionText, setSelectionText] = useState('')
+  const copy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      toast('Copied to clipboard', 'success')
+    } catch {
+      toast('Could not copy to clipboard', 'error')
+    }
+  }
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger
+        asChild
+        onContextMenuCapture={(event) => {
+          // Embedded editors retain their own editing menus.
+          if (event.target instanceof Element && event.target.closest('input, textarea, [contenteditable="true"]')) {
+            event.stopPropagation()
+          }
+        }}
+        onContextMenu={(event) => {
+          // Snapshot before the menu takes focus, and ignore selections in other messages.
+          const selection = window.getSelection()
+          setSelectionText(selection && !selection.isCollapsed
+            && event.currentTarget.contains(selection.anchorNode)
+            && event.currentTarget.contains(selection.focusNode)
+            ? selection.toString() : '')
+        }}
+      >
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {selectionText && (
+          <>
+            <ContextMenuItem onSelect={() => { void copy(selectionText) }}>
+              <Copy /> Copy selected text
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
+        <ContextMenuItem disabled={!text} onSelect={() => { void copy(text) }}>
+          <Copy /> Copy message
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/x/apps/renderer/src/components/sidebar-chat-context-menu.test.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-chat-context-menu.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SidebarChatContextMenu } from './sidebar-chat-context-menu'
+
+afterEach(cleanup)
+
+describe('sidebar chat context menu', () => {
+  it.each(['Open chat', 'Pin', 'Rename', 'Delete'])('routes %s without opening the chat on right-click', (action) => {
+    const onOpen = vi.fn()
+    const onTogglePin = vi.fn()
+    const onRename = vi.fn()
+    const onRequestDelete = vi.fn()
+    render(<SidebarChatContextMenu pinned={false} {...{ onOpen, onTogglePin, onRename, onRequestDelete }}>
+      <button onClick={onOpen}>My chat</button>
+    </SidebarChatContextMenu>)
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'My chat' }), { button: 2 })
+    expect(onOpen).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('menuitem', { name: action }))
+    const callbacks = { 'Open chat': onOpen, Pin: onTogglePin, Rename: onRename, Delete: onRequestDelete }
+    for (const [name, callback] of Object.entries(callbacks)) {
+      expect(callback).toHaveBeenCalledTimes(name === action ? 1 : 0)
+    }
+  })
+
+  it('offers Unpin for pinned chats and omits unavailable actions', () => {
+    const onTogglePin = vi.fn()
+    render(<SidebarChatContextMenu pinned onTogglePin={onTogglePin}><button>Chat</button></SidebarChatContextMenu>)
+    fireEvent.contextMenu(screen.getByRole('button'), { button: 2 })
+    expect(screen.getAllByRole('menuitem')).toHaveLength(1)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Unpin' }))
+    expect(onTogglePin).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/x/apps/renderer/src/components/sidebar-chat-context-menu.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-chat-context-menu.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react'
+import { MessageSquare, Pencil, Pin, Trash2 } from 'lucide-react'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from '@/components/ui/context-menu'
+
+export function SidebarChatContextMenu({ children, pinned, onOpen, onTogglePin, onRename, onRequestDelete }: {
+  children: ReactElement
+  pinned: boolean
+  onOpen?: () => void
+  onTogglePin: () => void
+  onRename?: () => void
+  onRequestDelete?: () => void
+}) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent onKeyDown={(event) => event.stopPropagation()}>
+        {onOpen && <ContextMenuItem onSelect={onOpen}><MessageSquare />Open chat</ContextMenuItem>}
+        <ContextMenuItem onSelect={onTogglePin}><Pin />{pinned ? 'Unpin' : 'Pin'}</ContextMenuItem>
+        {onRename && <ContextMenuItem onSelect={onRename}><Pencil />Rename</ContextMenuItem>}
+        {onRequestDelete && <>
+          <ContextMenuSeparator />
+          <ContextMenuItem className="text-destructive focus:text-destructive" onSelect={onRequestDelete}><Trash2 />Delete</ContextMenuItem>
+        </>}
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { SidebarChatContextMenu } from "./sidebar-chat-context-menu"
 import * as React from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
@@ -1139,13 +1140,21 @@ export function SidebarContentPanel({
                         </div>
                       ) : (
                         <>
-                          <SidebarMenuButton onClick={() => onOpenRun?.(chat.id)} className={onRenameRun ? 'pr-7' : undefined}>
-                            <MessageSquare className="size-4 shrink-0 text-muted-foreground" />
-                            <span className="flex-1 truncate">{chat.title || '(Untitled chat)'}</span>
-                            {pinnedChatIds.includes(chat.id) && (
-                              <Pin className="size-3 shrink-0 text-muted-foreground/70 transition-opacity group-hover/menu-item:opacity-0" />
-                            )}
-                          </SidebarMenuButton>
+                          <SidebarChatContextMenu
+                            pinned={pinnedChatIds.includes(chat.id)}
+                            onOpen={onOpenRun ? () => onOpenRun(chat.id) : undefined}
+                            onTogglePin={() => toggleChatPin(chat.id)}
+                            onRename={onRenameRun ? () => { setRenameDraft(chat.title || ''); setRenamingChatId(chat.id) } : undefined}
+                            onRequestDelete={onDeleteRun ? () => setDeleteChatTarget({ id: chat.id, title: chat.title || '(Untitled chat)' }) : undefined}
+                          >
+                            <SidebarMenuButton onClick={() => onOpenRun?.(chat.id)} className={onRenameRun ? 'pr-7' : undefined}>
+                              <MessageSquare className="size-4 shrink-0 text-muted-foreground" />
+                              <span className="flex-1 truncate">{chat.title || '(Untitled chat)'}</span>
+                              {pinnedChatIds.includes(chat.id) && (
+                                <Pin className="size-3 shrink-0 text-muted-foreground/70 transition-opacity group-hover/menu-item:opacity-0" />
+                              )}
+                            </SidebarMenuButton>
+                          </SidebarChatContextMenu>
                           {onRenameRun && (
                             <DropdownMenu>
                               <DropdownMenuTrigger asChild>

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState, type ReactNode } from 'react'
+import { FileListContextMenu } from '@/components/file-list-context-menu'
 import { Archive, ArchiveRestore, Bell, BellOff, Bot, Check, CornerDownRight, FileText, FolderPlus, MessageSquareOff, MessagesSquare, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
 import { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
@@ -473,6 +474,12 @@ export function SpaceRail({
                     </DropdownMenu>
                 </SectionHeader>
                 {!filesCollapsed && (
+                    <FileListContextMenu onOpenChange={onMenuOpenChange} actions={[
+                        { label: 'New file', onSelect: () => { setCreatingBoard(false); setCreatingFile({ prefix: '' }) } },
+                        { label: 'New folder', onSelect: () => { setCreatingBoard(false); setCreatingFolder(true) } },
+                        { label: 'New board', onSelect: () => { setCreatingFile(null); setCreatingFolder(false); setCreatingBoard(true) } },
+                        { label: 'Upload files…', onSelect: () => uploadInputRef.current?.click() },
+                    ]}>
                     <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
                         <FileTree
                             orgId={orgId}
@@ -513,6 +520,7 @@ export function SpaceRail({
                             </div>
                         )}
                     </div>
+                    </FileListContextMenu>
                 )}
             </section>
         </div>

--- a/apps/x/apps/renderer/src/components/tab-bar.test.tsx
+++ b/apps/x/apps/renderer/src/components/tab-bar.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TabBar } from './tab-bar'
+
+afterEach(cleanup)
+
+function renderTabs(tabs = ['First', 'Second', 'Third'], allowSingleTabClose = false) {
+  const onSwitchTab = vi.fn()
+  const onCloseTab = vi.fn()
+  const onCloseTabs = vi.fn()
+  render(
+    <TabBar
+      tabs={tabs}
+      activeTabId={tabs[0]}
+      getTabId={(tab) => tab}
+      getTabTitle={(tab) => tab}
+      isProcessing={() => true}
+      onSwitchTab={onSwitchTab}
+      onCloseTab={onCloseTab}
+      onCloseTabs={onCloseTabs}
+      allowSingleTabClose={allowSingleTabClose}
+    />,
+  )
+  return { onSwitchTab, onCloseTab, onCloseTabs }
+}
+
+function openMenu(title: string) {
+  fireEvent.contextMenu(screen.getByRole('button', { name: title }), {
+    button: 2, clientX: 100, clientY: 100,
+  })
+}
+
+describe('TabBar context menu', () => {
+  it('closes the right-clicked inactive, busy tab without switching to it', () => {
+    const { onSwitchTab, onCloseTab, onCloseTabs } = renderTabs()
+    openMenu('Second')
+    expect(onSwitchTab).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Close tab' }))
+    expect(onCloseTab).toHaveBeenCalledExactlyOnceWith('Second')
+    expect(onCloseTabs).not.toHaveBeenCalled()
+    expect(onSwitchTab).not.toHaveBeenCalled()
+  })
+
+  it('closes all other tabs in one callback, keeping the clicked tab', () => {
+    const { onCloseTabs, onCloseTab } = renderTabs()
+    openMenu('Second')
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Close other tabs' }))
+    expect(onCloseTabs).toHaveBeenCalledExactlyOnceWith(['First', 'Third'])
+    expect(onCloseTab).not.toHaveBeenCalled()
+  })
+
+  it('closes only tabs to the right in their displayed order', () => {
+    const { onCloseTabs } = renderTabs()
+    openMenu('First')
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Close tabs to the right' }))
+    expect(onCloseTabs).toHaveBeenCalledExactlyOnceWith(['Second', 'Third'])
+  })
+
+  it('disables closing to the right of the last tab', () => {
+    const { onCloseTabs } = renderTabs()
+    openMenu('Third')
+    const item = screen.getByRole('menuitem', { name: 'Close tabs to the right' })
+    expect(item).toHaveAttribute('aria-disabled', 'true')
+    fireEvent.click(item)
+    expect(onCloseTabs).not.toHaveBeenCalled()
+  })
+
+  it.each([false, true])('respects allowSingleTabClose=%s', (allowClose) => {
+    const { onCloseTab, onCloseTabs } = renderTabs(['First'], allowClose)
+    fireEvent.contextMenu(screen.getByText('First'), { button: 2 })
+    const close = screen.getByRole('menuitem', { name: 'Close tab' })
+    expect(close.getAttribute('aria-disabled')).toBe(allowClose ? null : 'true')
+    for (const name of ['Close other tabs', 'Close tabs to the right']) {
+      const item = screen.getByRole('menuitem', { name })
+      expect(item).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(item)
+    }
+    fireEvent.click(close)
+    expect(onCloseTab).toHaveBeenCalledTimes(allowClose ? 1 : 0)
+    expect(onCloseTabs).not.toHaveBeenCalled()
+  })
+
+  it('keeps the existing close button from switching tabs', () => {
+    const { onSwitchTab, onCloseTab } = renderTabs()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close tab' })[1])
+    expect(onCloseTab).toHaveBeenCalledExactlyOnceWith('Second')
+    expect(onSwitchTab).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/components/tab-bar.tsx
+++ b/apps/x/apps/renderer/src/components/tab-bar.tsx
@@ -2,6 +2,13 @@ import * as React from "react"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAllTabMeta } from "@/lib/tab-meta"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 
 export type ChatTab = {
   id: string
@@ -28,6 +35,8 @@ interface TabBarProps<T> {
   isProcessing?: (tab: T) => boolean
   onSwitchTab: (tabId: string) => void
   onCloseTab: (tabId: string) => void
+  /** Close the supplied tabs in one parent state update, preserving a surviving active tab. */
+  onCloseTabs: (tabIds: string[]) => void
   layout?: 'fill' | 'scroll'
   allowSingleTabClose?: boolean
 }
@@ -40,6 +49,7 @@ export function TabBar<T>({
   isProcessing,
   onSwitchTab,
   onCloseTab,
+  onCloseTabs,
   layout = 'fill',
   allowSingleTabClose = false,
 }: TabBarProps<T>) {
@@ -71,34 +81,59 @@ export function TabBar<T>({
             {index > 0 && (
               <div className="self-stretch w-px bg-border/70 shrink-0" aria-hidden="true" />
             )}
-            <button
-              type="button"
-              onClick={() => onSwitchTab(tabId)}
-              data-busy={busy || undefined}
-              className={cn(
-                'rowboat-tab titlebar-no-drag group/tab relative flex items-center gap-1.5 px-3 self-stretch text-xs transition-colors',
-                layout === 'scroll' ? 'min-w-[140px] max-w-[240px]' : 'min-w-0 max-w-[220px]',
-                isActive
-                  ? 'bg-background text-foreground'
-                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-              )}
-              style={layout === 'scroll' ? { flex: '0 0 auto' } : { flex: '1 1 0px' }}
-            >
-              <span className="truncate flex-1 text-left">{title}</span>
-              {(allowSingleTabClose || tabs.length > 1) && (
-                <span
-                  role="button"
-                  className="shrink-0 flex items-center justify-center rounded-sm p-0.5 opacity-0 group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10 transition-all"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onCloseTab(tabId)
-                  }}
-                  aria-label="Close tab"
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => onSwitchTab(tabId)}
+                  data-busy={busy || undefined}
+                  className={cn(
+                    'rowboat-tab titlebar-no-drag group/tab relative flex items-center gap-1.5 px-3 self-stretch text-xs transition-colors',
+                    layout === 'scroll' ? 'min-w-[140px] max-w-[240px]' : 'min-w-0 max-w-[220px]',
+                    isActive
+                      ? 'bg-background text-foreground'
+                      : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                  )}
+                  style={layout === 'scroll' ? { flex: '0 0 auto' } : { flex: '1 1 0px' }}
                 >
-                  <X className="size-3" />
-                </span>
-              )}
-            </button>
+                  <span className="truncate flex-1 text-left">{title}</span>
+                  {(allowSingleTabClose || tabs.length > 1) && (
+                    <span
+                      role="button"
+                      className="shrink-0 flex items-center justify-center rounded-sm p-0.5 opacity-0 group-hover/tab:opacity-60 hover:opacity-100! hover:bg-foreground/10 transition-all"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onCloseTab(tabId)
+                      }}
+                      aria-label="Close tab"
+                    >
+                      <X className="size-3" />
+                    </span>
+                  )}
+                </button>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem
+                  disabled={!allowSingleTabClose && tabs.length === 1}
+                  onSelect={() => onCloseTab(tabId)}
+                >
+                  Close tab
+                </ContextMenuItem>
+                <ContextMenuSeparator />
+                <ContextMenuItem
+                  disabled={tabs.length === 1}
+                  onSelect={() => onCloseTabs(tabs.filter((item) => getTabId(item) !== tabId).map(getTabId))}
+                >
+                  Close other tabs
+                </ContextMenuItem>
+                <ContextMenuItem
+                  disabled={index === tabs.length - 1}
+                  onSelect={() => onCloseTabs(tabs.slice(index + 1).map(getTabId))}
+                >
+                  Close tabs to the right
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
             {/* Right edge divider after last tab to close off the section */}
             {index === tabs.length - 1 && (
               <div className="self-stretch w-px bg-border/70 shrink-0" aria-hidden="true" />

--- a/apps/x/apps/renderer/src/components/turn-conversation.test.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { TurnConversation } from './turn-conversation'
 import type { ConversationItem } from '@/lib/chat-conversation'
 
@@ -35,6 +35,12 @@ const durableItem: ConversationItem = {
 }
 
 describe('TurnConversation — streaming → durable identity', () => {
+  it('opens a copy menu on the rendered assistant message', () => {
+    render(<TurnConversation items={[durableItem]} />)
+    fireEvent.contextMenu(screen.getByText(durableItem.content), { button: 2 })
+    expect(screen.getByRole('menuitem', { name: 'Copy message' })).toBeTruthy()
+  })
+
   it('keeps the assistant message DOM node across the swap (no remount flash)', () => {
     const { rerender } = render(<TurnConversation items={[streamingItem]} />)
     const before = document.querySelector('[data-message-id="turn-1:a0"]')

--- a/apps/x/apps/renderer/src/components/turn-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
+import { MessageContextMenu } from '@/components/message-context-menu'
 import {
   Message,
   MessageContent,
@@ -176,14 +177,16 @@ export function TurnConversation({
               </MessageContent>
               {item.content && (
                 <div className="flex flex-col items-end">
-                  <MessageContent>
-                    <MessageResponse
-                      components={streamdownComponents}
-                      remarkPlugins={userMessageRemarkPlugins}
-                    >
-                      {item.content}
-                    </MessageResponse>
-                  </MessageContent>
+                  <MessageContextMenu text={item.content}>
+                    <MessageContent>
+                      <MessageResponse
+                        components={streamdownComponents}
+                        remarkPlugins={userMessageRemarkPlugins}
+                      >
+                        {item.content}
+                      </MessageResponse>
+                    </MessageContent>
+                  </MessageContextMenu>
                   <MessageCopyButton text={item.content} className="mt-0.5" />
                 </div>
               )}
@@ -194,26 +197,28 @@ export function TurnConversation({
         return (
           <Message key={item.id} from={item.role} data-message-id={item.id}>
             <div className="flex flex-col items-end">
-              <MessageContent>
-                {files.length > 0 && (
-                  <div className="mb-2 flex flex-wrap gap-1.5">
-                    {files.map((filePath, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
-                      >
-                        @{wikiLabel(filePath)}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <MessageResponse
-                  components={streamdownComponents}
-                  remarkPlugins={userMessageRemarkPlugins}
-                >
-                  {message}
-                </MessageResponse>
-              </MessageContent>
+              <MessageContextMenu text={message}>
+                <MessageContent>
+                  {files.length > 0 && (
+                    <div className="mb-2 flex flex-wrap gap-1.5">
+                      {files.map((filePath, index) => (
+                        <span
+                          key={index}
+                          className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary"
+                        >
+                          @{wikiLabel(filePath)}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <MessageResponse
+                    components={streamdownComponents}
+                    remarkPlugins={userMessageRemarkPlugins}
+                  >
+                    {message}
+                  </MessageResponse>
+                </MessageContent>
+              </MessageContextMenu>
               <MessageCopyButton text={message} className="mt-0.5" />
             </div>
           </Message>
@@ -221,9 +226,11 @@ export function TurnConversation({
       }
       return (
         <Message key={item.id} from={item.role} data-message-id={item.id}>
-          <MessageContent>
-            <AssistantMessageBody text={item.content} streaming={item.streaming === true} />
-          </MessageContent>
+          <MessageContextMenu text={item.content}>
+            <MessageContent>
+              <AssistantMessageBody text={item.content} streaming={item.streaming === true} />
+            </MessageContent>
+          </MessageContextMenu>
         </Message>
       )
     }

--- a/apps/x/apps/renderer/src/components/workspace-view.tsx
+++ b/apps/x/apps/renderer/src/components/workspace-view.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { FileListContextMenu } from '@/components/file-list-context-menu'
 import {
   ChevronRight,
   Copy,
@@ -485,6 +486,16 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
       />
 
       <div className="flex flex-1 overflow-hidden">
+      <FileListContextMenu actions={isRoot ? [
+        { label: 'Add workspace', onSelect: () => setAddOpen(true) },
+      ] : [
+        { label: 'New note', onSelect: () => actions.createNote(currentPath) },
+        { label: 'New folder', onSelect: () => { void actions.createFolder(currentPath).catch(() => toast('Could not create folder', 'error')) } },
+        { label: 'New presentation', onSelect: () => actions.createPresentation(currentPath) },
+        { label: 'Add Google Doc', onSelect: () => actions.addGoogleDoc(currentPath) },
+        { label: 'Add files…', onSelect: () => filesInputRef.current?.click(), disabled: uploading },
+        { label: 'Add folder…', onSelect: () => folderInputRef.current?.click(), disabled: uploading },
+      ]}>
       <div
         className="relative flex-1 overflow-y-auto"
         onDragEnter={handleDragEnter}
@@ -614,6 +625,7 @@ export function WorkspaceView({ tree, initialPath, actions, onNavigate, onOpenNo
         )}
       </div>
 
+      </FileListContextMenu>
       {!isRoot && chatsOpen && (
         <aside className="flex w-72 shrink-0 flex-col overflow-hidden border-l border-border bg-background">
           <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-3">

--- a/apps/x/apps/renderer/src/lib/browser-context-menu.test.ts
+++ b/apps/x/apps/renderer/src/lib/browser-context-menu.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildBrowserContextMenu } from '../../../main/src/browser/context-menu'
+
+type Contents = Parameters<typeof buildBrowserContextMenu>[0]
+type Params = Parameters<typeof buildBrowserContextMenu>[1]
+
+function setup(overrides: Partial<Params> = {}) {
+  const contents = {
+    isDestroyed: vi.fn(() => false), focus: vi.fn(), undo: vi.fn(), redo: vi.fn(),
+    cut: vi.fn(), copy: vi.fn(), paste: vi.fn(), pasteAndMatchStyle: vi.fn(), selectAll: vi.fn(),
+    reload: vi.fn(), copyImageAt: vi.fn(), downloadURL: vi.fn(),
+    navigationHistory: {
+      canGoBack: vi.fn(() => true), canGoForward: vi.fn(() => false), goBack: vi.fn(), goForward: vi.fn(),
+    },
+  }
+  const actions = { openTab: vi.fn(), copyText: vi.fn() }
+  const params = {
+    x: 12, y: 34, isEditable: false, selectionText: '', linkURL: '', srcURL: '',
+    mediaType: 'none', pageURL: 'https://example.com/', hasImageContents: false,
+    editFlags: { canUndo: false, canRedo: false, canCut: false, canCopy: true, canPaste: true, canSelectAll: true },
+    ...overrides,
+  } as Params
+  const menu = buildBrowserContextMenu(contents as unknown as Contents, params, actions)
+  const item = (label: string) => {
+    const found = menu.find(entry => entry.label === label)
+    if (!found) throw new Error(`Missing menu item: ${label}`)
+    return found
+  }
+  const click = (label: string) => (item(label).click as () => void)()
+  return { contents, actions, menu, item, click }
+}
+
+describe('embedded browser context menu', () => {
+  it('uses the originating page history and rechecks it when clicked', () => {
+    const { contents, item, click } = setup()
+    expect(item('Back').enabled).toBe(true)
+    expect(item('Forward').enabled).toBe(false)
+    contents.navigationHistory.canGoBack.mockReturnValue(false)
+    click('Back')
+    expect(contents.navigationHistory.goBack).not.toHaveBeenCalled()
+    click('Reload')
+    expect(contents.reload).toHaveBeenCalledOnce()
+  })
+
+  it('respects editing capabilities and pastes into the original contents', () => {
+    const { contents, item, click, menu } = setup({ isEditable: true })
+    expect(item('Cut').enabled).toBe(false)
+    expect(item('Undo').enabled).toBe(false)
+    expect(item('Paste').enabled).toBe(true)
+    expect(menu.some(entry => entry.label === 'Back')).toBe(false)
+    click('Paste as plain text')
+    expect(contents.focus).toHaveBeenCalledOnce()
+    expect(contents.pasteAndMatchStyle).toHaveBeenCalledOnce()
+  })
+
+  it('copies the selected text captured before the menu takes focus', () => {
+    const { click, actions } = setup({ selectionText: 'Selected words' })
+    click('Copy')
+    expect(actions.copyText).toHaveBeenCalledWith('Selected words')
+  })
+
+  it('opens web links in an embedded tab and copies their full address', () => {
+    const url = 'https://example.com/path?q=hello#section'
+    const { click, actions } = setup({ linkURL: url })
+    click('Open link in new tab')
+    click('Copy link address')
+    expect(actions.openTab).toHaveBeenCalledWith(url)
+    expect(actions.copyText).toHaveBeenCalledWith(url)
+  })
+
+  it.each(['javascript:alert(1)', 'file:///secret', 'data:text/html,hello', 'mailto:person@example.com'])(
+    'does not turn a %s link into an embedded navigation', (linkURL) => {
+      const { item, click, actions } = setup({ linkURL })
+      expect(item('Open link in new tab').enabled).toBe(false)
+      click('Open link in new tab')
+      expect(actions.openTab).not.toHaveBeenCalled()
+    },
+  )
+
+  it('offers both link and image actions for linked images', () => {
+    const { item, click, contents, actions } = setup({
+      linkURL: 'https://example.com/article', mediaType: 'image',
+      srcURL: 'https://example.com/image.png', hasImageContents: true,
+    })
+    expect(item('Open link in new tab').enabled).toBe(true)
+    expect(item('Copy image').enabled).toBe(true)
+    click('Copy image')
+    expect(contents.copyImageAt).toHaveBeenCalledWith(12, 34)
+    click('Open image in new tab')
+    expect(actions.openTab).toHaveBeenCalledWith('https://example.com/image.png')
+  })
+
+  it('disables copying an unloaded image and does not call destroyed contents', () => {
+    const { item, click, contents } = setup({ mediaType: 'image' })
+    expect(item('Copy image').enabled).toBe(false)
+    contents.isDestroyed.mockReturnValue(true)
+    click('Copy image')
+    expect(contents.copyImageAt).not.toHaveBeenCalled()
+    expect(contents.focus).not.toHaveBeenCalled()
+  })
+
+  it.each(['https://example.com/photo.gif', 'blob:https://example.com/image-id', 'data:image/png;base64,aGVsbG8='])(
+    'saves %s through the originating browser contents', (srcURL) => {
+      const { item, click, contents } = setup({ mediaType: 'image', srcURL })
+      expect(item('Save image as…').enabled).toBe(true)
+      click('Save image as…')
+      expect(contents.downloadURL).toHaveBeenCalledWith(srcURL)
+    },
+  )
+
+  it.each(['', 'javascript:alert(1)', 'file:///secret', 'data:text/html,hello'])(
+    'does not download an unsupported image address: %s', (srcURL) => {
+      const { item, click, contents } = setup({ mediaType: 'image', srcURL })
+      expect(item('Save image as…').enabled).toBe(false)
+      click('Save image as…')
+      expect(contents.downloadURL).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not start a download after the originating tab is destroyed', () => {
+    const { click, contents } = setup({ mediaType: 'image', srcURL: 'https://example.com/image.png' })
+    contents.isDestroyed.mockReturnValue(true)
+    click('Save image as…')
+    expect(contents.downloadURL).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/lib/close-tabs.test.ts
+++ b/apps/x/apps/renderer/src/lib/close-tabs.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { closeTabs } from './close-tabs'
+
+describe('closing tab groups', () => {
+  const tabs = ['a', 'b', 'c', 'd']
+  const id = (tab: string) => tab
+  it('preserves an active survivor when closing tabs on both sides', () => {
+    expect(closeTabs(tabs, 'b', ['a', 'c'], id)).toEqual({ tabs: ['b', 'd'], activeId: 'b' })
+  })
+  it('chooses the next surviving neighbor when the active tab closes', () => {
+    expect(closeTabs(tabs, 'b', ['b', 'c'], id)).toEqual({ tabs: ['a', 'd'], activeId: 'd' })
+  })
+  it('falls back to the previous tab when everything to the right closes', () => {
+    expect(closeTabs(tabs, 'd', ['c', 'd'], id)).toEqual({ tabs: ['a', 'b'], activeId: 'b' })
+  })
+  it('supports closing the last file tab without mutating the input', () => {
+    expect(closeTabs(tabs, 'b', tabs, id)).toEqual({ tabs: [], activeId: null })
+    expect(tabs).toEqual(['a', 'b', 'c', 'd'])
+  })
+  it('ignores stale tab ids', () => {
+    expect(closeTabs(tabs, 'c', ['missing'], id)).toEqual({ tabs, activeId: 'c' })
+  })
+})

--- a/apps/x/apps/renderer/src/lib/close-tabs.ts
+++ b/apps/x/apps/renderer/src/lib/close-tabs.ts
@@ -1,0 +1,11 @@
+/** Preserve the active tab when possible, otherwise prefer its next surviving neighbor. */
+export function closeTabs<T>(tabs: T[], activeId: string | null, closingIds: string[], getId: (tab: T) => string) {
+  const closing = new Set(closingIds)
+  const remaining = tabs.filter((tab) => !closing.has(getId(tab)))
+  if (remaining.some((tab) => getId(tab) === activeId)) return { tabs: remaining, activeId }
+  const index = tabs.findIndex((tab) => getId(tab) === activeId)
+  const next = tabs.slice(index + 1).find((tab) => !closing.has(getId(tab)))
+    ?? tabs.slice(0, Math.max(0, index)).reverse().find((tab) => !closing.has(getId(tab)))
+    ?? remaining[0]
+  return { tabs: remaining, activeId: next ? getId(next) : null }
+}

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -3521,7 +3521,7 @@ export const ipcSchemas = {
     res: z.object({ ok: z.boolean() }),
   },
   'browser:reload': {
-    req: z.null(),
+    req: z.object({ tabId: z.string().min(1) }).nullable(),
     res: z.object({ ok: z.literal(true) }),
   },
   'browser:getState': {


### PR DESCRIPTION
﻿Adds right-click actions across chats, messages, email, meetings, background tasks, code projects/files, and workspace/knowledge/Spaces file lists. Chat and file tabs support closing other tabs or tabs to the right while preserving the surviving active tab.

The embedded browser also gains tab actions and native page menus for navigation, editing, links, and images, including Save image as. Native commands target the originating browser contents and guard against closed tabs.

Validation:
- 77 existing context-menu and conversation tests passed; 18 native browser-menu tests passed.
- Main and renderer type checks passed, and the app was rebuilt and launched after rebasing onto main.
- Renderer and backend health checks passed.
- Hands-on verification of native menus and the image save dialog remains pending.
