### PR TITLE
Compact markdown typography and split-pane heading scale

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -7109,6 +7109,10 @@ function App() {
   const dockFullScreen = useBottomTabs && isFullScreenChat
   const showAssistantDock = useBottomTabs && !isCodeOpen && !projectViewActive
   const chatPaneOpen = projectViewActive ? !!projectChatId && !projectDocumentOnly : isCodeOpen ? codeChatMain : isChatSidebarOpen
+  // The document pane shares the window with a docked chat (not maximized
+  // over it, not floating above it). The editor reads this to step its
+  // headings down so they sit level with chat prose.
+  const isSplitPane = chatPaneOpen && !dockFullScreen && !floatingAssistant && (projectViewActive ? !!selectedPath : !isRightPaneMaximized)
   const isRightPaneOnlyMode = (isRightPaneContext || floatingAssistant) && chatPaneOpen && isRightPaneMaximized
   const shouldCollapseLeftPane = isRightPaneOnlyMode && !projectViewActive
   const nonChatPaneStyle = React.useMemo<React.CSSProperties>(() => {
@@ -7286,6 +7290,7 @@ function App() {
                 shouldCollapseLeftPane && "pointer-events-none select-none"
               )}
               style={nonChatPaneStyle}
+              data-split-pane={isSplitPane ? '' : undefined}
               aria-hidden={shouldCollapseLeftPane}
               onMouseDownCapture={() => setActiveShortcutPane('left')}
               onFocusCapture={() => setActiveShortcutPane('left')}

--- a/apps/x/apps/renderer/src/components/chat-sidebar.tsx
+++ b/apps/x/apps/renderer/src/components/chat-sidebar.tsx
@@ -566,7 +566,10 @@ export function ChatSidebar({
                 })}
               </div>
 
-              <div className={cn('sticky bottom-0 z-10 bg-background pt-0 shadow-lg', floating ? 'pb-3' : 'pb-12')}>
+              {/* rowboat-composer-dock drops the utility shadow (same as the
+                  full-screen dock): the gradient below does the scroll fade,
+                  so the docked pane carries no container drop shadow. */}
+              <div className={cn('rowboat-composer-dock sticky bottom-0 z-10 bg-background pt-0 shadow-lg', floating ? 'pb-3' : 'pb-12')}>
                 <div className="pointer-events-none absolute inset-x-0 -top-6 h-6 bg-linear-to-t from-background to-transparent" />
                 <div className="mx-auto w-full max-w-4xl px-3">
                   {chatTabs.map((tab) => {

--- a/apps/x/apps/renderer/src/components/spaces-view.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-view.tsx
@@ -1016,7 +1016,12 @@ function SpacePane({ org, space, selection, onSelect, onSwitchSpace, onOpenSessi
                                 />
                             </Suspense>
                         ) : centerPath ? (
-                            <div className={cn('flex min-w-0 min-h-0 flex-1', !split && !getViewerType(centerPath) && 'mx-auto max-w-[880px]')}>
+                            <div
+                                className={cn('flex min-w-0 min-h-0 flex-1', !split && !getViewerType(centerPath) && 'mx-auto max-w-[880px]')}
+                                // Beside the stream the markdown editor steps its headings
+                                // down to the compact scale (see editor.css).
+                                data-split-pane={split ? '' : undefined}
+                            >
                                 <FileColumn
                                     key={centerPath}
                                     org={org}

--- a/apps/x/apps/renderer/src/styles/editor.css
+++ b/apps/x/apps/renderer/src/styles/editor.css
@@ -18,13 +18,15 @@
   position: relative;
 }
 
-/* Notion-like base typography */
+/* Notion-like base typography. The line-height is a variable so the task
+   checkbox can size itself to exactly one text line (see Task Lists). */
 .tiptap-editor .ProseMirror {
+  --editor-line-height: 1.45;
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif,
     "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
-  line-height: 1.5;
+  line-height: var(--editor-line-height);
   color: rgb(55, 53, 47);
   max-width: 720px;
   margin: 0 auto;
@@ -79,6 +81,29 @@
   padding: 3px 2px;
 }
 
+/* Split pane: the document shares the window with 15px chat prose, so
+   headings step down to compact sizes instead of dwarfing the conversation.
+   The host marks the pane with data-split-pane while a chat sits beside it.
+   Kept above the :first-child reset so that reset still wins at equal
+   specificity. */
+[data-split-pane] .tiptap-editor .ProseMirror h1 {
+  font-size: 21px;
+  line-height: 1.25;
+  margin-top: 1.5em;
+}
+
+[data-split-pane] .tiptap-editor .ProseMirror h2 {
+  font-size: 17px;
+  line-height: 1.3;
+  margin-top: 1.25em;
+}
+
+[data-split-pane] .tiptap-editor .ProseMirror h3 {
+  font-size: 16px;
+  line-height: 1.3;
+  margin-top: 1.1em;
+}
+
 .tiptap-editor .ProseMirror h1:first-child,
 .tiptap-editor .ProseMirror h2:first-child,
 .tiptap-editor .ProseMirror h3:first-child {
@@ -100,12 +125,22 @@
   list-style-type: decimal;
 }
 
+/* 2px per item (4px between neighbours); the paragraph inside drops its own
+   vertical padding so the item, not the paragraph, owns the rhythm. */
 .tiptap-editor .ProseMirror li {
-  padding: 3px 0;
+  padding: 2px 0;
 }
 
 .tiptap-editor .ProseMirror li p {
   margin: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+/* Nested lists hang a short step (~18px) in from the parent item's text. */
+.tiptap-editor .ProseMirror li ul,
+.tiptap-editor .ProseMirror li ol {
+  padding-left: 1.125em;
 }
 
 /* Blockquote */
@@ -236,15 +271,23 @@
   gap: 0.5em;
 }
 
+/* The label is exactly one text line tall and centers the box inside it, so
+   the box sits on the cap-height band of the item's first line no matter how
+   the text wraps. */
 .tiptap-editor .ProseMirror ul[data-type="taskList"] li > label {
+  display: flex;
+  align-items: center;
   flex-shrink: 0;
-  margin-top: 0.25em;
+  height: calc(var(--editor-line-height) * 1em);
+  margin: 0;
   cursor: pointer;
 }
 
 .tiptap-editor .ProseMirror ul[data-type="taskList"] li > label input[type="checkbox"] {
-  width: 1em;
-  height: 1em;
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin: 0;
   cursor: pointer;
   accent-color: var(--primary);
 }
@@ -253,14 +296,16 @@
   flex: 1;
 }
 
-.tiptap-editor .ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div {
+/* Only the item's own text is struck: nested tasks inside the same content
+   block keep their own checked state. */
+.tiptap-editor .ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div > p {
   text-decoration: line-through;
   opacity: 0.6;
 }
 
-/* Nested task lists */
+/* Nested task lists: same short step as nested bullets. */
 .tiptap-editor .ProseMirror ul[data-type="taskList"] ul[data-type="taskList"] {
-  margin-left: 1.5em;
+  margin-left: 1.125em;
 }
 
 /* Selection */


### PR DESCRIPTION
## Summary

- **Split-pane heading scale**: when a markdown document shares the window with a docked chat (App document pane) or with the Space stream (Space file column), headings step down to H1 21px / H2 17px / H3 16px so they sit level with 15px chat prose. The host marks the pane with `data-split-pane`; full-width documents keep the existing 30/24/20px scale.
- **Tighter vertical rhythm** across the markdown editor and read-only viewer: body line-height 1.45, list items 2px top and bottom (4px between neighbours) with the inner paragraph no longer adding its own padding.
- **Nested list compression**: nested bullets, ordered lists, and nested task lists indent 18px from the parent item's text.
- **Checkbox alignment**: 16px boxes, vertically centred inside a one-line-tall label so they land on the cap band of the first line regardless of wrapping.
- **No container drop shadow in split view**: the docked chat's sticky composer dock now carries `rowboat-composer-dock` (already `box-shadow: none` in the design tokens), matching the full-screen dock. The pane seam itself was already a 1px hairline in `--border`.
- **Fix**: a checked task no longer strikes through its unchecked nested tasks (the strike rule targeted the whole content block, it now targets the item's own paragraph).

## Verification

- Rendered the editor in a temporary Vite harness and screenshotted split and full modes with headless Chrome (harness removed before commit).
- Renderer: `vitest run` 90 files / 748 tests passing; `tsc -b` clean for renderer sources; ESLint adds no new findings on the touched files.

## Notes

- The composer-dock class change is the only visual change inside the chat pane; revert that one line if the dock shadow is wanted.
- Spaces stream messages are untouched; they use their own utility-class typography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)