### PR TITLE
feat(spaces): restore a file to any prior version from its history

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/files-tab.tsx
@@ -20,7 +20,8 @@ import type { OrgWithSpaces } from '@/hooks/use-spaces'
 import { MemberText } from '@/components/spaces/member-text'
 import {
     attributionLabel, blobAppUrl, blobWireUrl, buildFileTree, formatBytes, formatFeedTime, isImageMime,
-    parseAssetWireUrl, parseBlobAppUrl, resolveSpaceLink, rewriteBlobLinks, rewriteRelativeImages, toggleTaskAt,
+    isRestorableChangeSet, parseAssetWireUrl, parseBlobAppUrl, resolveSpaceLink, rewriteBlobLinks,
+    rewriteRelativeImages, toggleTaskAt,
     type FileTreeNode,
 } from '@/lib/spaces-presentation'
 import { toast } from '@/lib/toast'
@@ -29,8 +30,9 @@ import { uploadInputFor } from '@/lib/spaces-upload'
 
 // Files: the tree (README first) and the file column — rendered file
 // with one-tap checkboxes, Edit → draft→apply (merged / conflict handled),
-// History with diffs. Supported documents reuse the workspace viewers/editors;
-// other binary files retain the download card and versioned Replace action.
+// History with diffs and restore-to-version. Supported documents reuse the
+// workspace viewers/editors; other binary files retain the download card and
+// versioned Replace action.
 
 // ---------------------------------------------------------------------------
 // Files rail — the space's tree, README first, unread dots on moved files
