### PR TITLE
fix(spaces): one indent for every space's topics, and expand-all in the rail

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SpacesSidebarSection, ServerSpaceNavigation } from './spaces-sidebar-section'
 import { ServerOptionsMenu } from './spaces/server-options-menu'
 import { SidebarProvider } from '@/components/ui/sidebar'
+import { isSpaceExpanded, setSpacesExpanded, useSpaceExpansionVersion } from '@/lib/spaces-expansion'
 import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 
 const { org, topics } = vi.hoisted(() => ({
@@ -71,6 +72,34 @@ describe('server and space navigation', () => {
         expect(screen.getByText('Person 0')).toBeTruthy()
         fireEvent.click(screen.getByText('Direct messages'))
         expect(screen.queryByText('Person 0')).toBeNull()
+    })
+    it('moves every space from the rail\'s one expand-all / collapse-all control', () => {
+        // The rail header's control, standing in for space-rail.tsx: the space
+        // rows and the control share one store, so either can move the other.
+        function Navigation() {
+            useSpaceExpansionVersion()
+            const ids = org.spaces.map((space) => space.id)
+            const anyExpanded = ids.some((id) => isSpaceExpanded(org.id, id))
+            return <SidebarProvider>
+                <button type="button" onClick={() => setSpacesExpanded(org.id, ids, !anyExpanded)}>
+                    {anyExpanded ? 'Collapse all discussions' : 'Expand all discussions'}
+                </button>
+                <ServerSpaceNavigation org={org as unknown as OrgWithSpaces} spaceId="" onOpenSpace={vi.fn()}
+                    onOpenDiscussion={vi.fn()} activeDiscussionCount={0} renderActiveDiscussions={() => null} />
+            </SidebarProvider>
+        }
+        render(<Navigation />)
+        fireEvent.click(screen.getByRole('button', { name: 'Expand all discussions' }))
+        expect(screen.getByLabelText('Collapse #main')).toBeTruthy()
+        expect(screen.getByLabelText('Collapse #founders')).toBeTruthy()
+        // A partially expanded server must still offer Collapse all, as one button.
+        fireEvent.click(screen.getByLabelText('Collapse #founders'))
+        expect(screen.getByRole('button', { name: 'Collapse all discussions' })).toBeTruthy()
+        expect(screen.queryByRole('button', { name: 'Expand all discussions' })).toBeNull()
+        fireEvent.click(screen.getByRole('button', { name: 'Collapse all discussions' }))
+        expect(screen.getByLabelText('Expand #main')).toBeTruthy()
+        expect(screen.getByLabelText('Expand #founders')).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Expand all discussions' })).toBeTruthy()
     })
 })
 

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -15,6 +15,7 @@ import { AddOrgDialog, MemberAvatar } from '@/components/spaces/atoms'
 import { NewDirectDialog } from '@/components/spaces/new-direct-dialog'
 import { directAvatarId, isSelfDirect, isSelfDirectUnsupported, markSelfDirectUnsupported, selfDirectFailureMessage, selfDirectRefused, spaceDisplayName } from '@/lib/spaces-direct'
 import { prefetchMembers, useSelfDisplayName } from '@/hooks/use-space-members'
+import { isSpaceExpanded, setSpaceExpanded, useSpaceExpansionVersion } from '@/lib/spaces-expansion'
 import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
 import type { RailSelection } from '@/lib/spaces-selection'
 import { toast } from '@/lib/toast'
@@ -441,14 +442,15 @@ function CollapsibleSpace({ orgId, spaceId, name, showArchived, countOverride, d
     children: (expanded: boolean) => ReactNode
 }) {
     const feed = useSpaceFeed(orgId, spaceId)
-    const key = `spaces:spaceExpanded:${orgId}/${spaceId}`
-    const [expanded, setExpanded] = useState(() => sessionStorage.getItem(key) === 'true')
+    // Shared with the rail's expand-all / collapse-all, so one click can move every row.
+    useSpaceExpansionVersion()
+    const expanded = isSpaceExpanded(orgId, spaceId)
     const count = countOverride ?? feed.topics.filter((topic) => showArchived || !topic.archived).length
     return <SidebarMenuItem>
         <div className="flex items-center">
             {count > 0 ? <button type="button" aria-label={`${expanded ? 'Collapse' : 'Expand'} #${name}`} aria-expanded={expanded}
                 className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent"
-                onClick={() => setExpanded((value) => { sessionStorage.setItem(key, String(!value)); return !value })}>
+                onClick={() => setSpaceExpanded(orgId, spaceId, !expanded)}>
                 <ChevronRight className={cn('size-3.5', expanded && 'rotate-90')} />
             </button> : <span className="w-5.5 shrink-0" />}
             {children(expanded)}

--- a/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-rail.tsx
@@ -1,7 +1,7 @@
 import { SecondaryRailToggle } from '@/components/secondary-rail-toggle'
 import { useMemo, useRef, useState } from 'react'
 import { FileListContextMenu } from '@/components/file-list-context-menu'
-import { Archive, ArchiveRestore, Bot, CornerDownRight, FileText, FolderPlus, MessageSquareOff, MessagesSquare, MoreHorizontal, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
+import { Archive, ArchiveRestore, Bot, ChevronsDownUp, ChevronsUpDown, CornerDownRight, FileText, FolderPlus, MessageSquareOff, MessagesSquare, MoreHorizontal, Pencil, PenTool, Plus, Trash2, Upload } from 'lucide-react'
 import { spaces } from '@x/shared'
 import { cn } from '@/lib/utils'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -19,6 +19,7 @@ import type { SpacePresence, StreamState } from '@/hooks/use-space-chat'
 import { prefetchThread } from '@/hooks/use-space-chat'
 import { useMemberNames } from '@/components/spaces/member-text'
 import { threadRefOf } from '@/lib/spaces-conventions'
+import { isSpaceExpanded, setSpacesExpanded, useSpaceExpansionVersion } from '@/lib/spaces-expansion'
 import { formatFeedTime, resolveMentions } from '@/lib/spaces-presentation'
 import { getStreamReadOffset, isThreadUnread, threadBadge, useReadStateVersion } from '@/lib/spaces-read-state'
 import { UnreadBadge } from '@/components/spaces/unread-badge'
@@ -71,6 +72,12 @@ export function SpaceRail({
     const archivedKey = `spaces:showArchived:${orgId}`
     const [showArchived, setShowArchived] = useState(() => sessionStorage.getItem(archivedKey) === 'true')
     const uploadInputRef = useRef<HTMLInputElement | null>(null)
+
+    // Every space row keeps its open/shut flag in the shared expansion store,
+    // so the header can read the whole server's state and move it in one click.
+    useSpaceExpansionVersion()
+    const spaceIds = org.spaces.map((space) => space.id)
+    const anySpaceExpanded = spaceIds.some((id) => isSpaceExpanded(org.id, id))
 
     const {
         bodyRef, bottomRef: filesRef, topStyle: chatStyle, bottomStyle: filesStyle,
@@ -146,6 +153,17 @@ export function SpaceRail({
             <section style={chatStyle} className="group/section flex min-h-0 flex-col">
                 <div className="flex shrink-0 items-center gap-0.5 px-2 py-1">
                     <span className="min-w-0 flex-1 px-1 text-[13px] font-semibold text-muted-foreground">Spaces</span>
+                    {/* Same rule as the Projects rail: any space open means the
+                        button collapses everything; only with all shut does it expand. */}
+                    <button
+                        type="button"
+                        aria-label={anySpaceExpanded ? 'Collapse all discussions' : 'Expand all discussions'}
+                        title={anySpaceExpanded ? 'Collapse all discussions' : 'Expand all discussions'}
+                        onClick={() => setSpacesExpanded(org.id, spaceIds, !anySpaceExpanded)}
+                        className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                    >
+                        {anySpaceExpanded ? <ChevronsDownUp className="size-3.5" /> : <ChevronsUpDown className="size-3.5" />}
+                    </button>
                     <ServerOptionsMenu org={org} showArchived={showArchived} onToggleArchived={() => setShowArchived((value) => { sessionStorage.setItem(archivedKey, String(!value)); return !value })} onMenuOpenChange={onMenuOpenChange} />
                     <SecondaryRailToggle open={open} onToggle={togglePin} />
                 </div>
@@ -161,7 +179,7 @@ export function SpaceRail({
                             const working = (presence.working.get(topic.rootMessageId) ?? []).length > 0
                             if (renaming?.topicId === topic.id) {
                                 return (
-                                    <div key={topic.id} className="flex h-7 items-center rounded-md pl-5 pr-2">
+                                    <div key={topic.id} className="flex h-8 items-center rounded-md px-2">
                                         <input
                                             autoFocus
                                             value={renaming.value}
@@ -195,9 +213,11 @@ export function SpaceRail({
                                                         // and touched files ride the tooltip — the list is already
                                                         // sorted by activity.
                                                         className={cn(
-                                                            // One tree step (12px) in from Messages: these nest under it.
-                                                            // pr-7 keeps the title and indicators clear of the ⋯ slot.
-                                                            'flex h-8 w-full items-center gap-2 rounded pl-5 pr-7 text-left',
+                                                            // Same indent as a non-selected space's discussions
+                                                            // (SpaceDiscussions) - the tree step is the wrapper's
+                                                            // ml-3 + rule, not this row. pr-7 keeps the title and
+                                                            // indicators clear of the ⋯ slot.
+                                                            'flex h-8 w-full items-center gap-2 rounded pl-2 pr-7 text-left',
                                                             active ? 'bg-[var(--stream-mention-wash)] text-[var(--stream-link)]' : 'hover:bg-accent/50',
                                                             topic.archived && 'opacity-60',
                                                         )}

--- a/apps/x/apps/renderer/src/lib/spaces-expansion.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-expansion.ts
@@ -1,0 +1,43 @@
+import { useSyncExternalStore } from 'react'
+
+// Which spaces are showing their discussions. Kept per session, keyed by
+// org/space, so a space row's own chevron and the rail's expand-all control
+// read and write one truth instead of each holding its own useState.
+
+const listeners = new Set<() => void>()
+let version = 0
+
+const storageKey = (orgId: string, spaceId: string) => `spaces:spaceExpanded:${orgId}/${spaceId}`
+
+function emit(): void {
+    version += 1
+    for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+export function isSpaceExpanded(orgId: string, spaceId: string): boolean {
+    return sessionStorage.getItem(storageKey(orgId, spaceId)) === 'true'
+}
+
+/** One space, from its own chevron. */
+export function setSpaceExpanded(orgId: string, spaceId: string, expanded: boolean): void {
+    sessionStorage.setItem(storageKey(orgId, spaceId), String(expanded))
+    emit()
+}
+
+/** Every space in one go, from the rail's expand-all / collapse-all. */
+export function setSpacesExpanded(orgId: string, spaceIds: readonly string[], expanded: boolean): void {
+    for (const spaceId of spaceIds) sessionStorage.setItem(storageKey(orgId, spaceId), String(expanded))
+    emit()
+}
+
+/** Re-renders the caller on any expansion change; read the value with isSpaceExpanded. */
+export function useSpaceExpansionVersion(): number {
+    return useSyncExternalStore(subscribe, () => version)
+}


### PR DESCRIPTION
Two fixes to the Spaces secondary rail.

## 1. Topics under different spaces sat at different indents

The rail has **two** renderers for the same topic row, and they disagreed:

- topics under a non-selected space (`SpaceDiscussions`, spaces-sidebar-section.tsx) -> `px-2`
- topics under the selected space (`renderActiveDiscussions`, space-rail.tsx) -> `pl-5`

Both are wrapped by the same `<div className="ml-3 border-l border-border pl-1">`, so the `pl-5` was counting the tree step twice. Measured from the scroll container's content edge:

| row | icon x |
|---|---|
| space `#` | 26px |
| topics under a non-selected space | 25px |
| topics under the selected space | **37px** |

The selected space's topics now sit at `pl-2` with the rest. The inline rename row moves with them (`h-7 pl-5 pr-2` -> `h-8 px-2`) so renaming no longer shifts a row sideways or changes its height. The stale comment on that className referenced a "Messages" row that no longer exists; replaced.

## 2. Expand all / collapse all

Added to the "Spaces" rail header, left of the server-options menu, under the same rule the Projects rail uses: **any space expanded -> `ChevronsDownUp` "Collapse all discussions"; all collapsed -> `ChevronsUpDown` "Expand all discussions"**. Always rendered, no hover gate, matching Projects.

`CollapsibleSpace` kept its expanded flag in local `useState` seeded from `sessionStorage`, which the header could not read or move. That flag moves to a small shared store, `lib/spaces-expansion.ts` (`useSyncExternalStore`, same shape as the existing `spaces-read-state.ts`), on the same `spaces:spaceExpanded:<org>/<space>` keys - per-space state persists exactly as before, and the row chevrons and the header control now read one truth.

## Notes

- `spaces-view.tsx`'s empty-state aside renders the same tree but an effect auto-selects the first space whenever the org has one, so that surface only appears for orgs with zero spaces. Nothing to expand there, so it is unchanged.

## Testing

- New test in `spaces-sidebar-section.test.tsx` pins the expand-all/collapse-all behaviour, including the partially-expanded case (one space shut still offers Collapse all, as a single button).
- `npm run typecheck` clean; `npx vitest run` in apps/renderer: 730 passed (84 files).
- `npm run lint` reports no findings in the touched files (the repo's existing errors are elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)