### PR TITLE
Add managed OpenCode coding with free models and Go/Zen access

### DIFF
--- a/apps/x/apps/main/src/ipc.ts
+++ b/apps/x/apps/main/src/ipc.ts
@@ -73,7 +73,12 @@ import { ICodeModeConfigRepo } from '@x/core/dist/code-mode/repo.js';
 import { CodePermissionRegistry } from '@x/core/dist/code-mode/acp/permission-registry.js';
 import type { CodeRunFeed } from '@x/core/dist/code-mode/feed.js';
 import { checkCodeModeAgentStatus } from '@x/core/dist/code-mode/status.js';
-import { ensureEngine } from '@x/core/dist/code-mode/acp/engine-provisioner.js';
+import { ensureEngine, isEngineProvisioned, isEngineSupported, removeOpenCodeEngine } from '@x/core/dist/code-mode/acp/engine-provisioner.js';
+import { ENGINE_MANIFEST } from '@x/core/dist/code-mode/acp/engine-manifest.js';
+import { openCodeProcesses } from '@x/core/dist/code-mode/acp/opencode-process.js';
+import { openCodeSetup } from '@x/core/dist/code-mode/acp/opencode-setup.js';
+import { stopOpenCodeLogin } from '@x/core/dist/code-mode/acp/opencode-login.js';
+import { openCodeSetupHandlers } from './opencode-setup-ipc.js';
 import type { ICodeProjectsRepo } from '@x/core/dist/code-mode/projects/repo.js';
 import type { ICodeSessionsRepo } from '@x/core/dist/code-mode/sessions/repo.js';
 import { CodeSessionService } from '@x/core/dist/code-mode/sessions/service.js';
@@ -1714,13 +1719,29 @@ export function setupIpcHandlers() {
     'codeMode:checkAgentStatus': async () => {
       return await checkCodeModeAgentStatus();
     },
+    ...openCodeSetupHandlers,
+    'codeMode:openCodeEngineStatus': async () => ({
+      installed: isEngineProvisioned('opencode'), supported: isEngineSupported('opencode'),
+      version: ENGINE_MANIFEST.opencode.version, connection: 'not-verified' as const, ready: false as const,
+    }),
+    'codeMode:removeOpenCodeEngine': async () => {
+      try {
+        stopOpenCodeLogin();
+        openCodeSetup.stop();
+        openCodeProcesses.stopAll();
+        await removeOpenCodeEngine();
+        return { success: true };
+      } catch {
+        return { success: false, error: 'Could not remove OpenCode. Close running engine processes and retry.' };
+      }
+    },
     'codeMode:provisionEngine': async (_event, args) => {
       // Download + install the agent's engine, streaming progress back to the
       // requesting window so Settings can show a live bar. 'check' is instant — skip it.
       try {
         await ensureEngine(args.agent, {
           onProgress: (p) => {
-            if (p.phase === 'check') return;
+            if (p.phase === 'check' || _event.sender.isDestroyed()) return;
             _event.sender.send('codeMode:engineProgress', {
               agent: args.agent,
               phase: p.phase,
@@ -1791,7 +1812,7 @@ export function setupIpcHandlers() {
     },
     'codeMode:listModelOptions': async (_event, args) => {
       const manager = container.resolve<CodeModeManager>('codeModeManager');
-      return manager.listModelOptions(args.agent);
+      return manager.listModelOptions(args.agent, args.cwd, args.model, args.effort, args.mode, false);
     },
     'codeSession:setDone': async (_event, args) => {
       const service = container.resolve<CodeSessionService>('codeSessionService');

--- a/apps/x/apps/main/src/main.ts
+++ b/apps/x/apps/main/src/main.ts
@@ -50,6 +50,10 @@ import container, { registerBrowserControlService, registerNotificationService, 
 import { forwardRpc } from "./rpc-forwarder.js";
 import { bounceAllLive, getClient as getSpaceClient } from "@x/core/dist/spaces/orgs.js";
 import type { CodeModeManager } from "@x/core/dist/code-mode/acp/manager.js";
+import { openCodeProcesses } from '@x/core/dist/code-mode/acp/opencode-process.js';
+import { openCodeSetup } from '@x/core/dist/code-mode/acp/opencode-setup.js';
+import { stopOpenCodeLogin } from '@x/core/dist/code-mode/acp/opencode-login.js';
+import { cancelEngineInstallations } from '@x/core/dist/code-mode/acp/engine-provisioner.js';
 import type { ISessions } from "@x/core/dist/runtime/sessions/index.js";
 import { browserViewManager, BROWSER_PARTITION } from "./browser/view.js";
 import { setupBrowserEventForwarding } from "./browser/ipc.js";
@@ -820,6 +824,10 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  cancelEngineInstallations();
+  stopOpenCodeLogin();
+  openCodeSetup.stop();
+  openCodeProcesses.stopAll();
   // Clean up watcher on app quit
   stopWorkspaceWatcher();
   stopRunsWatcher();

--- a/apps/x/apps/main/src/opencode-setup-ipc.ts
+++ b/apps/x/apps/main/src/opencode-setup-ipc.ts
@@ -37,8 +37,8 @@ export const openCodeSetupHandlers = {
         const auth = await openCodeSetup.authorize(args.setupId, args.providerId, args.method, args.inputs);
         try { await shell.openExternal(auth.url); }
         catch { openCodeSetup.cancel(args.setupId); throw new SetupError('failed', 'Could not open the browser. Retry sign-in or use the managed login flow.'); }
-        const { url: _url, ...safe } = auth;
-        return safe;
+        const { attemptId, method, instructions, expiresAt } = auth;
+        return { attemptId, method, instructions, expiresAt };
     }),
     'opencodeSetup:complete': async (_event: IpcMainInvokeEvent, args: Setup & { attemptId: string; code?: string }) => result(() => openCodeSetup.complete(args.setupId, args.attemptId, args.code)),
     'opencodeSetup:cancel': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => { openCodeSetup.cancel(args.setupId); return null; }),

--- a/apps/x/apps/main/src/opencode-setup-ipc.ts
+++ b/apps/x/apps/main/src/opencode-setup-ipc.ts
@@ -1,0 +1,51 @@
+import { shell, type IpcMainInvokeEvent } from 'electron';
+import { openCodeSetup, safeSetupError, SetupError } from '@x/core/dist/code-mode/acp/opencode-setup.js';
+import { startOpenCodeLogin, stopOpenCodeLogin, readOpenCodeLogin, writeOpenCodeLogin } from '@x/core/dist/code-mode/acp/opencode-login.js';
+
+async function result<T>(work: () => T | Promise<T>) {
+    try { return { success: true as const, data: await work() }; }
+    catch (error) { return { success: false as const, error: safeSetupError(error) }; }
+}
+const owners = new Map<number, string>();
+const watched = new Set<number>();
+type Setup = { setupId: string };
+
+export const openCodeSetupHandlers = {
+    'opencodeSetup:openAccount': async () => result(async () => { await shell.openExternal('https://opencode.ai/auth'); return null; }),
+    'opencodeSetup:start': async (event: IpcMainInvokeEvent) => result(async () => {
+        const owner = event.sender.id;
+        if (!watched.has(owner)) {
+            watched.add(owner);
+            event.sender.once('destroyed', () => {
+                const id = owners.get(owner); if (id) stopOpenCodeLogin(id);
+                openCodeSetup.stopOwner(String(owner)); owners.delete(owner); watched.delete(owner);
+            });
+        }
+        const state = await openCodeSetup.start(String(owner)); owners.set(owner, state.setupId); return state;
+    }),
+    'opencodeSetup:stop': async (event: IpcMainInvokeEvent, args: { setupId?: string }) => {
+        const id = args.setupId ?? owners.get(event.sender.id);
+        if (id) { stopOpenCodeLogin(id); openCodeSetup.stop(id); }
+        else openCodeSetup.stopOwner(String(event.sender.id));
+        if (!args.setupId || owners.get(event.sender.id) === args.setupId) owners.delete(event.sender.id);
+        return { success: true as const, data: null };
+    },
+    'opencodeSetup:refresh': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => openCodeSetup.refresh(args.setupId)),
+    'opencodeSetup:saveKey': async (_event: IpcMainInvokeEvent, args: Setup & { providerId: string; method: number; key: string }) => result(() => openCodeSetup.saveKey(args.setupId, args.providerId, args.method, args.key)),
+    'opencodeSetup:disconnect': async (_event: IpcMainInvokeEvent, args: Setup & { providerId: string }) => result(() => openCodeSetup.disconnect(args.setupId, args.providerId)),
+    'opencodeSetup:authorize': async (_event: IpcMainInvokeEvent, args: Setup & { providerId: string; method: number; inputs: Record<string, string> }) => result(async () => {
+        const auth = await openCodeSetup.authorize(args.setupId, args.providerId, args.method, args.inputs);
+        try { await shell.openExternal(auth.url); }
+        catch { openCodeSetup.cancel(args.setupId); throw new SetupError('failed', 'Could not open the browser. Retry sign-in or use the managed login flow.'); }
+        const { url: _url, ...safe } = auth;
+        return safe;
+    }),
+    'opencodeSetup:complete': async (_event: IpcMainInvokeEvent, args: Setup & { attemptId: string; code?: string }) => result(() => openCodeSetup.complete(args.setupId, args.attemptId, args.code)),
+    'opencodeSetup:cancel': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => { openCodeSetup.cancel(args.setupId); return null; }),
+    'opencodeSetup:select': async (_event: IpcMainInvokeEvent, args: Setup & { providerId: string; modelId: string }) => result(() => openCodeSetup.select(args.setupId, args.providerId, args.modelId)),
+    'opencodeSetup:verify': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => openCodeSetup.verify(args.setupId)),
+    'opencodeSetup:loginStart': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => { startOpenCodeLogin(args.setupId); return null; }),
+    'opencodeSetup:loginRead': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => readOpenCodeLogin(args.setupId)),
+    'opencodeSetup:loginInput': async (_event: IpcMainInvokeEvent, args: Setup & { input: string }) => result(() => { writeOpenCodeLogin(args.setupId, args.input); return null; }),
+    'opencodeSetup:loginStop': async (_event: IpcMainInvokeEvent, args: Setup) => result(() => { stopOpenCodeLogin(args.setupId); return null; }),
+};

--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1563,11 +1563,11 @@ function App() {
     })
   }, [voice, cancelPttForSteal])
 
-  const handlePromptSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => Promise<void>) | null>(null)
+  const handlePromptSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex' | 'opencode', permissionMode?: PermissionMode) => Promise<void>) | null>(null)
   // Companion sends (bar submits, call utterances) — filled once
   // handleHoverSubmit exists; early callers (startCall's PTT callback) fire
   // at event time, long after render.
-  const handleHoverSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => Promise<void>) | null>(null)
+  const handleHoverSubmitRef = useRef<((message: PromptInputMessage, mentions?: FileMention[], stagedAttachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex' | 'opencode', permissionMode?: PermissionMode) => Promise<void>) | null>(null)
   // Late-bound handle to bindChatToRun (declared with the chat plumbing far
   // below) for early-declared effects like quick-ask open-chat.
   const bindChatToRunRef = useRef<((rid: string) => void) | null>(null)
@@ -2407,7 +2407,7 @@ function App() {
     mentions?: FileMention[],
     stagedAttachments: StagedAttachment[] = [],
     searchEnabled?: boolean,
-    codeMode?: 'claude' | 'codex',
+    codeMode?: 'claude' | 'codex' | 'opencode',
     permissionMode?: PermissionMode,
   ) => {
     const userMessage = message.text.trim()
@@ -2816,7 +2816,7 @@ function App() {
   // Composer locks for runs that are code sessions: the session's cwd + agent
   // are frozen in the chat input (the backend pins them server-side anyway).
   // Kept after the Code view unmounts — the chat stays bound to the session.
-  const [codeSessionLocks, setCodeSessionLocks] = useState<Record<string, { cwd: string; agent: 'claude' | 'codex' }>>({})
+  const [codeSessionLocks, setCodeSessionLocks] = useState<Record<string, { cwd: string; agent: 'claude' | 'codex' | 'opencode' }>>({})
   const codeSessionLocksRef = useRef(codeSessionLocks)
   codeSessionLocksRef.current = codeSessionLocks
   // Undo/redo handlers of the (single) mounted markdown editor.
@@ -4198,7 +4198,7 @@ function App() {
     mentions?: FileMention[],
     stagedAttachments: StagedAttachment[] = [],
     searchEnabled?: boolean,
-    codeMode?: 'claude' | 'codex',
+    codeMode?: 'claude' | 'codex' | 'opencode',
     permissionMode?: PermissionMode,
   ) => {
     const submitTabId = activeChatTabIdRef.current
@@ -5111,7 +5111,7 @@ function App() {
     mentions?: FileMention[]
     attachments: StagedAttachment[]
     searchEnabled?: boolean
-    codeMode?: 'claude' | 'codex'
+    codeMode?: 'claude' | 'codex' | 'opencode'
     permissionMode?: PermissionMode
   } | null>(null)
 
@@ -5120,7 +5120,7 @@ function App() {
     mentions?: FileMention[],
     stagedAttachments: StagedAttachment[] = [],
     searchEnabled?: boolean,
-    codeMode?: 'claude' | 'codex',
+    codeMode?: 'claude' | 'codex' | 'opencode',
     permissionMode?: PermissionMode,
   ) => {
     const text = message.text?.trim() ?? ''

--- a/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
+++ b/apps/x/apps/renderer/src/components/chat-input-with-mentions.tsx
@@ -212,7 +212,7 @@ const CALL_PRESET_MENU: Array<{ preset: CallPreset; label: string; description: 
 
 interface ChatInputInnerProps {
   draftKey?: string
-  onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
+  onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex' | 'opencode', permissionMode?: PermissionMode) => void
   onStop?: () => void
   isProcessing: boolean
   /**
@@ -273,7 +273,7 @@ interface ChatInputInnerProps {
    * and coding agent come from the session and are FROZEN — the backend pins
    * them server-side regardless, so the composer must not pretend otherwise.
    */
-  codeSessionLock?: { cwd: string; agent: 'claude' | 'codex' } | null
+  codeSessionLock?: { cwd: string; agent: 'claude' | 'codex' | 'opencode' } | null
   contextChip?: { label: string; icon?: 'todo' | 'reply'; quote?: string; onDismiss: () => void }
   placeholder?: string
   focusSignal?: number
@@ -342,11 +342,11 @@ function ChatInputInner({
   // tab's prior selection when the caller has one, else seeded once from the
   // settings pair when the catalog loads; thereafter it changes only on
   // picker interactions. null only before the seed resolves.
-  const [selection, setSelection] = useState<ModelSelection | null>(initialSelection)
+  const [selection, setSelection] = useState<ModelSelection | null>(initialSelection?.provider === 'rowboat-internal' ? null : initialSelection)
   const [lockedModel, setLockedModel] = useState<SelectedModel | null>(null)
   const [searchEnabled, setSearchEnabled] = useState(false)
   const [searchAvailable, setSearchAvailable] = useState(false)
-  const [codingAgent, setCodingAgent] = useState<'claude' | 'codex'>('claude')
+  const [codingAgent, setCodingAgent] = useState<'claude' | 'codex' | 'opencode'>('claude')
   const [codeModeEnabled, setCodeModeEnabled] = useState(false)
   const [codeModeFeatureEnabled, setCodeModeFeatureEnabled] = useState(false)
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('auto')
@@ -468,27 +468,27 @@ function ChatInputInner({
   }, [])
 
   // Load coding-agent preference for a given workdir.
-  // Storage: config/coding-agents.json — { [workDirPath]: 'claude' | 'codex' }
-  const loadCodingAgentFor = useCallback(async (dir: string | null): Promise<'claude' | 'codex'> => {
+  // Storage: config/coding-agents.json — { [workDirPath]: 'claude' | 'codex' | 'opencode' }
+  const loadCodingAgentFor = useCallback(async (dir: string | null): Promise<'claude' | 'codex' | 'opencode'> => {
     if (!dir) return 'claude'
     try {
       const result = await window.ipc.invoke('workspace:readFile', { path: 'config/coding-agents.json' })
       const parsed = JSON.parse(result.data) as Record<string, unknown>
       const value = parsed?.[dir]
-      if (value === 'codex' || value === 'claude') return value
+      if (value === 'codex' || value === 'claude' || value === 'opencode') return value
     } catch {
       /* file missing or invalid — fall through to default */
     }
     return 'claude'
   }, [])
 
-  const persistCodingAgent = useCallback(async (dir: string, agent: 'claude' | 'codex') => {
-    const existing: Record<string, 'claude' | 'codex'> = {}
+  const persistCodingAgent = useCallback(async (dir: string, agent: 'claude' | 'codex' | 'opencode') => {
+    const existing: Record<string, 'claude' | 'codex' | 'opencode'> = {}
     try {
       const result = await window.ipc.invoke('workspace:readFile', { path: 'config/coding-agents.json' })
       const parsed = JSON.parse(result.data) as Record<string, unknown>
       for (const [k, v] of Object.entries(parsed ?? {})) {
-        if (v === 'claude' || v === 'codex') existing[k] = v
+        if (v === 'claude' || v === 'codex' || v === 'opencode') existing[k] = v
       }
     } catch { /* start fresh */ }
     existing[dir] = agent
@@ -569,7 +569,7 @@ function ChatInputInner({
 
   const handleToggleCodingAgent = useCallback(async () => {
     if (isCodeLocked) return
-    const next: 'claude' | 'codex' = codingAgent === 'claude' ? 'codex' : 'claude'
+    const next: 'claude' | 'codex' | 'opencode' = codingAgent === 'claude' ? 'codex' : codingAgent === 'codex' ? 'opencode' : 'claude'
     setCodingAgent(next)
     // Persist only when scoped to a workdir; without one there's nothing to key on.
     if (!workDir) return
@@ -625,7 +625,7 @@ function ChatInputInner({
     if (selection !== null) return
     if (runId) {
       if (restoredSelection === undefined) return
-      if (restoredSelection) {
+      if (restoredSelection && restoredSelection.provider !== 'rowboat-internal') {
         setSelection(restoredSelection)
         onSelectionChange?.(restoredSelection)
         return
@@ -1151,8 +1151,8 @@ function ChatInputInner({
               </TooltipTrigger>
               <TooltipContent side="top">
                 {isCodeLocked
-                  ? `Coding session — ${codingAgent === 'claude' ? 'Claude Code' : 'Codex'}`
-                  : `Code mode on (${codingAgent === 'claude' ? 'Claude Code' : 'Codex'}) — click to disable`}
+                  ? `Coding session — ${codingAgent === 'claude' ? 'Claude Code' : codingAgent === 'codex' ? 'Codex' : 'OpenCode'}`
+                  : `Code mode on (${codingAgent === 'claude' ? 'Claude Code' : codingAgent === 'codex' ? 'Codex' : 'OpenCode'}) — click to disable`}
               </TooltipContent>
             </Tooltip>
           ) : (
@@ -1188,13 +1188,13 @@ function ChatInputInner({
                       isCodeLocked ? "cursor-default" : "hover:bg-secondary/70",
                     )}
                   >
-                    <span>{codingAgent === 'claude' ? 'Claude' : 'Codex'}</span>
+                    <span>{codingAgent === 'claude' ? 'Claude' : codingAgent === 'codex' ? 'Codex' : 'OpenCode'}</span>
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">
                   {isCodeLocked
-                    ? `Coding agent fixed by the session: ${codingAgent === 'claude' ? 'Claude Code' : 'Codex'}`
-                    : `Coding agent: ${codingAgent === 'claude' ? 'Claude Code' : 'Codex'} — click to swap`}
+                    ? `Coding agent fixed by the session: ${codingAgent === 'claude' ? 'Claude Code' : codingAgent === 'codex' ? 'Codex' : 'OpenCode'}`
+                    : `Coding agent: ${codingAgent === 'claude' ? 'Claude Code' : codingAgent === 'codex' ? 'Codex' : 'OpenCode'} — click to swap`}
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -1271,7 +1271,7 @@ function ChatInputInner({
                     <DropdownMenuItem disabled={isCodeLocked} onSelect={(e) => { e.preventDefault(); handleToggleCodingAgent() }}>
                       <Terminal className="size-4" />
                       <span className="min-w-0 flex-1">Coding agent</span>
-                      <span className="text-xs text-muted-foreground">{codingAgent === 'claude' ? 'Claude' : 'Codex'}</span>
+                      <span className="text-xs text-muted-foreground">{codingAgent === 'claude' ? 'Claude' : codingAgent === 'codex' ? 'Codex' : 'OpenCode'}</span>
                     </DropdownMenuItem>
                   )}
                 </>
@@ -1508,7 +1508,7 @@ export interface ChatInputWithMentionsProps {
   knowledgeFiles: string[]
   recentFiles: string[]
   visibleFiles: string[]
-  onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
+  onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex' | 'opencode', permissionMode?: PermissionMode) => void
   onStop?: () => void
   isProcessing: boolean
   /** Let Enter submit while processing (queue/steer) — see ChatInputInner. */
@@ -1542,7 +1542,7 @@ export interface ChatInputWithMentionsProps {
   workDir?: string | null
   onWorkDirChange?: (value: string | null) => void
   /** Set when this chat is bound to a Code-section session — freezes workdir + agent. */
-  codeSessionLock?: { cwd: string; agent: 'claude' | 'codex' } | null
+  codeSessionLock?: { cwd: string; agent: 'claude' | 'codex' | 'opencode' } | null
   /** Destination chip: the composer is visibly writing somewhere other than
    * the chat (e.g. "To-do"). Rendered above the input with a dismiss ✕;
    * Escape also dismisses. */

--- a/apps/x/apps/renderer/src/components/chat-session.tsx
+++ b/apps/x/apps/renderer/src/components/chat-session.tsx
@@ -266,7 +266,7 @@ export interface ChatSessionComposerProps {
     mentions?: FileMention[],
     stagedAttachments?: StagedAttachment[],
     searchEnabled?: boolean,
-    codeMode?: 'claude' | 'codex',
+    codeMode?: 'claude' | 'codex' | 'opencode',
     permissionMode?: PermissionMode,
   ) => void | Promise<void>
   onStop?: () => void | Promise<void>
@@ -284,7 +284,7 @@ export interface ChatSessionComposerProps {
   onPullQueued?: (queueId: string) => void
   presetMessage: string | undefined
   onPresetMessageConsumed: () => void
-  codeSessionLocks: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
+  codeSessionLocks: Record<string, { cwd: string; agent: 'claude' | 'codex' | 'opencode' }>
   initialDraft: string | undefined
   onDraftChange: (tabId: string, text: string) => void
   /**

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -92,7 +92,7 @@ interface ChatSidebarProps {
   isWaitingOnHuman?: boolean
   isStopping?: boolean
   onStop?: () => void
-  onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex', permissionMode?: PermissionMode) => void
+  onSubmit: (message: PromptInputMessage, mentions?: FileMention[], attachments?: StagedAttachment[], searchEnabled?: boolean, codeMode?: 'claude' | 'codex' | 'opencode', permissionMode?: PermissionMode) => void
   /** Pending-queue mirror for the ACTIVE tab's session (single store — see App). */
   queuedForActive?: QueuedSessionMessage[]
   onRemoveQueued?: (queueId: string) => void
@@ -111,7 +111,7 @@ interface ChatSidebarProps {
   restoredSelectionForActive?: ModelSelection | null
   workDirByTab?: Record<string, string | null>
   /** Composer locks for runs bound to Code-section sessions (cwd + agent frozen). */
-  codeSessionLocks?: Record<string, { cwd: string; agent: 'claude' | 'codex' }>
+  codeSessionLocks?: Record<string, { cwd: string; agent: 'claude' | 'codex' | 'opencode' }>
   /**
    * Set while a Rowboat-mode code session owns this pane: the chat is pinned to
    * the session, so the chat switcher / new-chat / history affordances hide.

--- a/apps/x/apps/renderer/src/components/code/code-agent-options.ts
+++ b/apps/x/apps/renderer/src/components/code/code-agent-options.ts
@@ -9,7 +9,8 @@ import type { CodeAgentModelOptions, CodeAgentOption } from '@x/shared/src/code-
 const EMPTY: CodeAgentModelOptions = { models: [], efforts: [] }
 const cache = new Map<CodingAgent, Promise<CodeAgentModelOptions>>()
 
-export function fetchCodeAgentOptions(agent: CodingAgent): Promise<CodeAgentModelOptions> {
+export function fetchCodeAgentOptions(agent: CodingAgent, cwd?: string, model?: string, mode?: string): Promise<CodeAgentModelOptions> {
+  if (agent === 'opencode') return window.ipc.invoke('codeMode:listModelOptions', { agent, cwd, model, mode })
   let pending = cache.get(agent)
   if (!pending) {
     pending = window.ipc.invoke('codeMode:listModelOptions', { agent }).catch(() => EMPTY)

--- a/apps/x/apps/renderer/src/components/code/code-agent-status.ts
+++ b/apps/x/apps/renderer/src/components/code/code-agent-status.ts
@@ -1,9 +1,9 @@
-import type { CodingAgent } from '@x/shared/src/code-mode.js'
+import { CODING_AGENT_CAPABILITIES, type EnabledCodingAgent as CodingAgent } from '@x/shared/src/code-mode.js'
 
 export type CodeAgentStatus = { installed: boolean; signedIn: boolean }
 export type CodeAgentsStatus = Record<CodingAgent, CodeAgentStatus>
 
-export const AGENT_LABEL: Record<CodingAgent, string> = { claude: 'Claude Code', codex: 'Codex' }
+export const AGENT_LABEL: Record<CodingAgent, string> = { claude: CODING_AGENT_CAPABILITIES.claude.name, codex: CODING_AGENT_CAPABILITIES.codex.name, opencode: CODING_AGENT_CAPABILITIES.opencode.name }
 
 // Which coding agents are installed and signed in. The probe touches the
 // shell and keychain, so it's cached briefly: the Code view warms it on
@@ -11,11 +11,13 @@ export const AGENT_LABEL: Record<CodingAgent, string> = { claude: 'Claude Code',
 // the click.
 const TTL_MS = 60_000
 let cached: { at: number; value: Promise<CodeAgentsStatus> } | null = null
+if (typeof window !== 'undefined') window.addEventListener('opencode-configuration-changed', () => { cached = null })
 
 export function fetchCodeAgentsStatus(opts?: { fresh?: boolean }): Promise<CodeAgentsStatus> {
   const now = Date.now()
   if (!opts?.fresh && cached && now - cached.at < TTL_MS) return cached.value
   const value = window.ipc.invoke('codeMode:checkAgentStatus', null).then((s) => ({
+    opencode: { installed: s.opencode?.installed ?? false, signedIn: s.opencode?.signedIn ?? false },
     claude: { installed: s.claude.installed, signedIn: s.claude.signedIn },
     codex: { installed: s.codex.installed, signedIn: s.codex.signedIn },
   }))
@@ -26,5 +28,5 @@ export function fetchCodeAgentsStatus(opts?: { fresh?: boolean }): Promise<CodeA
 
 export function isAgentReady(status: CodeAgentsStatus | null | undefined, agent: CodingAgent): boolean {
   const s = status?.[agent]
-  return Boolean(s && s.installed && s.signedIn)
+  return Boolean(s && s.installed && (agent === 'opencode' || s.signedIn))
 }

--- a/apps/x/apps/renderer/src/components/code/code-session-header.test.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-session-header.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import type { CodeSession } from '@x/shared/src/code-sessions.js'
+import { CodeSessionHeader } from './code-session-header'
+import { fetchCodeAgentOptions } from './code-agent-options'
+import { refreshCodeSessions } from './use-code-sessions'
+import { toast } from 'sonner'
+
+vi.mock('./code-agent-options', async importOriginal => ({
+  ...await importOriginal<typeof import('./code-agent-options')>(),
+  fetchCodeAgentOptions: vi.fn(),
+}))
+vi.mock('./use-code-sessions', () => ({ refreshCodeSessions: vi.fn() }))
+vi.mock('./code-agent-status', () => ({ AGENT_LABEL: { opencode: 'OpenCode' }, fetchCodeAgentsStatus: async () => null, isAgentReady: () => true }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+const session: CodeSession = { id: 'session', projectId: 'project', title: 'Example', agent: 'opencode', cwd: '/project with spaces', createdAt: '2026-09-11T00:00:00Z', agentModel: 'opencode/free' }
+const options = { models: [{ value: 'opencode/free', label: 'Free model' }, { value: 'opencode-go/model', label: 'Go model' }], efforts: [], currentModel: 'opencode/free' }
+let invoke: ReturnType<typeof vi.fn>
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(fetchCodeAgentOptions).mockResolvedValue(options)
+  invoke = vi.fn().mockResolvedValue(session)
+  Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+})
+afterEach(cleanup)
+function setup(status: 'idle' | 'working' = 'idle') {
+  return render(<CodeSessionHeader session={session} status={status} changedCount={0} panel={null} onTogglePanel={vi.fn()} />)
+}
+function openModels() {
+  fireEvent.keyDown(screen.getByRole('button', { name: 'Choose coding model' }), { key: 'ArrowDown' })
+}
+
+it('exposes the native model picker directly and persists the qualified selection', async () => {
+  setup()
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Choose coding model' })).toHaveTextContent('Free model'))
+  expect(fetchCodeAgentOptions).toHaveBeenCalledWith('opencode', session.cwd, session.agentModel, undefined)
+  openModels()
+  fireEvent.click(await screen.findByRole('menuitemradio', { name: 'Go model' }))
+  await waitFor(() => expect(invoke).toHaveBeenCalledWith('codeSession:update', { sessionId: 'session', patch: { agentModel: 'opencode-go/model' } }))
+  expect(refreshCodeSessions).toHaveBeenCalled()
+})
+
+it('shows loading, reports discovery failure and retries in the same picker', async () => {
+  let reject!: (error: Error) => void
+  vi.mocked(fetchCodeAgentOptions).mockImplementationOnce(() => new Promise((_resolve, fail) => { reject = fail }))
+  setup()
+  openModels()
+  expect(await screen.findByRole('status')).toHaveTextContent('Loading models')
+  reject(new Error('Engine unavailable'))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Engine unavailable')
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Refresh models' }))
+  expect(await screen.findByRole('menuitemradio', { name: 'Go model' })).toBeTruthy()
+})
+
+it('does not claim that a rejected model change succeeded', async () => {
+  invoke.mockRejectedValue(new Error('Model unavailable'))
+  setup()
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Choose coding model' })).toHaveTextContent('Free model'))
+  openModels()
+  fireEvent.click(await screen.findByRole('menuitemradio', { name: 'Go model' }))
+  await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Model unavailable'))
+  expect(refreshCodeSessions).not.toHaveBeenCalled()
+  expect(screen.getByRole('button', { name: 'Choose coding model' })).toHaveTextContent('Free model')
+})
+
+it('shows models while working but prevents changing them mid-operation', async () => {
+  setup('working')
+  openModels()
+  expect(await screen.findByRole('menuitemradio', { name: 'Go model' })).toHaveAttribute('aria-disabled', 'true')
+  expect(screen.getByText('Stop the current operation before changing models.')).toBeTruthy()
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+
+it('shows a Go/Zen switch for dual connections and only the chosen service models', async () => {
+  vi.mocked(fetchCodeAgentOptions).mockResolvedValue({ ...options, openCodeProviders: ['zen', 'go'] })
+  setup()
+  openModels()
+  expect(await screen.findByRole('group', { name: 'OpenCode service' })).toBeTruthy()
+  expect(screen.getByRole('menuitemradio', { name: 'Free model' })).toBeTruthy()
+  expect(screen.queryByRole('menuitemradio', { name: 'Go model' })).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Go' }))
+  expect(screen.getByRole('menuitemradio', { name: 'Go model' })).toBeTruthy()
+  expect(screen.queryByRole('menuitemradio', { name: 'Free model' })).toBeNull()
+  // Browsing a service alone must not silently change the selected coding model.
+  expect(invoke).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('menuitemradio', { name: 'Go model' }))
+  await waitFor(() => expect(invoke).toHaveBeenCalledWith('codeSession:update', { sessionId: 'session', patch: { agentModel: 'opencode-go/model' } }))
+})
+
+it('refreshes from Go-only to public free options on account disconnect', async () => {
+  vi.mocked(fetchCodeAgentOptions).mockResolvedValueOnce({ ...options, models: [options.models[1]], openCodeProviders: ['go'] })
+  setup()
+  openModels()
+  expect(await screen.findByText('Go subscription models')).toBeTruthy()
+  expect(screen.queryByRole('group', { name: 'OpenCode service' })).toBeNull()
+  expect(screen.queryByRole('menuitemradio', { name: 'Free model' })).toBeNull()
+  vi.mocked(fetchCodeAgentOptions).mockResolvedValue({ ...options, models: [options.models[0]], openCodeProviders: ['free'] })
+  fireEvent(window, new Event('opencode-configuration-changed'))
+  expect(await screen.findByText(/Free models.*no OpenCode account/)).toBeTruthy()
+  expect(screen.getByRole('menuitemradio', { name: 'Free model' })).toBeTruthy()
+  expect(screen.queryByRole('menuitemradio', { name: 'Go model' })).toBeNull()
+})

--- a/apps/x/apps/renderer/src/components/code/code-session-header.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-session-header.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Check, ChevronDown, Copy, GitBranch, RotateCcw, SlidersHorizontal } from 'lucide-react'
 import type { CodeSession, CodeSessionStatus, CodeAgentModelOptions } from '@x/shared/src/code-sessions.js'
-import type { ApprovalPolicy, CodingAgent } from '@x/shared/src/code-mode.js'
+import type { ApprovalPolicy, EnabledCodingAgent as CodingAgent } from '@x/shared/src/code-mode.js'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -39,7 +39,7 @@ export interface CodeSessionHeaderProps {
   onTogglePanel: (panel: CodePanel) => void
 }
 
-type SessionPatch = { agent?: CodingAgent; policy?: ApprovalPolicy; agentModel?: string; agentEffort?: string }
+type SessionPatch = { agent?: CodingAgent; policy?: ApprovalPolicy; agentModel?: string; agentEffort?: string; agentMode?: string }
 
 function StatusPill({ status }: { status: CodeSessionStatus }) {
   if (status === 'idle') return null
@@ -102,29 +102,47 @@ function WorktreeChip({ branch, path }: { branch: string; path: string }) {
 
 // Header of the chat while it is bound to a coding session — the chat is the
 // main surface, so this is where the session lives: its title and branch,
-// the agent's model / effort / approvals in one menu, and the doors to the
+// a visible model picker, additional session settings, and the doors to the
 // workspace drawer (changes, files, terminal).
 export function CodeSessionHeader({ session, status, changedCount, panel, onTogglePanel }: CodeSessionHeaderProps) {
   const [modelOpts, setModelOpts] = useState<CodeAgentModelOptions>({ models: [], efforts: [] })
+  const [optionsError, setOptionsError] = useState<string>()
+  const [optionsLoading, setOptionsLoading] = useState(true)
+  const [updating, setUpdating] = useState(false)
+  const [openCodeGroup, setOpenCodeGroup] = useState<'go' | 'zen'>()
+  useEffect(() => { setOpenCodeGroup(undefined) }, [session.id])
+  const [refreshOptions, setRefreshOptions] = useState(0)
   useEffect(() => {
     let cancelled = false
-    void fetchCodeAgentOptions(session.agent).then((opts) => { if (!cancelled) setModelOpts(opts) })
+    setModelOpts({ models: [], efforts: [] }); setOptionsError(undefined); setOptionsLoading(true)
+    void fetchCodeAgentOptions(session.agent, session.cwd, session.agentModel, session.agentMode)
+      .then((opts) => { if (!cancelled) { setModelOpts(opts); setOptionsError(opts.selectionError) } })
+      .catch((error: unknown) => { if (!cancelled) setOptionsError(error instanceof Error ? error.message : 'Could not discover model options') })
+      .finally(() => { if (!cancelled) setOptionsLoading(false) })
     return () => { cancelled = true }
-  }, [session.agent])
+  }, [session.agent, session.cwd, session.agentModel, session.agentMode, refreshOptions])
   // Which agents can be switched to (cached probe; null until known).
   const [agentsStatus, setAgentsStatus] = useState<CodeAgentsStatus | null>(null)
   useEffect(() => {
     let cancelled = false
-    fetchCodeAgentsStatus().then((s) => { if (!cancelled) setAgentsStatus(s) }).catch(() => {})
-    return () => { cancelled = true }
+    const refreshStatus = () => {
+      setRefreshOptions(n => n + 1)
+      void fetchCodeAgentsStatus().then((s) => { if (!cancelled) setAgentsStatus(s) }).catch(() => {})
+    }
+    void fetchCodeAgentsStatus().then((s) => { if (!cancelled) setAgentsStatus(s) }).catch(() => {})
+    window.addEventListener('opencode-configuration-changed', refreshStatus)
+    return () => { cancelled = true; window.removeEventListener('opencode-configuration-changed', refreshStatus) }
   }, [])
 
   const update = async (patch: SessionPatch) => {
+    setUpdating(true)
     try {
       await window.ipc.invoke('codeSession:update', { sessionId: session.id, patch })
       await refreshCodeSessions()
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to update session')
+    } finally {
+      setUpdating(false)
     }
   }
 
@@ -137,8 +155,15 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
       toast.error(err instanceof Error ? err.message : 'Failed to update session')
     }
   }
-  const models = withDefault(modelOpts.models)
-  const efforts = withDefault(modelOpts.efforts)
+  const allModels = session.agent === 'opencode' ? modelOpts.models : withDefault(modelOpts.models)
+  const providers = modelOpts.openCodeProviders ?? []
+  const bothServices = session.agent === 'opencode' && providers.includes('go') && providers.includes('zen')
+  const activeGroup = bothServices ? (openCodeGroup ?? (session.agentModel?.startsWith('opencode-go/') ? 'go' : 'zen')) : providers[0]
+  const models = bothServices ? allModels.filter(model => model.value.startsWith(activeGroup === 'go' ? 'opencode-go/' : 'opencode/')) : allModels
+  const efforts = session.agent === 'opencode' ? modelOpts.efforts : withDefault(modelOpts.efforts)
+  const selectedModel = session.agentModel ?? modelOpts.currentModel
+  const modelLabel = selectedModel ? optionLabel(allModels, selectedModel) : 'Choose model'
+  const configurationLocked = updating || status !== 'idle'
 
   return (
     <div className="titlebar-no-drag flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden pl-3 pr-1 @container">
@@ -150,19 +175,45 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
         )}
       </div>
 
-      {/* Session settings: one menu, three choices. */}
       <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" aria-label="Choose coding model" title={modelLabel} className="h-7 min-w-0 max-w-52 shrink gap-1 px-2 text-xs">
+            <span className="shrink-0">Model:</span>
+            <span className="truncate">{updating ? 'Applying...' : optionsLoading ? 'Loading...' : modelLabel}</span>
+            <ChevronDown className="size-3 shrink-0" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="max-h-80 w-72 overflow-y-auto">
+          <DropdownMenuLabel>{AGENT_LABEL[session.agent]} models</DropdownMenuLabel>
+          {bothServices && <div className="flex gap-1 px-2 pb-2" role="group" aria-label="OpenCode service">
+            {(['zen', 'go'] as const).map(group => <Button key={group} size="sm" variant={activeGroup === group ? 'secondary' : 'ghost'} aria-pressed={activeGroup === group} onClick={() => setOpenCodeGroup(group)}>{group === 'go' ? 'Go' : 'Zen'}</Button>)}
+          </div>}
+          {!bothServices && activeGroup && <p className="px-2 pb-1 text-xs text-muted-foreground">{activeGroup === 'free' ? 'Free models — no OpenCode account connected' : activeGroup === 'go' ? 'Go subscription models' : 'Zen models'}</p>}
+          {optionsLoading && <p role="status" className="px-2 py-1 text-xs text-muted-foreground">Loading models from the coding agent...</p>}
+          {optionsError && <p role="alert" className="px-2 py-1 text-xs text-destructive">{optionsError}</p>}
+          {!optionsLoading && !models.length && !optionsError && <p className="px-2 py-1 text-xs text-muted-foreground">No models are available. Refresh to try again.</p>}
+          {configurationLocked && <p className="px-2 py-1 text-xs text-muted-foreground">{updating ? 'Applying your selection...' : 'Stop the current operation before changing models.'}</p>}
+          <DropdownMenuRadioGroup value={selectedModel} onValueChange={value => void update({ agentModel: value })}>
+            {!optionsLoading && models.map(model => <DropdownMenuRadioItem key={model.value} value={model.value} disabled={configurationLocked}>{model.label}</DropdownMenuRadioItem>)}
+          </DropdownMenuRadioGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem disabled={optionsLoading || updating} onSelect={event => { event.preventDefault(); setRefreshOptions(n => n + 1) }}>Refresh models</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Additional session configuration. Models are directly accessible above. */}
+      <DropdownMenu onOpenChange={(open) => { if (open && session.agent === 'opencode') setRefreshOptions(n => n + 1) }}>
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-7 shrink-0 gap-1.5 px-2 text-xs text-muted-foreground">
+              <Button variant="ghost" size="sm" aria-label="Coding session settings" className="h-7 shrink-0 gap-1.5 px-2 text-xs text-muted-foreground">
                 <SlidersHorizontal className="size-3.5" />
                 <span className="hidden @[400px]:inline">{AGENT_LABEL[session.agent] ?? session.agent}</span>
                 <ChevronDown className="size-3" />
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Model, effort and approvals for this session</TooltipContent>
+          <TooltipContent side="bottom">Agent, mode, effort and approvals for this session</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="end" className="w-64">
           <DropdownMenuLabel className="flex flex-col gap-0.5">
@@ -172,6 +223,8 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
             </span>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
+          {optionsError && <p role="alert" className="px-2 py-1 text-xs text-destructive">{optionsError}</p>}
+          {session.agent === 'opencode' && <p className="px-2 py-1 text-xs text-muted-foreground">Approvals apply once. Subagent tasks are unavailable.</p>}
           {/* A quick-created session lands on the last-used agent; switching
               here starts the other engine fresh on the next turn. */}
           <DropdownMenuSub>
@@ -185,7 +238,7 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
                   value={session.agent}
                   onValueChange={(v) => void update({ agent: v as CodingAgent })}
                 >
-                  {(['claude', 'codex'] as CodingAgent[]).map((agent) => (
+                  {(['claude', 'codex', 'opencode'] as CodingAgent[]).map((agent) => (
                     <DropdownMenuRadioItem
                       key={agent}
                       value={agent}
@@ -198,34 +251,27 @@ export function CodeSessionHeader({ session, status, changedCount, panel, onTogg
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>
-          <DropdownMenuSub>
+          {!!modelOpts.modes?.length && <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-              <span className="flex-1">Model</span>
-              <span className="ml-3 truncate text-xs text-muted-foreground">{optionLabel(models, session.agentModel)}</span>
+              <span className="flex-1">Mode</span>
+              <span className="ml-3 text-xs text-muted-foreground">{optionLabel(modelOpts.modes, session.agentMode ?? modelOpts.currentMode)}</span>
             </DropdownMenuSubTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
-                <DropdownMenuRadioGroup
-                  value={session.agentModel ?? 'default'}
-                  onValueChange={(v) => void update({ agentModel: v })}
-                >
-                  {models.map((m) => (
-                    <DropdownMenuRadioItem key={m.value} value={m.value}>{m.label}</DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuSubContent>
-            </DropdownMenuPortal>
-          </DropdownMenuSub>
+            <DropdownMenuPortal><DropdownMenuSubContent>
+              <DropdownMenuRadioGroup value={session.agentMode ?? modelOpts.currentMode} onValueChange={v => void update({ agentMode: v })}>
+                {modelOpts.modes.map(mode => <DropdownMenuRadioItem key={mode.value} value={mode.value}>{mode.label}</DropdownMenuRadioItem>)}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent></DropdownMenuPortal>
+          </DropdownMenuSub>}
           {modelOpts.efforts.length > 0 && (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <span className="flex-1">Effort</span>
-                <span className="ml-3 truncate text-xs text-muted-foreground">{optionLabel(efforts, session.agentEffort)}</span>
+                <span className="ml-3 truncate text-xs text-muted-foreground">{optionLabel(efforts, session.agentEffort ?? modelOpts.currentEffort)}</span>
               </DropdownMenuSubTrigger>
               <DropdownMenuPortal>
                 <DropdownMenuSubContent>
                   <DropdownMenuRadioGroup
-                    value={session.agentEffort ?? 'default'}
+                    value={session.agentEffort ?? modelOpts.currentEffort ?? 'default'}
                     onValueChange={(v) => void update({ agentEffort: v })}
                   >
                     {efforts.map((e) => (

--- a/apps/x/apps/renderer/src/components/code/code-view.tsx
+++ b/apps/x/apps/renderer/src/components/code/code-view.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Code2, Plus } from 'lucide-react'
 import { codeWorkspaceKey, type CodeSession, type CodeSessionStatus } from '@x/shared/src/code-sessions.js'
-import type { CodingAgent } from '@x/shared/src/code-mode.js'
+import type { EnabledCodingAgent as CodingAgent } from '@x/shared/src/code-mode.js'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
@@ -69,8 +69,10 @@ export function CodeView({
   const [agentsStatus, setAgentsStatus] = useState<CodeAgentsStatus | null>(null)
   useEffect(() => {
     let cancelled = false
-    fetchCodeAgentsStatus().then((s) => { if (!cancelled) setAgentsStatus(s) }).catch(() => {})
-    return () => { cancelled = true }
+    const refreshStatus = () => { void fetchCodeAgentsStatus().then((s) => { if (!cancelled) setAgentsStatus(s) }).catch(() => {}) }
+    refreshStatus()
+    window.addEventListener('opencode-configuration-changed', refreshStatus)
+    return () => { cancelled = true; window.removeEventListener('opencode-configuration-changed', refreshStatus) }
   }, [])
 
   useEffect(() => {
@@ -122,8 +124,8 @@ export function CodeView({
         agent = lastUsed ?? 'claude'
       } else if (lastUsed && ready(lastUsed)) {
         agent = lastUsed
-      } else if (ready('claude') || ready('codex')) {
-        agent = ready('claude') ? 'claude' : 'codex'
+      } else if (ready('claude') || ready('codex') || ready('opencode')) {
+        agent = ready('claude') ? 'claude' : ready('codex') ? 'codex' : 'opencode'
       } else {
         throw new Error('No coding agent is ready — sign in to Claude Code or Codex in Settings.')
       }

--- a/apps/x/apps/renderer/src/components/code/session-rail.test.tsx
+++ b/apps/x/apps/renderer/src/components/code/session-rail.test.tsx
@@ -16,6 +16,7 @@ const session: CodeSession = {
   cwd: '/Example', createdAt: '2026-09-08T00:00:00Z',
 }
 const ready: CodeAgentsStatus = {
+  opencode: { installed: true, signedIn: true },
   claude: { installed: true, signedIn: true },
   codex: { installed: true, signedIn: true },
 }
@@ -66,7 +67,7 @@ describe('code rail context menus', () => {
   })
 
   it.each([
-    ['New worktree', undefined], ['New Claude Code worktree', 'claude'], ['New Codex worktree', 'codex'],
+    ['New worktree', undefined], ['New Claude Code worktree', 'claude'], ['New Codex worktree', 'codex'], ['New OpenCode worktree', 'opencode'],
   ] as const)('creates %s in the clicked project without collapsing it', (name, agent) => {
     const { onNewSession } = setup()
     openProjectMenu()
@@ -77,6 +78,7 @@ describe('code rail context menus', () => {
 
   it('disables agents that are missing or signed out', () => {
     const { onNewSession } = setup(false, {
+      opencode: { installed: true, signedIn: false },
       claude: { installed: false, signedIn: false },
       codex: { installed: true, signedIn: false },
     })
@@ -87,6 +89,8 @@ describe('code rail context menus', () => {
       fireEvent.click(item)
     }
     expect(onNewSession).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('menuitem', { name: 'New OpenCode worktree' }))
+    expect(onNewSession).toHaveBeenCalledWith('project', 'opencode')
   })
 
   it('keeps explicit agent choices enabled while status is loading', () => {

--- a/apps/x/apps/renderer/src/components/code/session-rail.tsx
+++ b/apps/x/apps/renderer/src/components/code/session-rail.tsx
@@ -13,7 +13,7 @@ import {
   Trash2,
 } from 'lucide-react'
 import { codeWorkspaceKey, type CodeSession, type CodeSessionStatus } from '@x/shared/src/code-sessions.js'
-import type { CodingAgent } from '@x/shared/src/code-mode.js'
+import type { EnabledCodingAgent as CodingAgent } from '@x/shared/src/code-mode.js'
 import { cn, compactPath, parentPath } from '@/lib/utils'
 import { formatRelativeTime } from '@/lib/relative-time'
 import { SecondaryRail } from '@/components/secondary-rail'
@@ -84,7 +84,7 @@ function ProjectMenuItems({ context = false, projectId, agentsStatus, onNewSessi
       <Item onSelect={() => onNewSession(projectId)}>
         <Plus className="size-4" /> New worktree
       </Item>
-      {(['claude', 'codex'] as CodingAgent[]).map((agent) => (
+      {(['claude', 'codex', 'opencode'] as CodingAgent[]).map((agent) => (
         <Item
           key={agent}
           disabled={agentsStatus !== null && !isAgentReady(agentsStatus, agent)}

--- a/apps/x/apps/renderer/src/components/coding-run.test.tsx
+++ b/apps/x/apps/renderer/src/components/coding-run.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { CodeRunPermissionRequest, reduceEvents } from './coding-run';
+
+afterEach(cleanup);
+it('shows OpenCode command details and hides unsupported persistent approval', () => {
+    const onDecide = vi.fn();
+    render(<CodeRunPermissionRequest ask={{ title: 'Run tests', kind: 'execute', isRead: false, allowAlways: false, detail: { command: 'npm test' } }} onDecide={onDecide} />);
+    expect(screen.queryByRole('button', { name: /Always allow/ })).toBeNull();
+    expect(screen.getByText('npm test')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }));
+    expect(onDecide).toHaveBeenCalledWith('reject');
+});
+
+it('retains failed command output and edit previews through late updates', () => {
+    const rows = reduceEvents([
+        { type: 'tool_call', id: 't', title: 'Pending', kind: 'execute', status: 'pending', detail: { command: 'npm test' } },
+        { type: 'tool_call_update', id: 't', title: 'Run tests', status: 'failed', diffs: ['/project/a'], detail: { output: 'test failed', edits: [{ path: '/project/a', oldText: 'old', newText: 'new' }] } },
+    ]);
+    expect(rows).toEqual([{ kind: 'tool', id: 't', title: 'Run tests', toolKind: 'execute', status: 'failed', diffs: ['/project/a'], detail: { command: 'npm test', output: 'test failed', edits: [{ path: '/project/a', oldText: 'old', newText: 'new' }] } }]);
+});

--- a/apps/x/apps/renderer/src/components/coding-run.tsx
+++ b/apps/x/apps/renderer/src/components/coding-run.tsx
@@ -29,7 +29,8 @@ import { useCodeDiffOpener } from '@/contexts/code-diff-context'
 // folding tool_call + tool_call_update (by id) and the latest plan in place.
 
 type TextRow = { kind: 'text'; id: string; text: string }
-type ToolRow = { kind: 'tool'; id: string; title?: string; toolKind?: string; status?: string; diffs: string[] }
+type Detail = NonNullable<PermissionAsk['detail']>
+type ToolRow = { kind: 'tool'; id: string; title?: string; toolKind?: string; status?: string; diffs: string[]; detail?: Detail }
 type PlanRow = { kind: 'plan'; id: string; entries: { content: string; status?: string }[] }
 type PermRow = { kind: 'perm'; id: string; title: string; decision: string }
 type Row = TextRow | ToolRow | PlanRow | PermRow
@@ -56,9 +57,10 @@ export function reduceEvents(events: CodeRunEvent[]): Row[] {
           r.title = e.title ?? r.title
           r.toolKind = e.kind ?? r.toolKind
           r.status = e.status ?? r.status
+          r.detail = e.detail ?? r.detail
         } else {
           toolIdx.set(id, rows.length)
-          rows.push({ kind: 'tool', id, title: e.title, toolKind: e.kind, status: e.status, diffs: [] })
+          rows.push({ kind: 'tool', id, title: e.title, toolKind: e.kind, status: e.status, diffs: [], detail: e.detail })
         }
         break
       }
@@ -72,6 +74,9 @@ export function reduceEvents(events: CodeRunEvent[]): Row[] {
         }
         const r = rows[at] as ToolRow
         if (e.status) r.status = e.status
+        r.title = e.title ?? r.title
+        r.toolKind = e.kind ?? r.toolKind
+        if (e.detail) r.detail = { ...r.detail, ...e.detail }
         for (const d of e.diffs) if (!r.diffs.includes(d)) r.diffs.push(d)
         break
       }
@@ -113,6 +118,20 @@ function planMarker(status?: string) {
 }
 
 const basename = (p: string) => p.split(/[\\/]/).pop() || p
+
+function ToolDetails({ detail }: { detail?: Detail }) {
+  if (!detail?.command && !detail?.output && !detail?.edits?.length) return null
+  return <details className="ml-7 min-w-0 text-xs">
+    <summary className="cursor-pointer text-muted-foreground">Output and changes</summary>
+    {detail.command && <pre className="overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2">{detail.command}</pre>}
+    {detail.output && <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2">{detail.output}</pre>}
+    {detail.edits?.map((edit, i) => <div key={`${edit.path}-${i}`} className="my-2">
+      <p className="break-all font-mono">{edit.path}</p>
+      <pre className="max-h-64 overflow-auto whitespace-pre-wrap bg-red-500/5 p-2">{edit.oldText ?? '(new file)'}</pre>
+      <pre className="max-h-64 overflow-auto whitespace-pre-wrap bg-green-500/5 p-2">{edit.newText}</pre>
+    </div>)}
+  </details>
+}
 
 export function CodingRunTimeline({
   events,
@@ -187,6 +206,7 @@ export function CodingRunTimeline({
                   ))}
                 </div>
               )}
+              <ToolDetails detail={row.detail} />
             </div>
           )
         }
@@ -250,22 +270,23 @@ export function CodeRunPermissionRequest({
           className={cn(btn, 'bg-foreground text-background hover:bg-foreground/90')}>
           Allow
         </button>
-        <button type="button" disabled={busy} onClick={() => decide('allow_always')}
+        {ask.allowAlways !== false && <button type="button" disabled={busy} onClick={() => decide('allow_always')}
           className={cn(btn, 'border hover:bg-muted')}>
-          Always allow{ask.kind ? ` (${ask.kind})` : ''}
-        </button>
+          Always allow
+        </button>}
         <button type="button" disabled={busy} onClick={() => decide('reject')}
           className={cn(btn, 'border border-red-500/40 text-red-600 hover:bg-red-500/10')}>
           Deny
         </button>
       </div>
+      <div className="w-full"><ToolDetails detail={ask.detail} /></div>
     </div>
   )
 }
 
 // ── Block wrapper (rendered in the chat for a code_agent_run tool call) ──
 
-const AGENT_LABEL: Record<string, string> = { claude: 'Claude Code', codex: 'Codex' }
+const AGENT_LABEL: Record<string, string> = { claude: 'Claude Code', codex: 'Codex', opencode: 'OpenCode' }
 
 export function CodingRunBlock({
   item,

--- a/apps/x/apps/renderer/src/components/onboarding/steps/code-mode-step.tsx
+++ b/apps/x/apps/renderer/src/components/onboarding/steps/code-mode-step.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { startProvisioning, type CodeModeAgentStatus } from "@/lib/code-mode-provisioning"
 import type { OnboardingState } from "../use-onboarding-state"
+import { OpenCodeEngineSettings } from '@/components/opencode-engine-settings'
 
 interface CodeModeStepProps {
   state: OnboardingState
@@ -35,7 +36,7 @@ export function CodeModeStep({ state }: CodeModeStepProps) {
         setStatus(result)
         const claudeInstalled = result.claude.installed
         const codexInstalled = result.codex.installed
-        if (claudeInstalled || codexInstalled) {
+        if (claudeInstalled || codexInstalled || result.opencode?.installed) {
           setEnabled(true)
           setSelected({ claude: claudeInstalled, codex: codexInstalled })
         }
@@ -128,6 +129,7 @@ export function CodeModeStep({ state }: CodeModeStepProps) {
       )}
 
       {/* Footer */}
+      {enabled && <div className="mt-4"><OpenCodeEngineSettings active={enabled} /></div>}
       <div className="flex flex-col gap-3 mt-8 pt-4 border-t">
         <Button onClick={onContinue} size="lg" className="h-12 text-base font-medium" disabled={saving}>
           {saving ? <Loader2 className="size-5 animate-spin" /> : "Continue"}

--- a/apps/x/apps/renderer/src/components/opencode-engine-settings.test.tsx
+++ b/apps/x/apps/renderer/src/components/opencode-engine-settings.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { OpenCodeEngineSettings } from './opencode-engine-settings'
+vi.mock('@xterm/xterm', () => ({ Terminal: vi.fn() }))
+
+afterEach(cleanup)
+
+it('reports installation without claiming readiness, and re-check clears a missing executable', async () => {
+  let installed = true
+  const invoke = vi.fn(async () => ({ installed, version: '1.18.30', supported: true, connection: 'setup-unavailable', ready: false }))
+  Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+  render(<OpenCodeEngineSettings active />)
+  await screen.findByText(/Installed\. Choose a free model/)
+  expect(screen.queryByText('Ready')).toBeNull()
+  installed = false
+  fireEvent.click(screen.getByRole('button', { name: 'Re-check' }))
+  await screen.findByText('Not installed')
+  expect(screen.getByRole('button', { name: 'Enable' })).toBeTruthy()
+  expect(screen.queryByRole('button', { name: 'Remove engine' })).toBeNull()
+})
+
+it('removes only through engine removal IPC and refreshes installation', async () => {
+  let installed = true
+  const invoke = vi.fn(async (channel: string) => {
+    if (channel === 'codeMode:removeOpenCodeEngine') { installed = false; return { success: true } }
+    return { installed, version: '1.18.30', supported: true, connection: 'setup-unavailable', ready: false }
+  })
+  Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+  render(<OpenCodeEngineSettings active />)
+  fireEvent.click(await screen.findByRole('button', { name: 'Remove engine' }))
+  await waitFor(() => expect(invoke).toHaveBeenCalledWith('codeMode:removeOpenCodeEngine', null))
+  await screen.findByText('Not installed')
+})

--- a/apps/x/apps/renderer/src/components/opencode-engine-settings.tsx
+++ b/apps/x/apps/renderer/src/components/opencode-engine-settings.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { z } from 'zod'
+import type { OpenCodeEngineStatus } from '@x/shared/dist/code-mode'
+import { Button } from '@/components/ui/button'
+import { startProvisioning, useProvisioning } from '@/lib/code-mode-provisioning'
+import { OpenCodeProviderSetup } from './opencode-provider-setup'
+
+export function OpenCodeEngineSettings({ active }: { active: boolean }) {
+  const [status, setStatus] = useState<z.infer<typeof OpenCodeEngineStatus> | null>(null)
+  const [error, setError] = useState<string>()
+  const [removing, setRemoving] = useState(false)
+  const [setup, setSetup] = useState(false)
+  const progress = useProvisioning('opencode')
+  const busy = removing || !!(progress && !progress.error)
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await window.ipc.invoke('codeMode:openCodeEngineStatus', null))
+      window.dispatchEvent(new Event('opencode-configuration-changed'))
+      setError(undefined)
+    } catch { setError('Could not check OpenCode installation. Re-check to try again.') }
+  }, [])
+  useEffect(() => { if (active) void refresh() }, [active, refresh])
+  useEffect(() => { if (!active) setSetup(false) }, [active])
+  const remove = async () => {
+    setSetup(false)
+    setRemoving(true)
+    try {
+      const result = await window.ipc.invoke('codeMode:removeOpenCodeEngine', null)
+      if (!result.success) setError(result.error)
+      else await refresh()
+    } catch { setError('Could not remove OpenCode. Try again.') }
+    finally { setRemoving(false) }
+  }
+  return <div className="rounded-md border px-3 py-2.5 space-y-2">
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm font-medium">OpenCode{status?.installed ? ` ${status.version}` : ''}</span>
+      <div className="flex gap-2">
+        <Button variant="ghost" size="sm" disabled={busy} onClick={() => void refresh()}>Re-check</Button>
+        {status?.installed
+          ? <Button variant="outline" size="sm" disabled={busy} onClick={() => void remove()}>Remove engine</Button>
+          : <Button variant="outline" size="sm" disabled={busy || !status?.supported} onClick={() => startProvisioning('opencode', refresh)}>{progress?.error ? 'Retry' : 'Enable'}</Button>}
+      </div>
+    </div>
+    <p className="text-xs text-muted-foreground" role="status">
+      {busy ? (removing ? 'Removing engine…' : `${progress?.phase ?? 'Preparing'}${progress?.pct != null && progress.phase === 'download' ? ` ${progress.pct}%` : ''}…`)
+        : !status ? 'Checking installation…'
+        : !status.supported ? 'No managed engine package is available for this platform.'
+        : status.installed ? 'Installed. Choose a free model in Code mode, or optionally connect Go / Zen.' : 'Not installed'}
+    </p>
+    {status?.installed && <p className="text-xs text-muted-foreground">Removing the engine keeps provider credentials and conversations.</p>}
+    {status?.installed && !setup && <Button size="sm" variant="outline" disabled={busy} onClick={() => setSetup(true)}>Connect Go / Zen (optional)</Button>}
+    {status?.installed && setup && active && <OpenCodeProviderSetup onClose={() => setSetup(false)} />}
+    {(error || progress?.error) && <p role="alert" className="text-xs text-destructive">{error || progress?.error}</p>}
+  </div>
+}

--- a/apps/x/apps/renderer/src/components/opencode-provider-setup.test.tsx
+++ b/apps/x/apps/renderer/src/components/opencode-provider-setup.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import type { OpenCodeSetupState } from '@x/shared/dist/opencode-setup'
+import { OpenCodeProviderSetup } from './opencode-provider-setup'
+let state: OpenCodeSetupState, invoke: ReturnType<typeof vi.fn>
+beforeEach(() => {
+  state = { setupId: 'lease', generation: 1, providers: ['opencode-go', 'opencode', 'openai'].map(id => ({ id, name: id, connected: false, methods: [{ index: 0, type: 'api', label: 'API key', supported: true, prompts: [] }], models: [] })) }
+  invoke = vi.fn(async (channel: string, args: any) => {
+    if (channel === 'opencodeSetup:saveKey' || channel === 'opencodeSetup:disconnect') state = { ...state, providers: state.providers.map(p => p.id === args.providerId ? { ...p, connected: channel === 'opencodeSetup:saveKey' } : p) }
+    return { success: true, data: state }
+  })
+  Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+})
+afterEach(() => { cleanup(); localStorage.clear() })
+it('offers only Go and Zen, explains public access, and keeps model selection out of Settings', async () => {
+  render(<OpenCodeProviderSetup onClose={vi.fn()} />)
+  await screen.findByLabelText('Account access')
+  expect(screen.getAllByRole('option')).toHaveLength(2)
+  expect(screen.getByText(/Free models work without an account/)).toBeTruthy()
+  expect(screen.queryByLabelText('Model')).toBeNull()
+  expect(screen.queryByText('Open managed login')).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Open OpenCode account' }))
+  await waitFor(() => expect(invoke).toHaveBeenCalledWith('opencodeSetup:openAccount', null))
+})
+it('saves only the selected account key, clears the field, and does not claim verification', async () => {
+  render(<OpenCodeProviderSetup onClose={vi.fn()} />)
+  const input = await screen.findByLabelText('OpenCode account API key')
+  fireEvent.change(input, { target: { value: 'secret-test' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save account key' }))
+  expect((input as HTMLInputElement).value).toBe('')
+  await screen.findByText('Account key saved. Choose a model in Code mode.')
+  expect(invoke).toHaveBeenCalledWith('opencodeSetup:saveKey', { setupId: 'lease', providerId: 'opencode-go', method: 0, key: 'secret-test' })
+  expect(JSON.stringify(localStorage)).not.toContain('secret-test')
+  expect(screen.queryByText(/Ready/)).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
+  await screen.findByText('Account disconnected. Free models remain available in Code mode.')
+  cleanup()
+  expect(invoke).toHaveBeenCalledWith('opencodeSetup:stop', { setupId: 'lease' })
+})
+it('clears secrets when switching accounts and reports save failure honestly', async () => {
+  render(<OpenCodeProviderSetup onClose={vi.fn()} />)
+  const input = await screen.findByLabelText('OpenCode account API key')
+  fireEvent.change(input, { target: { value: 'go-key' } })
+  fireEvent.change(screen.getByLabelText('Account access'), { target: { value: 'opencode' } })
+  expect((input as HTMLInputElement).value).toBe('')
+  invoke.mockResolvedValueOnce({ success: false, error: { message: 'Could not save account key.' } })
+  fireEvent.change(input, { target: { value: 'zen-key' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save account key' }))
+  await screen.findByRole('alert')
+  expect(screen.queryByText('Account key saved. Choose a model in Code mode.')).toBeNull()
+})
+it('stops a setup lease that arrives after the panel closes', async () => {
+  let finish!: (result: unknown) => void
+  invoke.mockImplementation((channel: string) => channel === 'opencodeSetup:start' ? new Promise(resolve => { finish = resolve }) : Promise.resolve({ success: true, data: null }))
+  const panel = render(<OpenCodeProviderSetup onClose={vi.fn()} />)
+  panel.unmount()
+  finish({ success: true, data: state })
+  await waitFor(() => expect(invoke).toHaveBeenCalledWith('opencodeSetup:stop', { setupId: 'lease' }))
+})

--- a/apps/x/apps/renderer/src/components/opencode-provider-setup.tsx
+++ b/apps/x/apps/renderer/src/components/opencode-provider-setup.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react'
+import type { OpenCodeSetupState } from '@x/shared/dist/opencode-setup'
+import { Button } from '@/components/ui/button'
+
+type Result = { success: true; data: OpenCodeSetupState } | { success: false; error: { message: string } }
+export function OpenCodeProviderSetup({ onClose }: { onClose: () => void }) {
+  const [state, setState] = useState<OpenCodeSetupState>()
+  const [providerId, setProviderId] = useState('opencode-go')
+  const [key, setKey] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string>()
+  const [notice, setNotice] = useState<string>()
+  const alive = useRef(false)
+  const lease = useRef<string | undefined>(undefined)
+  const generation = useRef(0)
+  const accept = (result: Result) => {
+    if (!result.success) { setError(result.error.message); return false }
+    setState(result.data)
+    lease.current = result.data.setupId
+    window.dispatchEvent(new Event('opencode-configuration-changed'))
+    return true
+  }
+  const start = async () => {
+    const current = ++generation.current
+    setBusy(true); setError(undefined)
+    try {
+      const result = await window.ipc.invoke('opencodeSetup:start', null)
+      if (!alive.current || current !== generation.current) {
+        if (result.success) void window.ipc.invoke('opencodeSetup:stop', { setupId: result.data.setupId }).catch(() => {})
+        return
+      }
+      accept(result)
+    } catch { if (alive.current && current === generation.current) setError('Could not open account setup. Retry setup.') }
+    finally { if (alive.current && current === generation.current) setBusy(false) }
+  }
+  useEffect(() => {
+    alive.current = true
+    void start()
+    return () => {
+      alive.current = false; generation.current++
+      if (lease.current) void window.ipc.invoke('opencodeSetup:stop', { setupId: lease.current }).catch(() => {})
+    }
+  }, [])
+  const run = async (work: () => Promise<Result>, message: string) => {
+    const current = ++generation.current
+    setBusy(true); setError(undefined); setNotice(undefined)
+    try {
+      const result = await work()
+      if (alive.current && current === generation.current && accept(result)) setNotice(message)
+    } catch { if (alive.current && current === generation.current) setError('Account setup was interrupted. Close and reopen it to retry.') }
+    finally { if (alive.current && current === generation.current) setBusy(false) }
+  }
+  const provider = state?.providers.find(p => p.id === providerId)
+  const method = provider?.methods.find(m => m.type === 'api' && m.supported)
+  return <section className="space-y-3 border-t pt-3" aria-label="OpenCode account setup">
+    <div className="flex items-center justify-between"><span className="text-sm font-medium">Go / Zen account (optional)</span><Button variant="ghost" size="sm" onClick={onClose}>Close setup</Button></div>
+    <p className="text-xs text-muted-foreground">Free models work without an account. Choose your model in Code mode. Connect Go for subscription models or Zen for pay-as-you-go models.</p>
+    <Button variant="outline" size="sm" onClick={async () => {
+      try {
+        const result = await window.ipc.invoke('opencodeSetup:openAccount', null)
+        if (alive.current && !result.success) setError(result.error.message)
+      } catch { if (alive.current) setError('Could not open your browser. Visit opencode.ai/auth to get your account key.') }
+    }}>Open OpenCode account</Button>
+    {error && <p role="alert" className="text-xs text-destructive">{error}</p>}
+    {notice && <p role="status" className="text-xs">{notice}</p>}
+    {!state ? <>{busy ? <p role="status">Opening account setup...</p> : <Button size="sm" onClick={() => void start()}>Retry setup</Button>}</> : <>
+      <label className="block text-xs">Account access
+        <select aria-label="Account access" disabled={busy} value={providerId} className="w-full rounded-md border bg-background p-2" onChange={e => { setProviderId(e.target.value); setKey(''); setNotice(undefined); setError(undefined) }}>
+          <option value="opencode-go">OpenCode Go - subscription</option>
+          <option value="opencode">OpenCode Zen - pay as you go</option>
+        </select>
+      </label>
+      {provider?.connected && <p className="text-xs">Account key saved. Model access is checked when you send a coding request.</p>}
+      <input aria-label="OpenCode account API key" type="password" autoComplete="off" spellCheck={false} value={key} disabled={busy} onChange={e => setKey(e.target.value)} placeholder="Paste your OpenCode account API key" className="w-full rounded-md border bg-background p-2 text-sm" />
+      <div className="flex gap-2">
+        <Button size="sm" disabled={busy || !key.trim() || !method} onClick={() => {
+          if (!method) return
+          const secret = key; setKey('')
+          void run(() => window.ipc.invoke('opencodeSetup:saveKey', { setupId: state.setupId, providerId, method: method.index, key: secret }), 'Account key saved. Choose a model in Code mode.')
+        }}>Save account key</Button>
+        {provider?.connected && <Button size="sm" variant="outline" disabled={busy} onClick={() => void run(() => window.ipc.invoke('opencodeSetup:disconnect', { setupId: state.setupId, providerId }), 'Account disconnected. Free models remain available in Code mode.')}>Disconnect</Button>}
+      </div>
+      {!method && <p className="text-xs">This account option is currently unavailable. Close and reopen setup to refresh.</p>}
+      {busy && <p role="status" className="text-xs">Working...</p>}
+    </>}
+  </section>
+}

--- a/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
+++ b/apps/x/apps/renderer/src/components/quick-ask-bar.tsx
@@ -382,7 +382,7 @@ export function QuickAskBar() {
       mentions?: FileMention[],
       attachments?: StagedAttachment[],
       searchEnabled?: boolean,
-      codeMode?: 'claude' | 'codex',
+      codeMode?: 'claude' | 'codex' | 'opencode',
       permissionMode?: PermissionMode,
     ) => {
       const text = message.text.trim()

--- a/apps/x/apps/renderer/src/components/settings-dialog.tsx
+++ b/apps/x/apps/renderer/src/components/settings-dialog.tsx
@@ -35,6 +35,7 @@ import type { ApprovalPolicy } from "@x/shared/src/code-mode.js"
 import { DEFAULT_TURN_LIMITS_SETTINGS } from "@x/shared/src/turn-limits.js"
 import type { ipc as ipcShared } from "@x/shared"
 import { startProvisioning, useProvisioning, enabledOptimistic, type AgentStatus, type CodeModeAgentStatus } from "@/lib/code-mode-provisioning"
+import { OpenCodeEngineSettings } from '@/components/opencode-engine-settings'
 import { ModelSelectionSection } from "@/components/settings/model-selection-section"
 import { PermissionsSettings } from "@/components/settings/permissions-settings"
 import { ShortcutSettings } from "@/components/settings/shortcut-settings"
@@ -1419,6 +1420,7 @@ function CodeModeSettings({ dialogOpen }: { dialogOpen: boolean }) {
             status={status?.codex ?? null}
             onProvisioned={loadStatus}
           />
+          <OpenCodeEngineSettings active={dialogOpen} />
         </div>
       </div>
 

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -58,7 +58,7 @@ export interface AgentOptions {
     model?: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' }
     permissionMode?: 'auto' | 'manual'
     searchEnabled?: boolean
-    codeMode?: 'claude' | 'codex'
+    codeMode?: 'claude' | 'codex' | 'opencode'
 }
 
 /** A pane-provided slash command; `args` absent = picking it runs immediately. */
@@ -273,7 +273,7 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
     const [model, setModel] = useState<ModelSelection | null>(null)
     const [permissionMode, setPermissionMode] = useState<'auto' | 'manual'>('auto')
     const [searchEnabled, setSearchEnabled] = useState(false)
-    const [codeMode, setCodeMode] = useState<'claude' | 'codex' | null>(null)
+    const [codeMode, setCodeMode] = useState<'claude' | 'codex' | 'opencode' | null>(null)
     const [codeModeAvailable, setCodeModeAvailable] = useState(false)
     useEffect(() => {
         const load = () => {

--- a/apps/x/apps/renderer/src/lib/code-mode-provisioning.ts
+++ b/apps/x/apps/renderer/src/lib/code-mode-provisioning.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import type { CodingAgent } from '@x/shared/dist/code-mode'
 
 export type AgentAccount = { email?: string; plan?: string }
 export type AgentStatus = { installed: boolean; signedIn: boolean; account?: AgentAccount }
@@ -10,7 +11,7 @@ export type CodeModeAgentStatus = { claude: AgentStatus; codex: AgentStatus }
 // instead of restarting. This is what lets a download kicked off from onboarding show
 // its progress later in Settings → Code Mode. A single persistent listener on the
 // progress channel feeds this store.
-export type ProvState = { pct: number | null; error?: string }
+export type ProvState = { pct: number | null; phase?: string; error?: string }
 const provStore: Record<string, ProvState | undefined> = {}
 // Agents we provisioned this session — used to show "Ready" immediately on success
 // without waiting for the async status refresh to round-trip (which caused the row to
@@ -21,7 +22,7 @@ let provChannelHooked = false
 
 function notifyProv() { provListeners.forEach((l) => l()) }
 
-export function startProvisioning(agent: 'claude' | 'codex', onDone: () => void | Promise<void>): void {
+export function startProvisioning(agent: CodingAgent, onDone: () => void | Promise<void>): void {
   if (provStore[agent] && !provStore[agent]!.error) return // already in flight
   provStore[agent] = { pct: null }
   notifyProv()
@@ -31,7 +32,7 @@ export function startProvisioning(agent: 'claude' | 'codex', onDone: () => void 
       const cur = provStore[p.agent]
       if (!cur) return
       const pct = p.totalBytes ? Math.floor(((p.receivedBytes ?? 0) / p.totalBytes) * 100) : cur.pct
-      provStore[p.agent] = { pct }
+      provStore[p.agent] = { pct, phase: p.phase }
       notifyProv()
     })
   }
@@ -44,7 +45,10 @@ export function startProvisioning(agent: 'claude' | 'codex', onDone: () => void 
         // in the background to sync the real status.
         enabledOptimistic.add(agent)
         provStore[agent] = undefined
-        void onDone()
+        Promise.resolve().then(onDone).catch(() => {}).finally(() => {
+          enabledOptimistic.delete(agent)
+          notifyProv()
+        })
       } else {
         provStore[agent] = { pct: null, error: res.error ?? 'Failed to enable' }
       }

--- a/apps/x/apps/renderer/src/lib/spaces-rowboat.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-rowboat.ts
@@ -15,7 +15,7 @@ export interface RowboatTurnOptions {
     model?: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' }
     permissionMode?: 'auto' | 'manual'
     searchEnabled?: boolean
-    codeMode?: 'claude' | 'codex'
+    codeMode?: 'claude' | 'codex' | 'opencode'
 }
 
 export function maybeInvokeRowboat(

--- a/apps/x/apps/server/src/code-model-options.test.ts
+++ b/apps/x/apps/server/src/code-model-options.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import container from '@x/core/dist/di/container.js';
+import { ipc } from '@x/shared';
+import { createCoreRpcHandlers } from './core-deps.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+it('forwards project and current model configuration through the server discovery handler', async () => {
+  const options = { models: [{ value: 'opencode/model', label: 'Model' }], efforts: [] };
+  const listModelOptions = vi.fn().mockResolvedValue(options);
+  vi.spyOn(container, 'resolve').mockReturnValue({ listModelOptions });
+  const args = ipc.validateRequest('codeMode:listModelOptions', {
+    agent: 'opencode', cwd: 'C:\\Projects with spaces\\worktree',
+    model: 'opencode/model', effort: 'high', mode: 'plan',
+  });
+  const handler = createCoreRpcHandlers()['codeMode:listModelOptions']!;
+  expect(await handler(args)).toEqual(options);
+  expect(listModelOptions).toHaveBeenCalledExactlyOnceWith('opencode', args.cwd, args.model, args.effort, args.mode, false);
+});

--- a/apps/x/apps/server/src/core-deps.ts
+++ b/apps/x/apps/server/src/core-deps.ts
@@ -1419,7 +1419,7 @@ export function createCoreRpcHandlers(opts?: { sessionsIndexReady?: Promise<void
     },
     'codeMode:listModelOptions': async (args) => {
       const manager = container.resolve<CodeModeManager>('codeModeManager');
-      return manager.listModelOptions(args.agent);
+      return manager.listModelOptions(args.agent, args.cwd, args.model, args.effort, args.mode, false);
     },
     'codeProject:add': async (args) => {
       const repo = container.resolve<ICodeProjectsRepo>('codeProjectsRepo');

--- a/apps/x/packages/core/scripts/gen-engine-manifest.mjs
+++ b/apps/x/packages/core/scripts/gen-engine-manifest.mjs
@@ -20,6 +20,17 @@ import * as path from 'path';
 
 const require = createRequire(import.meta.url);
 const REGISTRY = 'https://registry.npmjs.org';
+const OPENCODE_VERSION = '1.18.30';
+const OPENCODE_PACKAGES = {
+    'win32-x64': 'opencode-windows-x64-baseline',
+    'win32-arm64': 'opencode-windows-arm64',
+    'darwin-x64': 'opencode-darwin-x64-baseline',
+    'darwin-arm64': 'opencode-darwin-arm64',
+    'linux-x64': 'opencode-linux-x64-baseline',
+    'linux-arm64': 'opencode-linux-arm64',
+    'linux-x64-musl': 'opencode-linux-x64-baseline-musl',
+    'linux-arm64-musl': 'opencode-linux-arm64-musl',
+};
 
 // Platform keys we publish for each agent. These mirror the optionalDependencies of the
 // engine packages. claude ships musl variants; codex does not.
@@ -84,6 +95,7 @@ async function main() {
     console.log(`codex engine:  @openai/codex@${codexVersion}`);
 
     const manifest = {
+        opencode: await buildAgent(OPENCODE_VERSION, Object.keys(OPENCODE_PACKAGES), (key) => ({ pkg: OPENCODE_PACKAGES[key], version: OPENCODE_VERSION })),
         claude: await buildAgent(claudeVersion, CLAUDE_PLATFORMS, (key) => ({
             pkg: `@anthropic-ai/claude-agent-sdk-${key}`,
             version: claudeVersion,

--- a/apps/x/packages/core/src/application/lib/message-queue.ts
+++ b/apps/x/packages/core/src/application/lib/message-queue.ts
@@ -8,7 +8,7 @@ export type MiddlePaneContext =
     | { kind: 'note'; path: string; content: string }
     | { kind: 'browser'; url: string; title: string };
 
-export type CodeMode = 'claude' | 'codex';
+export type CodeMode = 'claude' | 'codex' | 'opencode';
 export type CodePolicy = 'ask' | 'auto-approve-reads' | 'yolo';
 
 type EnqueuedMessage = {

--- a/apps/x/packages/core/src/code-mode/acp/agents.ts
+++ b/apps/x/packages/core/src/code-mode/acp/agents.ts
@@ -4,14 +4,11 @@ import { fileURLToPath } from 'url';
 import type { CodingAgent } from './types.js';
 import { getProvisionedEnginePath } from './engine-provisioner.js';
 import { loginShellPath } from './shell-env.js';
+import { CODING_AGENT_CAPABILITIES } from '@x/shared/dist/code-mode.js';
 
 const require = createRequire(import.meta.url);
 
 // The ACP adapter npm package that exposes each coding agent as an ACP server.
-const ADAPTER_PACKAGE: Record<CodingAgent, string> = {
-    claude: '@agentclientprotocol/claude-agent-acp',
-    codex: '@agentclientprotocol/codex-acp',
-};
 
 export interface AgentLaunchSpec {
     /** Executable to spawn — always `node` so we never hit the Windows .cmd EINVAL. */
@@ -61,7 +58,9 @@ function resolveAdapterEntry(pkg: string): string {
 }
 
 export function getAgentLaunchSpec(agent: CodingAgent): AgentLaunchSpec {
-    const entry = resolveAdapterEntry(ADAPTER_PACKAGE[agent]);
+    const descriptor = CODING_AGENT_CAPABILITIES[agent];
+    if (descriptor.launch !== 'adapter') throw new Error('OpenCode must launch through the managed native process service.');
+    const entry = resolveAdapterEntry(descriptor.adapter);
     const env: NodeJS.ProcessEnv = { ...process.env };
 
     // Graft the user's login-shell PATH onto the engine's env. GUI (Finder) launches

--- a/apps/x/packages/core/src/code-mode/acp/client.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/client.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest';
+import { extractModelOptions, toEvent } from './client.js';
+
+it('keeps provider-qualified IDs, current values, grouped models and only advertised effort', () => {
+    const options = extractModelOptions([
+        { id: 'model', currentValue: 'provider/model', options: [{ name: 'Provider', options: [{ value: 'provider/model', name: 'Model' }] }] },
+        { id: 'mode', currentValue: 'review', options: [{ value: 'review', name: 'Review' }] },
+    ], undefined, true);
+    expect(options).toEqual({ models: [{ value: 'provider/model', label: 'Model' }], efforts: [], modes: [{ value: 'review', label: 'Review' }], currentModel: 'provider/model', currentMode: 'review', currentEffort: undefined });
+    expect(extractModelOptions([{ id: 'effort', currentValue: 'high', options: [{ value: 'high', name: 'High' }] }], undefined, true).efforts).toEqual([{ value: 'high', label: 'High' }]);
+});
+
+it('preserves command failures, output, edit previews and late tool titles', () => {
+    const event = toEvent({ sessionUpdate: 'tool_call_update', toolCallId: 'command', title: 'Run tests', kind: 'execute', status: 'failed', content: [
+        { type: 'content', content: { type: 'text', text: 'FAIL: expected true, got false' } },
+        { type: 'diff', path: '/project/app.ts', oldText: 'before', newText: 'after' },
+    ] });
+    expect(event).toMatchObject({ type: 'tool_call_update', title: 'Run tests', status: 'failed', diffs: ['/project/app.ts'], detail: { output: 'FAIL: expected true, got false', edits: [{ path: '/project/app.ts', oldText: 'before', newText: 'after' }] } });
+});

--- a/apps/x/packages/core/src/code-mode/acp/client.ts
+++ b/apps/x/packages/core/src/code-mode/acp/client.ts
@@ -19,6 +19,11 @@ import {
 import type { CodingAgent, CodeRunEvent } from './types.js';
 import type { PermissionBroker } from './permission-broker.js';
 import { getAgentLaunchSpec } from './agents.js';
+import { openCodeProcesses, type OpenCodeProcess } from './opencode-process.js';
+import { enforceOpenCodePolicy, openCodeRequest } from './opencode-policy.js';
+import { toolDetail } from './tool-detail.js';
+import { storedProviderIds } from './opencode-setup.js';
+import { openCodeModelAccess, type OpenCodeAccessGroup } from './opencode-model-access.js';
 
 export interface AcpClientOptions {
     agent: CodingAgent;
@@ -38,7 +43,7 @@ const STARTUP_TIMEOUT_MS = Number(process.env.ROWBOAT_ACP_STARTUP_TIMEOUT_MS) > 
     : 60_000;
 
 export interface CodeAgentOption { value: string; label: string }
-export interface CodeAgentModelOptions { models: CodeAgentOption[]; efforts: CodeAgentOption[] }
+export interface CodeAgentModelOptions { models: CodeAgentOption[]; efforts: CodeAgentOption[]; modes?: CodeAgentOption[]; currentModel?: string; currentEffort?: string; currentMode?: string; selectionError?: string; openCodeProviders?: OpenCodeAccessGroup[] }
 
 // The agent advertises its model + effort choices on the session it opens (the
 // same data that backs its `/model` picker), in one of two shapes:
@@ -48,7 +53,7 @@ export interface CodeAgentModelOptions { models: CodeAgentOption[]; efforts: Cod
 // We read configOptions first and fall back to `models`, then prepend a
 // synthetic "Default" so the user can always keep the engine default.
 type RawSelectOption = { value?: unknown; name?: unknown; options?: Array<{ value?: unknown; name?: unknown }> };
-type RawConfigOption = { id?: string; options?: RawSelectOption[] };
+type RawConfigOption = { id?: string; currentValue?: string; options?: RawSelectOption[] };
 type RawModelState = { availableModels?: Array<{ modelId?: unknown; name?: unknown }> };
 
 function withDefault(choices: CodeAgentOption[]): CodeAgentOption[] {
@@ -70,7 +75,7 @@ function modelStateChoices(models: RawModelState | undefined): CodeAgentOption[]
         .map((m) => ({ value: m.modelId, label: typeof m.name === 'string' && m.name ? m.name : m.modelId }));
 }
 
-export function extractModelOptions(configOptions: unknown, models?: unknown): CodeAgentModelOptions {
+export function extractModelOptions(configOptions: unknown, models?: unknown, native = false): CodeAgentModelOptions {
     const list = (Array.isArray(configOptions) ? configOptions : []) as RawConfigOption[];
     const modelOpt = list.find((o) => o.id === 'model');
     const effortOpt = list.find((o) => o.id === 'effort');
@@ -78,8 +83,9 @@ export function extractModelOptions(configOptions: unknown, models?: unknown): C
     return {
         // configOptions is authoritative when present; otherwise fall back to the
         // SessionModelState list (Codex reports models only there).
-        models: withDefault(modelChoices.length ? modelChoices : modelStateChoices(models as RawModelState)),
-        efforts: effortOpt ? withDefault(toChoices(effortOpt)) : [],
+        models: native ? modelChoices : withDefault(modelChoices.length ? modelChoices : modelStateChoices(models as RawModelState)),
+        efforts: effortOpt ? (native ? toChoices(effortOpt) : withDefault(toChoices(effortOpt))) : [],
+        ...(native ? { modes: toChoices(list.find(o => o.id === 'mode')), currentModel: modelOpt?.currentValue, currentEffort: effortOpt?.currentValue, currentMode: list.find(o => o.id === 'mode')?.currentValue } : {}),
     };
 }
 
@@ -106,8 +112,14 @@ function withClaudeAliases(options: CodeAgentModelOptions): CodeAgentModelOption
 }
 
 // Map a raw ACP session/update notification onto our small CodeRunEvent union.
-function toEvent(update: SessionUpdate): CodeRunEvent {
+export function toEvent(update: SessionUpdate): CodeRunEvent {
     switch (update.sessionUpdate) {
+        case 'config_option_update': {
+            const options = extractModelOptions(update.configOptions, undefined, true);
+            return { type: 'configuration', model: options.currentModel, effort: options.currentEffort, mode: options.currentMode };
+        }
+        case 'current_mode_update':
+            return { type: 'configuration', mode: update.currentModeId };
         case 'agent_message_chunk':
         case 'user_message_chunk': {
             const c = update.content;
@@ -123,12 +135,13 @@ function toEvent(update: SessionUpdate): CodeRunEvent {
                 title: update.title,
                 kind: update.kind ?? undefined,
                 status: update.status ?? undefined,
+                detail: toolDetail(update.content, update.rawInput),
             };
         case 'tool_call_update': {
             const diffs = (update.content ?? [])
                 .filter((c): c is Extract<typeof c, { type: 'diff' }> => c.type === 'diff')
                 .map((c) => c.path);
-            return { type: 'tool_call_update', id: update.toolCallId, status: update.status ?? undefined, diffs };
+            return { type: 'tool_call_update', id: update.toolCallId, title: update.title ?? undefined, kind: update.kind ?? undefined, status: update.status ?? undefined, diffs, detail: toolDetail(update.content, update.rawInput) };
         }
         case 'plan':
             return {
@@ -160,6 +173,10 @@ export class AcpClient {
     private child?: ChildProcess;
     private connection?: ClientSideConnection;
     private loadSession_ = false;
+    private managed?: OpenCodeProcess;
+    private readonly lifetime = new AbortController();
+    capabilities: unknown;
+    configuration: CodeAgentModelOptions = { models: [], efforts: [] };
     // Diagnostics: the adapter's stderr/exit are captured so a dropped connection
     // reports WHY (e.g. a crash) instead of the SDK's bare "ACP connection closed".
     private stderrTail = '';
@@ -184,18 +201,22 @@ export class AcpClient {
 
     // Spawn the adapter and negotiate the protocol. Returns once initialized.
     async start(): Promise<void> {
-        const spec = getAgentLaunchSpec(this.agent);
-        const child = spawn(spec.command, spec.args, {
+        this.lifetime.signal.throwIfAborted();
+        if (this.agent === 'opencode') this.managed = await openCodeProcesses.start('acp', { cwd: this.cwd, signal: this.lifetime.signal });
+        const spec = this.agent === 'opencode' ? undefined : getAgentLaunchSpec(this.agent);
+        const child = this.managed?.child ?? spawn(spec!.command, spec!.args, {
             cwd: this.cwd,
-            env: spec.env,
+            env: spec!.env,
             // Capture stderr (not inherit) so we can attribute a dropped connection.
             stdio: ['pipe', 'pipe', 'pipe'],
         });
         this.child = child;
         child.stderr?.on('data', (d: Buffer) => {
+            if (this.agent === 'opencode') return;
             this.stderrTail = (this.stderrTail + d.toString()).slice(-4000);
         });
         child.on('exit', (code, signal) => {
+            this.broker.cancel();
             this.exitInfo = `adapter exited (code ${code}${signal ? `, signal ${signal}` : ''})`;
         });
         child.on('error', (err) => {
@@ -212,9 +233,10 @@ export class AcpClient {
         try {
             const init = await this.withStartupTimeout(this.connection.initialize({
                 protocolVersion: PROTOCOL_VERSION,
-                clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+                clientCapabilities: { fs: { readTextFile: this.agent !== 'opencode', writeTextFile: this.agent !== 'opencode' } },
             }));
             this.loadSession_ = init.agentCapabilities?.loadSession === true;
+            this.capabilities = init.agentCapabilities;
         } catch (e) {
             throw this.enrich(e, 'initialize');
         }
@@ -244,6 +266,7 @@ export class AcpClient {
     async newSession(): Promise<string> {
         try {
             const res = await this.withStartupTimeout(this.conn().newSession({ cwd: this.cwd, mcpServers: [] }));
+            this.recordConfiguration(res);
             return res.sessionId;
         } catch (e) {
             throw this.enrich(e, 'newSession');
@@ -253,12 +276,23 @@ export class AcpClient {
     // Open a throwaway session purely to read the agent's advertised model +
     // effort choices, then let the caller dispose this client. Used for the
     // model picker before any real session exists.
-    async describeModelOptions(): Promise<CodeAgentModelOptions> {
+    async describeModelOptions(model?: string, effort?: string, mode?: string, strict = true): Promise<CodeAgentModelOptions> {
         try {
             const res = await this.withStartupTimeout(this.conn().newSession({ cwd: this.cwd, mcpServers: [] }));
             const r = res as { configOptions?: unknown; models?: unknown };
-            const options = extractModelOptions(r.configOptions, r.models);
-            return this.agent === 'claude' ? withClaudeAliases(options) : options;
+            this.recordConfiguration(r);
+            try {
+                if (mode) await this.setMode(res.sessionId, mode);
+                if (model && model !== 'default') await this.setModel(res.sessionId, model);
+                if (effort) await this.setEffort(res.sessionId, effort);
+                return this.agent === 'claude' ? withClaudeAliases(this.configuration) : this.configuration;
+            } catch (error) {
+                if (strict || this.agent !== 'opencode') throw error;
+                return { ...this.configuration, currentModel: undefined, currentEffort: undefined, currentMode: undefined,
+                    selectionError: 'The selected OpenCode model, effort or mode is unavailable. Choose an advertised option.' };
+            } finally {
+                if (this.managed) await openCodeRequest(this.managed, this.cwd, `/session/${encodeURIComponent(res.sessionId)}`, 'DELETE').catch(() => {});
+            }
         } catch (e) {
             throw this.enrich(e, 'describeModelOptions');
         }
@@ -266,7 +300,8 @@ export class AcpClient {
 
     async loadSession(sessionId: string): Promise<void> {
         try {
-            await this.withStartupTimeout(this.conn().loadSession({ sessionId, cwd: this.cwd, mcpServers: [] }));
+            const res = await this.withStartupTimeout(this.conn().loadSession({ sessionId, cwd: this.cwd, mcpServers: [] }));
+            this.recordConfiguration(res);
         } catch (e) {
             throw this.enrich(e, 'loadSession');
         }
@@ -278,15 +313,44 @@ export class AcpClient {
     // ACP 1.x folded model selection into the generic config-option system (the
     // 'model' category), so this goes through setSessionConfigOption just like
     // effort does — matching the id extractModelOptions reads.
+    async getOpenCodeModelAccess() {
+        if (!this.managed) throw new Error('OpenCode is not running. Refresh models to retry.');
+        const [credentials, catalog] = await Promise.all([
+            storedProviderIds(), openCodeRequest(this.managed, this.cwd, '/provider'),
+        ]);
+        return openCodeModelAccess(credentials, catalog);
+    }
+
     async setModel(sessionId: string, modelId: string): Promise<void> {
-        await this.conn().setSessionConfigOption({ sessionId, configId: 'model', value: modelId });
+        await this.setOption(sessionId, 'model', modelId);
     }
 
     // Set the reasoning-effort level via the agent's "effort" config option.
     // The option only exists for models that support it, so this throws for
     // others — again applied best-effort by the caller.
     async setEffort(sessionId: string, value: string): Promise<void> {
-        await this.conn().setSessionConfigOption({ sessionId, configId: 'effort', value });
+        await this.setOption(sessionId, 'effort', value);
+    }
+
+    async setMode(sessionId: string, value: string): Promise<void> { await this.setOption(sessionId, 'mode', value); }
+
+    private recordConfiguration(res: { configOptions?: unknown; models?: unknown }): void {
+        this.configuration = extractModelOptions(res.configOptions, res.models, this.agent === 'opencode');
+    }
+
+    private async setOption(sessionId: string, id: 'model' | 'effort' | 'mode', value: string): Promise<void> {
+        const choices = id === 'model' ? this.configuration.models : id === 'effort' ? this.configuration.efforts : this.configuration.modes ?? [];
+        if (this.agent === 'opencode' && !choices.some(o => o.value === value)) throw new Error(`OpenCode ${id} is unavailable: ${value}. Refresh the session options.`);
+        const res = await this.withStartupTimeout(this.conn().setSessionConfigOption({ sessionId, configId: id, value }))
+            .catch(error => { throw this.agent === 'opencode' ? this.enrich(error, `select ${id}`) : error; });
+        this.recordConfiguration(res);
+        const accepted = id === 'model' ? this.configuration.currentModel : id === 'effort' ? this.configuration.currentEffort : this.configuration.currentMode;
+        if (this.agent === 'opencode' && accepted !== value) throw new Error(`OpenCode did not accept the selected ${id}. Refresh the session options.`);
+    }
+
+    async preparePermissions(sessionId: string): Promise<void> {
+        if (this.managed) await enforceOpenCodePolicy(this.managed, this.cwd, sessionId, this.configuration.currentMode ?? 'build');
+        if (this.agent === 'opencode') this.onEvent({ type: 'configuration', model: this.configuration.currentModel, effort: this.configuration.currentEffort, mode: this.configuration.currentMode });
     }
 
     async prompt(sessionId: string, text: string): Promise<PromptResponse> {
@@ -300,6 +364,16 @@ export class AcpClient {
     // Wrap a connection error with the adapter's exit/stderr so failures are
     // self-explanatory rather than the SDK's opaque "ACP connection closed".
     private enrich(err: unknown, phase: string): Error {
+        if (this.agent === 'opencode') {
+            // Provider errors may echo request headers. Never persist that raw
+            // payload or stderr in Rowboat's durable conversation/logs.
+            const message = err instanceof Error ? err.message : '';
+            const reason = /401|403|unauthori[sz]ed|authentication/i.test(message) ? 'OpenCode account authentication failed. Reconnect Go / Zen in Settings, or choose a free model in Code mode.'
+                : /model.*not.*found|model.*unavailable/i.test(message) ? 'The selected model is unavailable. Refresh the session model options.'
+                : /timed out|timeout/i.test(message) ? 'The operation timed out. Retry or check the provider connection.'
+                : 'The engine request failed. Check the model in Code mode and your optional Go / Zen account in Settings, then retry.';
+            return new Error(`OpenCode ${phase}: ${reason}${this.exitInfo ? ` (${this.exitInfo})` : ''}`);
+        }
         const base = err instanceof Error ? err.message : String(err);
         const parts = [
             this.exitInfo,
@@ -313,6 +387,9 @@ export class AcpClient {
     }
 
     dispose(): void {
+        this.broker.cancel();
+        this.lifetime.abort();
+        if (this.managed) { this.managed.stop(); this.managed = undefined; }
         try {
             this.child?.kill();
         } catch {
@@ -338,10 +415,12 @@ export class AcpClient {
                 this.onEvent(toEvent(params.update));
             },
             readTextFile: async (params: ReadTextFileRequest): Promise<ReadTextFileResponse> => {
+                if (this.agent === 'opencode') throw new Error('Client filesystem access is disabled for OpenCode.');
                 const content = await fs.readFile(params.path, 'utf8');
                 return { content };
             },
             writeTextFile: async (params: WriteTextFileRequest): Promise<WriteTextFileResponse> => {
+                if (this.agent === 'opencode') throw new Error('Client filesystem access is disabled for OpenCode.');
                 await fs.writeFile(params.path, params.content);
                 return {};
             },

--- a/apps/x/packages/core/src/code-mode/acp/engine-manifest.ts
+++ b/apps/x/packages/core/src/code-mode/acp/engine-manifest.ts
@@ -3,6 +3,59 @@
 // Maps each agent + platform to the npm tarball + integrity of its native engine.
 
 export const ENGINE_MANIFEST = {
+    "opencode": {
+        "version": "1.18.30",
+        "platforms": {
+            "win32-x64": {
+                "pkg": "opencode-windows-x64-baseline",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.30.tgz",
+                "integrity": "sha512-BaqwQxA2TWBUNKsmrDoTF1gg3x6lbt7vA4WluRNuT6GuuJJhQ+lJzOTk2G9tqp4bMybR31p5zXAmPf9JwHP2GA=="
+            },
+            "win32-arm64": {
+                "pkg": "opencode-windows-arm64",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.30.tgz",
+                "integrity": "sha512-NLnAzRNqv+6ebLeK5DBGRcN6Fk3PM4STXyrp+IuI8w2WNLJ6JbIk7xxTfbMsrO+CBEV88DCurFOKHB4dpDBaYQ=="
+            },
+            "darwin-x64": {
+                "pkg": "opencode-darwin-x64-baseline",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.30.tgz",
+                "integrity": "sha512-DMQWRe9blvI+639fcwqG+JUxppTOVrPyasMF/uWhTi5N+5veXpB1K/wV15D8Lz7uqblH/CE7apxroaz/E7vudA=="
+            },
+            "darwin-arm64": {
+                "pkg": "opencode-darwin-arm64",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.30.tgz",
+                "integrity": "sha512-KO4FJGZpgmSz+NNQ6PizynT5qAzVfoZI5HJLpyD0tYNqePPu87g2/UgVmNW663Bock2r75koLZFjR5waZiFiqw=="
+            },
+            "linux-x64": {
+                "pkg": "opencode-linux-x64-baseline",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.30.tgz",
+                "integrity": "sha512-//sHZuMaNZXo6fzBtgUI5vf1oXiMX9Un2a2R3AUzajRahuW42+98wg9J33uuICblE3RS6G4HxobrvnWA8mr4VA=="
+            },
+            "linux-arm64": {
+                "pkg": "opencode-linux-arm64",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.30.tgz",
+                "integrity": "sha512-KU2VO9oGRhV3M9LCYJXeBBtadIIgJYf620KMHFeghrGL0967Zz7PAcMBFZqTy7gUqNEnMaqOqAkSGx57BIw41Q=="
+            },
+            "linux-x64-musl": {
+                "pkg": "opencode-linux-x64-baseline-musl",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.30.tgz",
+                "integrity": "sha512-8VAJb4VnNP6MbqWHMDMUwJ5k47tb5SPDqM0lcsCgfbeGjDy7rgFtlA8PYSgUgA9VTByBWmpfERR/34VVOHe82g=="
+            },
+            "linux-arm64-musl": {
+                "pkg": "opencode-linux-arm64-musl",
+                "pkgVersion": "1.18.30",
+                "tarball": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.30.tgz",
+                "integrity": "sha512-IQedvhqaisv886gwk3bR603fPTErdExQa0z3hmqi7waIeuSsQG9B+suhg6iaD74lmxMbYMRlPlg4kIioytiHGg=="
+            }
+        }
+    },
     "claude": {
         "version": "0.3.257",
         "platforms": {

--- a/apps/x/packages/core/src/code-mode/acp/engine-provisioner.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/engine-provisioner.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+const archive = Buffer.from('verified fixture archive');
+const integrity = `sha512-${createHash('sha512').update(archive).digest('base64')}`;
+let home: string;
+let provisioner: typeof import('./engine-provisioner.js');
+let spawn: ReturnType<typeof vi.fn>;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+    vi.resetModules();
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'rowboat engine test '));
+    vi.doMock('os', () => ({ ...os, homedir: () => home }));
+    vi.doMock('./shell-env.js', () => ({ loginShellPath: () => undefined }));
+    const platforms = Object.fromEntries(['win32-x64', 'win32-arm64', 'darwin-x64', 'darwin-arm64', 'linux-x64', 'linux-arm64', 'linux-x64-musl', 'linux-arm64-musl'].map(key => [key, { pkg: 'fixture', pkgVersion: '1.18.30', tarball: 'https://example.test/engine.tgz', integrity }]));
+    vi.doMock('./engine-manifest.js', () => ({ ENGINE_MANIFEST: { opencode: { version: '1.18.30', platforms } } }));
+    spawn = vi.fn((_command: string, args: string[]) => {
+        if (args[0] === '--version') return { status: 0, stdout: '1.18.30\n' };
+        const root = args[args.indexOf('-C') + 1];
+        fs.mkdirSync(path.join(root, 'bin'));
+        fs.writeFileSync(path.join(root, 'bin', process.platform === 'win32' ? 'opencode.exe' : 'opencode'), 'native fixture');
+        return { status: 0 };
+    });
+    vi.doMock('child_process', () => ({ spawnSync: spawn }));
+    fetchMock = vi.fn(async () => new Response(archive));
+    vi.stubGlobal('fetch', fetchMock);
+    provisioner = await import('./engine-provisioner.js');
+});
+afterEach(() => { vi.unstubAllGlobals(); fs.rmSync(home, { recursive: true, force: true }); });
+
+describe('managed OpenCode installation', () => {
+    it.each([
+        ['darwin', 'x64', { glibcVersionRuntime: '2.39' }, 'darwin-x64'],
+        ['darwin', 'arm64', {}, 'darwin-arm64'],
+        ['linux', 'x64', { glibcVersionRuntime: '2.39' }, 'linux-x64'],
+        ['linux', 'arm64', { glibcVersionRuntime: '2.39' }, 'linux-arm64'],
+        ['linux', 'x64', {}, 'linux-x64-musl'],
+        ['linux', 'arm64', {}, 'linux-arm64-musl'],
+        ['linux', 'x64', undefined, 'linux-x64'],
+    ])('selects %s/%s correctly, including libc, and validates the Unix executable', async (platform, arch, header, expected) => {
+        const previousPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        const previousArch = Object.getOwnPropertyDescriptor(process, 'arch')!;
+        Object.defineProperty(process, 'platform', { value: platform });
+        Object.defineProperty(process, 'arch', { value: arch });
+        vi.spyOn(process.report, 'getReport').mockReturnValue((header ? { header } : undefined) as never);
+        try {
+            const result = await provisioner.ensureEngine('opencode');
+            expect(path.basename(result.executablePath)).toBe('opencode');
+            const metadata = JSON.parse(fs.readFileSync(path.join(provisioner.ENGINES_ROOT, 'opencode', '.meta', 'opencode-1.18.30.json'), 'utf8'));
+            const expectedPlatform = !header && fs.existsSync('/lib/ld-musl-x86_64.so.1') ? 'linux-x64-musl' : expected;
+            expect(metadata.platform).toBe(expectedPlatform);
+            expect(metadata.validated).toBe(true);
+            expect(spawn.mock.calls[0][0]).toBe('tar');
+            expect(spawn.mock.calls[0][1]).toContain('--strip-components=1');
+        } finally {
+            Object.defineProperty(process, 'platform', previousPlatform);
+            Object.defineProperty(process, 'arch', previousArch);
+        }
+    });
+    it('deduplicates downloads, fans out progress, validates before activation and reuses installation', async () => {
+        const first = vi.fn(), second = vi.fn();
+        const [a, b] = await Promise.all([provisioner.ensureEngine('opencode', { onProgress: first }), provisioner.ensureEngine('opencode', { onProgress: second })]);
+        expect(a).toEqual(b);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(first).toHaveBeenCalledWith({ phase: 'validate' });
+        expect(second).toHaveBeenCalledWith({ phase: 'done' });
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(true);
+        await provisioner.ensureEngine('opencode');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const probe = spawn.mock.calls.find(call => call[1][0] === '--version')!;
+        expect(probe[0]).toContain(home);
+        expect(probe[2]).toMatchObject({ timeout: 15000, windowsHide: true, env: { OPENCODE_DISABLE_AUTOUPDATE: 'true' } });
+    });
+    it('does not accept a global executable or a missing managed executable, and repairs', async () => {
+        expect(() => provisioner.getProvisionedEnginePath('opencode')).toThrow('enabled');
+        const installed = await provisioner.ensureEngine('opencode');
+        fs.unlinkSync(installed.executablePath);
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(false);
+        expect(() => provisioner.getProvisionedEnginePath('opencode')).toThrow();
+        await provisioner.ensureEngine('opencode');
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(true);
+    });
+    it.each(['integrity', 'extraction', 'version', 'network'])('does not activate after %s failure and permits retry', async failure => {
+        if (failure === 'integrity') fetchMock.mockResolvedValueOnce(new Response('corrupt'));
+        if (failure === 'network') fetchMock.mockRejectedValueOnce(new Error('offline'));
+        if (failure === 'extraction') spawn.mockReturnValueOnce({ status: 1, stderr: 'bad tar' });
+        if (failure === 'version') spawn.mockImplementationOnce((_cmd, args) => {
+            const root = args[args.indexOf('-C') + 1];
+            fs.mkdirSync(path.join(root, 'bin'));
+            fs.writeFileSync(path.join(root, 'bin', process.platform === 'win32' ? 'opencode.exe' : 'opencode'), 'fixture');
+            return { status: 0 };
+        }).mockReturnValueOnce({ status: 1, stdout: 'wrong version' });
+        await expect(provisioner.ensureEngine('opencode')).rejects.toThrow();
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(false);
+        expect(fs.readdirSync(path.join(provisioner.ENGINES_ROOT, 'opencode')).filter(p => p.startsWith('.tmp-'))).toEqual([]);
+        await provisioner.ensureEngine('opencode');
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(true);
+    });
+    it('detaches one cancelled caller without cancelling another', async () => {
+        const controller = new AbortController();
+        const a = provisioner.ensureEngine('opencode', { signal: controller.signal });
+        const rejected = expect(a).rejects.toBeDefined();
+        const b = provisioner.ensureEngine('opencode');
+        controller.abort();
+        await rejected;
+        await b;
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    it('aborts when the only caller cancels, leaving no installed state', async () => {
+        const controller = new AbortController();
+        const result = provisioner.ensureEngine('opencode', { signal: controller.signal });
+        controller.abort();
+        await expect(result).rejects.toBeDefined();
+        await provisioner.removeOpenCodeEngine();
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(false);
+    });
+    it('preserves credentials and sessions on remove and reinstall', async () => {
+        await provisioner.ensureEngine('opencode');
+        const data = path.join(home, '.rowboat', 'opencode', 'data', 'auth.json');
+        fs.writeFileSync(data, 'retained state');
+        await provisioner.removeOpenCodeEngine();
+        expect(provisioner.isEngineProvisioned('opencode')).toBe(false);
+        expect(fs.readFileSync(data, 'utf8')).toBe('retained state');
+        await provisioner.ensureEngine('opencode');
+        expect(fs.readFileSync(data, 'utf8')).toBe('retained state');
+    });
+});

--- a/apps/x/packages/core/src/code-mode/acp/engine-provisioner.ts
+++ b/apps/x/packages/core/src/code-mode/acp/engine-provisioner.ts
@@ -20,6 +20,8 @@ import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import { ENGINE_MANIFEST } from './engine-manifest.js';
 import type { CodingAgent } from './types.js';
+import { CODING_AGENT_CAPABILITIES } from '@x/shared/dist/code-mode.js';
+import { buildOpenCodeEnvironment, prepareOpenCodeState, OPENCODE_ROOT } from './opencode-environment.js';
 
 export const ENGINES_ROOT = path.join(os.homedir(), '.rowboat', 'engines');
 
@@ -31,7 +33,7 @@ interface PlatformEntry {
 }
 
 export interface EngineProgress {
-    phase: 'check' | 'download' | 'verify' | 'extract' | 'done';
+    phase: 'check' | 'download' | 'verify' | 'extract' | 'validate' | 'done';
     /** Bytes received so far (download phase). */
     receivedBytes?: number;
     /** Total bytes, when the server reports content-length. */
@@ -61,7 +63,10 @@ function platformKey(agent: CodingAgent): string | null {
         candidates.push(`win32-${arch}`);
     } else if (process.platform === 'linux') {
         // Prefer a musl build on musl systems (Alpine); fall back to the glibc build.
-        if (isMuslLibc()) candidates.push(`linux-${arch}-musl`);
+        if (isMuslLibc()) {
+            candidates.push(`linux-${arch}-musl`);
+            if (agent === 'opencode') return candidates.find(c => c in plats) ?? null;
+        }
         candidates.push(`linux-${arch}`);
     }
     return candidates.find((c) => c in plats) ?? null;
@@ -73,15 +78,23 @@ function isMuslLibc(): boolean {
     try {
         const report = (process as unknown as { report?: { getReport?: () => unknown } }).report?.getReport?.();
         const header = (report as { header?: Record<string, unknown> } | undefined)?.header;
-        return !(header && 'glibcVersionRuntime' in header);
+        if (header) return !('glibcVersionRuntime' in header);
     } catch {
-        return false;
+        // Some embedded Node runtimes don't expose diagnostic reports.
     }
+    // A missing report is not evidence of musl. Probe its standard interpreter
+    // path before defaulting to glibc (the normal Linux Electron target).
+    const machine = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+    return fs.existsSync(`/lib/ld-musl-${machine}.so.1`);
 }
 
 // Locate the engine executable inside an extracted package root. We extract the whole npm
 // package (so codex's bundled ripgrep travels with it), then find the binary.
 function locateExecutable(agent: CodingAgent, root: string): string | null {
+    if (agent === 'opencode') {
+        const executable = path.join(root, 'bin', process.platform === 'win32' ? 'opencode.exe' : 'opencode');
+        try { return fs.statSync(executable).isFile() ? executable : null; } catch { return null; }
+    }
     if (agent === 'claude') {
         for (const name of ['claude', 'claude.exe']) {
             const p = path.join(root, name);
@@ -115,10 +128,19 @@ export function isEngineProvisioned(agent: CodingAgent): boolean {
     const version = ENGINE_MANIFEST[agent].version;
     const versionDir = path.join(ENGINES_ROOT, agent, version);
     const metaPath = path.join(ENGINES_ROOT, agent, '.meta', `${agent}-${version}.json`);
-    return locateExecutable(agent, versionDir) !== null && fs.existsSync(metaPath);
+    const executable = locateExecutable(agent, versionDir);
+    if (!executable) return false;
+    try {
+        const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+        const key = platformKey(agent);
+        const platform = key && (ENGINE_MANIFEST[agent].platforms as Record<string, PlatformEntry>)[key];
+        return !!platform && metadata.version === version && metadata.platform === key &&
+            metadata.integrity === platform.integrity && metadata.binRelPath === path.relative(versionDir, executable) &&
+            (agent !== 'opencode' || metadata.validated === true);
+    } catch { return false; }
 }
 
-const AGENT_LABEL: Record<CodingAgent, string> = { claude: 'Claude Code', codex: 'Codex' };
+const AGENT_LABEL = Object.fromEntries(Object.entries(CODING_AGENT_CAPABILITIES).map(([id, value]) => [id, value.name]));
 
 // Return the provisioned engine's executable path, or throw a clear, user-facing error.
 // The chat/run path uses this — we deliberately do NOT download here: the engine must be
@@ -128,7 +150,7 @@ const AGENT_LABEL: Record<CodingAgent, string> = { claude: 'Claude Code', codex:
 export function getProvisionedEnginePath(agent: CodingAgent): string {
     const version = ENGINE_MANIFEST[agent].version;
     const exe = locateExecutable(agent, path.join(ENGINES_ROOT, agent, version));
-    if (!exe) {
+    if (!exe || !isEngineProvisioned(agent)) {
         throw new Error(
             `${AGENT_LABEL[agent]} isn't enabled yet. Open Settings → Code Mode and click Enable to download it.`,
         );
@@ -163,7 +185,7 @@ function pruneOldVersions(agent: CodingAgent, keepVersion: string): void {
 
 async function downloadTo(url: string, dest: string, opts: EnsureEngineOptions): Promise<void> {
     opts.onProgress?.({ phase: 'download', receivedBytes: 0 });
-    const res = await fetch(url, { signal: opts.signal });
+    const res = await fetch(url, { signal: opts.signal ? AbortSignal.any([opts.signal, AbortSignal.timeout(600_000)]) : AbortSignal.timeout(600_000) });
     if (!res.ok || !res.body) {
         throw new Error(`Code mode: engine download failed (HTTP ${res.status}) — ${url}`);
     }
@@ -174,7 +196,7 @@ async function downloadTo(url: string, dest: string, opts: EnsureEngineOptions):
         received += chunk.length;
         opts.onProgress?.({ phase: 'download', receivedBytes: received, totalBytes: total });
     });
-    await pipeline(body, fs.createWriteStream(dest));
+    await pipeline(body, fs.createWriteStream(dest), { signal: opts.signal });
 }
 
 // Verify the tarball against the npm Subresource Integrity string ("sha512-<base64>").
@@ -214,7 +236,7 @@ function extractTarball(tarPath: string, destDir: string): void {
         }
     }
 
-    const r = spawnSync(tarCmd, tarArgs, spawnOpts);
+    const r = spawnSync(tarCmd, tarArgs, { ...spawnOpts, windowsHide: true, timeout: 120_000, maxBuffer: 1024 * 1024 });
     if (r.status !== 0) {
         const err = r.stderr?.toString().trim() || r.error?.message || `tar exited ${r.status}`;
         throw new Error(`Code mode: failed to extract engine — ${err}`);
@@ -240,7 +262,8 @@ function makeExecutable(agent: CodingAgent, root: string, exe: string): void {
  * Ensure the pinned engine for `agent` is provisioned locally, downloading it on first
  * use. Returns the absolute path to the engine executable. Idempotent and cached.
  */
-export async function ensureEngine(agent: CodingAgent, opts: EnsureEngineOptions = {}): Promise<ProvisionedEngine> {
+async function installEngine(agent: CodingAgent, opts: EnsureEngineOptions = {}): Promise<ProvisionedEngine> {
+    opts.signal?.throwIfAborted();
     const entry = ENGINE_MANIFEST[agent];
     const version = entry.version;
     const key = platformKey(agent);
@@ -257,18 +280,20 @@ export async function ensureEngine(agent: CodingAgent, opts: EnsureEngineOptions
     opts.onProgress?.({ phase: 'check' });
     // Fast path: already provisioned and intact.
     const existing = locateExecutable(agent, versionDir);
-    if (existing && fs.existsSync(metaPath)) {
+    if (existing && isEngineProvisioned(agent)) {
         opts.onProgress?.({ phase: 'done' });
         return { executablePath: existing, version };
     }
 
-    // Download to a unique temp dir, verify, extract, then swap into place. Concurrent
-    // callers each use their own temp dir; the final rename is idempotent (same content).
+    // Download to a unique temp dir, verify, extract, then swap into place.
+    // ensureEngine shares this operation among concurrent backend callers.
     fs.mkdirSync(agentRoot, { recursive: true });
+    fs.rmSync(metaPath, { force: true });
     const tmpRoot = fs.mkdtempSync(path.join(agentRoot, `.tmp-${version}-`));
     try {
         const tarPath = path.join(tmpRoot, 'engine.tgz');
         await downloadTo(plat.tarball, tarPath, opts);
+        opts.signal?.throwIfAborted();
 
         opts.onProgress?.({ phase: 'verify' });
         verifyIntegrity(tarPath, plat.integrity);
@@ -277,12 +302,25 @@ export async function ensureEngine(agent: CodingAgent, opts: EnsureEngineOptions
         const extractDir = path.join(tmpRoot, 'pkg');
         fs.mkdirSync(extractDir);
         extractTarball(tarPath, extractDir);
+        opts.signal?.throwIfAborted();
 
         const exe = locateExecutable(agent, extractDir);
         if (!exe) {
             throw new Error(`Code mode: ${agent} engine binary not found in the downloaded package.`);
         }
         if (process.platform !== 'win32') makeExecutable(agent, extractDir, exe);
+        if (agent === 'opencode') {
+            opts.onProgress?.({ phase: 'validate' });
+            prepareOpenCodeState();
+            const result = spawnSync(exe, ['--version'], {
+                env: buildOpenCodeEnvironment(), cwd: OPENCODE_ROOT,
+                windowsHide: true, timeout: 15_000, maxBuffer: 8192, encoding: 'utf8',
+            });
+            if (result.status !== 0 || result.stdout.trim() !== version) {
+                throw new Error(`OpenCode engine version validation failed; expected ${version}. Retry installation.`);
+            }
+        }
+        opts.signal?.throwIfAborted();
 
         // Swap the freshly extracted package into the versioned location.
         if (fs.existsSync(versionDir)) fs.rmSync(versionDir, { recursive: true, force: true });
@@ -298,15 +336,86 @@ export async function ensureEngine(agent: CodingAgent, opts: EnsureEngineOptions
             platform: key,
             integrity: plat.integrity,
             binRelPath: path.relative(versionDir, finalExe),
+            validated: true,
         }, null, 2));
 
         // A new version is in place — remove superseded versions so old engines
         // (~200 MB each) don't accumulate after a bump. Best-effort.
-        pruneOldVersions(agent, version);
+        if (agent !== 'opencode') pruneOldVersions(agent, version);
 
         opts.onProgress?.({ phase: 'done' });
         return { executablePath: finalExe, version };
     } finally {
-        fs.rmSync(tmpRoot, { recursive: true, force: true });
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* cleanup must not mask validation errors or a successful install */ }
     }
+}
+
+interface Installation {
+    controller: AbortController;
+    listeners: Set<(progress: EngineProgress) => void>;
+    promise: Promise<ProvisionedEngine>;
+    last?: EngineProgress;
+    subscribers: number;
+}
+const installations = new Map<CodingAgent, Installation>();
+let removingOpenCode = false;
+
+/** Subscribers share a download. An individual cancellation only detaches that
+ * subscriber; the operation aborts when nobody remains or the engine is removed. */
+export function ensureEngine(agent: CodingAgent, opts: EnsureEngineOptions = {}): Promise<ProvisionedEngine> {
+    if (agent === 'opencode' && removingOpenCode) return Promise.reject(new Error('OpenCode removal is in progress. Retry Enable when it finishes.'));
+    if (opts.signal?.aborted) return Promise.reject(opts.signal.reason);
+    let installation = installations.get(agent);
+    if (!installation) {
+        const state: Installation = { controller: new AbortController(), listeners: new Set(), subscribers: 0, promise: undefined! };
+        installations.set(agent, state);
+        state.promise = Promise.resolve().then(() => installEngine(agent, {
+            signal: state.controller.signal,
+            onProgress: progress => {
+                state.last = progress;
+                for (const listener of state.listeners) { try { listener(progress); } catch { /* closed renderer */ } }
+            },
+        })).finally(() => { if (installations.get(agent) === state) installations.delete(agent); });
+        installation = state;
+    }
+    const state = installation;
+    state.subscribers++;
+    if (opts.onProgress) {
+        state.listeners.add(opts.onProgress);
+        if (state.last) { try { opts.onProgress(state.last); } catch { /* closed renderer */ } }
+    }
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = () => {
+            if (settled) return false;
+            settled = true;
+            opts.signal?.removeEventListener('abort', abort);
+            if (opts.onProgress) state.listeners.delete(opts.onProgress);
+            if (--state.subscribers === 0) state.controller.abort();
+            return true;
+        };
+        const abort = () => { if (finish()) reject(opts.signal?.reason); };
+        opts.signal?.addEventListener('abort', abort, { once: true });
+        state.promise.then(value => { if (finish()) resolve(value); }, error => { if (finish()) reject(error); });
+    });
+}
+
+export function cancelEngineInstallations(): void {
+    for (const state of installations.values()) state.controller.abort();
+}
+
+/** Caller must stop owned processes first. Only the managed engine directory is removed. */
+export async function removeOpenCodeEngine(): Promise<void> {
+    if (removingOpenCode) throw new Error('OpenCode removal is already in progress.');
+    removingOpenCode = true;
+    try {
+        const installation = installations.get('opencode');
+        if (installation) {
+            installation.controller.abort();
+            await installation.promise.catch(() => {});
+        }
+        // Yield while deleting so Windows can deliver child exit/close callbacks
+        // and release executable handles after setup stops its native process.
+        await fs.promises.rm(path.join(ENGINES_ROOT, 'opencode'), { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } finally { removingOpenCode = false; }
 }

--- a/apps/x/packages/core/src/code-mode/acp/manager.ts
+++ b/apps/x/packages/core/src/code-mode/acp/manager.ts
@@ -1,7 +1,11 @@
+import { OPEN_CODE_ACCESS_ERROR } from './opencode-model-access.js';
 import * as os from 'os';
 import type { ApprovalPolicy, CodeRunEvent, CodingAgent, PermissionAsk, PermissionDecision, RunPromptResult } from './types.js';
 import { AcpClient, type CodeAgentModelOptions } from './client.js';
 import { PermissionBroker } from './permission-broker.js';
+
+import { ENGINE_MANIFEST } from './engine-manifest.js';
+import { OPENCODE_ROOT } from './opencode-environment.js';
 import { readStoredSession, writeStoredSession, clearStoredSession } from './session-store.js';
 
 export interface RunPromptArgs {
@@ -15,6 +19,7 @@ export interface RunPromptArgs {
     model?: string;
     /** Reasoning-effort level (e.g. "high"); applied alongside the model. */
     effort?: string;
+    mode?: string;
     /** Called when the policy needs the user to decide (the "ask" path). */
     ask: (ask: PermissionAsk) => Promise<PermissionDecision>;
     /** Stream sink for this prompt's run. */
@@ -55,6 +60,9 @@ const CANCEL_GRACE_MS = 2_000;
 // resumes the persisted session via session/load.
 export class CodeModeManager {
     private readonly runs = new Map<string, ActiveRun>();
+    private readonly busy = new Set<string>();
+    private readonly starting = new Map<string, AcpClient>();
+    isRunning(runId: string): boolean { return this.busy.has(runId); }
     // Per-agent model/effort choices, discovered once from the engine and reused
     // (the list only changes when the provider ships new models, and the app can
     // be restarted to pick those up). Avoids cold-starting an adapter per picker.
@@ -64,15 +72,39 @@ export class CodeModeManager {
     // the engine (what its `/model` picker would show). Spawns a short-lived
     // adapter, opens a throwaway session to read its advertised options, and
     // tears it down. Cached per agent for the lifetime of the process.
-    async listModelOptions(agent: CodingAgent): Promise<CodeAgentModelOptions> {
-        const cached = this.modelOptionsCache.get(agent);
+    async listModelOptions(agent: CodingAgent, cwd?: string, model?: string, effort?: string, mode?: string, strict = true): Promise<CodeAgentModelOptions> {
+        if (agent === 'opencode' && !cwd) throw new Error('Select a project before discovering OpenCode models.');
+
+        // OpenCode discovery is deliberately uncached: project config, credentials
+        // and model variants must all be read by a fresh process.
+        const cached = agent === 'opencode' ? undefined : this.modelOptionsCache.get(agent);
         if (cached) return cached;
         const broker = new PermissionBroker({ policy: 'yolo', ask: async () => 'reject' });
-        const client = new AcpClient({ agent, cwd: os.homedir(), broker, onEvent: () => {} });
+        const client = new AcpClient({ agent, cwd: cwd ?? os.homedir(), broker, onEvent: () => {} });
         try {
             await client.start();
-            const options = await client.describeModelOptions();
-            this.modelOptionsCache.set(agent, options);
+            const access = agent === 'opencode' ? await client.getOpenCodeModelAccess() : undefined;
+            let selectionError: string | undefined;
+            if (access && model && model !== 'default' && !access.models.has(model)) {
+                if (strict) throw new Error(OPEN_CODE_ACCESS_ERROR);
+                selectionError = OPEN_CODE_ACCESS_ERROR;
+                model = undefined;
+            }
+            if (access && !access.models.size) {
+                const message = 'No models are available through your current OpenCode connection. Refresh models or reconnect your account.';
+                if (strict) throw new Error(message);
+                return { models: [], efforts: [], openCodeProviders: access.groups, selectionError: message };
+            }
+            const discoveryModel = access && (!model || model === 'default') ? access.models.keys().next().value : model;
+            const options = await client.describeModelOptions(discoveryModel, effort, mode, strict);
+            if (access) {
+                options.openCodeProviders = access.groups;
+                options.models = options.models.filter(m => access.models.has(m.value)).map(m => ({ ...m,
+                    label: m.label + ' (' + ({ free: 'Free', zen: 'Zen', go: 'Go' }[access.models.get(m.value)!]) + ')',
+                }));
+                if (selectionError) { options.selectionError = selectionError; options.currentModel = undefined; options.currentEffort = undefined; }
+            }
+            if (agent !== 'opencode') this.modelOptionsCache.set(agent, options);
             return options;
         } finally {
             client.dispose();
@@ -80,19 +112,38 @@ export class CodeModeManager {
     }
 
     async runPrompt(args: RunPromptArgs): Promise<RunPromptResult> {
+        if (this.busy.has(args.runId)) throw new Error('This coding session already has a running operation.');
+        args.signal?.throwIfAborted();
+        this.busy.add(args.runId);
+        try { return await this.runPromptExclusive(args); }
+        finally { this.busy.delete(args.runId); }
+    }
+
+    private async runPromptExclusive(args: RunPromptArgs): Promise<RunPromptResult> {
         const { runId, agent, cwd, prompt, policy, model, effort, ask, onEvent, signal } = args;
 
         const broker = new PermissionBroker({
             policy,
             ask,
+            signal,
+            allowPersistent: agent !== 'opencode',
             onResolved: (a, decision, auto) => onEvent({ type: 'permission', ask: a, decision, auto }),
         });
 
-        const run = await this.ensureRun(runId, agent, cwd, broker, onEvent);
+        const run = await this.ensureRun(runId, agent, cwd, broker, onEvent, signal);
         // Re-apply the session's model + effort each turn (idempotent): a warm
         // connection keeps the last selection, but a cold session/load resets it,
         // and the user may have changed it from the header since the last turn.
-        await this.applyModelAndEffort(run, model, effort);
+        const abortPreparation = () => this.dispose(runId);
+        signal?.addEventListener('abort', abortPreparation, { once: true });
+        try {
+            signal?.throwIfAborted();
+            if (args.mode) await run.client.setMode(run.sessionId, args.mode);
+            await this.applyModelAndEffort(run, model, effort);
+            await run.client.preparePermissions(run.sessionId);
+            signal?.throwIfAborted();
+        } catch (error) { this.dispose(runId); throw error; }
+        finally { signal?.removeEventListener('abort', abortPreparation); }
         run.inflight++;
 
         let graceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -128,6 +179,7 @@ export class CodeModeManager {
             if (signal?.aborted) return { stopReason: 'cancelled', sessionId: run.sessionId };
             throw e;
         } finally {
+            broker.cancel();
             if (signal && onAbort) signal.removeEventListener('abort', onAbort);
             if (graceTimer) clearTimeout(graceTimer);
             run.inflight--;
@@ -139,6 +191,17 @@ export class CodeModeManager {
     // doesn't support, must not abort the turn — we log and proceed with the
     // engine default rather than surfacing a hard error to the user.
     private async applyModelAndEffort(run: ActiveRun, model?: string, effort?: string): Promise<void> {
+        if (run.agent === 'opencode') {
+            const access = await run.client.getOpenCodeModelAccess();
+            const explicit = model && model !== 'default' ? model : undefined;
+            if (explicit && !access.models.has(explicit)) throw new Error(OPEN_CODE_ACCESS_ERROR);
+            const current = run.client.configuration.currentModel;
+            const selected = explicit ?? (current && access.models.has(current) ? current : access.models.keys().next().value);
+            if (!selected) throw new Error('No OpenCode models are available. Refresh models or reconnect your account.');
+            await run.client.setModel(run.sessionId, selected);
+            if (effort) await run.client.setEffort(run.sessionId, effort);
+            return;
+        }
         if (model && model !== 'default') {
             try {
                 await run.client.setModel(run.sessionId, model);
@@ -156,6 +219,7 @@ export class CodeModeManager {
     }
 
     dispose(runId: string): void {
+        this.starting.get(runId)?.dispose();
         const run = this.runs.get(runId);
         if (!run) return;
         this.cancelDispose(run);
@@ -170,7 +234,7 @@ export class CodeModeManager {
         const run = this.runs.get(runId);
         if (!run || run.inflight > 0) return;
         this.cancelDispose(run);
-        if (DISPOSE_GRACE_MS <= 0) {
+        if (DISPOSE_GRACE_MS <= 0 || run.agent === 'opencode') {
             this.dispose(runId);
             return;
         }
@@ -190,6 +254,7 @@ export class CodeModeManager {
     }
 
     disposeAll(): void {
+        for (const client of this.starting.values()) client.dispose();
         for (const runId of [...this.runs.keys()]) this.dispose(runId);
     }
 
@@ -201,6 +266,7 @@ export class CodeModeManager {
         cwd: string,
         broker: PermissionBroker,
         onEvent: (event: CodeRunEvent) => void,
+        signal?: AbortSignal,
     ): Promise<ActiveRun> {
         const existing = this.runs.get(runId);
         if (existing && existing.agent === agent && existing.cwd === cwd) {
@@ -222,9 +288,14 @@ export class CodeModeManager {
         });
         // Dispose the client if startup fails (e.g. the startup-timeout fires) so the
         // spawned adapter process doesn't leak.
+        const abort = () => client.dispose();
+        this.starting.set(runId, client);
+        signal?.addEventListener('abort', abort, { once: true });
         try {
+            signal?.throwIfAborted();
             await client.start();
             const sessionId = await this.openSession(runId, agent, cwd, client);
+            signal?.throwIfAborted();
             client.setHandlers(broker, onEvent);
             const run: ActiveRun = { client, sessionId, agent, cwd, inflight: 0 };
             this.runs.set(runId, run);
@@ -232,6 +303,9 @@ export class CodeModeManager {
         } catch (e) {
             client.dispose();
             throw e;
+        } finally {
+            this.starting.delete(runId);
+            signal?.removeEventListener('abort', abort);
         }
     }
 
@@ -239,17 +313,22 @@ export class CodeModeManager {
     // and persist its id so a later restart can resume it.
     private async openSession(runId: string, agent: CodingAgent, cwd: string, client: AcpClient): Promise<string> {
         const stored = await readStoredSession(runId);
+        if (stored?.agent === 'opencode' && stored.stateNamespace && stored.stateNamespace !== OPENCODE_ROOT) throw new Error('The saved OpenCode session belongs to a different state directory. Restore its state or create a new Code session.');
         if (stored && stored.agent === agent && stored.cwd === cwd && client.loadSupported) {
             try {
                 await client.loadSession(stored.sessionId);
                 return stored.sessionId;
             } catch {
+                if (agent === 'opencode') throw new Error('The saved OpenCode session could not be loaded. Its history was preserved. Restore the managed OpenCode state or create a new Code session.');
                 // Stored session is stale/unloadable — fall through to a fresh one.
                 await clearStoredSession(runId);
             }
         }
+        if (stored && agent === 'opencode' && stored.agent === agent) throw new Error('The saved OpenCode session cannot resume in this working directory or engine. Create a new Code session.');
         const sessionId = await client.newSession();
-        await writeStoredSession({ runId, agent, cwd, sessionId });
+        await writeStoredSession({ runId, agent, cwd, sessionId,
+            ...(agent === 'opencode' ? { engineVersion: ENGINE_MANIFEST.opencode.version, stateNamespace: OPENCODE_ROOT, capabilities: client.capabilities } : {}),
+        });
         return sessionId;
     }
 }

--- a/apps/x/packages/core/src/code-mode/acp/opencode-environment.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-environment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as path from 'path';
+vi.mock('./shell-env.js', () => ({ loginShellPath: () => undefined }));
+import { buildOpenCodeEnvironment } from './opencode-environment.js';
+
+describe('OpenCode state isolation', () => {
+    it('preserves project tool PATH while excluding inherited credentials and injection overrides', () => {
+        const inherited = { Path: 'C:\\tools with spaces', HOME: '/home/user', OPENCODE_CONFIG: '/global/config', OPENCODE_DB: '/global/db', OPENAI_API_KEY: 'secret', AWS_PROFILE: 'global', GOOGLE_APPLICATION_CREDENTIALS: '/global/key', NODE_OPTIONS: '--require evil', CUSTOM_PROVIDER_TOKEN: 'secret', XDG_DATA_HOME: '/global/data' };
+        const env = buildOpenCodeEnvironment(inherited, '/rowboat state', undefined);
+        expect(env.PATH).toBe(inherited.Path);
+        expect(env.HOME).toBe(inherited.HOME);
+        for (const key of ['OPENCODE_CONFIG', 'OPENCODE_DB', 'OPENAI_API_KEY', 'AWS_PROFILE', 'GOOGLE_APPLICATION_CREDENTIALS', 'NODE_OPTIONS', 'CUSTOM_PROVIDER_TOKEN']) expect(env[key]).toBeUndefined();
+        expect(env.XDG_DATA_HOME).toBe(path.join('/rowboat state', 'data'));
+        expect(env.XDG_CONFIG_HOME).toBe(path.join('/rowboat state', 'config'));
+        expect(env.XDG_CACHE_HOME).toBe(path.join('/rowboat state', 'cache'));
+        expect(env.XDG_STATE_HOME).toBe(path.join('/rowboat state', 'state'));
+        expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT!)).toEqual({ enabled_providers: ['opencode', 'opencode-go'] });
+        expect(env.OPENCODE_DISABLE_AUTOUPDATE).toBe('true');
+        expect(inherited.XDG_DATA_HOME).toBe('/global/data');
+    });
+});

--- a/apps/x/packages/core/src/code-mode/acp/opencode-environment.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-environment.ts
@@ -1,0 +1,37 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { loginShellPath } from './shell-env.js';
+
+export const OPENCODE_ROOT = path.join(os.homedir(), '.rowboat', 'opencode');
+
+// Allowlist instead of an inevitably incomplete list of provider secret names.
+// Project tools keep PATH and basic OS/home/temp/locale settings, but credentials
+// and executable/config injection (NODE_OPTIONS, BUN_OPTIONS, etc.) are not imported.
+const SYSTEM_ENV = /^(PATH|PATHEXT|SYSTEMROOT|WINDIR|COMSPEC|SYSTEMDRIVE|TEMP|TMP|TMPDIR|HOME|USERPROFILE|HOMEDRIVE|HOMEPATH|APPDATA|LOCALAPPDATA|PROGRAMFILES|PROGRAMFILES\(X86\)|PROGRAMDATA|USERNAME|USER|LOGNAME|SHELL|LANG|LC_[A-Z_]+|TZ|TERM|COLORTERM)$/i;
+
+export function buildOpenCodeEnvironment(
+    inherited: NodeJS.ProcessEnv = process.env,
+    root = OPENCODE_ROOT,
+    toolPath = loginShellPath(),
+): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {};
+    for (const [key, value] of Object.entries(inherited)) {
+        if (SYSTEM_ENV.test(key) && key.toUpperCase() !== 'PATH') env[key] = value;
+    }
+    const inheritedPath = Object.entries(inherited).find(([key]) => key.toUpperCase() === 'PATH')?.[1];
+    env.PATH = [...new Set([toolPath, inheritedPath].filter(Boolean).flatMap(p => p!.split(path.delimiter)))].join(path.delimiter);
+    for (const [key, directory] of Object.entries({ XDG_CONFIG_HOME: 'config', XDG_DATA_HOME: 'data', XDG_CACHE_HOME: 'cache', XDG_STATE_HOME: 'state' })) {
+        env[key] = path.join(root, directory);
+    }
+    env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ enabled_providers: ['opencode', 'opencode-go'] });
+    env.OPENCODE_DISABLE_AUTOUPDATE = 'true';
+    env.OPENCODE_DISABLE_TERMINAL_TITLE = 'true';
+    return env;
+}
+
+export function prepareOpenCodeState(root = OPENCODE_ROOT): void {
+    for (const directory of ['config', 'data', 'cache', 'state']) {
+        fs.mkdirSync(path.join(root, directory), { recursive: true, mode: 0o700 });
+    }
+}

--- a/apps/x/packages/core/src/code-mode/acp/opencode-login.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-login.ts
@@ -1,0 +1,53 @@
+import * as pty from 'node-pty';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { ensureSpawnHelperExecutable } from '../../terminal/terminal.js';
+import { killProcessTree } from '../../terminal/kill-tree.js';
+import { buildOpenCodeEnvironment, OPENCODE_ROOT, prepareOpenCodeState } from './opencode-environment.js';
+import { getProvisionedEnginePath } from './engine-provisioner.js';
+import { openCodeSetup, SetupError } from './opencode-setup.js';
+
+// Dedicated ephemeral PTY: no generic terminal broadcasts or persisted backlog.
+let login: { id: string; process: pty.IPty; output: string; running: boolean; exitCode?: number; timer: ReturnType<typeof setTimeout> } | undefined;
+export function startOpenCodeLogin(id: string): void {
+    if (login) throw new SetupError('busy', 'A managed login is already open. Close it before starting another.');
+    openCodeSetup.beginLogin(id);
+    try {
+        prepareOpenCodeState(); ensureSpawnHelperExecutable();
+        const env = buildOpenCodeEnvironment();
+        env.OPENCODE_DISABLE_PROJECT_CONFIG = 'true';
+        const proc = pty.spawn(getProvisionedEnginePath('opencode'), ['auth', 'login'], {
+            cwd: OPENCODE_ROOT, env: Object.fromEntries(Object.entries(env).filter((item): item is [string, string] => item[1] !== undefined)),
+            cols: 80, rows: 20, name: 'xterm-256color',
+            // Avoid node-pty's legacy console-list helper racing tree termination.
+            useConptyDll: process.platform === 'win32',
+        });
+        const timer = setTimeout(() => stopOpenCodeLogin(id), 10 * 60_000); timer.unref?.();
+        const entry = { id, process: proc, output: '', running: true, exitCode: undefined as number | undefined, timer };
+        login = entry;
+        proc.onData(data => { entry.output = (entry.output + data).slice(-32768); });
+        proc.onExit(({ exitCode }) => { entry.running = false; entry.exitCode = exitCode; clearTimeout(timer); if (login === entry) openCodeSetup.endLogin(id); });
+    } catch { openCodeSetup.endLogin(id); throw new SetupError('failed', 'Could not open the managed login terminal. Re-check the engine and retry.'); }
+}
+export function readOpenCodeLogin(id: string) {
+    if (login?.id !== id) throw new SetupError('cancelled', 'The managed login terminal has closed.');
+    const output = login.output; login.output = '';
+    return { output, running: login.running, exitCode: login.exitCode };
+}
+export function writeOpenCodeLogin(id: string, input: string): void {
+    if (login?.id !== id || !login.running) throw new SetupError('cancelled', 'The managed login terminal has closed.');
+    login.process.write(input);
+}
+export function stopOpenCodeLogin(id?: string): void {
+    if (!login || (id && login.id !== id)) return;
+    const entry = login; login = undefined;
+    clearTimeout(entry.timer);
+    if (entry.running) {
+        if (process.platform === 'win32') {
+            spawnSync(path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'taskkill.exe'),
+                ['/pid', String(entry.process.pid), '/T', '/F'], { windowsHide: true, timeout: 5000, stdio: 'ignore' });
+        } else killProcessTree(entry.process.pid);
+        try { entry.process.kill(); } catch { /* exited */ }
+    }
+    openCodeSetup.endLogin(entry.id);
+}

--- a/apps/x/packages/core/src/code-mode/acp/opencode-model-access.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-model-access.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from 'vitest';
+import { openCodeModelAccess } from './opencode-model-access.js';
+
+const catalog = { all: [
+    { id: 'opencode', models: {
+        public: { id: 'public', name: 'No free keyword', cost: { input: 0, output: 0 } },
+        paid: { id: 'paid', name: 'Misleading Free model', cost: { input: 1, output: 2 } },
+        partial: { id: 'partial', cost: { input: 0, output: 2 } },
+        unknown: { id: 'unknown' },
+    } },
+    { id: 'opencode-go', models: { go: { id: 'go', cost: { input: 0, output: 0 } } } },
+    { id: 'other', models: { unrelated: { id: 'unrelated', cost: { input: 0, output: 0 } } } },
+] };
+
+it('allows only confirmed public free models without managed account credentials', () => {
+    const access = openCodeModelAccess(new Set(['other']), catalog);
+    expect(access.groups).toEqual(['free']);
+    expect([...access.models]).toEqual([['opencode/public', 'free']]);
+});
+it('shows only Go when Go is connected, hiding even public Zen models', () => {
+    const access = openCodeModelAccess(new Set(['opencode-go']), catalog);
+    expect(access.groups).toEqual(['go']);
+    expect([...access.models.keys()]).toEqual(['opencode-go/go']);
+});
+it('shows only Zen when Zen is connected', () => {
+    const access = openCodeModelAccess(new Set(['opencode']), catalog);
+    expect(access.groups).toEqual(['zen']);
+    expect([...access.models.keys()]).toEqual(['opencode/public', 'opencode/paid', 'opencode/partial', 'opencode/unknown']);
+});
+it('advertises both services only while both are connected, reverting to free on disconnect', () => {
+    const credentials = new Set(['opencode', 'opencode-go']);
+    expect(openCodeModelAccess(credentials, catalog).groups).toEqual(['zen', 'go']);
+    credentials.delete('opencode');
+    expect(openCodeModelAccess(credentials, catalog).models.has('opencode/paid')).toBe(false);
+    credentials.clear();
+    expect([...openCodeModelAccess(credentials, catalog).models.keys()]).toEqual(['opencode/public']);
+});
+it('rejects malformed catalog data without exposing it in the error', () => {
+    expect(() => openCodeModelAccess(new Set(), { secret: 'do-not-echo' })).toThrow('model access could not be read');
+});

--- a/apps/x/packages/core/src/code-mode/acp/opencode-model-access.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-model-access.ts
@@ -1,0 +1,31 @@
+import z from 'zod';
+
+export type OpenCodeAccessGroup = 'free' | 'zen' | 'go';
+const Catalog = z.object({ all: z.array(z.object({
+    id: z.string(), models: z.record(z.string(), z.object({
+        id: z.string(), cost: z.object({ input: z.number(), output: z.number() }).optional(),
+    })),
+})) });
+
+/** Saved connection IDs select the service, not an inferred subscription tier.
+ * Public access fails closed unless native pricing metadata confirms zero cost. */
+export function openCodeModelAccess(credentials: Set<string>, rawCatalog: unknown) {
+    const groups: OpenCodeAccessGroup[] = [];
+    if (credentials.has('opencode')) groups.push('zen');
+    if (credentials.has('opencode-go')) groups.push('go');
+    if (!groups.length) groups.push('free');
+    const models = new Map<string, OpenCodeAccessGroup>();
+    const parsed = Catalog.safeParse(rawCatalog);
+    if (!parsed.success) throw new Error('OpenCode model access could not be read. Refresh models to retry.');
+    for (const provider of parsed.data.all) {
+        const group = provider.id === 'opencode-go' ? 'go' : provider.id === 'opencode' ? (groups.includes('free') ? 'free' : 'zen') : undefined;
+        if (!group || !groups.includes(group)) continue;
+        for (const model of Object.values(provider.models)) {
+            if (group === 'free' && (model.cost?.input !== 0 || model.cost?.output !== 0)) continue;
+            models.set(`${provider.id}/${model.id}`, group);
+        }
+    }
+    return { groups, models };
+}
+
+export const OPEN_CODE_ACCESS_ERROR = 'This model is unavailable through your current OpenCode connection. Refresh models and choose a model from the available service.';

--- a/apps/x/packages/core/src/code-mode/acp/opencode-policy.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-policy.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { enforceOpenCodePolicy, rowboatOpenCodeRules } from './opencode-policy.js';
+import type { OpenCodeProcess } from './opencode-process.js';
+afterEach(() => vi.unstubAllGlobals());
+
+it('overrides configured allows while retaining project, custom-agent and session denials', () => {
+    const deny = { permission: 'bash', pattern: 'rm *', action: 'deny' };
+    const rules = rowboatOpenCodeRules([{ name: 'custom', permission: [{ permission: '*', pattern: '*', action: 'allow' }, deny] }], { permission: [{ ...deny, pattern: 'git push*' }] }, 'custom');
+    expect(rules[0]).toEqual({ permission: '*', pattern: '*', action: 'ask' });
+    expect(rules).toContainEqual(deny);
+    expect(rules).toContainEqual({ ...deny, pattern: 'git push*' });
+    expect(rules).toContainEqual({ permission: 'task', pattern: '*', action: 'deny' });
+    expect(rules.some(r => r.action === 'allow')).toBe(false);
+});
+it('fails closed on malformed permission discovery', () => {
+    expect(() => rowboatOpenCodeRules([{}], {}, 'build')).toThrow();
+});
+
+it('tightens and relaxes mode rules without losing explicit session denials or growing unchanged rules', async () => {
+    type Rule = { permission: string; pattern: string; action: string };
+    let session: { permission: Rule[]; metadata?: unknown } = { permission: [{ permission: 'read', pattern: '*.secret', action: 'deny' }] };
+    const agents = [{ name: 'build', permission: [] }, { name: 'plan', permission: [{ permission: 'edit', pattern: '*', action: 'deny' }] }];
+    const request = vi.fn(async (url: URL, init: RequestInit) => {
+        if (url.pathname === '/agent') return Response.json(agents);
+        if (init.method === 'PATCH') {
+            const body = JSON.parse(init.body as string);
+            session = { permission: [...session.permission, ...body.permission], metadata: body.metadata };
+        }
+        return Response.json(session);
+    });
+    vi.stubGlobal('fetch', request);
+    const handle = { url: 'http://127.0.0.1:1234', authorization: 'private' } as OpenCodeProcess;
+    await enforceOpenCodePolicy(handle, '/project', 's', 'plan');
+    const length = session.permission.length;
+    await enforceOpenCodePolicy(handle, '/project', 's', 'plan');
+    expect(session.permission).toHaveLength(length);
+    await enforceOpenCodePolicy(handle, '/project', 's', 'build');
+    const reversed = [...session.permission].reverse();
+    expect(reversed.find(r => r.permission === 'edit' || r.permission === '*')?.action).toBe('ask');
+    expect(reversed.find(r => r.permission === 'read' || r.permission === '*')?.action).toBe('deny');
+    session.permission.push({ permission: 'bash', pattern: '*', action: 'deny' });
+    await enforceOpenCodePolicy(handle, '/project', 's', 'build');
+    expect([...session.permission].reverse().find(r => r.permission === 'bash' || r.permission === '*')?.action).toBe('deny');
+    session.permission = [];
+    await expect(enforceOpenCodePolicy(handle, '/project', 's', 'build')).rejects.toThrow('changed outside Rowboat');
+});

--- a/apps/x/packages/core/src/code-mode/acp/opencode-policy.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-policy.ts
@@ -1,0 +1,55 @@
+import z from 'zod';
+import type { OpenCodeProcess } from './opencode-process.js';
+
+const Rule = z.object({ permission: z.string(), pattern: z.string(), action: z.enum(['allow', 'ask', 'deny']) });
+const Rules = z.array(Rule);
+
+/** Session rules run after agent rules. Preserve every explicit denial, including
+ * custom agents, while bringing configured auto-allows through Rowboat's broker.
+ * ACP 1.18.30 does not forward child-session approvals or persistent scope. */
+export function rowboatOpenCodeRules(agents: unknown, session: unknown, mode: string) {
+    const catalog = z.array(z.object({ name: z.string(), permission: Rules })).parse(agents);
+    const active = catalog.find(a => a.name === mode);
+    if (!active) throw new Error('OpenCode selected mode was not found in its permission catalog.');
+    const previous = z.object({ permission: Rules.optional() }).parse(session);
+    const rules = [
+        { permission: '*', pattern: '*', action: 'ask' as const },
+        ...[...active.permission, ...(previous.permission ?? [])].filter(r => r.action === 'deny'),
+        { permission: 'task', pattern: '*', action: 'deny' as const },
+        { permission: 'question', pattern: '*', action: 'deny' as const },
+    ];
+    return rules.filter((rule, index) => !rules.slice(index + 1).some(r => r.permission === rule.permission && r.pattern === rule.pattern && r.action === rule.action));
+}
+
+export async function openCodeRequest(handle: OpenCodeProcess, cwd: string, route: string, method = 'GET', body?: unknown): Promise<unknown> {
+    const url = new URL(route, handle.url);
+    url.searchParams.set('directory', cwd);
+    const response = await fetch(url, {
+        method, headers: { Authorization: handle.authorization, 'Content-Type': 'application/json' },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(15_000), redirect: 'error',
+    });
+    if (!response.ok) throw new Error(`OpenCode ${method} ${route.split('/')[1]} failed (HTTP ${response.status}).`);
+    return response.json();
+}
+
+export async function enforceOpenCodePolicy(handle: OpenCodeProcess, cwd: string, sessionId: string, mode: string): Promise<void> {
+    const route = `/session/${encodeURIComponent(sessionId)}`;
+    const [agents, session] = await Promise.all([
+        openCodeRequest(handle, cwd, '/agent'), openCodeRequest(handle, cwd, route),
+    ]);
+    const current = z.object({ permission: Rules.optional(), metadata: z.record(z.string(), z.unknown()).optional() }).parse(session);
+    const prior = current.metadata?.rowboatApprovalPolicy;
+    const snapshot = prior === undefined ? undefined : z.object({ baseline: Rules, installed: Rules }).parse(prior);
+    const existing = current.permission ?? [];
+    if (snapshot && JSON.stringify(existing.slice(0, snapshot.installed.length)) !== JSON.stringify(snapshot.installed)) {
+        throw new Error('OpenCode session permissions changed outside Rowboat. Create a new Code session to apply the current policy safely.');
+    }
+    const baseline = snapshot ? [...snapshot.baseline, ...existing.slice(snapshot.installed.length)] : existing;
+    const permission = rowboatOpenCodeRules(agents, { permission: baseline }, mode);
+    if (snapshot && JSON.stringify(existing.slice(-permission.length)) === JSON.stringify(permission)) return;
+    const metadata = { ...current.metadata, rowboatApprovalPolicy: { baseline, installed: [...existing, ...permission] } };
+    const updated = await openCodeRequest(handle, cwd, route, 'PATCH', { permission, metadata });
+    const accepted = z.object({ permission: Rules }).parse(updated).permission;
+    if (JSON.stringify(accepted.slice(-permission.length)) !== JSON.stringify(permission)) throw new Error('OpenCode did not accept Rowboat approval rules. Coding was not started.');
+}

--- a/apps/x/packages/core/src/code-mode/acp/opencode-process.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-process.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import * as path from 'path';
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn(), spawnSync: vi.fn(), fetch: vi.fn() }));
+vi.mock('child_process', () => ({ spawn: mocks.spawn, spawnSync: mocks.spawnSync }));
+vi.mock('./engine-provisioner.js', () => ({ getProvisionedEnginePath: () => path.resolve('managed engine', 'opencode.exe') }));
+vi.mock('./opencode-environment.js', () => ({ OPENCODE_ROOT: path.resolve('isolated state'), prepareOpenCodeState: vi.fn(), buildOpenCodeEnvironment: () => ({ PATH: 'project tools', OPENCODE_DISABLE_AUTOUPDATE: 'true' }) }));
+vi.mock('net', () => ({ createServer: () => ({ once: vi.fn(), listen: (_port: number, _host: string, cb: () => void) => cb(), address: () => ({ port: 43210 }), close: (cb: () => void) => cb() }) }));
+import { OpenCodeProcessService } from './opencode-process.js';
+
+let child: EventEmitter & { pid: number; exitCode: number | null; stdout: PassThrough; stderr: PassThrough; stdin: PassThrough; kill: ReturnType<typeof vi.fn> };
+afterEach(() => vi.unstubAllGlobals());
+beforeEach(() => {
+    child = Object.assign(new EventEmitter(), { pid: 987654321, exitCode: null, stdout: new PassThrough(), stderr: new PassThrough(), stdin: new PassThrough(), kill: vi.fn(() => { child.exitCode = 1; child.emit('exit', 1, null); return true; }) });
+    mocks.spawn.mockReturnValue(child);
+    mocks.spawnSync.mockReturnValue({ status: 0 });
+    mocks.fetch.mockResolvedValue({ ok: true, json: async () => ({ healthy: true }) });
+    vi.stubGlobal('fetch', mocks.fetch);
+});
+
+describe('OpenCode process lifecycle', () => {
+    it.each(['darwin', 'linux'])('creates and kills an owned process group on %s', async platform => {
+        const previous = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', { value: platform });
+        const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+        const service = new OpenCodeProcessService();
+        try {
+            const handle = await service.start('acp', { cwd: path.resolve('project with spaces') });
+            expect(mocks.spawn.mock.calls[0][2].detached).toBe(true);
+            handle.stop();
+            await handle.exited;
+            expect(kill).toHaveBeenCalledWith(-child.pid, 'SIGKILL');
+            expect(mocks.spawnSync).not.toHaveBeenCalled();
+        } finally {
+            service.stopAll();
+            Object.defineProperty(process, 'platform', previous);
+        }
+    });
+    it('uses native launch, private binding, ephemeral backend credentials and shared environment', async () => {
+        const service = new OpenCodeProcessService();
+        const handle = await service.start('acp', { cwd: path.resolve('project with spaces') });
+        const [command, args, options] = mocks.spawn.mock.calls[0];
+        expect(command).toContain('managed engine');
+        expect(args).toEqual(['acp', '--hostname', '127.0.0.1', '--port', '43210', '--mdns=false']);
+        expect(options).toMatchObject({ shell: false, windowsHide: true, cwd: path.resolve('project with spaces'), env: { OPENCODE_DISABLE_AUTOUPDATE: 'true' } });
+        expect(options.env.OPENCODE_SERVER_PASSWORD).toHaveLength(64);
+        expect(handle.authorization).toMatch(/^Basic /);
+        expect(child.stdout.listenerCount('data')).toBe(0);
+        service.stopAll();
+        await handle.exited;
+        expect(child.kill).toHaveBeenCalledOnce();
+        handle.stop();
+        expect(child.kill).toHaveBeenCalledOnce();
+    });
+    it('cleans up after startup timeout', async () => {
+        mocks.fetch.mockRejectedValue(new Error('connection refused'));
+        const service = new OpenCodeProcessService();
+        await expect(service.start('serve', { timeoutMs: 1 })).rejects.toThrow('timed out');
+        expect(child.kill).toHaveBeenCalledOnce();
+    });
+    it('cleans up on cancellation during startup', async () => {
+        const controller = new AbortController();
+        mocks.fetch.mockImplementation(async () => { controller.abort(); throw new Error('cancelled'); });
+        await expect(new OpenCodeProcessService().start('serve', { signal: controller.signal })).rejects.toBeDefined();
+        expect(child.kill).toHaveBeenCalledOnce();
+    });
+    it('handles spawn errors without leaving a live handle', async () => {
+        mocks.spawn.mockImplementationOnce(() => { queueMicrotask(() => child.emit('error', new Error('ENOENT'))); return child; });
+        await expect(new OpenCodeProcessService().start('serve')).rejects.toThrow('exited during startup');
+        expect(child.kill).toHaveBeenCalledOnce();
+    });
+    it('requires a project directory for coding', async () => {
+        await expect(new OpenCodeProcessService().start('acp')).rejects.toThrow('absolute project');
+    });
+});

--- a/apps/x/packages/core/src/code-mode/acp/opencode-process.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-process.ts
@@ -1,0 +1,111 @@
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'child_process';
+import { randomBytes } from 'crypto';
+import * as path from 'path';
+import * as net from 'net';
+import { getProvisionedEnginePath } from './engine-provisioner.js';
+import { buildOpenCodeEnvironment, prepareOpenCodeState, OPENCODE_ROOT } from './opencode-environment.js';
+
+export interface OpenCodeProcess {
+    child: ChildProcessWithoutNullStreams;
+    /** Backend-only connection details. Never serialize into IPC or logs. */
+    url: string;
+    authorization: string;
+    exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+    stop(): void;
+}
+
+async function availablePort(): Promise<number> {
+    const server = net.createServer();
+    return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as net.AddressInfo).port;
+            server.close(error => error ? reject(error) : resolve(port));
+        });
+    });
+}
+
+export function terminateOpenCodeTree(child: ChildProcessWithoutNullStreams): void {
+    if (!child.pid) return;
+    if (process.platform === 'win32') {
+        spawnSync(path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'taskkill.exe'),
+            ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true, timeout: 5_000, stdio: 'ignore' });
+    } else {
+        try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
+    if (child.exitCode === null) child.kill('SIGKILL');
+}
+
+export class OpenCodeProcessService {
+    private readonly owned = new Set<OpenCodeProcess>();
+    private generation = 0;
+
+    /** Both serve and ACP bind an authenticated private HTTP listener. ACP stdout
+     * remains untouched for the later coding protocol client. */
+    async start(mode: 'serve' | 'acp', options: { cwd?: string; signal?: AbortSignal; timeoutMs?: number } = {}): Promise<OpenCodeProcess> {
+        if (mode === 'acp' && (!options.cwd || !path.isAbsolute(options.cwd))) throw new Error('OpenCode ACP requires an absolute project working directory.');
+        const generation = this.generation;
+        options.signal?.throwIfAborted();
+        const executable = getProvisionedEnginePath('opencode');
+        prepareOpenCodeState();
+        const port = await availablePort();
+        options.signal?.throwIfAborted();
+        if (generation !== this.generation) throw new Error('OpenCode startup cancelled.');
+        const password = randomBytes(32).toString('hex');
+        const env = buildOpenCodeEnvironment();
+        env.OPENCODE_SERVER_USERNAME = 'rowboat';
+        env.OPENCODE_SERVER_PASSWORD = password;
+        if (mode === 'serve') env.OPENCODE_DISABLE_PROJECT_CONFIG = 'true';
+        const child = spawn(executable, [mode, '--hostname', '127.0.0.1', '--port', String(port), '--mdns=false'], {
+            cwd: mode === 'serve' ? OPENCODE_ROOT : options.cwd,
+            env, windowsHide: true, shell: false, detached: process.platform !== 'win32', stdio: 'pipe',
+        });
+        let failed = false;
+        // Consume diagnostics without logging potential provider secrets. Keep only
+        // a bounded byte count; exit code and startup phase are safe diagnostics.
+        let diagnosticBytes = 0;
+        child.stderr.on('data', (data: Buffer) => { diagnosticBytes = Math.min(8192, diagnosticBytes + data.length); });
+        if (mode === 'serve') child.stdout.resume();
+        const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(resolve => {
+            child.once('error', () => { failed = true; resolve({ code: null, signal: null }); });
+            child.once('exit', (code, signal) => { failed = true; resolve({ code, signal }); });
+        });
+        const handle: OpenCodeProcess = {
+            child, url: `http://127.0.0.1:${port}`, authorization: `Basic ${Buffer.from(`rowboat:${password}`).toString('base64')}`, exited,
+            stop: () => {
+                if (!this.owned.delete(handle)) return;
+                options.signal?.removeEventListener('abort', handle.stop);
+                terminateOpenCodeTree(child);
+            },
+        };
+        this.owned.add(handle);
+        options.signal?.addEventListener('abort', handle.stop, { once: true });
+        void exited.then(() => handle.stop());
+        const deadline = Date.now() + (options.timeoutMs ?? 30_000);
+        try {
+            while (Date.now() < deadline) {
+                options.signal?.throwIfAborted();
+                if (failed || !this.owned.has(handle)) throw new Error(`OpenCode ${mode} exited during startup (code ${child.exitCode ?? 'unavailable'}, diagnostic bytes ${diagnosticBytes}).`);
+                try {
+                    const response = await fetch(`${handle.url}/global/health`, {
+                        headers: { Authorization: handle.authorization }, signal: AbortSignal.timeout(500), redirect: 'error',
+                    });
+                    const health = response.ok ? await response.json() as { healthy?: boolean } : null;
+                    if (health?.healthy && this.owned.has(handle) && !failed && !options.signal?.aborted) return handle;
+                } catch { /* socket not listening yet */ }
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+            throw new Error(`OpenCode ${mode} startup timed out.`);
+        } catch (error) {
+            handle.stop();
+            throw error;
+        }
+    }
+
+    stopAll(): void {
+        this.generation++;
+        for (const handle of [...this.owned]) handle.stop();
+    }
+}
+
+export const openCodeProcesses = new OpenCodeProcessService();

--- a/apps/x/packages/core/src/code-mode/acp/opencode-setup.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-setup.test.ts
@@ -7,7 +7,7 @@ import type { OpenCodeProcess } from './opencode-process.js';
 
 let root: string, service: OpenCodeSetupService, fetcher: ReturnType<typeof vi.fn>, launch: ReturnType<typeof vi.fn>;
 let connected: boolean, modelError: unknown, wrongModel: boolean;
-const calls: { route: string; method: string; body: any; server: string }[] = [];
+const calls: { route: string; method: string; body: unknown; server: string }[] = [];
 beforeEach(() => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), 'rowboat provider test '));
     connected = false; modelError = undefined; wrongModel = false; calls.length = 0;
@@ -51,8 +51,8 @@ describe('OpenCode provider setup', () => {
         expect(fs.readFileSync(path.join(root, 'selection.json'), 'utf8')).toBe('{"providerId":"openai","modelId":"openai/model"}');
         const verified = await service.verify(id);
         expect(verified.verified).toMatchObject({ providerId: 'openai', modelId: 'openai/model', generation: verified.generation });
-        expect(calls.find(c => c.route === '/session')?.body.permission).toEqual([{ permission: '*', pattern: '*', action: 'deny' }]);
-        expect(calls.find(c => c.route.endsWith('/message'))?.body.tools).toEqual({ '*': false });
+        expect(calls.find(c => c.route === '/session')?.body).toMatchObject({ permission: [{ permission: '*', pattern: '*', action: 'deny' }] });
+        expect(calls.find(c => c.route.endsWith('/message'))?.body).toMatchObject({ tools: { '*': false } });
         expect(JSON.stringify(calls.filter(c => c.route.startsWith('/session')))).not.toContain('test-secret');
         expect(calls.some(c => c.route === '/session/session-test' && c.method === 'DELETE')).toBe(true);
     });
@@ -105,7 +105,7 @@ describe('OpenCode provider setup', () => {
         const auth = await service.authorize(setupId, 'openai', 0, {});
         await expect(service.complete(setupId, auth.attemptId)).rejects.toMatchObject({ code: 'invalid-input' });
         await service.complete(setupId, auth.attemptId, 'one-time-code');
-        expect(calls.find(c => c.route.endsWith('/callback'))?.body.code).toBe('one-time-code');
+        expect(calls.find(c => c.route.endsWith('/callback'))?.body).toMatchObject({ code: 'one-time-code' });
     });
     it('disconnects and invalidates verification while retaining selection', async () => {
         const id = await configured(); await service.verify(id);

--- a/apps/x/packages/core/src/code-mode/acp/opencode-setup.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-setup.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { OpenCodeSetupService, safeSetupError, validateAuthorizationUrl } from './opencode-setup.js';
+import type { OpenCodeProcess } from './opencode-process.js';
+
+let root: string, service: OpenCodeSetupService, fetcher: ReturnType<typeof vi.fn>, launch: ReturnType<typeof vi.fn>;
+let connected: boolean, modelError: unknown, wrongModel: boolean;
+const calls: { route: string; method: string; body: any; server: string }[] = [];
+beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'rowboat provider test '));
+    connected = false; modelError = undefined; wrongModel = false; calls.length = 0;
+    let serial = 0;
+    launch = vi.fn(async () => {
+        let exit!: (value: { code: number; signal: null }) => void;
+        const exited = new Promise<{ code: number; signal: null }>(resolve => { exit = resolve; });
+        return { url: `http://127.0.0.1:${30000 + serial++}`, authorization: 'Basic private-backend', exited, stop: vi.fn(() => exit({ code: 0, signal: null })) } as unknown as OpenCodeProcess;
+    });
+    fetcher = vi.fn(async (url: string, options: RequestInit) => {
+        const parsed = new URL(url), route = parsed.pathname, method = options.method ?? 'GET';
+        const body = options.body ? JSON.parse(String(options.body)) : undefined;
+        calls.push({ route, method, body, server: parsed.origin });
+        let data: unknown = true;
+        if (route === '/provider') data = { all: [{ id: 'openai', name: 'OpenAI', env: ['OPENAI_API_KEY'], models: { model: { id: 'model', name: 'Test model' } } }], connected: connected ? ['openai'] : [] };
+        if (route === '/provider/auth') data = { openai: [{ type: 'oauth', label: 'ChatGPT Pro/Plus (browser)' }, { type: 'api', label: 'API key' }] };
+        if (route === '/auth/openai') connected = method === 'PUT';
+        if (route.endsWith('/oauth/authorize')) data = { url: 'https://auth.openai.com/oauth/authorize?state=test', method: 'auto', instructions: 'Complete sign in' };
+        if (route.endsWith('/oauth/callback')) connected = true;
+        if (route === '/session') data = { id: 'session-test' };
+        if (route.endsWith('/message')) data = { info: { providerID: 'openai', modelID: wrongModel ? 'another-model' : 'model', finish: 'stop', ...(modelError ? { error: modelError } : {}) }, parts: [{ type: 'text', text: 'OK' }] };
+        return new Response(JSON.stringify(data), { status: 200 });
+    });
+    service = new OpenCodeSetupService(launch as (signal: AbortSignal) => Promise<OpenCodeProcess>, fetcher as typeof fetch, path.join(root, 'selection.json'), async () => new Set(connected ? ['openai'] : []));
+});
+afterEach(() => { service.stop(); vi.useRealTimers(); fs.rmSync(root, { recursive: true, force: true }); });
+async function configured() {
+    const state = await service.start('window');
+    await service.saveKey(state.setupId, 'openai', 1, 'test-secret-not-a-real-key');
+    await service.select(state.setupId, 'openai', 'openai/model');
+    return state.setupId;
+}
+
+describe('OpenCode provider setup', () => {
+    it('distinguishes saved credentials from verified provider/model and persists only selection', async () => {
+        const id = await configured();
+        const state = await service.refresh(id);
+        expect(state.providers[0].connected).toBe(true);
+        expect(state.verified).toBeUndefined();
+        expect(JSON.stringify(state)).not.toContain('test-secret');
+        expect(fs.readFileSync(path.join(root, 'selection.json'), 'utf8')).toBe('{"providerId":"openai","modelId":"openai/model"}');
+        const verified = await service.verify(id);
+        expect(verified.verified).toMatchObject({ providerId: 'openai', modelId: 'openai/model', generation: verified.generation });
+        expect(calls.find(c => c.route === '/session')?.body.permission).toEqual([{ permission: '*', pattern: '*', action: 'deny' }]);
+        expect(calls.find(c => c.route.endsWith('/message'))?.body.tools).toEqual({ '*': false });
+        expect(JSON.stringify(calls.filter(c => c.route.startsWith('/session')))).not.toContain('test-secret');
+        expect(calls.some(c => c.route === '/session/session-test' && c.method === 'DELETE')).toBe(true);
+    });
+    it('never marks rejected credentials ready, including errors inside HTTP 200', async () => {
+        const id = await configured();
+        modelError = { name: 'APIError', data: { statusCode: 401, message: 'upstream echoed test-secret' } };
+        await expect(service.verify(id)).rejects.toMatchObject({ code: 'invalid-credentials' });
+        expect((await service.refresh(id)).verified).toBeUndefined();
+    });
+    it('rejects silently substituted models and deletes the probe session', async () => {
+        const id = await configured(); wrongModel = true;
+        await expect(service.verify(id)).rejects.toThrow('selected model');
+        expect(calls.some(c => c.method === 'DELETE' && c.route.includes('session'))).toBe(true);
+    });
+    it('rejects unavailable models without persisting the selection', async () => {
+        const { setupId } = await service.start('window');
+        await expect(service.select(setupId, 'openai', 'openai/missing')).rejects.toMatchObject({ code: 'unavailable-model' });
+        expect(fs.existsSync(path.join(root, 'selection.json'))).toBe(false);
+    });
+    it('keeps one process alive across OAuth and restarts only after completion', async () => {
+        const { setupId } = await service.start('window');
+        const auth = await service.authorize(setupId, 'openai', 0, {});
+        await expect(service.refresh(setupId)).rejects.toMatchObject({ code: 'busy' });
+        const result = await service.complete(setupId, auth.attemptId);
+        const oauth = calls.filter(c => c.route.includes('/oauth/'));
+        expect(oauth[0].server).toBe(oauth[1].server);
+        expect(launch).toHaveBeenCalledTimes(2);
+        expect(result.providers[0].connected).toBe(true);
+        expect(result.verified).toBeUndefined();
+    });
+    it('cancels attempts and permits a fresh retry', async () => {
+        const { setupId } = await service.start('window');
+        const auth = await service.authorize(setupId, 'openai', 0, {});
+        service.cancel(setupId);
+        await expect(service.complete(setupId, auth.attemptId)).rejects.toMatchObject({ code: 'cancelled' });
+        const retry = await service.authorize(setupId, 'openai', 0, {});
+        expect(retry.attemptId).not.toBe(auth.attemptId);
+        await service.complete(setupId, retry.attemptId);
+    });
+    it('expires an idle authorization and kills its process', async () => {
+        const { setupId } = await service.start('window');
+        vi.useFakeTimers();
+        const auth = await service.authorize(setupId, 'openai', 0, {});
+        await vi.advanceTimersByTimeAsync(10 * 60_000 + 1);
+        await expect(service.complete(setupId, auth.attemptId)).rejects.toMatchObject({ code: 'expired' });
+    });
+    it('accepts code submission when advertised by a supported method', async () => {
+        const { setupId } = await service.start('window');
+        fetcher.mockResolvedValueOnce(new Response(JSON.stringify({ url: 'https://auth.openai.com/oauth/authorize', method: 'code', instructions: 'Paste code' })));
+        const auth = await service.authorize(setupId, 'openai', 0, {});
+        await expect(service.complete(setupId, auth.attemptId)).rejects.toMatchObject({ code: 'invalid-input' });
+        await service.complete(setupId, auth.attemptId, 'one-time-code');
+        expect(calls.find(c => c.route.endsWith('/callback'))?.body.code).toBe('one-time-code');
+    });
+    it('disconnects and invalidates verification while retaining selection', async () => {
+        const id = await configured(); await service.verify(id);
+        const result = await service.disconnect(id, 'openai');
+        expect(result.providers[0].connected).toBe(false); expect(result.verified).toBeUndefined();
+        expect(result.selection?.modelId).toBe('openai/model');
+    });
+    it('stops on window closure, prevents cross-window setup and rejects stale requests', async () => {
+        const { setupId } = await service.start('one');
+        await expect(service.start('two')).rejects.toMatchObject({ code: 'busy' });
+        service.stopOwner('two'); await service.refresh(setupId);
+        service.stopOwner('one'); await expect(service.refresh(setupId)).rejects.toMatchObject({ code: 'cancelled' });
+        expect((await service.start('two')).setupId).not.toBe(setupId);
+    });
+    it.each([401, 429, 500])('returns safe errors for HTTP %s without upstream bodies', async status => {
+        const { setupId } = await service.start('window');
+        fetcher.mockResolvedValueOnce(new Response('test-secret-in-body', { status }));
+        try { await service.saveKey(setupId, 'openai', 1, 'test-secret'); throw new Error('expected failure'); }
+        catch (error) { expect(JSON.stringify(safeSetupError(error))).not.toContain('test-secret'); }
+    });
+    it('sanitizes transport and unexpected errors', () => {
+        expect(safeSetupError(new Error('Authorization: secret')).message).not.toContain('secret');
+    });
+    it.each(['http://auth.openai.com/', 'https://evil.test/', 'file:///tmp/login', 'https://secret@auth.openai.com/'])('rejects unsafe authorization URL %s', url => {
+        expect(() => validateAuthorizationUrl('openai', url)).toThrow();
+    });
+});

--- a/apps/x/packages/core/src/code-mode/acp/opencode-setup.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-setup.ts
@@ -1,0 +1,294 @@
+import { randomUUID } from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { z } from 'zod';
+import { OpenCodeAuthPrompt, OpenCodeSelection, type OpenCodeAuthMethod, type OpenCodeProvider, type OpenCodeSetupState, type OpenCodeSetupError } from '@x/shared/dist/opencode-setup.js';
+import { openCodeProcesses, type OpenCodeProcess } from './opencode-process.js';
+import { OPENCODE_ROOT } from './opencode-environment.js';
+
+type ErrorCode = z.infer<typeof OpenCodeSetupError>['code'];
+export class SetupError extends Error {
+    constructor(readonly code: ErrorCode, message: string) { super(message); }
+}
+export function safeSetupError(error: unknown): { code: ErrorCode; message: string } {
+    return error instanceof SetupError ? { code: error.code, message: error.message }
+        : { code: 'failed', message: 'OpenCode setup failed. Re-open provider setup and try again.' };
+}
+const providerList = z.object({ all: z.array(z.object({
+    id: z.string(), name: z.string(), env: z.array(z.string()).optional(),
+    models: z.record(z.string(), z.object({ id: z.string(), name: z.string(), status: z.string().optional() })),
+})), connected: z.array(z.string()) });
+const methodList = z.record(z.string(), z.array(z.object({ type: z.string(), label: z.string(), prompts: z.array(z.unknown()).optional() })));
+const authorizationSchema = z.object({ url: z.string().url(), method: z.enum(['auto', 'code']), instructions: z.string().max(8000) });
+const OAUTH_LIFETIME = 10 * 60_000;
+export async function storedProviderIds(): Promise<Set<string>> {
+    try {
+        const entries: unknown = JSON.parse(await fs.readFile(path.join(OPENCODE_ROOT, 'data', 'opencode', 'auth.json'), 'utf8'));
+        if (!entries || typeof entries !== 'object' || Array.isArray(entries)) return new Set();
+        // Inspect only the managed credential store. Never return credential values.
+        return new Set(Object.entries(entries).filter(([, value]) => value && typeof value === 'object' &&
+            (('type' in value && value.type === 'api' && 'key' in value && typeof value.key === 'string' && value.key.length > 0) ||
+             ('type' in value && value.type === 'oauth' && 'refresh' in value && typeof value.refresh === 'string' && value.refresh.length > 0))).map(([id]) => id));
+    } catch { return new Set(); }
+}
+
+export async function readOpenCodeSelection(): Promise<z.infer<typeof OpenCodeSelection> | undefined> {
+    try { return OpenCodeSelection.parse(JSON.parse(await fs.readFile(path.join(OPENCODE_ROOT, 'state', 'rowboat-selection.json'), 'utf8'))); }
+    catch { return undefined; }
+}
+// Bounded built-in flows. Enterprise/custom plugins use the managed login terminal.
+function oauthSupported(provider: string, label: string, inputs?: Record<string, string>): boolean {
+    return (provider === 'openai' && ['ChatGPT Pro/Plus (browser)', 'ChatGPT Pro/Plus (headless)'].includes(label)) ||
+        (provider === 'github-copilot' && label === 'Login with GitHub Copilot' && (!inputs || inputs.deploymentType === 'github.com'));
+}
+export function validateAuthorizationUrl(provider: string, raw: string): string {
+    const url = new URL(raw);
+    const hosts = provider === 'openai' ? ['auth.openai.com'] : provider === 'github-copilot' ? ['github.com'] : [];
+    if (url.protocol !== 'https:' || url.username || url.password || url.port || !hosts.includes(url.hostname))
+        throw new SetupError('unsupported', 'This authorization address is unsupported. Use the managed login flow.');
+    return url.href;
+}
+
+interface Lease {
+    id: string; owner: string; controller: AbortController; process?: OpenCodeProcess;
+    starting?: Promise<OpenCodeProcess>; busy: boolean; providers: OpenCodeProvider[];
+    attempt?: { id: string; providerId: string; method: number; mode: 'auto' | 'code'; expiresAt: number; timer: ReturnType<typeof setTimeout>; expired: boolean; completing: boolean };
+}
+export class OpenCodeSetupService {
+    private lease?: Lease;
+    private generation = 0;
+    private selection?: z.infer<typeof OpenCodeSelection>;
+    private verified?: OpenCodeSetupState['verified'];
+    constructor(private readonly launch = (signal: AbortSignal) => openCodeProcesses.start('serve', { signal }), private readonly requestFetch: typeof fetch = fetch,
+        private readonly selectionFile = path.join(OPENCODE_ROOT, 'state', 'rowboat-selection.json'),
+        private readonly credentialIds = storedProviderIds) {}
+
+    private require(id: string): Lease {
+        if (!this.lease || this.lease.id !== id || this.lease.controller.signal.aborted)
+            throw new SetupError('cancelled', 'Provider setup was closed or cancelled. Open it again to continue.');
+        return this.lease;
+    }
+    private async process(lease: Lease): Promise<OpenCodeProcess> {
+        if (lease.process) return lease.process;
+        if (!lease.starting) lease.starting = this.launch(lease.controller.signal).then(handle => {
+            if (this.lease !== lease || lease.controller.signal.aborted) { handle.stop(); throw new SetupError('cancelled', 'Provider setup was cancelled.'); }
+            lease.process = handle;
+            void handle.exited.then(() => { if (lease.process === handle) { lease.process = undefined; this.verified = undefined; } });
+            return handle;
+        }).finally(() => { lease.starting = undefined; });
+        return lease.starting;
+    }
+    private restart(lease: Lease): void { lease.process?.stop(); lease.process = undefined; }
+    private async request(lease: Lease, route: string, method = 'GET', body?: unknown, timeout = 20_000): Promise<unknown> {
+        const handle = await this.process(lease);
+        this.require(lease.id);
+        try {
+            const response = await this.requestFetch(handle.url + route, { method,
+                headers: { Authorization: handle.authorization, 'Content-Type': 'application/json' },
+                body: body === undefined ? undefined : JSON.stringify(body), redirect: 'error',
+                signal: AbortSignal.any([lease.controller.signal, AbortSignal.timeout(timeout)]),
+            });
+            if (!response.ok) {
+                // Never surface raw upstream bodies; they may contain credentials.
+                void response.body?.cancel();
+                if ([401, 403].includes(response.status)) throw new SetupError('invalid-credentials', 'Credentials were rejected. Reconnect this provider and verify again.');
+                if (response.status === 429) throw new SetupError('rate-limit', 'The provider is rate limited or out of quota. Check your account and retry.');
+                if (response.status === 404) throw new SetupError('unavailable-model', 'The provider or model is unavailable. Refresh and select another model.');
+                throw new SetupError('failed', `OpenCode could not complete this operation (HTTP ${response.status}). Check the provider settings and retry.`);
+            }
+            return response.status === 204 ? undefined : await response.json();
+        } catch (error) {
+            if (error instanceof SetupError) throw error;
+            if (lease.controller.signal.aborted) throw new SetupError('cancelled', 'Provider setup was cancelled.');
+            throw new SetupError('unavailable', 'The request timed out or the connection was lost. Check your network and retry.');
+        }
+    }
+    private async exclusive<T>(id: string, work: (lease: Lease) => Promise<T>): Promise<T> {
+        const lease = this.require(id);
+        if (lease.busy || lease.attempt) throw new SetupError('busy', 'Finish or cancel the current operation first.');
+        lease.busy = true;
+        try { return await work(lease); } finally { lease.busy = false; }
+    }
+    async start(owner: string): Promise<OpenCodeSetupState> {
+        if (this.lease && this.lease.owner !== owner) throw new SetupError('busy', 'Provider setup is already open in another window.');
+        if (!this.lease) {
+            this.lease = { id: randomUUID(), owner, controller: new AbortController(), busy: false, providers: [] };
+        }
+        const lease = this.lease;
+        if (!lease.process && !lease.starting && !lease.busy) {
+            try { this.selection = OpenCodeSelection.parse(JSON.parse(await fs.readFile(this.selectionFile, 'utf8'))); } catch { this.selection = undefined; }
+        }
+        this.require(lease.id);
+        return this.refresh(lease.id);
+    }
+    stop(id?: string): void {
+        const lease = this.lease;
+        if (!lease || (id && lease.id !== id)) return;
+        this.lease = undefined;
+        if (lease.attempt) clearTimeout(lease.attempt.timer);
+        lease.controller.abort();
+        this.restart(lease);
+        this.verified = undefined;
+    }
+    stopOwner(owner: string): void { if (this.lease?.owner === owner) this.stop(); }
+    beginLogin(id: string): void {
+        const lease = this.require(id);
+        if (lease.busy || lease.attempt) throw new SetupError('busy', 'Finish or cancel the current operation first.');
+        lease.busy = true; this.restart(lease); this.changed();
+    }
+    endLogin(id: string): void { if (this.lease?.id === id) { this.lease.busy = false; this.changed(); } }
+    private state(lease: Lease): OpenCodeSetupState {
+        return { setupId: lease.id, generation: this.generation, providers: lease.providers, selection: this.selection, verified: this.verified };
+    }
+    private async discover(lease: Lease): Promise<OpenCodeSetupState> {
+        const [rawProviders, rawMethods] = await Promise.all([this.request(lease, '/provider'), this.request(lease, '/provider/auth')]);
+        const providers = providerList.parse(rawProviders), methods = methodList.parse(rawMethods);
+        const credentials = await this.credentialIds();
+        this.require(lease.id);
+        lease.providers = providers.all.map(provider => {
+            const available = methods[provider.id] ?? [(provider.env?.length ?? 0) > 1
+                ? { type: 'unsupported', label: 'Managed login (additional configuration required)' }
+                : { type: 'api', label: 'API key' }];
+            const auth: OpenCodeAuthMethod[] = available.map((method, index) => {
+                const prompts = (method.prompts ?? []).map(prompt => OpenCodeAuthPrompt.safeParse(prompt));
+                const supported = prompts.every(p => p.success) && ((method.type === 'api' && prompts.length === 0) || (method.type === 'oauth' && oauthSupported(provider.id, method.label)));
+                return { index, label: method.label, type: method.type === 'oauth' ? 'oauth' : method.type === 'api' ? 'api' : 'unsupported', supported,
+                    prompts: prompts.flatMap(p => p.success ? [p.data] : []) };
+            });
+            // Upstream `connected` also includes config-only/free providers; it is
+            // not proof of saved credentials and may remain true after DELETE auth.
+            return { id: provider.id, name: provider.name, connected: credentials.has(provider.id), methods: auth,
+                models: Object.values(provider.models).filter(model => model.status !== 'deprecated').map(model => ({ id: `${provider.id}/${model.id}`, name: model.name })) };
+        });
+        if (this.verified && !lease.providers.some(p => p.id === this.verified!.providerId && p.connected && p.models.some(m => m.id === this.verified!.modelId))) this.verified = undefined;
+        return this.state(lease);
+    }
+    async refresh(id: string): Promise<OpenCodeSetupState> {
+        return this.exclusive(id, async lease => { this.changed(); this.restart(lease); return this.discover(lease); });
+    }
+    private provider(lease: Lease, providerId: string): OpenCodeProvider {
+        const provider = lease.providers.find(p => p.id === providerId);
+        if (!provider) throw new SetupError('invalid-input', 'Select an available provider.');
+        return provider;
+    }
+    private changed(): void { this.generation++; this.verified = undefined; }
+    async saveKey(id: string, providerId: string, method: number, key: string): Promise<OpenCodeSetupState> {
+        return this.exclusive(id, async lease => {
+            const selected = this.provider(lease, providerId).methods.find(m => m.index === method);
+            if (!selected?.supported || selected.type !== 'api') throw new SetupError('unsupported', 'Use the managed login flow for this authentication method.');
+            if (!key.trim()) throw new SetupError('invalid-input', 'Enter an API key.');
+            this.changed();
+            await this.request(lease, `/auth/${encodeURIComponent(providerId)}`, 'PUT', { type: 'api', key: key.trim() });
+            this.restart(lease);
+            return this.discover(lease);
+        });
+    }
+    async disconnect(id: string, providerId: string): Promise<OpenCodeSetupState> {
+        return this.exclusive(id, async lease => {
+            this.provider(lease, providerId); this.changed();
+            await this.request(lease, `/auth/${encodeURIComponent(providerId)}`, 'DELETE');
+            this.restart(lease);
+            return this.discover(lease);
+        });
+    }
+    async authorize(id: string, providerId: string, method: number, inputs: Record<string, string>) {
+        return this.exclusive(id, async lease => {
+            const selected = this.provider(lease, providerId).methods.find(m => m.index === method);
+            if (!selected?.supported || selected.type !== 'oauth' || !oauthSupported(providerId, selected.label, inputs))
+                throw new SetupError('unsupported', 'Use the managed login flow for this provider or deployment.');
+            const filtered: Record<string, string> = {};
+            for (const prompt of selected.prompts) {
+                if (prompt.when && ((inputs[prompt.when.key] === prompt.when.value) !== (prompt.when.op === 'eq'))) continue;
+                const value = inputs[prompt.key];
+                if (!value || (prompt.type === 'select' && !prompt.options?.some(o => o.value === value))) throw new SetupError('invalid-input', 'Complete the authentication fields before continuing.');
+                filtered[prompt.key] = value;
+            }
+            this.changed();
+            const auth = authorizationSchema.parse(await this.request(lease, `/provider/${encodeURIComponent(providerId)}/oauth/authorize`, 'POST', { method, inputs: filtered }));
+            const url = validateAuthorizationUrl(providerId, auth.url);
+            const attemptId = randomUUID(), expiresAt = Date.now() + OAUTH_LIFETIME;
+            const timer = setTimeout(() => { if (lease.attempt?.id === attemptId) { lease.attempt.expired = true; this.restart(lease); } }, OAUTH_LIFETIME);
+            timer.unref?.();
+            lease.attempt = { id: attemptId, providerId, method, mode: auth.method, expiresAt, timer, expired: false, completing: false };
+            return { attemptId, method: auth.method, instructions: auth.instructions, expiresAt, url };
+        });
+    }
+    async complete(id: string, attemptId: string, code?: string): Promise<OpenCodeSetupState> {
+        const lease = this.require(id), attempt = lease.attempt;
+        if (!attempt || attempt.id !== attemptId) throw new SetupError('cancelled', 'This authorization attempt is no longer active. Start again.');
+        if (attempt.expired || Date.now() >= attempt.expiresAt) { this.cancel(id); throw new SetupError('expired', 'Authorization expired. Start sign-in again.'); }
+        if (attempt.completing) throw new SetupError('busy', 'Authorization is already being completed.');
+        if (attempt.mode === 'code' && !code?.trim()) throw new SetupError('invalid-input', 'Enter the authorization code.');
+        attempt.completing = true;
+        try {
+            const result = await this.request(lease, `/provider/${encodeURIComponent(attempt.providerId)}/oauth/callback`, 'POST', { method: attempt.method, ...(code ? { code: code.trim() } : {}) }, Math.max(1, attempt.expiresAt - Date.now()));
+            this.require(id);
+            if (lease.attempt !== attempt) throw new SetupError('cancelled', 'Authorization was cancelled.');
+            if (result !== true) throw new SetupError('failed', 'The provider did not complete authorization. Retry sign-in.');
+            clearTimeout(attempt.timer); lease.attempt = undefined;
+            this.changed(); this.restart(lease);
+            const state = await this.discover(lease);
+            if (!state.providers.some(provider => provider.id === attempt.providerId && provider.connected))
+                throw new SetupError('failed', 'Authorization returned without saved credentials. Retry sign-in or use the managed login flow.');
+            return state;
+        } catch (error) {
+            if (attempt.expired || Date.now() >= attempt.expiresAt) { this.cancel(id); throw new SetupError('expired', 'Authorization expired. Start sign-in again.'); }
+            if (this.lease === lease && lease.attempt === attempt) this.cancel(id);
+            throw error;
+        }
+    }
+    cancel(id: string): void {
+        const lease = this.require(id);
+        if (lease.attempt) clearTimeout(lease.attempt.timer);
+        lease.attempt = undefined;
+        this.restart(lease); this.changed();
+    }
+    async select(id: string, providerId: string, modelId: string): Promise<OpenCodeSetupState> {
+        return this.exclusive(id, async lease => {
+            const provider = this.provider(lease, providerId);
+            if (!provider.models.some(m => m.id === modelId)) throw new SetupError('unavailable-model', 'That model is no longer available. Refresh and choose another model.');
+            this.verified = undefined;
+            this.selection = { providerId, modelId };
+            await fs.mkdir(path.dirname(this.selectionFile), { recursive: true });
+            await fs.writeFile(this.selectionFile, JSON.stringify(this.selection), { mode: 0o600 });
+            return this.state(lease);
+        });
+    }
+    async verify(id: string): Promise<OpenCodeSetupState> {
+        return this.exclusive(id, async lease => {
+            this.verified = undefined;
+            const selected = this.selection;
+            if (!selected) throw new SetupError('invalid-input', 'Select a model first.');
+            const provider = this.provider(lease, selected.providerId);
+            if (!provider.connected) throw new SetupError('invalid-credentials', 'Connect this provider before verifying it.');
+            if (!provider.models.some(m => m.id === selected.modelId)) throw new SetupError('unavailable-model', 'Choose an available model.');
+            let sessionId: string | undefined;
+            try {
+                const session = z.object({ id: z.string() }).parse(await this.request(lease, '/session', 'POST', { title: 'Rowboat connection verification', permission: [{ permission: '*', pattern: '*', action: 'deny' }] }));
+                sessionId = session.id;
+                const result = z.object({ info: z.object({ error: z.unknown().optional(), providerID: z.string(), modelID: z.string(), finish: z.string().optional() }), parts: z.array(z.object({ type: z.string(), text: z.string().optional() })) }).parse(
+                    await this.request(lease, `/session/${encodeURIComponent(sessionId)}/message`, 'POST', {
+                        model: { providerID: selected.providerId, modelID: selected.modelId.slice(selected.providerId.length + 1) },
+                        tools: { '*': false }, parts: [{ type: 'text', text: 'Reply with only OK. Do not use any tools.' }],
+                    }, 60_000));
+                if (result.info.error) {
+                    const error = result.info.error as { name?: string; data?: { statusCode?: number } };
+                    if (error.name === 'ProviderAuthError' || [401, 403].includes(error.data?.statusCode ?? 0)) throw new SetupError('invalid-credentials', 'The provider rejected these credentials. Reconnect and try again.');
+                    if (error.data?.statusCode === 429) throw new SetupError('rate-limit', 'The provider is rate limited or out of quota. Check your account and retry.');
+                    throw new SetupError('failed', 'The model could not complete verification. Check credentials, account access and model availability, then retry.');
+                }
+                if (result.info.providerID !== selected.providerId || `${selected.providerId}/${result.info.modelID}` !== selected.modelId || !result.info.finish || !result.parts.some(p => p.type === 'text' && p.text?.trim()))
+                    throw new SetupError('failed', 'The selected model did not return a completed response. Choose another model or retry.');
+                this.require(id);
+                this.verified = { ...selected, at: Date.now(), generation: this.generation };
+                return this.state(lease);
+            } finally {
+                if (sessionId && this.lease === lease) {
+                    await this.request(lease, `/session/${encodeURIComponent(sessionId)}/abort`, 'POST', undefined, 3000).catch(() => {});
+                    await this.request(lease, `/session/${encodeURIComponent(sessionId)}`, 'DELETE', undefined, 3000).catch(() => {});
+                }
+            }
+        });
+    }
+}
+export const openCodeSetup = new OpenCodeSetupService();

--- a/apps/x/packages/core/src/code-mode/acp/opencode-smoke.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-smoke.test.ts
@@ -1,0 +1,206 @@
+// Opt in with ROWBOAT_OPENCODE_SMOKE=1. Downloads the pinned native engine into
+// a temporary home containing spaces; never reads/writes the real OpenCode state.
+import { expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as http from 'http';
+
+it.skipIf(process.env.ROWBOAT_OPENCODE_SMOKE !== '1')('downloads and launches the real managed engine with isolated authenticated serve and ACP', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'rowboat opencode smoke '));
+    vi.doMock('os', () => ({ ...os, homedir: () => home }));
+    vi.doMock('./shell-env.js', () => ({ loginShellPath: () => undefined }));
+    const { ensureEngine, isEngineProvisioned, removeOpenCodeEngine } = await import('./engine-provisioner.js');
+    const { openCodeProcesses } = await import('./opencode-process.js');
+    let setup: import('./opencode-setup.js').OpenCodeSetupService | undefined;
+    let providerServer: http.Server | undefined;
+    let failure: unknown;
+    let closeLogin: (() => void) | undefined;
+    try {
+        const engine = await ensureEngine('opencode');
+        expect(engine.executablePath).toContain(home);
+        expect(isEngineProvisioned('opencode')).toBe(true);
+        for (const mode of ['serve', 'acp'] as const) {
+            const handle = await openCodeProcesses.start(mode, { cwd: home, timeoutMs: 60_000 });
+            expect((await fetch(`${handle.url}/global/health`)).status).toBe(401);
+            expect((await fetch(`${handle.url}/global/health`, { headers: { Authorization: handle.authorization } })).status).toBe(200);
+            handle.stop();
+            await handle.exited;
+            await expect(fetch(`${handle.url}/global/health`, { signal: AbortSignal.timeout(1000) })).rejects.toThrow();
+        }
+        // Real OpenCode HTTP/setup/verification against a local fake inference
+        // provider. No real provider credential or paid inference is used.
+        const requests: string[] = [];
+        let toolAction: { name: string; arguments: string } | undefined;
+        providerServer = http.createServer(async (req, res) => {
+            let body = ''; for await (const chunk of req) body += chunk;
+            requests.push(body);
+            if (!['Bearer opencode-key', 'Bearer public'].includes(req.headers.authorization ?? '')) {
+                res.writeHead(401, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: { message: 'Invalid API key', type: 'authentication_error' } })); return;
+            }
+            if (JSON.parse(body || '{}').stream) {
+                if (toolAction && JSON.parse(body).tools?.some((t: { function?: { name: string } }) => t.function?.name === toolAction?.name)) {
+                    const action = toolAction; toolAction = undefined;
+                    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+                    res.write(`data: ${JSON.stringify({ id: 'chatcmpl-tool', object: 'chat.completion.chunk', created: 1, model: 'smoke', choices: [{ index: 0, delta: { role: 'assistant', tool_calls: [{ index: 0, id: 'call-' + Date.now(), type: 'function', function: action }] }, finish_reason: null }] })}\n\n`);
+                    res.write(`data: ${JSON.stringify({ id: 'chatcmpl-tool', object: 'chat.completion.chunk', created: 1, model: 'smoke', choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] })}\n\n`);
+                    res.end('data: [DONE]\n\n'); return;
+                }
+                res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+                for (const item of [
+                    { id: 'chatcmpl-test', object: 'chat.completion.chunk', created: 1, model: 'smoke', choices: [{ index: 0, delta: { role: 'assistant', content: 'OK' }, finish_reason: null }] },
+                    { id: 'chatcmpl-test', object: 'chat.completion.chunk', created: 1, model: 'smoke', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+                ]) res.write(`data: ${JSON.stringify(item)}\n\n`);
+                res.end('data: [DONE]\n\n');
+            } else {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ id: 'chatcmpl-test', object: 'chat.completion', created: 1, model: 'smoke', choices: [{ index: 0, message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } }));
+            }
+        });
+        await new Promise<void>(resolve => providerServer!.listen(0, '127.0.0.1', resolve));
+        const port = (providerServer.address() as { port: number }).port;
+        const configRoot = path.join(home, '.rowboat', 'opencode', 'config', 'opencode');
+        fs.mkdirSync(configRoot, { recursive: true });
+        fs.writeFileSync(path.join(configRoot, 'opencode.json'), JSON.stringify({ provider: {
+            'opencode': { npm: '@ai-sdk/openai-compatible', name: 'Rowboat smoke provider', options: { baseURL: `http://127.0.0.1:${port}/v1` }, models: { smoke: { name: 'Smoke model', cost: { input: 0, output: 0 }, limit: { context: 4096, output: 64 } } } },
+            'opencode-go': { npm: '@ai-sdk/openai-compatible', name: 'Go smoke provider', options: { baseURL: `http://127.0.0.1:${port}/v1` }, models: { smoke: { name: 'Go smoke model', cost: { input: 1, output: 1 }, limit: { context: 4096, output: 64 } } } },
+        }}));
+        const { OpenCodeSetupService } = await import('./opencode-setup.js');
+        setup = new OpenCodeSetupService();
+        let initial = await setup.start('smoke');
+        expect(initial.providers.find(p => p.id === 'opencode')?.connected).toBe(false);
+        expect(initial.providers.some(p => p.id === 'opencode')).toBe(true);
+        const { CodeModeManager: PublicManager } = await import('./manager.js');
+        const publicManager = new PublicManager();
+        const publicOptions = await publicManager.listModelOptions('opencode', home, 'opencode/smoke');
+        expect(publicOptions.currentModel).toBe('opencode/smoke');
+        expect(publicOptions.openCodeProviders).toEqual(['free']);
+        expect(publicOptions.models.every(m => m.value.startsWith('opencode/'))).toBe(true);
+        await publicManager.runPrompt({ runId: 'public-smoke', agent: 'opencode', cwd: home, model: 'opencode/smoke',
+            prompt: 'Say OK', policy: 'ask', ask: async () => 'reject', onEvent: () => {} });
+        expect(requests.length).toBeGreaterThan(0);
+        requests.length = 0;
+        const saved = await setup.saveKey(initial.setupId, 'opencode', 0, 'opencode-key');
+        expect(saved.verified).toBeUndefined();
+        await setup.select(initial.setupId, 'opencode', 'opencode/smoke');
+        const verified = await setup.verify(initial.setupId);
+        expect(verified.verified?.modelId).toBe('opencode/smoke');
+        expect(requests.length).toBeGreaterThan(0);
+        expect(requests.every(request => !request.includes('opencode-key'))).toBe(true);
+        expect(requests.every(request => { const data = JSON.parse(request); return !data.tools || data.tools.length === 0; })).toBe(true);
+        const zenOptions = await publicManager.listModelOptions('opencode', home, 'opencode/smoke');
+        expect(zenOptions.openCodeProviders).toEqual(['zen']);
+        expect(zenOptions.models.every(m => m.value.startsWith('opencode/'))).toBe(true);
+        await setup.saveKey(initial.setupId, 'opencode-go', 0, 'opencode-key');
+        const bothOptions = await publicManager.listModelOptions('opencode', home, 'opencode-go/smoke');
+        expect(bothOptions.openCodeProviders).toEqual(['zen', 'go']);
+        expect(bothOptions.models.some(m => m.value === 'opencode/smoke')).toBe(true);
+        expect(bothOptions.models.some(m => m.value === 'opencode-go/smoke')).toBe(true);
+        await setup.disconnect(initial.setupId, 'opencode');
+        const goOptions = await publicManager.listModelOptions('opencode', home, 'opencode-go/smoke');
+        expect(goOptions.openCodeProviders).toEqual(['go']);
+        expect(goOptions.models.every(m => m.value.startsWith('opencode-go/'))).toBe(true);
+        await expect(publicManager.runPrompt({ runId: 'blocked-service', agent: 'opencode', cwd: home, model: 'opencode/smoke',
+            prompt: 'Must not reach inference', policy: 'ask', ask: async () => 'reject', onEvent: () => {} })).rejects.toThrow('unavailable through your current');
+        await setup.saveKey(initial.setupId, 'opencode', 0, 'opencode-key');
+        await setup.disconnect(initial.setupId, 'opencode-go');
+        // Native ACP runtime: actual tools, approvals, cold-process resume and
+        // model rejection, against the same isolated managed credentials.
+        setup.stop();
+        const { CodeModeManager } = await import('./manager.js');
+        const manager = new CodeModeManager();
+        const projectA = path.join(home, 'project A'), projectB = path.join(home, 'project B');
+        fs.mkdirSync(projectA); fs.mkdirSync(projectB);
+        fs.writeFileSync(path.join(projectA, 'opencode.json'), JSON.stringify({ agent: { reviewer: { mode: 'primary', description: 'Review without editing', permission: { edit: 'deny' } } } }));
+        const projectOptionsA = await manager.listModelOptions('opencode', projectA, 'opencode/smoke');
+        const projectOptionsB = await manager.listModelOptions('opencode', projectB, 'opencode/smoke');
+        expect(projectOptionsA.modes?.some(m => m.value === 'reviewer')).toBe(true);
+        expect(projectOptionsB.modes?.some(m => m.value === 'reviewer')).toBe(false);
+        const options = await manager.listModelOptions('opencode', home, 'opencode/smoke');
+        expect(options.currentModel).toBe('opencode/smoke');
+        expect(options.modes?.some(m => m.value === 'build')).toBe(true);
+        const events: import('./types.js').CodeRunEvent[] = [];
+        const run = { runId: 'native-smoke', agent: 'opencode' as const, cwd: home, model: 'opencode/smoke', policy: 'ask' as const, prompt: 'Perform the requested smoke-test action.', ask: async () => 'allow_once' as const, onEvent: (event: import('./types.js').CodeRunEvent) => events.push(event) };
+        try {
+            const edited = path.join(home, 'approved.txt');
+            toolAction = { name: 'write', arguments: JSON.stringify({ filePath: edited, content: 'approved' }) };
+            const first = await manager.runPrompt(run);
+            expect(fs.existsSync(edited), JSON.stringify({ events, tools: requests.map(r => JSON.parse(r).tools?.map((t: { function?: { name: string } }) => t.function?.name)) })).toBe(true);
+            expect(fs.readFileSync(edited, 'utf8')).toBe('approved');
+            expect(events.some(e => e.type === 'permission' && e.decision === 'allow_once')).toBe(true);
+            const rejected = path.join(home, 'rejected.txt');
+            toolAction = { name: 'write', arguments: JSON.stringify({ filePath: rejected, content: 'rejected' }) };
+            const second = await manager.runPrompt({ ...run, ask: async () => 'reject' });
+            expect(second.sessionId).toBe(first.sessionId);
+            expect(fs.existsSync(rejected)).toBe(false);
+            expect(events.some(e => e.type === 'permission' && e.decision === 'reject')).toBe(true);
+            expect(events.some(e => e.type === 'message' && e.role === 'user')).toBe(false);
+            await manager.runPrompt({ ...run, mode: 'plan' });
+            toolAction = { name: 'write', arguments: JSON.stringify({ filePath: edited, content: 'after-plan' }) };
+            await manager.runPrompt({ ...run, mode: 'build', policy: 'yolo' });
+            expect(fs.readFileSync(edited, 'utf8')).toBe('after-plan');
+            toolAction = { name: 'write', arguments: JSON.stringify({ filePath: edited, content: 'must-not-write' }) };
+            await manager.runPrompt({ ...run, mode: 'build', ask: async () => 'reject' });
+            expect(fs.readFileSync(edited, 'utf8')).toBe('after-plan');
+            toolAction = { name: 'bash', arguments: JSON.stringify({ command: 'echo ROWBOAT_COMMAND_OUTPUT', description: 'Print smoke-test output' }) };
+            await manager.runPrompt(run);
+            expect(events.some(e => e.type === 'tool_call_update' && e.detail?.output?.includes('ROWBOAT_COMMAND_OUTPUT'))).toBe(true);
+            toolAction = { name: 'bash', arguments: JSON.stringify({ command: 'echo denied > denied-command.txt', description: 'Command that must be rejected' }) };
+            await manager.runPrompt({ ...run, ask: async () => 'reject' });
+            expect(fs.existsSync(path.join(home, 'denied-command.txt'))).toBe(false);
+            const abort = new AbortController();
+            toolAction = { name: 'write', arguments: JSON.stringify({ filePath: rejected, content: 'cancelled' }) };
+            const cancelled = await manager.runPrompt({ ...run, signal: abort.signal, ask: async () => { abort.abort(); return 'reject'; } });
+            expect(cancelled.stopReason).toBe('cancelled');
+            expect(fs.existsSync(rejected)).toBe(false);
+            await expect(manager.runPrompt({ ...run, model: 'opencode/missing' })).rejects.toThrow('unavailable');
+            const native = await openCodeProcesses.start('acp', { cwd: home });
+            try {
+                const url = new URL(`/session/${first.sessionId}`, native.url); url.searchParams.set('directory', home);
+                expect((await fetch(url, { method: 'DELETE', headers: { Authorization: native.authorization } })).ok).toBe(true);
+            } finally { native.stop(); await native.exited; }
+            await expect(manager.runPrompt(run)).rejects.toThrow('could not be loaded');
+        } finally { manager.disposeAll(); }
+        initial = await setup.start('smoke');
+        await setup.saveKey(initial.setupId, 'opencode', 0, 'invalid-key');
+        await expect(setup.verify(initial.setupId)).rejects.toMatchObject({ code: 'invalid-credentials' });
+        const disconnected = await setup.disconnect(initial.setupId, 'opencode');
+        expect(disconnected.verified).toBeUndefined();
+        expect(disconnected.providers.find(p => p.id === 'opencode')?.connected).toBe(false);
+        setup.stop();
+        const { openCodeSetup } = await import('./opencode-setup.js');
+        setup = openCodeSetup;
+        const loginState = await setup.start('native-login-smoke');
+        const nativeLogin = await import('./opencode-login.js');
+        closeLogin = () => nativeLogin.stopOpenCodeLogin(loginState.setupId);
+        nativeLogin.startOpenCodeLogin(loginState.setupId);
+        let loginOutput = '';
+        const loginDeadline = Date.now() + 15_000;
+        while (!loginOutput && Date.now() < loginDeadline) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+            loginOutput += nativeLogin.readOpenCodeLogin(loginState.setupId).output;
+        }
+        expect(loginOutput.length).toBeGreaterThan(0);
+        closeLogin(); setup.stop();
+        const logs = path.join(home, '.rowboat', 'opencode', 'data', 'opencode', 'log');
+        for (const file of fs.readdirSync(logs)) {
+            if (!file.endsWith('.log')) continue;
+            expect(fs.readFileSync(path.join(logs, file), 'utf8').includes('opencode-key')).toBe(false);
+        }
+        const sentinel = path.join(home, '.rowboat', 'opencode', 'state', 'retention-test');
+        fs.writeFileSync(sentinel, 'retained');
+        await removeOpenCodeEngine();
+        expect(isEngineProvisioned('opencode')).toBe(false);
+        expect(fs.readFileSync(sentinel, 'utf8')).toBe('retained');
+    } catch (error) { failure = error; throw error; } finally {
+        closeLogin?.();
+        setup?.stop();
+        providerServer?.closeAllConnections(); providerServer?.close();
+        openCodeProcesses.stopAll();
+        // Checked literal target: only this test's freshly allocated temporary home.
+        if (path.dirname(home) !== os.tmpdir() || !path.basename(home).startsWith('rowboat opencode smoke ')) throw new Error('Unexpected smoke-test cleanup target');
+        try { await fs.promises.rm(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }); }
+        catch (error) { if (!failure) throw error; }
+    }
+}, 600_000);

--- a/apps/x/packages/core/src/code-mode/acp/opencode-smoke.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/opencode-smoke.test.ts
@@ -15,6 +15,7 @@ it.skipIf(process.env.ROWBOAT_OPENCODE_SMOKE !== '1')('downloads and launches th
     let setup: import('./opencode-setup.js').OpenCodeSetupService | undefined;
     let providerServer: http.Server | undefined;
     let failure: unknown;
+    let failed = false;
     let closeLogin: (() => void) | undefined;
     try {
         const engine = await ensureEngine('opencode');
@@ -193,14 +194,19 @@ it.skipIf(process.env.ROWBOAT_OPENCODE_SMOKE !== '1')('downloads and launches th
         await removeOpenCodeEngine();
         expect(isEngineProvisioned('opencode')).toBe(false);
         expect(fs.readFileSync(sentinel, 'utf8')).toBe('retained');
-    } catch (error) { failure = error; throw error; } finally {
+    } catch (error) { failure = error; failed = true; } finally {
         closeLogin?.();
         setup?.stop();
         providerServer?.closeAllConnections(); providerServer?.close();
         openCodeProcesses.stopAll();
-        // Checked literal target: only this test's freshly allocated temporary home.
-        if (path.dirname(home) !== os.tmpdir() || !path.basename(home).startsWith('rowboat opencode smoke ')) throw new Error('Unexpected smoke-test cleanup target');
-        try { await fs.promises.rm(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }); }
-        catch (error) { if (!failure) throw error; }
+        // Only remove this test's freshly allocated temporary home. Preserve
+        // the original test failure if cleanup also fails.
+        if (path.dirname(home) !== os.tmpdir() || !path.basename(home).startsWith('rowboat opencode smoke ')) {
+            if (!failed) { failure = new Error('Unexpected smoke-test cleanup target'); failed = true; }
+        } else {
+            try { await fs.promises.rm(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }); }
+            catch (error) { if (!failed) { failure = error; failed = true; } }
+        }
     }
+    if (failed) throw failure;
 }, 600_000);

--- a/apps/x/packages/core/src/code-mode/acp/permission-broker.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/permission-broker.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RequestPermissionRequest } from '@agentclientprotocol/sdk';
+import { PermissionBroker } from './permission-broker.js';
+
+const request = (kinds = ['allow_once', 'allow_always', 'reject_once']): RequestPermissionRequest => ({
+    sessionId: 's', toolCall: { toolCallId: 't', title: 'Write file', kind: 'edit' },
+    options: kinds.map(kind => ({ kind, optionId: kind, name: kind })) as RequestPermissionRequest['options'],
+});
+describe('permission scope and cancellation', () => {
+    it('never widens allow once or picks an unrelated first option', async () => {
+        const broker = new PermissionBroker({ policy: 'ask', ask: async () => 'allow_once' });
+        expect(await broker.resolve(request(['allow_always']))).toEqual({ outcome: { outcome: 'cancelled' } });
+    });
+    it('rejects safely when no rejection option exists', async () => {
+        const broker = new PermissionBroker({ policy: 'ask', ask: async () => 'reject' });
+        expect(await broker.resolve(request(['allow_once']))).toEqual({ outcome: { outcome: 'cancelled' } });
+    });
+    it('does not remember approvals by broad tool kind', async () => {
+        const ask = vi.fn().mockResolvedValueOnce('allow_always').mockResolvedValueOnce('reject');
+        const broker = new PermissionBroker({ policy: 'ask', ask });
+        await broker.resolve(request());
+        expect(await broker.resolve(request())).toMatchObject({ outcome: { optionId: 'reject_once' } });
+        expect(ask).toHaveBeenCalledTimes(2);
+    });
+    it('YOLO grants only the individual request', async () => {
+        const broker = new PermissionBroker({ policy: 'yolo', ask: async () => 'reject' });
+        expect(await broker.resolve(request())).toMatchObject({ outcome: { optionId: 'allow_once' } });
+    });
+    it('rejects persistent approval when upstream scope is unavailable', async () => {
+        const broker = new PermissionBroker({ policy: 'ask', allowPersistent: false, ask: async ask => {
+            expect(ask.allowAlways).toBe(false); return 'allow_always';
+        } });
+        expect(await broker.resolve(request())).toEqual({ outcome: { outcome: 'cancelled' } });
+    });
+    it('disconnect rejects a pending approval', async () => {
+        const broker = new PermissionBroker({ policy: 'ask', ask: () => new Promise(() => {}) });
+        const pending = broker.resolve(request()); broker.cancel();
+        expect(await pending).toMatchObject({ outcome: { optionId: 'reject_once' } });
+    });
+});

--- a/apps/x/packages/core/src/code-mode/acp/permission-broker.ts
+++ b/apps/x/packages/core/src/code-mode/acp/permission-broker.ts
@@ -5,6 +5,7 @@ import type {
     PermissionOptionKind,
 } from '@agentclientprotocol/sdk';
 import type { ApprovalPolicy, PermissionDecision, PermissionAsk } from './types.js';
+import { toolDetail } from './tool-detail.js';
 
 // Tool kinds that don't mutate anything — eligible for `auto-approve-reads`.
 const READ_KINDS = new Set(['read', 'search', 'fetch', 'think']);
@@ -18,16 +19,17 @@ function toAsk(request: RequestPermissionRequest): PermissionAsk {
         title,
         kind,
         isRead: kind ? READ_KINDS.has(kind) : false,
+        detail: toolDetail(tc.content, tc.rawInput),
     };
 }
 
 // Map a desired decision to one of the options the agent actually offered.
 // Agents may offer only a subset (e.g. allow_once + reject_once, no allow_always),
-// so we fall back within the same allow/reject family before giving up.
+// so unmatched decisions cancel safely; allow-once never widens to persistent.
 function pickOption(options: PermissionOption[], decision: PermissionDecision): PermissionOption | undefined {
     const order: Record<PermissionDecision, PermissionOptionKind[]> = {
-        allow_always: ['allow_always', 'allow_once'],
-        allow_once: ['allow_once', 'allow_always'],
+        allow_always: ['allow_always'],
+        allow_once: ['allow_once'],
         reject: ['reject_once', 'reject_always'],
     };
     for (const kind of order[decision]) {
@@ -41,24 +43,24 @@ function selected(optionId: string): RequestPermissionResponse {
     return { outcome: { outcome: 'selected', optionId } };
 }
 
-// A request's identity for "always allow" memory: prefer tool kind, else title.
-function memoryKey(ask: PermissionAsk): string {
-    return ask.kind ? `kind:${ask.kind}` : `title:${ask.title}`;
-}
 
 export interface PermissionBrokerOptions {
     policy: ApprovalPolicy;
+    signal?: AbortSignal;
+    allowPersistent?: boolean;
     // Called only when the policy can't decide on its own (the "ask" path).
     ask: (ask: PermissionAsk) => Promise<PermissionDecision>;
     // Notified of every resolved request so the engine can emit a stream event.
     onResolved?: (ask: PermissionAsk, decision: PermissionDecision, auto: boolean) => void;
 }
 
-// Decides how to answer the agent's requestPermission calls. Holds per-session
-// "always allow" memory so a one-time approval sticks for the rest of the run.
+// Answers requestPermission without broad local approval memory. Persistent
+// scope, when supported, belongs to the engine's explicit offered option.
 export class PermissionBroker {
     private readonly opts: PermissionBrokerOptions;
-    private readonly alwaysAllow = new Set<string>();
+    private readonly cancelled = new AbortController();
+
+    cancel(): void { this.cancelled.abort(); }
 
     constructor(opts: PermissionBrokerOptions) {
         this.opts = opts;
@@ -66,26 +68,34 @@ export class PermissionBroker {
 
     async resolve(request: RequestPermissionRequest): Promise<RequestPermissionResponse> {
         const ask = toAsk(request);
-        const key = memoryKey(ask);
+        ask.allowAlways = this.opts.allowPersistent !== false && request.options.some(o => o.kind === 'allow_always');
 
         const finish = (decision: PermissionDecision, auto: boolean): RequestPermissionResponse => {
-            if (decision === 'allow_always') this.alwaysAllow.add(key);
-            this.opts.onResolved?.(ask, decision, auto);
-            const opt = pickOption(request.options, decision);
-            // If the agent offered no matching option we fall back to its first one
-            // (don't deadlock the turn); decision precedence above keeps this rare.
-            return selected(opt?.optionId ?? request.options[0]?.optionId ?? '');
+            const opt = decision === 'allow_always' && !ask.allowAlways ? undefined : pickOption(request.options, decision);
+            this.opts.onResolved?.(ask, opt ? decision : 'reject', auto);
+            return opt ? selected(opt.optionId) : { outcome: { outcome: 'cancelled' } };
         };
 
-        // 1. Sticky "always allow" from earlier this session.
-        if (this.alwaysAllow.has(key)) return finish('allow_always', true);
+        if (this.cancelled.signal.aborted || this.opts.signal?.aborted) return finish('reject', true);
 
         // 2. Policy-level auto decisions.
-        if (this.opts.policy === 'yolo') return finish('allow_always', true);
+        if (this.opts.policy === 'yolo') return finish('allow_once', true);
         if (this.opts.policy === 'auto-approve-reads' && ask.isRead) return finish('allow_once', true);
 
         // 3. Ask the user.
-        const decision = await this.opts.ask(ask);
-        return finish(decision, false);
+        const signals = [this.cancelled.signal, this.opts.signal].filter((s): s is AbortSignal => !!s);
+        let abort: () => void = () => {};
+        const cancelled = new Promise<PermissionDecision>(resolve => {
+            abort = () => resolve('reject');
+            for (const signal of signals) signal.addEventListener('abort', abort, { once: true });
+        });
+        try {
+            const decision = await Promise.race([this.opts.ask(ask), cancelled]);
+            return finish(signals.some(s => s.aborted) ? 'reject' : decision, false);
+        } catch {
+            return finish('reject', false);
+        } finally {
+            for (const signal of signals) signal.removeEventListener('abort', abort);
+        }
     }
 }

--- a/apps/x/packages/core/src/code-mode/acp/session-store.ts
+++ b/apps/x/packages/core/src/code-mode/acp/session-store.ts
@@ -11,6 +11,9 @@ export interface StoredSession {
     agent: CodingAgent;
     cwd: string;
     sessionId: string;
+    engineVersion?: string;
+    stateNamespace?: string;
+    capabilities?: unknown;
 }
 
 // Per-run ACP session state lives in its own directory (not WorkDir/config): it's
@@ -26,10 +29,11 @@ export async function readStoredSession(runId: string): Promise<StoredSession | 
     try {
         const raw = await fs.readFile(sessionFile(runId), 'utf8');
         const parsed = JSON.parse(raw) as StoredSession;
-        if (parsed && parsed.sessionId && parsed.agent && parsed.cwd) return parsed;
-        return null;
-    } catch {
-        return null;
+        if (parsed && typeof parsed.sessionId === 'string' && ['claude', 'codex', 'opencode'].includes(parsed.agent) && typeof parsed.cwd === 'string') return parsed;
+        throw new Error('Invalid coding session metadata');
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw new Error('Saved coding session metadata could not be read. Restore it or create a new Code session; the existing history has been preserved.');
     }
 }
 

--- a/apps/x/packages/core/src/code-mode/acp/shell-env.test.ts
+++ b/apps/x/packages/core/src/code-mode/acp/shell-env.test.ts
@@ -1,0 +1,20 @@
+import { expect, it, vi } from 'vitest';
+
+it('recovers Unix tool PATH through a shell path containing spaces without shell interpolation', async () => {
+    const previous = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    vi.stubEnv('SHELL', '/custom shells/zsh');
+    const execFileSync = vi.fn(() => 'profile message\n/opt/homebrew/bin:/usr/bin:/bin\n');
+    vi.doMock('child_process', () => ({ execFileSync }));
+    vi.resetModules();
+    try {
+        const { loginShellPath } = await import('./shell-env.js');
+        expect(loginShellPath()).toBe('/opt/homebrew/bin:/usr/bin:/bin');
+        expect(execFileSync).toHaveBeenCalledWith('/custom shells/zsh', ['-lc', 'printf "%s\\n" "$PATH"'], expect.objectContaining({ timeout: 5000, maxBuffer: 65536 }));
+        loginShellPath();
+        expect(execFileSync).toHaveBeenCalledOnce();
+    } finally {
+        Object.defineProperty(process, 'platform', previous);
+        vi.unstubAllEnvs();
+    }
+});

--- a/apps/x/packages/core/src/code-mode/acp/shell-env.ts
+++ b/apps/x/packages/core/src/code-mode/acp/shell-env.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as path from 'path';
 
 let cached: string | null = null;
@@ -22,7 +22,9 @@ export function loginShellPath(): string | undefined {
 
     for (const shell of shells) {
         try {
-            const out = execSync(`${shell} -lc 'echo $PATH'`, { timeout: 5000, encoding: 'utf-8' });
+            const out = execFileSync(shell, ['-lc', 'printf "%s\\n" "$PATH"'], {
+                timeout: 5000, maxBuffer: 64 * 1024, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'],
+            });
             // Profile scripts may echo their own lines; our `echo $PATH` runs last,
             // so take the last non-empty line and sanity-check it looks like a PATH.
             const lines = out.split('\n').map((l) => l.trim()).filter(Boolean);

--- a/apps/x/packages/core/src/code-mode/acp/tool-detail.ts
+++ b/apps/x/packages/core/src/code-mode/acp/tool-detail.ts
@@ -1,0 +1,13 @@
+import type { ToolCallContent } from '@agentclientprotocol/sdk';
+
+/** Keep command output and edit previews without persisting arbitrary protocol
+ * metadata. Cap oversized output explicitly rather than dropping all content. */
+export function toolDetail(content?: ToolCallContent[] | null, input?: unknown) {
+    const output = (content ?? []).flatMap(c => c.type === 'content' && c.content.type === 'text' ? [c.content.text] : []).join('\n');
+    const edits = (content ?? []).flatMap(c => c.type === 'diff' ? [{ path: c.path, oldText: c.oldText ?? null, newText: c.newText }] : []);
+    return {
+        ...(input && typeof input === 'object' && 'command' in input && typeof input.command === 'string' ? { command: input.command } : {}),
+        ...(output ? { output: output.length > 65_536 ? output.slice(0, 65_536) + '\n[Output truncated at 64 KiB]' : output } : {}),
+        ...(edits.length ? { edits } : {}),
+    };
+}

--- a/apps/x/packages/core/src/code-mode/sessions/opencode-selection.test.ts
+++ b/apps/x/packages/core/src/code-mode/sessions/opencode-selection.test.ts
@@ -1,0 +1,33 @@
+import { expect, it, vi } from 'vitest';
+import { CodeSessionService } from './service.js';
+
+function fixture() {
+    const get = vi.fn().mockResolvedValue({ id: 's', agent: 'opencode', cwd: '/worktree', agentModel: 'provider/old', agentEffort: 'high', agentMode: 'build' });
+    const save = vi.fn();
+    const listModelOptions = vi.fn();
+    const isRunning = vi.fn().mockReturnValue(false);
+    const service = new CodeSessionService({ codeSessionsRepo: { get, save }, codeModeManager: { listModelOptions, isRunning }, sessionBus: { subscribe: vi.fn() } } as unknown as ConstructorParameters<typeof CodeSessionService>[0]);
+    return { service, save, listModelOptions, isRunning };
+}
+
+it('does not persist a model change rejected by the engine', async () => {
+    const { service, save, listModelOptions } = fixture();
+    listModelOptions.mockRejectedValue(new Error('Model unavailable'));
+    await expect(service.update('s', { agentModel: 'provider/missing' })).rejects.toThrow('unavailable');
+    expect(save).not.toHaveBeenCalled();
+});
+
+it('discovers in the worktree and clears effort when the accepted model does not advertise it', async () => {
+    const { service, save, listModelOptions } = fixture();
+    listModelOptions.mockResolvedValue({ models: [], efforts: [], currentModel: 'provider/new', currentMode: 'build' });
+    await service.update('s', { agentModel: 'provider/new' });
+    expect(listModelOptions).toHaveBeenCalledWith('opencode', '/worktree', 'provider/new', undefined, 'build');
+    expect(save.mock.calls[0][0]).toMatchObject({ agentModel: 'provider/new', agentEffort: undefined });
+});
+
+it('requires stopping the current turn before changing approval policy', async () => {
+    const { service, save, isRunning } = fixture();
+    isRunning.mockReturnValue(true);
+    await expect(service.update('s', { policy: 'ask' })).rejects.toThrow('Stop the current coding operation');
+    expect(save).not.toHaveBeenCalled();
+});

--- a/apps/x/packages/core/src/code-mode/sessions/service.ts
+++ b/apps/x/packages/core/src/code-mode/sessions/service.ts
@@ -3,13 +3,14 @@ import path from 'path';
 import fs from 'fs/promises';
 import { WorkDir } from '../../config/config.js';
 import { codeWorkspaceKey, type CodeSession } from '@x/shared/dist/code-sessions.js';
-import type { CodingAgent, ApprovalPolicy } from '@x/shared/dist/code-mode.js';
+import type { EnabledCodingAgent as CodingAgent, ApprovalPolicy } from '@x/shared/dist/code-mode.js';
 import type { ISessions } from '../../runtime/sessions/api.js';
 import type { ISessionRepo } from '../../runtime/sessions/repo.js';
 import type { CodeModeManager } from '../acp/manager.js';
 import type { ICodeSessionsRepo } from './repo.js';
 import type { ICodeProjectsRepo } from '../projects/repo.js';
 import { clearStoredSession } from '../acp/session-store.js';
+
 import * as gitService from '../git/service.js';
 import { withFileLock } from '../../knowledge/file-lock.js';
 import type { EmitterSessionBus } from '../../runtime/sessions/bus.js';
@@ -29,6 +30,7 @@ export interface CreateSessionArgs {
     // the engine default. Re-applied to the ACP session on every turn.
     agentModel?: string;
     agentEffort?: string;
+    agentMode?: string;
     // In-repo only: pin a working directory inside the project (an adopted
     // run may target a subdirectory). Worktree isolation always works in the
     // worktree root.
@@ -240,6 +242,7 @@ export class CodeSessionService {
                 ...(worktree ? { worktree } : {}),
                 ...(args.agentModel ? { agentModel: args.agentModel } : {}),
                 ...(args.agentEffort ? { agentEffort: args.agentEffort } : {}),
+                ...(args.agentMode ? { agentMode: args.agentMode } : {}),
                 createdAt: new Date().toISOString(),
             };
             await this.codeSessionsRepo.save(session);
@@ -324,9 +327,12 @@ export class CodeSessionService {
         return best;
     }
 
-    async update(sessionId: string, patch: Partial<Pick<CodeSession, 'title' | 'policy' | 'agent' | 'agentModel' | 'agentEffort'>>): Promise<CodeSession> {
+    async update(sessionId: string, patch: Partial<Pick<CodeSession, 'title' | 'policy' | 'agent' | 'agentModel' | 'agentEffort' | 'agentMode'>>): Promise<CodeSession> {
         const session = await this.codeSessionsRepo.get(sessionId);
         if (!session) throw new Error(`Unknown session: ${sessionId}`);
+        if (this.codeModeManager.isRunning(sessionId) && (patch.policy !== undefined || patch.agent !== undefined || patch.agentModel !== undefined || patch.agentEffort !== undefined || patch.agentMode !== undefined)) {
+            throw new Error('Stop the current coding operation before changing its agent, approvals, model, effort or mode.');
+        }
         const updated: CodeSession = { ...session, ...patch };
         // Model and effort are ids of ONE engine's catalog — a Codex model on
         // a Claude Code session is nonsense. Switching agents drops them back
@@ -334,6 +340,15 @@ export class CodeSessionService {
         if (patch.agent && patch.agent !== session.agent) {
             if (patch.agentModel === undefined) delete updated.agentModel;
             if (patch.agentEffort === undefined) delete updated.agentEffort;
+            if (patch.agentMode === undefined) delete updated.agentMode;
+        }
+        const selectionChanged = patch.agent !== undefined || patch.agentModel !== undefined || patch.agentEffort !== undefined || patch.agentMode !== undefined;
+        if (updated.agent === 'opencode' && selectionChanged) {
+            const options = await this.codeModeManager.listModelOptions('opencode', updated.cwd, updated.agentModel,
+                patch.agentModel !== undefined && patch.agentEffort === undefined ? undefined : updated.agentEffort, updated.agentMode);
+            updated.agentModel = options.currentModel;
+            updated.agentEffort = options.currentEffort;
+            updated.agentMode = options.currentMode;
         }
         await this.codeSessionsRepo.save(updated);
         if (patch.title && patch.title !== session.title) {

--- a/apps/x/packages/core/src/code-mode/status.ts
+++ b/apps/x/packages/core/src/code-mode/status.ts
@@ -6,6 +6,7 @@ import fs from 'fs/promises';
 import { AgentAccount, CodeModeAgentStatus } from './types.js';
 import { isEngineProvisioned, getProvisionedEnginePath } from './acp/engine-provisioner.js';
 import { decodeJwtPayload } from '../auth/jwt.js';
+import { storedProviderIds } from './acp/opencode-setup.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -296,5 +297,6 @@ export async function checkCodeModeAgentStatus(): Promise<CodeModeAgentStatus> {
     return {
         claude: { installed: isEngineProvisioned('claude'), signedIn: claude.signedIn, account: claude.account },
         codex: { installed: isEngineProvisioned('codex'), signedIn: codex.signedIn, account: codex.account },
+        opencode: { installed: isEngineProvisioned('opencode'), signedIn: [...await storedProviderIds()].some(id => id === 'opencode' || id === 'opencode-go') },
     };
 }

--- a/apps/x/packages/core/src/code-mode/types.ts
+++ b/apps/x/packages/core/src/code-mode/types.ts
@@ -30,6 +30,7 @@ export const AgentStatus = z.object({
 export type AgentStatus = z.infer<typeof AgentStatus>;
 
 export const CodeModeAgentStatus = z.object({
+    opencode: AgentStatus,
     claude: AgentStatus,
     codex: AgentStatus,
 });

--- a/apps/x/packages/core/src/runtime/assembly/capabilities/modes.ts
+++ b/apps/x/packages/core/src/runtime/assembly/capabilities/modes.ts
@@ -53,7 +53,7 @@ export const MODE_CAPABILITIES: readonly EagerCapability[] = [
         promptFragment: (ctx: CapabilityContext) => {
             const { codeMode, codeCwd } = ctx;
             if (!codeMode) return null;
-            const agentDisplay = codeMode === "claude" ? "Claude Code" : "Codex";
+            const agentDisplay = codeMode === "claude" ? "Claude Code" : codeMode === "codex" ? "Codex" : "OpenCode";
             return CODE_MODE_TEMPLATE(agentDisplay, codeMode, codeCwd);
         },
     },
@@ -141,7 +141,7 @@ Confirmations name the work, not the mechanics: "Dispatched — taking down the 
 
 const CODE_MODE_TEMPLATE = (
     agentDisplay: string,
-    codeMode: "claude" | "codex",
+    codeMode: "claude" | "codex" | "opencode",
     codeCwd: string | null,
 ): string => `# Code Mode (Active) — Agent: ${agentDisplay}
 The user has turned on **code mode** and the composer chip is set to **${agentDisplay}** (\`${codeMode}\`). For EVERY task and question this turn — writing and editing code, but ALSO design, product, architecture, and infra questions about the project — use **${agentDisplay}**, and narrate that agent ("Using ${agentDisplay} to …").

--- a/apps/x/packages/core/src/runtime/assembly/capabilities/types.ts
+++ b/apps/x/packages/core/src/runtime/assembly/capabilities/types.ts
@@ -39,7 +39,7 @@ export const ModeFlags = z.object({
     voiceInput: z.boolean().default(false),
     voiceOutput: z.enum(["summary", "full"]).nullable().default(null),
     searchEnabled: z.boolean().default(false),
-    codeMode: z.enum(["claude", "codex"]).nullable().default(null),
+    codeMode: z.enum(["claude", "codex", "opencode"]).nullable().default(null),
     codeCwd: z.string().nullable().default(null),
     videoMode: z.boolean().default(false),
     coachMode: z.boolean().default(false),

--- a/apps/x/packages/core/src/runtime/assembly/skills/code-with-agents/skill.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/code-with-agents/skill.ts
@@ -5,7 +5,7 @@ Use this skill whenever the user asks you to write code, build a project, create
 
 Coding agents operate on **arbitrary file paths** (including paths outside the Rowboat workspace root, like \`G:/4th sem/CN\` or \`~/projects/foo\`). Do NOT raise "outside workspace" concerns, and do NOT fall back to your own \`executeCommand\` (PowerShell / bash) or workspace file tools to do code work yourself.
 
-All coding work runs through the **\`code_agent_run\`** tool. It launches the selected on-device coding agent (Claude Code / Codex), streams its tool calls, file diffs, and plan into the chat, and surfaces any action needing approval as an inline permission card. One persistent session is kept per chat, so follow-up requests resume with full context automatically.
+All coding work runs through the **\`code_agent_run\`** tool. It launches the selected on-device coding agent (Claude Code / Codex / OpenCode), streams its tool calls, file diffs, and plan into the chat, and surfaces any action needing approval as an inline permission card. One persistent session is kept per chat, so follow-up requests resume with full context automatically.
 
 ---
 
@@ -30,17 +30,17 @@ No chip is set, but code mode is enabled (this skill only loads when it is). **P
 2. The path from a "# User Work Directory" block in your context.
 3. **Neither exists → OMIT \`cwd\` entirely.** The run lands in the user's default code repo (their registered project), isolated on its own branch — this is the normal case when the user just says what they want ("take down the overview tab") without naming a folder. Do NOT ask "which folder?" — only if the tool errors that no default repo exists, relay that error (it tells the user how to set one up).
 
-**Pick the agent** (\`claude\` or \`codex\`): use the agent from the "# Code Mode (Active)" block (the composer chip) / the Step 1 choice. The chip is authoritative — do NOT carry over a different agent from earlier in this thread, and do NOT switch on an in-chat text request ("use codex"); tell the user to toggle the chip instead.
+**Pick the agent** (OpenCode \`opencode\`, or \`claude\` or \`codex\`): use the agent from the "# Code Mode (Active)" block (the composer chip) / the Step 1 choice. The chip is authoritative — do NOT carry over a different agent from earlier in this thread, and do NOT switch on an in-chat text request ("use codex"); tell the user to toggle the chip instead.
 
 **State your intent in one line, then call the tool immediately — do NOT wait for a "yes".** The tool's own permission cards are the user's confirmation, so an extra in-chat "reply yes to proceed" is redundant friction. Say something like:
 
-> Using [Claude Code / Codex] to [task description] in \`[folder]\` — or "in your default repo" when cwd is omitted.
+> Using [Claude Code / Codex / OpenCode] to [task description] in \`[folder]\` — or "in your default repo" when cwd is omitted.
 
 …and then immediately call:
 
 \`\`\`
 code_agent_run({
-  agent: "<claude|codex>",
+  agent: "<claude|codex|opencode>",
   cwd: "<resolved absolute folder — OMIT when unresolved, see above>",
   prompt: "<the user's request, forwarded almost verbatim>"
 })

--- a/apps/x/packages/core/src/runtime/legacy/engine.ts
+++ b/apps/x/packages/core/src/runtime/legacy/engine.ts
@@ -685,7 +685,7 @@ export async function* streamAgent({
     let voiceInput = false;
     let voiceOutput: 'summary' | 'full' | null = null;
     let searchEnabled = false;
-    let codeMode: 'claude' | 'codex' | null = null;
+    let codeMode: 'claude' | 'codex' | 'opencode' | null = null;
     let codeCwd: string | null = null;
     let codePolicy: 'ask' | 'auto-approve-reads' | 'yolo' | null = null;
     let middlePaneContext:

--- a/apps/x/packages/core/src/runtime/legacy/runs.ts
+++ b/apps/x/packages/core/src/runtime/legacy/runs.ts
@@ -41,7 +41,7 @@ export async function createRun(opts: z.infer<typeof CreateRunOptions>): Promise
     return run;
 }
 
-export async function createMessage(runId: string, message: UserMessageContentType, voiceInput?: boolean, voiceOutput?: VoiceOutputMode, searchEnabled?: boolean, middlePaneContext?: MiddlePaneContext, codeMode?: 'claude' | 'codex', codeCwd?: string, codePolicy?: 'ask' | 'auto-approve-reads' | 'yolo'): Promise<string> {
+export async function createMessage(runId: string, message: UserMessageContentType, voiceInput?: boolean, voiceOutput?: VoiceOutputMode, searchEnabled?: boolean, middlePaneContext?: MiddlePaneContext, codeMode?: 'claude' | 'codex' | 'opencode', codeCwd?: string, codePolicy?: 'ask' | 'auto-approve-reads' | 'yolo'): Promise<string> {
     // Code-section sessions carry their coding context in the session meta.
     // Pin it here — not in the composer — so EVERY path into the run (assistant
     // chat pane, voice, palette) drives the session's agent in its directory,

--- a/apps/x/packages/core/src/runtime/sessions/sessions.ts
+++ b/apps/x/packages/core/src/runtime/sessions/sessions.ts
@@ -1,3 +1,4 @@
+import { isOpenCodeDirect } from '../turns/bridges/opencode-direct.js';
 import type { z } from "zod";
 import type { UserMessage } from "@x/shared/dist/message.js";
 import type { SessionOrigin } from "@x/shared/dist/origins.js";
@@ -463,7 +464,7 @@ export class SessionsImpl implements ISessions {
         this.publishEntry(
             sessionIndexEntry(reduceSession([...events, ...batch]), "idle"),
         );
-        if (!state.title) {
+        if (!state.title && !isOpenCodeDirect(await this.resolvedModelOf(turnId))) {
             this.generateTitleInBackground(
                 sessionId,
                 defaultTitle(input),

--- a/apps/x/packages/core/src/runtime/tools/domains/code.ts
+++ b/apps/x/packages/core/src/runtime/tools/domains/code.ts
@@ -49,11 +49,11 @@ export const codeAgentRunTools: z.infer<typeof BuiltinToolsSchema> = {
         permission: "none",
         description: 'Run a coding/software task with the selected on-device coding agent (Claude Code or Codex) inside a project folder. Streams the agent\'s tool calls, file diffs, and plan into the chat and surfaces permission requests inline. Use this for ALL code-mode work (writing/editing/reading code, running tests, debugging, exploring a repo). Reuses one persistent session per chat, so follow-up requests keep context. The agent\'s entire output is directly visible to the user in the run card, so after the run reply with a ~2-line confirmation only — never re-summarize the agent\'s output.',
         inputSchema: z.object({
-            agent: z.enum(['claude', 'codex']).describe('Which coding agent to use: "claude" (Claude Code) or "codex". Set this to the active code-mode chip agent. Note: when the chip is set, the backend uses the chip agent regardless of this value — this only takes effect in the ask-human flow where no chip is set.'),
+            agent: z.enum(['claude', 'codex', 'opencode']).describe('Which coding agent to use: "claude" (Claude Code), "codex", or "opencode". Set this to the active code-mode chip agent. Note: when the chip is set, the backend uses the chip agent regardless of this value — this only takes effect in the ask-human flow where no chip is set.'),
             cwd: z.string().optional().describe('Absolute path to the working directory / project folder the agent should operate in. OMIT this when the user has not named a path — the run then uses their default code repo (the single registered project, or the one picked in Settings → Code). Only pass a path the user actually named or that prior context established.'),
             prompt: z.string().describe("The user's coding request, forwarded almost verbatim — fix only transcription artifacts, typos, and minor grammar; do NOT expand, rephrase, or add details the user never stated. Append extra context (clearly labeled) only when the user explicitly asked you to gather it first."),
         }),
-        execute: async ({ agent, cwd, prompt }: { agent: 'claude' | 'codex', cwd?: string, prompt: string }, ctx?: ToolContext) => {
+        execute: async ({ agent, cwd, prompt }: { agent: 'claude' | 'codex' | 'opencode', cwd?: string, prompt: string }, ctx?: ToolContext) => {
             if (!ctx) {
                 throw new Error('code_agent_run requires run context (runId / streaming).');
             }
@@ -199,6 +199,8 @@ export const codeAgentRunTools: z.infer<typeof BuiltinToolsSchema> = {
             // The full ordered timeline, published ONCE as a durable batch when the
             // run settles (see finally). The per-event copies below are ephemeral.
             const collected: CodeRunEventType[] = [];
+            const ownedApprovals = new Set<string>();
+            let acceptedConfiguration: Extract<CodeRunEventType, { type: 'configuration' }> | undefined;
             const feed = container.resolve<CodeRunFeed>('codeRunFeed');
             try {
                 const result = await manager.runPrompt({
@@ -212,8 +214,10 @@ export const codeAgentRunTools: z.infer<typeof BuiltinToolsSchema> = {
                     policy,
                     ...(pinned?.agentModel ? { model: pinned.agentModel } : {}),
                     ...(pinned?.agentEffort ? { effort: pinned.agentEffort } : {}),
+                    ...(pinned?.agentMode ? { mode: pinned.agentMode } : {}),
                     signal: ctx.signal,
                     onEvent: (event) => {
+                        if (event.type === 'configuration') acceptedConfiguration = { ...acceptedConfiguration, ...event };
                         if (event.type === 'message' && event.role === 'agent') finalText += event.text;
                         if (event.type === 'tool_call_update') for (const f of event.diffs) changedFiles.add(f);
                         collected.push(event);
@@ -230,6 +234,7 @@ export const codeAgentRunTools: z.infer<typeof BuiltinToolsSchema> = {
                         });
                     },
                     ask: (permAsk) => registry.request(ctx.runId, (requestId) => {
+                        ownedApprovals.add(requestId);
                         void ctx.publish({
                             runId: ctx.runId,
                             type: 'code-run-permission-request',
@@ -277,6 +282,13 @@ export const codeAgentRunTools: z.infer<typeof BuiltinToolsSchema> = {
                 }
                 throw new Error(`Coding agent failed: ${error instanceof Error ? error.message : String(error)}`);
             } finally {
+                for (const requestId of ownedApprovals) registry.resolve(requestId, 'reject');
+                if (acceptedConfiguration && effectiveAgent === 'opencode' && ctx.sessionId) {
+                    const repo = container.resolve<ICodeSessionsRepo>('codeSessionsRepo');
+                    const current = await repo.get(ctx.sessionId).catch(() => null);
+                    if (current?.agent === 'opencode') await repo.save({ ...current, agentModel: acceptedConfiguration.model ?? current.agentModel,
+                        agentEffort: acceptedConfiguration.effort, agentMode: acceptedConfiguration.mode ?? current.agentMode }).catch(() => {});
+                }
                 ctx.signal.removeEventListener('abort', onAbort);
                 // Durable record for replay-on-reload — one event with the whole
                 // (coalesced) timeline, on every settle path including errors and

--- a/apps/x/packages/core/src/runtime/tools/exec-tool.ts
+++ b/apps/x/packages/core/src/runtime/tools/exec-tool.ts
@@ -22,7 +22,7 @@ export interface ToolContext {
     // The composer code-mode chip for the message that triggered this turn. When set,
     // it is the authoritative coding agent — code_agent_run uses it rather than the
     // agent the model guessed, so switching the chip deterministically switches agents.
-    codeMode?: 'claude' | 'codex' | null;
+    codeMode?: 'claude' | 'codex' | 'opencode' | null;
     // Set for Code-section sessions: the session's working directory and approval
     // policy. code_agent_run honors these over the model's cwd argument and the
     // global approval policy.

--- a/apps/x/packages/core/src/runtime/turns/bridges/opencode-direct.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/opencode-direct.test.ts
@@ -1,0 +1,49 @@
+import { expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { RealAgentResolver } from './real-agent-resolver.js';
+import { RealModelRegistry } from './real-model-registry.js';
+import { OPENCODE_DIRECT, openCodeDirectModel } from './opencode-direct.js';
+import type { LlmStreamEvent, ModelStreamRequest } from '../model-registry.js';
+const request = (messages: ModelStreamRequest['messages']): ModelStreamRequest => ({ systemPrompt: JSON.stringify({ cwd: '/project with spaces' }), messages, tools: [], parameters: {}, signal: new AbortController().signal });
+async function collect(req: ModelStreamRequest) { const events: LlmStreamEvent[] = []; for await (const e of openCodeDirectModel().stream(req)) events.push(e); return events; }
+it('can still resume a persisted legacy direct-dispatch turn', async () => {
+    const forbidden = vi.fn(async () => { throw new Error('Legacy turn should not resolve a provider'); });
+    const registry = new RealModelRegistry({ resolveProvider: forbidden, invoke: forbidden as never });
+    expect((await registry.resolve(OPENCODE_DIRECT)).descriptor).toEqual(OPENCODE_DIRECT);
+    expect(forbidden).not.toHaveBeenCalled();
+});
+it.each(['codex', 'opencode'] as const)('routes new %s turns through the configured Rowboat model', async codeMode => {
+    const resolver = new RealAgentResolver({
+        load: async () => ({ name: 'copilot', instructions: '', tools: { code_agent_run: { type: 'builtin', name: 'code_agent_run' } } }),
+        defaultModel: async () => ({ provider: 'google', model: 'gemini-test' }),
+        builtins: { code_agent_run: { inputSchema: z.object({ prompt: z.string() }), description: 'Coding', permission: 'none', execute: async () => null } },
+        loadNotes: () => null, loadWorkDir: () => null,
+    });
+    const agent = await resolver.resolve({ agentId: 'copilot', overrides: { composition: { codeMode, codeCwd: '/project' } } });
+    expect(agent.model).toEqual({ provider: 'google', model: 'gemini-test' });
+    expect(agent.tools.map(t => t.name)).toContain('code_agent_run');
+    expect(agent.systemPrompt).toContain(codeMode);
+    const explicit = await resolver.resolve({ agentId: 'copilot', overrides: { model: { provider: 'custom', model: 'chat-model' }, composition: { codeMode } } });
+    expect(explicit.model).toEqual({ provider: 'custom', model: 'chat-model' });
+    const migrated = await resolver.resolve({ agentId: 'copilot', overrides: { model: OPENCODE_DIRECT, composition: { codeMode } } });
+    expect(migrated.model).toEqual({ provider: 'google', model: 'gemini-test' });
+});
+it('forwards new text verbatim once, including queued text, without replaying history or adding a second response', async () => {
+    const history: ModelStreamRequest['messages'] = [{ role: 'user', content: 'old' }, { role: 'tool', toolName: 'code_agent_run', toolCallId: 'old', content: 'done' }];
+    const messages: ModelStreamRequest['messages'] = [...history, { role: 'user', content: 'inspect this' }, { role: 'user', content: 'also test it' }];
+    const events = await collect(request(messages));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'completed', finishReason: 'tool-calls', message: { content: [{ toolName: 'code_agent_run', arguments: { agent: 'opencode', cwd: '/project with spaces', prompt: 'inspect this\n\nalso test it' } }] } });
+    expect(await collect(request([...messages, { role: 'tool', toolName: 'code_agent_run', toolCallId: 'new', content: 'done' }]))).toEqual([{ type: 'completed', message: { role: 'assistant', content: [] }, finishReason: 'stop', usage: {} }]);
+});
+it('honors cancellation and explicitly rejects unsupported inline images', async () => {
+    const controller = new AbortController(); controller.abort();
+    await expect(collect({ ...request([]), signal: controller.signal })).rejects.toThrow();
+    await expect(collect(request([{ role: 'user', content: [{ type: 'image', data: 'abc', mediaType: 'image/png' }] }]))).rejects.toThrow('image attachments');
+});
+
+it('does not carry the internal dispatcher model into another coding engine', async () => {
+    const resolver = new RealAgentResolver({ load: async () => ({ name: 'copilot', instructions: '', tools: {} }), defaultModel: async () => ({ provider: 'configured', model: 'regular' }), loadNotes: () => null, loadWorkDir: () => null });
+    const agent = await resolver.resolve({ agentId: 'copilot', overrides: { model: OPENCODE_DIRECT, composition: { codeMode: 'claude' } } });
+    expect(agent.model).toEqual({ provider: 'configured', model: 'regular' });
+});

--- a/apps/x/packages/core/src/runtime/turns/bridges/opencode-direct.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/opencode-direct.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from 'node:crypto';
+import { ConversationMessage } from '@x/shared/dist/turns.js';
+import type { JsonValue } from '@x/shared/dist/turns.js';
+import type { ResolvedModel, LlmStreamEvent } from '../model-registry.js';
+
+// Compatibility for already-persisted direct-dispatch turns. New OpenCode
+// turns use the same Rowboat-model delegation path as Codex.
+// This descriptor is internal: it never resolves a Rowboat AI provider.
+export const OPENCODE_DIRECT = { provider: 'rowboat-internal', model: 'opencode-direct' } as const;
+export function isOpenCodeDirect(model: { provider: string; model: string } | undefined): boolean {
+    return model?.provider === OPENCODE_DIRECT.provider && model.model === OPENCODE_DIRECT.model;
+}
+export function openCodeDirectModel(): ResolvedModel {
+    return {
+        descriptor: OPENCODE_DIRECT,
+        encodeMessages: messages => JSON.parse(JSON.stringify(messages)) as JsonValue[],
+        async *stream(request): AsyncGenerator<LlmStreamEvent> {
+            request.signal.throwIfAborted();
+            const messages = request.messages.map(m => ConversationMessage.parse(m));
+            // Include queued user messages since the last completed coding call.
+            // Native OpenCode owns conversation context; never replay old turns.
+            let boundary = -1;
+            for (let i = 0; i < messages.length; i++) {
+                const message = messages[i];
+                if (message.role === 'tool' || (message.role === 'assistant' && Array.isArray(message.content) && message.content.some(p => p.type === 'tool-call'))) boundary = i;
+            }
+            const users = messages.slice(boundary + 1).filter(m => m.role === 'user');
+            if (!users.length) {
+                yield { type: 'completed', message: { role: 'assistant', content: [] }, finishReason: 'stop', usage: {} };
+                return;
+            }
+            const prompt = users.map(m => {
+                if (typeof m.content === 'string') return m.content;
+                return m.content.map(p => {
+                    if (p.type === 'text') return p.text;
+                    if (p.type === 'attachment') return '\nReferenced file: ' + p.path + (p.lineNumber ? ':' + p.lineNumber : '');
+                    throw new Error('OpenCode image attachments are not supported yet. Send a text request instead.');
+                }).join('\n');
+            }).join('\n\n');
+            const config = JSON.parse(request.systemPrompt) as { cwd?: string };
+            yield {
+                type: 'completed', finishReason: 'tool-calls', usage: {},
+                message: { role: 'assistant', content: [{
+                    type: 'tool-call', toolCallId: randomUUID(), toolName: 'code_agent_run',
+                    arguments: { agent: 'opencode', ...(config.cwd ? { cwd: config.cwd } : {}), prompt },
+                }] },
+            };
+        },
+    };
+}

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-agent-resolver.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-agent-resolver.ts
@@ -22,6 +22,8 @@ import {
     toJsonValue,
 } from "../../tools/descriptors.js";
 
+import { isOpenCodeDirect } from './opencode-direct.js';
+
 export const ASK_HUMAN_TOOL = "ask-human";
 
 const ASK_HUMAN_DESCRIPTOR: z.infer<typeof ToolDescriptor> = {
@@ -149,6 +151,8 @@ export class RealAgentResolver {
 
         // Model precedence: createTurn override > agent config > app default.
         let model = requested.overrides?.model;
+        // A prior OpenCode turn is not a selectable LLM when switching engines.
+        if (isOpenCodeDirect(model)) model = undefined;
         if (!model) {
             const fallback = await this.defaultModel();
             model = {

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-model-registry.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-model-registry.ts
@@ -25,6 +25,8 @@ import type {
     ResolvedModel,
 } from "../model-registry.js";
 
+import { isOpenCodeDirect, openCodeDirectModel } from './opencode-direct.js';
+
 // Injectable seam over streamText so normalization is testable without a
 // provider. The bridge always requests exactly one step.
 export type StreamTextInvoker = (options: {
@@ -85,6 +87,7 @@ export class RealModelRegistry implements IModelRegistry {
     async resolve(
         descriptor: z.infer<typeof ModelDescriptor>,
     ): Promise<ResolvedModel> {
+        if (isOpenCodeDirect(descriptor)) return openCodeDirectModel();
         const providerConfig = await this.resolveProvider(descriptor.provider);
         const provider = this.createProviderImpl(providerConfig);
         // Local settings (Ollama context window) are applied here.

--- a/apps/x/packages/core/src/runtime/turns/bridges/real-usage-reporter.ts
+++ b/apps/x/packages/core/src/runtime/turns/bridges/real-usage-reporter.ts
@@ -1,3 +1,4 @@
+import { isOpenCodeDirect } from './opencode-direct.js';
 import { captureLlmUsage } from "../../../analytics/usage.js";
 import type { IUsageReporter, ModelUsageReport } from "../usage-reporter.js";
 
@@ -16,6 +17,7 @@ export class RealUsageReporter implements IUsageReporter {
     }
 
     reportModelUsage(report: ModelUsageReport): void {
+        if (isOpenCodeDirect(report.model)) return;
         this.capture({
             useCase: report.analytics.useCase,
             ...(report.analytics.subUseCase

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -3487,3 +3487,25 @@ describe("added inputs (steering)", () => {
         ]);
     });
 });
+
+
+it('runs OpenCode direct dispatch through durable turns once per prompt and resumes without replay', async () => {
+    const { OPENCODE_DIRECT, openCodeDirectModel } = await import('./bridges/opencode-direct.js');
+    const descriptor = { ...echoDescriptor, name: 'code_agent_run', toolId: 'builtin:code_agent_run' };
+    const execute = vi.fn(async (_input: unknown) => ({ output: { summary: 'native response' }, isError: false }));
+    const { runtime, repo, classifier } = makeRuntime({
+        agent: { agentId: 'copilot', systemPrompt: '{}', model: OPENCODE_DIRECT, tools: [descriptor] },
+        modelRegistry: { resolve: async () => openCodeDirectModel() },
+        tools: [syncTool(descriptor, execute)],
+    });
+    const first = await newTurn(runtime, { input: user('inspect project') });
+    expect((await advanceAndSettle(runtime, first)).outcome?.status).toBe('completed');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0][0]).toEqual({ agent: 'opencode', prompt: 'inspect project' });
+    const second = await newTurn(runtime, { context: { previousTurnId: first }, input: user('now test it') });
+    expect((await advanceAndSettle(runtime, second)).outcome?.status).toBe('completed');
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute.mock.calls[1][0]).toEqual({ agent: 'opencode', prompt: 'now test it' });
+    expect(classifier.batches).toHaveLength(0);
+    expect((await repo.read(second)).filter(e => e.type === 'tool_result')).toHaveLength(1);
+});

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -3492,7 +3492,7 @@ describe("added inputs (steering)", () => {
 it('runs OpenCode direct dispatch through durable turns once per prompt and resumes without replay', async () => {
     const { OPENCODE_DIRECT, openCodeDirectModel } = await import('./bridges/opencode-direct.js');
     const descriptor = { ...echoDescriptor, name: 'code_agent_run', toolId: 'builtin:code_agent_run' };
-    const execute = vi.fn(async (_input: unknown) => ({ output: { summary: 'native response' }, isError: false }));
+    const execute = vi.fn<SyncRuntimeTool["execute"]>(async () => ({ output: { summary: 'native response' }, isError: false }));
     const { runtime, repo, classifier } = makeRuntime({
         agent: { agentId: 'copilot', systemPrompt: '{}', model: OPENCODE_DIRECT, tools: [descriptor] },
         modelRegistry: { resolve: async () => openCodeDirectModel() },

--- a/apps/x/packages/core/src/spaces/topic-agent.ts
+++ b/apps/x/packages/core/src/spaces/topic-agent.ts
@@ -49,7 +49,7 @@ export interface InvokeTopicAgentInput {
     model?: { provider: string; model: string; effort?: 'low' | 'medium' | 'high' };
     permissionMode?: 'auto' | 'manual';
     searchEnabled?: boolean;
-    codeMode?: 'claude' | 'codex';
+    codeMode?: 'claude' | 'codex' | 'opencode';
   };
 }
 

--- a/apps/x/packages/core/src/terminal/terminal.ts
+++ b/apps/x/packages/core/src/terminal/terminal.ts
@@ -49,7 +49,7 @@ function broadcast(channel: 'terminal:data' | 'terminal:exit', payload: unknown)
 // main bundle happened to work.
 let helperFixed = false;
 let helperPath: string | null = null;
-function ensureSpawnHelperExecutable(): void {
+export function ensureSpawnHelperExecutable(): void {
   if (helperFixed || process.platform === 'win32') return;
   helperFixed = true;
   try {

--- a/apps/x/packages/core/src/todo/runner.ts
+++ b/apps/x/packages/core/src/todo/runner.ts
@@ -424,7 +424,7 @@ export async function runTodoItem(
         // item's thread before the first turn — worktree lane by default,
         // visible in the Code section, status-tracked. code_agent_run then
         // resolves the pin server-side like any Code-section session.
-        code?: { projectId: string; agent?: 'claude' | 'codex'; isolation?: 'in-repo' | 'worktree' };
+        code?: { projectId: string; agent?: 'claude' | 'codex' | 'opencode'; isolation?: 'in-repo' | 'worktree' };
     },
 ): Promise<TodoRunResult> {
     const norm = normalizeKey(key);

--- a/apps/x/packages/shared/src/code-mode.ts
+++ b/apps/x/packages/shared/src/code-mode.ts
@@ -4,8 +4,25 @@ import z from "zod";
 // core engine re-exports the inferred TS types, and runs.ts builds the RunEvent
 // variants that carry these to the renderer.
 
-export const CodingAgent = z.enum(["claude", "codex"]);
+export const CodingAgent = z.enum(["claude", "codex", "opencode"]);
 export type CodingAgent = z.infer<typeof CodingAgent>;
+// All currently provisioned agents have a coding implementation.
+export const EnabledCodingAgent = CodingAgent;
+export type EnabledCodingAgent = z.infer<typeof EnabledCodingAgent>;
+
+export const CODING_AGENT_CAPABILITIES = {
+    claude: { name: 'Claude Code', launch: 'adapter', adapter: '@agentclientprotocol/claude-agent-acp', provisioning: 'managed', authentication: 'native-login', codingEnabled: true, sessions: { resume: true, models: true, effort: true, modes: false } },
+    codex: { name: 'Codex', launch: 'adapter', adapter: '@agentclientprotocol/codex-acp', provisioning: 'managed', authentication: 'native-login', codingEnabled: true, sessions: { resume: true, models: true, effort: true, modes: false } },
+    opencode: { name: 'OpenCode', launch: 'native-acp', provisioning: 'managed', authentication: 'private-http', codingEnabled: true, sessions: { resume: true, models: true, effort: true, modes: true } },
+} as const satisfies Record<CodingAgent, unknown>;
+
+export const OpenCodeEngineStatus = z.object({
+    installed: z.boolean(),
+    version: z.string(),
+    supported: z.boolean(),
+    connection: z.literal('not-verified'),
+    ready: z.literal(false),
+});
 
 // How the permission broker answers the agent's requests before any per-tool
 // "always allow" memory is applied. `yolo` is the safe, scoped equivalent of
@@ -16,18 +33,27 @@ export type ApprovalPolicy = z.infer<typeof ApprovalPolicy>;
 export const PermissionDecision = z.enum(["allow_once", "allow_always", "reject"]);
 export type PermissionDecision = z.infer<typeof PermissionDecision>;
 
+export const CodeToolDetail = z.object({
+    command: z.string().optional(),
+    output: z.string().optional(),
+    edits: z.array(z.object({ path: z.string(), oldText: z.string().nullable(), newText: z.string() })).optional(),
+});
+
 // What the UI needs to render a permission card.
 export const PermissionAsk = z.object({
     toolCallId: z.string().optional(),
     title: z.string(),
     kind: z.string().optional(), // tool kind, e.g. "edit" | "execute" | "read"
     isRead: z.boolean(),
+    allowAlways: z.boolean().optional(),
+    detail: CodeToolDetail.optional(),
 });
 export type PermissionAsk = z.infer<typeof PermissionAsk>;
 
 // Normalized per-run stream items. The engine maps raw ACP session/update
 // notifications onto this union; the renderer renders them.
 export const CodeRunEvent = z.discriminatedUnion("type", [
+    z.object({ type: z.literal('configuration'), model: z.string().optional(), effort: z.string().optional(), mode: z.string().optional() }),
     // role distinguishes the agent's own output from replayed user turns
     // (loadSession streams the whole prior conversation back on resume).
     z.object({ type: z.literal("message"), role: z.enum(["agent", "user"]), text: z.string() }),
@@ -38,12 +64,16 @@ export const CodeRunEvent = z.discriminatedUnion("type", [
         title: z.string().optional(),
         kind: z.string().optional(),
         status: z.string().optional(),
+        detail: CodeToolDetail.optional(),
     }),
     z.object({
         type: z.literal("tool_call_update"),
         id: z.string().optional(),
         status: z.string().optional(),
         diffs: z.array(z.string()),
+        title: z.string().optional(),
+        kind: z.string().optional(),
+        detail: CodeToolDetail.optional(),
     }),
     z.object({
         type: z.literal("plan"),

--- a/apps/x/packages/shared/src/code-sessions.ts
+++ b/apps/x/packages/shared/src/code-sessions.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { CodingAgent, ApprovalPolicy } from "./code-mode.js";
+import { EnabledCodingAgent as CodingAgent, ApprovalPolicy } from "./code-mode.js";
 
 // Shared zod schemas for the Code section: registered projects and coding
 // sessions. A coding session IS a chat session on the turns runtime (session
@@ -69,6 +69,7 @@ export const CodeSession = z.object({
     doneAt: z.iso.datetime().optional(),
     agentModel: z.string().optional(),
     agentEffort: z.string().optional(),
+    agentMode: z.string().optional(),
     createdAt: z.iso.datetime(),
     lastActivityAt: z.iso.datetime().optional(),
 });
@@ -89,6 +90,12 @@ export type CodeAgentOption = z.infer<typeof CodeAgentOption>;
 export const CodeAgentModelOptions = z.object({
     models: z.array(CodeAgentOption),
     efforts: z.array(CodeAgentOption),
+    modes: z.array(CodeAgentOption).optional(),
+    currentModel: z.string().optional(),
+    currentEffort: z.string().optional(),
+    currentMode: z.string().optional(),
+    selectionError: z.string().optional(),
+    openCodeProviders: z.array(z.enum(['free', 'zen', 'go'])).optional(),
 });
 export type CodeAgentModelOptions = z.infer<typeof CodeAgentModelOptions>;
 

--- a/apps/x/packages/shared/src/ipc.ts
+++ b/apps/x/packages/shared/src/ipc.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { OpenCodeEngineStatus, EnabledCodingAgent } from './code-mode.js';
+import { OpenCodeSetupState, OpenCodeProviderId, OpenCodeAuthorization, setupResult } from './opencode-setup.js';
 import { UseCase } from './analytics.js';
 import { DeckOutline, DeckOutlineSlide, EditSlideRequest, GenerateDeckOutlineRequest, GenerateSlideRequest } from './deck.js';
 import { RelPath, Encoding, Stat, DirEntry, ReaddirOptions, ReadFileResult, WorkspaceChangeEvent, WriteFileOptions, WriteFileResult, RemoveOptions } from './workspace.js';
@@ -80,7 +82,7 @@ const QuickAskSubmitPayload = z.object({
     )
     .optional(),
   searchEnabled: z.boolean().optional(),
-  codeMode: z.enum(['claude', 'codex']).optional(),
+  codeMode: z.enum(['claude', 'codex', 'opencode']).optional(),
   permissionMode: z.enum(['manual', 'auto']).optional(),
   model: ModelRef.nullable().optional(),
   reasoningEffort: ReasoningEffort.nullable().optional(),
@@ -550,7 +552,7 @@ export const ipcSchemas = {
       voiceInput: z.boolean().optional(),
       voiceOutput: z.enum(['summary', 'full']).optional(),
       searchEnabled: z.boolean().optional(),
-      codeMode: z.enum(['claude', 'codex']).optional(),
+      codeMode: z.enum(['claude', 'codex', 'opencode']).optional(),
       // Code-section sessions pin the coding agent's working directory and
       // approval policy for the whole turn (see code_agent_run overrides).
       codeCwd: z.string().optional(),
@@ -1741,6 +1743,7 @@ export const ipcSchemas = {
   'codeMode:checkAgentStatus': {
     req: z.null(),
     res: z.object({
+      opencode: z.object({ installed: z.boolean(), signedIn: z.boolean() }),
       claude: z.object({
         installed: z.boolean(),
         signedIn: z.boolean(),
@@ -1758,14 +1761,14 @@ export const ipcSchemas = {
   // Download + install an agent's native engine (the Settings "Enable" action).
   // Streams progress over the 'codeMode:engineProgress' push channel while it runs.
   'codeMode:provisionEngine': {
-    req: z.object({ agent: z.enum(['claude', 'codex']) }),
+    req: z.object({ agent: CodingAgent }),
     res: z.object({ success: z.boolean(), error: z.string().optional() }),
   },
   // Push (main -> renderer): engine provisioning progress for the Settings UI.
   'codeMode:engineProgress': {
     req: z.object({
-      agent: z.enum(['claude', 'codex']),
-      phase: z.enum(['download', 'verify', 'extract', 'done']),
+      agent: CodingAgent,
+      phase: z.enum(['download', 'verify', 'extract', 'validate', 'done']),
       receivedBytes: z.number().optional(),
       totalBytes: z.number().optional(),
     }),
@@ -1773,6 +1776,27 @@ export const ipcSchemas = {
   },
   // ==========================================================================
   // Code section: project registry + coding sessions
+  'codeMode:openCodeEngineStatus': {
+    req: z.null(), res: OpenCodeEngineStatus,
+  },
+  'opencodeSetup:openAccount': { req: z.null(), res: setupResult(z.null()) },
+  'opencodeSetup:start': { req: z.null(), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:stop': { req: z.object({ setupId: z.string().optional() }), res: setupResult(z.null()) },
+  'opencodeSetup:refresh': { req: z.object({ setupId: z.string() }), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:saveKey': { req: z.object({ setupId: z.string(), providerId: OpenCodeProviderId, method: z.number().int().min(0), key: z.string().min(1).max(16000) }), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:disconnect': { req: z.object({ setupId: z.string(), providerId: OpenCodeProviderId }), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:authorize': { req: z.object({ setupId: z.string(), providerId: OpenCodeProviderId, method: z.number().int().min(0), inputs: z.record(z.string().max(100), z.string().max(4000)) }), res: setupResult(OpenCodeAuthorization) },
+  'opencodeSetup:complete': { req: z.object({ setupId: z.string(), attemptId: z.string(), code: z.string().max(16000).optional() }), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:cancel': { req: z.object({ setupId: z.string() }), res: setupResult(z.null()) },
+  'opencodeSetup:select': { req: z.object({ setupId: z.string(), providerId: OpenCodeProviderId, modelId: z.string().min(1).max(500) }), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:verify': { req: z.object({ setupId: z.string() }), res: setupResult(OpenCodeSetupState) },
+  'opencodeSetup:loginStart': { req: z.object({ setupId: z.string() }), res: setupResult(z.null()) },
+  'opencodeSetup:loginRead': { req: z.object({ setupId: z.string() }), res: setupResult(z.object({ output: z.string(), running: z.boolean(), exitCode: z.number().optional() })) },
+  'opencodeSetup:loginInput': { req: z.object({ setupId: z.string(), input: z.string().max(16000) }), res: setupResult(z.null()) },
+  'opencodeSetup:loginStop': { req: z.object({ setupId: z.string() }), res: setupResult(z.null()) },
+  'codeMode:removeOpenCodeEngine': {
+    req: z.null(), res: z.object({ success: z.boolean(), error: z.string().optional() }),
+  },
   // ==========================================================================
   'codeProject:add': {
     req: z.object({
@@ -1820,7 +1844,7 @@ export const ipcSchemas = {
     req: z.object({
       projectId: z.string(),
       title: z.string().optional(),
-      agent: CodingAgent,
+      agent: EnabledCodingAgent,
       // Only an explicit user choice; a quick-created session omits it and
       // follows the composer chip / global setting ("Auto").
       policy: ApprovalPolicy.optional(),
@@ -1848,7 +1872,7 @@ export const ipcSchemas = {
   'codeSession:update': {
     req: z.object({
       sessionId: z.string(),
-      patch: CodeSession.pick({ title: true, policy: true, agent: true, agentModel: true, agentEffort: true }).partial(),
+      patch: CodeSession.pick({ title: true, policy: true, agent: true, agentModel: true, agentEffort: true, agentMode: true }).partial(),
     }),
     res: z.object({
       session: CodeSession,
@@ -1857,7 +1881,7 @@ export const ipcSchemas = {
   // Live model + effort choices for a coding agent, discovered from the engine
   // (cached per agent in the main process). Mirrors what `/model` would show.
   'codeMode:listModelOptions': {
-    req: z.object({ agent: CodingAgent }),
+    req: z.object({ agent: CodingAgent, cwd: z.string().optional(), model: z.string().optional(), effort: z.string().optional(), mode: z.string().optional() }),
     res: CodeAgentModelOptions,
   },
   // Done is a flag, not a lifecycle change: the worktree, branch and chat are
@@ -3132,7 +3156,7 @@ export const ipcSchemas = {
       // resolves the pin server-side.
       code: z.object({
         projectId: z.string(),
-        agent: z.enum(['claude', 'codex']).optional(),
+        agent: z.enum(['claude', 'codex', 'opencode']).optional(),
         isolation: z.enum(['in-repo', 'worktree']).optional(),
       }).optional(),
     }),
@@ -4067,7 +4091,7 @@ export const ipcSchemas = {
           model: z.object({ provider: z.string(), model: z.string(), effort: z.enum(['low', 'medium', 'high']).optional() }).optional(),
           permissionMode: z.enum(['auto', 'manual']).optional(),
           searchEnabled: z.boolean().optional(),
-          codeMode: z.enum(['claude', 'codex']).optional(),
+          codeMode: z.enum(['claude', 'codex', 'opencode']).optional(),
         })
         .optional(),
     }),

--- a/apps/x/packages/shared/src/opencode-setup.ts
+++ b/apps/x/packages/shared/src/opencode-setup.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const OpenCodeProviderId = z.string().min(1).max(200).regex(/^[a-zA-Z0-9_.-]+$/);
+export const OpenCodeAuthPrompt = z.object({
+    type: z.enum(['text', 'select']), key: z.string(), message: z.string(), placeholder: z.string().optional(),
+    options: z.array(z.object({ label: z.string(), value: z.string() })).optional(),
+    when: z.object({ key: z.string(), op: z.enum(['eq', 'neq']), value: z.string() }).optional(),
+}).refine(prompt => prompt.type !== 'select' || (prompt.options?.length ?? 0) > 0, 'Select prompts require options');
+export const OpenCodeAuthMethod = z.object({
+    index: z.number().int(), type: z.enum(['api', 'oauth', 'unsupported']), label: z.string(),
+    supported: z.boolean(), prompts: z.array(OpenCodeAuthPrompt),
+});
+export const OpenCodeProvider = z.object({
+    id: OpenCodeProviderId, name: z.string(), connected: z.boolean(),
+    methods: z.array(OpenCodeAuthMethod), models: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+export const OpenCodeSelection = z.object({ providerId: OpenCodeProviderId, modelId: z.string().min(1).max(500) });
+export const OpenCodeSetupState = z.object({
+    setupId: z.string(), generation: z.number().int(), providers: z.array(OpenCodeProvider),
+    selection: OpenCodeSelection.optional(),
+    verified: OpenCodeSelection.extend({ at: z.number(), generation: z.number() }).optional(),
+});
+export const OpenCodeAuthorization = z.object({
+    attemptId: z.string(), method: z.enum(['auto', 'code']), instructions: z.string(), expiresAt: z.number(),
+});
+export type OpenCodeSetupState = z.infer<typeof OpenCodeSetupState>;
+export type OpenCodeProvider = z.infer<typeof OpenCodeProvider>;
+export type OpenCodeAuthMethod = z.infer<typeof OpenCodeAuthMethod>;
+export type OpenCodeAuthorization = z.infer<typeof OpenCodeAuthorization>;
+
+export const OpenCodeSetupError = z.object({
+    code: z.enum(['cancelled', 'expired', 'busy', 'unavailable', 'invalid-credentials', 'unavailable-model', 'rate-limit', 'unsupported', 'invalid-input', 'failed']),
+    message: z.string(),
+});
+export function setupResult<T extends z.ZodType>(data: T) {
+    return z.discriminatedUnion('success', [z.object({ success: z.literal(true), data }), z.object({ success: z.literal(false), error: OpenCodeSetupError })]);
+}

--- a/docs/opencode-coding-runtime.md
+++ b/docs/opencode-coding-runtime.md
@@ -1,0 +1,45 @@
+# OpenCode coding runtime — stages 5–7
+
+Enable OpenCode and create a Code session, choose a free model in the session header, and start coding without an account. Optionally connect Go or Zen in Settings for additional models. Model/effort/mode selection lives in Code mode and uses the actual worktree. Old Settings model selections are ignored. The native engine advertises available OpenCode models; Rowboat does not hardcode free model IDs.
+
+OpenCode uses the same two-model flow as Codex: the composer selects the Rowboat chat model, which delegates through `code_agent_run`; the Code header selects the native OpenCode coding model. A Rowboat chat model is required even when using a free OpenCode model. Approvals, native session resume and timeline persistence remain unchanged. Already-persisted direct-dispatch turns retain a compatibility adapter, while new turns use normal delegation.
+
+## Sessions and configuration
+
+Coding uses native ACP over stdio. The managed process service supplies the executable, isolated state, authenticated loopback listener and process-tree cleanup. ACP capabilities, native session ID, engine version, working directory and state namespace are recorded with Rowboat session metadata. Cold turns load the same native session; replayed history is muted because Rowboat already owns its durable transcript. An unreadable metadata file, missing native session or incompatible directory produces a recovery error without silently starting a replacement conversation.
+
+OpenCode processes end after every turn. This reloads credentials/project configuration and clears the engine's in-memory approvals before another turn. Cancellation also covers startup and configuration changes, and pending approvals reject on disconnect. Concurrent prompts for the same session are rejected. Stop the current operation before changing its approval policy or selections.
+
+OpenCode model discovery always uses a fresh process in the actual project/worktree directory. It is deliberately uncached, rather than sharing the older agents' per-agent cache: engine, provider, project and configuration changes cannot reuse stale options. This costs a cold start when opening the picker. Only advertised effort values are shown, with no synthetic Default choice for OpenCode. The backend validates changes before persisting them and applies them again before each prompt. Unavailable selections produce an error while discovery still offers the advertised alternatives. Accepted configuration events update session metadata.
+
+## Approval policy
+
+Before a prompt, Rowboat configures the idle native session through its private HTTP listener. Prompts, streaming, session load, cancellation and approval replies use ACP. Rowboat appends an Ask rule and then explicit denial rules from the selected agent's resolved project/global configuration and the session's original rules. The backend verifies the resulting rule suffix before coding starts. Metadata distinguishes Rowboat-owned mode restrictions from external rules, so Plan → Build can remove the former while preserving the latter. Unexpected external replacement of these rules fails closed.
+
+| Rowboat policy | OpenCode behavior |
+| --- | --- |
+| Ask | Each requested action goes to an approval card. |
+| Auto-approve reads | Read/search/fetch/think requests receive allow-once; other actions ask. |
+| YOLO | Requests receive allow-once automatically; explicit denials still apply. |
+| Deny / stopped / disconnected | A matching reject option or ACP cancelled response; never an arbitrary option. |
+
+Rowboat no longer remembers approvals by broad tool kind. It never converts allow-once to allow-always. OpenCode's pinned ACP bridge does not communicate the scope of persistent approvals, so its Always allow control is hidden and a forced persistent decision rejects safely.
+
+**Subagent tasks are disabled for this release.** In OpenCode 1.18.30, child sessions do not inherit the parent's Ask rules and the ACP permission bridge only handles registered ACP sessions. Rowboat denies `task` even in YOLO; this restriction is visible in the session settings. Structured `question` is also denied until a question interface exists. Custom primary modes and MCP actions use the selected mode's resolved denial rules and the same broker. Project tools and plugins still run with the user's permissions; state isolation is not a sandbox.
+
+## Timeline
+
+Tool status, late titles, command text/output, failed-tool output, diff paths and before/after edit previews survive normalization and durable replay. Command output has an explicit 64 KiB truncation marker. Permission cards expose the proposed command and edit preview. Raw provider error bodies and engine stderr are excluded from OpenCode error messages because they may echo authentication data. Errors retain the phase, safe exit details and recognized authentication/model/timeout recovery guidance.
+
+## Validation and release gates
+
+Automated native Windows validation downloads 1.18.30 into a temporary home containing spaces and uses a local fake inference provider with dummy credentials. It covers installation, isolated setup, API-key verification/failure, managed login PTY startup, two-project mode discovery, actual approved/rejected file writes, command output and rejection, cancellation during approval, cold-process resume without user-history replay, YOLO → Ask, Plan → Build, unavailable models, deleted native sessions, and retained state after removal. Focused tests cover permission fallback/scoping, malformed permission catalogs, mode changes with explicit denials, selection persistence, rich timeline reduction and UI agent selection.
+
+Run the opt-in native sequence from `apps/x/packages/core`:
+
+```powershell
+$env:ROWBOAT_OPENCODE_SMOKE='1'
+node node_modules/vitest/vitest.mjs run src/code-mode/acp/opencode-smoke.test.ts
+```
+
+Stage 8 remains a release gate: exercise the full Electron UI in a real Git worktree, packaged Windows builds, real Go/Zen accounts, public-model availability and network loss, long-running child commands on shutdown, and native macOS/Linux builds. The native test uses a temporary project, not an Electron window or a real provider account. Do not infer packaged or cross-platform certification from the Windows tests. Structured questions, attachments, richer subagent presentation/history operations, configuration import, WSL and managed local models remain deferred.

--- a/docs/opencode-integration-contract.md
+++ b/docs/opencode-integration-contract.md
@@ -1,0 +1,31 @@
+# Managed OpenCode contract (stages 1–4)
+
+Rowboat launches only its downloaded, manifest-pinned native OpenCode executable. PATH and global installations never select an engine. Installation requires a matching metadata record, executable file, verified archive integrity and successful bounded version probe before activation. Concurrent Enable requests share one backend operation; cancellation of one subscriber does not cancel other subscribers.
+
+Engine installation, optional account connection, and successful model access are separate states. Installation permits public free-model use without credentials. Go/Zen connection means an account key was saved; only a successful coding request establishes model access. No mandatory Settings verification or model selection is required.
+
+All OpenCode processes (version probes, private setup HTTP service and native ACP) use the same environment builder. XDG config/data/cache/state roots live under `~/.rowboat/opencode/`. Inherited OpenCode overrides, provider credentials and runtime injection variables are excluded through a system/tool environment allowlist. PATH is retained for project tools. Global configuration and credentials are never automatically imported. The shared launch environment restricts enabled providers to `opencode` and `opencode-go`. Deliberate project configuration remains enabled for coding, so these roots are application-state isolation, not a filesystem sandbox; commands retain user permissions.
+
+Setup uses a private authenticated loopback HTTP service owned by the backend. Coding uses ACP stdio with its internal HTTP listener also password protected, loopback-only and without discovery. Credentials must pass through narrow backend operations, never chat events, renderer persistence or logs. The Settings account form offers only OpenCode Go and Zen API-key access. Process handles and HTTP credentials never cross renderer IPC.
+
+Stopping setup/coding and application shutdown terminate owned process trees. Removing an engine first stops its processes and cancels installation, then removes only the engine tree. Credentials and conversations survive removal and upgrades. Disconnecting a provider removes that provider's managed credentials; explicitly resetting OpenCode data remains a separate future operation. Old versions are retained rather than pruning binaries that may be in use.
+
+The shared capability descriptors identify launch, provisioning, authentication and upstream session features. `codingEnabled` is a Rowboat release gate, distinct from upstream capabilities. Stage 5 must use the OpenCode process service rather than the adapter launcher; stage 6 must validate policy precedence before enabling coding. Stages 4–7 own verification, provider/model cache generations, native session persistence and approval semantics.
+
+Windows is the initial validation target. Manifest entries for macOS/Linux describe available packages, not packaged-build certification. x64 uses baseline packages where published; musl never silently falls back to glibc for OpenCode.
+
+## Validation for this milestone
+
+The focused installer/environment/process suite covers integrity and network failures, extraction and version failures, deduplication/progress, caller cancellation, missing executables, repair, data retention, private launch arguments, startup timeout, spawn error, and shutdown cleanup. Settings tests cover installed-versus-ready presentation, missing executable re-check and engine removal. Session-rail tests cover Claude, Codex and OpenCode selection.
+
+Run from `apps/x/packages/core`:
+
+```powershell
+node node_modules/vitest/vitest.mjs run src/code-mode/acp/engine-provisioner.test.ts src/code-mode/acp/opencode-environment.test.ts src/code-mode/acp/opencode-process.test.ts
+$env:ROWBOAT_OPENCODE_SMOKE='1'
+node node_modules/vitest/vitest.mjs run src/code-mode/acp/opencode-smoke.test.ts
+```
+
+The opt-in smoke test downloads the actual pinned package into a temporary home with spaces. It checks version validation, authenticated/unauthenticated HTTP access for both serve and ACP, listener closure after stop, and retained state on removal. Stage 4 extends it with the real provider/session APIs against a local fake inference provider: credential saving, verified model response, invalid-key rejection, disconnect, secret-free request bodies/logs, no tools exposed, and managed-login PTY startup/cleanup. It uses dummy credentials and no paid provider requests. The runtime smoke additionally exercises native ACP tools, permissions, model/mode discovery and cold-session resume; see the coding runtime contract. Packaged Electron builds, real account OAuth, long-running child-command shutdown, macOS/Linux and abnormal application crashes remain release acceptance gates.
+
+The macOS/Linux follow-up audit rechecked all six package URLs, SHA-512 integrity values and OS/CPU metadata against the registry. Simulated platform tests cover Darwin x64/ARM64, Linux x64/ARM64 on glibc/musl, missing diagnostic reports, native Unix executable lookup, extraction arguments and owned process-group termination. A missing diagnostic report now checks the musl interpreter path instead of automatically selecting musl. Login-shell PATH discovery now invokes the shell directly with an argument array, including shell paths containing spaces. These checks passed on the Windows host; they are not native macOS/Linux execution tests. Linux requires a compatible native runtime and `tar` on PATH; listing a musl engine does not establish that the Electron application itself runs on Alpine.

--- a/docs/opencode-manual-test-cases.md
+++ b/docs/opencode-manual-test-cases.md
@@ -1,0 +1,558 @@
+# OpenCode manual acceptance tests
+
+This checklist covers the current stages 1–7 implementation and the stage 8 release gate. It is a test plan, not a record of completed manual testing. Start every case as **Not run**. Automated test results do not establish a manual pass.
+
+Related contracts: [coding runtime](opencode-coding-runtime.md), [provider setup](opencode-provider-setup.md), [installation and isolation](opencode-integration-contract.md).
+
+## 1. Test record and priorities
+
+Create a separate result record for each build/platform combination. Use **Pass**, **Fail**, **Blocked**, **Not run**, or **Not applicable**. Record a reason for Blocked/Not applicable; neither counts as Pass.
+
+| Field | Record |
+| --- | --- |
+| Tester and date | |
+| Rowboat commit/build identifier | |
+| Execution | Development / packaged application |
+| OS version and CPU architecture | |
+| OpenCode engine version | Expected pinned version: 1.18.30; record observed version |
+| Provider and authentication method | Provider name/method only; no secrets |
+| Models used | Exact provider-qualified IDs |
+| Project/session/worktree | Test project path and Rowboat session identifier |
+| Case ID and result | |
+| Actual behavior and duration | |
+| Evidence / issue link | Redacted screenshots, relevant output, file diff, process observations |
+
+**P0:** Core flow, unintended execution, lost context, misleading readiness, or credential exposure; must pass before release. **P1:** Recovery, configuration, and supported platform behavior; required for the affected feature/platform. Fault-injection cases require a controlled test build or test harness when ordinary UI interaction cannot trigger the condition.
+
+Use a disposable OS account or backed-up test profile for clean-state and corruption cases. Do not delete your everyday Rowboat/OpenCode state. Use a disposable repository and restricted test-provider credentials. Real verification and coding requests can consume provider usage. Never paste credentials into test prompts, screenshots, issue reports, or shared evidence.
+
+## 2. Test fixtures
+
+### Repository A: a small Node project
+
+Create a directory whose path contains spaces, such as `C:\Rowboat QA\Project A` on Windows or `~/Rowboat QA/Project A` on macOS/Linux. Use a recent Node version supporting `node --test`.
+
+Create `package.json`:
+
+```json
+{
+  "name": "rowboat-opencode-qa",
+  "private": true,
+  "type": "module",
+  "scripts": { "test": "node --test" }
+}
+```
+
+Create `sum.js`:
+
+```js
+export function sum(a, b) {
+  return a - b; // Intentional defect for the edit-and-test case.
+}
+```
+
+Create `sum.test.js`:
+
+```js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sum } from './sum.js';
+
+test('adds positive numbers', () => assert.equal(sum(2, 3), 5));
+test('adds a negative number', () => assert.equal(sum(-2, 3), 1));
+```
+
+Create `heartbeat.cjs`:
+
+```js
+const fs = require('node:fs');
+console.log(`QA heartbeat PID=${process.pid}`);
+setInterval(() => fs.appendFileSync('heartbeat.log', `${Date.now()}\n`), 500);
+```
+
+Create `.gitignore` containing `heartbeat.log`. Initialize Git, stage these fixture files, and create an initial commit using your test identity. Run `npm test`: both tests must fail initially. Record the initial branch, commit and clean working-tree status. Register this repository in Rowboat's Code section.
+
+Create a second independent repository, **Project B**, with the same initial fixture. Do not reuse Project A's worktree as Project B.
+
+For project-specific mode tests, add this `opencode.json` to Project A only and commit it **before creating the test worktree**:
+
+```json
+{
+  "agent": {
+    "qa-review": {
+      "description": "Review the QA project without modifying files",
+      "mode": "primary",
+      "permission": { "edit": "deny", "bash": "deny" }
+    }
+  }
+}
+```
+
+For configuration changes after session creation, edit the configuration inside the **session's actual working directory**. Editing the original checkout does not automatically update an existing worktree.
+
+### Provider fixtures
+
+- A currently available OpenCode public free model, plus optional Go and Zen test accounts with model access.
+- A second available model; preferably one model with advertised effort and one without. If no available model advertises effort, mark effort-positive cases Blocked and record the catalog observed.
+- An invalid dummy key for negative tests. Do not invalidate the account's real key merely to simulate a failure.
+- Go and Zen account API keys for paid-account cases. Generic provider/OAuth/login-terminal flows are outside the shipped UI scope.
+- Optional controlled provider/MCP fixture for deterministic network, authentication, malformed-response and tool-approval tests. Never use production infrastructure for fault injection.
+
+### Evidence to capture
+
+Record the session's displayed cwd/worktree path, selected model/mode, approval decisions, relevant timeline rows and `git diff` in the actual session directory. For process cleanup, inspect executable path, parent/child relationships and the heartbeat file; a process name alone cannot distinguish a global OpenCode instance from Rowboat's owned engine.
+
+State locations to inspect locally when needed:
+
+```text
+~/.rowboat/engines/opencode/<version>/
+~/.rowboat/opencode/config/
+~/.rowboat/opencode/data/
+~/.rowboat/opencode/cache/
+~/.rowboat/opencode/state/
+~/.rowboat/code-mode/sessions/
+~/.rowboat/code-mode/sessions-meta/
+```
+
+The managed auth file contains secrets. Inspect credential presence locally without copying its contents into evidence. Never record the private HTTP listener's password or Authorization header.
+
+## 3. Recommended execution order
+
+For a quick stage 7 check on an existing installation, run **MOD-01 through MOD-09**, then **PERM-06**. For first-release acceptance, run the entire P0 sequence first: installation → API setup → model choice → worktree coding → approve/reject → stop → restart/resume → disconnect → remove/reinstall. Then run optional Go/Zen account cases, failure injection, and each intended packaged platform.
+
+If a prerequisite fails, mark dependent cases Blocked rather than treating the same failure as an independent result for every case. Restore the fixture or create a fresh Code session between destructive/corruption scenarios.
+
+## 4. Installation and isolated state
+
+### INS-01 — Fresh install without a global CLI [P0]
+
+**Precondition:** Fresh test profile; no managed engine/state and no global OpenCode executable.
+
+1. Open Settings → Code Mode → OpenCode.
+2. Confirm Not installed, then click Enable.
+3. Observe download/provisioning phases until completion.
+4. Inspect the running executable path when opening provider setup.
+
+**Expected:** The pinned managed engine installs successfully. Progress ends in Installed with an optional Connect Go / Zen action, not Ready. Executable selection is inside the managed engine directory. No global CLI installation is required.
+
+**Evidence:** Initial/final Settings state, version, executable path and approximate install time.
+
+### INS-02 — Repeated/concurrent Enable requests [P1]
+
+**Precondition:** No managed engine; use a sufficiently slow connection to observe installation.
+
+1. Trigger Enable twice through available UI entry points, or issue two provisioning requests using the development IPC harness.
+2. Observe progress and final status for both subscribers.
+3. After completion, request Enable again.
+
+**Expected:** Concurrent requests share one backend installation. Both callers settle accurately. Re-enabling an intact engine does not download another copy. No partial engine is marked installed.
+
+### INS-03 — Interrupted or failed installation [P0]
+
+1. Begin a fresh download, then disconnect the test machine's network.
+2. Observe the failure; restore networking and choose Retry.
+3. Repeat with an application shutdown during download/extraction, then reopen.
+
+**Expected:** Interrupted installation never reports success. Restart shows either a fully validated engine or a recoverable not-installed/failed state. Retry completes without manually repairing metadata.
+
+### INS-04 — Integrity, extraction and version failures [P0; harness]
+
+1. Supply a truncated archive or an archive whose bytes do not match the manifest hash.
+2. Separately simulate extraction failure and an executable that fails or hangs during the bounded version check.
+3. Restore the normal package source and Retry.
+
+**Expected:** Each invalid artifact is rejected before installation metadata is activated. Error state is recoverable; no corrupt executable becomes the selected engine. The version-check failure does not hang indefinitely.
+
+### INS-05 — Missing executable and repair [P0]
+
+**Precondition:** Installed engine; all owned OpenCode processes stopped.
+
+1. Move the managed executable to a backup location within the disposable test profile.
+2. Click Re-check in Settings.
+3. Enable/reinstall again.
+
+**Expected:** Re-check reports Not installed despite any stale metadata. Repair downloads/validates the managed executable and restores installation status. Credentials/conversations remain intact.
+
+### INS-06 — Global installation and state are untouched [P0]
+
+1. In the disposable account, prepare a separate global OpenCode installation/configuration with distinctive nonsecret settings. Record config hashes and global credential-file modification times without opening secrets in shared tooling.
+2. Launch managed provider setup and a coding turn.
+3. Inspect managed process executable paths and compare global files afterward.
+
+**Expected:** Rowboat selects its pinned executable, does not import global credentials automatically, and does not modify global OpenCode configuration/authentication state. Deliberate project configuration remains visible to coding.
+
+### INS-07 — Paths and inherited environment [P1]
+
+1. Launch Rowboat from a path/profile and project path containing spaces.
+2. In the disposable launch environment, set an OpenCode config override pointing at a harmless distinctive test config and a dummy provider-key environment variable.
+3. Start setup and coding; run a harmless project command such as `node --version` after approval.
+
+**Expected:** Managed launches work without shell quoting failures. Inherited overrides/dummy credentials do not silently optionally connect Go or Zen or change managed configuration. Project tools remain reachable on PATH.
+
+## 5. Provider setup
+
+### AUTH-01 - Start without an OpenCode account [P0]
+
+1. Use a clean disposable Rowboat profile without OpenCode credentials, and configure a Rowboat chat model.
+2. Enable OpenCode and create a Code session in Repository A.
+3. Open the model picker in the Code header and choose an advertised free model.
+4. Ask it to inspect the project; approve any requested reads.
+
+Expected: no OpenCode account gate or provider wizard. The composer displays the Rowboat chat model and the Code header displays the separate OpenCode coding model. Native activity and response appear. If the upstream public service is unavailable, record Blocked with the error; installation must not be reported missing.
+
+### AUTH-02 - Optional Go account [P0]
+
+1. Open Settings - Code Mode - OpenCode - Connect Go / Zen (optional).
+2. Open the account page, choose Go and paste its account key. Save.
+3. Return to Code mode and choose a Go model; send a short request.
+
+Expected: the field clears immediately. Settings says key saved, never verified/Ready merely from saving. The Code picker refreshes without app restart, labels Go, and the request uses that exact model.
+
+### AUTH-03 - Optional Zen account [P0]
+
+1. Choose Zen in account setup and save a valid account key.
+2. Select a Zen model in Code mode and send a short request.
+3. If Go is also connected, switch explicitly between Go and Zen models.
+
+Expected: billing distinctions are visible. Saving one service does not silently connect the other. Rowboat never automatically falls back from Go to Zen or changes the selected model after an error.
+
+### AUTH-04 - Invalid key and entitlement failure [P0]
+
+1. Save a dummy invalid key for a test account option.
+2. Choose a model requiring that account and submit a prompt.
+3. Replace it with a valid key and retry; separately test a model outside the account entitlement if available.
+
+Expected: saving alone makes no success claim about inference. The coding error is readable and secret-free. A failed request does not silently switch models. A corrected key refreshes options without app restart.
+
+### AUTH-05 - Free model disappears or is rate limited [P1]
+
+1. Use a controlled response fixture to return unavailable-model or rate-limit failure for a selected public model.
+2. Refresh the picker and choose another advertised free model.
+
+Expected: a visible recoverable error; no forced paid upgrade, automatic paid fallback, or hardcoded stale free-model list.
+
+### AUTH-06 - No unrelated providers in the picker [P0]
+
+1. Seed an unrelated provider credential in a disposable managed profile, or use retained state from an earlier build.
+2. Reopen Settings and the Code model picker.
+3. Open an old session that selected that unrelated provider.
+
+Expected: Settings offers only Go/Zen, Code discovery only OpenCode models. The old selection requires an explicit supported choice; conversations and unrelated credential files are not deleted.
+
+### AUTH-07 - Switch account form with an unsaved key [P0]
+
+1. Type a dummy key into Go, then switch the account option to Zen.
+2. Repeat in reverse, then close and reopen setup.
+
+Expected: every switch clears the password field. No key is saved until Save account key is clicked; no key appears in storage, logs or conversation events.
+
+### AUTH-08 - Setup failure and retry [P1]
+
+1. Interrupt setup-service startup using a controlled test harness or remove the executable in a disposable profile.
+2. Open account setup and inspect the error, then repair/re-check installation and retry.
+
+Expected: a useful retry action, no false connected state, and no orphaned setup processes. No raw executable path is presented as a login action.
+
+### AUTH-09 - Close setup and competing windows [P1]
+
+1. Open account setup, close it while starting, then reopen it.
+2. Open another Rowboat window and attempt setup concurrently.
+3. Close the owning window and inspect native processes.
+
+Expected: stale start responses clean up their own leases, ownership errors are clear, and closing the owner terminates its setup process without leaving secrets in the renderer.
+
+### AUTH-10 - Disconnect and reconnect [P0]
+
+1. Disconnect Go while Zen is connected; verify only Go credentials are removed.
+2. Disconnect Zen, refresh Code model options and choose a public free model.
+3. Send a request, then reconnect the desired account.
+
+Expected: free coding still works without account keys. An old paid selection reports unavailability until explicitly changed. Reconnection refreshes the picker without restart.
+
+Also verify all picker states: neither connected shows only free models; Go-only hides all Zen models; Zen-only hides Go models. When both are connected, switching Go/Zen changes the displayed list without sending a model update until a model is chosen. Disconnect the displayed service while the picker is open and verify the list refreshes to the remaining service. Submit a stale model selection through the test harness and confirm the backend rejects it before inference.
+
+### AUTH-11 - Secret handling and model delegation audit [P0]
+
+1. Save a distinctive dummy key; inspect renderer persistence, conversation events and logs without publishing actual secrets.
+2. Select a Rowboat chat model in the composer and a free OpenCode model in the Code header, then send a coding request.
+3. Inspect transport records using the controlled harness and restart/resume the session.
+
+Expected: no account key appears in those stores. Rowboat uses the selected chat model to delegate to OpenCode and provide a brief response. Native coding uses the separately selected OpenCode model; session history resumes without duplicate replay. Normal title generation may use the configured Rowboat model.
+
+## 6. Coding, history and workspace
+
+### CODE-01 — Select OpenCode across entry points [P0]
+
+1. Confirm OpenCode is available through onboarding setup, Settings, composer agent selection, new Code session selection, session header and session list.
+2. Create a session explicitly using OpenCode.
+3. Send a prompt and inspect the run's agent label.
+
+**Expected:** Selection reaches the runtime as OpenCode and labels remain consistent. No surface labels an OpenCode run as Codex/Claude. Installation/connection failures lead back to usable Settings actions.
+
+### CODE-02 — Inspect the actual worktree [P0]
+
+1. Create a Code session for Project A with worktree isolation.
+2. Record the displayed worktree path and branch.
+3. Prompt: `Inspect sum.js and sum.test.js. Report the defect and the working directory. Do not edit files or run tests yet.`
+4. Approve read actions as needed under Ask; inspect original checkout and worktree afterward.
+
+**Expected:** The session uses the recorded worktree, not the original checkout. Inspection is reflected in the timeline. No files change. Do not use the model's claimed cwd as sole proof: compare session metadata and later file changes.
+
+### CODE-03 — Approve an edit and run tests [P0]
+
+1. Prompt: `Fix only the sum function, then run npm test. Ask through the approval cards before actions that require approval.`
+2. Inspect the proposed edit and approve it once.
+3. Inspect the command and approve `npm test`.
+4. Inspect timeline output and the repository Changes view.
+
+**Expected:** The worktree's `sum.js` changes from subtraction to addition. Tests pass and their output is visible. The correct file appears in Changes. The original checkout remains unchanged until an explicit merge action.
+
+### CODE-04 — Failure output and previews [P0]
+
+1. In a fresh defective fixture, ask to run `npm test` without fixing anything and approve the command.
+2. Expand command output.
+3. Request the fix and inspect its before/after preview before approving.
+4. With a controlled fixture, produce output larger than 64 KiB.
+
+**Expected:** Failed-tool status and useful failure text remain visible. The preview shows the actual file/content change. Oversized output has an explicit truncation marker, not an unexplained empty/generic event.
+
+### CODE-05 — Follow-up and app restart [P0]
+
+1. Tell the coding agent: `Remember the project marker QA-RESUME-742 for this conversation; do not write it to a file.`
+2. Complete another turn, then stop/quit Rowboat normally.
+3. Reopen the same session and ask: `What project marker did I give you, and what file did we change? Inspect the current file if needed.`
+4. Compare native session IDs before/after locally and count existing transcript entries.
+
+**Expected:** The same native session resumes and retains useful context. Prior user/agent messages are not replayed as duplicate Rowboat entries. Native ID/cwd evidence is authoritative; a correct marker answer alone is insufficient proof.
+
+### CODE-06 — Missing/corrupt native session metadata [P0; disposable profile]
+
+1. Back up the test session state while Rowboat is closed.
+2. With a controlled harness, remove its native session while keeping Rowboat metadata/history, then reopen and submit a follow-up.
+3. Separately corrupt the test Rowboat ACP session metadata JSON or change its state-namespace/cwd association.
+
+**Expected:** Explicit recovery errors identify that the saved session cannot be used. Rowboat does not silently create a replacement and claim continuity. Existing conversation evidence remains intact. Restore the backup or create a new Code session for recovery.
+
+### CODE-07 — Stop and quit during a running command [P0]
+
+1. Prompt the agent to run `node heartbeat.cjs`, and approve the exact command.
+2. Confirm `heartbeat.log` is growing in the worktree and record the child PID.
+3. Click Stop; wait at least five seconds and observe the file and process tree.
+4. Repeat in a fresh turn, quitting Rowboat instead of clicking Stop.
+
+**Expected:** The operation unwinds, the composer becomes usable after Stop, and the owned process tree exits. Heartbeat growth stops. Reopening Rowboat does not leave a stale running state or orphan command. A process that continues writing is a release-blocking failure.
+
+### CODE-08 — Stop during startup and simultaneous prompts [P1; harness if needed]
+
+1. Send a prompt with a cold engine and immediately click Stop during startup/model configuration.
+2. Confirm no delayed project edit begins after cancellation.
+3. Attempt two simultaneous prompts against the same Code session using a controlled dispatcher harness.
+
+**Expected:** Cancellation also covers preparation, not just streaming. One session cannot run two overlapping operations; the second request receives a clear error. No extra native conversation or orphan process is created.
+
+## 7. Permission behavior
+
+For each case, record the chosen policy and actual approval card. If the model refuses to attempt the requested test action or chooses a different tool, record **Blocked** and use a deterministic test provider/harness; a model refusal is not proof that the permission system denied execution.
+
+### PERM-01 — Reject an edit [P0]
+
+1. Select Ask and record the hash/content of `sum.js`.
+2. Request a specific change to that file.
+3. Inspect the proposed change, then click Deny.
+4. Compare file contents and Git diff.
+
+**Expected:** The rejected edit does not occur. The timeline records the rejection/failed action accurately. A proposed diff alone must not mark the filesystem edit as applied.
+
+### PERM-02 — Reject a command [P0]
+
+1. Under Ask, request the explicit command `node -e "require('fs').writeFileSync('denied-command.txt','unexpected')"` in the disposable project.
+2. Deny the command approval and inspect the directory.
+
+**Expected:** `denied-command.txt` is absent. No alternative command performs the rejected action silently. The denied command remains identifiable in the timeline.
+
+### PERM-03 — Allow once stays local [P0]
+
+1. Under Ask, approve one write to `first.txt`.
+2. Request a write to `second.txt`; deny it.
+3. Request another write to `first.txt` on the next turn.
+
+**Expected:** The second and third actions require fresh approval. Approving one edit does not approve the entire edit tool kind. OpenCode's card has no Always allow button. A forced persistent decision through the harness rejects safely.
+
+### PERM-04 — Auto-approve reads [P1]
+
+1. Select Auto-approve reads while idle.
+2. Request a file inspection, then an edit and a test command.
+3. Observe which actions proceed automatically and which display cards.
+
+**Expected:** Eligible read/search/fetch/think requests can receive automatic allow-once. Edits and commands still require approval. Explicit configured denial rules are never converted to approvals.
+
+### PERM-05 — YOLO → Ask [P0]
+
+1. In an idle session, select YOLO and request a harmless marker-file edit.
+2. After the turn finishes, switch to Ask.
+3. Request another edit of the same file using the same tool; deny it.
+
+**Expected:** The YOLO action runs automatically, subject to explicit denials. The later Ask action requires a fresh card and rejection prevents the edit. No remembered upstream approval survives the policy change.
+
+### PERM-06 — Plan → Build and explicit denial preservation [P0]
+
+1. Select Plan and request a proposed fix; confirm no unapproved implementation occurs.
+2. Switch to Build while idle, request the implementation and approve it.
+3. In Project A, select `qa-review` and request an edit/command; repeat under YOLO.
+
+**Expected:** Leaving Plan permits Build actions through the current approval policy. The custom mode's explicit edit/bash denials still prevent those actions, including in YOLO. Rowboat removes only its own obsolete mode restrictions, not project/session denials.
+
+### PERM-07 — Policy change or shutdown while approval is pending [P0]
+
+1. Leave an edit approval unanswered.
+2. Attempt to change approval policy/model/mode during the running operation.
+3. Click Stop, then try responding to the old card.
+4. Repeat with application shutdown while the card is pending.
+
+**Expected:** Configuration changes during a running operation request that it be stopped first. Stop/disconnect rejects pending requests. An old or late Allow cannot execute the edit after the operation has ended. Restart does not restore a live approval against a dead process.
+
+### PERM-08 — Subagents and structured questions remain unavailable [P0]
+
+1. Ask OpenCode to delegate a task to a subagent, first under Ask and then YOLO.
+2. Where a deterministic fixture exists, attempt the upstream `task` and structured `question` tools directly.
+3. Inspect the header's capability note and the resulting turn.
+
+**Expected:** Subagent task execution is denied, rather than running without Rowboat approvals. Structured questions cannot leave the session hanging on an unsupported question interface. Ordinary textual questions remain possible. The UI states the subagent limitation.
+
+### PERM-09 — MCP and external permission changes [P1; controlled fixture]
+
+1. Configure a trusted local test MCP server with observable harmless read/write tools.
+2. Under Ask, invoke its write tool and deny it; repeat after configuring an explicit denial, including under YOLO.
+3. In a disposable session, replace the native permission rules outside Rowboat using the test harness, then send a new turn.
+
+**Expected:** An MCP write requiring approval cannot proceed after denial; explicit denials remain effective. Unexpected replacement of Rowboat-tracked native rules causes a safe recovery error before another prompt, rather than silently widening permissions. Record the exact tool name and matched configuration rule.
+
+## 8. Stage 7: model, effort and mode selection
+
+### MOD-01 — Qualified model IDs and accepted selection [P0]
+
+1. Create an OpenCode session without an account and select a free model in Code mode. Repeat with optional Go/Zen accounts.
+2. Open the session header's Model menu and record labels and full IDs.
+3. Select another accessible model, close/reopen the menu and send a short coding prompt.
+4. Inspect accepted session metadata and, where available, provider request/model evidence.
+
+**Expected:** Provider-qualified IDs are preserved. New sessions expose the native available choices; existing sessions keep their own accepted choice. Old Settings selections do not seed new sessions. The backend accepts the change before saving it. A label alone is not sufficient evidence of the model actually used.
+
+### MOD-02 — Advertised effort appears [P1]
+
+1. Select a model known to advertise effort through this engine/provider.
+2. Open Effort and select each intended supported level, sending a short turn with at least two levels.
+3. Close/reopen the session settings.
+
+**Expected:** Only engine-advertised values appear. The selected value is accepted and persisted. No fabricated effort option or OpenCode synthetic Default value is inserted.
+
+### MOD-03 — Unsupported effort disappears [P0]
+
+1. Start with a model and effort selected in MOD-02.
+2. Switch to a model that advertises no effort option.
+3. Reopen settings and send a turn.
+
+**Expected:** Effort selection disappears and stale effort is cleared. The turn does not send an unsupported old effort value. The header does not continue claiming that value is active.
+
+### MOD-04 — Build, Plan and custom primary modes [P0]
+
+1. In Project A's session, open Mode and select Build, then Plan, then `qa-review`, while idle.
+2. Close/reopen settings after each selection and send an appropriate inspection prompt.
+3. Run PERM-06 for behavioral confirmation.
+
+**Expected:** Modes are separate from engine/model selectors. Advertised custom primary modes appear and the accepted mode persists. Mode behavior respects its resolved restrictions.
+
+### MOD-05 — Project/worktree isolation of discovery [P0]
+
+1. Open Project A and Project B sessions alternately.
+2. Confirm `qa-review` appears only in Project A's configured working directory.
+3. Add a distinctly named custom mode to one session's worktree configuration, then reopen its picker.
+4. Reopen the other session's picker.
+
+**Expected:** Choices follow the actual cwd/worktree. No per-agent shared cache leaks one project's options into another. A committed original-checkout configuration is not mistaken for a later worktree-only change.
+
+### MOD-06 — Provider/configuration changes without app restart [P0]
+
+1. Keep a Code session available, then connect an optional Go or Zen account through Settings.
+2. Return to the session and reopen the model picker.
+3. Disconnect that provider and reopen again.
+4. Modify the session worktree's supported configuration and reopen the picker once more.
+
+**Expected:** Discovery runs against current credentials/configuration without restarting Rowboat. Record what the engine advertises: some catalogs may include models from disconnected providers, but attempting to use them must not silently succeed under another provider. Existing invalid selections produce a clear error/recovery path.
+
+### MOD-07 — Unavailable model and recovery [P0]
+
+1. Select a valid model, then make it unavailable using a controlled project/provider configuration or fixture.
+2. Reopen the picker and attempt a turn.
+3. Choose a valid advertised alternative.
+
+**Expected:** An unavailable-model/selection error is visible. Rowboat does not silently run a default model while claiming the old one. Discovery still offers valid alternatives where the engine can load its catalog. Selecting an alternative clears the problem after backend acceptance.
+
+### MOD-08 — Rejected selection does not persist [P0; harness for deterministic rejection]
+
+1. Record the current accepted model/effort/mode and stored session metadata.
+2. Make the engine reject one proposed change, or remove the selected option between discovery and submission.
+3. Attempt the change and reopen settings.
+
+**Expected:** An error appears and the previous accepted value remains stored. The UI does not claim that the rejected choice became active. A subsequent valid selection succeeds without recreating the Rowboat conversation.
+
+### MOD-09 — Refresh latency, repeated opening and idle cleanup [P1]
+
+1. Open/close the picker repeatedly, including shortly after a provider/configuration change.
+2. Observe loading/error states and the managed OpenCode process list.
+3. After discovery settles and no coding/setup is active, check for lingering discovery processes.
+
+**Expected:** Cold discovery can take several seconds; the UI remains responsive and never fabricates options to hide failures. Discovery sessions/processes are cleaned up. Results from an older UI request do not overwrite newer project/model selections.
+
+## 9. Retention, release and platform coverage
+
+### REL-01 — Remove/reinstall with retained state [P0]
+
+1. Finish a coding turn and record session IDs, selected model and conversation history.
+2. Remove the engine through Settings.
+3. Confirm installation becomes Not installed and managed processes stop.
+4. Reinstall, reopen provider setup and resume the existing Code session.
+
+**Expected:** Engine files are removed separately from managed credentials/conversations. Retained credentials remain configured but require a fresh verification to claim Ready. An intact native session resumes after reinstall. Reinstallation does not import global state or replay duplicate history.
+
+### REL-02 — Engine removal/shutdown during activity [P0]
+
+1. In separate disposable runs, remove the engine or quit while setup, model discovery, an approval, and a heartbeat command are active.
+2. Inspect process trees, listener closure and heartbeat growth.
+3. Restart and inspect installation/connection/session states.
+
+**Expected:** Owned operations fail/cancel coherently and no child process or authenticated setup listener remains orphaned. Installation status follows validated files, not stale metadata. Preserved state supports explicit recovery.
+
+### REL-03 — Packaged Windows acceptance [P0]
+
+1. Install/run the packaged build from a path containing spaces with ordinary user permissions.
+2. Run INS-01, AUTH-01, CODE-01 through CODE-07, PERM-01 through PERM-07, MOD-01 through MOD-08 and REL-01.
+3. Exercise public free-model access and optional Go and Zen accounts.
+
+**Expected:** The complete flow works without a development checkout, global OpenCode or developer-only PATH assumptions. Native login dependencies are packaged correctly. Record the installer/build identity separately from development-mode results.
+
+### REL-04 — macOS and Linux acceptance [P0 for each claimed platform]
+
+1. Repeat REL-03's applicable sequence on each OS/architecture you intend to support, using actual packaged builds.
+2. Launch from the desktop/application launcher, not only from a terminal; check project-tool PATH and executable permissions.
+3. Verify process-tree cleanup and native login on that OS.
+4. For Linux, record distribution/libc and extraction/runtime prerequisites. Test musl only if the application itself claims support for that environment.
+
+**Expected:** Native behavior is demonstrated on each claimed platform. Registry package availability or mocked platform tests do not count as execution evidence. Untested architectures remain explicitly unverified.
+
+### REL-05 — Claude/Codex regression [P1]
+
+1. Open existing Claude and Codex Code sessions in the test profile.
+2. Run a short inspection and approved/rejected action; check model selection and resume.
+3. Switch a disposable session between engines and inspect labels/model selections.
+
+**Expected:** Existing engines still function. Agent-specific selections do not leak across engines. Shared broker changes never widen allow-once or fall back to an unrelated permission option. Cross-engine switching is a new native conversation, not a promised history migration.
+
+## 10. Release sign-off
+
+- All applicable P0 cases pass on the actual release build/platform.
+- P1 failures/blocks have an explicit disposition and do not contradict advertised support.
+- Real-account Go/Zen and public-model results are recorded separately.
+- No known secret exposure, denied-action execution, orphan process or silent session replacement remains.
+- The product and release notes retain the current limitations: one-time OpenCode approvals; subagent tasks and structured question UI unavailable.
+- Attach the completed run records and issues. Leave untested platforms/methods marked unverified; do not replace missing evidence with automated-test results.

--- a/docs/opencode-provider-setup.md
+++ b/docs/opencode-provider-setup.md
@@ -1,0 +1,26 @@
+# OpenCode accounts and free access
+
+The coding-model picker follows Rowboat's saved OpenCode connections:
+
+| Connection | Visible coding models |
+| --- | --- |
+| Neither account connected | Public OpenCode models with zero input and output cost in native metadata |
+| Go only | Go models only, including hiding public Zen models |
+| Zen only | Zen models only |
+| Both | A Go/Zen switch, showing one service's models at a time |
+
+The switch browses a service; selecting a model commits the choice. Connection IDs describe the service configured in Rowboat, not a verified subscription entitlement. Model access is enforced during discovery, selection validation and before coding. A disconnected or otherwise unavailable explicit selection reports an error instead of silently switching services. Disconnecting both accounts restores the free list. Unknown pricing is not classified as free, and model names are not used to infer cost.
+
+Enable the managed engine, open a Code session, choose a native model, and start coding. Public free models require no account key. Availability and rate limits are controlled by OpenCode; Rowboat does not hardcode a free-model catalog or promise permanent availability.
+
+Settings - Code Mode - OpenCode offers **Connect Go / Zen (optional)**. Open the OpenCode account page, choose Go (subscription) or Zen (pay as you go), paste the account API key and save. The key connects only the selected service; Rowboat never switches from Go to Zen automatically. Select models in the Code session header, not Settings. The installed engine uses only the OpenCode and OpenCode Go providers.
+
+Saving means **account key saved**, not verified access. The actual coding request checks credentials and model entitlement. Invalid credentials produce a recoverable error, not a Ready badge. Disconnecting an account removes its managed credential; public free models remain selectable. A session pointing to an unavailable paid model requires choosing another model explicitly.
+
+Keys travel through typed IPC to the private backend-owned setup service. The password field clears immediately, and secrets never enter chat, renderer persistence, or diagnostics. The backend opens a fixed HTTPS account URL. Closing setup or quitting stops owned processes. Keys and conversations survive engine removal/reinstallation. Global OpenCode credentials are not imported.
+
+The generic provider/OAuth/verification backend helpers remain covered for compatibility, but those flows are not offered in Settings. Old Settings model selections are no longer used to seed or override Code sessions.
+
+OpenCode uses the same two-model flow as Codex. The Rowboat chat model selected in the composer delegates to `code_agent_run`; the coding model selected in the Code header runs inside native OpenCode. Rowboat handles the surrounding chat and normal title generation. Free OpenCode models need no OpenCode account, but this flow requires a configured Rowboat chat model. Existing native sessions retain their context. Already-persisted direct-dispatch turns remain resumable for compatibility; new turns use normal delegation.
+
+Validation includes renderer key clearing and account switching, Rowboat-model delegation and legacy direct-turn compatibility, native public access against a local fake model endpoint, native account-key rejection, disconnect and process cleanup. Real Go/Zen account entitlement, public service availability, packaged Electron, macOS and Linux remain manual release checks.


### PR DESCRIPTION
# Add managed OpenCode coding with free models and optional Go/Zen access

## Problem and resulting behavior

Rowboat's Code mode previously supported Claude Code and Codex. This change adds a managed OpenCode engine with an in-app account setup and native coding-model picker. A user can enable OpenCode, create a project/worktree session, select a public free model, and code without installing a global OpenCode CLI or connecting an OpenCode account. Optional Go and Zen account keys unlock their respective model catalogs.

OpenCode follows the same two-model flow as Codex: the Rowboat chat model selected in the composer delegates through `code_agent_run`, while the Code header selects the native OpenCode model. A configured Rowboat chat model is still required. Native OpenCode handles coding, streaming activity and conversation context; Rowboat handles surrounding chat and approval cards.

## Managed installation and isolation

- Extend the shared coding-agent contract, provisioning IPC, renderer state and agent selection surfaces to include OpenCode.
- Pin OpenCode 1.18.30 with platform package URLs and integrity hashes, including Windows, macOS and Linux mappings.
- Download exclusively into `~/.rowboat/engines/opencode/<version>/`; resolve the extracted native executable and validate its version before recording installation metadata.
- Deduplicate concurrent enable requests and handle interrupted downloads, extraction failures, repair and missing executables without reporting a successful installation.
- Share an environment/process service between setup and coding. Redirect XDG config, data, cache and state into `~/.rowboat/opencode/`, exclude inherited provider credentials and configuration overrides, preserve the project-tool PATH, and disable automatic engine updates.
- Use authenticated loopback HTTP for setup and native ACP for coding, with bounded startup/diagnostics and owned-process cleanup.
- Keep credential and conversation retention separate from engine removal. These state directories do not sandbox project commands.

## Account setup and model selection

Settings offers optional Go/Zen account-key setup, a fixed OpenCode account-page action and per-service disconnect. Secrets go through backend IPC, clear from the password field immediately, and never become chat messages or renderer persistence. Saving a key means configured credentials, not verified subscription entitlement.

| Managed connection | Coding-model picker |
| --- | --- |
| Neither Go nor Zen | Public models whose native metadata reports zero input and output cost |
| Go only | Go models only |
| Zen only | Zen models only |
| Both | Go/Zen switch showing one service at a time |

Filtering uses saved service connections and native catalog metadata, not model-name heuristics. Browsing a service does not commit a model change. The backend validates selections and enforces access before coding, rejecting stale/disconnected selections instead of silently switching services.

The Code header now exposes a visible Model button with loading, failure, retry and operation-lock states. Discovery uses the session's actual working directory and refreshes after account/configuration changes. Provider-qualified IDs, advertised effort options and Build/Plan/custom modes are preserved. Fix the server RPC handler to forward cwd, model, effort and mode rather than dropping everything except the agent name.

## Runtime, history and permissions

- Persist native ACP session IDs, working directory, engine/state metadata and capabilities; resume existing native conversations without duplicating replayed messages.
- Report missing, unreadable or incompatible native sessions explicitly rather than silently replacing their history.
- Preserve streamed messages, plans, usage, command output, tool failures and edit previews in the coding timeline, including explicit output truncation.
- Apply Ask/read-auto-approval/YOLO policy through the shared broker while preserving explicit denial rules. Never promote allow-once to persistent approval or fall back to an arbitrary offered permission option.
- Reject pending approvals on cancellation/disconnection and refresh native processes between turns so configuration and permission changes take effect.
- Retain compatibility for already-persisted direct-dispatch turns; all newly resolved OpenCode turns use the normal Rowboat-model delegation path.

## Validation completed locally

- Shared/core/server/preload/main compilation or type checks and renderer type checks passed during implementation; final filtering changes were checked across these build boundaries.
- Targeted tests passed for provisioning/isolation/process lifecycle, setup behavior, permission mapping, model access, session configuration, runtime delegation and legacy compatibility, timeline presentation and renderer controls.
- Latest filtering checks: 8 core tests and 6 model-picker tests passed.
- Server regression test verifies the model-discovery request retains the project path and complete selection configuration.
- Opt-in native Windows smoke test passed with OpenCode 1.18.30 in a temporary profile whose path contains spaces. The latest run completed in approximately 112 seconds.
- Native coverage includes public inference without saved credentials, Zen-only/Go-only/dual catalog transitions, rejection of a disconnected service before inference, account-key rejection, approved/rejected edits and commands, cancellation, cold-session resume, mode/policy transitions, missing sessions and state retention after engine removal.
- Rebuilt Electron, preload and standalone-server bundles locally. Generated build artifacts are not included in the commit.
- Staged diff whitespace checks passed.

The native smoke test uses a local fake inference endpoint and dummy keys. It does not establish real Go/Zen entitlement, public-service availability or packaged-platform support. The entire repository test suite was not rerun as one final aggregate command.

## Release acceptance still required

- [ ] Complete the real Electron flow: enable, select a real free model, inspect/edit/test a Git worktree, approve/reject, stop, restart and resume.
- [ ] Validate real Go and Zen accounts, entitlement failures, rate limits, disconnect/reconnect and both-service switching.
- [ ] Exercise network loss, unavailable models and shutdown while approvals or long-running commands are pending.
- [ ] Validate packaged Windows builds.
- [ ] Validate macOS and Linux before claiming support there.

Subagent tasks and structured questions are deliberately disabled because the pinned ACP permission path cannot safely support those interactions. Persistent approval is not offered for OpenCode. Full image/embedded-context support, richer subagent/history presentation, explicit global-state import, WSL and managed local-model installation remain deferred. Generic provider/OAuth backend helpers remain for compatibility but are not exposed in the simplified Go/Zen Settings flow.

## Reviewer guide

- `docs/opencode-integration-contract.md`: installation, state and process contract.
- `docs/opencode-provider-setup.md`: account handling and connection-specific model access.
- `docs/opencode-coding-runtime.md`: sessions, delegation, permissions and limitations.
- `docs/opencode-manual-test-cases.md`: detailed manual acceptance checklist; cases are not recorded as manual passes.
- Start code review with `engine-provisioner.ts`, `opencode-process.ts`, `opencode-model-access.ts`, `manager.ts`, `permission-broker.ts`, and the server/renderer model-selection path.