### PR TITLE
Fix space switching while a thread is open

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -5506,8 +5506,8 @@ function App() {
     openAppsView()
   }, [openAppsView])
 
-  const openSpace = useCallback((orgId: string, spaceId: string) => {
-    void navigateToView({ type: 'spaces', orgId, spaceId })
+  const openSpace = useCallback((orgId: string, spaceId: string, rail: RailSelection = { kind: 'general' }) => {
+    void navigateToView({ type: 'spaces', orgId, spaceId, rail })
   }, [navigateToView])
 
   /** The org's Activity surface (layer 3): everything that involves you, newest first. */
@@ -7653,6 +7653,7 @@ function App() {
                     active={activeMiddle === 'spaces'}
                     selection={spaceSelection}
                     onSelect={setSpaceSelection}
+                    onSwitchSpace={openSpace}
                     railSelection={railSelection}
                     onRailSelect={(rail) => {
                       // In-space navigation is real navigation: each selection is a history entry,

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -99,9 +99,11 @@ const WhiteboardPane = lazy(() => import('@/components/spaces/whiteboard-pane'))
 // Root view: the selected space (the org/space list lives in the app sidebar)
 // ---------------------------------------------------------------------------
 
-export function SpacesView({ selection, onSelect, railSelection, onRailSelect, onOpenSession, onOpenMessage, onOpenActivity, active = true }: {
+export function SpacesView({ selection, onSelect, onSwitchSpace, railSelection, onRailSelect, onOpenSession, onOpenMessage, onOpenActivity, active = true }: {
     selection: SpaceSelection
     onSelect: (selection: SpaceSelection) => void
+    /** Navigate to the destination and its rail together, without using the current space's selection. */
+    onSwitchSpace: (orgId: string, spaceId: string, selection?: RailSelection) => void
     /** What's selected inside the space (general / a topic / a file) — part of the app's history. */
     railSelection: RailSelection
     onRailSelect: (selection: RailSelection) => void
@@ -155,11 +157,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
                 space={selectedSpace}
                 selection={railSelection}
                 onSelect={onRailSelect}
-                onSwitchSpace={(orgId, spaceId, next = { kind: 'general' }) => {
-                    onSelect({ orgId, spaceId })
-                    // The old space's rail selection means nothing over there.
-                    onRailSelect(next)
-                }}
+                onSwitchSpace={onSwitchSpace}
                 onOpenSession={onOpenSession}
                 onOpenActivity={onOpenActivity}
                 active={active}
@@ -168,13 +166,9 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
     }
 
     if (selectedOrg) {
-        const openSpace = (orgId: string, spaceId: string) => {
-            onSelect({ orgId, spaceId })
-            onRailSelect({ kind: 'general' })
-        }
         return <div className="spaces-surface flex min-h-0 flex-1 flex-col">
             <header className="spaces-header flex shrink-0 items-center gap-2 border-b border-border">
-                <ServerSwitcher org={selectedOrg} onOpenSpace={openSpace} />
+                <ServerSwitcher org={selectedOrg} onOpenSpace={onSwitchSpace} />
             </header>
             <div className="flex min-h-0 flex-1">
             <aside className="w-64 shrink-0 overflow-y-auto border-r border-border bg-[var(--rowboat-panel-soft)] p-2">
@@ -182,7 +176,7 @@ export function SpacesView({ selection, onSelect, railSelection, onRailSelect, o
                     <span className="flex-1 px-1 text-[13px] font-semibold text-muted-foreground">Spaces</span>
                     <ServerOptionsMenu org={selectedOrg} showArchived={emptyShowArchived} onToggleArchived={() => setEmptyShowArchived((value) => !value)} onMenuOpenChange={() => {}} />
                 </div>
-                <ServerSpaceNavigation org={selectedOrg} spaceId="" onOpenSpace={openSpace} onOpenActivity={onOpenActivity}
+                <ServerSpaceNavigation org={selectedOrg} spaceId="" onOpenSpace={onSwitchSpace} onOpenActivity={onOpenActivity}
                     activityActive={selection?.view === 'activity'}
                     onOpenDiscussion={() => {}} activeDiscussionCount={0} renderActiveDiscussions={() => null} />
             </aside>


### PR DESCRIPTION
Clicking another space while a thread was open could close the thread and leave the user in the original space. The thread reset navigated using the previous space selection, overwriting the destination.

Route space switches through one navigation action carrying both the destination and its rail selection. This also preserves navigation to a discussion in another space and handles switching from an empty server.

Validation: all 18 existing tests across space navigation, sidebar navigation, and server switching passed. `git diff --check` passed. Full renderer typechecking was blocked by missing local dependencies and mismatched IPC types.
