### PR TITLE
Revert "Unify Assistant and Projects with a General project (#1014)"

### DIFF
--- a/apps/x/apps/renderer/src/App.css
+++ b/apps/x/apps/renderer/src/App.css
@@ -1715,36 +1715,3 @@
 @media (prefers-reduced-motion: reduce) {
   .caffeinate-steam path { animation: none; }
 }
-
-/* Assistant has one section-wide titlebar. Its rail and chat occupy the
-   row below it, so docking the rail cannot resize or clip the titlebar.
-   Keep the existing chat DOM in place when entering/leaving the section. */
-.assistant-section {
-  display: grid;
-  flex: 1 1 0;
-  min-width: 0;
-  min-height: 0;
-  grid-template-columns: auto minmax(0, 1fr);
-  grid-template-rows: auto minmax(0, 1fr);
-}
-.assistant-section > [data-slot="sidebar-inset"] { display: contents; }
-.assistant-section > [data-slot="sidebar-inset"] > header {
-  grid-column: 1 / -1;
-  grid-row: 1;
-}
-.assistant-section [data-assistant-content] {
-  grid-column: 1;
-  grid-row: 2;
-}
-.assistant-section > [data-chat-sidebar-root] {
-  grid-column: 2;
-  grid-row: 2;
-  width: 100% !important;
-  min-height: 0;
-  border-left: 0;
-}
-.assistant-section[data-document-open][data-chat-open] {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-}
-.assistant-section:not([data-chat-open]) [data-assistant-content] { grid-column: 1 / -1; }
-.assistant-section:not([data-chat-open]) > [data-chat-sidebar-root] { display: none; }

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7,7 +7,7 @@ import { RunEvent } from '@x/shared/src/runs.js';
 import type { ToolUIPart } from 'ai';
 import './App.css'
 import z from 'zod';
-import { CheckIcon, LoaderIcon, PanelLeftIcon, ArrowLeft, ArrowRight, MessageSquare, ChevronLeftIcon, ChevronRightIcon, Plus, HistoryIcon, SquarePen, X } from 'lucide-react';
+import { CheckIcon, LoaderIcon, PanelLeftIcon, ArrowLeft, ArrowRight, MessageSquare, ChevronLeftIcon, ChevronRightIcon, Plus, HistoryIcon, SquarePen, FolderOpen, X } from 'lucide-react';
 import { cn, compactPath, parentPath } from '@/lib/utils';
 import { SPACES_ENABLED } from '@/lib/feature-flags';
 import { MarkdownEditor, type MarkdownEditorHandle } from './components/markdown-editor';
@@ -944,7 +944,6 @@ function App() {
   const [isEmailOpen, setIsEmailOpen] = useState(false)
   const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(false)
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | null>(null)
-  const projectDraftTabsRef = useRef(new Map<string, string>())
   const [projectChatId, setProjectChatId] = useState<string | null>(null)
   const lastProjectLocationRef = useRef<ProjectLocation | null>(null)
   const { projects } = useProjects()
@@ -4206,7 +4205,6 @@ function App() {
       && chatTabsRef.current.find((tab) => tab.id === submitTabId)?.chatId === submitTab.chatId
     const submittedSelection = selectionByTabRef.current.get(submitTab.chatId)
     const submittedContext = buildMiddlePaneContext()
-    const submittedProject = isWorkspaceOpen && !projectChatId ? selectedProject : undefined
     if (activeIsProcessing && inCallRef.current) {
       // In-call input arrives at arbitrary moments — a hard
       // drop here silently ate utterances submitted while the previous turn
@@ -4297,9 +4295,7 @@ function App() {
       if (!currentRunId) {
         let creation = creatingSessionByChatRef.current.get(submitTab.chatId)
         if (!creation) {
-          creation = submittedProject
-            ? window.ipc.invoke('projects:createChat', { projectId: submittedProject.id })
-            : window.ipc.invoke('sessions:create', {})
+          creation = window.ipc.invoke('sessions:create', {})
           creatingSessionByChatRef.current.set(submitTab.chatId, creation)
           void creation.catch(() => creatingSessionByChatRef.current.delete(submitTab.chatId))
         }
@@ -4307,14 +4303,6 @@ function App() {
         currentRunId = createdSession.sessionId
         newRunCreatedAt = new Date().toISOString()
         if (isSubmitTabActive()) setRunId(currentRunId)
-        if (submittedProject) {
-          const view = currentViewStateRef.current
-          if (isSubmitTabActive() && view.type === 'workspace' && view.path === submittedProject.path && !view.runId) {
-            setProjectChatId(currentRunId)
-            lastProjectLocationRef.current = { path: submittedProject.path, runId: currentRunId, filePath: view.filePath }
-          }
-          void refreshProjects()
-        }
         analytics.chatSessionCreated(currentRunId)
         // Update active chat tab's runId to the new run
         setChatTabs((prev) => prev.map((tab) => (
@@ -4734,7 +4722,6 @@ function App() {
     setChatTabs((previous) => [...previous, tab])
     activateAssistantTab(tab)
     setIsChatSidebarOpen(true)
-    return tab
   }, [activateAssistantTab])
 
   const closeAssistantTab = useCallback((tabId: string) => {
@@ -4893,7 +4880,7 @@ function App() {
         const space = org ? findSpace(org, currentViewState.spaceId) : undefined
         return org && space ? spaceDisplayName(org, space) : 'Spaces'
       }
-      case 'workspace': return 'Assistant'
+      case 'workspace': return 'Projects'
       case 'knowledge-view': return 'Brain'
       case 'graph': return 'Graph View'
       case 'suggested-topics': return 'Suggested Topics'
@@ -4933,11 +4920,23 @@ function App() {
   }, [])
 
   const handleNewChatTab = useCallback(() => {
-    const path = selectedProject?.path ?? projects.find((project) => project.isDefault)?.path ?? WORKSPACE_ROOT
-    projectDraftTabsRef.current.delete(path)
+    if (useBottomTabs || chatTabsRef.current.length > 1) {
+      addAssistantTab()
+      if (isCodeOpen) {
+        closeAllSections()
+        setExpandedFrom(currentViewState)
+      }
+      return
+    }
+    // A fresh tab keeps the other conversations and drafts available.
+    createChatTab()
     dismissBrowserOverlay()
-    void applyViewStateRef.current?.({ type: 'workspace', path })
-  }, [dismissBrowserOverlay, selectedProject, projects])
+    // "New chat" opens the full-screen chat; remember where we came from so
+    // closing it can restore the section.
+    const from = currentViewState.type === 'chat' ? null : currentViewState
+    closeAllSections()
+    setExpandedFrom(from)
+  }, [dismissBrowserOverlay, closeAllSections, currentViewState, createChatTab, useBottomTabs, addAssistantTab, isCodeOpen])
 
   // Sidebar variant: add a chat without leaving file/graph context.
   // A caller with a selection already chosen for the fresh chat (the Home
@@ -5280,9 +5279,9 @@ function App() {
     // Remember where we came from so the close button can return.
     const from = currentViewState.type === 'chat' ? null : currentViewState
     dismissBrowserOverlay()
-    void applyViewStateRef.current?.({ type: 'chat', runId })
+    closeAllSections()
     setExpandedFrom(from)
-  }, [currentViewState, dismissBrowserOverlay, runId])
+  }, [closeAllSections, currentViewState, dismissBrowserOverlay])
 
   const handleCloseFullScreenChat = useCallback((): boolean => {
     if (!expandedFrom) return false
@@ -5324,13 +5323,6 @@ function App() {
     // Whether this navigation ENTERS Spaces (vs a click within it) — read
     // before closeAllSections resets the flag.
     const wasSpacesOpen = isSpacesOpen
-    if (view.type === 'chat') {
-      const requestedRunId = view.runId
-      const { projects: latest } = await window.ipc.invoke('projects:list', null)
-      const project = latest.find((item) => item.chats.some((chat) => chat.id === requestedRunId))
-        ?? latest.find((item) => item.isDefault)
-      view = { type: 'workspace', path: project?.path ?? WORKSPACE_ROOT, runId: view.runId ?? undefined }
-    }
     closeAllSections()
     switch (view.type) {
       case 'file':
@@ -5376,13 +5368,6 @@ function App() {
         setSelectedPath(view.filePath ?? null)
         setIsChatSidebarOpen(!!view.runId)
         if (view.runId) bindChatToRun(view.runId)
-        else if (!view.filePath) {
-          const key = view.path ?? ''
-          const draftId = projectDraftTabsRef.current.get(key)
-          const draft = chatTabsRef.current.find((tab) => tab.id === draftId && !tab.runId)
-          if (draft) activateAssistantTab(draft)
-          else projectDraftTabsRef.current.set(key, addAssistantTab().id)
-        }
         return
       case 'knowledge-view':
         setIsKnowledgeViewOpen(true)
@@ -5420,8 +5405,18 @@ function App() {
         if (!wasSpacesOpen) setIsChatSidebarOpen(false)
         setIsSpacesOpen(true)
         return
+      case 'chat':
+        if (view.runId) {
+          bindChatToRun(view.runId)
+        } else if (useBottomTabs || chatTabsRef.current.length > 1) {
+          const current = chatTabsRef.current.find((tab) => tab.id === activeChatTabIdRef.current)
+          if (current?.runId) addAssistantTab()
+        } else {
+          handleNewChat()
+        }
+        return
     }
-  }, [closeAllSections, bindChatToRun, isSpacesOpen, addAssistantTab, activateAssistantTab])
+  }, [closeAllSections, bindChatToRun, handleNewChat, isSpacesOpen, useBottomTabs, addAssistantTab])
   applyViewStateRef.current = applyViewState
 
   const navigateToView = useCallback(async (nextView: ViewState) => {
@@ -5446,24 +5441,32 @@ function App() {
   }, [appendUnique, applyViewState, cancelRecordingIfActive, setHistory, isBrowserOpen, dismissBrowserOverlay])
 
   const openAssistantRun = useCallback((sessionId: string) => {
-    void navigateToView({ type: 'chat', runId: sessionId })
-  }, [navigateToView])
+    const project = projects.find((p) => p.chats.some((chat) => chat.id === sessionId))
+    if (project) {
+      void navigateToView({ type: 'workspace', path: project.path, runId: sessionId })
+      return
+    }
+    if (useBottomTabs && !isCodeOpen && !isWorkspaceOpen) {
+      bindChatToRun(sessionId)
+      setIsChatSidebarOpen(true)
+    } else {
+      void navigateToView({ type: 'chat', runId: sessionId })
+    }
+  }, [useBottomTabs, isCodeOpen, bindChatToRun, navigateToView, projects, isWorkspaceOpen])
 
   const openProjectChat = useCallback((project: Project, sessionId: string) => {
     void navigateToView({ type: 'workspace', path: project.path, runId: sessionId })
   }, [navigateToView])
   const newProjectChat = useCallback(async (project: Project) => {
-    projectDraftTabsRef.current.delete(project.path)
-    await applyViewState({ type: 'workspace', path: project.path })
-  }, [applyViewState])
+    const { sessionId } = await window.ipc.invoke('projects:createChat', { projectId: project.id })
+    await refreshProjects()
+    await navigateToView({ type: 'workspace', path: project.path, runId: sessionId })
+  }, [navigateToView])
 
   const openProjects = useCallback((path?: string) => {
-    void (async () => {
-      const { projects: latest } = await window.ipc.invoke('projects:list', null)
-      const location = path ? { path } : resolveProjectsLocation(latest, lastProjectLocationRef.current)
-      await navigateToView({ type: 'workspace', ...location })
-    })().catch((error) => toast.error(String(error)))
-  }, [navigateToView])
+    const location = path ? { path } : resolveProjectsLocation(projects, lastProjectLocationRef.current)
+    void navigateToView({ type: 'workspace', ...location })
+  }, [navigateToView, projects])
 
   // Move the maximized/full-screen chat into the right side pane: restore the
   // view we expanded from (or fall back to Home) and dock the chat on the right.
