### PR TITLE
fix(spaces): return to the section where it was left

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -942,6 +942,19 @@ function App() {
   }, [spaceSelection])
   // What's selected inside the open space (general / topic / file) — part of the history.
   const [railSelection, setRailSelection] = useState<RailSelection>({ kind: 'general' })
+  /**
+   * The Spaces view correcting its own selection (the open space was deleted,
+   * or the last server went away). Not a navigation — no history entry. The
+   * rail selection goes with it: it names a discussion or a file IN the space
+   * it was made in, so it cannot follow to another one, and re-entering the
+   * section restores whatever is left here.
+   */
+  const selectSpace = useCallback((next: SpaceSelection) => {
+    setSpaceSelection(next)
+    if ((next?.orgId ?? '') !== (spaceSelection?.orgId ?? '') || (next?.spaceId ?? '') !== (spaceSelection?.spaceId ?? '')) {
+      setRailSelection({ kind: 'general' })
+    }
+  }, [spaceSelection])
   const [isEmailOpen, setIsEmailOpen] = useState(false)
   const [isWorkspaceOpen, setIsWorkspaceOpen] = useState(false)
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | null>(null)
@@ -4845,7 +4858,9 @@ function App() {
     if (isCodeOpen) return { type: 'code' }
     if (isBgTasksOpen) return { type: 'bg-tasks' }
     if (isAppsOpen) return { type: 'apps' }
-    if (isSpacesOpen) return spaceSelection ? { type: 'spaces', orgId: spaceSelection.orgId, spaceId: spaceSelection.spaceId, rail: railSelection } : { type: 'spaces' }
+    // The org-level surface (Activity) belongs in here too: without it, history
+    // records Activity as a plain space view and ‹ lands somewhere else.
+    if (isSpacesOpen) return spaceSelection ? { type: 'spaces', orgId: spaceSelection.orgId, spaceId: spaceSelection.spaceId, rail: railSelection, ...(spaceSelection.view ? { view: spaceSelection.view } : {}) } : { type: 'spaces' }
     if (selectedPath) return { type: 'file', path: selectedPath }
     if (isGraphOpen) return { type: 'graph' }
     return { type: 'chat', runId }
@@ -5518,11 +5533,19 @@ function App() {
     void navigateToView({ type: 'spaces', orgId, view: 'activity' })
   }, [navigateToView])
 
+  /**
+   * Re-entering the section (the nav item, the ⌥Tab switcher, the assistant)
+   * lands exactly where Spaces was left: the same space AND what was open
+   * inside it — a discussion, a file, a board — or the org's Activity surface.
+   * Both selections survive a section switch in state, so the live values ARE
+   * the memory; storage only covers the first entry after a relaunch.
+   */
   const openSpaces = useCallback(async () => {
     if (spacesLoading) await refreshSpacesOrgs()
-    const target = resolveSpacesLocation(getSpacesOrgs(), spaceSelection ?? readLastSpace())
+    const previous = spaceSelection ? { ...spaceSelection, rail: railSelection } : readLastSpace()
+    const target = resolveSpacesLocation(getSpacesOrgs(), previous)
     void navigateToView(target ? { type: 'spaces', ...target } : { type: 'spaces' })
-  }, [spacesLoading, spaceSelection, navigateToView])
+  }, [spacesLoading, spaceSelection, railSelection, navigateToView])
 
   const openMeetingsView = useCallback(() => {
     void navigateToView({ type: 'meetings' })
@@ -5855,7 +5878,9 @@ function App() {
         case 'workspace': openProjects(); break
         case 'code': void navigateToView({ type: 'code' }); break
         case 'apps': openAppsGrid(); break
-        case 'spaces': void navigateToView({ type: 'spaces' }); break
+        // Through openSpaces, like the nav item: a bare spaces view state would
+        // reset the rail and close whatever discussion was open.
+        case 'spaces': void openSpaces(); break
       }
     }
 
@@ -5979,7 +6004,7 @@ function App() {
         break
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navigateToFile, navigateToView, openAppsGrid, openProjects, selectedPath])
+  }, [navigateToFile, navigateToView, openAppsGrid, openProjects, openSpaces, selectedPath])
 
   // Legacy runs:events path: handleRunEvent stashes the result in a ref;
   // polled every render (the triggering event always causes one).
