### PR TITLE
fix(x): sidebar Meetings subtitle shows the genuinely next event (#932)

### DIFF
--- a/apps/x/apps/renderer/src/components/dock-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/dock-sidebar.tsx
@@ -273,8 +273,11 @@ function isSameLocalDay(a: Date, b: Date): boolean {
 }
 
 function formatMeetingTime(event: UpcomingMeeting): string {
-  if (event.isAllDay) return 'All day'
   const now = new Date()
+  if (event.isAllDay) {
+    if (isSameLocalDay(event.start, now)) return 'All day'
+    return `${event.start.toLocaleDateString([], { month: 'numeric', day: 'numeric' })} All day`
+  }
   const tomorrow = new Date(now)
   tomorrow.setDate(tomorrow.getDate() + 1)
   const time = event.start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
@@ -728,10 +731,7 @@ export function DockSidebar({
         }))
         const items: UpcomingMeeting[] = []
         for (const r of settled) if (r.status === 'fulfilled' && r.value) items.push(r.value)
-        items.sort((a, b) => {
-          if (a.isAllDay !== b.isAllDay) return a.isAllDay ? -1 : 1
-          return a.start.getTime() - b.start.getTime()
-        })
+        items.sort((a, b) => a.start.getTime() - b.start.getTime())
         if (!cancelled) setMeetings(items.slice(0, 1))
       } catch { /* ignore */ }
     }

--- a/apps/x/apps/renderer/src/components/sidebar-content.tsx
+++ b/apps/x/apps/renderer/src/components/sidebar-content.tsx
@@ -557,10 +557,7 @@ export function SidebarContentPanel({
         }))
         const items: UpcomingMeeting[] = []
         for (const r of settled) if (r.status === 'fulfilled' && r.value) items.push(r.value)
-        items.sort((a, b) => {
-          if (a.isAllDay !== b.isAllDay) return a.isAllDay ? -1 : 1
-          return a.start.getTime() - b.start.getTime()
-        })
+        items.sort((a, b) => a.start.getTime() - b.start.getTime())
         if (!cancelled) setMeetings(items.slice(0, 1))
       } catch { /* ignore */ }
     }
@@ -1503,8 +1500,11 @@ function isSameLocalDay(a: Date, b: Date): boolean {
 }
 
 function formatMeetingTime(event: UpcomingMeeting): string {
-  if (event.isAllDay) return 'All day'
   const now = new Date()
+  if (event.isAllDay) {
+    if (isSameLocalDay(event.start, now)) return 'All day'
+    return `${event.start.toLocaleDateString([], { month: 'numeric', day: 'numeric' })} All day`
+  }
   const tomorrow = new Date(now)
   tomorrow.setDate(tomorrow.getDate() + 1)
   const time = event.start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })


### PR DESCRIPTION
﻿## Summary
- upcoming-meetings loader now sorts purely by start time, so a future all-day event no longer masks a sooner timed event (fixes #932)
- all-day events that do not start today get a date qualifier in the subtitle (e.g. `9/9 All day`) instead of a bare `All day` label that reads as today
- applied the same fix in both places that carry the duplicated loader logic: `dock-sidebar.tsx` and `sidebar-content.tsx`

## Validation
- `git diff --check` clean
- no build or test run in this environment (no node_modules installed); the changed helpers are not exported and no existing test file covers these components
- expected behavior verified by inspection: with an all-day event on Sep 9 and a timed event on Aug 31, the sidebar now shows the Aug 31 event with its time, and the Sep 9 all-day event would render as `9/9 All day`
