### PR TITLE
fix(spaces): code fences become code blocks; threads open on the newest replies

### DIFF
--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { Editor } from '@tiptap/core'
-import { caretContext, composerExtensions, composerMarkdown } from './composer-editor'
+import { caretContext, closeFenceLine, composerExtensions, composerMarkdown, openFenceLine } from './composer-editor'
 
 // The composer's contract: what the editor holds serializes back to the
 // exact markdown the wire (and every downstream consumer: drafts, slash
@@ -134,6 +134,117 @@ describe('formatting commands produce wire markdown', () => {
         })
         expect(nodes).toBe(0)
         expect(composerMarkdown(editor)).toBe('@Ada Lovelace can you look?')
+    })
+})
+
+// jsdom has no ClipboardEvent; ProseMirror's paste entry points only hand
+// the event to handlePaste, so any Event stands in.
+const pasteEvent = () => new Event('paste') as unknown as ClipboardEvent
+const nodeNames = (e: Editor) => e.state.doc.content.content.map((n) => n.type.name)
+/** Keystrokes at the caret. (Any transaction lets StarterKit's TrailingNode add its empty paragraph after a trailing block.) */
+const type = (e: Editor, text: string) => e.view.dispatch(e.state.tr.insertText(text))
+
+describe('fenced code', () => {
+    it('a plain-text paste with a fence becomes a code block — lines, blank lines and the language kept, the prose around it literal', () => {
+        const e = makeEditor('')
+        e.commands.focus('end')
+        e.view.pasteText('Try this:\n```ts\nconst a = 1\n\nconst b = *2*\n```\nthen run it', pasteEvent())
+        expect(nodeNames(e)).toEqual(['paragraph', 'codeBlock', 'paragraph'])
+        expect(composerMarkdown(e)).toBe('Try this:\n\n```ts\nconst a = 1\n\nconst b = *2*\n```\n\nthen run it')
+    })
+
+    it('a pasted fence alone is one code block, and one pasted after typed text lands under it', () => {
+        const alone = makeEditor('')
+        alone.commands.focus('end')
+        alone.view.pasteText('```\nconst x = 1\nconst y = 2\n```', pasteEvent())
+        expect(composerMarkdown(alone)).toBe('```\nconst x = 1\nconst y = 2\n```')
+        const after = makeEditor('hello')
+        after.commands.focus('end')
+        after.view.pasteText('```\ncode\n```', pasteEvent())
+        expect(composerMarkdown(after)).toBe('hello\n\n```\ncode\n```')
+        // Mid-sentence, the block splits the paragraph rather than merging into it.
+        const mid = makeEditor('hello world')
+        mid.commands.setTextSelection(6)
+        mid.view.pasteText('```\ncode\n```', pasteEvent())
+        expect(nodeNames(mid)).toEqual(['paragraph', 'codeBlock', 'paragraph'])
+    })
+
+    it('a pasted <pre> block (a rendered page, a code editor) stays a block after typed text too', () => {
+        const e = makeEditor('here is the error:')
+        e.commands.focus('end')
+        e.view.pasteHTML('<pre><code class="language-sh">npm ERR! code 1</code></pre>', pasteEvent())
+        expect(composerMarkdown(e)).toBe('here is the error:\n\n```sh\nnpm ERR! code 1\n```')
+    })
+
+    it('an unclosed fence, and text without one, paste as before — literal lines', () => {
+        const open = makeEditor('')
+        open.commands.focus('end')
+        open.view.pasteText('```\ncode', pasteEvent())
+        expect(composerMarkdown(open)).toBe('\\`\\`\\`\n\ncode')
+        const plain = makeEditor('')
+        plain.commands.focus('end')
+        plain.view.pasteText('line1\nline2', pasteEvent())
+        expect(composerMarkdown(plain)).toBe('line1\n\nline2')
+    })
+
+    it('an HTML paste whose fence lines arrived as paragraphs, or as one paragraph of hard breaks, folds into a code block', () => {
+        const paragraphs = makeEditor('')
+        paragraphs.commands.focus('end')
+        paragraphs.view.pasteHTML('<p><strong>bold</strong> intro</p><p>```</p><p>x = 1</p><p>```</p>', pasteEvent())
+        expect(composerMarkdown(paragraphs)).toBe('**bold** intro\n\n```\nx = 1\n```')
+        const breaks = makeEditor('')
+        breaks.commands.focus('end')
+        breaks.view.pasteHTML('<p>see:<br>```py<br>print(1)<br>```<br>done</p>', pasteEvent())
+        expect(nodeNames(breaks)).toEqual(['paragraph', 'codeBlock', 'paragraph'])
+        expect(composerMarkdown(breaks)).toBe('see:\n\n```py\nprint(1)\n```\n\ndone')
+    })
+
+    it('openFenceLine turns a typed ```lang line into a code block, alone or under prose', () => {
+        const alone = makeEditor('\\`\\`\\`js')
+        alone.commands.focus('end')
+        expect(openFenceLine(alone)).toBe(true)
+        expect(nodeNames(alone)).toEqual(['codeBlock', 'paragraph'])
+        type(alone, 'let a')
+        expect(composerMarkdown(alone)).toBe('```js\nlet a\n```')
+        const under = makeEditor('intro')
+        under.chain().focus('end').setHardBreak().run()
+        type(under, '```')
+        expect(openFenceLine(under)).toBe(true)
+        expect(nodeNames(under)).toEqual(['paragraph', 'codeBlock', 'paragraph'])
+        type(under, 'x')
+        expect(composerMarkdown(under)).toBe('intro\n\n```\nx\n```')
+    })
+
+    it('openFenceLine leaves any other line alone', () => {
+        const e = makeEditor('not a fence')
+        e.commands.focus('end')
+        expect(openFenceLine(e)).toBe(false)
+        expect(composerMarkdown(e)).toBe('not a fence')
+    })
+
+    it('closeFenceLine on a typed closing ``` leaves the block for the paragraph after it; a code line stays code', () => {
+        const e = makeEditor('```\nhello\n```')
+        e.commands.focus('end')
+        type(e, '\n```')
+        expect(closeFenceLine(e)).toBe(true)
+        // The editor's own trailing paragraph is reused, not doubled.
+        expect(nodeNames(e)).toEqual(['codeBlock', 'paragraph'])
+        type(e, 'after')
+        expect(composerMarkdown(e)).toBe('```\nhello\n```\n\nafter')
+        const code = makeEditor('```\nhello\n```')
+        code.commands.focus('end')
+        expect(closeFenceLine(code)).toBe(false)
+        expect(composerMarkdown(code)).toBe('```\nhello\n```')
+    })
+
+    it('closeFenceLine on a block holding nothing but the closer drops the block', () => {
+        const e = makeEditor('```\n```')
+        e.commands.focus('end')
+        type(e, '```')
+        expect(nodeNames(e)).toEqual(['codeBlock', 'paragraph'])
+        expect(closeFenceLine(e)).toBe(true)
+        expect(nodeNames(e)).toEqual(['paragraph'])
+        expect(composerMarkdown(e)).toBe('')
     })
 })
 