@@ -7655,7 +7680,7 @@ function App() {
                   <SpacesView
                     active={activeMiddle === 'spaces'}
                     selection={spaceSelection}
-                    onSelect={setSpaceSelection}
+                    onSelect={selectSpace}
                     onSwitchSpace={openSpace}
                     railSelection={railSelection}
                     onRailSelect={(rail) => {

--- a/apps/x/apps/renderer/src/lib/spaces-navigation.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-navigation.test.ts
@@ -15,6 +15,26 @@ describe('returning to Spaces', () => {
     it('keeps the previous server when its saved space was removed', () => {
         expect(resolveSpacesLocation(orgs, { orgId: 'second', spaceId: 'removed' })).toEqual({ orgId: 'second', spaceId: 'founders' })
     })
+    it.each([
+        { kind: 'thread', rootMessageId: 'msg1' },
+        { kind: 'file', path: 'notes/plan.md', fromThreadRootId: 'msg1' },
+        { kind: 'whiteboard', path: 'whiteboards/sketch.excalidraw' },
+    ] as const)('reopens what was open inside the space (%j)', (rail) => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'second', spaceId: 'design', rail }))
+            .toEqual({ orgId: 'second', spaceId: 'design', rail })
+    })
+    it('leaves the rail behind when the saved space is gone', () => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'second', spaceId: 'removed', rail: { kind: 'thread', rootMessageId: 'msg1' } }))
+            .toEqual({ orgId: 'second', spaceId: 'founders' })
+    })
+    it('returns to the Activity surface instead of a space', () => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'second', spaceId: '', view: 'activity' }))
+            .toEqual({ orgId: 'second', spaceId: '', view: 'activity' })
+    })
+    it('falls back to a space when the Activity surface names a server that is gone', () => {
+        expect(resolveSpacesLocation(orgs, { orgId: 'removed', spaceId: '', view: 'activity' }))
+            .toEqual({ orgId: 'first', spaceId: 'main' })
+    })
     it.each([null, {}, 'invalid', { orgId: 'removed', spaceId: 'gone' }])('chooses an available server for invalid saved state %j', (saved) => {
         expect(resolveSpacesLocation(orgs, saved)).toEqual({ orgId: 'first', spaceId: 'main' })
     })

--- a/apps/x/apps/renderer/src/lib/spaces-navigation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-navigation.ts
@@ -1,21 +1,57 @@
 import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import type { RailSelection } from '@/lib/spaces-selection'
 
 export const LAST_SPACE_STORAGE_KEY = 'x:last-space'
 
-type SpaceLocation = { orgId: string; spaceId: string }
+/**
+ * Where Spaces was left. The space is only half of it: an open discussion, a
+ * file, a board — or the org's Activity surface instead of a space — is part
+ * of the location too, so re-entering the section restores the whole thing
+ * rather than dropping the reader back on the stream.
+ */
+export type SpaceLocation = {
+    orgId: string
+    spaceId: string
+    /** What was open inside the space (a discussion, a file, a board). */
+    rail?: RailSelection
+    /** An org-level surface instead of a space (spaceId is '' then): Activity. */
+    view?: 'activity'
+}
 
 /** Restore a valid location, preferring another space on the same server if it was deleted. */
 export function resolveSpacesLocation(orgs: OrgWithSpaces[], previous: unknown): SpaceLocation | null {
-    const saved = previous && typeof previous === 'object' && 'orgId' in previous && 'spaceId' in previous
-        && typeof previous.orgId === 'string' && typeof previous.spaceId === 'string' ? { orgId: previous.orgId, spaceId: previous.spaceId } : null
+    const saved = readLocation(previous)
     const previousOrg = saved ? orgs.find((org) => org.id === saved.orgId) : undefined
+    // An org-level surface has no space to validate against — the server being
+    // there is the whole of it.
+    if (previousOrg && saved?.view === 'activity') return { orgId: previousOrg.id, spaceId: '', view: 'activity' }
     if (previousOrg && saved && [...previousOrg.spaces, ...previousOrg.directs].some((space) => space.id === saved.spaceId)) {
-        return { orgId: previousOrg.id, spaceId: saved.spaceId }
+        // The space survived, so what was open inside it comes back with it.
+        return { orgId: previousOrg.id, spaceId: saved.spaceId, ...(saved.rail ? { rail: saved.rail } : {}) }
     }
+    // Landing on a different space than the saved one: its rail selection named
+    // a discussion or a file in the space that is gone, so it stays behind.
     const org = previousOrg ?? orgs.find((org) => org.spaces.length > 0 || org.directs.length > 0) ?? orgs[0]
     return org ? { orgId: org.id, spaceId: org.spaces[0]?.id ?? org.directs[0]?.id ?? '' } : null
 }
 
