### PR TITLE
Spaces: a discussion can be about one file (opens beside the thread)

### DIFF
--- a/apps/harbor/CONTRACT.md
+++ b/apps/harbor/CONTRACT.md
@@ -112,8 +112,15 @@ team and a Roadboard space (`src/main.ts`).
 - **EOF newline** merges as a three-way property: the side that changed it wins;
   both-changed-and-disagree keeps the newline.
 - **Replying to an archived topic unarchives it** (and emits a topic event).
-- **Topic events** fire on create/retitle/archive/unarchive/merge — not on
-  every reply; clients derive `lastActivityAt`/counts from message events.
+- **Topic events** fire on create/retitle/archive/unarchive/merge and on
+  document attach/detach — not on every reply; clients derive
+  `lastActivityAt`/counts from message events.
+- **A topic may be about one file** (`Topic.documentPath`, migration 019 —
+  2026-09-11): the row stores the asset's internal id, the wire projects the
+  asset's CURRENT live path (renames keep the link; a trashed file projects
+  nothing until restored). `createTopic.documentPath` sets it at birth;
+  `manageTopic` `attach_document` (path, replaces) / `detach_document` change
+  it, idempotently. The UI opens the file beside the thread.
 - **Every space is born with its stream**: a `kind: 'general'` topic (titled
   "messages", empty — no seed message) seeded at space creation, exactly one
   per space (partial unique index). All other topics are `kind: 'discussion'`.

--- a/apps/harbor/packages/protocol/src/api.ts
+++ b/apps/harbor/packages/protocol/src/api.ts
@@ -621,6 +621,8 @@ export const routes = {
         rootMessageId: MessageId.optional(),
         title: z.string().min(1).max(256),
         body: z.string().min(1).max(65_536).optional(),
+        /** Attach a space file at birth (a live asset path; moved paths resolve). */
+        documentPath: AssetPath.optional(),
         actingMode: ActingMode,
         agentName: z.string().max(64).optional(),
       })
@@ -635,6 +637,9 @@ export const routes = {
    * One-row lifecycle ops on the annotation — none can touch a message.
    * `remove` deletes the row ("convert back to thread"); the conversation
    * stays in the stream untouched, and re-promoting later is lossless.
+   * `attach_document` links one live space file (Topic.documentPath) —
+   * replacing any earlier link; `detach_document` clears it. Both are
+   * idempotent (no event when nothing changes).
    */
   manageTopic: {
     method: 'POST',
@@ -645,6 +650,8 @@ export const routes = {
       z.object({ action: z.literal('archive'), actingMode: ActingMode, agentName: z.string().max(64).optional() }),
       z.object({ action: z.literal('unarchive'), actingMode: ActingMode, agentName: z.string().max(64).optional() }),
       z.object({ action: z.literal('remove'), actingMode: ActingMode, agentName: z.string().max(64).optional() }),
+      z.object({ action: z.literal('attach_document'), path: AssetPath, actingMode: ActingMode, agentName: z.string().max(64).optional() }),
+      z.object({ action: z.literal('detach_document'), actingMode: ActingMode, agentName: z.string().max(64).optional() }),
     ]),
     response: z.object({ topic: Topic }),
   },

--- a/apps/harbor/packages/protocol/src/core.ts
+++ b/apps/harbor/packages/protocol/src/core.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ChangeSetId, MemberId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
+import { AssetPath, ChangeSetId, MemberId, MessageId, SpaceId, StreamOffset, TopicId } from './ids.js';
 
 // Core objects shared by both faces. Every act in a space belongs to a member
 // (spec §2, principle 4); attribution carries the acting mode, never a separate
@@ -92,6 +92,15 @@ export const Topic = z.object({
   createdAt: z.iso.datetime(),
   /** Off the rail. Nothing else anywhere changes; a new reply revives (un-archives). */
   archived: z.boolean(),
+  /**
+   * The one file this discussion is about (2026-09-11): a space asset the
+   * UI opens beside the thread. Stored as the asset's internal id, so a
+   * rename keeps the link; PROJECTED here as the asset's CURRENT live path
+   * at read time — absent when nothing is attached and while the file sits
+   * in the trash (a restore brings it back, nothing to clean up). Set via
+   * createTopic.documentPath or manageTopic attach_document/detach_document.
+   */
+  documentPath: AssetPath.optional(),
 });
 export type Topic = z.infer<typeof Topic>;
 

