### PR TITLE
feat(x): add --show-pairing CLI to rowboat-server (#938)

### DIFF
--- a/apps/x/apps/server/src/standalone.ts
+++ b/apps/x/apps/server/src/standalone.ts
@@ -1,4 +1,6 @@
 import process from 'node:process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { WorkDir } from '@x/core/dist/config/config.js';
 import { initConfigs } from '@x/core/dist/config/initConfigs.js';
 import container, {
@@ -18,6 +20,9 @@ import { installLoopbackRelay } from './loopback-relay.js';
 import { createFileCipher } from './file-cipher.js';
 import { setTokenCipher as setChatGPTTokenCipher } from '@x/core/dist/auth/chatgpt-auth.js';
 import { setTokenCipher as setGithubTokenCipher } from '@x/core/dist/apps/github-auth.js';
+import { SERVER_KEY_FILE } from './auth.js';
+import { loadServerConfig } from './config.js';
+import { buildPairingPayload } from './pairing.js';
 
 // Headless rowboat-server: the RFC's end-state entrypoint, where main spawns
 // this as a child process (or it runs on a remote box) and core lives here.
@@ -30,7 +35,47 @@ import { setTokenCipher as setGithubTokenCipher } from '@x/core/dist/apps/github
 // isolated ROWBOAT_WORKDIR.
 //
 
+// Lock-free by design: reads the same key file and config a live server
+// would use, but never calls createRowboatServer, so it works fine
+// alongside a running server (no lock contention) and needs no core boot.
+async function showPairing(): Promise<void> {
+  const config = await loadServerConfig(WorkDir);
+  const keyPath = path.join(WorkDir, SERVER_KEY_FILE);
+  let key: string;
+  try {
+    key = (await fs.readFile(keyPath, 'utf8')).trim();
+  } catch {
+    console.error(`[server] no server key found at ${keyPath}. Start the server once to generate one.`);
+    process.exit(1);
+    return;
+  }
+
+  const payload = buildPairingPayload(config.port, config.lanEnabled, key);
+  console.log('[server] pairing addresses:');
+  for (const url of payload.urls) {
+    console.log(`[server]   ${url}`);
+  }
+  console.log(`[server] access code: ${key}`);
+
+  const payloadJson = JSON.stringify(payload);
+  console.log('[server] pairing payload (scan with the mobile app):');
+  console.log(payloadJson);
+
+  if (process.argv.includes('--qr')) {
+    try {
+      const QRCode = (await import('qrcode')).default;
+      console.log(await QRCode.toString(payloadJson, { type: 'terminal', small: true }));
+    } catch (err) {
+      console.error('[server] failed to render QR code, showing pairing payload only:', err);
+    }
+  }
+}
+
 async function main(): Promise<void> {
+  if (process.argv.includes('--show-pairing')) {
+    await showPairing();
+    process.exit(0);
+  }
   // The workdir lock is acquired by createRowboatServer itself — a live
   // Electron-hosted transport makes this boot fail loudly, as it must.
   await initConfigs();


### PR DESCRIPTION
﻿## Summary
- adds a `--show-pairing` mode to the standalone rowboat-server entry (fixes #938): operators on a headless box no longer need SSH plus `cat server-key` to pair a desktop or phone
- prints the pairing URLs (loopback always, LAN addresses when LAN exposure is enabled), the access code, and the exact pairing payload JSON the mobile app consumes; optional `--qr` renders a terminal QR via the already-present `qrcode` dependency, so no new deps
- the mode short-circuits before any boot work: no capability registrations, no cipher setup, no core services, no workspace watcher, no `createRowboatServer`, and no workdir lock, so it can run alongside a live server
- missing key fails with a clear message and exit code 1; QR render failure falls back to the printed payload

## Validation
- `git diff --check` clean
- no build or test run in this environment (no node_modules, installs unavailable); a `tsc` pass in CI is recommended as usual, particularly the dynamic `qrcode` import typing
- confirmed the imports resolve against existing exports: `SERVER_KEY_FILE` (`apps/x/apps/server/src/auth.ts`), `loadServerConfig` (`apps/x/apps/server/src/config.ts`), `buildPairingPayload` (`apps/x/apps/server/src/pairing.ts`)
