### PR TITLE
fix: load Browser Harness skills from canonical directory

### DIFF
--- a/apps/x/packages/core/src/application/browser-skills/loader.test.ts
+++ b/apps/x/packages/core/src/application/browser-skills/loader.test.ts
@@ -1,0 +1,78 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { matchSkillsForUrl } from './matcher.js';
+
+let workDir: string;
+let requests: string[];
+const skillPath = 'agent-workspace/domain-skills/github/repo-actions.md';
+const markdown = '# GitHub repo actions\n\nRead the page before acting.\n';
+
+beforeEach(async () => {
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'rowboat-browser-skills-test-'));
+  requests = [];
+  vi.resetModules();
+  vi.doMock('../../config/config.js', () => ({ WorkDir: workDir }));
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+    requests.push(url);
+    if (url.endsWith('/branches/main')) {
+      return Response.json({ commit: { commit: { tree: { sha: 'tree-sha' } } } });
+    }
+    if (url.endsWith('/git/trees/tree-sha?recursive=1')) {
+      return Response.json({ truncated: false, tree: [
+        { type: 'blob', path: skillPath, sha: 'skill-sha' },
+        { type: 'tree', path: 'agent-workspace/domain-skills/github', sha: 'dir-sha' },
+        { type: 'blob', path: 'agent-workspace/domain-skills/github/image.png', sha: 'image-sha' },
+        { type: 'blob', path: 'README.md', sha: 'readme-sha' },
+      ] });
+    }
+    if (url === `https://raw.githubusercontent.com/browser-use/browser-harness/main/${skillPath}`) {
+      return new Response(markdown);
+    }
+    throw new Error(`Unexpected network request: ${url}`);
+  }));
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.doUnmock('../../config/config.js');
+  vi.resetModules();
+  await fs.rm(workDir, { recursive: true, force: true });
+});
+
+describe('Browser Harness skill source', () => {
+  it('loads canonical domain skills, preserving IDs, local paths and URL suggestions', async () => {
+    const { ensureLoaded, readSkillContent } = await import('./loader.js');
+    const status = await ensureLoaded();
+    expect(status.status).toBe('ready');
+    if (status.status !== 'ready') throw new Error('Expected a ready skill index');
+    expect(status.index.entries).toEqual([{
+      id: 'github/repo-actions', site: 'github', fileName: 'repo-actions.md',
+      title: 'GitHub repo actions', path: skillPath,
+      localPath: path.join(workDir, 'cache', 'browser-skills', 'domain-skills', 'github', 'repo-actions.md'),
+    }]);
+    expect(matchSkillsForUrl(status.index, 'https://github.com/rowboatlabs/rowboat')
+      .map(entry => entry.id)).toEqual(['github/repo-actions']);
+    expect(await readSkillContent('github/repo-actions')).toMatchObject({ ok: true, content: markdown });
+    const disk = JSON.parse(await fs.readFile(path.join(workDir, 'cache', 'browser-skills', 'manifest.json'), 'utf8'));
+    expect(disk.entries).toEqual(status.index.entries);
+    expect(requests).toHaveLength(3);
+  });
+
+  it('keeps the existing fresh-cache behavior without another network request', async () => {
+    const { refreshFromRemote, ensureLoaded } = await import('./loader.js');
+    const index = await refreshFromRemote();
+    requests.length = 0;
+    expect(await ensureLoaded()).toEqual({ status: 'ready', index });
+    expect(requests).toEqual([]);
+  });
+
+  it('still reports GitHub failures without writing a successful empty cache', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('unavailable', { status: 503 })));
+    const { ensureLoaded } = await import('./loader.js');
+    expect(await ensureLoaded()).toMatchObject({ status: 'error', error: expect.stringContaining('503') });
+    await expect(fs.stat(path.join(workDir, 'cache', 'browser-skills', 'manifest.json'))).rejects.toThrow();
+  });
+});

--- a/apps/x/packages/core/src/application/browser-skills/loader.ts
+++ b/apps/x/packages/core/src/application/browser-skills/loader.ts
@@ -5,7 +5,7 @@ import { WorkDir } from '../../config/config.js';
 const REPO_OWNER = 'browser-use';
 const REPO_NAME = 'browser-harness';
 const REPO_BRANCH = 'main';
-const DOMAIN_SKILLS_PREFIX = 'domain-skills/';
+const DOMAIN_SKILLS_PREFIX = 'agent-workspace/domain-skills/';
 
 const MANIFEST_TTL_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 20_000;
@@ -15,7 +15,7 @@ export type SkillEntry = {
   site: string;            // e.g. "github"
   fileName: string;        // e.g. "repo-actions.md"
   title: string;           // first H1 from the markdown, or a derived title
-  path: string;            // relative repo path, e.g. "domain-skills/github/repo-actions.md"
+  path: string;            // relative repo path, e.g. "agent-workspace/domain-skills/github/repo-actions.md"
   localPath: string;       // absolute path on disk
 };
 


### PR DESCRIPTION
Read Browser Harness domain skills from `agent-workspace/domain-skills/`. The old top-level directory was removed upstream on May 19, so a fresh Rowboat cache currently reports ready with zero skills.

I ran the actual loader against the same live GitHub tree (`00ffc0cd71c78b70039a9c7a05f5056c063dfaa0`): the unchanged code loaded 0 entries; this patch loaded 107 and read `github/repo-actions` successfully. The work directory was a disposable local directory; no browser or model ran.

Keep IDs, local cache paths, the 24-hour TTL and the existing browser security restrictions unchanged. Existing fresh caches still follow that TTL; `load-browser-skill({ action: "refresh" })` updates them immediately.

Added three focused tests covering canonical paths, cached reads and GitHub failures. Before the patch: one regression failed, two controls passed. After: all three passed on Vitest 4.1.7. Scoped TypeScript 5.9.3 checks passed for the loader, matcher and test with the unrelated config module reduced to its `WorkDir: string` contract. The full app suite, Electron build and browser UI were not run.