@@ -7081,8 +7084,8 @@ function App() {
   const isRightPaneContext = Boolean(selectedPath || isGraphOpen || isSuggestedTopicsOpen || isMeetingsOpen || isLiveNotesOpen || isBgTasksOpen || isAppsOpen || isSpacesOpen || isEmailOpen || isWorkspaceOpen || isKnowledgeViewOpen || isChatHistoryOpen || isHomeOpen || isCodeOpen || isBrowserOpen)
   // Code mode with a session selected: the chat is the main surface — the
   // middle pane is just the session rail and the chat fills the rest, with
-  // the workspace drawer at its edge. Project roots show the same blank
-  // assistant composer until the first message creates a project session.
+  // the workspace drawer at its edge. Before a session is picked the empty
+  // state owns the pane and the chat stays out of the way.
   const projectViewActive = isWorkspaceOpen && !isBrowserOpen
   const codeChatMain = isCodeOpen && activeCodeSession !== null
   const [projectContentWidth, setProjectContentWidth] = useState(Infinity)
@@ -7102,12 +7105,14 @@ function App() {
   const floatingAssistant = useBottomTabs && !isFullScreenChat && !isCodeOpen && !isBrowserOpen && !projectViewActive
   const dockFullScreen = useBottomTabs && isFullScreenChat
   const showAssistantDock = useBottomTabs && !isCodeOpen && !projectViewActive
-  const chatPaneOpen = projectViewActive ? (!!projectChatId || !selectedPath) && !projectDocumentOnly : isCodeOpen ? codeChatMain : isChatSidebarOpen
+  const chatPaneOpen = projectViewActive ? !!projectChatId && !projectDocumentOnly : isCodeOpen ? codeChatMain : isChatSidebarOpen
   const isRightPaneOnlyMode = (isRightPaneContext || floatingAssistant) && chatPaneOpen && isRightPaneMaximized
   const shouldCollapseLeftPane = isRightPaneOnlyMode && !projectViewActive
   const nonChatPaneStyle = React.useMemo<React.CSSProperties>(() => {
     const style: React.CSSProperties = { maxWidth: insetMaxWidth }
-    if (projectViewActive) return {}
+    // A rail-only pane must size to the rail, overriding SidebarInset's w-full.
+    if (projectViewActive && projectChatId && !selectedPath) return { ...style, width: 'auto', flex: '0 0 auto' }
+    if (projectViewActive && selectedPath) return { ...style, width: 0, flex: '1 1 0' }
     if (dockFullScreen) return { display: 'none' }
     if (floatingAssistant && !isRightPaneMaximized) return style
     if (!isRightPaneContext || !chatPaneOpen || isRightPaneMaximized) return style
@@ -7121,7 +7126,7 @@ function App() {
       return { ...style, width: DEFAULT_CHAT_PANE_WIDTH, flex: '0 0 auto' }
     }
     return style
-  }, [projectViewActive, chatPaneSize, codeChatMain, codeRailWidth, chatPaneOpen, insetMaxWidth, isRightPaneContext, isRightPaneMaximized, floatingAssistant, dockFullScreen])
+  }, [projectViewActive, projectChatId, selectedPath, chatPaneSize, codeChatMain, codeRailWidth, chatPaneOpen, insetMaxWidth, isRightPaneContext, isRightPaneMaximized, floatingAssistant, dockFullScreen])
   // Collapsing: pin max-width to the snapshot px (no transition) for one frame so it's
   // binding immediately (no flex jump), then animate to 0. Expanding goes back to 100%
   // — its non-binding range lands at the end of the range, where it isn't visible.