@@ -409,7 +411,9 @@ export function FileColumn({ org, space, path, entries = [], memberNames, refres
     const [draft, setDraft] = useState<DraftState | null>(null)
     const [applying, setApplying] = useState(false)
     const [historyOpen, setHistoryOpen] = useState(false)
-    const [diffView, setDiffView] = useState<{ title: string; unified: string } | null>(null)
+    const [diffView, setDiffView] = useState<{ title: string; unified: string; restorable: number | null } | null>(null)
+    /** The older version the reader asked to bring back (confirmed in a dialog). */
+    const [restoreTarget, setRestoreTarget] = useState<number | null>(null)
 
     const load = useCallback(async () => {
         try {
@@ -488,10 +492,13 @@ export function FileColumn({ org, space, path, entries = [], memberNames, refres
         }
     }
 
-    const showDiff = async (from: number, to: number) => {
+    // `restorable` is the version the diff's change-set produced, when going
+    // back to it is offered — the history row decides that, so the dialog and
+    // the row can never disagree.
+    const showDiff = async (from: number, to: number, restorable: number | null) => {
         try {
             const res = await window.ipc.invoke('spaces:diff', { orgId: org.id, spaceId: space.id, path, from, to })
-            setDiffView({ title: `${path} · v${from} → v${to}`, unified: res.unified })
+            setDiffView({ title: `${path} · v${from} → v${to}`, unified: res.unified, restorable })
         } catch (err) {
             toast(err instanceof Error ? err.message : 'Could not load the diff', 'error')
         }
@@ -891,8 +898,10 @@ export function FileColumn({ org, space, path, entries = [], memberNames, refres
                         path={path}
                         memberNames={memberNames}
                         refreshTick={refreshTick}
+                        currentVersion={asset.version}
                         onClose={() => setHistoryOpen(false)}
-                        onShowDiff={(from, to) => void showDiff(from, to)}
+                        onShowDiff={(from, to, restorable) => void showDiff(from, to, restorable)}
+                        onRestore={setRestoreTarget}
                     />
                 )}
             </div>
@@ -904,8 +913,39 @@ export function FileColumn({ org, space, path, entries = [], memberNames, refres
                     <pre className="max-h-[60vh] overflow-auto text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap">
                         {diffView?.unified}
                     </pre>
+                    {/* Inspecting a diff is usually how someone decides to go back,
+                        so the action sits right where that decision is made. */}
+                    {diffView?.restorable != null && (
+                        <div className="flex justify-end">
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-7 text-xs"
+                                onClick={() => {
+                                    setRestoreTarget(diffView.restorable)
+                                    setDiffView(null)
+                                }}
+                            >
+                                <RotateCcw className="size-3 mr-1" /> Restore to v{diffView.restorable}
+                            </Button>
+                        </div>
+                    )}
                 </DialogContent>
             </Dialog>
+            {restoreTarget !== null && asset && (
+                <RestoreVersionDialog
+                    orgId={org.id}
+                    spaceId={space.id}
+                    path={path}
+                    version={restoreTarget}
+                    currentVersion={asset.version}
+                    onClose={() => setRestoreTarget(null)}
+                    onRestored={async () => {
+                        await load()
+                        onChanged()
+                    }}
+                />
+            )}
         </section>
     )
 }
@@ -946,14 +986,17 @@ function ConflictNotice({ conflict, memberNames, onUseCurrent, onRebase }: {
     )
 }
 
-function HistoryPanel({ org, space, path, memberNames, refreshTick, onClose, onShowDiff }: {
+function HistoryPanel({ org, space, path, memberNames, refreshTick, currentVersion, onClose, onShowDiff, onRestore }: {
     org: OrgWithSpaces
     space: spaces.Space
     path: string
     memberNames: Map<string, string>
     refreshTick: number
+    /** The head — rows at or above it have nothing to restore. */
+    currentVersion: number
     onClose: () => void
-    onShowDiff: (from: number, to: number) => void
+    onShowDiff: (from: number, to: number, restorable: number | null) => void
+    onRestore: (version: number) => void
 }) {
     const [changeSets, setChangeSets] = useState<spaces.ChangeSet[]>([])
 
@@ -980,29 +1023,129 @@ function HistoryPanel({ org, space, path, memberNames, refreshTick, onClose, onS
             </div>
             <div className="flex-1 overflow-y-auto">
                 {changeSets.map((cs) => (
-                    <button
-                        key={cs.id}
-                        className="w-full text-left px-3 py-2 border-b border-border/50 hover:bg-accent/40"
-                        onClick={() => onShowDiff(cs.baseVersion, cs.resultVersion)}
-                    >
-                        <div className="flex items-center gap-2">
-                            <MemberAvatar id={cs.attribution.memberId} name={memberNames.get(cs.attribution.memberId) ?? cs.attribution.memberId} size="sm" />
-                            <div className="text-xs font-medium truncate">{attributionLabel(cs.attribution, memberNames)}</div>
-                        </div>
-                        {cs.op && (
-                            <div className="mt-1 pl-7 text-[12px] text-muted-foreground">
-                                {cs.op === 'move' ? `moved from ${cs.movedFrom ?? '…'}` : cs.op === 'delete' ? 'deleted' : 'restored'}
+                    <div key={cs.id} className="group/histrow relative border-b border-border/50">
+                        <button
+                            className="w-full text-left px-3 py-2 hover:bg-accent/40"
+                            onClick={() => onShowDiff(cs.baseVersion, cs.resultVersion, isRestorableChangeSet(cs, currentVersion) ? cs.resultVersion : null)}
+                        >
+                            <div className="flex items-center gap-2 pr-14">
+                                <MemberAvatar id={cs.attribution.memberId} name={memberNames.get(cs.attribution.memberId) ?? cs.attribution.memberId} size="sm" />
+                                <div className="text-xs font-medium truncate">{attributionLabel(cs.attribution, memberNames)}</div>
                             </div>
+                            {cs.op && (
+                                <div className="mt-1 pl-7 text-[12px] text-muted-foreground">
+                                    {cs.op === 'move' ? `moved from ${cs.movedFrom ?? '…'}` : cs.op === 'delete' ? 'deleted' : 'restored'}
+                                </div>
+                            )}
+                            {cs.reason && <div className="text-xs text-muted-foreground mt-1 pl-7">&ldquo;<MemberText text={cs.reason} />&rdquo;</div>}
+                            <div className="text-[10.5px] text-muted-foreground mt-1 pl-7 flex items-center gap-1">
+                                <Clock className="size-2.5" /> {formatFeedTime(cs.committedAt)} · v{cs.resultVersion}
+                            </div>
+                        </button>
+                        {isRestorableChangeSet(cs, currentVersion) && (
+                            <button
+                                type="button"
+                                aria-label={`Restore to v${cs.resultVersion}`}
+                                title={`Bring this file back to v${cs.resultVersion}`}
+                                onClick={() => onRestore(cs.resultVersion)}
+                                className="absolute right-1.5 top-1.5 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-muted-foreground opacity-0 hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover/histrow:opacity-100"
+                            >
+                                <RotateCcw className="size-2.5" /> Restore
+                            </button>
                         )}
-                        {cs.reason && <div className="text-xs text-muted-foreground mt-1 pl-7">&ldquo;<MemberText text={cs.reason} />&rdquo;</div>}
-                        <div className="text-[10.5px] text-muted-foreground mt-1 pl-7 flex items-center gap-1">
-                            <Clock className="size-2.5" /> {formatFeedTime(cs.committedAt)} · v{cs.resultVersion}
-                        </div>
-                    </button>
+                    </div>
                 ))}
                 {changeSets.length === 0 && <div className="px-3 py-2 text-xs text-muted-foreground">No history yet.</div>}
             </div>
         </aside>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Restore to a previous version. Going back is an ordinary change-set, not a
+// rewind: the old bytes are re-proposed against the head, so every version in
+// between survives in history (and the restore itself is restorable).
+// ---------------------------------------------------------------------------
+
+export function RestoreVersionDialog({ orgId, spaceId, path, version, currentVersion, onClose, onRestored }: {
+    orgId: string
+    spaceId: string
+    path: string
+    /** The older version whose content becomes the new head. */
+    version: number
+    /** The head as the reader last saw it — re-read at confirm time. */
+    currentVersion: number
+    onClose: () => void
+    onRestored: () => void
+}) {
+    const [busy, setBusy] = useState(false)
+    const [head, setHead] = useState(currentVersion)
+    const fileName = path.split('/').pop() ?? path
+
+    const confirm = async () => {
+        setBusy(true)
+        try {
+            // Read the head immediately before proposing so the base is as
+            // fresh as possible: a restore that three-way-merges someone's
+            // concurrent edit isn't the verbatim restore that was asked for.
+            const current = await window.ipc.invoke('spaces:readAsset', { orgId, spaceId, path })
+            setHead(current.version)
+            const snapshot = await window.ipc.invoke('spaces:readAsset', { orgId, spaceId, path, version })
+            const result = await window.ipc.invoke('spaces:proposeChange', {
+                orgId,
+                spaceId,
+                input: {
+                    assetPath: path,
+                    baseVersion: current.version,
+                    // Binary versions re-reference the blob they already point
+                    // at — the bytes never travel, and nothing is re-uploaded.
+                    ...(snapshot.blob ? { blob: snapshot.blob.hash } : { newContent: snapshot.content }),
+                    reason: `restore to v${version}`,
+                },
+            })
+            onRestored()
+            if (result.outcome === 'conflict') {
+                // Someone committed inside that window. Nothing was written;
+                // the dialog stays open so confirming again retries on the new head.
+                setHead(result.currentVersion)
+                toast(`${fileName} changed while restoring - it's now v${result.currentVersion}, try again`, 'error')
+                return
+            }
+            toast(
+                result.outcome === 'merged'
+                    ? `Restored v${version} with concurrent changes folded in - now v${result.version}`
+                    : `Restored v${version} - now v${result.version}`,
+                'success',
+            )
+            onClose()
+        } catch (err) {
+            toast(err instanceof Error ? err.message : 'Could not restore', 'error')
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    return (
+        <Dialog open onOpenChange={(open) => !open && !busy && onClose()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle className="break-words text-sm">Restore “{fileName}” to v{version}?</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-3">
+                    <p className="text-xs text-muted-foreground">
+                        This saves v{version}&rsquo;s content as v{head + 1} for everyone in the space. Nothing is lost -
+                        v{head} stays in history, so you can come back to it the same way.
+                    </p>
+                    <div className="flex justify-end gap-2">
+                        <Button variant="ghost" size="sm" className="h-7 text-xs" disabled={busy} onClick={onClose}>Cancel</Button>
+                        <Button size="sm" className="h-7 text-xs" disabled={busy} onClick={() => void confirm()}>
+                            {busy ? <Loader2 className="size-3 mr-1 animate-spin" /> : <RotateCcw className="size-3 mr-1" />}
+                            Restore v{version}
+                        </Button>
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
     )
 }
 

--- a/apps/x/apps/renderer/src/components/spaces/version-restore.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/version-restore.test.tsx
@@ -1,0 +1,217 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { spaces } from '@x/shared'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { FileColumn, RestoreVersionDialog } from './files-tab'
+import { isRestorableChangeSet } from '@/lib/spaces-presentation'
+
+vi.mock('@/components/markdown-editor', () => ({ MarkdownEditor: () => null }))
+vi.mock('@/components/rich-markdown-viewer', () => ({ RichMarkdownViewer: () => null }))
+const toasts: { message: string; kind: string }[] = []
+vi.mock('@/lib/toast', () => ({ toast: (message: string, kind: string) => { toasts.push({ message, kind }) } }))
+
+const org = { id: 'org', address: 'spaces.example.com' } as OrgWithSpaces
+const space = { id: '01ARZ3NDEKTSV4RRFFQ69G5FAV', name: 'Team' } as spaces.Space
+const hash = 'a'.repeat(64)
+
+function changeSet(over: Partial<spaces.ChangeSet> & { resultVersion: number }): spaces.ChangeSet {
+    return {
+        id: `cs-${over.resultVersion}-${over.op ?? 'edit'}`,
+        spaceId: space.id,
+        assetPath: 'notes.md',
+        baseVersion: over.resultVersion - 1,
+        attribution: { memberId: 'm1', actingMode: 'direct' },
+        committedAt: '2026-09-10T10:00:00.000Z',
+        offset: over.resultVersion,
+        ...over,
+    } as spaces.ChangeSet
+}
+
+const invoke = vi.fn()
+/** Every version that exists server-side, newest last. */
+let versions: Record<number, { content: string; blob?: { hash: string; size: number; mime: string } }>
+let history: spaces.ChangeSet[]
+let head: number
+let proposals: spaces.SpacesProposeInput[]
+/** Queued propose outcomes (a conflict, say) used before the default apply. */
+let responses: unknown[]
+
+beforeEach(() => {
+    toasts.length = 0
+    versions = { 1: { content: 'first' }, 2: { content: 'second' }, 3: { content: 'third' } }
+    history = [changeSet({ resultVersion: 3 }), changeSet({ resultVersion: 2 }), changeSet({ resultVersion: 1, baseVersion: 0 })]
+    head = 3
+    proposals = []
+    responses = []
+    invoke.mockReset().mockImplementation(async (channel: string, args: Record<string, unknown>) => {
+        if (channel === 'spaces:readAsset') {
+            const version = (args.version as number | undefined) ?? head
+            const data = versions[version]
+            if (!data) throw new Error(`no version ${version}`)
+            return { path: args.path, content: data.content, ...(data.blob ? { blob: data.blob } : {}), version, recentHistory: history }
+        }
+        if (channel === 'spaces:assetHistory') return { changeSets: history }
+        if (channel === 'spaces:diff') return { unified: '--- a\n+++ b\n' }
+        if (channel === 'spaces:proposeChange') {
+            proposals.push(args.input as spaces.SpacesProposeInput)
+            if (responses.length) {
+                const response = responses.shift()
+                if (response instanceof Error) throw response
+                return response
+            }
+            head += 1
+            return { outcome: 'applied', version: head }
+        }
+        throw new Error(`Unexpected channel ${channel}`)
+    })
+    Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+})
+afterEach(cleanup)
+
+describe('isRestorableChangeSet', () => {
+    it('offers older content versions', () => {
+        expect(isRestorableChangeSet(changeSet({ resultVersion: 2 }), 3)).toBe(true)
+    })
+    it('skips the head — it is already what the file says', () => {
+        expect(isRestorableChangeSet(changeSet({ resultVersion: 3 }), 3)).toBe(false)
+    })
+    it.each(['move', 'delete', 'restore'] as const)('skips %s ops, which carry no content of their own', (op) => {
+        expect(isRestorableChangeSet(changeSet({ resultVersion: 2, op }), 3)).toBe(false)
+    })
+})
+
+describe('restoring from the history panel', () => {
+    const openHistory = async () => {
+        render(
+            <FileColumn
+                org={org}
+                space={space}
+                path="notes.md"
+                memberNames={new Map([['m1', 'Ada']])}
+                refreshTick={0}
+                onChanged={vi.fn()}
+            />,
+        )
+        fireEvent.click(await screen.findByRole('button', { name: /History/ }))
+        return screen.findByRole('button', { name: 'Restore to v2' })
+    }
+
+    it('restores an older version through a confirmation', async () => {
+        fireEvent.click(await openHistory())
+        expect(await screen.findByText(/Restore “notes.md” to v2\?/)).toBeVisible()
+        expect(proposals).toHaveLength(0)
+        fireEvent.click(screen.getByRole('button', { name: 'Restore v2' }))
+        await waitFor(() => expect(proposals).toHaveLength(1))
+        // v2's content, proposed against the head — a new version, not a rewind.
+        expect(proposals[0]).toMatchObject({ assetPath: 'notes.md', baseVersion: 3, newContent: 'second', reason: 'restore to v2' })
+        await waitFor(() => expect(toasts.at(-1)).toEqual({ message: 'Restored v2 - now v4', kind: 'success' }))
+    })
+
+    it('leaves the head alone when the confirmation is cancelled', async () => {
+        fireEvent.click(await openHistory())
+        fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+        await waitFor(() => expect(screen.queryByText(/Restore “notes.md” to v2\?/)).not.toBeInTheDocument())
+        expect(proposals).toHaveLength(0)
+    })
+
+    it('does not offer restore for the version the file is already on', async () => {
+        await openHistory()
+        expect(screen.queryByRole('button', { name: 'Restore to v3' })).not.toBeInTheDocument()
+    })
+
+    it('offers the same restore from the diff it was inspected in', async () => {
+        render(
+            <FileColumn org={org} space={space} path="notes.md" memberNames={new Map()} refreshTick={0} onChanged={vi.fn()} />,
+        )
+        fireEvent.click(await screen.findByRole('button', { name: /History/ }))
+        // The row body opens the diff; the diff offers the same going-back action.
+        fireEvent.click(await screen.findByText('v2', { exact: false, selector: 'div' }))
+        const diff = await screen.findByRole('dialog')
+        expect(within(diff).getByText('notes.md · v1 → v2')).toBeVisible()
+        fireEvent.click(within(diff).getByRole('button', { name: 'Restore to v2' }))
+        expect(await screen.findByRole('button', { name: 'Restore v2' })).toBeVisible()
+    })
+
+    it('keeps an op change-set out of the diff’s restore action too', async () => {
+        history = [changeSet({ resultVersion: 3 }), changeSet({ resultVersion: 2, baseVersion: 2, op: 'move', movedFrom: 'old.md' }), changeSet({ resultVersion: 1, baseVersion: 0 })]
+        render(
+            <FileColumn org={org} space={space} path="notes.md" memberNames={new Map()} refreshTick={0} onChanged={vi.fn()} />,
+        )
+        fireEvent.click(await screen.findByRole('button', { name: /History/ }))
+        fireEvent.click(await screen.findByText('moved from old.md'))
+        const diff = await screen.findByRole('dialog')
+        expect(within(diff).queryByRole('button', { name: /^Restore to v/ })).not.toBeInTheDocument()
+    })
+})
+
+describe('RestoreVersionDialog', () => {
+    const open = (version = 2, currentVersion = 3, path = 'notes.md') => {
+        const onRestored = vi.fn()
+        const onClose = vi.fn()
+        render(
+            <RestoreVersionDialog
+                orgId={org.id}
+                spaceId={space.id}
+                path={path}
+                version={version}
+                currentVersion={currentVersion}
+                onRestored={onRestored}
+                onClose={onClose}
+            />,
+        )
+        return { onRestored, onClose, confirm: () => fireEvent.click(screen.getByRole('button', { name: `Restore v${version}` })) }
+    }
+
+    it('re-references a binary version’s blob instead of re-uploading bytes', async () => {
+        versions[2] = { content: '', blob: { hash, size: 10, mime: 'application/pdf' } }
+        const { confirm } = open()
+        confirm()
+        await waitFor(() => expect(proposals).toHaveLength(1))
+        expect(proposals[0]).toMatchObject({ assetPath: 'notes.md', baseVersion: 3, blob: hash })
+        expect(proposals[0].newContent).toBeUndefined()
+    })
+
+    it('proposes against the freshly read head, not the one the panel was showing', async () => {
+        head = 5
+        versions[4] = { content: 'fourth' }
+        versions[5] = { content: 'fifth' }
+        const { confirm } = open(2, 3)
+        confirm()
+        await waitFor(() => expect(proposals).toHaveLength(1))
+        expect(proposals[0].baseVersion).toBe(5)
+    })
+
+    it('keeps the dialog open on a conflict so confirming again retries on the new head', async () => {
+        responses = [{ outcome: 'conflict', currentVersion: 7, currentContent: 'theirs', regions: [], recentHistory: [] }]
+        const { confirm, onClose, onRestored } = open()
+        confirm()
+        await waitFor(() => expect(toasts.at(-1)?.kind).toBe('error'))
+        expect(toasts.at(-1)?.message).toContain("it's now v7")
+        expect(onClose).not.toHaveBeenCalled()
+        // The pane underneath still refreshes — the file really did move on.
+        expect(onRestored).toHaveBeenCalled()
+        expect(await screen.findByText(/stays in history/)).toHaveTextContent('as v8')
+        head = 7
+        versions[7] = { content: 'theirs' }
+        confirm()
+        await waitFor(() => expect(proposals).toHaveLength(2))
+        expect(proposals[1].baseVersion).toBe(7)
+    })
+
+    it('reports a clean merge honestly rather than claiming a verbatim restore', async () => {
+        responses = [{ outcome: 'merged', version: 8, mergedContent: 'folded' }]
+        const { confirm, onClose } = open()
+        confirm()
+        await waitFor(() => expect(onClose).toHaveBeenCalled())
+        expect(toasts.at(-1)).toEqual({ message: 'Restored v2 with concurrent changes folded in - now v8', kind: 'success' })
+    })
+
+    it('surfaces a failure and stays open for a retry', async () => {
+        responses = [new Error('Connection lost')]
+        const { confirm, onClose } = open()
+        confirm()
+        await waitFor(() => expect(toasts.at(-1)).toEqual({ message: 'Connection lost', kind: 'error' }))
+        expect(onClose).not.toHaveBeenCalled()
+        expect(screen.getByRole('button', { name: 'Restore v2' })).toBeEnabled()
+    })
+})

--- a/apps/x/apps/renderer/src/lib/spaces-presentation.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-presentation.ts
@@ -172,6 +172,15 @@ export function shortId(id: string): string {
     return id.slice(-6).toLowerCase()
 }
 
+/**
+ * Whether a history row can offer "restore this version": op change-sets
+ * (move/delete/restore) carry no content of their own — they reuse the version
+ * the file already had — and the head is already what the file says.
+ */
+export function isRestorableChangeSet(cs: spaces.ChangeSet, currentVersion: number): boolean {
+    return !cs.op && cs.resultVersion < currentVersion
+}
+
 // ---------------------------------------------------------------------------
 // Blobs — uploads referenced from markdown (contract decision 1, amended).
 // The wire form is the link grammar's canonical https URL on the org address


### PR DESCRIPTION
## What

The Spaces version history view was read-only: you could open a change-set's diff and inspect it, but there was no way to act on it. Restoring a file to a prior version is now a one-click action, offered in the two places where that decision actually gets made.

- **History panel rows** carry a hover/focus-revealed **Restore** button. The row body still opens the diff, so nothing that worked before changed.
- **The diff dialog** carries the same **Restore to vN** action in its footer, since inspecting a diff is usually how someone decides to go back.
- Both route through a confirmation dialog that names the version being brought back and the version it will become.

## How

A restore is an ordinary change-set, not a rewind: read the head, read the target version, propose that content against the head. Every version in between survives in history, and the restore itself is restorable. Binary versions re-reference the blob hash they already point at, so no bytes travel and nothing is re-uploaded.

**No protocol or IPC change was needed.** `readAsset`'s `version` query and `proposeChange` were already plumbed end to end through both host surfaces (`apps/main/src/spaces/ipc.ts` and `apps/server/src/spaces-deps.ts`, both channels already in `RPC_CHANNELS`) - the time-travel read simply had no UI calling it. So this works identically in Electron-main and rowboat-server mode.

### Correctness details

- **The head is re-read immediately before proposing.** A restore that three-way-merges someone's concurrent edit isn't the verbatim restore that was asked for, so the base is kept as fresh as possible.
- **All three propose outcomes are reported honestly.** `applied` succeeds; `merged` says concurrent changes were folded in rather than claiming a verbatim restore; `conflict` writes nothing and leaves the dialog open with the version numbers updated to the new head, so confirming again retries.
- **`isRestorableChangeSet`** (in `spaces-presentation.ts`) is the single rule both the row and the diff dialog consult, so they can never disagree: op change-sets (move/delete/restore) carry no content of their own - they reuse the version the file already had - and the head is already what the file says.

The history row was restructured from a single `<button>` into a `div` wrapper so the diff action and the restore action can coexist without nested buttons.

## Testing

15 new tests in `version-restore.test.tsx` cover the restorability rule, confirm and cancel, the text and binary proposals, proposing against a freshly read head rather than a stale one, conflict retry on the new head, merged reporting, and error retry.

- Full renderer suite: 763 tests across 91 files, all passing
- `tsc` and eslint clean on all three touched files

Not verified by launching the app - that needs a live Harbor org server plus an Electron install this worktree doesn't have.

## Adjacent issue left alone

History rows for move/delete/restore ops request `diff?from=N&to=N` and get back an empty patch - effectively dead clicks. Those rows now correctly offer no Restore, but the empty diff is pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)