### PR TITLE
fix(spaces): plain newlines for Shift+Enter, and keep the link warning in its card

### DIFF
--- a/apps/x/apps/mobile/src/components/markdown.tsx
+++ b/apps/x/apps/mobile/src/components/markdown.tsx
@@ -11,7 +11,10 @@ import { useColors } from '@/theme/colors';
 // \(…\)/\[…\] into math_* tokens; MathJax→SVG typesets them natively (no
 // WebView, Expo Go safe). The stub engine stops texmath require()-ing katex —
 // markdown-display walks tokens itself and never calls md.renderer.
-const markdownIt = MarkdownIt({ typographer: true }).use(texmath, {
+// `breaks` because typed line breaks reach here as plain newlines — the mobile
+// composer is a TextInput and the desktop one serializes Shift+Enter the same
+// way — and a chat line break has to survive without a blank line after it.
+const markdownIt = MarkdownIt({ typographer: true, breaks: true }).use(texmath, {
   delimiters: ['dollars', 'brackets'],
   engine: { renderToString: () => '' },
 });

--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
@@ -37,6 +37,7 @@ describe('markdown round trip', () => {
         ['code block', '```\nconst x = 1\nconst y = 2\n```'],
         ['image', '![](https://example.com/cat.gif)'],
         ['two paragraphs', 'first\n\nsecond'],
+        ['line break', 'first\nsecond'],
         ['slash command draft', '/ask how do I ship this'],
         ['mention text (prose)', '@Ada Lovelace can you look?'],
         ['member mention token', '[@Ada Lovelace](#member:01HADA) can you look?'],
@@ -102,6 +103,27 @@ describe('formatting commands produce wire markdown', () => {
             { kind: 'rowboat', id: null, label: 'rowboat' },
         ])
         expect(composerMarkdown(editor)).toBe(body)
+    })
+
+    it('Shift+Enter serializes as a newline, never a backslash escape', () => {
+        const e = makeEditor('one')
+        e.chain().focus('end').setHardBreak().insertContent({ type: 'text', text: 'two' }).run()
+        expect(composerMarkdown(e)).toBe('one\ntwo')
+    })
+
+    it('a break before a line that opens a block leaves no stray backslash', () => {
+        // CommonMark's `\` hard break renders as itself once the next line
+        // starts a list/heading/quote — the case that put backslashes in
+        // sent messages.
+        const e = makeEditor('Plan:')
+        e.chain().focus('end').setHardBreak().insertContent({ type: 'text', text: '- one' }).run()
+        expect(composerMarkdown(e)).toBe('Plan:\n- one')
+    })
+
+    it('a break inside a list item indents the continuation', () => {
+        const e = makeEditor('- one')
+        e.chain().focus('end').setHardBreak().insertContent({ type: 'text', text: 'two' }).run()
+        expect(composerMarkdown(e)).toBe('- one\n  two')
     })
 
     it('a bare @name stays text — nothing rewrites prose into an address', () => {

--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.ts
@@ -31,6 +31,50 @@ const ChatFormatKeys = Extension.create({
     },
 })
 
+/**
+ * Shift+Enter writes a plain newline, not CommonMark's backslash escape.
+ *
+ * tiptap-markdown serializes a hard break as `\` followed by a newline, which
+ * only reads as a line break while the paragraph keeps going: the moment the
+ * next line opens a block of its own (`- item`, `# heading`, `> quote`), the
+ * backslash has nothing to escape and renders as itself. That is where the
+ * trailing backslashes in sent messages came from, and every plain-text
+ * surface off the same body (copies, quotes, excerpts, thread titles, the
+ * text handed to @rowboat) showed them unconditionally. A newline carries the
+ * break instead — the composer parses one straight back to a hard break
+ * (markdown-it `breaks`), and so does every renderer of a space body. Inside
+ * a table a newline would end the row, so those keep the HTML break.
+ */
+function serializeHardBreak(
+    state: { write(text: string): void; inTable?: boolean },
+    node: ProseMirrorNode,
+    parent: ProseMirrorNode,
+    index: number,
+): void {
+    for (let i = index + 1; i < parent.childCount; i++) {
+        if (parent.child(i).type !== node.type) {
+            state.write(state.inTable ? '<br>' : '\n')
+            return
+        }
+    }
+}
+
+/**
+ * StarterKit owns the hardBreak node and doesn't re-export it, so the kit is
+ * re-wrapped to hand that one extension the markdown spec above —
+ * tiptap-markdown reads an extension's own spec before falling back to its
+ * default, and everything else in the kit passes through untouched.
+ */
+const ChatStarterKit = StarterKit.extend({
+    addExtensions() {
+        return (this.parent?.() ?? []).map((extension) =>
+            extension.name === 'hardBreak'
+                ? extension.extend({ addStorage: () => ({ markdown: { serialize: serializeHardBreak, parse: {} } }) })
+                : extension,
+        )
+    },
+})
+
 type MentionKind = 'member' | 'here' | 'rowboat'
 
 function refOf(attrs: { kind: MentionKind; id: string | null; label: string }): MentionRef {
@@ -123,7 +167,7 @@ export const MentionNode = Node.create({
  */
 export function composerExtensions(getPlaceholder: () => string) {
     return [
-        StarterKit.configure({ link: false }),
+        ChatStarterKit.configure({ link: false }),
         Link.configure({ openOnClick: false, autolink: true }),
         MentionNode,
         // Pasted GIF/image links become the image itself (matches what the

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
@@ -60,6 +60,57 @@ describe('Spaces message image carousel', () => {
     })
 })
 
+describe('Message body line breaks', () => {
+    it('renders a newline inside a paragraph as a break, the way both composers write one', async () => {
+        const { container } = render(<SpaceMarkdown body={'line one\nline two'} />)
+        await waitFor(() => expect(container.querySelector('p')).toBeInTheDocument())
+        expect(container.querySelector('p br')).toBeInTheDocument()
+    })
+
+    it('still separates paragraphs on a blank line', async () => {
+        const { container } = render(<SpaceMarkdown body={'first\n\nsecond'} />)
+        await waitFor(() => expect(container.querySelectorAll('p')).toHaveLength(2))
+        expect(container.querySelector('br')).not.toBeInTheDocument()
+    })
+})
+
+describe('External link gate', () => {
+    // Tunnel and preview hosts are long enough to blow a button's width out
+    // past the dialog card, which is what this shape guards.
+    const tunnel = '3f8a-2401-4900-1c1a-b5e8-6d31-9f04-a71c.ngrok-free.app'
+    const open = vi.fn()
+
+    beforeEach(() => { localStorage.clear(); open.mockReset(); vi.stubGlobal('open', open) })
+    afterEach(() => vi.unstubAllGlobals())
+
+    it('elides a long hostname down to its registrable tail, keeping the full one addressable', async () => {
+        render(<SpaceMarkdown body={`See [the preview](https://${tunnel}/session/abcdef)`} />)
+        fireEvent.click(await screen.findByRole('link', { name: 'the preview' }))
+        const dialog = screen.getByRole('dialog')
+        expect(within(dialog).getByText(`https://${tunnel}/session/abcdef`)).toBeVisible()
+        const trust = within(dialog).getByRole('button', { name: `Trust ${tunnel}` })
+        expect(trust).toHaveAttribute('title', tunnel)
+        expect(trust.textContent).not.toContain(tunnel)
+        expect(trust.textContent).toMatch(/^Trust ….*\.ngrok-free\.app$/)
+        // Enter on a warning must not mean "trust this domain forever".
+        await waitFor(() => expect(within(dialog).getByRole('button', { name: 'Cancel' })).toHaveFocus())
+    })
+
+    it('names a short hostname in full and remembers it once trusted', async () => {
+        render(<SpaceMarkdown body="See [the docs](https://example.com/docs)" />)
+        fireEvent.click(await screen.findByRole('link', { name: 'the docs' }))
+        const trust = screen.getByRole('button', { name: 'Trust example.com' })
+        expect(trust.textContent).toBe('Trust example.com')
+        fireEvent.click(trust)
+        expect(open).toHaveBeenCalledWith('https://example.com/docs')
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+        // A trusted domain opens straight through on the next click.
+        fireEvent.click(screen.getByRole('link', { name: 'the docs' }))
+        expect(open).toHaveBeenCalledTimes(2)
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+})
+
 describe('Space file attachments', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: async () => new Blob(['hello'], { type: 'text/plain' }) }))

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { ImageLightbox as SharedImageLightbox } from '@/components/image-lightbox'
 import { isTrustedDomain, linkDomain, trustDomain } from '@/lib/trusted-domains'
+import { userMessageRemarkPlugins } from '@/lib/markdown-render'
 import { toast } from '@/lib/toast'
 import { MemberProfilePopover } from '@/components/spaces/atoms'
 import { useMemberNames, useSpaceProfiles } from '@/components/spaces/member-text'
@@ -454,12 +455,23 @@ function ExternalImage({ src, alt }: { src: string; alt: string }) {
 }
 
 /**
+ * A hostname short enough to label a button with. Tunnel and preview hosts
+ * (ngrok, vercel, codespaces) carry a long random head, so it is the head that
+ * goes: the registrable domain at the tail is the part the trust decision
+ * actually turns on, and the dialog shows the full URL above regardless.
+ */
+function shortDomain(domain: string): string {
+    return domain.length <= 28 ? domain : `…${domain.slice(-27)}`
+}
+
+/**
  * An external link: blue, clickable — and gated. The first click on a domain
  * shows the full destination and offers to trust the domain (stored locally);
  * links to trusted domains open straight in the system browser.
  */
 function ExternalLink({ href, children }: { href: string; children?: ReactNode }) {
     const [confirming, setConfirming] = useState(false)
+    const cancelRef = useRef<HTMLButtonElement>(null)
     const domain = linkDomain(href)
     // Only http(s) leaves the app; anything else renders inert.
     if (!domain) return <span>{children}</span>
@@ -481,18 +493,41 @@ function ExternalLink({ href, children }: { href: string; children?: ReactNode }
             </a>
             {confirming && (
                 <Dialog open onOpenChange={(o) => { if (!o) setConfirming(false) }}>
-                    <DialogContent className="sm:max-w-md">
+                    <DialogContent
+                        className="sm:max-w-md"
+                        // The trust control leads the row, so the opening focus
+                        // is pinned past it: Enter on a gate like this one must
+                        // not mean "trust this domain forever".
+                        onOpenAutoFocus={(e) => { e.preventDefault(); cancelRef.current?.focus() }}
+                    >
                         <DialogTitle>Leaving Rowboat</DialogTitle>
-                        <div className="text-sm text-muted-foreground">
+                        {/* min-w-0 throughout: these are grid children, which
+                            size to their content by default and would push a
+                            long hostname straight through the card's edge. */}
+                        <div className="min-w-0 text-sm text-muted-foreground">
                             This link opens in your browser:
                             <div className="mt-2 max-h-24 overflow-y-auto break-all rounded-md bg-muted px-2 py-1.5 font-mono text-xs text-foreground">{href}</div>
                         </div>
-                        <div className="flex flex-wrap justify-end gap-2">
-                            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>Cancel</Button>
-                            <Button variant="outline" size="sm" onClick={() => { trustDomain(domain); setConfirming(false); open() }}>
-                                Trust {domain}
+                        <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+                            {/* The one control the message gets to size, so it
+                                leads the row and takes the whole line when it
+                                wraps — shrinking and eliding, never growing. */}
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="mr-auto min-w-0 max-w-full"
+                                title={domain}
+                                aria-label={`Trust ${domain}`}
+                                onClick={() => { trustDomain(domain); setConfirming(false); open() }}
+                            >
+                                <span className="min-w-0 truncate">Trust {shortDomain(domain)}</span>
                             </Button>
-                            <Button size="sm" onClick={() => { setConfirming(false); open() }}>Open link</Button>
+                            {/* Grouped so the answer to the dialog never splits
+                                across lines when the trust control wraps. */}
+                            <div className="flex shrink-0 items-center gap-2">
+                                <Button ref={cancelRef} variant="ghost" size="sm" onClick={() => setConfirming(false)}>Cancel</Button>
+                                <Button size="sm" onClick={() => { setConfirming(false); open() }}>Open link</Button>
+                            </div>
                         </div>
                     </DialogContent>
                 </Dialog>
@@ -601,7 +636,11 @@ export const SpaceMarkdown = memo(function SpaceMarkdown({ body, className }: { 
     return (
         <div className={cn(className)}>
             <MessageImageGallery key={text}>
-                <Streamdown components={spaceComponents}>{text}</Streamdown>
+                {/* Chat line breaks are newlines on the wire (both composers
+                    write them that way), so a single newline inside a
+                    paragraph has to render as one — remarkBreaks, same as
+                    every other typed-message surface. */}
+                <Streamdown components={spaceComponents} remarkPlugins={userMessageRemarkPlugins}>{text}</Streamdown>
             </MessageImageGallery>
         </div>
     )


### PR DESCRIPTION
Two Spaces bugs flagged by @Ramnique Singh.

## 1. Shift+Enter saved literal trailing backslashes

`tiptap-markdown` serializes a ProseMirror `hardBreak` as CommonMark's backslash escape (`"\\\n"`). That only *reads* as a line break while the paragraph continues. The moment the next line opens a block of its own - `- item`, `# heading`, `> quote`, or end of message - the backslash has nothing to escape and renders as itself.

So typing `Plan:` then Shift+Enter then `- one` stored `"Plan:\\\n- one"` and rendered a literal `\`. Worse, every plain-text surface off the same body showed the backslashes unconditionally: copy, quote-reply, forward, pinned/bookmark excerpts, thread titles, and the text handed to `@rowboat`.

`ChatStarterKit` re-wraps StarterKit to give its `hardBreak` a markdown spec that writes a plain `\n` (`<br>` inside a table, where a newline would end the row). StarterKit does not re-export HardBreak, hence the `addExtensions` wrap. This covers the composer and the inline edit box, which share `composerExtensions`.

Because the wire now carries bare newlines, both renderers had to honour them:

- `space-markdown.tsx` passes `userMessageRemarkPlugins` (the existing streamdown defaults + `remarkBreaks`) to `Streamdown` - the same plugin set every other typed-message surface already uses.
- mobile `markdown.tsx` sets `breaks: true` on markdown-it.

The mobile change also fixes messages composed *on mobile*, whose `TextInput` already posted bare `\n` and whose line breaks were being dropped on both platforms.

**Not included:** messages already stored with `\` are left alone. A regex to strip them would corrupt fenced code blocks, where shell line continuations legitimately end in `\`.

## 2. "Leaving Rowboat" modal overflow

`DialogContent` is a CSS grid, and grid children default to `min-width: auto` - so a `whitespace-nowrap` "Trust `<long-hostname>`" button forced the footer wider than the card and pushed Cancel and Open link out onto the dark overlay.

- `min-w-0` on the dialog's grid children so they cannot force the track wider than the card.
- The trust control gets `mr-auto min-w-0 max-w-full` with an inner `truncate` span: it leads the row and takes a whole line when it wraps, shrinking rather than growing.
- Cancel and Open link are grouped in a `shrink-0` wrapper, so the dialog's actual answer never splits across lines.
- `shortDomain()` elides the *head* of a long hostname (`…31-9f04-a71c.ngrok-free.app`), keeping the registrable tail - the part the trust decision turns on - visible. The full hostname stays in `title` and `aria-label`, and the full URL is already shown above.
- Since the trust control now leads the row, `onOpenAutoFocus` pins opening focus to Cancel. Without it Radix focuses the first tabbable element, which would make Enter mean "trust this domain forever" on a security gate.

## Verification

- Full renderer suite green: 90 files, 756 tests (4 new - hard-break serialization including the list-interruption case, and the modal's elision, focus and trust-persistence behaviour).
- `tsc -b` and `eslint` clean on the touched files.
- Screenshotted the real `ExternalLink` dialog with a long ngrok host and a short host and measured the laid-out rects: every control sits inside the card's content box in both cases.

Mobile has no `typecheck` script, so the markdown-it one-liner there is unverified beyond being a standard option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