--- a/apps/x/apps/renderer/src/components/spaces/composer-editor.ts
+++ b/apps/x/apps/renderer/src/components/spaces/composer-editor.ts
@@ -1,5 +1,6 @@
 import { Extension, Node, mergeAttributes, type Editor } from '@tiptap/core'
-import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { Fragment, Slice, type Mark, type Node as ProseMirrorNode, type NodeType, type Schema } from '@tiptap/pm/model'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
 import Image from '@tiptap/extension-image'
@@ -161,6 +162,296 @@ export const MentionNode = Node.create({
     },
 })
 
+// ---------------------------------------------------------------------------
+// Fenced code. Markdown nodes come from input rules and the toolbar; a fence
+// typed or pasted as TEXT is just backticks in a paragraph, and the
+// serializer escapes those (\`\`\`), so the posted message showed the
+// backticks instead of a code block. Three paths make a real codeBlock node
+// of it: a plain-text paste (clipboardTextParser — the fence's lines land
+// verbatim, blank lines included), an HTML paste whose lines arrived as
+// paragraphs (transformPasted), and a fence line typed at the caret
+// (openFenceLine / closeFenceLine, which the hosts wire to Enter and
+// Shift+Enter). The prose around a fence stays literal, as every paste does.
+// ---------------------------------------------------------------------------
+
+interface FenceOpen {
+    /** The fence marker (``` or ~~~, possibly longer); the closer must match it. */
+    marker: string
+    language: string
+}
+
+/** A line that opens a fence: the marker, then an optional info string whose first word is the language. */
+function matchFenceOpen(line: string): FenceOpen | null {
+    const m = /^ {0,3}(`{3,}|~{3,})[ \t]*([^\s`]*)[^`]*$/.exec(line)
+    return m ? { marker: m[1]!, language: m[2]! } : null
+}
+
+/** A line that closes a fence: the opener's character, at least as many of them, nothing else. */
+function isFenceClose(line: string, marker?: string): boolean {
+    const m = /^ {0,3}(`{3,}|~{3,})[ \t]*$/.exec(line)
+    if (!m) return false
+    return !marker || (m[1]![0] === marker[0] && m[1]!.length >= marker.length)
+}
+
+/**
+ * How far a pasted slice opens at an edge: into a paragraph (the default
+ * parser's shape — the first line joins the paragraph the caret is in),
+ * never into a code block, whose text must not merge into prose.
+ */
+function edgeDepth(node: ProseMirrorNode | undefined, paragraph: NodeType, max: number): number {
+    return node && node.type === paragraph ? Math.min(max, 1) : 0
+}
+
+/**
+ * Pasted text as blocks with its fences made real: each closed fence becomes
+ * a codeBlock holding its lines verbatim (blank lines included); every other
+ * line is a paragraph, exactly as ProseMirror's own text parser lays it out.
+ * Null when there is no closed fence — the default parser keeps its job.
+ */
+export function parseFencedText(text: string, schema: Schema, marks: readonly Mark[] = []): Slice | null {
+    const codeBlock = schema.nodes.codeBlock
+    const paragraph = schema.nodes.paragraph
+    if (!codeBlock || !paragraph) return null
+    const lines = text.replace(/\r\n?/g, '\n').split('\n')
+    const blocks: ProseMirrorNode[] = []
+    let fenced = false
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!
+        const open = matchFenceOpen(line)
+        let close = -1
+        if (open) {
+            for (let j = i + 1; j < lines.length; j++) {
+                if (isFenceClose(lines[j]!, open.marker)) {
+                    close = j
+                    break
+                }
+            }
+        }
+        if (open && close >= 0) {
+            const code = lines.slice(i + 1, close).join('\n')
+            blocks.push(codeBlock.create({ language: open.language || null }, code ? schema.text(code) : null))
+            fenced = true
+            i = close
+        } else if (line) {
+            blocks.push(paragraph.create(null, schema.text(line, marks)))
+        }
+    }
+    if (!fenced) return null
+    return new Slice(Fragment.from(blocks), edgeDepth(blocks[0], paragraph, 1), edgeDepth(blocks[blocks.length - 1], paragraph, 1))
+}
+
+type PasteUnit =
+    | { kind: 'line'; nodes: ProseMirrorNode[]; text: string; block: number }
+    | { kind: 'block'; node: ProseMirrorNode }
+
+/**
+ * The same conversion for a slice already parsed: an HTML paste (a code
+ * editor, a rendered page) delivers fence lines as paragraphs, or as one
+ * paragraph broken by hard breaks. Top-level paragraphs read as lines, a
+ * closed fence's lines fold into a codeBlock, and the lines around it
+ * regroup as they came. Untouched when no closed fence is found.
+ */
+export function fenceSlice(slice: Slice, schema: Schema): Slice {
+    const codeBlock = schema.nodes.codeBlock
+    const paragraph = schema.nodes.paragraph
+    const hardBreak = schema.nodes.hardBreak
+    if (!codeBlock || !paragraph) return slice
+    const units: PasteUnit[] = []
+    slice.content.forEach((node, _offset, index) => {
+        if (node.type !== paragraph) {
+            units.push({ kind: 'block', node })
+            return
+        }
+        let nodes: ProseMirrorNode[] = []
+        const flush = () => {
+            units.push({ kind: 'line', nodes, text: nodes.map((n) => n.text ?? '').join(''), block: index })
+            nodes = []
+        }
+        node.forEach((child) => {
+            if (hardBreak && child.type === hardBreak) flush()
+            else nodes.push(child)
+        })
+        flush()
+    })
+    const out: PasteUnit[] = []
+    let fenced = false
+    for (let i = 0; i < units.length; i++) {
+        const unit = units[i]!
+        const open = unit.kind === 'line' ? matchFenceOpen(unit.text) : null
+        let close = -1
+        if (open) {
+            for (let j = i + 1; j < units.length; j++) {
+                const u = units[j]!
+                if (u.kind === 'line' && isFenceClose(u.text, open.marker)) {
+                    close = j
+                    break
+                }
+            }
+        }
+        if (open && close >= 0) {
+            const code = units
+                .slice(i + 1, close)
+                .map((u) => (u.kind === 'line' ? u.text : u.node.textBetween(0, u.node.content.size, '\n')))
+                .join('\n')
+            out.push({ kind: 'block', node: codeBlock.create({ language: open.language || null }, code ? schema.text(code) : null) })
+            fenced = true
+            i = close
+        } else {
+            out.push(unit)
+        }
+    }
+    if (!fenced) return slice
+    // Lines regroup as they came: consecutive lines from one source paragraph
+    // rejoin with hard breaks; lines from different ones stay apart.
+    const blocks: ProseMirrorNode[] = []
+    let para: ProseMirrorNode[] | null = null
+    let paraBlock = -1
+    const flushPara = () => {
+        if (para) blocks.push(paragraph.create(null, para))
+        para = null
+    }
+    for (const unit of out) {
+        if (unit.kind === 'block') {
+            flushPara()
+            blocks.push(unit.node)
+        } else if (para && unit.block === paraBlock && hardBreak) {
+            para.push(hardBreak.create(), ...unit.nodes)
+        } else {
+            flushPara()
+            para = [...unit.nodes]
+            paraBlock = unit.block
+        }
+    }
+    flushPara()
+    return new Slice(
+        Fragment.from(blocks),
+        edgeDepth(blocks[0], paragraph, slice.openStart),
+        edgeDepth(blocks[blocks.length - 1], paragraph, slice.openEnd),
+    )
+}
+
+/**
+ * Enter or Shift+Enter on a line that is only an opening fence (```, ```ts):
+ * the line becomes a real code block with the caret inside — what typing a
+ * fence in a chat means. Only at the end of a top-level paragraph; anywhere
+ * else the keys keep their meaning. False = not handled.
+ */
+export function openFenceLine(editor: Editor): boolean {
+    const { state } = editor
+    const { $from, empty } = state.selection
+    const codeBlock = state.schema.nodes.codeBlock
+    if (!empty || !codeBlock || $from.depth !== 1 || $from.parent.type !== state.schema.nodes.paragraph) return false
+    if ($from.parentOffset !== $from.parent.content.size) return false
+    // The caret's line: whatever follows the paragraph's last hard break.
+    let lineStart = 0
+    $from.parent.forEach((child, offset) => {
+        if (child.type.name === 'hardBreak') lineStart = offset + child.nodeSize
+    })
+    const open = matchFenceOpen($from.parent.textBetween(lineStart, $from.parentOffset))
+    if (!open) return false
+    const block = codeBlock.create({ language: open.language || null })
+    const tr = state.tr
+    if (lineStart === 0) {
+        // The paragraph IS the fence line: it becomes the code block.
+        tr.replaceWith($from.before(), $from.after(), block)
+        tr.setSelection(TextSelection.create(tr.doc, $from.before() + 1))
+    } else {
+        // A fence typed under prose: cut the line (and the break before it),
+        // open the block right after the paragraph.
+        tr.delete($from.start() + lineStart - 1, $from.pos)
+        const at = tr.mapping.map($from.after())
+        tr.insert(at, block)
+        tr.setSelection(TextSelection.create(tr.doc, at + 1))
+    }
+    editor.view.dispatch(tr.scrollIntoView())
+    return true
+}
+
+/**
+ * Enter at the end of a code block whose last line is only a closing fence:
+ * the fence line goes and the caret leaves the block — typed markdown's way
+ * out (Shift+Enter, the editor's own exit, keeps working). False = not handled.
+ */
+export function closeFenceLine(editor: Editor): boolean {
+    const { state } = editor
+    const { $from, empty } = state.selection
+    const paragraph = state.schema.nodes.paragraph
+    if (!empty || !paragraph || $from.parent.type.name !== 'codeBlock') return false
+    if ($from.parentOffset !== $from.parent.content.size) return false
+    const text = $from.parent.textContent
+    const newline = text.lastIndexOf('\n')
+    if (!isFenceClose(text.slice(newline + 1))) return false
+    // The caret lands in the paragraph after the block — the empty one the
+    // editor keeps after a trailing block (StarterKit's TrailingNode) when
+    // there is one, a fresh one otherwise.
+    const after = $from.after()
+    const next = state.doc.nodeAt(after)
+    const emptyNext = !!next && next.type === paragraph && next.content.size === 0
+    const tr = state.tr
+    if (newline < 0 && emptyNext) {
+        // Nothing but the closer: the block goes.
+        tr.delete($from.before(), after)
+        tr.setSelection(TextSelection.create(tr.doc, $from.before() + 1))
+    } else if (newline < 0) {
+        // Nothing but the closer, nothing after: the block reverts to a paragraph.
+        tr.delete($from.start(), $from.pos)
+        tr.setBlockType($from.start(), $from.start(), paragraph)
+    } else {
+        tr.delete($from.start() + newline, $from.pos)
+        const at = tr.mapping.map(after)
+        if (!emptyNext) tr.insert(at, paragraph.create())
+        tr.setSelection(TextSelection.create(tr.doc, at + 1))
+    }
+    editor.view.dispatch(tr.scrollIntoView())
+    return true
+}
+
+/**
+ * A pasted slice that opens into a code block at either edge, closed there.
+ * ProseMirror re-opens every external paste as far as it goes, and its range
+ * fitter then pours an open code block's text into the paragraph the caret
+ * sits in ("here's the error:" + a pasted block became one line of prose).
+ * Closed, the block lands as a block — after the paragraph, or splitting it.
+ */
+function closeCodeEdges(slice: Slice, schema: Schema): Slice {
+    const codeBlock = schema.nodes.codeBlock
+    if (!codeBlock) return slice
+    const openStart = slice.openStart && slice.content.firstChild?.type === codeBlock ? 0 : slice.openStart
+    const openEnd = slice.openEnd && slice.content.lastChild?.type === codeBlock ? 0 : slice.openEnd
+    if (openStart === slice.openStart && openEnd === slice.openEnd) return slice
+    return new Slice(slice.content, openStart, openEnd)
+}
+
+/** The paste hooks above, as an extension — ahead of the defaults so a text paste reaches parseFencedText first. */
+const CodeFences = Extension.create({
+    name: 'codeFences',
+    priority: 1000,
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: new PluginKey('codeFences'),
+                props: {
+                    // Null declines: ProseMirror falls through to its own text
+                    // parser when there is no fence (the prop's runtime contract).
+                    clipboardTextParser: (text, $context) => parseFencedText(text, this.editor.schema, $context.marks()) as Slice,
+                    transformPasted: (slice) => fenceSlice(slice, this.editor.schema),
+                    handlePaste: (view, event, slice) => {
+                        // The editor's own copies carry their open depths on
+                        // purpose (a code selection pasted into prose pastes as
+                        // text); only what came from outside closes.
+                        if (event.clipboardData?.getData('text/html').includes('data-pm-slice')) return false
+                        const closed = closeCodeEdges(slice, this.editor.schema)
+                        if (closed === slice) return false
+                        // The default paste's own dispatch, with the metas the paste rules key on.
+                        view.dispatch(view.state.tr.replaceSelection(closed).scrollIntoView().setMeta('paste', true).setMeta('uiEvent', 'paste'))
+                        return true
+                    },
+                },
+            }),
+        ]
+    },
+})
+
 /**
  * The chat editor's extension set. `getPlaceholder` is read per render so a
  * changing placeholder prop never needs an editor rebuild.
@@ -179,9 +470,11 @@ export function composerExtensions(getPlaceholder: () => string) {
             breaks: true,
             tightLists: true,
             // Pastes stay literal text — a pasted `*` must not turn italic.
+            // (Fences are the one exception: CodeFences makes them code blocks.)
             transformPastedText: false,
             transformCopiedText: false,
         }),
+        CodeFences,
         ChatFormatKeys,
     ]
 }

--- a/apps/x/apps/renderer/src/components/spaces/composer.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/composer.tsx
@@ -15,7 +15,7 @@ import { VoiceWaveform } from '@/components/chat-input-with-mentions'
 import { useVoiceMode } from '@/hooks/useVoiceMode'
 import { useVoiceInputAvailable } from '@/hooks/use-voice-available'
 import { CALL_VOICE_HOLDER, acquireVoice, releaseVoice, voiceOwnerId } from '@/lib/voice-ownership'
-import { caretContext, composerExtensions, composerMarkdown, type CaretContext } from '@/components/spaces/composer-editor'
+import { caretContext, closeFenceLine, composerExtensions, composerMarkdown, openFenceLine, type CaretContext } from '@/components/spaces/composer-editor'
 import { RichFormattingToolbar } from '@/components/spaces/composer-toolbar'
 import { MentionMenu, useMentionAutocomplete } from '@/components/spaces/mention-autocomplete'
 import { isDirectImageUrl, useSpaceRefs } from '@/components/spaces/space-markdown'
@@ -649,17 +649,20 @@ export function Composer({ placeholder, onSend, onSchedule, onCreatePoll, busy, 
         }
         if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && editor) {
             // Shift+Enter continues a list — next item, or out of the list
-            // from an empty one; elsewhere the default hard break applies.
+            // from an empty one; a typed fence line (```) opens a code
+            // block; elsewhere the default hard break applies.
             if (editor.isActive('listItem')) {
                 const { $from } = editor.state.selection
                 if ($from.parent.textContent === '') return editor.chain().focus().liftListItem('listItem').run()
                 return editor.chain().focus().splitListItem('listItem').run()
             }
-            return false
+            return openFenceLine(editor)
         }
         if (!e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !view.composing) {
-            // Inside a code fence Enter breaks the line (the editor behavior);
-            // everywhere else it sends.
+            // A typed fence line opens a code block (or, inside one, closes
+            // it) rather than sending; inside a code fence Enter breaks the
+            // line (the editor behavior); everywhere else it sends.
+            if (editor && (openFenceLine(editor) || closeFenceLine(editor))) return true
             if (view.state.selection.$from.parent.type.name === 'codeBlock') return false
             void send()
             return true

--- a/apps/x/apps/renderer/src/components/spaces/edit-box.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/edit-box.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { spaces } from '@x/shared'
 import { MessageEditBox } from './edit-box'
@@ -48,5 +48,20 @@ describe('MessageEditBox', () => {
     it('renders an empty body without crashing (an image-only message)', () => {
         mount('')
         expect(document.querySelector('.ProseMirror')?.textContent).toBe('')
+    })
+
+    it('Enter on a typed fence line opens a code block instead of saving', () => {
+        const onSave = vi.fn()
+        // The escaped form is how a literal ``` line is stored — a paragraph, not a fence.
+        render(
+            <SpaceProfilesProvider members={[]} here={new Set()} selfId="01HAAA">
+                <MessageEditBox initial={'\\`\\`\\`'} onChange={vi.fn()} onSave={onSave} onCancel={vi.fn()} />
+            </SpaceProfilesProvider>,
+        )
+        const pm = document.querySelector('.ProseMirror')!
+        expect(pm.querySelector('pre')).toBeNull()
+        fireEvent.keyDown(pm, { key: 'Enter' })
+        expect(onSave).not.toHaveBeenCalled()
+        expect(pm.querySelector('pre')).toBeTruthy()
     })
 })

--- a/apps/x/apps/renderer/src/components/spaces/edit-box.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/edit-box.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import type { EditorView } from '@tiptap/pm/view'
-import { composerExtensions, composerMarkdown } from '@/components/spaces/composer-editor'
+import { closeFenceLine, composerExtensions, composerMarkdown, openFenceLine } from '@/components/spaces/composer-editor'
 import { RichFormattingToolbar } from '@/components/spaces/composer-toolbar'
 import { MentionMenu, useMentionAutocomplete } from '@/components/spaces/mention-autocomplete'
 import { useSpaceProfiles } from '@/components/spaces/member-text'
@@ -61,9 +61,13 @@ export function MessageEditBox({ initial, onChange, onSave, onCancel, children }
                 onSave()
                 return true
             }
+            // A typed fence line (```) opens a code block on Enter or
+            // Shift+Enter, and Enter on a closing fence leaves it — the
+            // composer's posture.
+            if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && editor) return openFenceLine(editor)
             if (!e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !view.composing) {
-                // Inside a code fence Enter breaks the line (the composer's
-                // posture); everywhere else it saves.
+                if (editor && (openFenceLine(editor) || closeFenceLine(editor))) return true
+                // Inside a code fence Enter breaks the line; everywhere else it saves.
                 if (view.state.selection.$from.parent.type.name === 'codeBlock') return false
                 onSave()
                 return true

--- a/apps/x/apps/renderer/src/components/spaces/message-prose.ts
+++ b/apps/x/apps/renderer/src/components/spaces/message-prose.ts
@@ -1,2 +1,12 @@
 // Shared typography for timeline messages, thread roots, and replies.
-export const MESSAGE_PROSE = 'text-[15px] leading-[22px] [&_p]:my-0.5 [&_h1]:text-base [&_h2]:text-[15px] [&_h3]:text-sm [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-semibold [&_h1]:mt-3 [&_h2]:mt-3 [&_h3]:mt-2 [&_h1]:mb-1 [&_h2]:mb-1 [&_h3]:mb-1 [&_ul]:my-1 [&_ol]:my-1 [&_blockquote]:my-1 [&_blockquote]:border-l-4 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground [&_pre]:my-1 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:border [&_pre]:border-border [&_pre]:bg-muted/40 [&_pre]:p-2.5 [&_pre]:text-[13px] [&_pre]:leading-normal'
+//
+// Block code is Streamdown's own card — a header (language, copy, download)
+// over the highlighted body — reached through its data-streamdown hooks and
+// sized down for a chat row. It renders no bare <pre> of its own (the body
+// IS the <pre>), so nothing here frames a <pre>: a border and radius on it
+// would draw a second box inside the card.
+export const MESSAGE_PROSE =
+    'text-[15px] leading-[22px] [&_p]:my-0.5 [&_h1]:text-base [&_h2]:text-[15px] [&_h3]:text-sm [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-semibold [&_h1]:mt-3 [&_h2]:mt-3 [&_h3]:mt-2 [&_h1]:mb-1 [&_h2]:mb-1 [&_h3]:mb-1 [&_ul]:my-1 [&_ol]:my-1 [&_blockquote]:my-1 [&_blockquote]:border-l-4 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground ' +
+    '[&_[data-streamdown=code-block]]:my-1.5 [&_[data-streamdown=code-block]]:rounded-lg ' +
+    '[&_[data-streamdown=code-block-header]]:px-2.5 [&_[data-streamdown=code-block-header]]:py-1.5 ' +
+    '[&_[data-streamdown=code-block-body]]:p-2.5 [&_[data-streamdown=code-block-body]]:text-[13px] [&_[data-streamdown=code-block-body]]:leading-normal'

--- a/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/space-markdown.test.tsx
@@ -111,6 +111,21 @@ describe('External link gate', () => {
     })
 })
 
+describe('fenced code', () => {
+    it('renders a multi-line fence as one code block, every line in it, the prose around it as paragraphs', async () => {
+        const { container } = render(<SpaceMarkdown body={'before\n```ts\nconst a = 1\n\nconst b = 2\n```\nafter'} />)
+        // The code block is a lazy chunk — it lands a tick after the prose.
+        await waitFor(() => expect(container.querySelector('[data-streamdown="code-block-body"]')).toBeTruthy())
+        const body = container.querySelector('[data-streamdown="code-block-body"]')!
+        expect(body.tagName).toBe('PRE')
+        expect(container.querySelector('[data-streamdown="code-block"]')).toHaveAttribute('data-language', 'ts')
+        const lines = Array.from(body.querySelectorAll('code > span')).map((line) => line.textContent)
+        expect(lines.slice(0, 3)).toEqual(['const a = 1', '', 'const b = 2'])
+        expect(container.textContent).not.toContain('```')
+        expect(Array.from(container.querySelectorAll('p')).map((p) => p.textContent)).toEqual(['before', 'after'])
+    })
+})
+
 describe('Space file attachments', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: async () => new Blob(['hello'], { type: 'text/plain' }) }))

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.test.tsx
@@ -1,0 +1,178 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { spaces } from '@x/shared'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import type { SpacePresence } from '@/hooks/use-space-chat'
+
+// The pane's scroll contract, with everything around the list stubbed: it
+// opens on the newest replies, stays pinned there while bodies keep
+// growing, lets go once the reader scrolls up, and puts the spot back after
+// a hide/show. jsdom has no layout, so the list's geometry is faked.
+
+vi.mock('@/components/spaces/composer', () => ({ Composer: () => null }))
+vi.mock('@/components/spaces/message-row', () => ({
+    MessageRow: ({ message }: { message: { id: string; body: string } }) => <div data-mid={message.id}>{message.body}</div>,
+    NewDivider: () => null,
+    TypingIndicator: () => null,
+}))
+vi.mock('@/components/spaces/artifacts', () => ({ ArtifactsSummary: () => null }))
+vi.mock('@/components/spaces/atoms', () => ({
+    MemberAvatar: () => <span />,
+    MemberProfilePopover: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/components/spaces/member-text', () => ({
+    MemberName: ({ id }: { id: string }) => <span>{id}</span>,
+    MemberText: ({ text }: { text: string }) => <span>{text}</span>,
+}))
+vi.mock('@/components/spaces/space-markdown', () => ({ SpaceMarkdown: ({ body }: { body: string }) => <p>{body}</p> }))
+vi.mock('@/components/spaces/poll-dialog', () => ({ PollDialogHost: () => null }))
+vi.mock('@/components/spaces/forward-dialog', () => ({ ForwardDialog: () => null }))
+vi.mock('@/components/spaces/attach-document-dialog', () => ({ AttachDocumentDialog: () => null }))
+vi.mock('@/hooks/use-space-chat', () => ({
+    buildPendingMessage: vi.fn(),
+    getThreadSnapshot: () => null,
+    ingestTopic: vi.fn(),
+    putThreadSnapshot: vi.fn(),
+    removeTopicByRoot: vi.fn(),
+    updateStreamMessage: vi.fn(),
+    usePresenceSender: () => ({ onType: vi.fn() }),
+}))
+vi.mock('@/hooks/use-topic-agent-permission', () => ({ useTopicAgentPermissionWait: () => [] }))
+vi.mock('@/lib/spaces-agent-activity', () => ({ useSpaceAgentActivity: () => new Map() }))
+vi.mock('@/lib/spaces-read-state', () => ({
+    getThreadReadState: () => null,
+    markThreadRead: vi.fn(),
+    noteThread: vi.fn(),
+    useReadStateVersion: () => 0,
+}))
+vi.mock('@/lib/spaces-saved', () => ({ toggleSaved: vi.fn(), useSaved: () => [] }))
+vi.mock('@/lib/spaces-rowboat', () => ({ maybeInvokeRowboat: vi.fn() }))
+vi.mock('@/lib/spaces-response-chat', () => ({ openResponseChat: vi.fn() }))
+vi.mock('@/lib/toast', () => ({ toast: vi.fn() }))
+vi.mock('@/lib/analytics', () => ({
+    spacesMessagePosted: vi.fn(),
+    spacesFoldRequested: vi.fn(),
+    spacesReactionToggled: vi.fn(),
+    spacesMessageDeleted: vi.fn(),
+    spacesTopicStarted: vi.fn(),
+}))
+
+import { ThreadPane } from './thread-pane'
+
+const message = (id: string, body: string, offset: number, threadRoot?: string) =>
+    ({
+        id, body, offset, spaceId: 'space', ...(threadRoot ? { threadRoot } : {}),
+        author: { memberId: 'alex', actingMode: 'direct' }, postedAt: '2026-09-09T09:00:00Z', replyCount: 0,
+    }) as spaces.Message
+
+const root = message('root', 'the root', 1)
+const replies = [message('r1', 'reply 1', 2, 'root'), message('r2', 'reply 2', 3, 'root')]
+const org = { id: 'org', memberId: 'me', address: 'org.example', name: 'Org', spaces: [], directs: [], directLabels: {} } as unknown as OrgWithSpaces
+const space = { id: 'space', name: 'Space', createdAt: '2026-09-01T00:00:00Z', kind: 'shared' } as spaces.Space
+const presence: SpacePresence = { here: [], typing: new Map(), working: new Map() }
+
+/** The list's geometry: a content height and a viewport; scrollTop clamps like a browser's. */
+function fakeScrollBox(el: HTMLElement, box: { scrollHeight: number; clientHeight: number }) {
+    let top = 0
+    Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => box.scrollHeight })
+    Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => box.clientHeight })
+    Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: () => top,
+        set: (v: number) => {
+            top = Math.max(0, Math.min(v, box.scrollHeight - box.clientHeight))
+        },
+    })
+}
+
+const resizeCallbacks: Array<() => void> = []
+beforeEach(() => {
+    resizeCallbacks.length = 0
+    vi.stubGlobal('ResizeObserver', class {
+        constructor(cb: () => void) {
+            resizeCallbacks.push(cb)
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    })
+    Object.defineProperty(window, 'ipc', {
+        configurable: true,
+        value: {
+            invoke: vi.fn(async (channel: string) => {
+                if (channel === 'spaces:listThread') return { root, topic: null, messages: replies, hasMore: false, following: false, readOffset: null }
+                if (channel === 'spaces:topicSession') return { sessionId: null }
+                return {}
+            }),
+        },
+    })
+})
+afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+})
+
+function mount(visible = true) {
+    const props = {
+        org, space, rootMessageId: 'root', rootFromStream: root, topicFromStream: undefined, changeSets: [], entries: [], presence,
+        members: [], memberNames: new Map([['alex', 'Alex']]), refreshTick: 0, showBack: true, onBack: vi.fn(), onOpenFile: vi.fn(),
+        artifactsRailOpen: false, onToggleArtifactsRail: vi.fn(),
+    }
+    const utils = render(<ThreadPane {...props} visible={visible} />)
+    const list = document.querySelector<HTMLElement>('.spaces-message-list')!
+    const box = { scrollHeight: 1000, clientHeight: 300 }
+    fakeScrollBox(list, box)
+    return { ...utils, list, box, rerender: (next: { visible: boolean }) => utils.rerender(<ThreadPane {...props} visible={next.visible} />) }
+}
+
+/** The list grows (an image loaded, a code block highlighted) and the observer reports it. */
+function grow(box: { scrollHeight: number }, by: number) {
+    box.scrollHeight += by
+    act(() => {
+        for (const cb of resizeCallbacks) cb()
+    })
+}
+
+describe('ThreadPane scroll position', () => {
+    it('opens on the newest replies and stays pinned there while the content keeps growing', async () => {
+        const { list, box } = mount()
+        await screen.findByText('reply 2')
+        expect(list.scrollTop).toBe(700)
+        grow(box, 400)
+        expect(list.scrollTop).toBe(1100)
+    })
+
+    it('lets go once the reader scrolls up, and keeps their spot across a hide/show', async () => {
+        const { list, box, rerender } = mount()
+        await screen.findByText('reply 2')
+        fireEvent.wheel(list)
+        list.scrollTop = 120
+        fireEvent.scroll(list)
+        grow(box, 400)
+        expect(list.scrollTop).toBe(120)
+        // Hidden (display:none) drops the geometry; showing again puts it back.
+        rerender({ visible: false })
+        list.scrollTop = 0
+        rerender({ visible: true })
+        expect(list.scrollTop).toBe(120)
+    })
+
+    it('a scroll the reader did not make, while following, re-pins the bottom', async () => {
+        const { list } = mount()
+        await screen.findByText('reply 2')
+        // Anchoring's compensation for a late layout: no wheel, no pointer.
+        list.scrollTop = 400
+        fireEvent.scroll(list)
+        expect(list.scrollTop).toBe(700)
+    })
+
+    it('back from hidden while following lands on the bottom again', async () => {
+        const { list, rerender } = mount()
+        await screen.findByText('reply 2')
+        rerender({ visible: false })
+        list.scrollTop = 0
+        rerender({ visible: true })
+        expect(list.scrollTop).toBe(700)
+    })
+})

