### PR TITLE
spaces: thread receipts are reactions (👀 → ✅ / ❗), post only when the ask wants words

### DIFF
--- a/apps/x/packages/core/src/runtime/assembly/__snapshots__/compose-instructions.test.ts.snap
+++ b/apps/x/packages/core/src/runtime/assembly/__snapshots__/compose-instructions.test.ts.snap
@@ -407,15 +407,15 @@ If Middle pane state is browser, only the URL and page title are supplied; the p
 
 ## When invoked from a thread
 
-You are in a session bound to one thread in the space "Roadboard" (spaceId 01M07B68G1BQFP70TX5RPHJX89, thread root 01M07ROOTAAAAAAAAAAAAAAAA1), org "org-1" — pass org: "org-1" on every spaces tool call. Messages here arrive because your person typed \`@rowboat …\` in that thread; the whole room saw the ask. Your reply is the team's receipt.
+You are in a session bound to one thread in the space "Roadboard" (spaceId 01M07B68G1BQFP70TX5RPHJX89, thread root 01M07ROOTAAAAAAAAAAAAAAAA1), org "org-1" — pass org: "org-1" on every spaces tool call. Messages here arrive because your person typed \`@rowboat …\` in that thread; the whole room saw the ask. The room reads everything you post, so your receipt is a reaction on the invoking message (its id is in the \`[@rowboat …]\` header) — a reply only when the ask wants words.
 
+- \`react\` 👀 before you start, and on any follow-up \`@rowboat\` message that arrives while you work (fold those in). That is the whole "on it" — never post one.
 - If the task is about the conversation, \`read_thread\` first.
 - Do the work. Any \`propose_change\` reason ends with \` · thread:01M07ROOTAAAAAAAAAAAAAAAA1\` — that files the change under this thread.
-- End with exactly one \`post_message\` reply into that thread (threadRoot 01M07ROOTAAAAAAAAAAAAAAAA1): outcome first, one or two sentences. If you could not do it, say what blocked you.
-- Your reply answers the ask. Nothing you read while working goes in it unless it is the answer.
-- No "on it", no progress posts. One reply.
-- Follow-up \`@rowboat\` messages may arrive while you work. Fold them in; still one reply covering what actually happened.
-- To address a person in your reply, write a mention token — \`[@Their Name](#member:<memberId>)\`, the id from \`list_members\`. A bare name is prose and reaches nobody; never guess an id.
+- Done: swap 👀 for ✅ and post nothing when the outcome speaks for itself — a file edited, a thread titled, a message pinned or scheduled. The team can open the file.
+- Post exactly one \`post_message\` reply (threadRoot 01M07ROOTAAAAAAAAAAAAAAAA1) only when the ask wants an answer — a question, an opinion, a lookup. Outcome first, one or two sentences, no cheering, no recap of the edit. Nothing you read while working goes in unless it is the answer.
+- Need your person — a confirmation, a choice, a blocker, or anything you could only explain with private detail: swap 👀 for ❗, say nothing in the thread, and ask here in this chat, which only they see. When they answer and you finish, swap ❗ for ✅.
+- To address a person, write a mention token — \`[@Their Name](#member:<memberId>)\`, the id from \`list_members\`. A bare name reaches nobody; never guess an id.
 
 ## Privacy
 

--- a/apps/x/packages/core/src/runtime/assembly/skills/spaces/procedures.ts
+++ b/apps/x/packages/core/src/runtime/assembly/skills/spaces/procedures.ts
@@ -12,7 +12,7 @@ export interface ThreadContext {
 }
 
 /**
- * "When invoked from a thread" — the receipt contract. With `ctx`, the ids are
+ * "When invoked from a thread" — the receipt contract (react 👀 → ✅, or ❗ when the person is needed in the private chat; post only when words are needed). With `ctx`, the ids are
  * concrete (the pinned form); without, the generic form the skill carries.
  */
 export function threadProcedure(ctx?: ThreadContext): string {
@@ -24,15 +24,15 @@ export function threadProcedure(ctx?: ThreadContext): string {
     return [
         "## When invoked from a thread",
         "",
-        `${where} Your reply is the team's receipt.`,
+        `${where} The room reads everything you post, so your receipt is a reaction on the invoking message (its id is in the \`[@rowboat …]\` header) — a reply only when the ask wants words.`,
         "",
+        "- `react` 👀 before you start, and on any follow-up `@rowboat` message that arrives while you work (fold those in). That is the whole \"on it\" — never post one.",
         "- If the task is about the conversation, `read_thread` first.",
         `- Do the work. Any \`propose_change\` reason ends with \` · thread:${root}\` — that files the change under this thread.`,
-        `- End with exactly one \`post_message\` reply into that thread (threadRoot ${root}): outcome first, one or two sentences. If you could not do it, say what blocked you.`,
-        "- Your reply answers the ask. Nothing you read while working goes in it unless it is the answer.",
-        "- No \"on it\", no progress posts. One reply.",
-        "- Follow-up `@rowboat` messages may arrive while you work. Fold them in; still one reply covering what actually happened.",
-        "- To address a person in your reply, write a mention token — `[@Their Name](#member:<memberId>)`, the id from `list_members`. A bare name is prose and reaches nobody; never guess an id.",
+        "- Done: swap 👀 for ✅ and post nothing when the outcome speaks for itself — a file edited, a thread titled, a message pinned or scheduled. The team can open the file.",
+        `- Post exactly one \`post_message\` reply (threadRoot ${root}) only when the ask wants an answer — a question, an opinion, a lookup. Outcome first, one or two sentences, no cheering, no recap of the edit. Nothing you read while working goes in unless it is the answer.`,
+        "- Need your person — a confirmation, a choice, a blocker, or anything you could only explain with private detail: swap 👀 for ❗, say nothing in the thread, and ask here in this chat, which only they see. When they answer and you finish, swap ❗ for ✅.",
+        "- To address a person, write a mention token — `[@Their Name](#member:<memberId>)`, the id from `list_members`. A bare name reaches nobody; never guess an id.",
     ].join("\n");
 }
 


### PR DESCRIPTION
## Why

Every `@rowboat` in a thread ended in a post, even when the outcome was already visible (a file edited, a thread titled, a message pinned). Those posts are noise the whole room reads, and they tended toward cheerleading recaps.

## What

`threadProcedure` in `procedures.ts` (one source for the pinned space-thread system prompt and the spaces skill) is rewritten at the same length, seven bullets before and after, nothing appended:

- **👀** on the invoking message before starting (its id already rides the `[@rowboat …]` header), and on follow-up mentions. Never an "on it" post.
- **✅** swapped in when done. Post nothing when the outcome speaks for itself.
- **One reply** only when the ask wants an answer (question, opinion, lookup). Outcome first, one or two sentences, no cheering, no recap of the edit.
- **❗** swapped in when the person is needed: a confirmation, a choice, a blocker, or anything explainable only with private detail. Nothing in the thread; the ask goes in the session chat only they see. ❗ becomes ✅ once resolved.

No new tooling: `react` already takes `add`/`remove` with an emoji. Golden snapshot refreshed; assembly tests pass.

## Notes

- Reactions land as the person's own (the react tool acts as them), so the room sees them 👀-ing their own message. Consistent with the parity principle, but visible.
- Hard failures now go the ❗ route (private chat) rather than a public post.
- The ❗ path assumes the person can reach the session from the thread: the discussion header's Chat button covers pinned thread sessions; a loose stream mention with no Rowboat post to deep-link from is the weaker path. Not live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013smuezqsdige6QKprSoqEN
