### PR TITLE
feat(spaces): sidebar shows a few unread and recent channels per server

### DIFF
--- a/apps/x/apps/renderer/src/App.tsx
+++ b/apps/x/apps/renderer/src/App.tsx
@@ -1,6 +1,7 @@
 import { WorkspaceSessionTabs } from './components/code/workspace-session-tabs'
 import { DocumentFileViewer } from '@/components/document-file-viewer'
 import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
+import { noteSpaceVisit } from '@/lib/spaces-visits'
 import * as React from 'react'
 import { Activity, useCallback, useEffect, useLayoutEffect, useMemo, useState, useRef } from 'react'
 import { workspace, quickAskShortcut, pttKey, type ipc } from '@x/shared';
@@ -5414,6 +5415,10 @@ function App() {
         // so the app lands on the default full-screen chat.
         if (!SPACES_ENABLED) return
         if (view.orgId) setSpaceSelection({ orgId: view.orgId, spaceId: view.spaceId ?? '', ...(view.view ? { view: view.view } : {}) })
+        // A navigation IS the visit the sidebar's working set remembers — the
+        // Spaces view correcting its own selection goes through selectSpace
+        // instead and does not count.
+        if (view.orgId && view.spaceId) noteSpaceVisit(view.orgId, view.spaceId)
         setRailSelection(view.rail ?? { kind: 'general' })
         // A message to land on: the pane consumes the jump once it paints.
         if (view.messageId) requestJump({ topicId: view.rail?.kind === 'thread' ? view.rail.rootMessageId : STREAM_READ_KEY, messageId: view.messageId })

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.test.tsx
@@ -1,22 +1,46 @@
 import { useState } from 'react'
-import { cleanup, fireEvent, render, screen, within, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, within, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SpacesSidebarSection, ServerSpaceNavigation } from './spaces-sidebar-section'
 import { ServerOptionsMenu } from './spaces/server-options-menu'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { isSpaceExpanded, setSpacesExpanded, useSpaceExpansionVersion } from '@/lib/spaces-expansion'
+import { forgetOrg, loadUnread, markStreamRead } from '@/lib/spaces-read-state'
+import { resetServerFoldForTest } from '@/lib/spaces-sidebar-fold'
+import { noteSpaceVisit, resetSpaceVisitsForTest } from '@/lib/spaces-visits'
 import { useSpacesOrgs, type OrgWithSpaces } from '@/hooks/use-spaces'
 
-const { org, topics } = vi.hoisted(() => ({
+const { org, other, topics } = vi.hoisted(() => ({
     org: {
         id: 'server', name: 'Our server', memberId: 'me', directLabels: {},
-        spaces: [{ id: 'main', name: 'main' }, { id: 'founders', name: 'founders' }],
+        spaces: [{ id: 'main', name: 'main', createdAt: '2026-09-01' }, { id: 'founders', name: 'founders', createdAt: '2026-09-02' }],
         directs: Array.from({ length: 5 }, (_, i) => ({ id: `dm${i}`, name: `Person ${i}`, createdAt: `2026-09-0${i + 1}` })),
+    },
+    other: {
+        id: 'other', name: 'Other server', memberId: 'me', directLabels: {},
+        spaces: [{ id: 'welcome', name: 'welcome', createdAt: '2026-09-01' }], directs: [],
     },
     topics: [{ id: 'archived', rootMessageId: 'archived', title: 'Archived discussion', lastActivityAt: '2026-09-05', archived: true }, ...Array.from({ length: 4 }, (_, i) => ({ id: `topic${i}`, rootMessageId: `root${i}`, title: `Discussion ${i}`, lastActivityAt: `2026-09-0${i + 1}` }))],
 }))
 vi.mock('@/hooks/use-spaces', () => ({ useSpacesOrgs: vi.fn(() => ({ orgs: [org], loading: false, refresh: vi.fn() })), useSpaceFeed: () => ({ topics, loaded: true }), openSelfDirect: vi.fn() }))
-vi.mock('@/hooks/use-space-chat', () => ({ useSpacesUnreadCounts: () => new Map(), prefetchStream: vi.fn(), spaceLastActivityAt: () => null }))
+// The unread map is the ONE thing both surfaces read; here it is built from the
+// real org-owned read state, so a mark moving in the store must move both.
+vi.mock('@/hooks/use-space-chat', async () => {
+    const read = await vi.importActual<typeof import('@/lib/spaces-read-state')>('@/lib/spaces-read-state')
+    return {
+        prefetchStream: vi.fn(),
+        spaceLastActivityAt: () => null,
+        useSpacesUnreadCounts: () => {
+            read.useReadStateVersion()
+            const counts = new Map<string, ReturnType<typeof read.spaceBadge>>()
+            for (const server of [org, other]) {
+                for (const space of server.spaces) counts.set(`${server.id}/${space.id}`, read.spaceBadge(server.id, space.id, false))
+                for (const dm of server.directs) counts.set(`${server.id}/${dm.id}`, read.spaceBadge(server.id, dm.id, true))
+            }
+            return counts
+        },
+    }
+})
 vi.mock('@/hooks/use-space-members', () => ({ prefetchMembers: vi.fn(), useSelfDisplayName: () => 'Me' }))
 vi.mock('@/components/spaces-view', () => ({ AddOrgDialog: () => null, OrgMonogram: () => null }))
 vi.mock('@/components/spaces/atoms', () => ({ MemberAvatar: () => null, AddOrgDialog: () => null }))
@@ -27,31 +51,122 @@ vi.mock('@/lib/spaces-direct', () => ({
     spaceDisplayName: (_org: unknown, dm: { name: string }) => dm.name,
 }))
 beforeEach(() => { vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }))) })
