### PR TITLE
Add rich chat paste, formatted copying, and prompt editing

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -1419,6 +1419,7 @@ export function setupIpcHandlers() {
       const sessionId = await container.resolve<ISessions>('sessions').createSession(args);
       return { sessionId };
     },
+    'sessions:editMessage': async (_event, args) => container.resolve<ISessions>('sessions').editMessage(args.sessionId, args.turnId, args.text),
     'sessions:list': async () => {
       await sessionsIndexReady;
       return { sessions: container.resolve<ISessions>('sessions').listSessions() };

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7938,6 +7938,7 @@ function App() {
                     const isActive = tab.id === activeChatTabId
                     return (
                       <ChatSessionPane
+                        onOpenRevisedChat={openAssistantRun}
                         // Keyed by CHAT identity: rebinding this tab to a
                         // different session remounts the panel (fresh
                         // scroll/DOM state); first-send runId binding does not.
@@ -8050,6 +8051,7 @@ function App() {
             {(isRightPaneContext || useBottomTabs) && (
               <CodeDiffOpenerProvider onOpenDiff={codeChatMain ? openCodeDiff : null}>
               <ChatSidebar
+                onOpenRevisedChat={openAssistantRun}
                 floating={floatingAssistant && !isRightPaneMaximized}
                 keepMounted={projectViewActive || useBottomTabs || chatTabs.length > 1}
                 onMinimize={showAssistantDock && !dockFullScreen ? () => {

--- a/apps/x/apps/renderer/src/components/ai-elements/message.tsx
+++ b/apps/x/apps/renderer/src/components/ai-elements/message.tsx
@@ -24,6 +24,8 @@ import {
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
 import { Streamdown } from "streamdown";
+import { copyChatMessage } from "@/lib/chat-clipboard";
+import { toast } from "@/lib/toast";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -56,13 +58,17 @@ export const MessageCopyButton = ({
     <button
       type="button"
       aria-label="Copy message"
-      onClick={() => {
-        void navigator.clipboard.writeText(text);
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1200);
+      onClick={async () => {
+        try {
+          await copyChatMessage(text);
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        } catch {
+          toast('Could not copy to clipboard', 'error');
+        }
       }}
       className={cn(
-        "shrink-0 rounded-md p-1.5 text-muted-foreground/60 opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100",
+        "shrink-0 rounded-md p-1.5 text-muted-foreground/60 opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
         className
       )}
     >

--- a/apps/x/apps/renderer/src/components/assistant-composer.test.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-composer.test.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AssistantComposer } from './assistant-composer'
+import { PromptInputProvider, usePromptInputController } from './ai-elements/prompt-input'
+
+afterEach(() => { cleanup(); vi.restoreAllMocks() })
+
+function Harness({ submit }: { submit: (text: string) => void }) {
+  const controller = usePromptInputController()
+  const [focus, setFocus] = useState(0)
+  return <>
+    <AssistantComposer active={false} focusTrigger={String(focus)} onSubmit={() => submit(controller.textInput.value)} />
+    <output data-testid="wire">{controller.textInput.value}</output>
+    <button onClick={() => { controller.textInput.setInput('**Restored** draft'); setFocus(f => f + 1) }}>Restore</button>
+  </>
+}
+function mount() {
+  const submit = vi.fn()
+  render(<PromptInputProvider><Harness submit={submit} /></PromptInputProvider>)
+  return { submit, box: screen.getByRole('textbox', { name: 'Message' }) }
+}
+function paste(box: HTMLElement, plain: string, html = '') {
+  fireEvent.paste(box, { clipboardData: { files: [], getData: (type: string) => type === 'text/html' ? html : type === 'text/plain' ? plain : '' } })
+}
+
+describe('assistant composer integration', () => {
+  it('pastes an HTML table as an editable table and submits its Markdown', async () => {
+    const { box, submit } = mount()
+    paste(box, 'Item\tCount\nApple\t3', '<table><tr><th>Item</th><th>Count</th></tr><tr><td>Apple</td><td>3</td></tr></table>')
+    await waitFor(() => expect(box.querySelectorAll('tr')).toHaveLength(2))
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(submit).toHaveBeenCalledWith(expect.stringContaining('| Apple | 3 |'))
+  })
+  it('pastes a plain spreadsheet range as a table', async () => {
+    const { box } = mount()
+    paste(box, 'Apple\t3\nPear\t')
+    await waitFor(() => expect(box.querySelectorAll('td')).toHaveLength(4))
+    expect(screen.getByTestId('wire').textContent).toContain('| Pear |  |')
+  })
+  it('preserves rich paste and updates the editor when a saved draft is restored', async () => {
+    const { box } = mount()
+    paste(box, 'Bold link', '<p><strong>Bold</strong> <a href="https://example.com">link</a></p>')
+    await waitFor(() => expect(box.querySelector('strong')).toHaveTextContent('Bold'))
+    expect(screen.getByTestId('wire').textContent).toContain('[link](https://example.com)')
+    fireEvent.click(screen.getByText('Restore'))
+    await waitFor(() => expect(box.querySelector('strong')).toHaveTextContent('Restored'))
+  })
+  it('does not submit Shift+Enter or IME confirmation', () => {
+    const { box, submit } = mount()
+    paste(box, 'hello')
+    fireEvent.keyDown(box, { key: 'Enter', shiftKey: true })
+    fireEvent.keyDown(box, { key: 'Enter', isComposing: true })
+    expect(submit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/components/assistant-composer.tsx
+++ b/apps/x/apps/renderer/src/components/assistant-composer.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import type { EditorView } from '@tiptap/pm/view'
+import { assistantEditorExtensions, assistantMarkdown, clipboardTable, tableContent } from '@/lib/assistant-editor'
+import { usePromptInputController, useProviderKnowledgeFiles } from './ai-elements/prompt-input'
+import { MentionPopover, ROWBOAT_MENTION_SENTINEL } from './mention-popover'
+import { toKnowledgePath } from '@/lib/wiki-links'
+import type { CaretCoordinates } from '@/lib/textarea-caret'
+import '@/styles/assistant-composer.css'
+
+interface Mention { from: number; to: number; query: string; position: CaretCoordinates }
+
+export function AssistantComposer({ placeholder = 'Type your message...', active, focusTrigger, onSubmit, onEscape }: {
+  placeholder?: string
+  active: boolean
+  focusTrigger: string
+  onSubmit: () => void
+  onEscape?: () => void
+}) {
+  const controller = usePromptInputController()
+  const knowledge = useProviderKnowledgeFiles()
+  const container = useRef<HTMLDivElement>(null)
+  const [mention, setMention] = useState<Mention | null>(null)
+  const [dismissed, setDismissed] = useState<number | null>(null)
+  const mentionOpen = !!mention && dismissed !== mention.from
+  const latest = useRef({ controller, placeholder, onSubmit, onEscape, mentionOpen })
+  useLayoutEffect(() => {
+    latest.current = { controller, placeholder, onSubmit, onEscape, mentionOpen }
+  }, [controller, placeholder, onSubmit, onEscape, mentionOpen])
+
+  const updateCaret = (view: EditorView) => {
+    const { selection } = view.state
+    const { $from } = selection
+    if (!selection.empty || !$from.parent.isTextblock || $from.parent.type.name === 'codeBlock') {
+      setMention(null); setDismissed(null); return
+    }
+    const before = $from.parent.textBetween(0, $from.parentOffset, '\n', '\ufffc')
+    const match = /(?:^|\s)@([^\s@]*)$/.exec(before)
+    if (!match) { setMention(null); setDismissed(null); return }
+    const from = selection.from - match[1].length - 1
+    const rect = container.current?.getBoundingClientRect()
+    const coords = view.coordsAtPos(from)
+    setMention({ from, to: selection.from, query: match[1], position: {
+      left: coords.left - (rect?.left ?? 0), top: coords.top - (rect?.top ?? 0), height: coords.bottom - coords.top,
+    } })
+  }
+
+  const editor = useEditor({
+    // TipTap calls this getter from its decoration plugin, after rendering.
+    // eslint-disable-next-line react-hooks/refs
+    extensions: assistantEditorExtensions(() => latest.current.placeholder),
+    content: controller.textInput.value,
+    editorProps: {
+      attributes: { role: 'textbox', 'aria-label': 'Message', 'aria-multiline': 'true', class: 'assistant-composer-editor', dir: 'auto' },
+      handleKeyDown: (view, event) => {
+        if (view.composing || event.isComposing || event.keyCode === 229) return false
+        if (latest.current.mentionOpen && ['Enter', 'Tab', 'ArrowUp', 'ArrowDown', 'Escape'].includes(event.key)) return true
+        if (event.key === 'Enter' && !event.shiftKey) {
+          latest.current.onSubmit(); return true
+        }
+        if (event.key === 'Escape' && latest.current.onEscape) {
+          latest.current.onEscape(); return true
+        }
+        return false
+      },
+      handlePaste: (view, event) => {
+        const clipboard = event.clipboardData
+        if (!clipboard) return false
+        // Spreadsheet apps can include an image representation alongside HTML.
+        if (/<table[\s>]/i.test(clipboard.getData('text/html'))) return false
+        const files = Array.from(clipboard.files)
+        if (files.length) {
+          latest.current.controller.attachments.add(files)
+          return true
+        }
+        // HTML is parsed by the editor schema: tables, lists, links and marks
+        // survive while scripts, handlers and unsupported markup are discarded.
+        if (clipboard.getData('text/html') || view.state.selection.$from.parent.type.name === 'codeBlock') return false
+        const rows = clipboardTable(clipboard.getData('text/plain'))
+        if (!rows) return false
+        const node = view.state.schema.nodeFromJSON(tableContent(rows))
+        view.dispatch(view.state.tr.replaceSelectionWith(node).scrollIntoView())
+        return true
+      },
+    },
+    onUpdate: ({ editor }) => {
+      latest.current.controller.textInput.setInput(assistantMarkdown(editor))
+      const paths = new Set<string>()
+      editor.state.doc.descendants(node => { if (node.type.name === 'assistantFileMention') paths.add(node.attrs.path) })
+      for (const entry of latest.current.controller.mentions.mentions) {
+        if (!paths.has(entry.path) && !editor.getText().includes(`@${entry.displayName}`)) latest.current.controller.mentions.removeMention(entry.id)
+      }
+    },
+    onSelectionUpdate: ({ editor }) => updateCaret(editor.view),
+    onTransaction: ({ editor, transaction }) => { if (transaction.docChanged) updateCaret(editor.view) },
+  })
+
+  useEffect(() => {
+    if (editor && assistantMarkdown(editor) !== controller.textInput.value) {
+      editor.commands.setContent(controller.textInput.value, { emitUpdate: false })
+    }
+  }, [editor, controller.textInput.value])
+
+  useEffect(() => {
+    if (!active || !editor) return
+    editor.commands.focus(undefined, { scrollIntoView: false })
+  }, [active, editor, focusTrigger])
+
+  return <div ref={container} className="assistant-composer relative min-w-0">
+    <EditorContent editor={editor} />
+    <MentionPopover
+      files={knowledge?.files ?? []} recentFiles={knowledge?.recentFiles} visibleFiles={knowledge?.visibleFiles}
+      query={mention?.query ?? ''} position={mention?.position ?? null} containerRef={container} open={mentionOpen}
+      onClose={() => setDismissed(mention?.from ?? null)}
+      onSelect={(path, label) => {
+        if (!editor || !mention) return
+        const filePath = path === ROWBOAT_MENTION_SENTINEL ? null : toKnowledgePath(path)
+        editor.chain().focus().insertContentAt({ from: mention.from, to: mention.to }, filePath
+          ? [{ type: 'assistantFileMention', attrs: { path: filePath, label } }, { type: 'text', text: ' ' }]
+          : `@${label} `).run()
+        if (filePath) controller.mentions.addMention(filePath, label)
+        setMention(null)
+      }}
+    />
+  </div>
+}

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -34,6 +34,7 @@ import {
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { AssistantComposer } from '@/components/assistant-composer'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -59,7 +60,6 @@ import {
   type FileMention,
   type PromptInputMessage,
   PromptInputProvider,
-  PromptInputTextarea,
   usePromptInputController,
 } from '@/components/ai-elements/prompt-input'
 import { toast } from 'sonner'
@@ -717,18 +717,6 @@ function ChatInputInner({
     // turns it off explicitly. (Not persisted across app restarts.)
   }, [attachments, canSubmit, controller, message, onSubmit, searchEnabled, codeModeEnabled, codingAgent, permissionMode, workDir, codeSessionLock])
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSubmit()
-      return
-    }
-    if (e.key === 'Escape' && contextChip) {
-      e.preventDefault()
-      contextChip.onDismiss()
-    }
-  }, [handleSubmit, contextChip])
-
   useEffect(() => {
     if (!isActive) return
     const onDragOver = (e: DragEvent) => {
@@ -904,12 +892,12 @@ function ChatInputInner({
       )}
       {/* Composer: the input line gets real air above the controls row. */}
       <div className="px-4 pt-5 pb-3">
-        <PromptInputTextarea
+        <AssistantComposer
           placeholder={placeholder ?? 'Type your message...'}
-          onKeyDown={handleKeyDown}
-          autoFocus={isActive}
-          focusTrigger={isActive ? `${runId ?? 'new'}:${focusNonce}:${focusSignal ?? 0}` : undefined}
-          className="min-h-6 rounded-none border-0 py-0 shadow-none focus-visible:ring-0"
+          onSubmit={handleSubmit}
+          onEscape={contextChip?.onDismiss}
+          active={isActive}
+          focusTrigger={`${runId ?? 'new'}:${focusNonce}:${focusSignal ?? 0}`}
         />
       </div>
       <div ref={toolbarRef} className="flex items-center gap-2 px-4 pb-3">

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -60,6 +60,7 @@ export interface ChatSessionPaneProps {
   tabState: ChatTabViewState
   viewportAnchor: ChatViewportAnchorState | undefined
   onPickPrompt: (prompt: string) => void
+  onOpenRevisedChat?: (sessionId: string) => void
   /** `undefined` = no explicit choice; TurnConversation applies the per-tool default. */
   isToolOpenForTab: (tabId: string, toolId: string) => boolean | undefined
   setToolOpenForTab: (tabId: string, toolId: string, open: boolean) => void
@@ -89,6 +90,7 @@ export function ChatSessionPane({
   tabState,
   viewportAnchor,
   onPickPrompt,
+  onOpenRevisedChat,
   isToolOpenForTab,
   setToolOpenForTab,
   onPermissionResponse,
@@ -189,6 +191,10 @@ export function ChatSessionPane({
             <>
               <TurnConversation
                 items={tabState.conversation}
+                onEditMessage={tab.runId && !isCodeSession && !activeIsProcessing && onOpenRevisedChat ? async (messageId, text) => {
+                  const result = await window.ipc.invoke('sessions:editMessage', { sessionId: tab.runId!, turnId: messageId.slice(0, -':user'.length), text })
+                  onOpenRevisedChat(result.sessionId)
+                } : undefined}
                 isToolOpen={(toolId) => isToolOpenForTab(tab.id, toolId)}
                 onToolOpenChange={(toolId, open) => setToolOpenForTab(tab.id, toolId, open)}
                 permissionRequests={tabState.allPermissionRequests}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -54,6 +54,7 @@ function getInitialPaneWidth(defaultWidth: number): number {
 }
 
 interface ChatSidebarProps {
+  onOpenRevisedChat?: (sessionId: string) => void
   floating?: boolean
   keepMounted?: boolean
   onMinimize?: () => void
@@ -231,6 +232,7 @@ export function ChatSidebar({
   onEndCall,
   callAvailable,
   onComposioConnected,
+  onOpenRevisedChat,
 }: ChatSidebarProps) {
   const { state: sidebarState } = useSidebar()
   // Content-reported tab meta (see lib/tab-meta.ts): the header title prefers
@@ -541,6 +543,7 @@ export function ChatSidebar({
                   const isActive = tab.id === activeChatTabId && isOpen
                   return (
                     <ChatSessionPane
+                      onOpenRevisedChat={onOpenRevisedChat}
                       // Keyed by chat identity — see App's chat panel key.
                       key={tab.chatId}
                       tab={tab}

--- a/apps/x/apps/renderer/src/components/edit-chat-message.test.tsx
+++ b/apps/x/apps/renderer/src/components/edit-chat-message.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EditChatMessage } from './edit-chat-message'
+
+afterEach(cleanup)
+describe('editing a chat prompt', () => {
+  it('keeps an unsuccessful edit available and closes only after successful submission', async () => {
+    const save = vi.fn().mockRejectedValueOnce(new Error('Offline')).mockResolvedValue(undefined)
+    render(<EditChatMessage text="Original" onSave={save} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit message' }))
+    expect(screen.getByRole('button', { name: 'Save & submit' })).toBeDisabled()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Revised message' }), { target: { value: 'Revised' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save & submit' }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Offline'))
+    expect(screen.getByRole('textbox')).toHaveValue('Revised')
+    fireEvent.click(screen.getByRole('button', { name: 'Save & submit' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save).toHaveBeenLastCalledWith('Revised')
+  })
+  it('cancel never submits an edit', () => {
+    const save = vi.fn()
+    render(<EditChatMessage text="Original" onSave={save} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit message' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(save).not.toHaveBeenCalled()
+  })
+})

--- a/apps/x/apps/renderer/src/components/edit-chat-message.tsx
+++ b/apps/x/apps/renderer/src/components/edit-chat-message.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { Loader2, Pencil } from 'lucide-react'
+import { Button } from './ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog'
+
+export function EditChatMessage({ text, onSave }: { text: string; onSave: (text: string) => Promise<void> }) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState(text)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const save = async () => {
+    if (saving || !draft.trim()) return
+    setSaving(true); setError('')
+    try { await onSave(draft); setOpen(false) }
+    catch (err) { setError(err instanceof Error ? err.message : 'Could not submit your edit. Please try again.') }
+    finally { setSaving(false) }
+  }
+  return <Dialog open={open} onOpenChange={value => {
+    if (saving) return
+    if (value) { setDraft(text); setError('') }
+    setOpen(value)
+  }}>
+    <DialogTrigger asChild>
+      <button type="button" aria-label="Edit message" title="Edit message" className="shrink-0 rounded-md p-1.5 text-muted-foreground/60 opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100">
+        <Pencil className="size-3.5" />
+      </button>
+    </DialogTrigger>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Edit message</DialogTitle>
+        <DialogDescription>This starts a revised chat from this message. Earlier context and this message’s attachments are kept. Your original chat stays in history.</DialogDescription>
+      </DialogHeader>
+      <textarea aria-label="Revised message" value={draft} disabled={saving} onChange={e => setDraft(e.target.value)}
+        className="min-h-40 max-h-80 w-full resize-y rounded-md border border-input bg-background p-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onKeyDown={e => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !e.nativeEvent.isComposing) { e.preventDefault(); void save() } }} />
+      {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+      <DialogFooter>
+        <Button variant="outline" disabled={saving} onClick={() => setOpen(false)}>Cancel</Button>
+        <Button disabled={saving || !draft.trim() || draft === text} onClick={() => void save()}>
+          {saving && <Loader2 className="size-4 animate-spin" />} {saving ? 'Submitting…' : 'Save & submit'}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+}

--- a/apps/x/apps/renderer/src/components/message-context-menu.tsx
+++ b/apps/x/apps/renderer/src/components/message-context-menu.tsx
@@ -1,15 +1,17 @@
 import { useState, type ReactNode } from 'react'
 import { Copy } from 'lucide-react'
 import { toast } from '@/lib/toast'
+import { copyChatMessage } from '@/lib/chat-clipboard'
 import {
   ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 
 export function MessageContextMenu({ text, children }: { text: string; children: ReactNode }) {
   const [selectionText, setSelectionText] = useState('')
-  const copy = async (value: string) => {
+  const copy = async (value: string, formatted = false) => {
     try {
-      await navigator.clipboard.writeText(value)
+      if (formatted) await copyChatMessage(value)
+      else await navigator.clipboard.writeText(value)
       toast('Copied to clipboard', 'success')
     } catch {
       toast('Could not copy to clipboard', 'error')
@@ -45,7 +47,7 @@ export function MessageContextMenu({ text, children }: { text: string; children:
             <ContextMenuSeparator />
           </>
         )}
-        <ContextMenuItem disabled={!text} onSelect={() => { void copy(text) }}>
+        <ContextMenuItem disabled={!text} onSelect={() => { void copy(text, true) }}>
           <Copy /> Copy message
         </ContextMenuItem>
       </ContextMenuContent>

--- a/apps/x/apps/renderer/src/components/turn-conversation.tsx
+++ b/apps/x/apps/renderer/src/components/turn-conversation.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 import { MessageContextMenu } from '@/components/message-context-menu'
+import { EditChatMessage } from '@/components/edit-chat-message'
 import {
   Message,
   MessageContent,
@@ -109,6 +110,7 @@ const EMPTY_AUTO_DECISIONS: ChatTabViewState['autoPermissionDecisions'] = new Ma
 
 export interface TurnConversationProps {
   items: ConversationItem[]
+  onEditMessage?: (messageId: string, text: string) => Promise<void>
   /**
    * Tool-row open state. Chat panes lift this to the tab store so it survives
    * tab switches; omit both for local per-mount state (transcript surfaces).
@@ -134,6 +136,7 @@ export interface TurnConversationProps {
 
 export function TurnConversation({
   items,
+  onEditMessage,
   isToolOpen: isToolOpenProp,
   onToolOpenChange: onToolOpenChangeProp,
   permissionRequests = EMPTY_PERMISSION_REQUESTS,
@@ -187,7 +190,10 @@ export function TurnConversation({
                       </MessageResponse>
                     </MessageContent>
                   </MessageContextMenu>
-                  <MessageCopyButton text={item.content} className="mt-0.5" />
+                  <div className="mt-0.5 flex items-center gap-1">
+                    <MessageCopyButton text={item.content} />
+                    {onEditMessage && item.id.endsWith(':user') && <EditChatMessage text={item.content} onSave={text => onEditMessage(item.id, text)} />}
+                  </div>
                 </div>
               )}
             </Message>
@@ -219,7 +225,10 @@ export function TurnConversation({
                   </MessageResponse>
                 </MessageContent>
               </MessageContextMenu>
-              <MessageCopyButton text={message} className="mt-0.5" />
+              <div className="mt-0.5 flex items-center gap-1">
+                <MessageCopyButton text={message} />
+                {onEditMessage && item.id.endsWith(':user') && <EditChatMessage text={message} onSave={text => onEditMessage(item.id, text)} />}
+              </div>
             </div>
           </Message>
         )

--- a/apps/x/apps/renderer/src/lib/assistant-editor.test.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-editor.test.ts
@@ -1,0 +1,45 @@
+import { Editor } from '@tiptap/core'
+import { afterEach, describe, expect, it } from 'vitest'
+import { assistantEditorExtensions, assistantMarkdown, clipboardTable, tableContent } from './assistant-editor'
+
+const editors: Editor[] = []
+function editor(content: string | object = '') {
+  const e = new Editor({ element: document.createElement('div'), extensions: assistantEditorExtensions(() => ''), content })
+  editors.push(e)
+  return e
+}
+afterEach(() => { editors.splice(0).forEach(e => e.destroy()) })
+
+describe('assistant rich input', () => {
+  it('preserves formatted clipboard HTML as Markdown', () => {
+    const e = editor('<p><strong>Bold</strong> and <em>italic</em> <a href="https://example.com">link</a></p><ul><li>First</li><li>Second</li></ul><blockquote><p>Quote</p></blockquote>')
+    const md = assistantMarkdown(e)
+    expect(md).toContain('**Bold** and *italic* [link](https://example.com)')
+    expect(md).toContain('- First\n- Second')
+    expect(md).toContain('> Quote')
+    expect(editor(md).getHTML()).toContain('<strong>Bold</strong>')
+  })
+  it('keeps headerless spreadsheet data, empty cells and escaped pipes', () => {
+    const e = editor('<table><tr><td>Apples</td><td>3</td></tr><tr><td>A | B</td><td></td></tr></table>')
+    const md = assistantMarkdown(e)
+    expect(md).toContain('| Apples | 3 |')
+    expect(md).toContain('| A \\| B |  |')
+    expect(md).not.toContain('[table]')
+    const restored = editor(md)
+    expect(restored.getHTML()).toContain('Apples')
+    expect(restored.getHTML()).toContain('A | B')
+  })
+  it('keeps multi-paragraph cells and reserves merged cells', () => {
+    const md = assistantMarkdown(editor('<table><tr><th colspan="2">Header</th></tr><tr><td><p>First</p><p>Second</p></td><td>Value</td></tr></table>'))
+    expect(md).toContain('| Header |  |')
+    expect(md).toContain('| First<br>Second | Value |')
+  })
+  it('parses quoted spreadsheet cells without splitting embedded tabs/newlines', () => {
+    const rows = clipboardTable('Name\tNotes\r\nA\t"two\nlines"\r\nB\t"x\ty"\r\n')
+    expect(rows).toEqual([['Name', 'Notes'], ['A', 'two\nlines'], ['B', 'x\ty']])
+    expect(assistantMarkdown(editor({ type: 'doc', content: [tableContent(rows!)] }))).toContain('two<br>lines')
+    expect(clipboardTable('plain\ntext')).toBeNull()
+    expect(clipboardTable('Apples\t3')).toEqual([['Apples', '3']])
+    expect(clipboardTable('one\ttwo\nindented code')).toBeNull()
+  })
+})

--- a/apps/x/apps/renderer/src/lib/assistant-editor.ts
+++ b/apps/x/apps/renderer/src/lib/assistant-editor.ts
@@ -1,0 +1,124 @@
+import { Node, type Editor } from '@tiptap/core'
+import type { Node as DocumentNode } from '@tiptap/pm/model'
+import { TableMap } from '@tiptap/pm/tables'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
+import { Markdown } from 'tiptap-markdown'
+
+interface MarkdownWriter {
+  out: string
+  inTable: boolean
+  write: (value: string) => void
+  renderInline: (node: DocumentNode) => void
+  closeBlock: (node: DocumentNode) => void
+}
+
+// Clipboard tables often have no header or have merged/multi-paragraph cells.
+// Serialize a rectangular grid instead of tiptap-markdown's lossy [table]
+// fallback. Empty headers keep the first data row as data; spans reserve cells.
+const AssistantTable = Table.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownWriter, node: DocumentNode) {
+          state.inTable = true
+          const map = TableMap.get(node)
+          const seen = new Set<number>()
+          const hasHeader = node.firstChild?.firstChild?.type.name === 'tableHeader'
+          const delimiter = `| ${Array(map.width).fill('---').join(' | ')} |\n`
+          if (!hasHeader) state.write(`| ${Array(map.width).fill('').join(' | ')} |\n${delimiter}`)
+          for (let row = 0; row < map.height; row++) {
+            state.write('| ')
+            for (let col = 0; col < map.width; col++) {
+              if (col) state.write(' | ')
+              const pos = map.map[row * map.width + col]
+              const cell = node.nodeAt(pos)
+              if (!seen.has(pos) && cell) {
+                seen.add(pos)
+                const start = state.out.length
+                cell.descendants((child) => {
+                  if (!child.isTextblock) return true
+                  if (state.out.length > start) state.write('<br>')
+                  state.renderInline(child)
+                  return false
+                })
+                state.out = state.out.slice(0, start) + state.out.slice(start)
+                  .replace(/\r?\n/g, '<br>').replace(/(?<!\\)\|/g, '\\|')
+              }
+            }
+            state.write(' |\n')
+            if (row === 0 && hasHeader) state.write(delimiter)
+          }
+          state.closeBlock(node)
+          state.inTable = false
+        },
+      },
+    }
+  },
+})
+
+export const AssistantFileMention = Node.create({
+  name: 'assistantFileMention',
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: false,
+  addAttributes: () => ({ path: { default: '' }, label: { default: '' } }),
+  parseHTML: () => [{ tag: 'span[data-assistant-file]', getAttrs: element => ({
+    path: element.getAttribute('data-assistant-file') ?? '',
+    label: element.textContent?.replace(/^@/, '') ?? '',
+  }) }],
+  renderHTML: ({ node }) => ['span', { 'data-assistant-file': node.attrs.path, class: 'assistant-file-mention' }, `@${node.attrs.label}`],
+  renderText: ({ node }) => `@${node.attrs.label}`,
+  addStorage: () => ({ markdown: {
+    serialize(state: MarkdownWriter, node: DocumentNode) { state.write(`@${node.attrs.label}`) },
+  } }),
+})
+
+export function assistantEditorExtensions(placeholder: () => string) {
+  return [
+    StarterKit.configure({ link: false }),
+    Link.configure({ openOnClick: false }),
+    Placeholder.configure({ placeholder }),
+    AssistantTable.configure({ resizable: false }), TableRow, TableCell, TableHeader,
+    AssistantFileMention,
+    Markdown.configure({ html: true, breaks: true, tightLists: true, transformPastedText: false, transformCopiedText: false }),
+  ]
+}
+
+export function assistantMarkdown(editor: Editor): string {
+  return (editor.storage as unknown as { markdown: { getMarkdown: () => string } }).markdown.getMarkdown().replace(/\n+$/, '')
+}
+
+/** Plain spreadsheet clipboard data, including quoted tabs/newlines and empty cells. */
+export function clipboardTable(text: string): string[][] | null {
+  if (!text.includes('\t')) return null
+  const rows: string[][] = []
+  let row: string[] = [], cell = '', quoted = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (c === '"' && (quoted || cell === '')) {
+      if (quoted && text[i + 1] === '"') { cell += '"'; i++ }
+      else quoted = !quoted
+    } else if (!quoted && (c === '\t' || c === '\n' || c === '\r')) {
+      row.push(cell); cell = ''
+      if (c !== '\t') {
+        rows.push(row); row = []
+        if (c === '\r' && text[i + 1] === '\n') i++
+      }
+    } else cell += c
+  }
+  if (cell || row.length) { row.push(cell); rows.push(row) }
+  if (quoted || !rows.length || rows[0].length < 2 || rows.some(r => r.length !== rows[0].length)) return null
+  return rows
+}
+
+export function tableContent(rows: string[][]) {
+  return { type: 'table', content: rows.map(row => ({ type: 'tableRow', content: row.map(value => ({
+    type: 'tableCell', content: [{ type: 'paragraph', content: value.split(/\r?\n/).flatMap((line, i) => [
+      ...(i ? [{ type: 'hardBreak' }] : []), ...(line ? [{ type: 'text', text: line }] : []),
+    ]) }],
+  })) })) }
+}

--- a/apps/x/apps/renderer/src/lib/chat-clipboard.test.ts
+++ b/apps/x/apps/renderer/src/lib/chat-clipboard.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyChatMessage, messageClipboardHtml } from './chat-clipboard'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('formatted response copying', () => {
+  it('exports semantic tables, formatting, links and code without UI controls', () => {
+    const html = messageClipboardHtml('| Item | Count |\n| --- | --- |\n| Apple | 3 |\n\n**Bold** [link](https://example.com)\n\n```python\nprint("hello")\n```')
+    const dom = new DOMParser().parseFromString(html, 'text/html')
+    expect(dom.querySelectorAll('tr')).toHaveLength(2)
+    expect(dom.querySelector('strong')?.textContent).toBe('Bold')
+    expect(dom.querySelector('a')?.href).toBe('https://example.com/')
+    expect(dom.querySelector('pre code')?.textContent).toContain('print("hello")')
+    expect(dom.querySelector('button')).toBeNull()
+    expect(messageClipboardHtml('<script>alert(1)</script>')).not.toContain('<script>')
+  })
+  it('writes both clipboard representations', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const writeText = vi.fn()
+    const items: Record<string, Blob>[] = []
+    vi.stubGlobal('ClipboardItem', class { constructor(data: Record<string, Blob>) { items.push(data) } })
+    vi.stubGlobal('navigator', { userAgent: navigator.userAgent, platform: navigator.platform, clipboard: { write, writeText } })
+    await copyChatMessage('**Hello**')
+    expect(Object.keys(items[0])).toEqual(['text/html', 'text/plain'])
+    expect(write).toHaveBeenCalledOnce()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+  it('falls back to text and propagates total clipboard failure', async () => {
+    vi.stubGlobal('ClipboardItem', class {})
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { userAgent: navigator.userAgent, platform: navigator.platform, clipboard: { write: vi.fn().mockRejectedValue(new Error('Unsupported')), writeText } })
+    await copyChatMessage('**Hello**')
+    expect(writeText).toHaveBeenCalledWith('**Hello**')
+    writeText.mockRejectedValue(new Error('Denied'))
+    await expect(copyChatMessage('Hello')).rejects.toThrow('Denied')
+  })
+})

--- a/apps/x/apps/renderer/src/lib/chat-clipboard.ts
+++ b/apps/x/apps/renderer/src/lib/chat-clipboard.ts
@@ -1,0 +1,42 @@
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import { TableKit } from '@tiptap/extension-table'
+import { Markdown } from 'tiptap-markdown'
+
+/** Parse Markdown through an allowlisted editor schema, never raw response HTML. */
+export function messageClipboardHtml(markdown: string): string {
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: [
+      StarterKit.configure({ link: false }),
+      Link.configure({ openOnClick: false }),
+      TableKit,
+      Markdown.configure({ html: false, breaks: true }),
+    ],
+    content: markdown,
+    editable: false,
+  })
+  try {
+    return editor.getHTML()
+  } finally {
+    editor.destroy()
+  }
+}
+
+/** Markdown remains available to text-only destinations and older clipboard APIs. */
+export async function copyChatMessage(markdown: string): Promise<void> {
+  if (typeof ClipboardItem !== 'undefined' && navigator.clipboard?.write) {
+    try {
+      await navigator.clipboard.write([new ClipboardItem({
+        'text/html': new Blob([messageClipboardHtml(markdown)], { type: 'text/html' }),
+        'text/plain': new Blob([markdown], { type: 'text/plain' }),
+      })])
+      return
+    } catch {
+      // Some hosts expose rich clipboard writes but reject a MIME type.
+      // Only report success once at least the text fallback has completed.
+    }
+  }
+  await navigator.clipboard.writeText(markdown)
+}

--- a/apps/x/apps/renderer/src/styles/assistant-composer.css
+++ b/apps/x/apps/renderer/src/styles/assistant-composer.css
@@ -1,0 +1,15 @@
+.assistant-composer-editor { min-height: 1.5rem; max-height: 18rem; overflow: auto; outline: none; font-size: 15px; line-height: 1.6; overflow-wrap: anywhere; }
+.assistant-composer-editor p { margin: 0; }
+.assistant-composer-editor > * + * { margin-top: .5rem; }
+.assistant-composer-editor p.is-editor-empty:first-child::before { content: attr(data-placeholder); float: left; color: var(--muted-foreground); height: 0; pointer-events: none; }
+.assistant-composer-editor ul { list-style: disc; padding-left: 1.5rem; }
+.assistant-composer-editor ol { list-style: decimal; padding-left: 1.5rem; }
+.assistant-composer-editor blockquote { border-left: 2px solid var(--border); padding-left: .75rem; }
+.assistant-composer-editor pre { background: var(--muted); border-radius: .4rem; padding: .5rem; overflow-x: auto; white-space: pre; }
+.assistant-composer-editor code { font-family: monospace; background: var(--muted); }
+.assistant-composer-editor a { color: var(--primary); text-decoration: underline; }
+.assistant-composer-editor table { border-collapse: collapse; table-layout: fixed; width: 100%; margin: .5rem 0; }
+.assistant-composer-editor td, .assistant-composer-editor th { border: 1px solid var(--border); padding: .35rem .5rem; min-width: 4rem; vertical-align: top; position: relative; }
+.assistant-composer-editor th { background: var(--muted); font-weight: 600; text-align: start; }
+.assistant-composer-editor .selectedCell::after { content: ''; position: absolute; inset: 0; background: var(--primary); opacity: .12; pointer-events: none; }
+.assistant-file-mention { background: var(--accent); border-radius: .25rem; padding: 0 .15rem; }

--- a/apps/x/apps/server/src/channels.ts
+++ b/apps/x/apps/server/src/channels.ts
@@ -13,6 +13,7 @@ export const RPC_CHANNELS = [
   'projects:createChat',
   'sessions:list',
   'sessions:create',
+  'sessions:editMessage',
   'sessions:get',
   'sessions:getTurn',
   'sessions:sendMessage',

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -166,6 +166,7 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
       const sessionId = await sessions().createSession(args);
       return { sessionId };
     },
+    'sessions:editMessage': async (args) => sessions().editMessage(args.sessionId, args.turnId, args.text),
     'sessions:list': async () => {
       await opts?.sessionsIndexReady;
       return { sessions: sessions().listSessions() };

--- a/apps/x/packages/core/src/runtime/sessions/api.ts
+++ b/apps/x/packages/core/src/runtime/sessions/api.ts
@@ -51,6 +51,8 @@ export interface ISessions {
     // does (a space thread). Main-process callers only — the renderer's
     // sessions:create contract deliberately accepts title alone.
     createSession(input?: { title?: string; origin?: SessionOrigin }): Promise<string>;
+    /** Preserve the original and submit a revised prompt with only its preceding history. */
+    editMessage(sessionId: string, turnId: string, text: string): Promise<{ sessionId: string; turnId: string }>;
     listSessions(): SessionIndexEntry[];
     getSession(sessionId: string): Promise<SessionState>;
     getTurn(turnId: string): Promise<Turn>;

--- a/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.test.ts
@@ -343,6 +343,69 @@ function makeSessions(opts: { repo?: ISessionRepo; fake?: FakeTurnRuntime } = {}
 
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
+describe("editing earlier prompts", () => {
+    async function conversation() {
+        const env = makeSessions();
+        const sessionId = await env.sessions.createSession({ title: "Original" });
+        const ids: string[] = [];
+        for (const text of ["First", "Second", "Third"]) {
+            const { turnId } = await env.sessions.sendMessage(sessionId, user(text), { agent: { agentId: "copilot" } });
+            await flush();
+            const completed = turnLog(turnId, sessionId, "completed").slice(1);
+            const created = env.fake.logs.get(turnId)![0];
+            if (created.type === 'turn_created' && !Array.isArray(created.context)) {
+                for (const event of completed) if (event.type === 'model_call_requested') event.request.contextRef = created.context;
+            }
+            env.fake.logs.get(turnId)!.push(...completed);
+            ids.push(turnId);
+        }
+        return { ...env, sessionId, ids };
+    }
+
+    it("revises with only preceding context and never replays or changes the original", async () => {
+        const { sessions, repo, fake, sessionId, ids } = await conversation();
+        const original = await repo.read(sessionId);
+        const calls = fake.advanceCalls.length;
+        const revised = await sessions.editMessage(sessionId, ids[1], "Revised second");
+        expect(revised.sessionId).not.toBe(sessionId);
+        expect(await repo.read(sessionId)).toEqual(original);
+        expect((await sessions.getSession(revised.sessionId)).turns.map(t => t.turnId)).toEqual([ids[0], revised.turnId]);
+        expect(fake.createTurnInputs.at(-1)).toMatchObject({
+            context: { previousTurnId: ids[0] }, input: user("Revised second"),
+        });
+        expect(fake.advanceCalls).toHaveLength(calls + 1);
+    });
+
+    it("editing the first prompt starts without the original answer as context", async () => {
+        const { sessions, fake, sessionId, ids } = await conversation();
+        await sessions.editMessage(sessionId, ids[0], "New first");
+        expect(fake.createTurnInputs.at(-1)?.context).toEqual([]);
+    });
+
+    it("preserves attachments and turn configuration while replacing text", async () => {
+        const { sessions, fake, sessionId, ids } = await conversation();
+        const definition = fake.logs.get(ids[1])![0];
+        if (definition.type !== 'turn_created') throw new Error('fixture');
+        const attachment = { type: 'attachment' as const, path: '/tmp/report.pdf', filename: 'report.pdf', mimeType: 'application/pdf' };
+        definition.input.content = [attachment, { type: 'text', text: 'Old text' }];
+        definition.config.reasoningEffort = 'high';
+        await sessions.editMessage(sessionId, ids[1], "New text");
+        expect(fake.createTurnInputs.at(-1)).toMatchObject({
+            input: { content: [attachment, { type: 'text', text: 'New text' }] },
+            config: { reasoningEffort: 'high' },
+        });
+    });
+
+    it("rejects invalid or busy edits before creating a new session", async () => {
+        const { sessions, fake, sessionId, ids } = await conversation();
+        await expect(sessions.editMessage(sessionId, ids[0], " ")).rejects.toThrow('empty');
+        await expect(sessions.editMessage(sessionId, 'unrelated', "Edit")).rejects.toThrow('belong');
+        fake.logs.set(ids[2], turnLog(ids[2], sessionId, 'idle'));
+        await expect(sessions.editMessage(sessionId, ids[0], "Edit")).rejects.toThrow('Stop');
+        expect(sessions.listSessions()).toHaveLength(1);
+    });
+});
+
 describe("createSession and listing", () => {
     it("persists session_created and publishes an index entry with status none", async () => {
         const { sessions, repo, bus } = makeSessions();

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -188,6 +188,54 @@ export class SessionsImpl implements ISessions {
         return this.index.list();
     }
 
+    async editMessage(sessionId: string, turnId: string, text: string): Promise<{ sessionId: string; turnId: string }> {
+        if (!text.trim()) throw new Error("A revised message cannot be empty");
+        return this.sessionRepo.withLock(sessionId, async () => {
+            const source = await this.getSession(sessionId);
+            if (source.origin) throw new Error("Only personal assistant chats can be revised");
+            const position = source.turns.findIndex(ref => ref.turnId === turnId);
+            if (position < 0) throw new Error("Message does not belong to this conversation");
+            const latest = await this.latestTurnStatus(source);
+            if (!["completed", "failed", "cancelled"].includes(latest)) {
+                throw new Error("Stop the current response before editing a message");
+            }
+            const original = reduceTurn((await this.turnRuntime.getTurn(turnId)).events).definition;
+            const message = original.input;
+            const input: z.infer<typeof UserMessage> = {
+                ...message,
+                content: typeof message.content === "string" ? text.trim() : [
+                    ...message.content.filter(part => part.type !== "text"),
+                    { type: "text" as const, text: text.trim() },
+                ],
+            };
+            // Share immutable historical turn references; never execute old
+            // turns again or mutate a transcript that another tab is reading.
+            // Session deletion intentionally retains referenced turn files.
+            const revisedId = await this.createSession({ title: `${source.title || "Chat"} (edited)` });
+            const preceding = source.turns.slice(0, position);
+            if (preceding.length) {
+                await this.sessionRepo.append(revisedId, preceding.map(ref => ({
+                    type: "turn_appended" as const,
+                    sessionId: revisedId,
+                    ts: this.clock.now(),
+                    turnId: ref.turnId,
+                    sessionSeq: ref.sessionSeq,
+                    agentId: ref.agentId,
+                    model: ref.model,
+                })));
+            }
+            const revised = await this.getSession(revisedId);
+            this.publishEntry(sessionIndexEntry(revised, await this.latestTurnStatus(revised)));
+            const sent = await this.sendMessage(revisedId, input, {
+                agent: original.agent.requested,
+                ...original.config,
+                useCase: original.analytics?.useCase,
+                subUseCase: original.analytics?.subUseCase,
+            });
+            return { sessionId: revisedId, turnId: sent.turnId };
+        });
+    }
+
     async getSession(sessionId: string): Promise<SessionState> {
         return reduceSession(await this.sessionRepo.read(sessionId));
     }

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -662,6 +662,10 @@ export const ipcSchemas = {
     req: z.object({ title: z.string().optional() }),
     res: z.object({ sessionId: z.string() }),
   },
+  'sessions:editMessage': {
+    req: z.object({ sessionId: z.string(), turnId: z.string(), text: z.string().trim().min(1) }),
+    res: z.object({ sessionId: z.string(), turnId: z.string() }),
+  },
   'sessions:list': {
     req: z.object({}),
     res: z.object({ sessions: z.array(z.custom<SessionIndexEntry>()) }),


### PR DESCRIPTION
The assistant composer loses structure when pasting tables and formatted text, copying answers only provides plain text, and earlier prompts cannot be revised. This adds rich paste and copy support plus an edit action that starts a revised conversation from the selected prompt.

Changes:
- Use a rich composer that preserves HTML tables, spreadsheet TSV, lists, links, and text formatting. Serialize messages as Markdown, including headerless tables, merged cells, and multiline cells.
- Copy full messages as HTML with a plain-text Markdown fallback. Show success only after a clipboard write succeeds.
- Add prompt editing for idle personal assistant chats. Preserve preceding context and the edited message's attachments in a new conversation while leaving the original intact. Keep the draft available if submission fails.
- Wire editing through desktop IPC and server RPC. Code sessions and mid-response steering messages are excluded.

Validation:
- Renderer: 87 test files, 736 tests passed.
- Core sessions: 53 tests passed.
- Renderer, shared, core, server, and desktop main TypeScript checks passed.
- New frontend files pass ESLint; git diff whitespace check passed.
- Live visual verification remains outstanding: browser access was blocked by automatic approval review because unrelated private tabs could be exposed.