@@ -7193,7 +7198,7 @@ function App() {
       : isEmailOpen ? 'email'
       : isMeetingsOpen ? 'meetings'
       : isCodeOpen ? 'code'
-      : isWorkspaceOpen ? 'assistant'
+      : isWorkspaceOpen ? 'workspaces'
       : (isKnowledgeViewOpen || isGraphOpen || (selectedPath != null && selectedPath.startsWith('knowledge/'))) ? 'knowledge'
       : isBgTasksOpen ? 'agents'
       : isAppsOpen ? 'apps'
@@ -7268,11 +7273,6 @@ function App() {
               browserOpen={isBrowserOpen}
               switcherOnly={sidebarOpen}
             />
-            <div
-              className={projectViewActive ? 'assistant-section' : 'contents'}
-              data-document-open={projectViewActive && !!selectedPath || undefined}
-              data-chat-open={projectViewActive && chatPaneOpen || undefined}
-            >
             <SidebarInset
               className={cn(
                 "min-h-0 min-w-0",
@@ -7289,6 +7289,7 @@ function App() {
             >
               {/* Header - also serves as titlebar drag region */}
               <ContentHeader
+                className={projectViewActive ? "[contain:inline-size]" : undefined}
                 onNavigateBack={() => { void navigateBack() }}
                 onNavigateForward={() => { void navigateForward() }}
                 canNavigateBack={canNavigateBack}
@@ -7427,7 +7428,7 @@ function App() {
               </ContentHeader>
 
               {/* Secondary rails belong below the titlebar, as in Spaces and Email. */}
-              <div data-assistant-content className={projectViewActive ? "flex min-h-0 min-w-0 flex-1" : "contents"}>
+              <div className={projectViewActive ? "flex min-h-0 min-w-0 flex-1" : "contents"}>
                 {/* Keep the shared rail mounted across section visits, like the Spaces view. */}
                 {(isWorkspaceOpen || sectionMounted('workspace')) && <Activity mode={projectViewActive ? 'visible' : 'hidden'}><ProjectsRail
                   tree={tree}
@@ -7445,7 +7446,7 @@ function App() {
               <div
                 data-project-document-pane
                 className={projectViewActive ? "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden" : "contents"}
-                style={projectViewActive && !selectedPath ? { display: 'none' } : undefined}
+                style={projectViewActive && projectChatId && !selectedPath ? { display: 'none' } : undefined}
               >
 
 {/* Middle pane. Section views wrapped in <Activity> stay
@@ -7672,6 +7673,18 @@ function App() {
                 <Activity mode={activeMiddle === 'email' ? 'visible' : 'hidden'}>
                 <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
                   <EmailView initialThreadId={emailInitialThreadId} threadIdVersion={emailThreadIdVersion} initialSearchQuery={emailInitialSearchQuery} searchQueryVersion={emailSearchQueryVersion} onOpenNote={openNoteFromEmail} />
+                </div>
+                </Activity>
+              )}
+              {sectionMounted('workspace') && (
+                <Activity mode={activeMiddle === 'workspace' ? 'visible' : 'hidden'}>
+                <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+                  <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+                    <FolderOpen className="size-9 text-muted-foreground" />
+                    <h1 className="text-xl font-semibold">{selectedProject?.name ?? 'Projects'}</h1>
+                    <p className="max-w-sm text-sm text-muted-foreground">{selectedProject ? 'Choose a chat or file in the rail, or start a new conversation with Rowboat.' : 'Choose a project in the rail, or create one to organize your chats and local files.'}</p>
+                    {selectedProject && <Button onClick={() => void newProjectChat(selectedProject).catch((e) => toast.error(String(e)))}><Plus className="mr-2 size-4" />New chat</Button>}
+                  </div>
                 </div>
                 </Activity>
               )}
@@ -8085,21 +8098,11 @@ function App() {
                 isOpen={dockFullScreen || chatPaneOpen}
                 isMaximized={projectViewActive ? !selectedPath : dockFullScreen || isRightPaneMaximized}
                 chatTabs={chatTabs}
-                onSwitchChatTab={(tabId) => {
-                  if (!projectViewActive) { switchChatTab(tabId); return }
-                  const tab = chatTabs.find((item) => item.id === tabId)
-                  if (tab?.runId) { openAssistantRun(tab.runId); return }
-                  const path = [...projectDraftTabsRef.current].find(([, id]) => id === tabId)?.[0]
-                    ?? projects.find((item) => item.isDefault)?.path ?? WORKSPACE_ROOT
-                  projectDraftTabsRef.current.set(path, tabId)
-                  void applyViewState({ type: 'workspace', path })
-                }}
+                onSwitchChatTab={switchChatTab}
                 onCloseChatTabs={closeChatTabs}
                 activeChatTabId={activeChatTabId}
                 getChatTabTitle={getChatTabTitle}
                 onNewChatTab={() => { if (projectViewActive && selectedProject) void newProjectChat(selectedProject).catch((e) => toast.error(String(e))); else handleNewChatTabInSidebar() }}
-                embedded={projectViewActive}
-                projectName={projectViewActive && !selectedProject?.isDefault ? selectedProject?.name : undefined}
                 recentRuns={chatRuns}
                 onSelectRun={projectViewActive ? openAssistantRun : bindChatToRun}
                 onOpenChatHistory={() => void navigateToView({ type: 'chat-history' })}
@@ -8196,7 +8199,6 @@ function App() {
               />
               </CodeDiffOpenerProvider>
             )}
-            </div>
             {useBottomTabs && (
               <AssistantChatDock
                 hidden={!showAssistantDock}
@@ -8296,7 +8298,7 @@ function App() {
                 last so its no-drag region paints over the drag regions. */}
             <FixedSidebarToggle
               leftInsetPx={isMac ? MACOS_TRAFFIC_LIGHTS_RESERVED_PX : 0}
-              onNewChat={handleNewChatTab}
+              onNewChat={handleNewChat}
               onWidthChange={setTitlebarControlsWidthPx}
             />
             <MenuSidebarToggleBridge />

--- a/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.test.tsx
@@ -31,24 +31,6 @@ const props = {
 }
 
 describe('floating ChatSidebar', () => {
-  it('leaves section navigation and titlebar spacing to the parent when embedded', () => {
-    render(<ChatSidebar {...props} floating={false} isOpen isMaximized embedded
-      onNavigateBack={vi.fn()} onNavigateForward={vi.fn()} collapsedLeftPaddingPx={88} />)
-    expect(screen.queryByRole('button', { name: 'Go back' })).toBeNull()
-    const header = screen.getByText('Chat header').parentElement!
-    expect(header.style.paddingLeft).toBe('12px')
-    expect(header.classList.contains('titlebar-drag-region')).toBe(false)
-  })
-
-  it('shows project context in the unified Assistant composer without affecting other sections', () => {
-    const { rerender } = render(<ChatSidebar {...props} isOpen projectName="General" />)
-    expect(screen.getByLabelText('Current project').textContent).toBe('Project: General')
-    rerender(<ChatSidebar {...props} isOpen projectName="Alpha" />)
-    expect(screen.getByLabelText('Current project').textContent).toBe('Project: Alpha')
-    rerender(<ChatSidebar {...props} isOpen />)
-    expect(screen.queryByLabelText('Current project')).toBeNull()
-  })
-
   it('preserves composer instances when minimized, switched and expanded', () => {
     const { rerender } = render(<ChatSidebar {...props} isOpen />)
     fireEvent.change(screen.getByLabelText('first'), { target: { value: 'Unsent draft' } })

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -69,8 +69,6 @@ interface ChatSidebarProps {
   onCloseChatTabs: (tabIds: string[]) => void
   activeChatTabId: string
   getChatTabTitle: (tab: ChatTab) => string
-  embedded?: boolean
-  projectName?: string
   onNewChatTab: () => void
   recentRuns?: { id: string; title?: string; createdAt: string }[]
   onSelectRun?: (runId: string) => void
@@ -167,8 +165,6 @@ export function ChatSidebar({
   onCloseChatTabs,
   activeChatTabId,
   getChatTabTitle,
-  embedded = false,
-  projectName,
   onNewChatTab,
   recentRuns = [],
   onSelectRun,
@@ -457,9 +453,9 @@ export function ChatSidebar({
       {showContent && (
         <>
           <header
-            className={cn(floating || embedded ? 'titlebar-no-drag' : 'titlebar-drag-region', 'flex h-10 shrink-0 items-stretch border-b border-border bg-sidebar')}
+            className={cn(floating ? 'titlebar-no-drag' : 'titlebar-drag-region', 'flex h-10 shrink-0 items-stretch border-b border-border bg-sidebar')}
             style={{
-              paddingLeft: embedded ? 12 : isMaximized ? (sidebarState === 'collapsed' ? collapsedLeftPaddingPx : 12) : undefined,
+              paddingLeft: isMaximized ? (sidebarState === 'collapsed' ? collapsedLeftPaddingPx : 12) : undefined,
               paddingRight: isMaximized ? 12 : undefined,
               transition: isMaximized ? 'padding-left 200ms linear' : undefined,
             }}
@@ -467,7 +463,7 @@ export function ChatSidebar({
             {/* Maximized, the pane covers the main ContentHeader — carry the
                 same back/forward pair so history navigation stays reachable
                 (navigating restores the underlying view and un-maximizes). */}
-            {!embedded && isMaximized && onNavigateBack && onNavigateForward && (
+            {isMaximized && onNavigateBack && onNavigateForward && (
               <>
                 <div className="titlebar-no-drag flex items-center gap-1 pr-2 shrink-0">
                   <button
@@ -571,7 +567,6 @@ export function ChatSidebar({
               <div className={cn('sticky bottom-0 z-10 bg-background pt-0 shadow-lg', floating ? 'pb-3' : 'pb-12')}>
                 <div className="pointer-events-none absolute inset-x-0 -top-6 h-6 bg-linear-to-t from-background to-transparent" />
                 <div className="mx-auto w-full max-w-4xl px-3">
-                  {projectName && <div className="mb-2 text-xs text-muted-foreground" aria-label="Current project">Project: {projectName}</div>}
                   {chatTabs.map((tab) => {
                     const isActive = tab.id === activeChatTabId && isOpen
                     return (

--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -12,6 +12,7 @@ import { Bell,
   Code2,
   FileText,
   FilePlus,
+  Folder,
   Globe,
   History,
   Home,
@@ -800,6 +801,22 @@ export function DockSidebar({
     return () => clearInterval(tick)
   }, [latestNoteMtime])
 
+  // ----- data: workspace count -----
+  const workspaceCount = useMemo(() => {
+    const find = (nodes: TreeNode[]): TreeNode | null => {
+      for (const n of nodes) {
+        if (n.path === 'knowledge/Workspace') return n
+        if (n.kind === 'dir' && n.children?.length) {
+          const found = find(n.children)
+          if (found) return found
+        }
+      }
+      return null
+    }
+    const node = find(tree)
+    return node?.children?.filter((c) => c.kind === 'dir').length ?? 0
+  }, [tree])
+
   // ----- data: background agents label -----
   const [bgAgentsLabel, setBgAgentsLabel] = useState<string | null>(null)
   const bgAgentsFailed = bgTaskSummaries.some((t) => t.lastRunError)
@@ -914,21 +931,32 @@ export function DockSidebar({
           : (currentBillingPlan?.displayName ?? syncStatusLabel)
   const settingsAlert = outOfCredits || hasOauthError || (!isSyncing && hasServiceErrors)
 
+  // The most recently touched chat, for the Assistant tile (recency only —
+  // pinning shouldn't hijack "continue where I left off").
+  const lastChat = useMemo(() => {
+    const recency = (r: { createdAt: string; modifiedAt?: string }) => {
+      const ms = new Date(r.modifiedAt ?? r.createdAt).getTime()
+      return Number.isFinite(ms) ? ms : 0
+    }
+    return [...recentRuns].sort((a, b) => recency(b) - recency(a))[0] ?? null
+  }, [recentRuns])
+
   // ----- the item list -----
   const rows = useMemo<DockRow[]>(() => {
     const items: DockRow[] = [
-      // The top section: Assistant (restores the last project location)
-      // with Spaces right under it, then a
+      // The top section: Assistant (resumes the most recent chat, falling
+      // back to a fresh one — white tile) with Spaces right under it, then a
       // divider before the destinations.
       ...(onOpenRun || onNewChat ? [
         {
           item: {
-            key: 'assistant', label: 'Assistant', tourId: 'nav-assistant', icon: MascotFaceIcon as unknown as LucideIcon,
+            key: 'assistant', label: 'Assistant', icon: MascotFaceIcon as unknown as LucideIcon,
             status: 'Rowboat assistant',
             running: activeNav === 'assistant',
             onClick: () => {
               closeFlyouts()
-              knowledgeActions.openWorkspaceAt()
+              if (lastChat && onOpenRun) onOpenRun(lastChat.id)
+              else onNewChat?.()
             },
           },
         },
@@ -1023,6 +1051,14 @@ export function DockSidebar({
           onClick: () => { closeFlyouts(); onOpenBgTasks?.() },
         },
       },
+      {
+        item: {
+          key: 'workspaces', label: 'Projects', icon: Folder, tourId: 'nav-workspaces',
+          status: workspaceCount === 0 ? 'No projects' : `${workspaceCount} project${workspaceCount === 1 ? '' : 's'}`,
+          running: activeNav === 'workspaces',
+          onClick: () => { closeFlyouts(); knowledgeActions.openWorkspaceAt() },
+        },
+      },
       ...(onToggleBrowser ? [{
         item: {
           key: 'browser', label: 'Browser', icon: Globe,
@@ -1058,8 +1094,8 @@ export function DockSidebar({
     knowledgeUpdatedLabel, knowledgeActions, onOpenApps, pinnedApps, onOpenApp,
     bgAgentsFailed, bgAgentsLabel, onToggleBrowser, browserOpen,
     switcherOnly, openLastSpace, onOpenChatHistory,
-    onNewChat, onOpenRun,
-    onOpenBgTasks, totalSpacesUnread, totalSpaces, spacesOpen, chatsOpen,
+    onNewChat, lastChat, onOpenRun,
+    onOpenBgTasks, workspaceCount, totalSpacesUnread, totalSpaces, spacesOpen, chatsOpen,
     outOfCredits, hasOauthError, settingsStatus, settingsAlert,
   ])
 

--- a/apps/x/apps/renderer/src/components/product-tour.tsx
+++ b/apps/x/apps/renderer/src/components/product-tour.tsx
@@ -112,11 +112,11 @@ const TOUR_STEPS: TourStep[] = [
   },
   {
     id: 'workspaces',
-    targetId: 'nav-assistant',
+    targetId: 'nav-workspaces',
     navigate: 'workspaces',
     hat: 'explorer',
-    title: 'Assistant',
-    text: 'Assistant organizes your chats and local files into projects. Everyday conversations appear under Chats, below Projects. Pick a chat in the rail to work with Rowboat, or open a file alongside it.',
+    title: 'Projects',
+    text: 'Projects keep local files and related chats together. Pick a chat in the rail to work with Rowboat, or open a file alongside it.',
   },
   {
     id: 'chats',

--- a/apps/x/apps/renderer/src/components/projects-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/projects-rail.test.tsx
@@ -8,7 +8,6 @@ import { SidebarProvider, useSidebar } from './ui/sidebar'
 const { projects } = vi.hoisted(() => ({ projects: [
     { id: 'alpha', name: 'Alpha', path: 'knowledge/Workspace/Alpha', chats: [{ id: 'chat-1', title: 'Review report', modifiedAt: '2026-09-10' }] },
     { id: 'beta', name: 'Beta', path: 'knowledge/Workspace/Beta', chats: [] },
-    { id: 'default', name: 'General', path: 'knowledge/Workspace', isDefault: true, chats: [{ id: 'general', title: 'General chat', modifiedAt: '2026-09-10' }] },
 ] }))
 vi.mock('@/hooks/use-projects', () => ({ useProjects: () => ({ projects, ready: true, refresh: vi.fn() }) }))
 vi.mock('@/lib/session-title', () => ({ useSessionTitle: () => undefined }))
@@ -26,42 +25,6 @@ function props() {
     }
 }
 describe('Projects rail', () => {
-    it('keeps Files collapsed until a named project is selected', () => {
-        const input = props()
-        const view = render(<ProjectsRail {...input} selectedPath={null} />)
-        expect(screen.getByTitle('Show files')).toBeDisabled()
-        expect(screen.queryByText('Select a project to see its files.')).toBeNull()
-        expect(screen.getByTitle('Show files').closest('section')).toHaveStyle({ flex: '0 0 auto' })
-        view.rerender(<ProjectsRail {...input} selectedPath={projects[2].path} />)
-        expect(screen.getByTitle('Show files')).toHaveAttribute('aria-expanded', 'false')
-        expect(screen.queryByLabelText('Add to project files')).toBeNull()
-        view.rerender(<ProjectsRail {...input} />)
-        expect(screen.getByTitle('Hide files')).toBeEnabled()
-        expect(screen.getByRole('button', { name: 'report.md' })).toBeVisible()
-        view.rerender(<ProjectsRail {...input} selectedPath={projects[2].path} />)
-        expect(screen.getByTitle('Show files')).toHaveAttribute('aria-expanded', 'false')
-    })
-    it('shows General chats in a separate Chats section and keeps their project association', () => {
-        const input = { ...props(), selectedPath: projects[2].path, selectedChat: 'general' }
-        render(<ProjectsRail {...input} />)
-        expect(screen.getAllByRole('button', { name: /^Collapse (Alpha|Beta|General)$/ }).map(button => button.getAttribute('aria-label'))).toEqual(['Collapse Alpha', 'Collapse Beta'])
-        expect(screen.queryByRole('button', { name: 'General' })).toBeNull()
-        expect(screen.getByRole('button', { name: 'Chats' })).toBeVisible()
-        expect(screen.queryByRole('button', { name: 'Actions for General' })).toBeNull()
-        const chat = screen.getByRole('button', { name: 'General chat' })
-        expect(chat).toHaveAttribute('aria-current', 'page')
-        fireEvent.click(chat)
-        expect(input.onOpenChat).toHaveBeenCalledWith(projects[2], 'general')
-        fireEvent.click(screen.getByRole('button', { name: 'New chat' }))
-        expect(input.onNewChat).toHaveBeenCalledWith(projects[2])
-        fireEvent.click(screen.getByRole('button', { name: 'Projects' }))
-        expect(screen.getByRole('button', { name: 'General chat' })).toBeVisible()
-        expect(screen.queryByRole('button', { name: 'Alpha' })).toBeNull()
-        fireEvent.click(screen.getByRole('button', { name: 'Chats' }))
-        expect(screen.queryByRole('button', { name: 'General chat' })).toBeNull()
-        fireEvent.click(screen.getByTitle('Show chats'))
-        expect(screen.getByRole('button', { name: 'General chat' })).toBeVisible()
-    })
     it('starts open with all chat lists expanded and supports bulk collapse and expand', () => {
         localStorage.setItem('projects:railOpen', 'false')
         render(<ProjectsRail {...props()} />)
@@ -76,7 +39,6 @@ describe('Projects rail', () => {
         expect(screen.getByRole('button', { name: 'Expand Alpha' })).toHaveAttribute('aria-expanded', 'false')
         expect(screen.getByRole('button', { name: 'Expand Beta' })).toHaveAttribute('aria-expanded', 'false')
         expect(screen.queryByRole('button', { name: 'Review report' })).toBeNull()
-        expect(screen.getByRole('button', { name: 'General chat' })).toBeVisible()
         expect(screen.getByRole('button', { name: 'report.md' })).toBeVisible()
         fireEvent.click(screen.getByRole('button', { name: 'Expand all project chats' }))
         expect(screen.getByRole('button', { name: 'Review report' })).toBeVisible()

--- a/apps/x/apps/renderer/src/components/projects-rail.tsx
+++ b/apps/x/apps/renderer/src/components/projects-rail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { ChevronsDownUp, ChevronsUpDown, ChevronRight, CornerDownRight, File, FilePlus, Folder, FolderOpen, FolderPlus, Loader2, MessageSquare, MoreHorizontal, Plus, Presentation, Upload } from 'lucide-react'
+import { ChevronsDownUp, ChevronsUpDown, ChevronRight, CornerDownRight, File, FilePlus, Folder, FolderOpen, FolderPlus, Loader2, MoreHorizontal, Plus, Presentation, Upload } from 'lucide-react'
 import { FileListContextMenu } from './file-list-context-menu'
 import { SecondaryRail } from './secondary-rail'
 import { SecondaryRailToggle } from './secondary-rail-toggle'
@@ -24,11 +24,11 @@ type Actions = {
     addGoogleDoc: (path?: string) => void
     createFolder: (path?: string) => Promise<string>
 }
-function ChatRow({ chat, selected, onOpen, working, nested = true }: { nested?: boolean; working: boolean; chat: Project['chats'][number]; selected: boolean; onOpen: () => void }) {
+function ChatRow({ chat, selected, onOpen, working }: { working: boolean; chat: Project['chats'][number]; selected: boolean; onOpen: () => void }) {
     const title = useSessionTitle(chat.id)
     return <button onClick={onOpen} title={title ?? chat.title ?? 'New chat'} aria-current={selected ? 'page' : undefined}
-        className={cn('flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13.5px]', selected ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50')}>
-        {working ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-label="Working" /> : nested ? <CornerDownRight className="size-3.5 shrink-0 text-muted-foreground" /> : <MessageSquare className="size-3.5 shrink-0 text-muted-foreground" />}
+        className={cn('flex h-8 w-full items-center gap-2 rounded pl-7 pr-2 text-left text-[13px]', selected ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent/50')}>
+        {working ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-label="Working" /> : <CornerDownRight className="size-3.5 shrink-0" />}
         <span className="truncate">{title ?? chat.title ?? 'New chat'}</span>
     </button>
 }
@@ -39,26 +39,23 @@ export function ProjectsRail({ tree, selectedPath, selectedFile, selectedChat, p
     onNewChat: (project: Project) => Promise<void>; onOpenFile: (path: string) => void; onCreateProject: (name: string) => Promise<string>
 }) {
     const { projects, ready, error, refresh } = useProjects()
-    const namedProjects = projects.filter(item => !item.isDefault)
-    const generalProject = projects.find(item => item.isDefault)
-    const project = projects.find((p) => selectedPath === p.path || selectedPath?.startsWith(`${p.path}/`))
-    const [chatsCollapsed, setChatsCollapsed] = useState(() => localStorage.getItem('projects:chatsCollapsed') === 'true')
     const [open, setOpen] = useState(true)
     // Track exceptions so projects discovered asynchronously also start expanded.
     const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(new Set())
-    const expanded = new Set(namedProjects.filter(item => !collapsedProjects.has(item.id)).map(item => item.id))
+    const expanded = new Set(projects.filter(item => !collapsedProjects.has(item.id)).map(item => item.id))
     const [folders, setFolders] = useState<Set<string>>(new Set())
     const {
         bodyRef, bottomRef: filesRef, topStyle: projectsStyle, bottomStyle: filesStyle,
         topCollapsed: projectsCollapsed, bottomCollapsed: filesCollapsed,
         toggleTop: toggleProjects, toggleBottom: toggleFiles, resizing, dividerProps,
-    } = useSecondaryRailSections({ collapsedKey: 'projects:railCollapsed', heightKey: 'projects:filesHeight', topKey: 'projects', topHasExpandedContent: !!generalProject && !chatsCollapsed, bottomEnabled: !!project && !project.isDefault })
+    } = useSecondaryRailSections({ collapsedKey: 'projects:railCollapsed', heightKey: 'projects:filesHeight', topKey: 'projects' })
     const [dialog, setDialog] = useState<{ kind: 'project' | 'rename'; path?: string; name: string } | null>(null)
     const [busy, setBusy] = useState(false)
     const [dialogError, setDialogError] = useState('')
     const uploadRef = useRef<HTMLInputElement>(null)
     const uploadFolderRef = useRef<HTMLInputElement>(null)
     const uploadTarget = useRef<string | null>(null)
+    const project = projects.find((p) => selectedPath === p.path || selectedPath?.startsWith(`${p.path}/`))
     const selectedProjectId = project?.id
     useEffect(() => { if (selectedProjectId) setCollapsedProjects((prev) => { const next = new Set(prev); next.delete(selectedProjectId); return next }) }, [selectedProjectId])
     const find = (nodes: TreeNode[], target: string): TreeNode | undefined => {
@@ -67,7 +64,6 @@ export function ProjectsRail({ tree, selectedPath, selectedFile, selectedChat, p
             if (target.startsWith(`${node.path}/`)) { const found = find(node.children ?? [], target); if (found) return found }
         }
     }
-    const projectFiles = project ? (find(tree, project.path)?.children ?? []).filter(node => !project.isDefault || !projects.some(item => !item.isDefault && item.path === node.path)) : []
     const run = async (fn: () => Promise<unknown>) => {
         try { await fn(); await refresh() } catch (e) { toast(e instanceof Error ? e.message : 'Project action failed', 'error') }
     }
@@ -121,7 +117,7 @@ export function ProjectsRail({ tree, selectedPath, selectedFile, selectedChat, p
     }
     const renderFiles = (nodes: TreeNode[], depth = 0): React.ReactNode => [...nodes].sort((a,b) => a.kind === b.kind ? a.name.localeCompare(b.name) : a.kind === 'dir' ? -1 : 1).map((node) => <div key={node.path}>
         <div className="group/file flex items-center rounded hover:bg-accent/50">
-            <button className={cn('flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md pr-2 text-left text-[13.5px]', selectedFile === node.path ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50')} style={{ paddingLeft: 8 + depth * 12 }}
+            <button className={cn('flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded pr-1 text-left text-[13px]', selectedFile === node.path && 'bg-accent')} style={{ paddingLeft: 8 + depth * 12 }}
                 onClick={() => node.kind === 'file' ? onOpenFile(node.path) : setFolders((prev) => { const next = new Set(prev); if (next.has(node.path)) next.delete(node.path); else next.add(node.path); return next })}>
                 {node.kind === 'dir' ? <ChevronRight className={cn('size-3 shrink-0', folders.has(node.path) && 'rotate-90')} /> : <File className="size-3.5 shrink-0 text-muted-foreground" />}
                 <span className="truncate">{node.name}</span>
@@ -148,59 +144,46 @@ export function ProjectsRail({ tree, selectedPath, selectedFile, selectedChat, p
             {({ togglePin, onMenuOpenChange }) => {
                 menuChanged = onMenuOpenChange
                 return <div ref={bodyRef} className={cn('flex h-full min-h-0 flex-col', resizing && 'select-none')}>
-                    <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border pl-3 pr-1.5">
-                        <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">Assistant</span>
+                    <div className="flex shrink-0 items-center gap-0.5 px-2 py-1">
+                        <span className="min-w-0 flex-1 px-1 text-[13px] font-semibold text-muted-foreground">Projects</span>
                         <SecondaryRailToggle open={open} onToggle={togglePin} />
                     </div>
-                    <div className="min-h-0 overflow-y-auto pt-2" style={projectsStyle}>
-                    <section className="group/section flex flex-col">
-                        <SecondaryRailSectionHeader variant="email" label="Projects" collapsed={projectsCollapsed} count={namedProjects.length} onToggle={toggleProjects}>
-                            {namedProjects.length > 0 && <button
+                    <section className="group/section flex min-h-0 flex-col" style={projectsStyle}>
+                        <SecondaryRailSectionHeader label="Projects" collapsed={projectsCollapsed} count={projects.length} onToggle={toggleProjects}>
+                            <button
                                 type="button"
                                 aria-label={expanded.size > 0 ? 'Collapse all project chats' : 'Expand all project chats'}
                                 title={expanded.size > 0 ? 'Collapse all project chats' : 'Expand all project chats'}
                                 onClick={() => {
-                                    if (expanded.size > 0) setCollapsedProjects(new Set(namedProjects.map(item => item.id)))
+                                    if (expanded.size > 0) setCollapsedProjects(new Set(projects.map(item => item.id)))
                                     else { setCollapsedProjects(new Set()); if (projectsCollapsed) toggleProjects() }
                                 }}
-                                className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                                className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
                             >
                                 {expanded.size > 0 ? <ChevronsDownUp className="size-3.5" /> : <ChevronsUpDown className="size-3.5" />}
-                            </button>}
-                            <button aria-label="New project" title="Create a project to organize chats and local files." onClick={() => { setDialogError(''); setDialog({ kind: 'project', name: '' }) }} className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"><Plus className="size-3.5" /></button></SecondaryRailSectionHeader>
+                            </button>
+                            <button aria-label="New project" onClick={() => { setDialogError(''); setDialog({ kind: 'project', name: '' }) }} className="rounded p-1 hover:bg-accent"><Plus className="size-3.5" /></button></SecondaryRailSectionHeader>
                         {!projectsCollapsed && <FileListContextMenu onOpenChange={onMenuOpenChange} actions={[
                             { label: 'New project', onSelect: () => { setDialogError(''); setDialog({ kind: 'project', name: '' }) } },
-                        ]}><div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2">
+                        ]}><div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
                             {!ready && <Loader2 className="m-3 size-4 animate-spin" />}
                             {error && <button className="p-2 text-xs text-destructive" onClick={() => void refresh()}>{error} · Retry</button>}
-                            {namedProjects.map((item) => <div key={item.id}>
-                                <div className={cn('group/file flex h-8 items-center rounded-md', project?.id === item.id ? 'bg-accent font-medium text-foreground' : 'text-foreground/90 hover:bg-accent/50')}>
-                                    <button aria-label={`${expanded.has(item.id) ? 'Collapse' : 'Expand'} ${item.name}`} aria-expanded={expanded.has(item.id)} className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent" onClick={() => setCollapsedProjects((prev) => { const next = new Set(prev); if (next.has(item.id)) next.delete(item.id); else next.add(item.id); return next })}><ChevronRight className={cn('size-3.5', expanded.has(item.id) && 'rotate-90')} /></button>
-                                    <button title={item.name} aria-current={project?.id === item.id ? 'page' : undefined} onClick={() => onSelect(item)} className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md pl-1 pr-2 text-left text-[13.5px]"><Folder className="size-3.5 shrink-0 text-muted-foreground" /><span className="truncate">{item.name}</span></button>
-                                    <button aria-label={`New chat in ${item.name}`} title="New chat" className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground" onClick={() => void run(() => onNewChat(item))}><Plus className="size-3.5" /></button>
-                                    {!item.isDefault && fileMenu({ ...item, kind: 'dir' })}
+                            {ready && !error && projects.length === 0 && <p className="p-2 text-xs text-muted-foreground">Create a project to organize chats and local files.</p>}
+                            {projects.map((item) => <div key={item.id}>
+                                <div className={cn('group/file flex h-8 items-center rounded', project?.id === item.id ? 'bg-accent/60' : 'hover:bg-accent/50')}>
+                                    <button aria-label={`${expanded.has(item.id) ? 'Collapse' : 'Expand'} ${item.name}`} aria-expanded={expanded.has(item.id)} className="p-1" onClick={() => setCollapsedProjects((prev) => { const next = new Set(prev); if (next.has(item.id)) next.delete(item.id); else next.add(item.id); return next })}><ChevronRight className={cn('size-3', expanded.has(item.id) && 'rotate-90')} /></button>
+                                    <button title={item.name} onClick={() => onSelect(item)} className="flex min-w-0 flex-1 items-center gap-2 text-left text-[13px]"><Folder className="size-3.5 shrink-0 text-muted-foreground" /><span className="truncate">{item.name}</span></button>
+                                    <button aria-label={`New chat in ${item.name}`} title="New chat" className="rounded p-1 hover:bg-accent" onClick={() => void run(() => onNewChat(item))}><Plus className="size-3.5" /></button>
+                                    {fileMenu({ ...item, kind: 'dir' })}
                                 </div>
-                                {expanded.has(item.id) && <div className="ml-5 flex flex-col gap-0.5">{item.chats.map((chat) => <ChatRow key={chat.id} working={processingRunIds.has(chat.id)} chat={chat} selected={selectedChat === chat.id && project?.id === item.id} onOpen={() => onOpenChat(item, chat.id)} />)}{item.chats.length === 0 && <button className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground" onClick={() => void run(() => onNewChat(item))}>Start a chat with Rowboat</button>}</div>}
+                                {expanded.has(item.id) && <div>{item.chats.map((chat) => <ChatRow key={chat.id} working={processingRunIds.has(chat.id)} chat={chat} selected={selectedChat === chat.id && project?.id === item.id} onOpen={() => onOpenChat(item, chat.id)} />)}{item.chats.length === 0 && <button className="h-8 pl-7 text-xs text-muted-foreground hover:text-foreground" onClick={() => void run(() => onNewChat(item))}>Start a chat with Rowboat</button>}</div>}
                             </div>)}
                         </div></FileListContextMenu>}
                     </section>
-                    {generalProject && <section className="group/section flex flex-col">
-                        <SecondaryRailSectionHeader variant="email" label="Chats" collapsed={chatsCollapsed} count={generalProject.chats.length} onToggle={() => setChatsCollapsed(value => {
-                            localStorage.setItem('projects:chatsCollapsed', String(!value))
-                            return !value
-                        })}>
-                            <button aria-label="New chat" title="New chat" className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground" onClick={() => void run(() => onNewChat(generalProject))}><Plus className="size-3.5" /></button>
-                        </SecondaryRailSectionHeader>
-                        {!chatsCollapsed && <div className="flex flex-col gap-0.5 px-2 pb-2">
-                            {generalProject.chats.map(chat => <ChatRow key={chat.id} nested={false} working={processingRunIds.has(chat.id)} chat={chat} selected={selectedChat === chat.id && project?.id === generalProject.id} onOpen={() => onOpenChat(generalProject, chat.id)} />)}
-                            {generalProject.chats.length === 0 && <button className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground" onClick={() => void run(() => onNewChat(generalProject))}>Start a chat with Rowboat</button>}
-                        </div>}
-                    </section>}
-                    </div>
                     <section ref={filesRef} className="group/section flex min-h-0 flex-col" style={filesStyle} onDragOver={(e) => { if (project && Array.from(e.dataTransfer.types).includes('Files')) { e.preventDefault(); e.stopPropagation() } }} onDrop={(e) => { if (project && e.dataTransfer.files.length) { e.preventDefault(); e.stopPropagation(); uploadTarget.current = project.path; void upload(Array.from(e.dataTransfer.files)) } }}>
                         <SecondaryRailDivider {...dividerProps} />
-                        <SecondaryRailSectionHeader variant="email" label="Files" collapsed={filesCollapsed} count={project && !project.isDefault ? projectFiles.length : 0} onToggle={toggleFiles} disabled={!project || project.isDefault}>
-                            {project && !project.isDefault && <DropdownMenu onOpenChange={onMenuOpenChange}><DropdownMenuTrigger asChild><button aria-label="Add to project files" className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"><Plus className="size-3.5" /></button></DropdownMenuTrigger><DropdownMenuContent align="end">
+                        <SecondaryRailSectionHeader label="Files" collapsed={filesCollapsed} count={project ? (find(tree, project.path)?.children?.length ?? 0) : 0} onToggle={toggleFiles}>
+                            {project && <DropdownMenu onOpenChange={onMenuOpenChange}><DropdownMenuTrigger asChild><button aria-label="Add to project files" className="rounded p-1 hover:bg-accent"><Plus className="size-3.5" /></button></DropdownMenuTrigger><DropdownMenuContent align="end">
                                 <DropdownMenuItem onClick={() => actions.createNote(project.path)}><FilePlus className="mr-2 size-3.5" />New note</DropdownMenuItem>
                                 <DropdownMenuItem onClick={() => void run(() => actions.createFolder(project.path))}><FolderPlus className="mr-2 size-3.5" />New folder</DropdownMenuItem>
                                 <DropdownMenuItem onClick={() => actions.createPresentation(project.path)}><Presentation className="mr-2 size-3.5" />New presentation</DropdownMenuItem>
@@ -218,7 +201,7 @@ export function ProjectsRail({ tree, selectedPath, selectedFile, selectedChat, p
                             { label: 'Add Google Doc', onSelect: () => actions.addGoogleDoc(project.path) },
                             { label: 'Add files…', onSelect: () => { uploadTarget.current = project.path; uploadRef.current?.click() } },
                             { label: 'Add folder…', onSelect: () => { uploadTarget.current = project.path; uploadFolderRef.current?.click() } },
-                        ] : []}><div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2">{project ? renderFiles(projectFiles) : <p className="p-2 text-xs text-muted-foreground">Select a project to see its files.</p>}</div></FileListContextMenu>}
+                        ] : []}><div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">{project ? renderFiles(find(tree, project.path)?.children ?? []) : <p className="p-2 text-xs text-muted-foreground">Select a project to see its files.</p>}</div></FileListContextMenu>}
                     </section>
                 </div>
             }}

--- a/apps/x/apps/renderer/src/components/secondary-rail-section.tsx
+++ b/apps/x/apps/renderer/src/components/secondary-rail-section.tsx
@@ -8,27 +8,24 @@ import { cn } from '@/lib/utils'
  * ones key off group/section, which the PANE carries — hovering anywhere in
  * it shows them).
  */
-export function SecondaryRailSectionHeader({ label, collapsed, count, onToggle, children, disabled = false, variant = 'default' }: {
+export function SecondaryRailSectionHeader({ label, collapsed, count, onToggle, children }: {
     label: string
     collapsed: boolean
     count: number
     onToggle: () => void
     children?: ReactNode
-    disabled?: boolean
-    variant?: 'default' | 'email'
 }) {
     return (
         <div className="flex h-8 shrink-0 items-center gap-1 pl-3 pr-1.5">
             <button
                 type="button"
-                disabled={disabled}
                 onClick={onToggle}
                 aria-expanded={!collapsed}
                 title={collapsed ? `Show ${label.toLowerCase()}` : `Hide ${label.toLowerCase()}`}
-                className={cn('flex h-full min-w-0 flex-1 items-center gap-2 text-left text-[13px] text-muted-foreground hover:text-foreground', variant === 'email' ? 'font-normal' : 'font-semibold')}
+                className="flex h-full min-w-0 flex-1 items-center gap-1.5 text-left text-[13px] font-semibold text-muted-foreground hover:text-foreground"
             >
                 <span className="truncate">{label}</span>
-                {collapsed && count > 0 && <span className={cn('font-normal tabular-nums', variant === 'email' && 'text-[11px] text-muted-foreground/70')}>{count}</span>}
+                {collapsed && count > 0 && <span className="font-normal tabular-nums">{count}</span>}
             </button>
             {children}
         </div>

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -2,7 +2,7 @@
 
 import { SidebarChatContextMenu } from "./sidebar-chat-context-menu"
 import * as React from "react"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   AppWindow,
   ArrowUpRight,
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   Code2,
   FileText,
+  Folder,
   Globe,
   AlertTriangle,
   Home,
@@ -590,6 +591,16 @@ export function SidebarContentPanel({
       .slice(0, 10)
   }, [tree])
 
+  // The most recently touched chat, for the Assistant row (recency only —
+  // pinning shouldn't hijack "continue where I left off"). Mirrors the dock.
+  const lastChat = useMemo(() => {
+    const recency = (r: { createdAt: string; modifiedAt?: string }) => {
+      const ms = new Date(r.modifiedAt ?? r.createdAt).getTime()
+      return Number.isFinite(ms) ? ms : 0
+    }
+    return [...recentRuns].sort((a, b) => recency(b) - recency(a))[0] ?? null
+  }, [recentRuns])
+
   // Pinned chats: a per-machine UI preference, persisted in localStorage.
   const [pinnedChatIds, setPinnedChatIds] = useState<string[]>(() => {
     try {
@@ -662,6 +673,23 @@ export function SidebarContentPanel({
     if (!title || title === (current?.title ?? '')) return
     onRenameRun?.(chatId, title)
   }, [renameDraft, recentChats, onRenameRun])
+
+  // Workspace count for the Projects sublabel — top-level dir children of
+  // knowledge/Workspace (matches the Projects rail).
+  const workspaceCount = React.useMemo(() => {
+    const find = (nodes: TreeNode[]): TreeNode | null => {
+      for (const n of nodes) {
+        if (n.path === 'knowledge/Workspace') return n
+        if (n.kind === 'dir' && n.children?.length) {
+          const found = find(n.children)
+          if (found) return found
+        }
+      }
+      return null
+    }
+    const node = find(tree)
+    return node?.children?.filter((c) => c.kind === 'dir').length ?? 0
+  }, [tree])
 
   // "Updated 4m ago" sublabel under Knowledge, based on the most recently
   // modified note. Recomputed in an effect (not during render) and ticked so
@@ -827,10 +855,10 @@ export function SidebarContentPanel({
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  data-tour-id="nav-assistant"
                   isActive={activeNav === 'assistant'}
                   onClick={() => {
-                    knowledgeActions.openWorkspaceAt()
+                    if (lastChat && onOpenRun) onOpenRun(lastChat.id)
+                    else onNewChat?.()
                   }}
                 >
                   <MascotFaceIcon className="size-4 shrink-0" />
@@ -1036,6 +1064,22 @@ export function SidebarContentPanel({
                         {bgAgentsLabel}
                       </span>
                     )}
+                  </div>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-tour-id="nav-workspaces"
+                  isActive={activeNav === 'workspaces'}
+                  onClick={() => knowledgeActions.openWorkspaceAt()}
+                  className="h-auto items-start py-1"
+                >
+                  <Folder className="mt-0.5 size-4 shrink-0" />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">Projects</span>
+                    <span className="truncate text-[11px] text-muted-foreground">
+                      {workspaceCount === 0 ? 'No projects' : `${workspaceCount} project${workspaceCount === 1 ? '' : 's'}`}
+                    </span>
                   </div>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/apps/x/apps/renderer/src/hooks/use-secondary-rail-sections.ts
+++ b/apps/x/apps/renderer/src/hooks/use-secondary-rail-sections.ts
@@ -6,13 +6,11 @@ const NAVIGATION_MIN = 120
 /** Spaces and Projects share the same 60/40 split, persisted file-pane
  * height, and collapse behavior. Keys are supplied to preserve existing
  * Spaces preferences and keep each section's preferences independent. */
-export function useSecondaryRailSections({ collapsedKey, heightKey, topKey = 'navigation', bottomKey = 'files', topHasExpandedContent = false, bottomEnabled = true }: {
+export function useSecondaryRailSections({ collapsedKey, heightKey, topKey = 'navigation', bottomKey = 'files' }: {
     collapsedKey: string
     heightKey: string
     topKey?: string
-    topHasExpandedContent?: boolean
     bottomKey?: string
-    bottomEnabled?: boolean
 }) {
     const [height, setHeight] = useState<number | null>(() => {
         const stored = Number(localStorage.getItem(heightKey))
@@ -38,9 +36,8 @@ export function useSecondaryRailSections({ collapsedKey, heightKey, topKey = 'na
         return next
     })
     const topCollapsed = collapsed.has(topKey)
-    const bottomCollapsed = !bottomEnabled || collapsed.has(bottomKey)
-    const topFullyCollapsed = topCollapsed && !topHasExpandedContent
-    const bothOpen = !topFullyCollapsed && !bottomCollapsed
+    const bottomCollapsed = collapsed.has(bottomKey)
+    const bothOpen = !topCollapsed && !bottomCollapsed
     const startResize = (event: MouseEvent) => {
         event.preventDefault()
         dragCleanup.current?.()
@@ -68,7 +65,7 @@ export function useSecondaryRailSections({ collapsedKey, heightKey, topKey = 'na
         window.addEventListener('mousemove', onMove)
         window.addEventListener('mouseup', onUp)
     }
-    const topStyle: CSSProperties = topFullyCollapsed ? { flex: '0 0 auto' }
+    const topStyle: CSSProperties = topCollapsed ? { flex: '0 0 auto' }
         : !bothOpen || height !== null ? { flex: '1 1 0%' } : { flex: '60 1 0%' }
     const bottomStyle: CSSProperties = bottomCollapsed ? { flex: '0 0 auto' }
         : !bothOpen ? { flex: '1 1 0%' }
@@ -76,7 +73,7 @@ export function useSecondaryRailSections({ collapsedKey, heightKey, topKey = 'na
         : { flex: '40 1 0%' }
     return {
         bodyRef, bottomRef, topStyle, bottomStyle, topCollapsed, bottomCollapsed, resizing,
-        toggleTop: () => toggle(topKey), toggleBottom: () => { if (bottomEnabled) toggle(bottomKey) },
+        toggleTop: () => toggle(topKey), toggleBottom: () => toggle(bottomKey),
         dividerProps: { enabled: bothOpen, resizing, onMouseDown: startResize },
     }
 }

--- a/apps/x/apps/renderer/src/lib/projects-navigation.test.ts
+++ b/apps/x/apps/renderer/src/lib/projects-navigation.test.ts
@@ -4,21 +4,7 @@ import { resolveProjectsLocation } from './projects-navigation'
 const alpha = { id: 'alpha', name: 'Alpha', path: 'knowledge/Workspace/Alpha', chats: [{ id: 'chat-1', title: 'Report', modifiedAt: '2026-09-10' }] }
 const beta = { id: 'beta', name: 'Beta', path: 'knowledge/Workspace/Beta', chats: [] }
 
-const general = { id: 'default', name: 'General', path: 'knowledge/Workspace', isDefault: true, chats: [] }
-
-describe('returning to Assistant', () => {
-    it('opens General on first entry even though it is last in the rail', () => {
-        expect(resolveProjectsLocation([alpha, beta, general], null)).toEqual({ path: general.path })
-    })
-    it('restores a renamed project by chat before falling back to General', () => {
-        const renamed = { ...alpha, path: 'knowledge/Workspace/Renamed' }
-        expect(resolveProjectsLocation([renamed, general], { path: alpha.path, runId: 'chat-1' }))
-            .toEqual({ path: renamed.path, runId: 'chat-1' })
-    })
-    it('falls back to General without retaining a removed project file', () => {
-        expect(resolveProjectsLocation([general], { path: alpha.path, filePath: `${alpha.path}/report.md` }))
-            .toEqual({ path: general.path })
-    })
+describe('returning to Projects', () => {
     it('opens a project on first entry rather than a pathless file rail', () => {
         expect(resolveProjectsLocation([alpha, beta], null)).toEqual({ path: alpha.path })
     })

--- a/apps/x/apps/renderer/src/lib/projects-navigation.ts
+++ b/apps/x/apps/renderer/src/lib/projects-navigation.ts
@@ -5,12 +5,11 @@ export type ProjectLocation = { path: string; runId?: string; filePath?: string 
 /** Section entry restores the last project instead of opening a pathless
  * root and clearing its chats/files. History entries still apply exactly. */
 export function resolveProjectsLocation(projects: Project[], previous: ProjectLocation | null): ProjectLocation | null {
-    const project = projects.find((item) => previous && (previous.path === item.path || (!item.isDefault && previous.path.startsWith(`${item.path}/`))))
+    const project = projects.find((item) => previous && (previous.path === item.path || previous.path.startsWith(`${item.path}/`)))
         ?? projects.find((item) => previous?.runId && item.chats.some((chat) => chat.id === previous.runId))
-        ?? projects.find((item) => item.isDefault)
         ?? projects[0]
     if (!project) return null
-    const sameProject = previous && (previous.path === project.path || (!project.isDefault && previous.path.startsWith(`${project.path}/`))
+    const sameProject = previous && (previous.path === project.path || previous.path.startsWith(`${project.path}/`)
         || project.chats.some((chat) => chat.id === previous.runId))
     if (!sameProject) return { path: project.path }
     const runId = project.chats.some((chat) => chat.id === previous.runId) ? previous.runId : undefined

--- a/apps/x/packages/core/src/projects/projects.ts
+++ b/apps/x/packages/core/src/projects/projects.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { WorkDir } from '../config/config.js';
-import { listRuns, listRunsByWorkDir, fetchRun } from '../runtime/legacy/runs.js';
+import { listRunsByWorkDir, fetchRun } from '../runtime/legacy/runs.js';
 import type { ISessions } from '../runtime/sessions/index.js';
-import { ProjectStore, type ProjectChat } from './store.js';
+import { ProjectStore } from './store.js';
 
 const store = new ProjectStore(WorkDir, async (dir) => (await listRunsByWorkDir(dir)).runs, async (id) => {
     try {
@@ -14,15 +14,6 @@ const store = new ProjectStore(WorkDir, async (dir) => (await listRunsByWorkDir(
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
         throw error;
     }
-}, async () => {
-    const chats: ProjectChat[] = [];
-    let cursor: string | undefined;
-    do {
-        const page = await listRuns(cursor);
-        chats.push(...page.runs.filter((run) => !run.useCase && ['copilot', 'rowboatx'].includes(run.agentId)));
-        cursor = page.nextCursor;
-    } while (cursor);
-    return chats;
 });
 export const listProjects = (sessions: ISessions) => store.list(sessions);
 export const createProjectChat = (sessions: ISessions, projectId: string) => store.createChat(sessions, projectId);

--- a/apps/x/packages/core/src/projects/store.test.ts
+++ b/apps/x/packages/core/src/projects/store.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { DEFAULT_PROJECT_ID, ProjectStore, relativeInside } from './store.js';
+import { ProjectStore, relativeInside } from './store.js';
 import type { SessionIndexEntry } from '@x/shared/dist/sessions.js';
 
 const roots: string[] = [];
@@ -56,7 +56,7 @@ describe('local project associations', () => {
         const [project] = await store.list(sessions);
         expect(project!.chats).toEqual([]);
         await fs.rm(folder, { recursive: true });
-        expect((await store.list(sessions)).map((p) => p.id)).toEqual([DEFAULT_PROJECT_ID]);
+        expect(await store.list(sessions)).toEqual([]);
         await expect(store.createChat(sessions, project!.id)).rejects.toThrow('no longer available');
     });
     it('serializes concurrent creation so no membership is lost', async () => {
@@ -85,35 +85,6 @@ describe('local project associations', () => {
         inFolder = false;
         await fs.writeFile(sidecar, JSON.stringify({ path: '/tmp/elsewhere' }));
         expect((await store.list(sessions))[0]!.chats).toEqual([chat]);
-    });
-    it('always lists General last and includes general chats without changing their working directories', async () => {
-        const { root, sessions, store } = await fixture();
-        await fs.mkdir(path.join(root, 'knowledge/Workspace/Zebra'));
-        const id = await sessions.createSession();
-        const projects = await store.list(sessions);
-        expect(projects.map((p) => p.name)).toEqual(['Alpha', 'Zebra', 'General']);
-        expect(projects.at(-1)).toMatchObject({ id: DEFAULT_PROJECT_ID, isDefault: true, chats: [{ id }] });
-        await expect(fs.stat(path.join(root, 'config', `workdir-${id}.json`))).rejects.toMatchObject({ code: 'ENOENT' });
-        const created = await store.createChat(sessions, DEFAULT_PROJECT_ID);
-        expect((await new ProjectStore(root).list(sessions)).at(-1)!.chats.map((c) => c.id)).toEqual([id, created]);
-    });
-    it('allows a general chat to acquire a folder association and falls back when that folder is deleted', async () => {
-        const { root, folder, sessions, store } = await fixture();
-        const id = await sessions.createSession();
-        await store.list(sessions);
-        await fs.writeFile(path.join(root, 'config', `workdir-${id}.json`), JSON.stringify({ path: folder }));
-        expect((await store.list(sessions))[0]!.chats.map((c) => c.id)).toEqual([id]);
-        await fs.rm(folder, { recursive: true });
-        expect((await store.list(sessions)).at(-1)!.chats.map((c) => c.id)).toEqual([id]);
-    });
-    it('includes general legacy chats once and keeps code sessions excluded', async () => {
-        const { root, sessions } = await fixture();
-        const chat = { id: 'legacy-general', modifiedAt: '2026-09-10' };
-        const code = { id: 'code', modifiedAt: '2026-09-10' };
-        await fs.mkdir(path.join(root, 'code-mode/sessions-meta'), { recursive: true });
-        await fs.writeFile(path.join(root, 'code-mode/sessions-meta/code.json'), '{}');
-        const store = new ProjectStore(root, undefined, undefined, async () => [chat, chat, code]);
-        expect((await store.list(sessions)).at(-1)!.chats).toEqual([chat]);
     });
     it('checks directory boundaries', () => {
         expect(relativeInside('/tmp/project', '/tmp/project/a')).toBe('a');

--- a/apps/x/packages/core/src/projects/store.ts
+++ b/apps/x/packages/core/src/projects/store.ts
@@ -4,9 +4,7 @@ import { randomUUID } from 'node:crypto';
 import type { SessionIndexEntry } from '@x/shared/dist/sessions.js';
 
 export interface ProjectChat { id: string; title?: string; modifiedAt: string }
-export interface Project { id: string; name: string; path: string; isDefault?: boolean; chats: ProjectChat[] }
-export const DEFAULT_PROJECT_ID = 'default';
-const defaultProject = (): Project => ({ id: DEFAULT_PROJECT_ID, name: 'General', path: 'knowledge/Workspace', isDefault: true, chats: [] });
+export interface Project { id: string; name: string; path: string; chats: ProjectChat[] }
 interface RecordEntry { id: string; path: string; identity: string }
 interface Registry { projects: RecordEntry[]; chats: Record<string, string> }
 interface Sessions {
@@ -23,7 +21,7 @@ export function relativeInside(parent: string, child: string): string | null {
  * rename, while session membership survives later working-directory changes. */
 export class ProjectStore {
     private pending: Promise<unknown> = Promise.resolve();
-    constructor(private root: string, private legacyChats: (dir: string) => Promise<ProjectChat[]> = async () => [], private legacyChat: (id: string) => Promise<ProjectChat | null> = async () => null, private generalLegacyChats: () => Promise<ProjectChat[]> = async () => []) {}
+    constructor(private root: string, private legacyChats: (dir: string) => Promise<ProjectChat[]> = async () => [], private legacyChat: (id: string) => Promise<ProjectChat | null> = async () => null) {}
     private exclusive<T>(fn: () => Promise<T>): Promise<T> {
         const next = this.pending.then(fn);
         this.pending = next.catch(() => {});
@@ -94,19 +92,15 @@ export class ProjectStore {
             const before = JSON.stringify(registry);
             const live = await this.discover(registry);
             const projects: Project[] = live.map((p) => ({ id: p.id, name: path.basename(p.path), path: p.path, chats: [] }));
-            const fallback = defaultProject();
-            projects.push(fallback);
             const add = async (chat: ProjectChat) => {
                 let projectId = registry.chats[chat.id];
                 if (!projectId) {
                     const dir = await this.workDir(chat.id);
-                    const project = dir ? projects.find((p) => !p.isDefault && relativeInside(path.join(this.root, p.path), dir) !== null) : undefined;
+                    const project = dir ? projects.find((p) => relativeInside(path.join(this.root, p.path), dir) !== null) : undefined;
                     if (project) registry.chats[chat.id] = projectId = project.id;
                 }
-                // Keep the fallback implicit so a general chat can later acquire a
-                // folder association. Preserve saved associations if folders return.
-                const project = projects.find((p) => p.id === projectId) ?? fallback;
-                if (!project.chats.some((c) => c.id === chat.id)) project.chats.push(chat);
+                const project = projects.find((p) => p.id === projectId);
+                if (project && !project.chats.some((c) => c.id === chat.id)) project.chats.push(chat);
             };
             let codeIds = new Set<string>();
             try { codeIds = new Set((await fs.readdir(path.join(this.root, 'code-mode', 'sessions-meta'))).map((name) => name.replace(/\.json$/, ''))); }
@@ -117,13 +111,8 @@ export class ProjectStore {
                 await add({ id: session.sessionId, title: session.title, modifiedAt: session.updatedAt });
             }
             const knownSessions = new Set(sessions.listSessions().map((session) => session.sessionId));
-            for (const chat of await this.generalLegacyChats()) {
-                if (!knownSessions.has(chat.id) && !codeIds.has(chat.id)) await add(chat);
-            }
             for (const project of projects) {
-                if (!project.isDefault) for (const chat of await this.legacyChats(path.join(this.root, project.path))) {
-                    if (!knownSessions.has(chat.id) && !codeIds.has(chat.id)) await add(chat);
-                }
+                for (const chat of await this.legacyChats(path.join(this.root, project.path))) await add(chat);
                 for (const [id, projectId] of Object.entries(registry.chats)) {
                     if (projectId !== project.id || knownSessions.has(id) || codeIds.has(id) || project.chats.some((chat) => chat.id === id)) continue;
                     const chat = await this.legacyChat(id);
@@ -138,11 +127,11 @@ export class ProjectStore {
     createChat(sessions: Sessions, projectId: string): Promise<string> {
         return this.exclusive(async () => {
             const registry = await this.readRegistry();
-            const project = projectId === DEFAULT_PROJECT_ID ? defaultProject() : (await this.discover(registry)).find((p) => p.id === projectId);
+            const project = (await this.discover(registry)).find((p) => p.id === projectId);
             if (!project) throw new Error('Project folder is no longer available');
             const id = await sessions.createSession({});
             await fs.mkdir(path.join(this.root, 'config'), { recursive: true });
-            if (projectId !== DEFAULT_PROJECT_ID) await fs.writeFile(path.join(this.root, 'config', `workdir-${id}.json`), JSON.stringify({ path: path.join(this.root, project.path) }, null, 2));
+            await fs.writeFile(path.join(this.root, 'config', `workdir-${id}.json`), JSON.stringify({ path: path.join(this.root, project.path) }, null, 2));
             registry.chats[id] = projectId;
             await this.save(registry);
             return id;

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -650,7 +650,7 @@ export const ipcSchemas = {
   'projects:list': {
     req: z.null(),
     res: z.object({ projects: z.array(z.object({
-      id: z.string(), name: z.string(), path: z.string(), isDefault: z.boolean().optional(),
+      id: z.string(), name: z.string(), path: z.string(),
       chats: z.array(z.object({ id: z.string(), title: z.string().optional(), modifiedAt: z.string() })),
     })) }),
   },


### PR DESCRIPTION
Reverts #1014 (squash commit `b4b0c094dd62990571899542cbba995ee16832f9`), restoring the separate Assistant and Projects navigation and the previous project behavior.

Validation:
- Renderer sidebar, Projects rail, and project navigation tests: 17 passed.
- Core project store tests: 7 passed.
- `git diff --check` passed.
- Verified the resulting tree exactly matches the parent of the reverted squash commit.