+/**
+ * Shape-check a remembered location. It arrives either as live app state or as
+ * whatever JSON.parse handed back from storage, so the identifying fields are
+ * checked; `rail` only ever comes from the typed in-session record.
+ */
+function readLocation(previous: unknown): SpaceLocation | null {
+    if (!previous || typeof previous !== 'object') return null
+    const { orgId, spaceId, rail, view } = previous as Partial<SpaceLocation>
+    if (typeof orgId !== 'string' || typeof spaceId !== 'string') return null
+    return { orgId, spaceId, ...(rail ? { rail } : {}), ...(view === 'activity' ? { view } : {}) }
+}
+
+/**
+ * The last space opened, persisted by App. Carries the space (and Activity),
+ * not the rail: a relaunch lands on the conversation, clean — the same call
+ * the per-space column memory makes.
+ */
 export function readLastSpace(): unknown {
     try { return JSON.parse(localStorage.getItem(LAST_SPACE_STORAGE_KEY) ?? 'null') }
     catch { return null }


### PR DESCRIPTION
## The defect

Leaving Spaces and coming back closed whatever was open inside the space. Every route back in - the nav item, the ⌥Tab switcher, the assistant's "open spaces" - goes through `openSpaces`, which rebuilt the destination from `resolveSpacesLocation`, and that only ever returned `{orgId, spaceId}`. `applyViewState` then ran `setRailSelection(view.rail ?? { kind: 'general' })`, so an open discussion, file or board was dropped for the general stream.

The org-level Activity surface was lost the same way: `resolveSpacesLocation` discarded `view: 'activity'` and sent the reader to a space instead.

## The fix

A `SpaceLocation` now carries the `rail` (the open discussion / file / board / attachment) and the `view`, and `resolveSpacesLocation` restores both. `openSpaces` feeds the live `spaceSelection` + `railSelection` in as the remembered location - both already survive a section switch in state, so the live values are the memory.

Guarded properly: the rail only comes back when the saved space still exists, since a thread id or file path from a deleted space names nothing in the space you land on instead. Activity resolves off the server alone - it has no space to validate against.

Three supporting fixes fell out of it:

- `currentViewState` records `spaceSelection.view`. Without it, history stored Activity as a plain space view, so ‹ from another section landed somewhere else and the header read "Spaces" instead of "Activity".
- The assistant's `open-view spaces` goes through `openSpaces`, matching how `workspace` and `apps` already work next to it. The bare `{type:'spaces'}` reset the rail.
- `selectSpace` wraps the view's self-correcting `onSelect` (which fires when the open space is deleted) to clear the rail with it. This keeps the invariant the restore depends on: a remembered rail always belongs to the remembered space. Kept as a `useCallback` rather than an inline arrow because `SpacesView` lists `onSelect` in an effect's deps.

A relaunch still lands on the conversation, clean: `x:last-space` keeps the space and Activity but not the rail, matching the existing per-space column memory decision.

## Testing

- 8 new cases in `spaces-navigation.test.ts`: thread / file / whiteboard rails restored, rail dropped when the saved space is gone, Activity restored, Activity falling back when its server is gone.
- Full renderer suite: 754 passed (90 files). `tsc -b` clean. eslint clean on the touched files (only the 6 pre-existing `exhaustive-deps` warnings elsewhere in `App.tsx`).
- Not driven in the real app - that needs a harbor server with a joined org, and the dev instance was holding :3220/:5173. There is no App-level test harness in this repo (nothing imports `@/App`), so the decision point is covered by unit tests and the four `App.tsx` wiring edits by review.

## Adjacent gap, left alone

An open file in the doc column keeps its place in the tree on re-show, but its scroll offset resets to the top: `<Activity mode="hidden">` drops the scroll geometry and `FileColumn` has no re-show restore. `GeneralStream` has one; `ThreadPane` re-pins to its tail, which is its design. Fixing `FileColumn` means threading a `visible` prop down to it - a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)