### PR TITLE
fix(renderer): clear React dev performance-track entries so long dev sessions stop crashing

### DIFF
--- a/apps/x/apps/renderer/src/main.tsx
+++ b/apps/x/apps/renderer/src/main.tsx
@@ -10,6 +10,22 @@ import { MeetingDetectedPopup } from '@/components/meeting-detected-popup'
 import { QuickAskBar } from '@/components/quick-ask-bar'
 import { ScreenPointerOverlay } from '@/components/screen-pointer-overlay'
 
+// React's development build records a performance.measure entry (with a
+// serialized `detail`) for every component render — its DevTools
+// "Components ⚛" track — and never clears them. Chromium keeps user-timing
+// entries until told otherwise, ~1 KB each, so a dev window left open for
+// hours accumulates millions of entries until Blink's allocator gives up and
+// the renderer dies (blank window, `render-process-gone` exitCode=5). Clear
+// the buffer periodically: the Performance panel still shows React's tracks,
+// since those are emitted as trace events at call time, not read back from
+// this buffer. Production React has no performance tracks, so this is dev-only.
+if (import.meta.env.DEV) {
+  setInterval(() => {
+    performance.clearMeasures()
+    performance.clearMarks()
+  }, 10_000)
+}
+
 // Fetch the stable installation ID from main so renderer + main share one
 // PostHog distinct_id. Falls back to PostHog's auto-generated anonymous ID
 // if the IPC call fails (rare — main is always up before renderer).


### PR DESCRIPTION
## Summary

Dev-only fix for the blank-window crash (`[Crash] renderer gone: reason=crashed exitCode=5`) that hits anyone who leaves the dev app open for a few hours.

**Root cause:** React 19.2's development build records a `performance.measure` entry, with a serialized `detail`, for every component render (its DevTools "Components ⚛" track) and never clears them. Chromium keeps user-timing entries until told otherwise, at about 1 KB each. Three crash reports from today, symbolicated against the Electron 39.2.7 dSYM, all end in `blink::Partitions::HandleOutOfMemory`, two of them inside `performance.measure` called from React's scheduler. The affected window had 7,128,822 entries and a 7.15 GB renderer at the time of reading.

**Fix:** in dev only, clear measures and marks every 10 seconds at renderer startup. The Chrome Performance panel still shows React's tracks, since those are trace events at call time. Production React has zero `performance.measure` calls, so packaged builds were never affected.

Full evidence (symbolicated frames, per-entry measurements, plateau experiment) is in the commit message.

## Test plan

- [x] Headless Electron experiment on the same binary: 800k measures without clearing grew RSS linearly to 612 MB; with `clearMeasures()` per round it plateaued at ~300 MB
- [x] ESLint clean on `main.tsx`; no type errors in the changed file
- [ ] Leave the dev app open for a few hours; `performance.getEntriesByType('measure').length` in DevTools should stay in the low thousands and the renderer's memory flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UaKyhU2emLMKJ9spr9oQj