### PR TITLE
Fix sidebar New Chat button reopening the last chat

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -8266,7 +8266,7 @@ function App() {
                 last so its no-drag region paints over the drag regions. */}
             <FixedSidebarToggle
               leftInsetPx={isMac ? MACOS_TRAFFIC_LIGHTS_RESERVED_PX : 0}
-              onNewChat={handleNewChat}
+              onNewChat={handleNewChatTab}
               onWidthChange={setTitlebarControlsWidthPx}
             />
             <MenuSidebarToggleBridge />


### PR DESCRIPTION
The top-left New Chat button cleared transient state but kept the active tab bound to the previous conversation, so the last chat remained mounted.

Wire the button to the existing new-chat tab handler so it creates and activates a fresh conversation.

Validation: `git diff --check` passed. Runtime tests were not run because dependencies are not installed in this checkout.