-afterEach(() => { cleanup(); sessionStorage.clear(); vi.unstubAllGlobals() })
+afterEach(() => {
+    cleanup()
+    sessionStorage.clear()
+    localStorage.clear()
+    resetServerFoldForTest()
+    resetSpaceVisitsForTest()
+    forgetOrg(org.id)
+    forgetOrg(other.id)
+    vi.mocked(useSpacesOrgs).mockImplementation(() => ({ orgs: [org] as unknown as OrgWithSpaces[], loading: false, refresh: vi.fn() }))
+    vi.unstubAllGlobals()
+})
+
+// --- the sidebar's working set ---------------------------------------------
+// A short, fixed list per server: the open space, then what is waiting, then
+// what the reader keeps coming back to, then a deterministic backfill.
+
+describe('the sidebar working set', () => {
+    const bothServers = () => vi.mocked(useSpacesOrgs).mockImplementation(
+        () => ({ orgs: [org, other] as unknown as OrgWithSpaces[], loading: false, refresh: vi.fn() }))
+    const sidebar = (props: Partial<Parameters<typeof SpacesSidebarSection>[0]> = {}) => render(
+        <SidebarProvider>
+            <SpacesSidebarSection active activeSpace={{ orgId: org.id, spaceId: 'founders' }}
+                onOpenSpaces={vi.fn()} onOpenSpace={vi.fn()} {...props} />
+        </SidebarProvider>)
+    /** Put unread roots on spaces, the way the org's snapshot does. */
+    const seedUnread = async (orgId: string, spaces: Array<{ spaceId: string; unreadRoots: number; unreadMentions?: number }>) => {
+        vi.stubGlobal('ipc', {
+            on: vi.fn(() => () => {}),
+            invoke: vi.fn(async (channel: string) => channel === 'spaces:getUnread'
+                ? { spaces: spaces.map((s) => ({ head: s.unreadRoots, readOffset: 0, unreadMentions: 0, threads: [], ...s })) }
+                : {}),
+        })
+        await act(async () => { await loadUnread(orgId, 'me') })
+    }
+
+    it('shows the open space pinned, then backfills to exactly three rows', () => {
+        sidebar()
+        const rows = ['founders', 'main', 'Person 0']
+        for (const name of rows) expect(screen.getByText(name)).toBeTruthy()
+        // The fourth candidate stays out, and a discussion is never a row.
+        expect(screen.queryByText('Person 1')).toBeNull()
+        expect(screen.queryByText('Discussion 0')).toBeNull()
+        expect(screen.getByText('founders').closest('button')).toHaveAttribute('data-active', 'true')
+    })
+
+    it('opens a server holding the open space or anything unread, and leaves the rest closed', async () => {
+        bothServers()
+        sidebar()
+        const header = (name: string) => screen.getByText(name).closest('button')!
+        expect(header('Our server')).toHaveAttribute('aria-expanded', 'true')
+        expect(header('Other server')).toHaveAttribute('aria-expanded', 'false')
+        expect(screen.queryByText('welcome')).toBeNull()
+        await seedUnread(other.id, [{ spaceId: 'welcome', unreadRoots: 2 }])
+        expect(header('Other server')).toHaveAttribute('aria-expanded', 'true')
+        expect(screen.getByText('welcome')).toHaveClass('font-medium')
+    })
+
+    it('shows a closed server the sum of its items\' badges, and opens on a click', async () => {
+        bothServers()
+        await seedUnread(org.id, [{ spaceId: 'main', unreadRoots: 3, unreadMentions: 1 }, { spaceId: 'dm1', unreadRoots: 4 }])
+        sidebar({ activeSpace: null })
+        // Both servers are open (one holds the restored location, one has unread),
+        // so close ours by hand to read its rolled-up badge.
+        fireEvent.click(screen.getByText('Our server'))
+        const header = screen.getByText('Our server').closest('button')!
+        expect(header).toHaveAttribute('aria-expanded', 'false')
+        // 3 roots + 4 in a DM, of which 1 mention + the DM's 4 are for me.
+        expect(within(header).getByLabelText('7 unread · 5 for you')).toBeTruthy()
+        expect(screen.queryByText('main')).toBeNull()
+        fireEvent.click(screen.getByText('Our server'))
+        expect(screen.getByText('main')).toBeTruthy()
+    })
+
+    it('keeps the reader\'s own toggle over the automatic rule, across relaunches', () => {
+        const view = sidebar()
+        expect(screen.getByText('Our server').closest('button')).toHaveAttribute('aria-expanded', 'true')
+        fireEvent.click(screen.getByText('Our server'))
+        expect(screen.queryByText('founders')).toBeNull()
+        view.unmount()
+        // A relaunch: the in-memory mirror is gone, the answer is not.
+        resetServerFoldForTest()
+        sidebar()
+        expect(screen.getByText('Our server').closest('button')).toHaveAttribute('aria-expanded', 'false')
+        expect(screen.queryByText('founders')).toBeNull()
+    })
+
+    it('holds a row in place once it is showing, and gives an entering one its rank', async () => {
+        const view = sidebar()
+        // Each row is titled with its name; the server header's title is its own sentence.
+        const shown = () => screen.getAllByRole('button').map((b) => b.getAttribute('title'))
+            .filter((t) => ['founders', 'main', 'Person 0', 'Person 3'].includes(t ?? ''))
+        expect(shown()).toEqual(['founders', 'main', 'Person 0'])
+        // Visiting one already showing must not move it.
+        act(() => noteSpaceVisit(org.id, 'main', 9_000))
+        expect(shown()).toEqual(['founders', 'main', 'Person 0'])
+        // A DM goes unread: it enters behind the open space, ahead of the backfill,
+        // and the row it displaced leaves.
+        await seedUnread(org.id, [{ spaceId: 'dm3', unreadRoots: 1 }])
+        expect(shown()).toEqual(['founders', 'Person 3', 'main'])
+        view.unmount()
+    })
+
+    it('reaches the siderail and the sidebar from one read state', async () => {
+        render(<SidebarProvider>
+            <SpacesSidebarSection active activeSpace={{ orgId: org.id, spaceId: 'main' }} onOpenSpaces={vi.fn()} onOpenSpace={vi.fn()} />
+            <ServerSpaceNavigation org={org as unknown as OrgWithSpaces} spaceId="main" onOpenSpace={vi.fn()}
+                onOpenDiscussion={vi.fn()} activeDiscussionCount={0} renderActiveDiscussions={() => null} />
+        </SidebarProvider>)
+        await seedUnread(org.id, [{ spaceId: 'founders', unreadRoots: 2 }])
+        expect(screen.getAllByLabelText('2 unread · none for you')).toHaveLength(2)
+        act(() => markStreamRead(org.id, 'founders', 2, { sync: false }))
+        expect(screen.queryByLabelText('2 unread · none for you')).toBeNull()
+    })
+})
 
 describe('server and space navigation', () => {
-    it('shows nested server names and preserves the current location when returning to Spaces', () => {
-        const onOpenSpaces = vi.fn()
-        render(<SidebarProvider><SpacesSidebarSection active={false} activeSpace={{ orgId: org.id, spaceId: 'founders' }} onOpenSpaces={onOpenSpaces} onOpenSpace={vi.fn()} /></SidebarProvider>)
-        expect(screen.getByText('Our server')).toHaveClass('font-medium')
-        expect(screen.getByText('Our server').closest('button')?.querySelector('svg')).toBeNull()
-        expect(screen.queryByText('main')).toBeNull()
-        expect(screen.queryByText('Direct messages')).toBeNull()
-        fireEvent.click(screen.getByRole('button', { name: 'Spaces' }))
-        expect(onOpenSpaces).toHaveBeenCalledTimes(1)
-        fireEvent.click(screen.getByText('Our server'))
-        expect(onOpenSpaces).toHaveBeenCalledTimes(2)
-    })
-    it('navigates to a different server when its name is clicked', () => {
-        const other = { ...org, id: 'other', name: 'Other server', spaces: [{ id: 'welcome', name: 'welcome' }] }
-        vi.mocked(useSpacesOrgs).mockReturnValueOnce({ orgs: [org, other] as unknown as OrgWithSpaces[], loading: false, refresh: vi.fn() })
-        const onOpenSpace = vi.fn()
-        render(<SidebarProvider><SpacesSidebarSection active activeSpace={{ orgId: org.id, spaceId: 'founders' }}
-            onOpenSpaces={vi.fn()} onOpenSpace={onOpenSpace} /></SidebarProvider>)
-        expect(screen.getByText('Other server')).toHaveClass('font-normal')
-        fireEvent.click(screen.getByText('Other server'))
-        expect(onOpenSpace).toHaveBeenCalledWith('other', 'welcome')
-    })
     it('nests three recent discussions, expands and collapses them, and folds DMs', () => {
         const onOpenDiscussion = vi.fn()
         render(<SidebarProvider><ServerSpaceNavigation org={org as unknown as OrgWithSpaces} spaceId="main" onOpenSpace={vi.fn()}

--- a/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
+++ b/apps/x/apps/renderer/src/components/spaces-sidebar-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Bell, ChevronRight, CornerDownRight, Hash, MessagesSquare, Pencil, Plus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuAction, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
@@ -17,11 +17,20 @@ import { directAvatarId, isSelfDirect, isSelfDirectUnsupported, markSelfDirectUn
 import { prefetchMembers, useSelfDisplayName } from '@/hooks/use-space-members'
 import { isSpaceExpanded, setSpaceExpanded, useSpaceExpansionVersion } from '@/lib/spaces-expansion'
 import { readLastSpace, resolveSpacesLocation } from '@/lib/spaces-navigation'
+import { serverFoldOverride, setServerFoldOverride, useServerFoldVersion } from '@/lib/spaces-sidebar-fold'
+import { spaceVisitedAt, useSpaceVisitsVersion } from '@/lib/spaces-visits'
+import { ITEMS_PER_SERVER, resolveExpanded, selectServerItems, serverItems, sumBadges, type WorkingSetItem } from '@/lib/spaces-working-set'
 import type { RailSelection } from '@/lib/spaces-selection'
 import { toast } from '@/lib/toast'
 
 const MAX_VISIBLE_DIRECTS = 3
 
+/**
+ * The sidebar's Spaces section: every server, and under the open ones the few
+ * channels and DMs the reader is likeliest to want next (spaces-working-set).
+ * The siderail is the full tree; this stays short and stable, so the rows only
+ * move when one of them enters or leaves the set.
+ */
 export function SpacesSidebarSection({ active, activeSpace, onOpenSpaces, onOpenSpace }: {
     active: boolean
     activeSpace: SpaceSelection
@@ -29,13 +38,17 @@ export function SpacesSidebarSection({ active, activeSpace, onOpenSpaces, onOpen
     onOpenSpace: (orgId: string, spaceId: string) => void
 }) {
     const { orgs, refresh } = useSpacesOrgs()
+    // The siderail's own counts, from the org-owned read state: one store, so
+    // reading a space anywhere clears it everywhere.
+    const unread = useSpacesUnreadCounts()
     const [addOrgOpen, setAddOrgOpen] = useState(false)
     const current = resolveSpacesLocation(orgs, activeSpace ?? readLastSpace())
     return <SidebarGroup className="pt-0">
         <SidebarGroupContent>
             <SidebarMenu>
                 <SidebarMenuItem>
-                    <SidebarMenuButton data-tour-id="nav-spaces" isActive={active} onClick={onOpenSpaces}>
+                    <SidebarMenuButton data-tour-id="nav-spaces" isActive={active} onClick={onOpenSpaces}
+                        title="Showing a few unread and recent channels">
                         <MessagesSquare className="size-4 shrink-0" />
                         <span>Spaces</span>
                     </SidebarMenuButton>
@@ -44,26 +57,111 @@ export function SpacesSidebarSection({ active, activeSpace, onOpenSpaces, onOpen
                         <Plus />
                     </SidebarMenuAction>
                     {orgs.length > 0 && <SidebarMenu className="ml-4 w-auto gap-0 border-l border-sidebar-border pl-2">
-                        {orgs.map((org) => {
-                            const selected = current?.orgId === org.id
-                            return <SidebarMenuItem key={org.id}>
-                                <SidebarMenuButton
-                                    aria-current={active && selected ? 'page' : undefined}
-                                    className="h-7 text-[13px]"
-                                    onClick={() => {
-                                        if (selected) onOpenSpaces()
-                                        else onOpenSpace(org.id, org.spaces[0]?.id ?? org.directs[0]?.id ?? '')
-                                    }}>
-                                    <span className={cn('truncate', selected ? 'font-medium text-sidebar-foreground' : 'font-normal text-muted-foreground')}>{org.name}</span>
-                                </SidebarMenuButton>
-                            </SidebarMenuItem>
-                        })}
+                        {/* Servers in the siderail's order; every one keeps its header row. */}
+                        {orgs.map((org) => <ServerWorkingSet key={org.id} org={org} unread={unread} active={active}
+                            currentItemId={current?.orgId === org.id ? (current.spaceId || null) : null}
+                            onOpenSpace={onOpenSpace} />)}
                     </SidebarMenu>}
                 </SidebarMenuItem>
             </SidebarMenu>
         </SidebarGroupContent>
         <AddOrgDialog open={addOrgOpen} onOpenChange={setAddOrgOpen} onAdded={() => void refresh()} />
     </SidebarGroup>
+}
+
+/** One server: its header, and while open its working set of channels and DMs. */
+function ServerWorkingSet({ org, unread, active, currentItemId, onOpenSpace }: {
+    org: OrgWithSpaces
+    unread: Map<string, SpaceBadge>
+    /** Is Spaces the section on screen? Only then does a row read as the open one. */
+    active: boolean
+    /** The open channel or DM, when it is this server's; it always keeps a row. */
+    currentItemId: string | null
+    onOpenSpace: (orgId: string, spaceId: string) => void
+}) {
+    const visits = useSpaceVisitsVersion()
+    useServerFoldVersion()
+    // Your notes-to-self DM is a DM like any other, labelled the way the
+    // siderail labels it: your name, then a quiet "you".
+    const selfDm = org.directs.find((dm) => isSelfDirect(dm, org.memberId))
+    const selfRosterIds = useMemo(
+        () => (selfDm ? [selfDm.id] : org.spaces.slice(0, 1).map((s) => s.id)),
+        [selfDm, org.spaces],
+    )
+    const selfName = useSelfDisplayName(org.id, org.memberId, selfRosterIds)
+        ?? (selfDm ? spaceDisplayName(org, selfDm).replace(/ \(you\)$/, '') : org.memberId)
+    const items = useMemo(
+        () => serverItems(org, {
+            badge: (spaceId) => unread.get(`${org.id}/${spaceId}`) ?? NO_BADGE,
+            visitedAt: (spaceId) => spaceVisitedAt(org.id, spaceId),
+            activityAt: (spaceId) => spaceLastActivityAt(org.id, spaceId),
+            label: (space) => (isSelfDirect(space, org.memberId) ? selfName : spaceDisplayName(org, space)),
+        }),
+        // `visits` and the unread map's identity are the two things that move underneath.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [org, unread, visits, selfName],
+    )
+    const expanded = resolveExpanded({ items }, currentItemId, serverFoldOverride(org.id))
+    // What is on screen now, so a row already there keeps its place.
+    const shown = useRef<string[]>([])
+    const rows = expanded ? selectServerItems(items, currentItemId, ITEMS_PER_SERVER, shown.current) : []
+    useEffect(() => {
+        // Collapsing remembers the rows, so reopening the server shows the same ones.
+        if (expanded) shown.current = rows.map((row) => row.id)
+    })
+    const badge = sumBadges(items)
+    return <>
+        <SidebarMenuItem>
+            <SidebarMenuButton
+                className="h-7 text-[13px]"
+                aria-expanded={expanded}
+                title={`${expanded ? 'Collapse' : 'Expand'} ${org.name}`}
+                onClick={() => setServerFoldOverride(org.id, !expanded)}
+            >
+                <ChevronRight className={cn('size-3.5 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')} />
+                <span className={cn('flex-1 truncate',
+                    currentItemId || (!expanded && badge.unread > 0) ? 'font-medium text-sidebar-foreground' : 'font-normal text-muted-foreground')}>
+                    {org.name}
+                </span>
+                {/* Closed, the header carries its items' badges; open, each row carries its own. */}
+                {!expanded && <UnreadBadge badge={badge} />}
+            </SidebarMenuButton>
+        </SidebarMenuItem>
+        {rows.map((item) => <WorkingSetRow key={item.id} orgId={org.id} item={item}
+            active={active && item.id === currentItemId} onOpenSpace={onOpenSpace} />)}
+    </>
+}
+
+/** A channel or a DM, in the siderail's own row shape. */
+function WorkingSetRow({ orgId, item, active, onOpenSpace }: {
+    orgId: string
+    item: WorkingSetItem
+    active: boolean
+    onOpenSpace: (orgId: string, spaceId: string) => void
+}) {
+    return <SidebarMenuItem>
+        <SidebarMenuButton
+            isActive={active}
+            aria-current={active ? 'page' : undefined}
+            className="h-7 pl-6 text-[13px]"
+            title={item.name}
+            onClick={() => onOpenSpace(orgId, item.id)}
+            // Hover = intent: warm the cached tail + roster so the click paints instantly.
+            onMouseEnter={() => {
+                prefetchStream(orgId, item.id)
+                prefetchMembers(orgId, item.id)
+            }}
+        >
+            {item.kind === 'channel'
+                ? <Hash className="size-3.5 shrink-0 text-muted-foreground" />
+                : <MemberAvatar id={item.avatarId ?? item.id} name={item.name} size="sm" className="size-4 rounded-[3px] text-[8px]" />}
+            <span className={cn('flex-1 truncate', item.badge.unread > 0 && !active && 'font-medium text-foreground')}>
+                {item.name}
+                {item.self && <span className="ml-1.5 font-normal text-muted-foreground">you</span>}
+            </span>
+            {!active && <UnreadBadge badge={item.badge} direct={item.kind === 'direct'} />}
+        </SidebarMenuButton>
+    </SidebarMenuItem>
 }
 
 function OrgRows({ org, activeSpace, unread, onOpenSpace, onOpenActivity, activityActive = false, onChanged, renderDiscussions, showArchived = false, activeDiscussionCount }: {

--- a/apps/x/apps/renderer/src/lib/spaces-sidebar-fold.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-sidebar-fold.ts
@@ -1,0 +1,64 @@
+import { useSyncExternalStore } from 'react'
+
+// Whether a server's rows are showing in the sidebar's Spaces section. Only
+// the reader's OWN toggles live here: with no entry for a server the section
+// decides for itself (resolveExpanded — the current space, or anything
+// unread, opens it). A toggle is that reader's standing answer, so it is kept
+// across relaunches rather than for the session.
+
+const STORAGE_KEY = 'x:spaces-sidebar-fold'
+
+const listeners = new Set<() => void>()
+let version = 0
+let overrides: Record<string, boolean> | null = null
+
+function load(): Record<string, boolean> {
+    if (overrides) return overrides
+    overrides = {}
+    try {
+        const raw = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown
+        if (raw && typeof raw === 'object') {
+            for (const [orgId, expanded] of Object.entries(raw as Record<string, unknown>)) {
+                if (typeof expanded === 'boolean') overrides[orgId] = expanded
+            }
+        }
+    } catch {
+        // unreadable storage — every server falls back to the automatic rule
+    }
+    return overrides
+}
+
+/** The reader's own answer for this server, or null while the automatic rule holds. */
+export function serverFoldOverride(orgId: string): boolean | null {
+    return load()[orgId] ?? null
+}
+
+/** The reader worked the chevron: their answer stands for this server from now on. */
+export function setServerFoldOverride(orgId: string, expanded: boolean): void {
+    overrides = { ...load(), [orgId]: expanded }
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides))
+    } catch {
+        // storage unavailable — the toggle still holds for this session
+    }
+    version += 1
+    for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+/** Re-renders the caller on every toggle; read the values with serverFoldOverride. */
+export function useServerFoldVersion(): number {
+    return useSyncExternalStore(subscribe, () => version)
+}
+
+/** Tests only — drops the in-memory mirror so the next read re-reads storage. */
+export function resetServerFoldForTest(): void {
+    overrides = null
+    version += 1
+}

--- a/apps/x/apps/renderer/src/lib/spaces-visits.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-visits.ts
@@ -1,0 +1,76 @@
+import { useSyncExternalStore } from 'react'
+
+// When this install last opened each channel or DM. The sidebar's working set
+// falls back to it once nothing is unread ("the ones you keep coming back
+// to"), so it is written from App's one route into Spaces — every navigation
+// funnels through there, and a correction the Spaces view makes to its own
+// selection is not a visit.
+
+const STORAGE_KEY = 'x:space-visits'
+/** Enough to outlive any working set; the oldest entries fall off the write. */
+const MAX_ENTRIES = 200
+
+const listeners = new Set<() => void>()
+let version = 0
+let visits: Record<string, number> | null = null
+
+const key = (orgId: string, spaceId: string) => `${orgId}/${spaceId}`
+
+function load(): Record<string, number> {
+    if (visits) return visits
+    visits = {}
+    try {
+        const raw = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown
+        if (raw && typeof raw === 'object') {
+            for (const [id, at] of Object.entries(raw as Record<string, unknown>)) {
+                if (typeof at === 'number' && Number.isFinite(at)) visits[id] = at
+            }
+        }
+    } catch {
+        // unreadable storage — the working set backfills deterministically
+    }
+    return visits
+}
+
+function persist(next: Record<string, number>): void {
+    const entries = Object.entries(next).sort((a, b) => b[1] - a[1]).slice(0, MAX_ENTRIES)
+    visits = Object.fromEntries(entries)
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(visits))
+    } catch {
+        // storage full or unavailable — the in-memory record still serves this session
+    }
+}
+
+/** This install opened the space just now. */
+export function noteSpaceVisit(orgId: string, spaceId: string, at = Date.now()): void {
+    if (!orgId || !spaceId) return
+    const current = load()
+    if (current[key(orgId, spaceId)] === at) return
+    persist({ ...current, [key(orgId, spaceId)]: at })
+    version += 1
+    for (const listener of listeners) listener()
+}
+
+/** When the space was last opened here, or null if it never was. */
+export function spaceVisitedAt(orgId: string, spaceId: string): number | null {
+    return load()[key(orgId, spaceId)] ?? null
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+/** Re-renders the caller on every visit; read the values with spaceVisitedAt. */
+export function useSpaceVisitsVersion(): number {
+    return useSyncExternalStore(subscribe, () => version)
+}
+
+/** Tests only — drops the in-memory mirror so the next read re-reads storage. */
+export function resetSpaceVisitsForTest(): void {
+    visits = null
+    version += 1
+}

--- a/apps/x/apps/renderer/src/lib/spaces-working-set.test.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-working-set.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { NO_BADGE } from '@/lib/spaces-read-state'
+import {
+    ITEMS_PER_SERVER, resolveExpanded, selectServerItems, serverItems, sumBadges, type WorkingSetItem,
+} from '@/lib/spaces-working-set'
+
+const K = ITEMS_PER_SERVER
+
+function item(id: string, over: Partial<WorkingSetItem> = {}): WorkingSetItem {
+    return {
+        id,
+        kind: 'channel',
+        name: id,
+        badge: NO_BADGE,
+        lastActivityAt: '2026-09-01T00:00:00.000Z',
+        lastVisitedAt: null,
+        ...over,
+    }
+}
+
+const ids = (items: readonly WorkingSetItem[]) => items.map((i) => i.id)
+
+describe('selectServerItems', () => {
+    it('pins the open item and never evicts it, however cold it is', () => {
+        const items = [
+            item('cold'),
+            item('loud', { badge: { unread: 9, forYou: 2 }, lastActivityAt: '2026-09-10T00:00:00.000Z' }),
+            item('louder', { badge: { unread: 4, forYou: 0 }, lastActivityAt: '2026-09-11T00:00:00.000Z' }),
+            item('recent', { lastVisitedAt: 5_000 }),
+            item('alsoRecent', { lastVisitedAt: 4_000 }),
+        ]
+        expect(ids(selectServerItems(items, 'cold', K))).toEqual(['cold', 'louder', 'loud'])
+    })
+
+    it('takes unread before recent, and recent before the backfill', () => {
+        const items = [
+            item('default', { isDefault: true }),
+            item('zebra'),
+            item('unread', { badge: { unread: 2, forYou: 0 } }),
+            item('visited', { lastVisitedAt: 1_000 }),
+        ]
+        expect(ids(selectServerItems(items, null, K))).toEqual(['unread', 'visited', 'default'])
+    })
+
+    it('orders unread by activity and recent by last visit', () => {
+        const items = [
+            item('old-unread', { badge: { unread: 1, forYou: 0 }, lastActivityAt: '2026-09-02T00:00:00.000Z' }),
+            item('new-unread', { badge: { unread: 1, forYou: 0 }, lastActivityAt: '2026-09-09T00:00:00.000Z' }),
+            item('older-visit', { lastVisitedAt: 10 }),
+            item('newer-visit', { lastVisitedAt: 99 }),
+        ]
+        expect(ids(selectServerItems(items, null, 4))).toEqual(['new-unread', 'old-unread', 'newer-visit', 'older-visit'])
+    })
+
+    it('backfills to exactly K: the default channel, then channels A-Z, then DMs A-Z', () => {
+        const items = [
+            item('d1', { kind: 'direct', name: 'Ada' }),
+            item('c2', { name: 'beta' }),
+            item('c3', { name: 'alpha' }),
+            item('c1', { name: 'general', isDefault: true }),
+            item('d2', { kind: 'direct', name: 'Zoe' }),
+        ]
+        const rows = selectServerItems(items, null, K)
+        expect(rows).toHaveLength(K)
+        expect(rows.map((r) => r.name)).toEqual(['general', 'alpha', 'beta'])
+        expect(selectServerItems(items, null, 5).map((r) => r.name)).toEqual(['general', 'alpha', 'beta', 'Ada', 'Zoe'])
+    })
+
+    it('shows everything a server has when it has fewer than K items', () => {
+        const items = [item('only'), item('other')]
+        expect(ids(selectServerItems(items, null, K))).toEqual(['only', 'other'])
+        expect(selectServerItems([], null, K)).toEqual([])
+    })
+
+    it('holds a showing row in place when it is revisited or goes unread', () => {
+        const items = [
+            item('a', { isDefault: true }),
+            item('b', { name: 'b' }),
+            item('c', { name: 'c' }),
+            item('d', { name: 'd' }),
+        ]
+        const first = ids(selectServerItems(items, null, K))
+        expect(first).toEqual(['a', 'b', 'c'])
+        // 'c' is opened and read: it now outranks the others, but it is already showing.
+        const revisited = items.map((i) => (i.id === 'c' ? { ...i, lastVisitedAt: 9_000 } : i))
+        expect(ids(selectServerItems(revisited, 'c', K, first))).toEqual(['a', 'b', 'c'])
+        // And again once it is unread rather than current.
+        const noisy = items.map((i) => (i.id === 'c' ? { ...i, badge: { unread: 3, forYou: 1 } } : i))
+        expect(ids(selectServerItems(noisy, null, K, first))).toEqual(['a', 'b', 'c'])
+    })
+
+    it('reorders only when an item enters, placing it by rank', () => {
+        const items = [item('a', { isDefault: true }), item('b'), item('c'), item('d')]
+        const first = ids(selectServerItems(items, null, K)) // a, b, c
+        // 'd' goes unread: it enters at the top and evicts the last backfill row.
+        const entering = items.map((i) => (i.id === 'd' ? { ...i, badge: { unread: 1, forYou: 0 } } : i))
+        const second = ids(selectServerItems(entering, null, K, first))
+        expect(second).toEqual(['d', 'a', 'b'])
+        // Opening it reads it and records the visit: it keeps its row, in place.
+        const read = items.map((i) => (i.id === 'd' ? { ...i, lastVisitedAt: 9_000 } : i))
+        expect(ids(selectServerItems(read, null, K, second))).toEqual(['d', 'a', 'b'])
+    })
+
+    it('drops ids that are gone and survives a stale previous list', () => {
+        const items = [item('a'), item('b')]
+        expect(ids(selectServerItems(items, null, K, ['gone', 'b', 'b']))).toEqual(['a', 'b'])
+    })
+})
+
+describe('serverItems', () => {
+    const org = {
+        id: 'server',
+        memberId: 'me',
+        directLabels: { dm: 'Ada' },
+        spaces: [
+            { id: 'general', name: 'general', createdAt: '2026-09-01T00:00:00.000Z', kind: 'shared' },
+            { id: 'design', name: 'design', createdAt: '2026-09-02T00:00:00.000Z', kind: 'shared' },
+        ],
+        directs: [{ id: 'dm', name: 'direct', createdAt: '2026-09-03T00:00:00.000Z', kind: 'direct', participants: ['me', 'ada'] }],
+    } as unknown as OrgWithSpaces
+
+    const read = {
+        badge: () => NO_BADGE,
+        visitedAt: () => null,
+        activityAt: () => null,
+        label: () => 'Ada',
+    }
+
+    it('lists channels and DMs only — a discussion is never an item', () => {
+        const items = serverItems(org, read)
+        expect(items.map((i) => i.id)).toEqual(['general', 'design', 'dm'])
+        expect(items.filter((i) => i.kind === 'channel').map((i) => i.isDefault)).toEqual([true, false])
+        expect(items[2]).toMatchObject({ kind: 'direct', name: 'Ada' })
+    })
+
+    it('falls back to the space\'s createdAt until something happens in it', () => {
+        expect(serverItems(org, read)[0].lastActivityAt).toBe('2026-09-01T00:00:00.000Z')
+        expect(serverItems(org, { ...read, activityAt: () => '2026-09-12T00:00:00.000Z' })[0].lastActivityAt)
+            .toBe('2026-09-12T00:00:00.000Z')
+    })
+})
+
+describe('sumBadges', () => {
+    it('is the sum of the server\'s item badges', () => {
+        expect(sumBadges([
+            item('a', { badge: { unread: 3, forYou: 1 } }),
+            item('b', { badge: { unread: 4, forYou: 0 } }),
+            item('c'),
+        ])).toEqual({ unread: 7, forYou: 1 })
+        expect(sumBadges([item('a'), item('b')])).toEqual(NO_BADGE)
+        expect(sumBadges([])).toEqual(NO_BADGE)
+    })
+})
+
+describe('resolveExpanded', () => {
+    const quiet = { items: [item('a'), item('b')] }
+    const noisy = { items: [item('a'), item('b', { badge: { unread: 1, forYou: 0 } })] }
+
+    it('opens the server holding the open item', () => {
+        expect(resolveExpanded(quiet, 'a', null)).toBe(true)
+        expect(resolveExpanded(quiet, 'elsewhere', null)).toBe(false)
+    })
+
+    it('opens a server with anything unread, and closes every other', () => {
+        expect(resolveExpanded(noisy, null, null)).toBe(true)
+        expect(resolveExpanded({ items: [item('a', { badge: { unread: 0, forYou: 2 } })] }, null, null)).toBe(true)
+        expect(resolveExpanded(quiet, null, null)).toBe(false)
+        expect(resolveExpanded({ items: [] }, null, null)).toBe(false)
+    })
+
+    it('lets the reader\'s own toggle stand over either rule', () => {
+        expect(resolveExpanded(noisy, 'a', false)).toBe(false)
+        expect(resolveExpanded(quiet, null, true)).toBe(true)
+    })
+})

--- a/apps/x/apps/renderer/src/lib/spaces-working-set.ts
+++ b/apps/x/apps/renderer/src/lib/spaces-working-set.ts
@@ -1,0 +1,156 @@
+import type { spaces } from '@x/shared'
+import type { OrgWithSpaces } from '@/hooks/use-spaces'
+import { directAvatarId, isSelfDirect } from '@/lib/spaces-direct'
+import { NO_BADGE, type SpaceBadge } from '@/lib/spaces-read-state'
+
+// The sidebar's working set: per server, the few channels and DMs the reader
+// is likeliest to open next. The siderail stays the full tree — this is a
+// short, STABLE list, so the rows must not shuffle under the pointer: only an
+// item entering or leaving the set moves anything.
+
+/** Rows one expanded server shows. Constant: the section's height is 1 + K per server. */
+export const ITEMS_PER_SERVER = 3
+
+/**
+ * One row. A discussion is never one of these: it belongs to its parent
+ * channel and is shown only in the siderail.
+ */
+export interface WorkingSetItem {
+    id: string
+    kind: 'channel' | 'direct'
+    /** What the row shows, and the alphabetical backfill's sort key. */
+    name: string
+    /** From the shared read-state store — the same badge the siderail reads. */
+    badge: SpaceBadge
+    /** Newest activity, ISO; the space's createdAt until something happens in it. */
+    lastActivityAt: string
+    /** When this install last opened it (epoch ms); null = never. */
+    lastVisitedAt: number | null
+    /** The server's landing channel — first in the deterministic backfill. */
+    isDefault?: boolean
+    /** DMs: the face the row wears. */
+    avatarId?: string
+    /** DMs: your notes-to-self, which is a DM like any other. */
+    self?: boolean
+}
+
+function hasUnread(item: WorkingSetItem): boolean {
+    return item.badge.unread > 0 || item.badge.forYou > 0
+}
+
+/** The server's own number: its items' badges, summed (a collapsed server shows it). */
+export function sumBadges(items: readonly { badge: SpaceBadge }[]): SpaceBadge {
+    let unread = 0
+    let forYou = 0
+    for (const item of items) {
+        unread += item.badge.unread
+        forYou += item.badge.forYou
+    }
+    return unread === 0 ? NO_BADGE : { unread, forYou }
+}
+
+/**
+ * A server's channels and DMs as rows — the one place the "threads are not
+ * items" rule is kept, by reading only the org's spaces and directs.
+ */
+export function serverItems(
+    org: OrgWithSpaces,
+    read: {
+        badge: (spaceId: string) => SpaceBadge
+        visitedAt: (spaceId: string) => number | null
+        activityAt: (spaceId: string) => string | null
+        label: (space: spaces.Space) => string
+    },
+): WorkingSetItem[] {
+    // The first shared space is the server's landing channel: every "open this
+    // server" path in the app lands there.
+    const channels = org.spaces.map((space, index): WorkingSetItem => ({
+        id: space.id,
+        kind: 'channel',
+        name: space.name,
+        badge: read.badge(space.id),
+        lastActivityAt: read.activityAt(space.id) ?? space.createdAt,
+        lastVisitedAt: read.visitedAt(space.id),
+        isDefault: index === 0,
+    }))
+    const directs = org.directs.map((dm): WorkingSetItem => ({
+        id: dm.id,
+        kind: 'direct',
+        name: read.label(dm),
+        badge: read.badge(dm.id),
+        lastActivityAt: read.activityAt(dm.id) ?? dm.createdAt,
+        lastVisitedAt: read.visitedAt(dm.id),
+        avatarId: directAvatarId(dm, org.memberId),
+        self: isSelfDirect(dm, org.memberId),
+    }))
+    return [...channels, ...directs]
+}
+
+function byName(a: WorkingSetItem, b: WorkingSetItem): number {
+    return a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
+}
+
+/**
+ * Every item, best claim on a row first: the open one, then what is waiting
+ * (newest activity first), then what the reader keeps coming back to, then a
+ * deterministic backfill so the list is never short and never arbitrary.
+ */
+function rankItems(items: readonly WorkingSetItem[], currentItemId: string | null): WorkingSetItem[] {
+    const current = items.find((item) => item.id === currentItemId)
+    const rest = items.filter((item) => item.id !== current?.id)
+    const unread = rest.filter(hasUnread)
+        .sort((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt) || byName(a, b))
+    const visited = rest.filter((item) => !hasUnread(item) && item.lastVisitedAt !== null)
+        .sort((a, b) => (b.lastVisitedAt ?? 0) - (a.lastVisitedAt ?? 0) || byName(a, b))
+    const cold = rest.filter((item) => !hasUnread(item) && item.lastVisitedAt === null)
+    const backfill = [
+        ...cold.filter((item) => item.kind === 'channel' && item.isDefault),
+        ...cold.filter((item) => item.kind === 'channel' && !item.isDefault).sort(byName),
+        ...cold.filter((item) => item.kind === 'direct').sort(byName),
+    ]
+    return [...(current ? [current] : []), ...unread, ...visited, ...backfill]
+}
+
+/**
+ * The K rows one server shows, in the order they should render.
+ *
+ * `previous` is the ids showing now: a row already on screen keeps its place,
+ * however its unread or recency has moved since — revisiting what is already
+ * there must not make the list jump. Only an item joining or dropping out
+ * moves anything, and a joining one lands where its rank puts it.
+ */
+export function selectServerItems(
+    items: readonly WorkingSetItem[],
+    currentItemId: string | null,
+    k: number = ITEMS_PER_SERVER,
+    previous: readonly string[] = [],
+): WorkingSetItem[] {
+    const chosen = rankItems(items, currentItemId).slice(0, Math.max(0, k))
+    const rank = new Map(chosen.map((item, index) => [item.id, index]))
+    const order: string[] = []
+    for (const id of previous) if (rank.has(id) && !order.includes(id)) order.push(id)
+    for (const item of chosen) {
+        if (order.includes(item.id)) continue
+        // Behind everything already showing that outranks it, ahead of the rest.
+        let at = order.length
+        while (at > 0 && rank.get(order[at - 1])! > rank.get(item.id)!) at -= 1
+        order.splice(at, 0, item.id)
+    }
+    const byId = new Map(chosen.map((item) => [item.id, item]))
+    return order.map((id) => byId.get(id)!)
+}
+
+/**
+ * Is this server's list open? Automatic until the reader says otherwise: a
+ * server holding the open space, or anything unread, opens itself; every
+ * other one stays shut. `manualOverride` is that reader's standing answer.
+ */
+export function resolveExpanded(
+    server: { items: readonly WorkingSetItem[] },
+    currentItemId: string | null,
+    manualOverride?: boolean | null,
+): boolean {
+    if (typeof manualOverride === 'boolean') return manualOverride
+    if (currentItemId && server.items.some((item) => item.id === currentItemId)) return true
+    return server.items.some(hasUnread)
+}


### PR DESCRIPTION
The sidebar's Spaces section listed server names only. It now surfaces what you are likely to open next, while the siderail stays the full tree (unchanged).

## What it does

- **Server headers, always.** Every server keeps a header row with a chevron, in the siderail's order. Headers never appear or disappear. Hovering "Spaces" says "Showing a few unread and recent channels".
- **Three items per open server**, chosen in order: the open channel/DM (pinned, never evicted), then anything unread by newest activity, then the most recently visited, then a deterministic backfill (the server's default channel, remaining channels A-Z, then DMs A-Z). Height is fixed at 1 + 3 rows.
- **Stable rows.** A row already on screen keeps its place however its unread or recency moves, so revisiting what is already there never makes the list jump. Only an item entering or leaving the set moves anything, and an entrant lands at its rank.
- **Open or closed, decided then remembered.** A server opens itself when it holds the open space or has anything unread, and closes otherwise. The reader's own chevron toggle overrides that for the server and is kept across relaunches. A closed server shows its items' badges summed on the right.
- Threads are never rows: they belong to their parent channel and stay in the siderail.

## How it is wired

- `lib/spaces-working-set.ts` (pure): `selectServerItems(items, currentItemId, K, previous)`, `resolveExpanded(server, currentItemId, manualOverride)`, `sumBadges`, and `serverItems(org, read)` - the one place the "a thread is never an item" rule lives, since it reads only the org's spaces and directs. `previous` is what is on screen, which is what makes the list stable.
- `lib/spaces-visits.ts`: persisted `lastVisitedAt` per channel/DM, written from `App.applyViewState`'s `case 'spaces'` - the single route into Spaces, so the view correcting its own selection does not count as a visit.
- `lib/spaces-sidebar-fold.ts`: the per-server manual toggle, tri-state (absent = the automatic rule).
- Badges come from `useSpacesUnreadCounts()`, the same org-owned read state the siderail reads, with its existing per-row aggregation. No second copy, so marking read on either surface clears both.
- Item rows keep the siderail's shape: `#` for channels, an avatar for DMs, bold plus the dot-and-count badge while unread, the quiet "you" on your self-DM, hover prefetch of the tail and roster.

## One behaviour change worth a look

Clicking a server header now toggles its fold instead of opening that server. Navigation moved to the item rows, and the default channel is always in the backfill, so an open server always offers it. Easy to switch back to "chevron folds, the rest of the row navigates" if you would rather keep the old click.

## Tests

`lib/spaces-working-set.test.ts` (14) covers the pin, unread over recent over backfill, backfill to exactly K, a server with fewer than K items, no reorder on revisit and reorder on entry/exit, thread exclusion, the three expand rules, and the badge sum. Six component tests cover the same through the rendered sidebar, including one that renders the sidebar and the siderail together and moves a read mark through the real store to show both follow it. Full renderer suite: 93 files, 810 tests, green.

Also verified in a browser against a stubbed IPC: light and dark, an auto-open server, an auto-closed one, and a manually closed server with unread showing its summed badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)