### PR TITLE
feat(turns): record cause chain and idle gap on failed model calls

### DIFF
--- a/apps/x/packages/core/docs/turn-runtime-design.md
+++ b/apps/x/packages/core/docs/turn-runtime-design.md
@@ -707,6 +707,11 @@ interface ModelCallFailed extends BaseTurnEvent {
   type: "model_call_failed";
   modelCallIndex: number;
   error: string;
+  // Present when a live call died: ms since model_call_requested, and ms
+  // since the provider's last stream event. A dropped connection shows a
+  // long idle gap; a slow but healthy stream does not.
+  elapsedMs?: number;
+  idleMs?: number;
 }
 ```
 
@@ -715,7 +720,10 @@ content duplicates provider step events.
 
 Any successfully completed assistant response without tool calls completes the
 turn, including responses whose finish reason is `length` or `content-filter`.
-Provider and stream failures fail the turn.
+Provider and stream failures fail the turn. `error` is the provider's message
+plus, when available, the HTTP status, the response body, and the error's
+`cause` chain — a socket failure such as `read ETIMEDOUT` or a body timeout
+surfaces only there, behind a generic `terminated`.
 
 Only the primary model calls directly controlled by the turn loop are recorded
 as model calls. Internal model calls hidden inside the permission classifier or

--- a/apps/x/packages/core/src/runtime/turns/runtime.test.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.test.ts
@@ -1272,6 +1272,27 @@ describe("failures (26.6)", () => {
         ]);
     });
 
+    it("a stream failure records its cause chain and timing", async () => {
+        const cause = Object.assign(new Error("read ETIMEDOUT"), { code: "ETIMEDOUT" });
+        const dropped: ScriptedCall = async function* () {
+            yield { type: "reasoning_delta", delta: "thinking" };
+            throw new TypeError("terminated", { cause });
+        };
+        const { runtime, repo } = makeRuntime({ models: [dropped] });
+        const turnId = await newTurn(runtime);
+        const { outcome } = await advanceAndSettle(runtime, turnId);
+        expect(outcome).toMatchObject({
+            status: "failed",
+            error: "terminated [cause: read ETIMEDOUT]",
+        });
+        const log = await persisted(repo, turnId);
+        expect(log.find((e) => e.type === "model_call_failed")).toMatchObject({
+            error: "terminated [cause: read ETIMEDOUT]",
+            elapsedMs: expect.any(Number),
+            idleMs: expect.any(Number),
+        });
+    });
+
     it("a sync tool throw becomes an error result and the turn continues", async () => {
         const tools: RuntimeTool[] = [
             syncTool(echoDescriptor, async () => {

--- a/apps/x/packages/core/src/runtime/turns/runtime.ts
+++ b/apps/x/packages/core/src/runtime/turns/runtime.ts
@@ -1275,10 +1275,11 @@ class TurnAdvance {
             parameters:
                 reasoningEffort === undefined ? {} : { reasoningEffort },
         };
+        const requestedAt = this.now();
         await this.append({
             type: "model_call_requested",
             turnId: this.turnId,
-            ts: this.now(),
+            ts: requestedAt,
             modelCallIndex: index,
             request,
         });
@@ -1293,6 +1294,10 @@ class TurnAdvance {
 
         let completion: Extract<LlmStreamEvent, { type: "completed" }> | null =
             null;
+        // Last time the provider produced anything; a failure's idle gap is
+        // measured from here (deltas are not persisted, so this is the only
+        // record of when the stream went quiet).
+        let lastEventAt = requestedAt;
         try {
             for await (const event of this.model.stream({
                 systemPrompt: composed.systemPrompt,
@@ -1301,6 +1306,7 @@ class TurnAdvance {
                 parameters: composed.parameters,
                 signal: this.signal,
             })) {
+                lastEventAt = this.now();
                 switch (event.type) {
                     case "text_delta":
                         this.pushDelta({
@@ -1336,20 +1342,23 @@ class TurnAdvance {
                 throw new Error("model stream ended without a completed response");
             }
         } catch (error) {
+            const failedAt = this.now();
+            const timing = callTiming(requestedAt, lastEventAt, failedAt);
             if (this.signal.aborted) {
                 await this.append(
                     modelCallFailedEvent(
                         this.turnId,
-                        this.now(),
+                        failedAt,
                         index,
                         "model call was cancelled",
+                        timing,
                     ),
                 );
                 return this.cancel();
             }
             const message = errorMessage(error);
             await this.append(
-                modelCallFailedEvent(this.turnId, this.now(), index, message),
+                modelCallFailedEvent(this.turnId, failedAt, index, message, timing),
             );
             await this.append({
                 type: "turn_failed",
@@ -1487,7 +1496,33 @@ function errorMessage(error: unknown): string {
     if (typeof responseBody === "string" && responseBody.trim().length > 0) {
         details.push(responseBody.slice(0, 2000));
     }
+    // Transport failures carry nothing but a generic message ("terminated",
+    // "fetch failed"); the socket-level reason (read ETIMEDOUT, other side
+    // closed, body timeout) lives only on the cause chain.
+    const cause = describeCause(source);
+    if (cause !== undefined) {
+        details.push(cause);
+    }
     return details.length > 0 ? `${message} [${details.join(" — ")}]` : message;
+}
+
+function describeCause(error: unknown): string | undefined {
+    const parts: string[] = [];
+    let cursor = (error as { cause?: unknown } | null)?.cause;
+    for (let depth = 0; cursor !== undefined && cursor !== null && depth < 3; depth++) {
+        const link = cursor as { message?: unknown; code?: unknown; name?: unknown; cause?: unknown };
+        const message = typeof link.message === "string" && link.message.length > 0
+            ? link.message
+            : String(cursor);
+        const code = typeof link.code === "string"
+            ? link.code
+            : typeof link.name === "string" && link.name !== "Error"
+                ? link.name
+                : undefined;
+        parts.push(code !== undefined && !message.includes(code) ? `${message} (${code})` : message);
+        cursor = link.cause;
+    }
+    return parts.length > 0 ? `cause: ${parts.join(" <- ")}` : undefined;
 }
 
 function outcomeFromTerminal(state: TurnState): TurnOutcome {
@@ -1546,8 +1581,31 @@ function modelCallFailedEvent(
     ts: string,
     modelCallIndex: number,
     error: string,
+    timing?: ModelCallTiming,
 ): z.infer<typeof ModelCallFailed> {
-    return { type: "model_call_failed", turnId, ts, modelCallIndex, error };
+    return { type: "model_call_failed", turnId, ts, modelCallIndex, error, ...timing };
+}
+
+type ModelCallTiming = { elapsedMs: number; idleMs: number };
+
+// Durations for a failed model call from the runtime clock's ISO timestamps:
+// since the request was issued, and since the provider last produced a
+// stream event. Undefined when a timestamp is unparsable (a custom clock).
+function callTiming(
+    requestedAt: string,
+    lastEventAt: string,
+    failedAt: string,
+): ModelCallTiming | undefined {
+    const requested = Date.parse(requestedAt);
+    const last = Date.parse(lastEventAt);
+    const failed = Date.parse(failedAt);
+    if (![requested, last, failed].every(Number.isFinite)) {
+        return undefined;
+    }
+    return {
+        elapsedMs: Math.max(0, failed - requested),
+        idleMs: Math.max(0, failed - last),
+    };
 }
 
 function runtimeResultEvent(

--- a/apps/x/packages/shared/src/turns.ts
+++ b/apps/x/packages/shared/src/turns.ts
@@ -313,6 +313,13 @@ export const ModelCallFailed = z.object({
     ts: z.string(),
     modelCallIndex: z.number().int().nonnegative(),
     error: z.string(),
+    // Transport diagnostics for a live call that died (turn-runtime-design.md,
+    // "Model call events"): how long the call had been running, and how long
+    // since the model last produced a stream event. A dropped stream shows a
+    // long idle gap; a slow but healthy one does not. Absent when the failure
+    // happened before streaming began.
+    elapsedMs: z.number().int().nonnegative().optional(),
+    idleMs: z.number().int().nonnegative().optional(),
 });
 
 export const ToolPermissionRequired = z.object({


### PR DESCRIPTION
## Why

Four turns on 2026-09-11 failed with the bare word "terminated" after 133–301s of silence following the first reasoning chunk. That message is undici's generic wrapper; the real reason (`read ETIMEDOUT` from TCP keepalive, or `UND_ERR_BODY_TIMEOUT` after 300s with no bytes) lives only on the error's `cause`, which `errorMessage()` dropped. Turn files don't persist deltas either, so nothing recorded when the stream went quiet. Both signatures look identical today, and they point at different fixes.

## What

- `errorMessage()` in `runtime.ts` appends the cause chain (up to 3 links, error code in parentheses when it isn't already in the message): `terminated [cause: read ETIMEDOUT]`, `terminated [cause: Body Timeout Error (UND_ERR_BODY_TIMEOUT)]`. The OpenRouter provider forwards the original error object, so the chain survives to here.
- `model_call_failed` gains optional `elapsedMs` (since `model_call_requested`) and `idleMs` (since the provider's last stream event). A dropped connection shows a long idle gap; a slow but healthy stream does not. Schema (`@x/shared` turns) and `turn-runtime-design.md` updated. Additive and optional, so existing turn files parse unchanged.
- Test: a scripted stream that yields a delta then throws `TypeError("terminated", { cause })` records the cause text and both timing fields.

## Verification

- `packages/core` runtime tests: 83 passed. `packages/shared` schema tests: 104 passed. Shared type-check clean.

Companion backend PR adds a gateway heartbeat and raises the Vercel function's max duration to 800s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w1LMFWecH5PVLKZMaiPw1