--- a/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
+++ b/apps/x/apps/renderer/src/components/spaces/thread-pane.tsx
@@ -96,8 +96,11 @@ export function ThreadPane({
     // Starts at the cache's depth: hasMore above describes exactly that.
     const oldestLoadedRef = useRef<number | null>(seeded?.messages[0]?.offset ?? null)
     const [folding, setFolding] = useState(false)
-    const bottomRef = useRef<HTMLDivElement | null>(null)
     const scrollRef = useRef<HTMLDivElement | null>(null)
+    /** The list's one measurable child — the tail pin observes its size. */
+    const contentRef = useRef<HTMLDivElement | null>(null)
+    /** null = following the tail; a number = where the reader parked (kept across hide/show). */
+    const parkedTopRef = useRef<number | null>(null)
     /** Composer prefill (quote-reply, mention-from-profile); a new nonce re-applies it. */
     const [seed, setSeed] = useState<{ text: string; nonce: number; append?: boolean } | null>(null)
     const { onType } = usePresenceSender(org.id, space.id, rootMessageId, visible)
@@ -254,7 +257,10 @@ export function ThreadPane({
         if (!mid) return
         const el = scrollRef.current
         if (!el) return
-        if (scrollToMessage(el, mid) || loaded) {
+        const landed = scrollToMessage(el, mid)
+        // The landing spot is the reader's own now — the tail pin lets go.
+        if (landed) parkedTopRef.current = el.scrollTop
+        if (landed || loaded) {
             // Landed — or the window is loaded and the row just isn't in it.
             setTimeout(() => {
                 pendingJumpRef.current = null
@@ -262,10 +268,57 @@ export function ThreadPane({
         }
     }, [jumpNonce, loaded, messages.length])
 
+    // Opening lands on the newest replies: the bottom, pinned before paint (a
+    // layout effect — no flash of the top). The pin is not one-shot: bodies
+    // keep growing after first layout (lazy images, code highlighting, the
+    // code-block chunk), and each late growth above the viewport would
+    // strand a one-time scroll mid-thread. While the reader is following
+    // the tail, any content-size change re-pins it; the moment they scroll
+    // away the pin lets go and their spot is kept — across a hide/show too
+    // (display:none drops the scroll geometry; the flip back restores it).
+    // Only a scroll the READER made may unpin: the browser fires scroll
+    // events of its own (anchoring compensates for a late layout above the
+    // viewport), indistinguishable by position alone — so track intent: a
+    // wheel/touch stamps a time, a pointer held down (the scrollbar, a
+    // selection drag) counts for as long as it's down.
+    const userScrollAtRef = useRef(0)
+    const pointerDownRef = useRef(false)
     useEffect(() => {
-        if (pendingJumpRef.current) return
-        bottomRef.current?.scrollIntoView({ block: 'end' })
-    }, [messages.length, workingAgents.length, permissionWait.length])
+        const up = () => {
+            pointerDownRef.current = false
+        }
+        window.addEventListener('pointerup', up)
+        window.addEventListener('pointercancel', up)
+        return () => {
+            window.removeEventListener('pointerup', up)
+            window.removeEventListener('pointercancel', up)
+        }
+    }, [])
+    const pinBottom = () => {
+        const el = scrollRef.current
+        if (el && parkedTopRef.current === null && !pendingJumpRef.current) el.scrollTop = el.scrollHeight
+    }
+    const typingCount = presence.typing.get(rootMessageId)?.length ?? 0
+    useLayoutEffect(pinBottom, [loaded, root?.id, messages.length, spinningAgents.length, permissionWait.length, typingCount])
+    useEffect(() => {
+        const el = scrollRef.current
+        const content = contentRef.current
+        if (!el || !content) return
+        const ro = new ResizeObserver(pinBottom)
+        // The content's growth, and the viewport's own (the column resized,
+        // the composer growing under it).
+        ro.observe(content)
+        ro.observe(el)
+        return () => ro.disconnect()
+    }, [])
+    const wasVisibleRef = useRef(visible)
+    useLayoutEffect(() => {
+        const was = wasVisibleRef.current
+        wasVisibleRef.current = visible
+        const el = scrollRef.current
+        if (!el || !visible || was) return
+        el.scrollTop = parkedTopRef.current ?? el.scrollHeight
+    }, [visible])
 
     const groups = useMemo(() => artifactsForThread(changeSets, rootMessageId), [changeSets, rootMessageId])
 
@@ -288,7 +341,10 @@ export function ThreadPane({
     }
     const jumpToNew = () => {
         setNewJumped(true)
-        scrollRef.current?.querySelector<HTMLElement>('[data-new-divider]')?.scrollIntoView({ block: 'center' })
+        const el = scrollRef.current
+        el?.querySelector<HTMLElement>('[data-new-divider]')?.scrollIntoView({ block: 'center' })
+        // The reader's own spot now — the tail pin lets go.
+        if (el) parkedTopRef.current = el.scrollTop
     }
     useEffect(() => {
         if (!visible || !loaded || !hasNewLine || newFading) return
@@ -807,7 +863,35 @@ export function ThreadPane({
             </div>
 
             <div className="relative flex-1 min-h-0 flex flex-col">
-            <div ref={scrollRef} className="flex-1 min-h-0 spaces-message-list overflow-y-auto py-2">
+            <div
+                ref={scrollRef}
+                className="flex-1 min-h-0 spaces-message-list overflow-y-auto py-2"
+                onWheel={() => {
+                    userScrollAtRef.current = performance.now()
+                }}
+                onTouchMove={() => {
+                    userScrollAtRef.current = performance.now()
+                }}
+                onPointerDown={() => {
+                    pointerDownRef.current = true
+                }}
+                onScroll={(e) => {
+                    const el = e.currentTarget
+                    const fromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+                    const userScroll = pointerDownRef.current || performance.now() - userScrollAtRef.current < 250
+                    if (fromBottom < 8) {
+                        // At the bottom = following the tail.
+                        parkedTopRef.current = null
+                    } else if (userScroll || parkedTopRef.current !== null) {
+                        parkedTopRef.current = el.scrollTop
+                    } else if (!pendingJumpRef.current) {
+                        // A scroll the reader didn't make, while following —
+                        // anchoring's compensation for a late layout. Re-pin.
+                        el.scrollTop = el.scrollHeight
+                    }
+                }}
+            >
+                <div ref={contentRef}>
                 {!loaded && !root && <div className="px-2 py-2 text-sm text-muted-foreground">Loading…</div>}
 
                 {/* Reply-to-activity-row provenance: the change this root answers. */}
@@ -928,7 +1012,7 @@ export function ThreadPane({
                     </div>
                 )}
                 <TypingIndicator names={typingNames} />
-                <div ref={bottomRef} />
+                </div>
             </div>
             {hasNewLine && newCount > 0 && !newJumped && (
                 <button


### PR DESCRIPTION
## Summary

**Fenced code in messages.** A fence typed or pasted into the composer was only backticks in a paragraph; the markdown serializer escaped them, and the posted message showed literal backticks instead of a code block. Three paths now make a real code block of it:
- a plain-text paste: each closed fence keeps its lines verbatim, blank lines included; prose around it stays literal, as every paste does
- an HTML paste whose fence lines arrived as paragraphs or hard breaks (a code editor, a rendered page)
- a fence typed at the caret: Enter or Shift+Enter on a ``` line opens a block, Enter on a closing ``` leaves it. Inside a block Enter still breaks the line and Cmd+Enter still sends. The inline edit box gets the same wiring.

Also fixes a pre-existing paste bug found on the way: ProseMirror re-opens every external paste to full depth and its range fitter poured a pasted code block's text into the paragraph the caret sat in, so pasting a `<pre>` after "here's the error:" became one line of prose. Code-block edges are now closed on external pastes so the block lands as a block (the editor's own copies keep their open depths, so a code selection pasted into prose still pastes as text).

On the render side, Streamdown draws block code as its own card with no bare `pre`, so the message prose's `pre` border and radius drew a second box inside the card. The prose now styles the card through its data hooks, sized for a chat row, in both the stream and the thread pane. Verified in a browser harness in light and dark.

**Thread / discussion pane scroll.** The pane scrolled to the bottom once, after paint, and never again: late growth from lazy images, syntax highlighting and the lazy code-block chunk pushed the bottom away, and a hide/show of the pane (display:none drops the scroll geometry) left the reader at the top. It now pins the bottom before paint, re-pins on any content or viewport resize while the reader is following the tail, lets go the moment they scroll up, and puts their spot back after a hide/show. Same reader-intent tracking as the general stream, so the browser's own anchoring scrolls never unpin it. Jump-to-message and jump-to-unread count as the reader's own position.

## Test plan

- [x] New tests: text and HTML fence pastes (blank lines, language, marks kept), placement after typed text and mid-sentence, both caret helpers, the edit box's Enter wiring, multi-line fence rendering through Streamdown, four thread-pane scroll scenarios (open at bottom, re-pin on growth, let go on user scroll and keep the spot across hide/show, re-pin on non-user scroll)
- [x] Full renderer suite on the rebased branch: 92 files, 792 tests passing
- [x] `tsc -b` and eslint clean
- [ ] In the app: paste a fenced snippet after typed text, type ``` + Enter, then send; open a discussion with images or code in it and confirm it lands on the newest reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)