### PR TITLE
docs: add Serply web search MCP setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,29 @@ This connects through Rowboat's existing Streamable HTTP client. Ask Rowboat to 
 
 Once configured, Rowboat can invoke these tools during its work, subject to your MCP tool permissions. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. This setup leaves Exa and other configured providers unchanged. To remove it, delete the `parallel` entry in **Settings → MCP Servers** and save.
 
+### Example: Serply web search
+
+[Serply MCP](https://serply.io/docs) provides `google_search`, `bing_search`, `google_news_search`, `google_scholar_search`, `google_maps_search`, and `scrape_url` for keyed web search and page scraping. It requires a [Serply](https://serply.io) API key, which is sent in the `X-Api-Key` header. New accounts start with free credits.
+
+Open **Settings**, then **MCP Servers**, add the `serply` entry to your existing `mcpServers` object with your key, and click **Save**. Keep any other server entries. If no servers are configured, use:
+
+```json
+{
+  "mcpServers": {
+    "serply": {
+      "url": "https://api.serply.io/mcp",
+      "headers": {
+        "X-Api-Key": "YOUR_SERPLY_API_KEY"
+      }
+    }
+  }
+}
+```
+
+This connects through Rowboat's existing Streamable HTTP client, which forwards the configured headers. Ask Rowboat to list the tools on the `serply` server, then try: "Use Serply to find recent news about Model Context Protocol."
+
+Once configured, Rowboat can invoke these tools during its work, subject to your MCP tool permissions. Queries, requested URLs, and your API key are sent to Serply. This setup leaves Exa and other configured providers unchanged. To remove it, delete the `serply` entry under **Settings**, **MCP Servers** and save.
+
 ## Local-first by design
 
 - All data is stored locally as plain Markdown


### PR DESCRIPTION
## Summary

Adds a Serply MCP setup example to the README, directly after the Parallel example (#969). It shows how to add a keyed Streamable HTTP server with an `X-Api-Key` header through the existing Settings, MCP Servers path, how to keep other entries, and how to remove it.

This is documentation only. Existing providers and defaults are unchanged. The text explains that queries, requested URLs, and the API key are sent to Serply.

Disclosure: I work with Serply, which operates this MCP server.

## Verification

- Connected to `https://api.serply.io/mcp` with `@modelcontextprotocol/sdk` 1.30 using `StreamableHTTPClientTransport` and `requestInit.headers`, the same shape `apps/x/packages/core/src/mcp/mcp.ts` builds from the `headers` field. `listTools` returned nine tools and a `google_news_search` call returned results.
- The JSON in the example validates against `HttpMcpServerConfig` in `apps/x/packages/shared/src/mcp.ts` (`url` plus optional `headers`).
- README is the only changed file.