--- a/apps/harbor/packages/protocol/src/events.ts
+++ b/apps/harbor/packages/protocol/src/events.ts
@@ -14,15 +14,15 @@ export const SpaceEvent = z.discriminatedUnion('type', [
   z.object({ type: z.literal('message'), message: Message }),
   /**
    * A topic's lifecycle: created (promote or from-scratch), retitled,
-   * archived, unarchived — the full row plus who did it, so clients can
-   * render attributed lifecycle lines in the thread. Idempotent re-archives
-   * emit nothing; a reply reviving an archived topic emits 'unarchived'
-   * attributed to the replier.
+   * archived, unarchived, document attached/detached — the full row plus
+   * who did it, so clients can render attributed lifecycle lines in the
+   * thread. Idempotent re-archives emit nothing; a reply reviving an
+   * archived topic emits 'unarchived' attributed to the replier.
    */
   z.object({
     type: z.literal('topic'),
     topic: Topic,
-    action: z.enum(['created', 'retitled', 'archived', 'unarchived']),
+    action: z.enum(['created', 'retitled', 'archived', 'unarchived', 'document_attached', 'document_detached']),
     by: Attribution,
   }),
   /** The row deleted ("convert back to thread") — the thread itself is untouched. */

--- a/apps/harbor/packages/protocol/src/mcp.ts
+++ b/apps/harbor/packages/protocol/src/mcp.ts
@@ -196,7 +196,8 @@ export const readStream = tool({
 export const readThread = tool({
   name: 'read_thread',
   description:
-    'Read one flat thread: the root message, its topic row (null = a plain untitled thread), and ' +
+    'Read one flat thread: the root message, its topic row (null = a plain untitled thread; its ' +
+    'documentPath, when set, is the file the discussion is about — read_asset it for context), and ' +
     'the replies (each attributed to its member and acting mode), oldest first (default 50). ' +
     'Use this to catch up before replying or to answer questions about a conversation. A reply id ' +
     'resolves to its root. When `truncated` is true, pass `beforeOffset` to page back before ' +
@@ -346,13 +347,16 @@ export const createTopic = tool({
     'Give a thread a title (the UI calls it a Discussion), putting it on the rail. Provide ' +
     'rootMessageId to title an existing thread (use its root, not a reply), or body to post a new ' +
     'root message and title it in one step — exactly one of the two. Titles are goals ' +
-    '("Decide: launch cut"), not summaries. At most one topic per thread. ' +
+    '("Decide: launch cut"), not summaries. At most one topic per thread. Pass documentPath ' +
+    "(a live file's path from list_assets) to make the discussion about that file — the UI " +
+    'opens it beside the thread. ' +
     MENTION_GRAMMAR,
   input: z.object({
     spaceId: SpaceId,
     rootMessageId: MessageId.optional(),
     title: z.string().min(1).max(256),
     body: z.string().min(1).max(65_536).optional(),
+    documentPath: AssetPath.optional(),
   }),
   output: z.object({ topic: Topic, rootMessageId: MessageId }),
 });
@@ -361,14 +365,17 @@ export const manageTopic = tool({
   name: 'manage_topic',
   description:
     'One-row lifecycle ops on a topic: retitle (needs title), archive (off the rail; a new reply ' +
-    'revives it), unarchive, or remove (deletes the annotation — the thread and every message stay ' +
-    'in the stream untouched; "convert back to thread"). None of these can touch a message. ' +
-    'Attributed to your person like everything else.',
+    'revives it), unarchive, remove (deletes the annotation — the thread and every message stay ' +
+    'in the stream untouched; "convert back to thread"), attach_document (needs path: link ONE ' +
+    "live space file as what the discussion is about — the topic's documentPath; the UI opens it " +
+    'beside the thread; read it with read_asset), or detach_document. None of these can touch a ' +
+    'message. Attributed to your person like everything else.',
   input: z.object({
     spaceId: SpaceId,
     topicId: TopicId,
-    action: z.enum(['retitle', 'archive', 'unarchive', 'remove']),
+    action: z.enum(['retitle', 'archive', 'unarchive', 'remove', 'attach_document', 'detach_document']),
     title: z.string().min(1).max(256).optional(),
+    path: AssetPath.optional(),
   }),
   output: z.object({ topic: Topic }),
 });

--- a/apps/harbor/packages/server/src/mcp.ts
+++ b/apps/harbor/packages/server/src/mcp.ts
@@ -347,7 +347,7 @@ async function dispatch(
       return { topics: await service.listTopics(ctx, a.spaceId, a.includeArchived ?? false) };
     }
     case 'create_topic': {
-      const a = args as { spaceId: string; rootMessageId?: string; title: string; body?: string };
+      const a = args as { spaceId: string; rootMessageId?: string; title: string; body?: string; documentPath?: string };
       // One-of lives here rather than in the JSON schema (kept plain on purpose).
       if ((a.rootMessageId === undefined) === (a.body === undefined)) {
         throw new HarborError('invalid_request', 'provide exactly one of rootMessageId (promote a thread) or body (post + annotate)');
@@ -356,6 +356,7 @@ async function dispatch(
         ...(a.rootMessageId !== undefined ? { rootMessageId: a.rootMessageId } : {}),
         title: a.title,
         ...(a.body !== undefined ? { body: a.body } : {}),
+        ...(a.documentPath !== undefined ? { documentPath: a.documentPath } : {}),
         actingMode: actor.actingMode,
         ...(actor.agentName ? { agentName: actor.agentName } : {}),
       });
@@ -365,8 +366,9 @@ async function dispatch(
       const a = args as {
         spaceId: string;
         topicId: string;
-        action: 'retitle' | 'archive' | 'unarchive' | 'remove';
+        action: 'retitle' | 'archive' | 'unarchive' | 'remove' | 'attach_document' | 'detach_document';
         title?: string;
+        path?: string;
       };
       const attribution = {
         actingMode: actor.actingMode,
@@ -376,6 +378,9 @@ async function dispatch(
       if (a.action === 'retitle') {
         if (!a.title) throw new HarborError('invalid_request', 'retitle needs a title');
         action = { action: 'retitle', title: a.title, ...attribution };
+      } else if (a.action === 'attach_document') {
+        if (!a.path) throw new HarborError('invalid_request', 'attach_document needs a path');
+        action = { action: 'attach_document', path: a.path, ...attribution };
       } else {
         action = { action: a.action, ...attribution };
       }

--- a/apps/harbor/packages/server/src/memory-store.ts
+++ b/apps/harbor/packages/server/src/memory-store.ts
@@ -37,7 +37,8 @@ interface SpaceState {
   blobs: Map<string, StoredSpaceBlob>; // hash → registration (first write wins)
   changeSets: ChangeSet[]; // append order == offset order
   changeSetsById: Map<string, ChangeSet>;
-  topics: Map<string, Topic>; // annotation rows (id → row); messages never reference them
+  topics: Map<string, Topic>; // annotation rows (id → row, never carrying documentPath); messages never reference them
+  topicDocuments: Map<string, string>; // topicId → linked assetId (migration 019); reads project the live path
   messages: Message[]; // the one stream, roots and replies interleaved, oldest first
   messagesById: Map<string, Message>;
   reactions: Map<string, StoredReaction[]>; // messageId → oldest first
@@ -115,6 +116,7 @@ export class MemoryStore implements Store {
       changeSets: [],
       changeSetsById: new Map(),
       topics: new Map(),
+      topicDocuments: new Map(),
       messages: [],
       messagesById: new Map(),
       reactions: new Map(),
@@ -298,24 +300,53 @@ export class MemoryStore implements Store {
     return out;
   }
 
+  /** The wire shape: the row plus the linked document's CURRENT live path (mirrors pg TOPIC_SELECT). */
+  private projectTopic(s: SpaceState, topic: Topic): Topic {
+    const assetId = s.topicDocuments.get(topic.id);
+    const asset = assetId ? s.assets.get(assetId) : undefined;
+    const { documentPath: _drop, ...row } = topic;
+    return asset && asset.state === 'live' ? { ...row, documentPath: asset.path } : row;
+  }
+
+  private topicsOf(spaceId: string): Topic[] {
+    const s = this.must(spaceId);
+    return [...s.topics.values()].map((t) => this.projectTopic(s, t));
+  }
+
   async getTopic(spaceId: string, topicId: string): Promise<Topic | undefined> {
-    return this.state(spaceId)?.topics.get(topicId);
+    const s = this.state(spaceId);
+    const topic = s?.topics.get(topicId);
+    return s && topic ? this.projectTopic(s, topic) : undefined;
   }
 
   async putTopic(topic: Topic): Promise<void> {
-    this.must(topic.spaceId).topics.set(topic.id, topic);
+    // The projected path never lands in the row — the link lives in topicDocuments.
+    const { documentPath: _drop, ...row } = topic;
+    this.must(topic.spaceId).topics.set(topic.id, row);
+  }
+
+  async setTopicDocument(spaceId: string, topicId: string, assetId: string | null): Promise<void> {
+    const s = this.must(spaceId);
+    if (assetId === null) s.topicDocuments.delete(topicId);
+    else s.topicDocuments.set(topicId, assetId);
+  }
+
+  async getTopicDocument(spaceId: string, topicId: string): Promise<string | undefined> {
+    return this.state(spaceId)?.topicDocuments.get(topicId);
   }
 
   async deleteTopic(spaceId: string, topicId: string): Promise<void> {
-    this.must(spaceId).topics.delete(topicId);
+    const s = this.must(spaceId);
+    s.topics.delete(topicId);
+    s.topicDocuments.delete(topicId);
   }
 
   async listTopics(spaceId: string, includeArchived: boolean): Promise<Topic[]> {
-    return [...this.must(spaceId).topics.values()].filter((t) => includeArchived || !t.archived);
+    return this.topicsOf(spaceId).filter((t) => includeArchived || !t.archived);
   }
 
   async getTopicByRoot(spaceId: string, rootMessageId: string): Promise<Topic | undefined> {
-    return [...this.must(spaceId).topics.values()].find((t) => t.rootMessageId === rootMessageId);
+    return this.topicsOf(spaceId).find((t) => t.rootMessageId === rootMessageId);
   }
 
   async getMessage(spaceId: string, messageId: string): Promise<Message | undefined> {
@@ -365,7 +396,7 @@ export class MemoryStore implements Store {
 
   async searchTopics(spaceId: string, query: SearchQuery, limit: number): Promise<Topic[]> {
     if (query.terms.length === 0) return [];
-    return [...this.must(spaceId).topics.values()]
+    return this.topicsOf(spaceId)
       .filter((t) => matchesAllTerms(searchTextFor(t.title), query))
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id))
       .slice(0, limit);

--- a/apps/harbor/packages/server/src/migrations.ts
+++ b/apps/harbor/packages/server/src/migrations.ts
@@ -601,6 +601,19 @@ export const MIGRATIONS: Migration[] = [
       )`,
     ],
   },
+  {
+    id: '019-topic-document',
+    statements: [
+      // The discussion's one file (2026-09-11): a nullable pointer on the
+      // annotation row to the asset's INTERNAL id (the inode model, 007), so
+      // a rename never breaks the link. Reads project the asset's current
+      // live path onto the wire; a trashed file simply projects nothing
+      // until restored — no cascade, no cleanup. The partial index answers
+      // "which discussions are about this file" from the file's side.
+      `alter table topics add column if not exists document_asset_id text`,
+      `create index if not exists topics_document on topics (space_id, document_asset_id) where document_asset_id is not null`,
+    ],
+  },
 ];
 
 export async function migrate(db: SqlDb): Promise<void> {

--- a/apps/harbor/packages/server/src/pg-store.ts
+++ b/apps/harbor/packages/server/src/pg-store.ts
@@ -121,7 +121,18 @@ interface TopicRow {
   created_by: Topic['createdBy'];
   created_at: string;
   archived: boolean;
+  /** Projected by TOPIC_SELECT: the linked asset's current path, null unless it is live. */
+  document_path: string | null;
 }
+
+/**
+ * Every topic read goes through this projection: the row plus the linked
+ * document's CURRENT live path (migration 019). A trashed file projects
+ * null — the link is kept on the row and comes back on restore.
+ */
+const TOPIC_SELECT = `select t.*, a.path as document_path
+  from topics t
+  left join assets a on a.space_id = t.space_id and a.id = t.document_asset_id and a.state = 'live'`;
 
 function rowToTopic(r: TopicRow): Topic {
   return {
@@ -132,6 +143,7 @@ function rowToTopic(r: TopicRow): Topic {
     createdBy: r.created_by,
     createdAt: r.created_at,
     archived: r.archived,
+    ...(r.document_path !== null && r.document_path !== undefined ? { documentPath: r.document_path } : {}),
   };
 }
 
@@ -686,8 +698,20 @@ export class PgStore implements Store {
   // --- topics & messages -----------------------------------------------------
 
   async getTopic(spaceId: string, topicId: string): Promise<Topic | undefined> {
-    const rows = await this.sql.query<TopicRow>('select * from topics where space_id = $1 and id = $2', [spaceId, topicId]);
+    const rows = await this.sql.query<TopicRow>(`${TOPIC_SELECT} where t.space_id = $1 and t.id = $2`, [spaceId, topicId]);
     return rows[0] ? rowToTopic(rows[0]) : undefined;
+  }
+
+  async setTopicDocument(spaceId: string, topicId: string, assetId: string | null): Promise<void> {
+    await this.sql.query('update topics set document_asset_id = $3 where space_id = $1 and id = $2', [spaceId, topicId, assetId]);
+  }
+
+  async getTopicDocument(spaceId: string, topicId: string): Promise<string | undefined> {
+    const rows = await this.sql.query<{ document_asset_id: string | null }>(
+      'select document_asset_id from topics where space_id = $1 and id = $2',
+      [spaceId, topicId],
+    );
+    return rows[0]?.document_asset_id ?? undefined;
   }
 
   async putTopic(topic: Topic): Promise<void> {
@@ -715,7 +739,7 @@ export class PgStore implements Store {
 
   async getTopicByRoot(spaceId: string, rootMessageId: string): Promise<Topic | undefined> {
     const rows = await this.sql.query<TopicRow>(
-      'select * from topics where space_id = $1 and root_message_id = $2',
+      `${TOPIC_SELECT} where t.space_id = $1 and t.root_message_id = $2`,
       [spaceId, rootMessageId],
     );
     return rows[0] ? rowToTopic(rows[0]) : undefined;
@@ -723,8 +747,8 @@ export class PgStore implements Store {
 
   async listTopics(spaceId: string, includeArchived: boolean): Promise<Topic[]> {
     const rows = await this.sql.query<TopicRow>(
-      `select * from topics where space_id = $1 ${includeArchived ? '' : 'and archived = false'}
-       order by created_at desc, id desc`,
+      `${TOPIC_SELECT} where t.space_id = $1 ${includeArchived ? '' : 'and t.archived = false'}
+       order by t.created_at desc, t.id desc`,
       [spaceId],
     );
     return rows.map(rowToTopic);
@@ -788,8 +812,8 @@ export class PgStore implements Store {
   async searchTopics(spaceId: string, query: SearchQuery, limit: number): Promise<Topic[]> {
     if (query.terms.length === 0) return [];
     const rows = await this.sql.query<TopicRow>(
-      `select * from topics where space_id = $1 and title_tsv @@ to_tsquery('simple', $2)
-       order by ts_rank(title_tsv, to_tsquery('simple', $2)) desc, created_at desc, id desc limit $3`,
+      `${TOPIC_SELECT} where t.space_id = $1 and t.title_tsv @@ to_tsquery('simple', $2)
+       order by ts_rank(t.title_tsv, to_tsquery('simple', $2)) desc, t.created_at desc, t.id desc limit $3`,
       [spaceId, toTsQueryString(query), limit],
     );
     return rows.map(rowToTopic);

--- a/apps/harbor/packages/server/src/service.ts
+++ b/apps/harbor/packages/server/src/service.ts
@@ -1288,6 +1288,10 @@ export class HarborService {
         offset += 1;
       }
 
+      // The file the discussion is about, resolved before anything is
+      // written: a bad path refuses the whole ceremony (no half-born topic).
+      const document = input.documentPath !== undefined ? await this.requireLiveAsset(spaceId, input.documentPath) : undefined;
+
       const topic: Topic = {
         id: this.ulid(),
         spaceId,
@@ -1296,8 +1300,10 @@ export class HarborService {
         createdBy: by,
         createdAt: at,
         archived: false,
+        ...(document ? { documentPath: document.path } : {}),
       };
       await this.store.putTopic(topic);
+      if (document) await this.store.setTopicDocument(spaceId, topic.id, document.id);
       await this.append(spaceId, offset, at, { type: 'topic', topic, action: 'created', by });
       return { topic, rootMessage: root };
     });
@@ -1679,8 +1685,38 @@ export class HarborService {
           await this.append(spaceId, offset, at, { type: 'topic_removed', removal });
           return topic;
         }
+        case 'attach_document': {
+          // Resolves through redirects, so an old link to a moved file lands
+          // on the file; the row keeps the asset id, the wire the live path.
+          const asset = await this.requireLiveAsset(spaceId, action.path);
+          if (topic.documentPath === asset.path) return topic; // idempotent, no event
+          await this.store.setTopicDocument(spaceId, topicId, asset.id);
+          const updated: Topic = { ...topic, documentPath: asset.path };
+          const offset = (await this.store.head(spaceId)) + 1;
+          await this.append(spaceId, offset, at, { type: 'topic', topic: updated, action: 'document_attached', by });
+          return updated;
+        }
+        case 'detach_document': {
+          // A link to a trashed file projects no path but still exists —
+          // detaching it is a real change, so the row (not the projection)
+          // decides idempotency.
+          if (!(await this.store.getTopicDocument(spaceId, topicId))) return topic;
+          await this.store.setTopicDocument(spaceId, topicId, null);
+          const { documentPath: _gone, ...rest } = topic;
+          const updated: Topic = rest;
+          const offset = (await this.store.head(spaceId)) + 1;
+          await this.append(spaceId, offset, at, { type: 'topic', topic: updated, action: 'document_detached', by });
+          return updated;
+        }
       }
     });
+  }
+
+  /** A live asset at `path` (moved paths follow their redirect), else not_found. */
+  private async requireLiveAsset(spaceId: string, path: string): Promise<AssetRecord> {
+    const resolved = await this.resolveAsset(spaceId, path);
+    if (!resolved) throw new HarborError('not_found', `no such file: ${path}`);
+    return resolved.asset;
   }
 
   /**

--- a/apps/harbor/packages/server/src/store.ts
+++ b/apps/harbor/packages/server/src/store.ts
@@ -252,8 +252,16 @@ export interface Store {
   getTopic(spaceId: string, topicId: string): Promise<Topic | undefined>;
   /** The topic annotating this thread, if one exists (rootMessageId is unique). */
   getTopicByRoot(spaceId: string, rootMessageId: string): Promise<Topic | undefined>;
-  /** Insert or update (retitle / archive flips) — the row is the whole object. */
+  /**
+   * Insert or update (retitle / archive flips) — the row is the whole object
+   * EXCEPT the document link, which only setTopicDocument writes (the wire
+   * shape carries a projected path, never the stored asset id).
+   */
   putTopic(topic: Topic): Promise<void>;
+  /** Point the topic at one asset (by internal id) or clear it (null). Reads project the live path. */
+  setTopicDocument(spaceId: string, topicId: string, assetId: string | null): Promise<void>;
+  /** The stored link itself (live or trashed asset alike) — what detach's idempotency reads. */
+  getTopicDocument(spaceId: string, topicId: string): Promise<string | undefined>;
   /** "Convert back to thread": the row goes, the messages never knew it existed. */
   deleteTopic(spaceId: string, topicId: string): Promise<void>;
   listTopics(spaceId: string, includeArchived: boolean): Promise<Topic[]>;

--- a/apps/harbor/packages/server/test/api.test.ts
+++ b/apps/harbor/packages/server/test/api.test.ts
@@ -568,6 +568,86 @@ describe('feed: the stream, threads, and topic annotations', () => {
     expect(removedEvent.removal).toMatchObject({ topicId: made.body.topic.id, rootMessageId: made.body.rootMessage.id, by: { memberId: 'ramnique' } });
     live.close();
   });
+
+  it('a discussion can be about one file: the link follows renames, hides in the trash, returns on restore', async () => {
+    const live = await liveClient(harbor, 'dev-ramnique');
+    live.send({ kind: 'subscribe', spaceId });
+    await live.until((frames) => frames.some((f) => f.kind === 'subscribed'), 'subscribed');
+
+    const file = await ramnique.post(`/v1/spaces/${spaceId}/changes`, {
+      assetPath: 'briefs/launch.md', baseVersion: 0, newContent: '# Launch brief\n', actingMode: 'direct',
+    });
+    expect(file.body.outcome).toBe('applied');
+
+    // Born with its file — the path is validated before anything is written.
+    const missing = await gagan.post(`/v1/spaces/${spaceId}/topics`, {
+      title: 'Review: launch brief', body: 'Thoughts on the brief?', documentPath: 'briefs/nope.md', actingMode: 'direct',
+    });
+    expect(missing.status).toBe(404);
+    const made = await gagan.post(`/v1/spaces/${spaceId}/topics`, {
+      title: 'Review: launch brief', body: 'Thoughts on the brief?', documentPath: 'briefs/launch.md', actingMode: 'direct',
+    });
+    expect(made.status).toBe(200);
+    expect(made.body.topic.documentPath).toBe('briefs/launch.md');
+    const topicId = made.body.topic.id;
+
+    // Every read surface projects it: the rail, the thread, the stream page.
+    const thread = await ramnique.get(`/v1/spaces/${spaceId}/threads/${made.body.rootMessage.id}`);
+    expect(thread.body.topic.documentPath).toBe('briefs/launch.md');
+    const rail = await ramnique.get(`/v1/spaces/${spaceId}/topics`);
+    expect(rail.body.topics.find((t: any) => t.id === topicId).documentPath).toBe('briefs/launch.md');
+
+    // Re-attaching the same file is a no-op; attaching another replaces.
+    const same = await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'attach_document', path: 'briefs/launch.md', actingMode: 'direct' });
+    expect(same.body.topic.documentPath).toBe('briefs/launch.md');
+    await ramnique.post(`/v1/spaces/${spaceId}/changes`, { assetPath: 'briefs/faq.md', baseVersion: 0, newContent: '# FAQ\n', actingMode: 'direct' });
+    const swapped = await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'attach_document', path: 'briefs/faq.md', actingMode: 'direct' });
+    expect(swapped.body.topic.documentPath).toBe('briefs/faq.md');
+    // An old path still reaches its file through the redirect; a missing one refuses.
+    const bad = await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'attach_document', path: 'briefs/nope.md', actingMode: 'direct' });
+    expect(bad.status).toBe(404);
+    const back = await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'attach_document', path: 'briefs/launch.md', actingMode: 'direct' });
+    expect(back.body.topic.documentPath).toBe('briefs/launch.md');
+
+    // The link is to the FILE, not the path: a rename shows the new path.
+    const moved = await gagan.post(`/v1/spaces/${spaceId}/assets/move`, {
+      fromPath: 'briefs/launch.md', toPath: 'briefs/launch-v2.md', baseVersion: 1, actingMode: 'direct',
+    });
+    expect(moved.body.outcome).toBe('moved');
+    expect((await ramnique.get(`/v1/spaces/${spaceId}/topics`)).body.topics.find((t: any) => t.id === topicId).documentPath).toBe('briefs/launch-v2.md');
+
+    // Trash hides it (no cleanup anywhere); restore brings it straight back.
+    const deleted = await gagan.post(`/v1/spaces/${spaceId}/assets/delete`, { path: 'briefs/launch-v2.md', baseVersion: 1, actingMode: 'direct' });
+    expect(deleted.body.outcome).toBe('deleted');
+    expect((await ramnique.get(`/v1/spaces/${spaceId}/topics`)).body.topics.find((t: any) => t.id === topicId).documentPath).toBeUndefined();
+    await gagan.post(`/v1/spaces/${spaceId}/assets/restore`, { path: 'briefs/launch-v2.md', actingMode: 'direct' });
+    expect((await ramnique.get(`/v1/spaces/${spaceId}/topics`)).body.topics.find((t: any) => t.id === topicId).documentPath).toBe('briefs/launch-v2.md');
+
+    // Detach clears it; detaching again is silent.
+    const detached = await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'detach_document', actingMode: 'direct' });
+    expect(detached.status).toBe(200);
+    expect(detached.body.topic.documentPath).toBeUndefined();
+    await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'detach_document', actingMode: 'direct' });
+
+    await live.until(
+      (frames) => frames.some((f) => f.kind === 'event' && f.event.type === 'topic' && f.event.action === 'document_detached'),
+      'document lifecycle events',
+    );
+    const actions = live
+      .events()
+      .filter((f) => f.event.type === 'topic' && f.event.topic.id === topicId)
+      .map((f) => (f.event.type === 'topic' ? f.event.action : ''));
+    // created (with the file), the swap, the swap back, the detach — no-ops emit nothing.
+    expect(actions).toEqual(['created', 'document_attached', 'document_attached', 'document_detached']);
+    const createdEvent = live.events().find((f) => f.event.type === 'topic' && f.event.topic.id === topicId)!.event as Extract<
+      ReturnType<typeof live.events>[number]['event'],
+      { type: 'topic' }
+    >;
+    expect(createdEvent.topic.documentPath).toBe('briefs/launch.md');
+    live.close();
+
+    await ramnique.post(`/v1/spaces/${spaceId}/topics/${topicId}`, { action: 'remove', actingMode: 'direct' });
+  });
 });
 
 describe('reactions', () => {

--- a/apps/harbor/packages/server/test/mcp.test.ts
+++ b/apps/harbor/packages/server/test/mcp.test.ts
@@ -324,6 +324,29 @@ describe('agent face (MCP)', () => {
     ).structuredContent as { topic: { title: string } };
     expect(managed.topic.title).toBe('Decide: webhook retry policy (v2)');
 
+    // The discussion can be about one file: attach needs a path, read_thread shows it.
+    const proposed = await client.callTool({
+      name: 'propose_change',
+      arguments: { spaceId, path: 'retries.md', baseVersion: 0, newContent: '# Retry policy\n', reason: 'the policy doc' },
+    });
+    expect(proposed.isError, JSON.stringify(proposed.content)).toBeFalsy();
+    const noPath = await client.callTool({
+      name: 'manage_topic',
+      arguments: { spaceId, topicId: annotated.topic.id, action: 'attach_document' },
+    });
+    expect(noPath.isError).toBe(true);
+    const attachedResult = await client.callTool({
+      name: 'manage_topic',
+      arguments: { spaceId, topicId: annotated.topic.id, action: 'attach_document', path: 'retries.md' },
+    });
+    expect(attachedResult.isError, JSON.stringify(attachedResult.content)).toBeFalsy();
+    const attached = attachedResult.structuredContent as { topic: { documentPath?: string } };
+    expect(attached.topic.documentPath).toBe('retries.md');
+    const withDoc = (
+      await client.callTool({ name: 'read_thread', arguments: { spaceId, rootMessageId: started.messageId } })
+    ).structuredContent as { topic: { documentPath?: string } | null };
+    expect(withDoc.topic?.documentPath).toBe('retries.md');
+
     // remove converts back to a thread — the messages stay readable.
     await client.callTool({
       name: 'manage_topic',

--- a/apps/harbor/packages/server/test/pg-store.test.ts
+++ b/apps/harbor/packages/server/test/pg-store.test.ts
@@ -100,6 +100,40 @@ describe('PgStore through the service', () => {
     expect(thread.messages.map((m) => m.body)).toEqual(['A follow-up']);
   });
 
+  it('a topic\'s document is stored by asset id and projected as the live path (migration 019)', async () => {
+    await service.proposeChange(ram, spaceId, { assetPath: 'brief.md', baseVersion: 0, newContent: '# Brief\n', actingMode: 'direct' });
+    const b = await service.postMessage(ram, spaceId, { body: 'Root B', actingMode: 'direct' });
+    const { topic } = await service.createTopic(ram, spaceId, {
+      rootMessageId: b.message.id,
+      title: 'Review: the brief',
+      documentPath: 'brief.md',
+      actingMode: 'direct',
+    });
+    expect(topic.documentPath).toBe('brief.md');
+    // The row keeps the internal id; putTopic (a retitle) must not disturb it.
+    const asset = await store.getLiveAssetByPath(spaceId, 'brief.md');
+    expect(await store.getTopicDocument(spaceId, topic.id)).toBe(asset!.id);
+    const retitled = await service.manageTopic(ram, spaceId, topic.id, { action: 'retitle', title: 'Review: the brief (v2)', actingMode: 'direct' });
+    expect(retitled.documentPath).toBe('brief.md');
+
+    // Rename → new path on every read; the getTopicByRoot and thread paths project too.
+    await service.moveAsset(ram, spaceId, { fromPath: 'brief.md', toPath: 'journal.md', baseVersion: 1, actingMode: 'direct' });
+    expect((await store.getTopicByRoot(spaceId, b.message.id))?.documentPath).toBe('journal.md');
+    expect((await service.listThread(ram, spaceId, b.message.id)).topic?.documentPath).toBe('journal.md');
+
+    // Trash → projected away, link kept; detach is still a real change then.
+    await service.deleteAsset(ram, spaceId, { path: 'journal.md', baseVersion: 1, actingMode: 'direct' });
+    expect((await store.getTopic(spaceId, topic.id))?.documentPath).toBeUndefined();
+    expect(await store.getTopicDocument(spaceId, topic.id)).toBe(asset!.id);
+    const detached = await service.manageTopic(ram, spaceId, topic.id, { action: 'detach_document', actingMode: 'direct' });
+    expect(detached.documentPath).toBeUndefined();
+    expect(await store.getTopicDocument(spaceId, topic.id)).toBeUndefined();
+    const events = await store.listEventsAfter(spaceId, 0);
+    expect(events.filter((e) => e.event.type === 'topic' && e.event.topic.id === topic.id).map((e) => (e.event as { action: string }).action))
+      .toEqual(['created', 'retitled', 'document_detached']);
+    await service.restoreAsset(ram, spaceId, { path: 'journal.md', actingMode: 'direct' });
+  });
+
   it('search finds topic-title and body matches across jsonb-backed rows', async () => {
     const posted = await service.postMessage(ram, spaceId, { body: 'exponential backoff, capped', actingMode: 'direct' });
     await service.createTopic(ram, spaceId, {

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -586,6 +586,35 @@ function SpacePane({ org, space, selection, onSelect, onSwitchSpace, onOpenSessi
         // current width when it runs; a resize must not re-place anything.
     }, [selKey])
 
+    // A discussion's linked file opens beside it (2026-09-11). The org
+    // projects the link as the file's CURRENT live path, so whatever lands
+    // here exists. Once per visit: closing the column marks the thread as
+    // dismissed until the reader leaves it (closeDoc); a different file they
+    // open themselves is never fought — this only fires when the selection
+    // or the link itself changes, and only where two columns fit (narrow,
+    // the chat wins, as everywhere). The stream copy is read first: it is
+    // the one a local attach updates before the feed refetches.
+    const selectedThreadRoot = selection.kind === 'thread' ? selection.rootMessageId : null
+    const linkedDocPath = selectedThreadRoot
+        ? (stream.topicsByRoot.get(selectedThreadRoot) ?? feed.topics.find((t) => t.rootMessageId === selectedThreadRoot))?.documentPath ?? null
+        : null
+    const linkedDocDismissedRef = useRef<string | null>(null)
+    useEffect(() => {
+        // Leaving the dismissed thread — for the stream or another thread —
+        // forgets the dismissal; a file opened from it keeps it.
+        if (selection.kind === 'general' || (selectedThreadRoot && linkedDocDismissedRef.current !== selectedThreadRoot)) {
+            linkedDocDismissedRef.current = null
+        }
+    }, [selection.kind, selectedThreadRoot])
+    useEffect(() => {
+        if (!selectedThreadRoot || !linkedDocPath || !twoFits) return
+        if (linkedDocDismissedRef.current === selectedThreadRoot) return
+        setDocPath((open) => (open === linkedDocPath ? open : linkedDocPath))
+        setChatOpen(true)
+        // Keyed on the thread and the link — not on docPath, which the
+        // reader moves freely once the column is open.
+    }, [selectedThreadRoot, linkedDocPath, twoFits])
+
     // The last closed file — the header chip reopens it beside the chat.
     const [lastDoc, setLastDoc] = useState<{ path: string; fromThreadRootId?: string } | null>(null)
 
@@ -631,6 +660,9 @@ function SpacePane({ org, space, selection, onSelect, onSwitchSpace, onOpenSessi
         if (selection.kind === 'file' && !spaces.isWhiteboardPath(selection.path)) {
             setLastDoc({ path: selection.path, fromThreadRootId: selection.fromThreadRootId })
         }
+        // Closing beside a discussion is a choice: its linked file stays
+        // closed until the reader leaves and comes back.
+        if (chatRootId) linkedDocDismissedRef.current = chatRootId
         setDocPath(null)
         setChatOpen(true)
         if (selection.kind === 'file' || selection.kind === 'whiteboard' || selection.kind === 'attachment') {

--- a/apps/x/apps/renderer/src/components/spaces/attach-document-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/attach-document-dialog.tsx
@@ -1,0 +1,79 @@
+import { useMemo, useState } from 'react'
+import { FileText, PenTool, Search } from 'lucide-react'
+import type { spaces } from '@x/shared'
+import { spaces as spacesLib } from '@x/shared'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { filterAttachable } from '@/lib/spaces-documents'
+import { cn } from '@/lib/utils'
+
+// The one-file link on a discussion (2026-09-11): pick a live space file and
+// the org points the topic row at it (manageTopic attach_document). The list
+// is the space's live entries (lib/spaces-documents), the currently linked
+// file floating to the top.
+
+export function AttachDocumentDialog({ entries, current, onPick, onClose }: {
+    entries: spaces.SpacesAssetEntry[]
+    /** The file linked today, if any — shown first and marked. */
+    current?: string
+    onPick: (path: string) => void
+    onClose: () => void
+}) {
+    const [query, setQuery] = useState('')
+    const shown = useMemo(() => filterAttachable(entries, query, current), [entries, query, current])
+
+    return (
+        <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+            <DialogContent className="sm:max-w-md">
+                <DialogTitle className="flex items-center gap-2">
+                    <FileText className="size-4" /> {current ? 'Change the linked file' : 'Link a file'}
+                </DialogTitle>
+                <p className="text-xs text-muted-foreground">
+                    The linked file opens beside this discussion whenever it is opened.
+                </p>
+                <label className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground focus-within:border-foreground/30">
+                    <Search className="size-3" />
+                    <input
+                        autoFocus
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder="Search files…"
+                        className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                    />
+                </label>
+                <div className="max-h-64 overflow-y-auto rounded-md border border-border p-1">
+                    {shown.map((e) => {
+                        const linked = e.path === current
+                        return (
+                            <button
+                                key={e.path}
+                                type="button"
+                                onClick={() => onPick(e.path)}
+                                className={cn(
+                                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px]',
+                                    linked ? 'bg-accent text-foreground' : 'hover:bg-accent/60',
+                                )}
+                            >
+                                {spacesLib.isWhiteboardPath(e.path) ? (
+                                    <PenTool className="size-3.5 shrink-0 text-muted-foreground" />
+                                ) : (
+                                    <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                                )}
+                                <span className="min-w-0 flex-1 truncate font-mono text-xs">{e.path}</span>
+                                {linked && <span className="shrink-0 text-[11px] text-muted-foreground">linked</span>}
+                            </button>
+                        )
+                    })}
+                    {shown.length === 0 && (
+                        <div className="px-2 py-3 text-xs text-muted-foreground">
+                            {entries.some((e) => e.state !== 'deleted') ? 'No file matches.' : 'This space has no files yet.'}
+                        </div>
+                    )}
+                </div>
+                <div className="flex justify-end">
+                    <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -1,13 +1,14 @@
 import { MESSAGE_PROSE } from '@/components/spaces/message-prose'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { cn } from '@/lib/utils'
-import { Anchor, Archive, ArchiveRestore, ArrowLeft, ArrowUp, Bell, BellOff, Bot, Loader2, MessageSquareOff, MoreHorizontal, Maximize2, Minimize2, Pencil, ShieldAlert, Square, Tag, X } from 'lucide-react'
+import { Anchor, Archive, ArchiveRestore, ArrowLeft, ArrowUp, Bell, BellOff, Bot, FileText, Loader2, MessageSquareOff, MoreHorizontal, Maximize2, Minimize2, Paperclip, Pencil, ShieldAlert, Square, Tag, Unlink, X } from 'lucide-react'
 import type { spaces } from '@x/shared'
 import { Button } from '@/components/ui/button'
 import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { ArtifactsSummary } from '@/components/spaces/artifacts'
+import { AttachDocumentDialog } from '@/components/spaces/attach-document-dialog'
 import { MemberAvatar, MemberProfilePopover } from '@/components/spaces/atoms'
 import { Composer, type AgentOptions } from '@/components/spaces/composer'
 import { ForwardDialog } from '@/components/spaces/forward-dialog'
@@ -561,6 +562,10 @@ export function ThreadPane({
         }
     }
 
+    // The one file this discussion is about: picked from the space's live
+    // files; the org keeps the link by asset id, so it survives renames.
+    const [attaching, setAttaching] = useState(false)
+
     // Inline title editing (window.prompt is a no-op in Electron). null = not
     // editing; the same field serves rename AND first-time goal setting.
     const [editingTitle, setEditingTitle] = useState<string | null>(null)
@@ -705,6 +710,17 @@ export function ThreadPane({
                         </>
                     )}
                 </span>
+                {topic?.documentPath && (
+                    <button
+                        type="button"
+                        onClick={() => onOpenFile(topic.documentPath!)}
+                        title={`Open ${topic.documentPath} beside this discussion`}
+                        className="inline-flex h-6 max-w-[12rem] shrink-0 items-center gap-1 rounded-md border border-border bg-background px-1.5 text-[11px] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                    >
+                        <FileText className="size-3 shrink-0" />
+                        <span className="truncate font-mono">{topic.documentPath.split('/').pop()}</span>
+                    </button>
+                )}
                 <span className="flex-1" />
                 {hasSession && onOpenSession && (
                     // Persistent, unlike the working chip: the conversation the
@@ -736,6 +752,14 @@ export function ThreadPane({
                                 <DropdownMenuItem onClick={() => setEditingTitle(topic.title)}>
                                     <Pencil className="size-3.5 mr-2" /> Rename
                                 </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => setAttaching(true)}>
+                                    <Paperclip className="size-3.5 mr-2" /> {topic.documentPath ? 'Change linked file…' : 'Link a file…'}
+                                </DropdownMenuItem>
+                                {topic.documentPath && (
+                                    <DropdownMenuItem onClick={() => void manage({ action: 'detach_document' })}>
+                                        <Unlink className="size-3.5 mr-2" /> Unlink file
+                                    </DropdownMenuItem>
+                                )}
                                 {topic.archived ? (
                                     <DropdownMenuItem onClick={() => void manage({ action: 'unarchive' })}><ArchiveRestore className="size-3.5 mr-2" /> Unarchive</DropdownMenuItem>
                                 ) : (
@@ -918,6 +942,17 @@ export function ThreadPane({
             )}
             </div>
 
+            {attaching && topic && (
+                <AttachDocumentDialog
+                    entries={entries}
+                    current={topic.documentPath}
+                    onClose={() => setAttaching(false)}
+                    onPick={(path) => {
+                        setAttaching(false)
+                        if (path !== topic.documentPath) void manage({ action: 'attach_document', path })
+                    }}
+                />
+            )}
             {forwarding && (
                 <ForwardDialog org={org} space={space} message={forwarding} memberNames={memberNames} onClose={() => setForwarding(null)} />
             )}

--- a/apps/x/apps/renderer/src/lib/spaces-documents.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-documents.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { spaces } from '@x/shared'
+import { filterAttachable } from './spaces-documents'
+
+const entry = (path: string, state?: 'deleted'): spaces.SpacesAssetEntry => ({ path, version: 1, updatedAt: '2026-09-11T00:00:00Z', ...(state ? { state } : {}) })
+
+describe('filterAttachable', () => {
+    const entries = [entry('roadmap.md'), entry('briefs/launch.md'), entry('briefs/faq.md'), entry('old/plan.md', 'deleted'), entry('whiteboards/arch.excalidraw')]
+
+    it('lists live files A–Z, never the trash', () => {
+        expect(filterAttachable(entries, '').map((e) => e.path)).toEqual([
+            'briefs/faq.md', 'briefs/launch.md', 'roadmap.md', 'whiteboards/arch.excalidraw',
+        ])
+    })
+
+    it('every term must match somewhere in the path, case-insensitively', () => {
+        expect(filterAttachable(entries, 'BRIEFS launch').map((e) => e.path)).toEqual(['briefs/launch.md'])
+        expect(filterAttachable(entries, 'briefs nope')).toEqual([])
+    })
+
+    it('the currently linked file floats to the top', () => {
+        expect(filterAttachable(entries, '', 'roadmap.md')[0]!.path).toBe('roadmap.md')
+        expect(filterAttachable(entries, 'briefs', 'roadmap.md').map((e) => e.path)).toEqual(['briefs/faq.md', 'briefs/launch.md'])
+    })
+})

--- a/apps/x/apps/renderer/src/lib/spaces-documents.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-documents.ts
@@ -1,0 +1,15 @@
+import type { spaces } from '@x/shared'
+
+// The one-file link on a discussion (Topic.documentPath, 2026-09-11): the
+// picker's candidate list. Live entries only — the org projects a trashed
+// link as absent, so offering the trash would be a lie — boards included,
+// since the doc column renders them too.
+
+/** Live entries matching every whitespace-separated term of `query` (path, case-insensitive), A–Z, the current link first. */
+export function filterAttachable(entries: spaces.SpacesAssetEntry[], query: string, current?: string): spaces.SpacesAssetEntry[] {
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
+    return entries
+        .filter((e) => e.state !== 'deleted')
+        .filter((e) => terms.every((t) => e.path.toLowerCase().includes(t)))
+        .sort((a, b) => Number(b.path === current) - Number(a.path === current) || a.path.localeCompare(b.path))
+}

--- a/apps/x/packages/core/src/runtime/assembly/skills/spaces/skill.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/spaces/skill.ts
@@ -56,7 +56,7 @@ nobody and badges nobody.
 | "edit / delete my message" | \`edit_message\` / \`delete_message\` |
 | "react", "pin" | \`react\` (pin is the 📌 emoji) |
 | "start a poll", "vote" | \`post_message\` with \`poll\` / \`vote_poll\` |
-| "title this thread", "archive it" | \`create_topic\` / \`manage_topic\` |
+| "title this thread", "archive it", "make it about roadmap.md" | \`create_topic\` / \`manage_topic\` (\`attach_document\`) |
 | "add X to roadmap.md" | \`read_asset\` → \`propose_change\` |
 | "rename / move / delete / restore a file" | \`move_asset\` / \`delete_asset\` / \`restore_asset\` |
 | "share this image / PDF" | \`spaces-upload-blob\` → reference it in a post or file |

--- a/apps/x/packages/shared/src/spaces.ts
+++ b/apps/x/packages/shared/src/spaces.ts
@@ -159,7 +159,10 @@ export type SpacesManageTopicAction =
   | { action: 'retitle'; title: string }
   | { action: 'archive' }
   | { action: 'unarchive' }
-  | { action: 'remove' };
+  | { action: 'remove' }
+  /** Link one live space file as what the discussion is about (replaces any earlier link). */
+  | { action: 'attach_document'; path: string }
+  | { action: 'detach_document' };
 
 /**
  * What the renderer may propose. actingMode is deliberately absent: everything


### PR DESCRIPTION
## What

A discussion (topic) can link **one** space file. Opening the discussion opens that file in the doc column beside the thread. Link and unlink from the thread header's ⋯ menu; a chip in the header names the file and opens it.

## Design

- **Storage: asset id, not path.** Migration 019 adds a nullable `topics.document_asset_id` pointing at the asset's internal id (the inode model from 007), plus a partial index for the file-side lookup later. A rename keeps the link.
- **Wire: the projected live path.** Every topic read left-joins `assets` and projects `Topic.documentPath` as the file's *current* path. A trashed file projects nothing until restored, so there's no cascade and nothing to clean up.
- **API.** `createTopic.documentPath` sets it at birth. `manageTopic` gains `attach_document { path }` (replaces; old paths resolve through redirects; 404 on a missing file) and `detach_document`. Both idempotent; no event when nothing changes.
- **Events.** The `topic` event's `action` gains `document_attached` / `document_detached`, full row riding along as before.
- **Agent face.** `create_topic` / `manage_topic` carry the same; `read_thread` tells agents the topic's `documentPath` is the file to `read_asset`. Skill table row updated.
- **App.** The doc column already existed. Selecting a thread whose topic has `documentPath` opens it where two columns fit (narrow, the chat wins as everywhere). Closing the column is remembered for that thread until the reader leaves it; a file the reader opens themselves is never fought. Header chip + "Link a file…" picker (live files, boards included) + "Unlink file".

## Rollout

Fleet first, app after. The new event actions fail the closed `action` enum on older desktop clients, but the client drops an unparseable frame and keeps the socket, so the only effect on a stale client is not seeing the link change live until the next listing resync.

## Tests

- REST: born with a file (bad path refused before anything is written), projection on rail/thread/stream, re-attach no-op, swap, redirect resolution, rename follows, trash hides, restore returns, detach clears, exact event sequence.
- Postgres (pglite): row keeps the asset id through a retitle, projection on every read path, trashed link still detaches as a real change.
- MCP: attach needs a path, `read_thread` shows the link.
- Renderer: the picker's filter helper.

Harbor suite: 364 passed. Renderer spaces/lib suites: 464 passed. Lint parity with main on the edited files. Not live-verified on staging.

## Not in this PR

- "Discuss this file" from the file viewer (the `createTopic.documentPath` half is ready for it).
- A file-side "discussions about this file" list (the index is there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9114HLatfxeEKpKTowkvL
